### PR TITLE
feat: add job required roles schema scaffolding

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2861,6 +2861,88 @@ export type Database = {
           },
         ]
       }
+      job_required_roles: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          department: string
+          id: string
+          job_id: string
+          notes: string | null
+          quantity: number
+          role_code: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          department: string
+          id?: string
+          job_id: string
+          notes?: string | null
+          quantity?: number
+          role_code: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          department?: string
+          id?: string
+          job_id?: string
+          notes?: string | null
+          quantity?: number
+          role_code?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_required_roles_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_required_roles_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_required_roles_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_required_roles_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "v_job_tech_payout_2025"
+            referencedColumns: ["job_id"]
+          },
+          {
+            foreignKeyName: "job_required_roles_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_required_roles_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       job_whatsapp_group_requests: {
         Row: {
           created_at: string
@@ -5643,6 +5725,15 @@ export type Database = {
           equipment_name: string | null
           rental_boost: number | null
           total_available: number | null
+        }
+        Relationships: []
+      }
+      job_required_roles_summary: {
+        Row: {
+          department: string | null
+          job_id: string | null
+          roles: Json | null
+          total_required: number | null
         }
         Relationships: []
       }

--- a/supabase/migrations/20251010120000_create_job_required_roles.sql
+++ b/supabase/migrations/20251010120000_create_job_required_roles.sql
@@ -1,0 +1,87 @@
+-- Crew staffing requirements per job/department/role
+create table if not exists public.job_required_roles (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid not null references public.jobs(id) on delete cascade,
+  department text not null,
+  role_code text not null,
+  quantity integer not null default 0 check (quantity >= 0),
+  notes text null,
+  created_at timestamptz not null default now(),
+  created_by uuid null references public.profiles(id) on delete set null,
+  updated_at timestamptz not null default now(),
+  updated_by uuid null references public.profiles(id) on delete set null
+);
+
+create unique index if not exists uq_job_required_roles_job_dept_role
+  on public.job_required_roles(job_id, department, role_code);
+
+create index if not exists idx_job_required_roles_job
+  on public.job_required_roles(job_id);
+
+comment on table public.job_required_roles is 'Required staffing slots for each job segmented by department and role code.';
+comment on column public.job_required_roles.department is 'Department identifier (sound, lights, video, etc.).';
+comment on column public.job_required_roles.role_code is 'Role code from the role registry expected for this job.';
+comment on column public.job_required_roles.quantity is 'Number of technicians required for this role.';
+
+alter table public.job_required_roles enable row level security;
+
+drop policy if exists job_required_roles_manage on public.job_required_roles;
+-- Allow admins/management to manage requirements
+create policy job_required_roles_manage on public.job_required_roles
+  for all to authenticated
+  using (public.get_current_user_role() = any (array['admin'::text,'management'::text]))
+  with check (public.get_current_user_role() = any (array['admin'::text,'management'::text]));
+
+drop policy if exists job_required_roles_select on public.job_required_roles;
+-- Authenticated users can read requirements for jobs they can access via assignments or elevated roles
+create policy job_required_roles_select on public.job_required_roles
+  for select to authenticated
+  using (
+    public.get_current_user_role() = any (array['admin'::text,'management'::text,'coordinator'::text,'logistics'::text])
+    or exists (
+      select 1
+      from public.job_assignments ja
+      where ja.job_id = job_required_roles.job_id
+        and ja.technician_id = auth.uid()
+    )
+  );
+
+-- Maintain updated_at automatically
+create or replace function public.trg_job_required_roles_set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_job_required_roles_set_updated_at on public.job_required_roles;
+create trigger trg_job_required_roles_set_updated_at
+  before update on public.job_required_roles
+  for each row
+  execute function public.trg_job_required_roles_set_updated_at();
+
+-- Aggregated view for quick lookups per job/department
+create or replace view public.job_required_roles_summary as
+select
+  job_id,
+  department,
+  sum(quantity) as total_required,
+  jsonb_agg(
+    jsonb_build_object(
+      'role_code', role_code,
+      'quantity', quantity,
+      'notes', notes
+    )
+    order by role_code
+  ) as roles
+from public.job_required_roles
+group by job_id, department;
+
+grant select on public.job_required_roles to authenticated, service_role;
+grant insert, update, delete on public.job_required_roles to authenticated;
+grant all on public.job_required_roles to service_role;
+
+grant select on public.job_required_roles_summary to authenticated, service_role;


### PR DESCRIPTION
## Summary
- create a job_required_roles table to store per-job staffing requirements with policies and grants
- expose an aggregated job_required_roles_summary view for consumers
- extend generated Supabase TypeScript definitions for the new table and view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef906fd478832fa9ac537a46829141