### PR TITLE
Add management Rates & Extras Center

### DIFF
--- a/docs/rates-centralization-plan.md
+++ b/docs/rates-centralization-plan.md
@@ -1,0 +1,89 @@
+# Rates & Extras Centralization Plan
+
+## 1. Current landscape audit
+
+### 1.1 UI touchpoints
+- **Tour-specific management dialog** – `TourRatesManagerDialog` combines job selection, approval toggles, extras editing (via `JobExtrasEditor`), and base-rate tabs inside a modal that only opens from tour context. The modal orchestrates disparate queries for jobs, assignments, profiles, and extras without persistent navigation or cross-tour visibility.【F:src/components/tours/TourRatesManagerDialog.tsx†L30-L200】
+- **House tech override editor** – The settings page component focuses solely on per-profile overrides, replicating contextual data (default category rates) and save flows that overlap with tour editing but live elsewhere in the product hierarchy.【F:src/components/settings/HouseTechRateEditor.tsx†L25-L198】
+- **Tour job rates panel (read only)** – A job-level panel visualises quotes per assignment, but the heavy lifting for editing, approvals, and extras happens outside of this surface, reinforcing the fragmentation between overview and configuration.【F:src/components/tours/TourRatesPanel.tsx†L17-L200】
+- **Job extras editor** – Managers edit extras inside each technician card; the same component powers both manager and technician views, mixing approval-related logic with day-to-day data entry.【F:src/components/jobs/JobExtrasEditor.tsx†L28-L200】
+
+### 1.2 Hooks & data sources
+- **Rate catalogs & overrides** – Multiple hooks hit separate Supabase tables/views for base tour rates, extras amounts, and house-tech overrides (`rate_cards_tour_2025`, `rate_extras_2025`, `house_tech_rates`). Each hook manages its own cache keys, invalidations, and toasts, with little shared infrastructure.【F:src/hooks/useTourBaseRates.ts†L12-L48】【F:src/hooks/useRateExtrasCatalog.ts†L10-L46】【F:src/hooks/useHouseTechRates.ts†L22-L85】
+- **Approvals & quotes** – Manager flows fetch approval state and compute quotes per job/tour using bespoke hooks; technicians consume different hooks scoped to their assignments, duplicating grouping logic client-side.【F:src/hooks/useTourRatesApproval.ts†L5-L37】【F:src/hooks/useTourJobRateQuotesForManager.ts†L9-L98】【F:src/hooks/useJobExtras.ts†L6-L114】
+
+### 1.3 Database primitives
+- Rate tables for 2025 (base tiers, extras catalog, per-profile overrides) already exist with RLS rules that restrict writes to managers, but there is no unified API layer that exposes them together.【F:supabase/migrations/20250917082106_6c478d6d-5e51-499f-ace7-7e99a1ff1853.sql†L3-L118】【F:supabase/migrations/20250920151521_ec9eb57c-334c-4f96-aa82-c883e3bb7fcf.sql†L3-L19】【F:supabase/migrations/20250920091546_6ee5e3f2-53ad-4af3-b3b6-6657b2062716.sql†L1-L143】
+
+## 2. Pain points & risks
+1. **Modal-only workflow** – Managers must jump into a tour modal to make changes, lacking global context (e.g., comparing rates across tours or confirming default catalogs before approving).
+2. **Redundant data fetches** – Each hook independently loads profiles, rate cards, and extras, increasing Supabase round-trips and creating cache invalidation complexity when a change should fan out to many surfaces.
+3. **Approval ambiguity** – Approval toggles live inside the modal, but technicians see status elsewhere; there is no consolidated audit trail tying approvals, rate edits, and extras adjustments together.
+4. **Fragmented editing controls** – Extras, base rate defaults, and house overrides use different UI patterns; managers must learn multiple micro-flows to accomplish related tasks.
+5. **Limited bulk operations** – Managers cannot view multi-tour data, duplicate settings, or apply changes in bulk; everything is per-tour/per-technician.
+
+## 3. UX centralization vision
+Create a dedicated **Rates & Extras Center** accessible from the management settings navigation. The page becomes the authoritative hub for configuring defaults, overrides, and approvals across tours, jobs, and profiles.
+
+### 3.1 Page scaffolding
+1. **Global header** – Summaries of pending approvals, recently edited items, and quick actions (e.g., "Approve next tour", "Review extras catalog").
+2. **Tabs/sections** (persistent, not modal):
+   - **Rate Catalogs** – Edit base tour categories and extras in a side-by-side layout; re-use forms from current modal but surface them simultaneously for quicker cross-referencing. Add inline history badges sourced from activity log.
+   - **House Tech Overrides** – Searchable list of technicians with inline editing drawers using the existing `HouseTechRateEditor`, but now embedded with category context and differential indicators (default vs override).
+   - **Tour & Job Approvals** – Table summarizing tours/jobs, approval status, total assignments, and blockers (e.g., missing categories or extras). Allow inline actions to open detailed drawers.
+   - **Assignment Drill-down** – Dedicated panel (drawer or right-side inspector) showing the current `TourRatesManagerDialog` content but in-page, enabling persistent navigation.
+
+3. **Contextual drawers** – Instead of modals, open drawers for granular edits (e.g., editing extras for a single job). They inherit shared toolbars (approve, revoke, log) for consistency.
+
+### 3.2 Interaction workflows
+- **Setting default rates** – Managers adjust tour category rates and extras on one screen; saves trigger consolidated mutation handlers that optimistically update caches for dependent sections (e.g., approvals list).
+- **Managing overrides** – From the overrides tab, managers can filter by discrepancy (override vs default). Editing uses a shared drawer component with side-by-side comparison of default vs override values, reducing context switching.
+- **Approving tours/jobs** – Approval table surfaces computed readiness states (e.g., missing house rate). Tapping a row opens the assignment drill-down with aggregated warnings from quote breakdowns. Approvals log actions in the global activity feed.
+- **Bulk operations** – Provide checkboxes in the approval table to approve/revoke multiple items, optionally with a confirmation dialog summarizing changes.
+
+### 3.3 Visual design considerations
+- Use consistent iconography (Euro badge, shield for approval) already established in existing components to maintain familiarity.【F:src/components/tours/TourRatesManagerDialog.tsx†L124-L167】
+- Adopt responsive two-column layout for large screens (catalogs/overrides left, detail inspector right) and stacked sections on mobile.
+- Introduce status chips (e.g., "Override", "Missing category", "Extras pending") that read from the same data map powering warnings today.【F:src/components/tours/TourRatesPanel.tsx†L156-L200】
+
+## 4. Data & architecture alignment
+
+### 4.1 Consolidated data service
+- Build a **RatesService** module that composes existing queries (rate cards, extras, house overrides, approvals) and exposes typed fetchers/mutations. This reduces repeated Supabase wiring scattered in hooks.【F:src/hooks/useTourBaseRates.ts†L12-L48】【F:src/hooks/useRateExtrasCatalog.ts†L10-L46】【F:src/hooks/useHouseTechRates.ts†L22-L85】
+- Provide batched endpoints via Supabase RPC (e.g., `management_fetch_rates_context`) returning combined payloads (tour info + quotes + extras), minimizing sequential queries currently issued in the modal.【F:src/components/tours/TourRatesManagerDialog.tsx†L30-L200】
+
+### 4.2 Cache invalidation strategy
+- Centralize React Query keys under a `rates` namespace, enabling broad invalidation when base catalogs change instead of manually listing keys across hooks.【F:src/hooks/useJobExtras.ts†L47-L105】
+- When creating the RatesService, export helper functions (`invalidateRatesContext`) that sections call after mutations, ensuring extras, quotes, and approvals refresh together.
+
+### 4.3 Activity & audit integration
+- Leverage existing activity log RPC used for house tech edits to capture base rate and extras changes as well; extend the log payload with entity type metadata for a cohesive timeline.【F:src/hooks/useHouseTechRates.ts†L70-L85】
+- Surface this audit trail in the Rates Center header to give managers immediate feedback on recent adjustments.
+
+### 4.4 Authorization guardrails
+- Keep RLS policies unchanged but encapsulate permission checks client-side by gating Rates Center routes for `management`/`admin` roles only; fall back to readonly tables for others, reusing the read policies in `rate_extras_2025` and `house_tech_rates` for safe data display.【F:supabase/migrations/20250920151521_ec9eb57c-334c-4f96-aa82-c883e3bb7fcf.sql†L3-L19】【F:supabase/migrations/20250920091546_6ee5e3f2-53ad-4af3-b3b6-6657b2062716.sql†L1-L27】
+
+## 5. Implementation roadmap
+
+### Phase 1 – Foundation
+1. Introduce the RatesService module with consolidated fetchers/mutations and shared React Query keys.
+2. Create management-only `RatesCenterPage` route with placeholder tabs (catalogs, overrides, approvals).
+3. Migrate existing modal forms (base rates, extras) into dedicated tab panels using existing components.
+
+### Phase 2 – Approvals & drill-downs
+1. Build approval summary table sourcing quotes/flags from new batched RPC.
+2. Replace modal with in-page drawer that leverages current `TourRatesManagerDialog` internals refactored into smaller child components (job selector, extras editor, approval toolbar).
+3. Add bulk approve/revoke actions and ensure audit logging covers each action.
+
+### Phase 3 – Enhancements & polish
+1. Add discrepancy filters (e.g., show technicians missing overrides) and diff badges (default vs override values).
+2. Surface aggregated analytics (total extras per tour, average rate per category) using existing quote breakdowns.【F:src/components/tours/TourRatesPanel.tsx†L153-L200】
+3. Implement success/error toasts and activity feed panel to deliver immediate feedback on configuration changes.【F:src/hooks/useRateExtrasCatalog.ts†L37-L44】【F:src/hooks/useHouseTechRates.ts†L59-L66】
+
+## 6. Success metrics
+- **Operational efficiency** – Reduced time for managers to approve a full tour (measured via usability testing) compared to modal workflow.
+- **Data consistency** – Lower incidence of missing overrides or extras mismatches flagged by quote breakdown errors.【F:src/components/tours/TourRatesPanel.tsx†L195-L200】
+- **System load** – Fewer Supabase requests per approval session thanks to batched service layer.
+
+---
+With this plan, the rates ecosystem gains a single navigable hub, consistent editing patterns, and a data layer ready for future expansions (e.g., 2026 catalogs, region-specific extras). Managers retain the depth of current tooling while eliminating the fragmentation that slows them down today.

