### PR TITLE
Add nickname support across user management and technician UI

### DIFF
--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -25,6 +25,7 @@ export const SignUpForm = ({ onBack, preventAutoLogin = false }: SignUpFormProps
     password: "",
     confirmPassword: "",
     firstName: "",
+    nickname: "",
     lastName: "",
     phone: "",
     department: "",
@@ -66,6 +67,7 @@ export const SignUpForm = ({ onBack, preventAutoLogin = false }: SignUpFormProps
       const created = await createUserAsAdmin({
         email: formData.email,
         firstName: formData.firstName,
+        nickname: formData.nickname,
         lastName: formData.lastName,
         phone: formData.phone,
         department: formData.department,
@@ -99,6 +101,7 @@ export const SignUpForm = ({ onBack, preventAutoLogin = false }: SignUpFormProps
         email: formData.email,
         password: formData.password,
         firstName: formData.firstName,
+        nickname: formData.nickname,
         lastName: formData.lastName,
         phone: formData.phone,
         department: formData.department,
@@ -132,6 +135,16 @@ export const SignUpForm = ({ onBack, preventAutoLogin = false }: SignUpFormProps
             value={formData.firstName}
             onChange={(e) => setFormData({ ...formData, firstName: e.target.value })}
             required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="nickname">Nickname</Label>
+          <Input
+            id="nickname"
+            type="text"
+            value={formData.nickname}
+            onChange={(e) => setFormData({ ...formData, nickname: e.target.value })}
+            placeholder="Optional"
           />
         </div>
         <div className="space-y-2">

--- a/src/components/auth/signup/SignUpFormFields.tsx
+++ b/src/components/auth/signup/SignUpFormFields.tsx
@@ -10,6 +10,7 @@ interface SignUpFormData {
   email: string;
   password: string;
   firstName: string;
+  nickname: string;
   lastName: string;
   phone: string;
   department: Department;
@@ -30,6 +31,7 @@ export const SignUpFormFields = ({ onSubmit, error, isLoading, hidePassword = fa
     email: "",
     password: "",
     firstName: "",
+    nickname: "",
     lastName: "",
     phone: "",
     department: "sound",
@@ -84,6 +86,16 @@ export const SignUpFormFields = ({ onSubmit, error, isLoading, hidePassword = fa
           value={formData.firstName}
           onChange={(e) => handleChange("firstName", e.target.value)}
           required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="nickname">Nickname</Label>
+        <Input
+          id="nickname"
+          type="text"
+          value={formData.nickname}
+          onChange={(e) => handleChange("nickname", e.target.value)}
+          placeholder="Optional"
         />
       </div>
 

--- a/src/components/matrix/AssignmentMatrix.tsx
+++ b/src/components/matrix/AssignmentMatrix.tsx
@@ -16,6 +16,7 @@ interface AssignmentMatrixProps {
   technicians: Array<{
     id: string;
     first_name: string;
+    nickname?: string | null;
     last_name: string;
     email: string;
     department: string;
@@ -75,6 +76,7 @@ export const AssignmentMatrix = ({ technicians, dates, jobs }: AssignmentMatrixP
           *,
           profiles (
             first_name,
+            nickname,
             last_name,
             department
           ),

--- a/src/components/matrix/OptimizedAssignmentMatrix.tsx
+++ b/src/components/matrix/OptimizedAssignmentMatrix.tsx
@@ -40,6 +40,7 @@ interface OptimizedAssignmentMatrixProps {
   technicians: Array<{
     id: string;
     first_name: string;
+    nickname?: string | null;
     last_name: string;
     email: string;
     phone?: string | null;

--- a/src/components/matrix/OptimizedMatrixCell.tsx
+++ b/src/components/matrix/OptimizedMatrixCell.tsx
@@ -11,12 +11,14 @@ import { useCancelStaffingRequest, useSendStaffingEmail } from '@/features/staff
 import { supabase } from '@/lib/supabase';
 import { toast } from 'sonner';
 import { labelForCode } from '@/utils/roles';
+import { formatUserName } from '@/utils/userName';
 import { pickTextColor, rgbaFromHex } from '@/utils/color';
 
 interface OptimizedMatrixCellProps {
   technician: {
     id: string;
     first_name: string;
+    nickname?: string | null;
     last_name: string;
     department: string;
   };
@@ -72,6 +74,7 @@ export const OptimizedMatrixCell = memo(({
   const confirmedBg = hasAssignment && assignment.status === 'confirmed' ? (assignment?.job?.color || null) : null;
   const confirmedTextColor = confirmedBg ? pickTextColor(confirmedBg) : undefined;
   const confirmedSubTextColor = confirmedTextColor ? (rgbaFromHex(confirmedTextColor, 0.9) || confirmedTextColor) : undefined;
+  const displayName = formatUserName(technician.first_name, technician.nickname, technician.last_name) || 'Technician';
 
   // Staffing status: use provided batched data exclusively for performance
   const staffingStatusByJob = staffingStatusProvided;
@@ -118,7 +121,7 @@ export const OptimizedMatrixCell = memo(({
     // Availability path: open job selection; preselect only if assignment provides it
     const targetJobId = jobId || assignment?.job_id || undefined;
     onClick('select-job-for-staffing', targetJobId);
-  }, [jobId, assignment?.job_id, technician.id, technician.first_name, technician.last_name, hasAssignment, assignment, date, onClick, staffingStatusByDate]);
+  }, [jobId, assignment?.job_id, technician.id, technician.first_name, technician.nickname, technician.last_name, hasAssignment, assignment, date, onClick, staffingStatusByDate]);
 
   const handleMouseEnter = useCallback(() => {
     // Prefetch data when hovering over cell
@@ -543,7 +546,7 @@ export const OptimizedMatrixCell = memo(({
             <DialogHeader>
               <DialogTitle>{pendingCancel.phase === 'availability' ? 'Cancel availability request?' : 'Cancel offer?'}</DialogTitle>
               <DialogDescription>
-                This will mark the {pendingCancel.phase} as cancelled (expired) for {technician.first_name} {technician.last_name}.
+                This will mark the {pendingCancel.phase} as cancelled (expired) for {displayName}.
               </DialogDescription>
             </DialogHeader>
             <DialogFooter>
@@ -576,7 +579,7 @@ export const OptimizedMatrixCell = memo(({
             <DialogHeader>
               <DialogTitle>Remove assignment?</DialogTitle>
               <DialogDescription>
-                This will remove the assignment of {technician.first_name} {technician.last_name} from this job.
+                This will remove the assignment of {displayName} from this job.
               </DialogDescription>
             </DialogHeader>
             <DialogFooter>
@@ -609,7 +612,7 @@ export const OptimizedMatrixCell = memo(({
       >
         <div className="space-y-1 text-sm">
           <div className="font-semibold">
-            {technician.first_name} {technician.last_name}
+            {displayName}
           </div>
           <div className="text-muted-foreground">
             {technician.department}

--- a/src/components/matrix/TechnicianRow.tsx
+++ b/src/components/matrix/TechnicianRow.tsx
@@ -11,11 +11,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
 import { startOfMonth, endOfMonth, startOfYear, endOfYear } from 'date-fns';
 import { useToast } from '@/hooks/use-toast';
+import { formatUserName } from '@/utils/userName';
 
 interface TechnicianRowProps {
   technician: {
     id: string;
     first_name: string;
+    nickname?: string | null;
     last_name: string;
     email: string;
     phone?: string | null;
@@ -131,8 +133,14 @@ const TechnicianRowComp = ({ technician, height, isFridge = false }: TechnicianR
     }
   };
   const getInitials = () => {
-    return `${technician.first_name?.[0] || ''}${technician.last_name?.[0] || ''}`.toUpperCase();
+    const firstInitial = technician.first_name?.[0] ?? '';
+    const secondSource = technician.nickname || technician.last_name || '';
+    const secondInitial = secondSource?.[0] ?? '';
+    const initials = `${firstInitial}${secondInitial}`.trim();
+    return initials ? initials.toUpperCase() : 'T';
   };
+
+  const displayName = formatUserName(technician.first_name, technician.nickname, technician.last_name) || 'Technician';
 
   const getDepartmentColor = (department: string) => {
     switch (department?.toLowerCase()) {
@@ -175,7 +183,7 @@ const TechnicianRowComp = ({ technician, height, isFridge = false }: TechnicianR
             
             <div className="flex-1 min-w-0">
               <div className="font-medium text-sm truncate">
-                {technician.first_name} {technician.last_name}
+                {displayName}
                 {isFridge && (
                   <Refrigerator className="inline-block h-3.5 w-3.5 ml-1 text-sky-600" />
                 )}
@@ -209,7 +217,7 @@ const TechnicianRowComp = ({ technician, height, isFridge = false }: TechnicianR
             </Avatar>
             <div>
               <div className="font-semibold">
-                {technician.first_name} {technician.last_name}
+                {displayName}
               </div>
               <div className="text-sm text-muted-foreground">
                 {technician.role === 'house_tech' ? 'House Technician' : 'Technician'}
@@ -357,7 +365,7 @@ const TechnicianRowComp = ({ technician, height, isFridge = false }: TechnicianR
     {isManagementUser && (
       <ManageSkillsDialog
         profileId={technician.id}
-        fullName={`${technician.first_name} ${technician.last_name}`}
+        fullName={displayName}
         open={skillsOpen}
         onOpenChange={handleSkillsOpenChange}
       />

--- a/src/components/personal/HouseTechBadge.tsx
+++ b/src/components/personal/HouseTechBadge.tsx
@@ -9,6 +9,7 @@ interface HouseTechBadgeProps {
   technician: {
     id: string;
     first_name: string | null;
+    nickname?: string | null;
     last_name: string | null;
     department: string | null;
     phone: string | null;
@@ -49,8 +50,10 @@ export const HouseTechBadge: React.FC<HouseTechBadgeProps> = ({
 
   const getInitials = () => {
     const first = technician.first_name?.[0] || '';
-    const last = technician.last_name?.[0] || '';
-    return (first + last).toUpperCase() || 'HT';
+    const secondSource = technician.nickname || technician.last_name || '';
+    const second = secondSource?.[0] || '';
+    const combined = `${first}${second}`.trim();
+    return combined ? combined.toUpperCase() : 'HT';
   };
 
   const getRole = () => {

--- a/src/components/personal/TechDetailModal.tsx
+++ b/src/components/personal/TechDetailModal.tsx
@@ -7,6 +7,7 @@ import { format } from 'date-fns';
 import { formatInJobTimezone } from '@/utils/timezoneUtils';
 import { MapPin, Clock, User, Phone, Briefcase, Calendar, Plane, Stethoscope, Home, X, Warehouse } from 'lucide-react';
 import { labelForCode } from '@/utils/roles';
+import { formatUserName } from '@/utils/userName';
 
 interface TechDetailModalProps {
   open: boolean;
@@ -14,6 +15,7 @@ interface TechDetailModalProps {
   technician: {
     id: string;
     first_name: string | null;
+    nickname?: string | null;
     last_name: string | null;
     department: string | null;
     phone: string | null;
@@ -51,7 +53,8 @@ export const TechDetailModal: React.FC<TechDetailModalProps> = ({
   onAvailabilityRemove,
 }) => {
   const getFullName = () => {
-    return `${technician.first_name || ''} ${technician.last_name || ''}`.trim() || 'Unknown';
+    const name = formatUserName(technician.first_name, technician.nickname, technician.last_name);
+    return name || 'Unknown';
   };
 
   const getRole = () => {

--- a/src/components/personal/TechnicianTooltip.tsx
+++ b/src/components/personal/TechnicianTooltip.tsx
@@ -6,11 +6,13 @@ import { format } from 'date-fns';
 import { formatInJobTimezone } from '@/utils/timezoneUtils';
 import { MapPin, Clock, User, Phone, Briefcase } from 'lucide-react';
 import { labelForCode } from '@/utils/roles';
+import { formatUserName } from '@/utils/userName';
 
 interface TechnicianTooltipProps {
   technician: {
     id: string;
     first_name: string | null;
+    nickname?: string | null;
     last_name: string | null;
     department: string | null;
     phone: string | null;
@@ -45,7 +47,8 @@ export const TechnicianTooltip: React.FC<TechnicianTooltipProps> = ({
   children,
 }) => {
   const getFullName = () => {
-    return `${technician.first_name || ''} ${technician.last_name || ''}`.trim() || 'Unknown';
+    const name = formatUserName(technician.first_name, technician.nickname, technician.last_name);
+    return name || 'Unknown';
   };
 
   const getRole = () => {

--- a/src/components/users/EditUserDialog.tsx
+++ b/src/components/users/EditUserDialog.tsx
@@ -12,6 +12,7 @@ import { Separator } from "@/components/ui/separator";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { HouseTechRateEditor } from "@/components/settings/HouseTechRateEditor";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
+import { formatUserName } from "@/utils/userName";
 
 interface EditUserDialogProps {
   user: Profile | null;
@@ -62,6 +63,7 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
     const updatedData: Partial<Profile> = {
       id: user.id,
       first_name: formData.get('firstName') as string,
+      nickname: formData.get('nickname') as string,
       last_name: formData.get('lastName') as string,
       phone: formData.get('phone') as string,
       department: formData.get('department') as Department,
@@ -90,6 +92,15 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
                 id="firstName"
                 name="firstName"
                 defaultValue={user?.first_name || ''}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="nickname">Nickname</Label>
+              <Input
+                id="nickname"
+                name="nickname"
+                defaultValue={user?.nickname || ''}
+                placeholder="Optional"
               />
             </div>
             <div className="space-y-2">
@@ -240,7 +251,7 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
               <Separator />
               <HouseTechRateEditor
                 profileId={user.id}
-                profileName={`${user.first_name} ${user.last_name}`}
+                profileName={formatUserName(user.first_name, user.nickname, user.last_name) || ''}
                 category={user.role === 'house_tech' ? 'tecnico' : 'tecnico'}
               />
             </>

--- a/src/components/users/UserCard.tsx
+++ b/src/components/users/UserCard.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Profile } from "./types";
 import { AlertTriangle, Pencil, Trash2, Award } from "lucide-react";
+import { formatUserName } from "@/utils/userName";
 
 interface UserCardProps {
   user: Profile;
@@ -14,7 +15,7 @@ interface UserCardProps {
 }
 
 export const UserCard = ({ user, onEdit, onDelete, showPasswordAlert = false, onManageSkills }: UserCardProps) => {
-  const fullName = `${user.first_name || ''} ${user.last_name || ''}`.trim();
+  const fullName = formatUserName(user.first_name, user.nickname, user.last_name);
 
   return (
     <div className="group flex items-center justify-between p-3 border rounded-lg hover:bg-accent/5 transition-colors">

--- a/src/components/users/UsersList.tsx
+++ b/src/components/users/UsersList.tsx
@@ -81,7 +81,7 @@ export const UsersList = ({
       try {
         let query = supabase
           .from('profiles')
-          .select('id, first_name, last_name, email, role, phone, department, dni, residencia, assignable_as_tech, flex_resource_id', { count: 'exact' });
+          .select('id, first_name, nickname, last_name, email, role, phone, department, dni, residencia, assignable_as_tech, flex_resource_id', { count: 'exact' });
 
         // Apply filters
         if (roleFilter) {
@@ -93,7 +93,7 @@ export const UsersList = ({
         }
 
         if (searchQuery) {
-          query = query.or(`first_name.ilike.%${searchQuery}%,last_name.ilike.%${searchQuery}%,email.ilike.%${searchQuery}%`);
+          query = query.or(`first_name.ilike.%${searchQuery}%,nickname.ilike.%${searchQuery}%,last_name.ilike.%${searchQuery}%,email.ilike.%${searchQuery}%`);
         }
 
         // Apply sorting

--- a/src/components/users/UsersListContent.tsx
+++ b/src/components/users/UsersListContent.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/accordion";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ManageSkillsDialog } from "@/components/users/ManageSkillsDialog";
+import { formatUserName } from "@/utils/userName";
 
 interface UsersListContentProps {
   users: Profile[];
@@ -72,7 +73,7 @@ export const UsersListContent = ({ users, groupBy, isManagementUser = false }: U
         {/* Skills management dialog */}
         <ManageSkillsDialog
           profileId={skillsUser?.id || null}
-          fullName={[skillsUser?.first_name, skillsUser?.last_name].filter(Boolean).join(' ')}
+          fullName={formatUserName(skillsUser?.first_name, skillsUser?.nickname, skillsUser?.last_name) || ''}
           open={!!skillsUser}
           onOpenChange={(open) => !open && setSkillsUser(null)}
         />
@@ -134,7 +135,7 @@ export const UsersListContent = ({ users, groupBy, isManagementUser = false }: U
       {/* Skills dialog for grouped view */}
       <ManageSkillsDialog
         profileId={skillsUser?.id || null}
-        fullName={[skillsUser?.first_name, skillsUser?.last_name].filter(Boolean).join(' ')}
+        fullName={formatUserName(skillsUser?.first_name, skillsUser?.nickname, skillsUser?.last_name) || ''}
         open={!!skillsUser}
         onOpenChange={(open) => !open && setSkillsUser(null)}
       />

--- a/src/components/users/import/ImportUsersDialog.tsx
+++ b/src/components/users/import/ImportUsersDialog.tsx
@@ -29,7 +29,7 @@ export const ImportUsersDialog = ({ open, onOpenChange }: ImportUsersDialogProps
   };
 
   const downloadTemplate = () => {
-    const template = "email,firstName,lastName,role,department,phone,dni,residencia\n";
+    const template = "email,firstName,nickname,lastName,role,department,phone,dni,residencia\n";
     const blob = new Blob([template], { type: "text/csv" });
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/src/components/users/types.ts
+++ b/src/components/users/types.ts
@@ -3,6 +3,7 @@ import { Department } from "@/types/department";
 export type Profile = {
   id: string;
   first_name: string | null;
+  nickname: string | null;
   last_name: string | null;
   email: string;
   role: string;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -30,6 +30,7 @@ interface SignUpData {
   email: string;
   password: string;
   firstName: string;
+  nickname?: string;
   lastName: string;
   phone?: string;
   department?: string;
@@ -253,6 +254,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         options: {
           data: {
             first_name: userData.firstName,
+            nickname: userData.nickname,
             last_name: userData.lastName,
             phone: userData.phone,
             department: userData.department,

--- a/src/hooks/useOptimizedAuth.tsx
+++ b/src/hooks/useOptimizedAuth.tsx
@@ -34,6 +34,7 @@ interface SignUpData {
   email: string;
   password: string;
   firstName: string;
+  nickname?: string;
   lastName: string;
   phone?: string;
   department?: string;
@@ -355,6 +356,7 @@ export const OptimizedAuthProvider = ({ children }: { children: ReactNode }) => 
         options: {
           data: {
             first_name: userData.firstName,
+            nickname: userData.nickname,
             last_name: userData.lastName,
             phone: userData.phone,
             department: userData.department,
@@ -417,6 +419,7 @@ export const OptimizedAuthProvider = ({ children }: { children: ReactNode }) => 
         body: {
           email: userData.email.toLowerCase(),
           firstName: userData.firstName,
+          nickname: userData.nickname,
           lastName: userData.lastName,
           phone: userData.phone,
           department: userData.department,

--- a/src/hooks/useOptimizedMatrixData.ts
+++ b/src/hooks/useOptimizedMatrixData.ts
@@ -33,7 +33,7 @@ interface AssignmentWithJob {
 }
 
 interface OptimizedMatrixDataProps {
-  technicians: Array<{ id: string; first_name: string; last_name: string; email: string; department: string; role: string; }>;
+  technicians: Array<{ id: string; first_name: string; nickname?: string | null; last_name: string; email: string; department: string; role: string; }>;
   dates: Date[];
   jobs: MatrixJob[];
 }
@@ -267,7 +267,7 @@ export const useOptimizedMatrixData = ({ technicians, dates, jobs }: OptimizedMa
       queryFn: async () => {
         const { data, error } = await supabase
           .from('profiles')
-          .select('first_name, last_name, department')
+          .select('first_name, nickname, last_name, department')
           .eq('id', technicianId)
           .single();
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -70,6 +70,7 @@ export const Profile = () => {
         .from('profiles')
         .update({
           first_name: profile.first_name,
+          nickname: profile.nickname,
           last_name: profile.last_name,
           phone: profile.phone,
           department: profile.department,
@@ -227,6 +228,15 @@ export const Profile = () => {
                       id="firstName"
                       value={profile.first_name || ''}
                       onChange={(e) => setProfile({ ...profile, first_name: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="nickname">Nickname</Label>
+                    <Input
+                      id="nickname"
+                      value={profile.nickname || ''}
+                      onChange={(e) => setProfile({ ...profile, nickname: e.target.value })}
+                      placeholder="Optional"
                     />
                   </div>
                   <div className="space-y-2">

--- a/src/types/assignment.ts
+++ b/src/types/assignment.ts
@@ -9,6 +9,7 @@ export interface Assignment {
   video_role: string | null;
   profiles: {
     first_name: string;
+    nickname?: string | null;
     last_name: string;
     email: string;
     department: string;

--- a/src/types/festival-scheduling.ts
+++ b/src/types/festival-scheduling.ts
@@ -23,6 +23,7 @@ export interface ShiftAssignment {
   profiles?: {
     id: string;
     first_name: string;
+    nickname?: string | null;
     last_name: string;
     email: string;
     department: string;
@@ -37,6 +38,7 @@ export interface ShiftWithAssignments extends FestivalShift {
 export interface Technician {
   id: string;
   first_name: string;
+  nickname?: string | null;
   last_name: string;
   email: string;
   department: string;

--- a/src/types/timesheet.ts
+++ b/src/types/timesheet.ts
@@ -51,6 +51,7 @@ export interface Timesheet {
   approved_by_manager?: boolean;
   technician?: {
     first_name: string;
+    nickname?: string | null;
     last_name: string;
     email: string;
     department: string;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -6,6 +6,7 @@ export interface User {
   email: string;
   role: UserRole;
   first_name?: string;
+  nickname?: string;
   last_name?: string;
   department?: string;  // Added department field
   custom_folder_structure?: any; // Custom folder structure for local folder creation

--- a/src/utils/userName.ts
+++ b/src/utils/userName.ts
@@ -1,0 +1,26 @@
+export const formatUserName = (
+  first?: string | null,
+  nickname?: string | null,
+  last?: string | null
+) => {
+  const parts: string[] = [];
+
+  if (first?.trim()) {
+    parts.push(first.trim());
+  }
+
+  if (nickname?.trim()) {
+    parts.push(`"${nickname.trim()}"`);
+  }
+
+  if (last?.trim()) {
+    parts.push(last.trim());
+  }
+
+  if (parts.length === 0) {
+    return "";
+  }
+
+  return parts.join(" ");
+};
+

--- a/supabase/functions/create-user/index.ts
+++ b/supabase/functions/create-user/index.ts
@@ -9,6 +9,7 @@ const corsHeaders = {
 interface CreateUserBody {
   email: string;
   firstName: string;
+  nickname?: string;
   lastName: string;
   department?: string;
   phone?: string;
@@ -74,6 +75,7 @@ serve(async (req) => {
       email_confirm: true,
       user_metadata: {
         first_name: body.firstName,
+        nickname: body.nickname,
         last_name: body.lastName,
         phone: body.phone,
         department: body.department,
@@ -88,6 +90,7 @@ serve(async (req) => {
     // Optionally set role and flex_resource_id if provided
     const updates: Record<string, any> = {};
     if (body.role) updates.role = body.role;
+    if (body.nickname) updates.nickname = body.nickname;
     if (body.flex_resource_id) updates.flex_resource_id = body.flex_resource_id;
     if (Object.keys(updates).length > 0) {
       const { error: updErr } = await supabaseAdmin

--- a/supabase/functions/import-users/index.ts
+++ b/supabase/functions/import-users/index.ts
@@ -11,6 +11,7 @@ const corsHeaders = {
 interface CSVUserData {
   email: string;
   firstName: string;
+  nickname?: string;
   lastName: string;
   role: string;
   department: string;
@@ -55,6 +56,7 @@ serve(async (req) => {
           email_confirm: true,
           user_metadata: {
             first_name: record.firstName,
+            nickname: record.nickname,
             last_name: record.lastName,
             phone: record.phone,
             department: record.department,
@@ -69,7 +71,7 @@ serve(async (req) => {
         // Update role in profiles table
         const { error: profileError } = await supabase
           .from('profiles')
-          .update({ role: record.role })
+          .update({ role: record.role, nickname: record.nickname ?? null })
           .eq('id', authData.user.id);
 
         if (profileError) throw profileError;


### PR DESCRIPTION
## Summary
- add nickname inputs to user sign-up, edit, profile pages, and the import template
- extend Supabase edge functions and client hooks to persist the new nickname field
- update technician displays to render nicknames between first and last names with a shared formatter

## Testing
- npm run lint *(fails: missing @eslint/js package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eeb4d6436c832fb02f243d93a7584f