### PR TITLE
Fix festival date comparison baseline

### DIFF
--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -15,7 +15,9 @@ export const findClosestFestival = (festivals: any[]) => {
   today.setHours(0, 0, 0, 0); // Reset time to start of day for accurate comparison
 
   let closestFestival = festivals[0];
-  let smallestDifference = Math.abs(new Date(festivals[0].start_time).getTime() - today.getTime());
+  const initialFestivalDate = new Date(festivals[0].start_time);
+  initialFestivalDate.setHours(0, 0, 0, 0);
+  let smallestDifference = Math.abs(initialFestivalDate.getTime() - today.getTime());
 
   festivals.forEach(festival => {
     const festivalDate = new Date(festival.start_time);


### PR DESCRIPTION
## Summary
- normalize the baseline festival date to the start of the day when finding the closest festival

## Testing
- npm run lint *(fails: missing dependency `@eslint/js` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed1242937c832f854f00b4ac7a2e92