--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -17,7 +17,8 @@ import {
   FileText,
   Megaphone,
   Activity,
-  CalendarCheck
+  CalendarCheck,
+  Euro
 } from "lucide-react";
 import { TimesheetSidebarTrigger } from "@/components/timesheet/TimesheetSidebarTrigger";
 import { SidebarNavigationSkeleton } from './SidebarNavigationSkeleton';
@@ -141,6 +142,20 @@ export const SidebarNavigation = ({ userRole, userDepartment }: SidebarNavigatio
             >
               <Grid3X3 className="h-4 w-4" />
               <span>Assignment Matrix</span>
+            </Button>
+          </Link>
+        )}
+
+        {isManagementUser && (
+          <Link to="/management/rates">
+            <Button
+              variant="ghost"
+              className={`w-full justify-start gap-2 ${
+                location.pathname === "/management/rates" ? "bg-accent" : ""
+              }`}
+            >
+              <Euro className="h-4 w-4" />
+              <span>Rates &amp; Extras</span>
             </Button>
           </Link>
         )}

--- a/src/components/tours/TourRatesManagerDialog.tsx
+++ b/src/components/tours/TourRatesManagerDialog.tsx
@@ -7,19 +7,17 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Separator } from '@/components/ui/separator';
-import { Euro, Wrench, AlertTriangle, Calendar, Users, ShieldCheck, ShieldX } from 'lucide-react';
+import { Euro, AlertTriangle, Calendar, Users, ShieldCheck, ShieldX } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { format } from 'date-fns';
 import { useTourJobRateQuotesForManager } from '@/hooks/useTourJobRateQuotesForManager';
-import { useRateExtrasCatalog, useSaveRateExtra } from '@/hooks/useRateExtrasCatalog';
-import { useTourBaseRates, useSaveTourBaseRate } from '@/hooks/useTourBaseRates';
 import { useSaveHouseTechRate } from '@/hooks/useHouseTechRates';
 import { JobExtrasEditor } from '@/components/jobs/JobExtrasEditor';
 import { formatCurrency } from '@/lib/utils';
 import { useTourRatesApproval } from '@/hooks/useTourRatesApproval';
+import { ExtrasCatalogEditor, BaseRatesEditor } from '@/features/rates/components/CatalogEditors';
 
 type TourRatesManagerDialogProps = {
   open: boolean;
@@ -328,90 +326,5 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
         </Tabs>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function ExtrasCatalogEditor() {
-  const { data: rows = [] } = useRateExtrasCatalog();
-  const save = useSaveRateExtra();
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Wrench className="h-4 w-4" /> Extras Catalog (2025)
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <Alert>
-          <AlertDescription>
-            Define unit amounts for travel and rest day extras. Managers can adjust these at any time.
-          </AlertDescription>
-        </Alert>
-        {rows.map((r) => (
-          <div key={r.extra_type} className="flex items-center gap-3">
-            <Label className="w-40 capitalize">{r.extra_type.replace('_', ' ')}</Label>
-            <Input
-              type="number"
-              defaultValue={r.amount_eur}
-              className="w-40"
-              onBlur={(e) => {
-                const v = parseFloat(e.target.value);
-                if (!isNaN(v) && v !== r.amount_eur) {
-                  save.mutate({ extra_type: r.extra_type as any, amount_eur: v });
-                }
-              }}
-            />
-            <span className="text-xs text-muted-foreground">EUR</span>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
-  );
-}
-
-function BaseRatesEditor() {
-  const { data: rows = [] } = useTourBaseRates();
-  const save = useSaveTourBaseRate();
-  const categories: Array<{ key: 'tecnico' | 'especialista' | 'responsable'; label: string }> = [
-    { key: 'tecnico', label: 'Técnico' },
-    { key: 'especialista', label: 'Especialista' },
-    { key: 'responsable', label: 'Responsable' },
-  ];
-
-  const map = useMemo(() => Object.fromEntries(rows.map(r => [r.category, r.base_day_eur])) as Record<string, number>, [rows]);
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Euro className="h-4 w-4" /> Tour Base Rates (2025)
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <Alert>
-          <AlertDescription>
-            Set daily base amounts per category. Weekly multipliers apply when technicians are on the tour team.
-          </AlertDescription>
-        </Alert>
-        {categories.map(c => (
-          <div key={c.key} className="flex items-center gap-3">
-            <Label className="w-40">{c.label}</Label>
-            <Input
-              type="number"
-              defaultValue={map[c.key] ?? ''}
-              className="w-40"
-              onBlur={(e) => {
-                const v = parseFloat(e.target.value);
-                if (!isNaN(v)) {
-                  save.mutate({ category: c.key, base_day_eur: v });
-                }
-              }}
-            />
-            <span className="text-xs text-muted-foreground">EUR</span>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
   );
 }

--- a/src/constants/ratesQueryKeys.ts
+++ b/src/constants/ratesQueryKeys.ts
@@ -1,0 +1,10 @@
+export const RATES_QUERY_KEYS = {
+  overview: ['rates', 'overview'] as const,
+  extrasCatalog: ['rates', 'catalog', 'extras'] as const,
+  baseRates: ['rates', 'catalog', 'base'] as const,
+  houseTechList: ['rates', 'house-tech', 'list'] as const,
+  houseTechRate: (profileId: string) => ['rates', 'house-tech', 'rate', profileId] as const,
+  approvals: ['rates', 'approvals'] as const,
+};
+
+export type RatesQueryKey = ReturnType<typeof RATES_QUERY_KEYS.houseTechRate> | typeof RATES_QUERY_KEYS.overview | typeof RATES_QUERY_KEYS.extrasCatalog | typeof RATES_QUERY_KEYS.baseRates | typeof RATES_QUERY_KEYS.houseTechList | typeof RATES_QUERY_KEYS.approvals;

--- a/src/features/rates/components/CatalogEditors.tsx
+++ b/src/features/rates/components/CatalogEditors.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Euro, Wrench } from 'lucide-react';
+import { useRateExtrasCatalog, useSaveRateExtra } from '@/hooks/useRateExtrasCatalog';
+import { useTourBaseRates, useSaveTourBaseRate } from '@/hooks/useTourBaseRates';
+import { cn } from '@/lib/utils';
+
+type CatalogEditorProps = {
+  className?: string;
+};
+
+export function ExtrasCatalogEditor({ className }: CatalogEditorProps) {
+  const { data: rows = [], isLoading } = useRateExtrasCatalog();
+  const save = useSaveRateExtra();
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Wrench className="h-4 w-4" /> Extras Catalog (2025)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Alert>
+          <AlertDescription>
+            Define unit amounts for travel and rest day extras. Managers can adjust these at any time.
+          </AlertDescription>
+        </Alert>
+        {isLoading && (
+          <div className="text-sm text-muted-foreground">Loading extras catalog…</div>
+        )}
+        {!isLoading && rows.map((r) => (
+          <div key={r.extra_type} className="flex items-center gap-3">
+            <Label className="w-40 capitalize">{r.extra_type.replace('_', ' ')}</Label>
+            <Input
+              type="number"
+              defaultValue={r.amount_eur}
+              className="w-40"
+              onBlur={(e) => {
+                const v = parseFloat(e.target.value);
+                if (!isNaN(v) && v !== r.amount_eur) {
+                  save.mutate({ extra_type: r.extra_type as any, amount_eur: v });
+                }
+              }}
+              aria-label={`Amount for ${r.extra_type}`}
+            />
+            <span className="text-xs text-muted-foreground">EUR</span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function BaseRatesEditor({ className }: CatalogEditorProps) {
+  const { data: rows = [], isLoading } = useTourBaseRates();
+  const save = useSaveTourBaseRate();
+  const categories: Array<{ key: 'tecnico' | 'especialista' | 'responsable'; label: string }> = [
+    { key: 'tecnico', label: 'Técnico' },
+    { key: 'especialista', label: 'Especialista' },
+    { key: 'responsable', label: 'Responsable' },
+  ];
+
+  const map = useMemo(
+    () => Object.fromEntries(rows.map(r => [r.category, r.base_day_eur])) as Record<string, number>,
+    [rows]
+  );
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Euro className="h-4 w-4" /> Tour Base Rates (2025)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Alert>
+          <AlertDescription>
+            Set daily base amounts per category. Weekly multipliers apply when technicians are on the tour team.
+          </AlertDescription>
+        </Alert>
+        {isLoading && (
+          <div className="text-sm text-muted-foreground">Loading base rates…</div>
+        )}
+        {!isLoading && categories.map(c => (
+          <div key={c.key} className="flex items-center gap-3">
+            <Label className="w-40">{c.label}</Label>
+            <Input
+              type="number"
+              defaultValue={map[c.key] ?? ''}
+              className="w-40"
+              onBlur={(e) => {
+                const v = parseFloat(e.target.value);
+                if (!isNaN(v)) {
+                  save.mutate({ category: c.key, base_day_eur: v });
+                }
+              }}
+              aria-label={`Base rate for ${c.label}`}
+            />
+            <span className="text-xs text-muted-foreground">EUR</span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/rates/components/HouseTechOverridesPanel.tsx
+++ b/src/features/rates/components/HouseTechOverridesPanel.tsx
@@ -1,0 +1,82 @@
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { HouseTechRateEditor } from '@/components/settings/HouseTechRateEditor';
+import { useRatesHouseTechList } from '@/features/rates/hooks/useRatesHouseTechList';
+import { format } from 'date-fns';
+import { formatCurrency } from '@/lib/utils';
+
+export function HouseTechOverridesPanel() {
+  const { data: technicians = [], isLoading } = useRatesHouseTechList();
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return technicians;
+    return technicians.filter((tech) =>
+      tech.profileName.toLowerCase().includes(term)
+    );
+  }, [technicians, search]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex flex-col gap-2 text-base sm:flex-row sm:items-end sm:justify-between">
+          <span>House tech overrides</span>
+          <Input
+            placeholder="Search house techs"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="sm:w-64"
+          />
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && <Skeleton className="h-32 w-full" />}
+        {!isLoading && filtered.length === 0 && (
+          <p className="text-sm text-muted-foreground">No house techs found with that name.</p>
+        )}
+        {!isLoading && filtered.length > 0 && (
+          <Accordion type="single" collapsible className="space-y-2">
+            {filtered.map((tech) => (
+              <AccordionItem key={tech.profileId} value={tech.profileId} className="border rounded-lg">
+                <AccordionTrigger className="px-4 py-3 hover:no-underline">
+                  <div className="flex flex-col items-start gap-2 text-left sm:flex-row sm:items-center sm:justify-between sm:w-full">
+                    <div>
+                      <div className="font-medium leading-tight">{tech.profileName}</div>
+                      <div className="text-xs text-muted-foreground">
+                        Default category: {tech.defaultCategory ?? '—'}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {tech.overrideBaseDay ? (
+                        <Badge variant="secondary">Override: {formatCurrency(tech.overrideBaseDay)}</Badge>
+                      ) : (
+                        <Badge variant="outline">Using default</Badge>
+                      )}
+                      {tech.overrideUpdatedAt && (
+                        <span className="text-xs text-muted-foreground">
+                          Updated {format(new Date(tech.overrideUpdatedAt), 'PPP')}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </AccordionTrigger>
+                <AccordionContent className="px-4 pb-4">
+                  <HouseTechRateEditor
+                    profileId={tech.profileId}
+                    profileName={tech.profileName}
+                    category={tech.defaultCategory ?? undefined}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/rates/components/RatesApprovalsTable.tsx
+++ b/src/features/rates/components/RatesApprovalsTable.tsx
@@ -1,0 +1,80 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useRatesApprovals } from '@/features/rates/hooks/useRatesApprovals';
+import { format } from 'date-fns';
+
+interface RatesApprovalsTableProps {
+  onManageTour: (tourId: string) => void;
+}
+
+export function RatesApprovalsTable({ onManageTour }: RatesApprovalsTableProps) {
+  const { data: rows = [], isLoading } = useRatesApprovals();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Tour approval readiness</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-48 w-full" />
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No tours available yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Tour</TableHead>
+                  <TableHead>Start</TableHead>
+                  <TableHead className="text-right">Tour dates</TableHead>
+                  <TableHead className="text-right">Assignments</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell>
+                      <div className="font-medium leading-tight">{row.title}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {row.endDate ? `Ends ${format(new Date(row.endDate), 'PPP')}` : 'End date TBD'}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {row.startDate ? format(new Date(row.startDate), 'PPP') : '—'}
+                    </TableCell>
+                    <TableCell className="text-right">{row.jobCount}</TableCell>
+                    <TableCell className="text-right">{row.assignmentCount}</TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {row.pendingIssues.length === 0 ? (
+                          <Badge variant="outline">Ready</Badge>
+                        ) : (
+                          row.pendingIssues.map((issue) => (
+                            <Badge key={issue} variant={issue === 'Approval required' ? 'destructive' : 'secondary'}>
+                              {issue}
+                            </Badge>
+                          ))
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button size="sm" onClick={() => onManageTour(row.id)}>
+                        Manage
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/rates/components/RatesCenterHeader.tsx
+++ b/src/features/rates/components/RatesCenterHeader.tsx
@@ -1,0 +1,100 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { RatesOverview } from '@/services/ratesService';
+import { format } from 'date-fns';
+import { formatCurrency } from '@/lib/utils';
+
+interface RatesCenterHeaderProps {
+  overview?: RatesOverview;
+  isLoading: boolean;
+}
+
+export function RatesCenterHeader({ overview, isLoading }: RatesCenterHeaderProps) {
+  const totals = overview?.totals;
+  const pendingTours = overview?.pendingTours ?? [];
+  const recentOverrides = overview?.recentOverrides ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard title="Pending approvals" value={totals?.pendingTours} isLoading={isLoading} />
+        <SummaryCard title="Base rate categories" value={totals?.baseRates} isLoading={isLoading} />
+        <SummaryCard title="Extras configured" value={totals?.extras} isLoading={isLoading} />
+        <SummaryCard title="House overrides" value={totals?.houseOverrides} isLoading={isLoading} />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Upcoming approvals</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            {isLoading && <Skeleton className="h-20 w-full" />}
+            {!isLoading && pendingTours.length === 0 && (
+              <p className="text-muted-foreground">All tours are approved. Great job!</p>
+            )}
+            {!isLoading && pendingTours.map((tour) => (
+              <div key={tour.id} className="flex items-center justify-between rounded-lg border p-3">
+                <div className="space-y-1">
+                  <div className="font-medium leading-tight">{tour.title}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {tour.start_date ? format(new Date(tour.start_date), 'PPP') : 'No start date'}
+                  </div>
+                </div>
+                <Badge variant="secondary">Approval required</Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Recent house overrides</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            {isLoading && <Skeleton className="h-20 w-full" />}
+            {!isLoading && recentOverrides.length === 0 && (
+              <p className="text-muted-foreground">No overrides recorded yet.</p>
+            )}
+            {!isLoading && recentOverrides.map((override) => (
+              <div key={`${override.profileId}-${override.updatedAt}`} className="flex items-center justify-between rounded-lg border p-3">
+                <div className="space-y-1">
+                  <div className="font-medium leading-tight">{override.profileName}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {override.updatedAt ? format(new Date(override.updatedAt), 'PPP p') : 'Fecha desconocida'}
+                  </div>
+                </div>
+                <Badge variant="outline">
+                  {override.baseDayEur != null ? formatCurrency(override.baseDayEur) : '—'}
+                </Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+interface SummaryCardProps {
+  title: string;
+  value?: number;
+  isLoading: boolean;
+}
+
+function SummaryCard({ title, value, isLoading }: SummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-8 w-20" />
+        ) : (
+          <div className="text-3xl font-semibold">{value ?? '—'}</div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/rates/hooks/useRatesApprovals.ts
+++ b/src/features/rates/hooks/useRatesApprovals.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchRatesApprovals } from '@/services/ratesService';
+import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
+
+export function useRatesApprovals() {
+  return useQuery({
+    queryKey: RATES_QUERY_KEYS.approvals,
+    queryFn: fetchRatesApprovals,
+    staleTime: 30 * 1000,
+  });
+}

--- a/src/features/rates/hooks/useRatesHouseTechList.ts
+++ b/src/features/rates/hooks/useRatesHouseTechList.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchHouseTechOverrides } from '@/services/ratesService';
+import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
+
+export function useRatesHouseTechList() {
+  return useQuery({
+    queryKey: RATES_QUERY_KEYS.houseTechList,
+    queryFn: fetchHouseTechOverrides,
+    staleTime: 60 * 1000,
+  });
+}

--- a/src/features/rates/hooks/useRatesOverview.ts
+++ b/src/features/rates/hooks/useRatesOverview.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchRatesOverview } from '@/services/ratesService';
+import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
+
+export function useRatesOverview() {
+  return useQuery({
+    queryKey: RATES_QUERY_KEYS.overview,
+    queryFn: fetchRatesOverview,
+    staleTime: 60 * 1000,
+  });
+}

--- a/src/hooks/useEnhancedRouteSubscriptions.ts
+++ b/src/hooks/useEnhancedRouteSubscriptions.ts
@@ -62,9 +62,17 @@ export const ROUTE_SUBSCRIPTIONS: Record<string, Array<{
     { table: 'tour_dates', priority: 'medium' }
   ],
   '/project-management': [
-    { table: 'jobs', priority: 'high' }, 
-    { table: 'job_assignments', priority: 'medium' }, 
+    { table: 'jobs', priority: 'high' },
+    { table: 'job_assignments', priority: 'medium' },
     { table: 'job_departments', priority: 'medium' }
+  ],
+  '/management/rates': [
+    { table: 'rate_cards_tour_2025', priority: 'high' },
+    { table: 'rate_extras_2025', priority: 'high' },
+    { table: 'house_tech_rates', priority: 'high' },
+    { table: 'tours', priority: 'medium' },
+    { table: 'jobs', priority: 'medium' },
+    { table: 'job_assignments', priority: 'medium' }
   ],
   
   // Festival specific routes

--- a/src/hooks/useHouseTechRates.ts
+++ b/src/hooks/useHouseTechRates.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
 
 export interface HouseTechRate {
   profile_id: string;
@@ -21,7 +22,7 @@ export interface HouseTechRateInput {
 
 export function useHouseTechRate(profileId: string) {
   return useQuery({
-    queryKey: ['house-tech-rate', profileId],
+    queryKey: RATES_QUERY_KEYS.houseTechRate(profileId),
     queryFn: async () => {
       const { data, error } = await supabase
         .from('house_tech_rates')
@@ -57,7 +58,7 @@ export function useSaveHouseTechRate() {
       return data;
     },
     onSuccess: (data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['house-tech-rate', variables.profile_id] });
+      queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.houseTechRate(variables.profile_id) });
       toast.success('House tech rate saved successfully');
     },
     onError: (error) => {

--- a/src/hooks/useRateExtrasCatalog.ts
+++ b/src/hooks/useRateExtrasCatalog.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
 
 export interface RateExtraRow {
   extra_type: 'travel_half' | 'travel_full' | 'day_off';
@@ -9,7 +10,7 @@ export interface RateExtraRow {
 
 export function useRateExtrasCatalog() {
   return useQuery({
-    queryKey: ['rate-extras-catalog'],
+    queryKey: RATES_QUERY_KEYS.extrasCatalog,
     queryFn: async (): Promise<RateExtraRow[]> => {
       const { data, error } = await supabase
         .from('rate_extras_2025')
@@ -35,7 +36,7 @@ export function useSaveRateExtra() {
       return data as RateExtraRow;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['rate-extras-catalog'] });
+      queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.extrasCatalog });
       toast.success('Extras catalog updated');
     },
     onError: (err: any) => {

--- a/src/hooks/useTourBaseRates.ts
+++ b/src/hooks/useTourBaseRates.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
 
 export type TourCategory = 'tecnico' | 'especialista' | 'responsable';
 
@@ -11,7 +12,7 @@ export interface TourBaseRateRow {
 
 export function useTourBaseRates() {
   return useQuery({
-    queryKey: ['tour-base-rates-2025'],
+    queryKey: RATES_QUERY_KEYS.baseRates,
     queryFn: async (): Promise<TourBaseRateRow[]> => {
       const { data, error } = await supabase
         .from('rate_cards_tour_2025')
@@ -37,7 +38,7 @@ export function useSaveTourBaseRate() {
       return data as TourBaseRateRow;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tour-base-rates-2025'] });
+      queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.baseRates });
       toast.success('Tour base rate saved');
     },
     onError: (err: any) => {

--- a/src/pages/RatesCenterPage.tsx
+++ b/src/pages/RatesCenterPage.tsx
@@ -1,0 +1,69 @@
+import { useMemo, useState } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { RatesCenterHeader } from '@/features/rates/components/RatesCenterHeader';
+import { ExtrasCatalogEditor, BaseRatesEditor } from '@/features/rates/components/CatalogEditors';
+import { HouseTechOverridesPanel } from '@/features/rates/components/HouseTechOverridesPanel';
+import { RatesApprovalsTable } from '@/features/rates/components/RatesApprovalsTable';
+import { useRatesOverview } from '@/features/rates/hooks/useRatesOverview';
+import { TourRatesManagerDialog } from '@/components/tours/TourRatesManagerDialog';
+
+const TABS = [
+  { id: 'catalogs', label: 'Rate catalogs' },
+  { id: 'overrides', label: 'House overrides' },
+  { id: 'approvals', label: 'Approvals' },
+] as const;
+
+export default function RatesCenterPage() {
+  const { data: overview, isLoading } = useRatesOverview();
+  const [activeTab, setActiveTab] = useState<typeof TABS[number]['id']>('catalogs');
+  const [dialogTourId, setDialogTourId] = useState<string | null>(null);
+
+  const dialogOpen = useMemo(() => Boolean(dialogTourId), [dialogTourId]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">Rates &amp; Extras Center</h1>
+        <p className="text-sm text-muted-foreground">
+          Configure tour defaults, extras, and house overrides from a single management hub.
+        </p>
+      </div>
+
+      <RatesCenterHeader overview={overview} isLoading={isLoading} />
+
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof TABS[number]['id'])}>
+        <TabsList className="w-full sm:w-auto">
+          {TABS.map((tab) => (
+            <TabsTrigger key={tab.id} value={tab.id} className="flex-1 sm:flex-none">
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        <TabsContent value="catalogs" className="mt-4">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <ExtrasCatalogEditor />
+            <BaseRatesEditor />
+          </div>
+        </TabsContent>
+        <TabsContent value="overrides" className="mt-4">
+          <HouseTechOverridesPanel />
+        </TabsContent>
+        <TabsContent value="approvals" className="mt-4">
+          <RatesApprovalsTable onManageTour={setDialogTourId} />
+        </TabsContent>
+      </Tabs>
+
+      {dialogTourId && (
+        <TourRatesManagerDialog
+          open={dialogOpen}
+          onOpenChange={(open) => {
+            if (!open) {
+              setDialogTourId(null);
+            }
+          }}
+          tourId={dialogTourId}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,7 @@ import { FestivalManagementWrapper } from "@/components/festival/FestivalManagem
 import { TourManagementWrapper } from "@/components/tours/TourManagementWrapper";
 import Auth from "@/pages/Auth";
 import { RequireAuth } from "@/components/RequireAuth";
+import RatesCenterPage from "@/pages/RatesCenterPage";
 
 // Create a placeholder for missing pages
 const Placeholder = () => (
@@ -52,6 +53,10 @@ const router = createBrowserRouter([
       {
         path: "/vacation-management",
         element: <VacationManagement />,
+      },
+      {
+        path: "/management/rates",
+        element: <RatesCenterPage />,
       },
       {
         path: "/jobs",

--- a/src/services/ratesService.ts
+++ b/src/services/ratesService.ts
@@ -1,0 +1,246 @@
+import { QueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { RateExtraRow } from '@/hooks/useRateExtrasCatalog';
+import { TourBaseRateRow } from '@/hooks/useTourBaseRates';
+import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
+
+type Nullable<T> = T | null | undefined;
+
+export interface RatesOverview {
+  totals: {
+    pendingTours: number;
+    baseRates: number;
+    extras: number;
+    houseOverrides: number;
+  };
+  pendingTours: Array<{ id: string; title: string; start_date: string | null; rates_approved: boolean }>;
+  extrasCatalog: RateExtraRow[];
+  baseRates: TourBaseRateRow[];
+  recentOverrides: Array<{ profileId: string; profileName: string; baseDayEur: number | null; updatedAt: string | null }>;
+}
+
+export interface HouseTechOverrideListItem {
+  profileId: string;
+  profileName: string;
+  defaultCategory: string | null;
+  overrideBaseDay: number | null;
+  overrideUpdatedAt: string | null;
+}
+
+export interface RatesApprovalRow {
+  id: string;
+  title: string;
+  startDate: string | null;
+  endDate: string | null;
+  ratesApproved: boolean;
+  jobCount: number;
+  assignmentCount: number;
+  pendingIssues: string[];
+}
+
+const DEFAULT_CATEGORY = 'tecnico';
+
+export async function fetchRatesOverview(): Promise<RatesOverview> {
+  const [toursResult, extrasResult, baseRatesResult, overridesResult] = await Promise.all([
+    supabase
+      .from('tours')
+      .select('id, title, start_date, rates_approved')
+      .order('start_date', { ascending: true })
+      .eq('rates_approved', false)
+      .limit(5),
+    supabase
+      .from('rate_extras_2025')
+      .select('*')
+      .order('extra_type', { ascending: true }),
+    supabase
+      .from('rate_cards_tour_2025')
+      .select('*')
+      .order('category', { ascending: true }),
+    supabase
+      .from('house_tech_rates')
+      .select('profile_id, base_day_eur, updated_at', { count: 'exact' })
+      .order('updated_at', { ascending: false })
+      .limit(5),
+  ]);
+
+  if (toursResult.error) throw toursResult.error;
+  if (extrasResult.error) throw extrasResult.error;
+  if (baseRatesResult.error) throw baseRatesResult.error;
+  if (overridesResult.error) throw overridesResult.error;
+
+  const recentOverridesRaw = overridesResult.data || [];
+  const overrideProfileIds = recentOverridesRaw.map((row) => row.profile_id).filter(Boolean) as string[];
+  let profileNameMap: Record<string, string> = {};
+
+  if (overrideProfileIds.length > 0) {
+    const { data: profilesData, error: profilesError } = await supabase
+      .from('profiles')
+      .select('id, first_name, last_name')
+      .in('id', overrideProfileIds);
+
+    if (profilesError) throw profilesError;
+
+    profileNameMap = Object.fromEntries(
+      (profilesData || []).map((profile) => [
+        profile.id,
+        `${profile.first_name ?? ''} ${profile.last_name ?? ''}`.trim() || 'Sin nombre',
+      ]),
+    );
+  }
+
+  const extrasCatalog = (extrasResult.data || []) as RateExtraRow[];
+  const baseRates = (baseRatesResult.data || []) as TourBaseRateRow[];
+
+  return {
+    totals: {
+      pendingTours: (toursResult.data || []).length,
+      baseRates: baseRates.length,
+      extras: extrasCatalog.length,
+      houseOverrides: overridesResult.count ?? recentOverridesRaw.length,
+    },
+    pendingTours: (toursResult.data || []) as Array<{
+      id: string;
+      title: string;
+      start_date: string | null;
+      rates_approved: boolean;
+    }>,
+    extrasCatalog,
+    baseRates,
+    recentOverrides: recentOverridesRaw.map((row) => ({
+      profileId: row.profile_id,
+      profileName: profileNameMap[row.profile_id] || 'Sin nombre',
+      baseDayEur: row.base_day_eur ?? null,
+      updatedAt: row.updated_at ?? null,
+    })),
+  };
+}
+
+export async function fetchHouseTechOverrides(): Promise<HouseTechOverrideListItem[]> {
+  const { data: technicians, error: techniciansError } = await supabase
+    .from('profiles')
+    .select('id, first_name, last_name, default_timesheet_category, role')
+    .eq('role', 'house_tech')
+    .order('first_name', { ascending: true });
+
+  if (techniciansError) throw techniciansError;
+
+  const technicianList = technicians || [];
+  const profileIds = technicianList.map((tech) => tech.id);
+
+  let overrideMap: Record<string, { base_day_eur: Nullable<number>; updated_at: Nullable<string> }> = {};
+
+  if (profileIds.length > 0) {
+    const { data: overrides, error: overridesError } = await supabase
+      .from('house_tech_rates')
+      .select('profile_id, base_day_eur, updated_at')
+      .in('profile_id', profileIds);
+
+    if (overridesError) throw overridesError;
+
+    overrideMap = Object.fromEntries(
+      (overrides || []).map((override) => [
+        override.profile_id,
+        { base_day_eur: override.base_day_eur, updated_at: override.updated_at },
+      ]),
+    );
+  }
+
+  return technicianList.map((tech) => ({
+    profileId: tech.id,
+    profileName: `${tech.first_name ?? ''} ${tech.last_name ?? ''}`.trim() || 'Sin nombre',
+    defaultCategory: tech.default_timesheet_category ?? DEFAULT_CATEGORY,
+    overrideBaseDay: overrideMap[tech.id]?.base_day_eur ?? null,
+    overrideUpdatedAt: overrideMap[tech.id]?.updated_at ?? null,
+  }));
+}
+
+export async function fetchRatesApprovals(): Promise<RatesApprovalRow[]> {
+  const { data: tours, error: toursError } = await supabase
+    .from('tours')
+    .select('id, title, start_date, end_date, rates_approved')
+    .order('start_date', { ascending: true })
+    .limit(25);
+
+  if (toursError) throw toursError;
+
+  const tourList = tours || [];
+  const tourIds = tourList.map((tour) => tour.id).filter(Boolean) as string[];
+
+  const jobCounts: Record<string, { jobCount: number; jobIds: string[]; assignmentCount: number }> = {};
+
+  if (tourIds.length > 0) {
+    const { data: jobs, error: jobsError } = await supabase
+      .from('jobs')
+      .select('id, tour_id, job_type')
+      .in('tour_id', tourIds)
+      .eq('job_type', 'tourdate');
+
+    if (jobsError) throw jobsError;
+
+    const jobIds: string[] = [];
+
+    (jobs || []).forEach((job) => {
+      if (!job.tour_id) return;
+      if (!jobCounts[job.tour_id]) {
+        jobCounts[job.tour_id] = { jobCount: 0, jobIds: [], assignmentCount: 0 };
+      }
+      jobCounts[job.tour_id].jobCount += 1;
+      jobCounts[job.tour_id].jobIds.push(job.id);
+      jobIds.push(job.id);
+    });
+
+    if (jobIds.length > 0) {
+      const { data: assignments, error: assignmentsError } = await supabase
+        .from('job_assignments')
+        .select('id, job_id')
+        .in('job_id', jobIds);
+
+      if (assignmentsError) throw assignmentsError;
+
+      const assignmentCountByJob: Record<string, number> = {};
+
+      (assignments || []).forEach((assignment) => {
+        if (!assignment.job_id) return;
+        assignmentCountByJob[assignment.job_id] = (assignmentCountByJob[assignment.job_id] || 0) + 1;
+      });
+
+      Object.values(jobCounts).forEach((info) => {
+        info.assignmentCount = info.jobIds.reduce((acc, jobId) => acc + (assignmentCountByJob[jobId] || 0), 0);
+      });
+    }
+  }
+
+  return tourList.map((tour) => {
+    const counts = jobCounts[tour.id] || { jobCount: 0, jobIds: [], assignmentCount: 0 };
+    const pendingIssues: string[] = [];
+
+    if (!tour.rates_approved) {
+      pendingIssues.push('Approval required');
+    }
+    if (counts.jobCount === 0) {
+      pendingIssues.push('No tour dates');
+    }
+    if (counts.assignmentCount === 0) {
+      pendingIssues.push('No assignments');
+    }
+
+    return {
+      id: tour.id,
+      title: tour.title,
+      startDate: tour.start_date ?? null,
+      endDate: tour.end_date ?? null,
+      ratesApproved: Boolean(tour.rates_approved),
+      jobCount: counts.jobCount,
+      assignmentCount: counts.assignmentCount,
+      pendingIssues,
+    };
+  });
+}
+
+export function invalidateRatesContext(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.overview });
+  queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.extrasCatalog });
+  queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.baseRates });
+  queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.houseTechList });
+  queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.approvals });
+}


### PR DESCRIPTION
## Summary
- add a management-only Rates & Extras Center route with centralized catalogs, house overrides, and approvals tabs
- introduce a shared rates service, namespaced query keys, and new hooks powering the management view
- update existing navigation, route subscriptions, and modal editors to use the new shared catalog components

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ed1ced16bc832fa47e89292f90a3ce