### PR TITLE
Translate technician dashboard interface to Spanish

### DIFF
--- a/src/components/dashboard/TechnicianTourRates.tsx
+++ b/src/components/dashboard/TechnicianTourRates.tsx
@@ -5,6 +5,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Euro, Info, ChevronDown, ChevronUp, ChevronLeft, ChevronRight } from "lucide-react";
 import { format, getISOWeek, getISOWeekYear, startOfWeek, endOfWeek } from "date-fns";
+import { es } from "date-fns/locale";
 import { useTechnicianTourRateQuotes } from "@/hooks/useTourJobRateQuotes";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useTourRatesApprovalMap } from "@/hooks/useTourRatesApproval";
@@ -24,6 +25,11 @@ export const TechnicianTourRates: React.FC = () => {
       currency: 'EUR',
       minimumFractionDigits: 2,
     }).format(amount);
+  };
+
+  const formatDatesBadge = (count: number) => {
+    if (count === 1) return '1 fecha esta semana';
+    return `${count} fechas esta semana`;
   };
 
   const weekGroups = useMemo(() => {
@@ -87,15 +93,15 @@ export const TechnicianTourRates: React.FC = () => {
         <div className="flex items-center gap-2">
           <CardTitle className="flex items-center gap-2">
             <Euro className="h-5 w-5" />
-            Your Tour Rates
+            Tus tarifas de gira
           </CardTitle>
-          <Badge variant="outline">{selectedQuotes.length} dates this week</Badge>
+          <Badge variant="outline">{formatDatesBadge(selectedQuotes.length)}</Badge>
         </div>
         <Button
           variant="ghost"
           size="icon"
           onClick={() => setExpanded((prev) => !prev)}
-          aria-label={expanded ? 'Collapse tour rates' : 'Expand tour rates'}
+          aria-label={expanded ? 'Contraer tarifas de gira' : 'Expandir tarifas de gira'}
         >
           {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
         </Button>
@@ -110,7 +116,7 @@ export const TechnicianTourRates: React.FC = () => {
           ) : error ? (
             <Alert variant="destructive">
               <AlertDescription>
-                Failed to load your tour rates: {(error as any).message}
+                No se pudieron cargar tus tarifas de gira: {(error as any).message}
               </AlertDescription>
             </Alert>
           ) : (
@@ -119,13 +125,13 @@ export const TechnicianTourRates: React.FC = () => {
                 <Info className="h-4 w-4" />
                 <AlertDescription>
                   {isHouseTech
-                    ? "As a house technician, you receive your profile-specific base rate. Weekly multipliers apply when you're assigned to the tour team."
-                    : "Tour rates use your category base. Weekly multipliers only apply if you're on the tour team for that routing."}
+                    ? "Como técnico residente, recibes la tarifa base específica de tu perfil. Los multiplicadores semanales se aplican cuando formas parte del equipo de la gira."
+                    : "Las tarifas de gira usan tu tarifa base de categoría. Los multiplicadores semanales solo se aplican si estás en el equipo de la gira para ese itinerario."}
                 </AlertDescription>
               </Alert>
 
               {(!quotes || quotes.length === 0) && (
-                <div className="text-muted-foreground">You have no upcoming tour date assignments.</div>
+                <div className="text-muted-foreground">No tienes asignaciones de fechas de gira próximas.</div>
               )}
 
           {allowedWeekKeys.length > 0 && activeWeekKey && (
@@ -136,7 +142,7 @@ export const TechnicianTourRates: React.FC = () => {
                   const sampleDate = selectedQuotes[0] ? new Date(selectedQuotes[0].start_time) : new Date();
                   const weekStart = startOfWeek(sampleDate, { weekStartsOn: 1 });
                   const weekEnd = endOfWeek(sampleDate, { weekStartsOn: 1 });
-                  return `Week ${week} of ${year} (${format(weekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')})`;
+                  return `Semana ${week} de ${year} (${format(weekStart, "d 'de' MMM", { locale: es })} - ${format(weekEnd, "d 'de' MMM", { locale: es })})`;
                 })()}
               </div>
               <div className="flex items-center gap-2">
@@ -145,7 +151,7 @@ export const TechnicianTourRates: React.FC = () => {
                   size="icon"
                   onClick={() => activeWeekIndex > 0 && setActiveWeekKey(allowedWeekKeys[activeWeekIndex - 1])}
                   disabled={activeWeekIndex <= 0}
-                  aria-label="Previous week"
+                  aria-label="Semana anterior"
                 >
                   <ChevronLeft className="h-4 w-4" />
                 </Button>
@@ -157,7 +163,7 @@ export const TechnicianTourRates: React.FC = () => {
                   size="icon"
                   onClick={() => activeWeekIndex >= 0 && activeWeekIndex < allowedWeekKeys.length - 1 && setActiveWeekKey(allowedWeekKeys[activeWeekIndex + 1])}
                   disabled={activeWeekIndex === allowedWeekKeys.length - 1}
-                  aria-label="Next week"
+                  aria-label="Semana siguiente"
                 >
                   <ChevronRight className="h-4 w-4" />
                 </Button>
@@ -178,20 +184,20 @@ export const TechnicianTourRates: React.FC = () => {
                         </Badge>
                       )}
                       {quote.is_house_tech && (
-                        <Badge variant="secondary" className="text-xs">House Rate</Badge>
+                        <Badge variant="secondary" className="text-xs">Tarifa fija</Badge>
                       )}
                       {quote.is_tour_team_member && quote.multiplier > 1 && (
                         <Badge variant="outline" className="text-xs">
-                          Week multiplier ×{quote.multiplier}
+                          Multiplicador semanal ×{quote.multiplier}
                         </Badge>
                       )}
                     </div>
                     <div className="text-sm text-muted-foreground mt-1">
-                      {format(new Date(quote.start_time), 'EEEE, MMM d, yyyy')}
+                      {format(new Date(quote.start_time), "EEEE, d 'de' MMM, yyyy", { locale: es })}
                     </div>
                     {!quote.is_tour_team_member && (
                       <div className="text-xs text-muted-foreground mt-2">
-                        Tour multiplier not applied — you are not on the tour team for this routing.
+                        Multiplicador de gira no aplicado: no formas parte del equipo de la gira para este recorrido.
                       </div>
                     )}
                   </div>
@@ -200,7 +206,7 @@ export const TechnicianTourRates: React.FC = () => {
                     <div className="text-xs text-muted-foreground">
                       Base {formatCurrency(quote.base_day_eur)}
                       {quote.is_tour_team_member && quote.multiplier > 1 && (
-                        <span> × {quote.multiplier} ({quote.week_count} dates)</span>
+                        <span> × {quote.multiplier} ({quote.week_count} {quote.week_count === 1 ? 'fecha' : 'fechas'})</span>
                       )}
                     </div>
                   </div>
@@ -208,13 +214,13 @@ export const TechnicianTourRates: React.FC = () => {
               ))
             ) : (
               <div className="text-sm text-muted-foreground">
-                {pendingQuotes.length > 0 ? 'Rates for this week are pending approval.' : 'No tour rate entries for this week.'}
+                {pendingQuotes.length > 0 ? 'Las tarifas de esta semana están pendientes de aprobación.' : 'No hay tarifas de gira registradas para esta semana.'}
               </div>
             )}
           </div>
 
           <div className="border-t pt-3 text-xs text-muted-foreground">
-            Amounts shown are per tour date. Use pagination to review past or upcoming routings.
+            Los importes mostrados son por fecha de gira. Usa la paginación para revisar recorridos pasados o futuros.
           </div>
             </>
           )}

--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -21,6 +21,7 @@ import {
   Calendar
 } from "lucide-react";
 import { format } from "date-fns";
+import { es } from "date-fns/locale";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { PlacesRestaurantService } from "@/utils/hoja-de-ruta/services/places-restaurant-service";
@@ -285,13 +286,13 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
   };
 
   const formatDateTime = (dateTime: string | null | undefined) => {
-    if (!dateTime) return 'Not set';
+    if (!dateTime) return 'Sin definir';
     try {
       const date = new Date(dateTime);
-      if (isNaN(date.getTime())) return 'Invalid date';
-      return format(date, 'PPp');
+      if (isNaN(date.getTime())) return 'Fecha no válida';
+      return format(date, 'PPPp', { locale: es });
     } catch (error) {
-      return 'Invalid date';
+      return 'Fecha no válida';
     }
   };
 
@@ -313,19 +314,19 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Calendar className="h-5 w-5" />
-            {jobDetails?.title || 'Job Details'}
+            {jobDetails?.title || 'Detalles del trabajo'}
           </DialogTitle>
         </DialogHeader>
 
         <Tabs value={selectedTab} onValueChange={setSelectedTab} className="w-full">
           <TabsList className={`grid w-full ${jobDetails?.job_type === 'tourdate' ? (showExtrasTab ? 'grid-cols-7' : 'grid-cols-6') : (showExtrasTab ? 'grid-cols-6' : 'grid-cols-5')}`}>
-            <TabsTrigger value="info">Info</TabsTrigger>
-            <TabsTrigger value="location">Location</TabsTrigger>
-            <TabsTrigger value="personnel">Personnel</TabsTrigger>
-            <TabsTrigger value="documents">Documents</TabsTrigger>
-            <TabsTrigger value="restaurants">Restaurants</TabsTrigger>
+            <TabsTrigger value="info">Información</TabsTrigger>
+            <TabsTrigger value="location">Ubicación</TabsTrigger>
+            <TabsTrigger value="personnel">Personal</TabsTrigger>
+            <TabsTrigger value="documents">Documentos</TabsTrigger>
+            <TabsTrigger value="restaurants">Restaurantes</TabsTrigger>
             {jobDetails?.job_type === 'tourdate' && (
-              <TabsTrigger value="tour-rates">Tour Rates</TabsTrigger>
+              <TabsTrigger value="tour-rates">Tarifas de gira</TabsTrigger>
             )}
             {showExtrasTab && <TabsTrigger value="extras">Extras</TabsTrigger>}
           </TabsList>
@@ -345,13 +346,13 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                   
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <p className="text-sm font-medium">Start Time</p>
+                      <p className="text-sm font-medium">Hora de inicio</p>
                       <p className="text-sm text-muted-foreground">
                         {formatDateTime(jobDetails?.start_time)}
                       </p>
                     </div>
                     <div>
-                      <p className="text-sm font-medium">End Time</p>
+                      <p className="text-sm font-medium">Hora de finalización</p>
                       <p className="text-sm text-muted-foreground">
                         {formatDateTime(jobDetails?.end_time)}
                       </p>
@@ -359,7 +360,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                   </div>
 
                   <div>
-                    <p className="text-sm font-medium mb-2">Job Type</p>
+                    <p className="text-sm font-medium mb-2">Tipo de trabajo</p>
                     <Badge variant="outline">{jobDetails?.job_type}</Badge>
                   </div>
 
@@ -367,9 +368,9 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                     <div className="flex items-center justify-between p-3 border rounded-md bg-muted/30">
                       <div className="flex items-center gap-2">
                         <Badge variant={jobDetails?.rates_approved ? 'default' : 'secondary'}>
-                          {jobDetails?.rates_approved ? 'Rates Approved' : 'Approval Required'}
+                          {jobDetails?.rates_approved ? 'Tarifas aprobadas' : 'Aprobación necesaria'}
                         </Badge>
-                        <span className="text-xs text-muted-foreground">Controls technician visibility of per-job payouts</span>
+                        <span className="text-xs text-muted-foreground">Controla la visibilidad de los pagos por trabajo para los técnicos</span>
                       </div>
                       <div>
                         {jobDetails?.rates_approved ? (
@@ -384,7 +385,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                               queryClient.invalidateQueries({ queryKey: ['job-details', job.id] });
                             }}
                           >
-                            Revoke
+                            Revocar
                           </Button>
                         ) : (
                           <Button
@@ -398,7 +399,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                               queryClient.invalidateQueries({ queryKey: ['job-details', job.id] });
                             }}
                           >
-                            Approve
+                            Aprobar
                           </Button>
                         )}
                       </div>
@@ -407,7 +408,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
 
                       {jobDetails?.locations && (
                         <div>
-                          <p className="text-sm font-medium">Venue</p>
+                          <p className="text-sm font-medium">Recinto</p>
                           <p className="text-sm text-muted-foreground">
                             {jobDetails.locations.name}
                           </p>
@@ -426,16 +427,16 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
               <Card className="p-4">
                 {jobDetails?.locations ? (
                   <div className="space-y-4">
-                    <div className="flex items-start justify-between">
-                      <div>
-                        <h3 className="font-semibold">{jobDetails.locations.name}</h3>
-                        {jobDetails.locations.formatted_address && (
-                          <p className="text-muted-foreground">{jobDetails.locations.formatted_address}</p>
-                        )}
-                      </div>
+                      <div className="flex items-start justify-between">
+                        <div>
+                          <h3 className="font-semibold">{jobDetails.locations.name}</h3>
+                          {jobDetails.locations.formatted_address && (
+                            <p className="text-muted-foreground">{jobDetails.locations.formatted_address}</p>
+                          )}
+                        </div>
                       <Button onClick={openGoogleMaps} size="sm">
                         <MapPin className="h-4 w-4 mr-2" />
-                        Open Maps
+                        Abrir mapas
                       </Button>
                     </div>
 
@@ -443,16 +444,16 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                       <div className="aspect-video bg-muted rounded-lg flex items-center justify-center">
                         <div className="text-center">
                           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-2"></div>
-                          <p className="text-sm text-muted-foreground">Loading map preview...</p>
+                          <p className="text-sm text-muted-foreground">Cargando vista previa del mapa...</p>
                         </div>
                       </div>
                     )}
                     {!isMapLoading && mapPreviewUrl && (
                       <div className="rounded-lg overflow-hidden border">
-                        <img src={mapPreviewUrl} alt="Venue Map" className="w-full h-auto" />
+                        <img src={mapPreviewUrl} alt="Mapa del recinto" className="w-full h-auto" />
                         <div className="p-2 flex justify-end">
                           <Button onClick={openGoogleMaps} size="sm">
-                            View directions
+                            Ver indicaciones
                           </Button>
                         </div>
                       </div>
@@ -461,9 +462,9 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                       <div className="aspect-video bg-muted rounded-lg flex items-center justify-center">
                         <div className="text-center">
                           <MapPin className="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
-                          <p className="text-sm text-muted-foreground">Map preview unavailable</p>
+                          <p className="text-sm text-muted-foreground">Vista previa del mapa no disponible</p>
                           <Button onClick={openGoogleMaps} size="sm" className="mt-2">
-                            Open Google Maps
+                            Abrir Google Maps
                           </Button>
                         </div>
                       </div>
@@ -474,7 +475,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                       <div>
                         <h4 className="font-semibold mb-2 flex items-center gap-2">
                           <Truck className="h-4 w-4" />
-                          Logistics
+                          Logística
                         </h4>
                         <div className="space-y-2">
                           {jobDetails.logistics_events.map((event: any) => (
@@ -486,7 +487,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                                 </span>
                               </div>
                               <div className="text-sm text-muted-foreground">
-                                {event.event_date ? format(new Date(event.event_date), 'PP') : 'No date'} at {event.event_time || 'No time'}
+                                {event.event_date ? format(new Date(event.event_date), 'PPP', { locale: es }) : 'Sin fecha'} a las {event.event_time || 'sin hora'}
                               </div>
                             </div>
                           ))}
@@ -497,7 +498,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                 ) : (
                   <div className="text-center py-8">
                     <MapPin className="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
-                    <p className="text-muted-foreground">No location information available</p>
+                    <p className="text-muted-foreground">No hay información de ubicación disponible</p>
                   </div>
                 )}
               </Card>
@@ -507,38 +508,38 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
               <Card className="p-4">
                 <h3 className="font-semibold mb-4 flex items-center gap-2">
                   <Users className="h-4 w-4" />
-                  Assigned Personnel
+                  Personal asignado
                 </h3>
-                
+
                 {jobDetails?.job_assignments && jobDetails.job_assignments.length > 0 ? (
                   <div className="space-y-3">
                     {jobDetails.job_assignments.map((assignment: any) => (
                       <div key={assignment.technician_id} className="flex items-center justify-between p-3 bg-muted rounded">
                         <div>
                           <p className="font-medium">
-                            {assignment.profiles 
+                            {assignment.profiles
                               ? `${assignment.profiles.first_name} ${assignment.profiles.last_name}`
-                              : assignment.external_technician_name || 'Unknown'
+                              : assignment.external_technician_name || 'Desconocido'
                             }
                           </p>
                           <p className="text-sm text-muted-foreground">
-                            {assignment.profiles?.department || 'External'}
+                            {assignment.profiles?.department || 'Externo'}
                           </p>
                         </div>
                         <div className="flex gap-1">
                           {assignment.sound_role && (
                             <Badge variant="outline" className="text-xs">
-                              Sound: {labelForCode(assignment.sound_role)}
+                              Sonido: {labelForCode(assignment.sound_role)}
                             </Badge>
                           )}
                           {assignment.lights_role && (
                             <Badge variant="outline" className="text-xs">
-                              Lights: {labelForCode(assignment.lights_role)}
+                              Luces: {labelForCode(assignment.lights_role)}
                             </Badge>
                           )}
                           {assignment.video_role && (
                             <Badge variant="outline" className="text-xs">
-                              Video: {labelForCode(assignment.video_role)}
+                              Vídeo: {labelForCode(assignment.video_role)}
                             </Badge>
                           )}
                         </div>
@@ -548,7 +549,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                 ) : (
                   <div className="text-center py-8">
                     <Users className="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
-                    <p className="text-muted-foreground">No personnel assigned yet</p>
+                    <p className="text-muted-foreground">No hay personal asignado aún</p>
                   </div>
                 )}
               </Card>
@@ -558,9 +559,9 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
               <Card className="p-4">
                 <h3 className="font-semibold mb-4 flex items-center gap-2">
                   <FileText className="h-4 w-4" />
-                  Job Documents
+                  Documentos del trabajo
                 </h3>
-                
+
                 {jobDetails?.job_documents && jobDetails.job_documents.length > 0 ? (
                   <div className="space-y-2">
                     {jobDetails.job_documents.map((doc: any) => (
@@ -568,25 +569,25 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                         <div>
                           <p className="font-medium">{doc.file_name}</p>
                           <p className="text-sm text-muted-foreground">
-                            {doc.uploaded_at ? `Uploaded ${format(new Date(doc.uploaded_at), 'PP')}` : 'Upload date unknown'}
+                            {doc.uploaded_at ? `Subido el ${format(new Date(doc.uploaded_at), 'PPP', { locale: es })}` : 'Fecha de subida desconocida'}
                           </p>
                         </div>
                         <div className="flex gap-2">
-                          <Button 
+                          <Button
                             onClick={() => handleViewDocument(doc)}
                             size="sm"
                             variant="outline"
                           >
                             <Eye className="h-4 w-4 mr-2" />
-                            View
+                            Ver
                           </Button>
-                          <Button 
+                          <Button
                             onClick={() => handleDownloadDocument(doc)}
                             size="sm"
                             variant="outline"
                           >
                             <Download className="h-4 w-4 mr-2" />
-                            Download
+                            Descargar
                           </Button>
                         </div>
                       </div>
@@ -595,7 +596,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                 ) : (
                   <div className="text-center py-8">
                     <FileText className="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
-                    <p className="text-muted-foreground">No documents uploaded yet</p>
+                    <p className="text-muted-foreground">No se han subido documentos</p>
                   </div>
                 )}
               </Card>
@@ -603,24 +604,24 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
               <Card className="p-4">
                 <h3 className="font-semibold mb-4 flex items-center gap-2">
                   <Users className="h-4 w-4" />
-                  Artist Riders
+                  Riders de artistas
                 </h3>
                 {isRidersLoading ? (
-                  <div className="text-center py-4 text-muted-foreground">Loading riders…</div>
+                  <div className="text-center py-4 text-muted-foreground">Cargando riders…</div>
                 ) : riderFiles.length > 0 ? (
                   <div className="space-y-2">
                     {riderFiles.map((file) => (
                       <div key={file.id} className="flex items-center justify-between p-3 bg-muted rounded">
                         <div>
                           <p className="font-medium">{file.file_name}</p>
-                          <p className="text-sm text-muted-foreground">Artist: {artistNameMap.get(file.artist_id) || 'Unknown'}</p>
+                          <p className="text-sm text-muted-foreground">Artista: {artistNameMap.get(file.artist_id) || 'Desconocido'}</p>
                         </div>
                         <div className="flex gap-2">
                           <Button size="sm" variant="outline" onClick={() => viewRider(file)}>
-                            <Eye className="h-4 w-4 mr-1" /> View
+                            <Eye className="h-4 w-4 mr-1" /> Ver
                           </Button>
                           <Button size="sm" variant="outline" onClick={() => downloadRider(file)}>
-                            <Download className="h-4 w-4 mr-1" /> Download
+                            <Download className="h-4 w-4 mr-1" /> Descargar
                           </Button>
                         </div>
                       </div>
@@ -629,7 +630,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                 ) : (
                   <div className="text-center py-8">
                     <Users className="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
-                    <p className="text-muted-foreground">No artist riders uploaded yet</p>
+                    <p className="text-muted-foreground">No se han subido riders de artistas</p>
                   </div>
                 )}
               </Card>
@@ -639,13 +640,13 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
               <Card className="p-4">
                 <h3 className="font-semibold mb-4 flex items-center gap-2">
                   <UtensilsCrossed className="h-4 w-4" />
-                  Nearby Restaurants
+                  Restaurantes cercanos
                 </h3>
-                
+
                 {isRestaurantsLoading ? (
                   <div className="text-center py-8">
                     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-2"></div>
-                    <p className="text-muted-foreground">Finding nearby restaurants...</p>
+                    <p className="text-muted-foreground">Buscando restaurantes cercanos...</p>
                   </div>
                 ) : restaurants && restaurants.length > 0 ? (
                   <div className="space-y-3">
@@ -669,7 +670,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                               )}
                               {restaurant.distance && (
                                 <Badge variant="outline" className="text-xs">
-                                  {Math.round(restaurant.distance)}m away
+                                  A {Math.round(restaurant.distance)} m
                                 </Badge>
                               )}
                             </div>
@@ -699,9 +700,9 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                   <div className="text-center py-8">
                     <UtensilsCrossed className="h-8 w-8 mx-auto mb-2 text-muted-foreground" />
                     <p className="text-muted-foreground">
-                      {jobDetails?.locations?.formatted_address 
-                        ? "No restaurants found nearby" 
-                        : "No venue address available to search for restaurants"
+                      {jobDetails?.locations?.formatted_address
+                        ? "No se encontraron restaurantes cercanos"
+                        : "No hay dirección del recinto para buscar restaurantes"
                       }
                     </p>
                   </div>

--- a/src/components/messages/DirectMessageCard.tsx
+++ b/src/components/messages/DirectMessageCard.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { CheckCircle, MessageSquare, Trash2 } from "lucide-react";
 import { format } from "date-fns";
+import { es } from "date-fns/locale";
 import { DirectMessage } from "./types";
 
 interface DirectMessageCardProps {
@@ -21,7 +22,7 @@ export const DirectMessageCard = ({
   const showMarkAsRead = isRecipient && message.status === 'unread';
 
   const handleDelete = () => {
-    if (window.confirm('Are you sure you want to permanently delete this message?')) {
+    if (window.confirm('¿Seguro que deseas eliminar este mensaje de forma permanente?')) {
       onDelete(message.id);
     }
   };
@@ -37,13 +38,13 @@ export const DirectMessageCard = ({
                 {message.sender.first_name} {message.sender.last_name}
               </span>
               <span className="text-sm text-muted-foreground">
-                to {message.recipient.first_name} {message.recipient.last_name}
+                para {message.recipient.first_name} {message.recipient.last_name}
               </span>
             </div>
           </div>
           <div className="flex items-center gap-2">
             <span className="text-sm text-muted-foreground">
-              {format(new Date(message.created_at), 'PPp')}
+              {format(new Date(message.created_at), 'PPp', { locale: es })}
             </span>
             {showMarkAsRead && (
               <Button
@@ -53,7 +54,7 @@ export const DirectMessageCard = ({
                 className="flex items-center gap-2"
               >
                 <CheckCircle className="h-4 w-4" />
-                Mark as Read
+                Marcar como leído
               </Button>
             )}
             {(currentUserId === message.sender_id || currentUserId === message.recipient_id) && (
@@ -61,7 +62,7 @@ export const DirectMessageCard = ({
                 variant="ghost"
                 size="icon"
                 onClick={handleDelete}
-                title="Delete message"
+                title="Eliminar mensaje"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>

--- a/src/components/messages/DirectMessagesList.tsx
+++ b/src/components/messages/DirectMessagesList.tsx
@@ -90,7 +90,7 @@ export const DirectMessagesList = () => {
       console.error("Error in fetchMessages:", error);
       toast({
         title: "Error",
-        description: "Failed to fetch messages",
+        description: "No se pudieron obtener los mensajes",
         variant: "destructive",
       });
     } finally {
@@ -132,14 +132,14 @@ export const DirectMessagesList = () => {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between pb-2">
-        <h3 className="text-lg font-medium">Direct Messages</h3>
+        <h3 className="text-lg font-medium">Mensajes directos</h3>
         <SubscriptionIndicator tables={['direct_messages']} variant="compact" />
       </div>
-      
+
       {loading ? (
-        <p className="text-muted-foreground">Loading messages...</p>
+        <p className="text-muted-foreground">Cargando mensajes...</p>
       ) : messages.length === 0 ? (
-        <p className="text-muted-foreground">No direct messages.</p>
+        <p className="text-muted-foreground">No hay mensajes directos.</p>
       ) : (
         messages.map((message) => (
           <DirectMessageCard

--- a/src/components/messages/MessageCard.tsx
+++ b/src/components/messages/MessageCard.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import { es } from "date-fns/locale";
 import { MessageSquare, Trash2, CheckCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -32,20 +33,20 @@ export const MessageCard = ({
                 {message.sender.first_name} {message.sender.last_name}
               </span>
               <span className="text-sm text-muted-foreground">
-                Department: {message.department}
+                Departamento: {message.department}
               </span>
             </div>
           </div>
           <div className="flex items-center gap-2">
             <span className="text-sm text-muted-foreground">
-              {format(new Date(message.created_at), 'PPp')}
+              {format(new Date(message.created_at), 'PPp', { locale: es })}
             </span>
             {showMarkAsRead && onMarkAsRead && (
               <Button
                 variant="ghost"
                 size="icon"
                 onClick={() => onMarkAsRead(message.id)}
-                title="Mark as read"
+                title="Marcar como leído"
               >
                 <CheckCircle className="h-4 w-4" />
               </Button>
@@ -55,7 +56,7 @@ export const MessageCard = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => onDelete(message.id)}
-                title="Delete message"
+                title="Eliminar mensaje"
               >
                 <Trash2 className="h-4 w-4" />
               </Button>

--- a/src/components/messages/MessagesList.tsx
+++ b/src/components/messages/MessagesList.tsx
@@ -42,16 +42,16 @@ export const MessagesList = () => {
   const { handleDeleteMessage, handleMarkAsRead } = useMessageOperations(messages, setMessages, toast);
 
   if (loading) {
-    return <div>Loading messages...</div>;
+    return <div>Cargando mensajes...</div>;
   }
 
   return (
     <div className="space-y-4">
       {isFetching && !loading && (
-        <div className="text-xs text-muted-foreground mb-2">Refreshing messages...</div>
+        <div className="text-xs text-muted-foreground mb-2">Actualizando mensajes...</div>
       )}
       {messages.length === 0 ? (
-        <p className="text-muted-foreground">No messages in this department.</p>
+        <p className="text-muted-foreground">No hay mensajes en este departamento.</p>
       ) : (
         messages.map((message) => (
           <MessageCard

--- a/src/components/messages/SendMessage.tsx
+++ b/src/components/messages/SendMessage.tsx
@@ -44,14 +44,14 @@ export const SendMessage = ({ department }: SendMessageProps) => {
       console.log("Message sent successfully");
       setMessage("");
       toast({
-        title: "Message sent",
-        description: "Your message has been sent to management.",
+        title: "Mensaje enviado",
+        description: "Tu mensaje se ha enviado a la dirección.",
       });
     } catch (error) {
       console.error("Error sending message:", error);
       toast({
         title: "Error",
-        description: "Failed to send message. Please try again.",
+        description: "No se pudo enviar el mensaje. Inténtalo de nuevo.",
         variant: "destructive",
       });
     } finally {
@@ -64,16 +64,16 @@ export const SendMessage = ({ department }: SendMessageProps) => {
       <Textarea
         value={message}
         onChange={(e) => setMessage(e.target.value)}
-        placeholder="Type your message here..."
+        placeholder="Escribe tu mensaje aquí..."
         className="min-h-[100px]"
       />
       <Button type="submit" disabled={sending || !message.trim()} className="w-full">
         {sending ? (
-          "Sending..."
+          "Enviando..."
         ) : (
           <>
             <Send className="mr-2 h-4 w-4" />
-            Send Message
+            Enviar mensaje
           </>
         )}
       </Button>

--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -137,7 +137,7 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
                 <CollapsibleTrigger asChild>
                   <Button variant="ghost" size="sm" className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground">
                     <FileText className="h-3 w-3" />
-                    {jobData.job_documents.length} doc{jobData.job_documents.length !== 1 ? 's' : ''}
+                    {jobData.job_documents.length} documento{jobData.job_documents.length !== 1 ? 's' : ''}
                     {expandedDocuments ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
                   </Button>
                 </CollapsibleTrigger>

--- a/src/components/technician/MessageManagementDialog.tsx
+++ b/src/components/technician/MessageManagementDialog.tsx
@@ -15,12 +15,12 @@ export const MessageManagementDialog = ({ department, trigger = true }: MessageM
   const content = (
     <DialogContent className="max-w-2xl">
       <DialogHeader>
-        <DialogTitle>Messages</DialogTitle>
+        <DialogTitle>Mensajes</DialogTitle>
       </DialogHeader>
       <Tabs defaultValue="department" className="w-full">
         <TabsList className="w-full">
-          <TabsTrigger value="department" className="flex-1">Department Messages</TabsTrigger>
-          <TabsTrigger value="direct" className="flex-1">Direct Messages</TabsTrigger>
+          <TabsTrigger value="department" className="flex-1">Mensajes del departamento</TabsTrigger>
+          <TabsTrigger value="direct" className="flex-1">Mensajes directos</TabsTrigger>
         </TabsList>
         <TabsContent value="department" className="space-y-4">
           {department && <SendMessage department={department} />}
@@ -42,7 +42,7 @@ export const MessageManagementDialog = ({ department, trigger = true }: MessageM
       <DialogTrigger asChild>
         <Button className="gap-2">
           <MessageSquare className="h-4 w-4" />
-          Message Management
+          Gestión de mensajes
         </Button>
       </DialogTrigger>
       {content}

--- a/src/components/technician/MyToursSection.tsx
+++ b/src/components/technician/MyToursSection.tsx
@@ -6,6 +6,7 @@ import { Calendar, MapPin, User, Music } from "lucide-react";
 import { useMyTours } from "@/hooks/useMyTours";
 import { useNavigate } from "react-router-dom";
 import { format } from "date-fns";
+import { es } from "date-fns/locale";
 
 export const MyToursSection = () => {
   const { activeTours, isLoading } = useMyTours();
@@ -28,19 +29,37 @@ export const MyToursSection = () => {
     }
   };
 
+  const getDepartmentLabel = (department: string) => {
+    switch (department.toLowerCase()) {
+      case 'sound':
+        return 'sonido';
+      case 'lights':
+        return 'luces';
+      case 'video':
+        return 'vídeo';
+      default:
+        return department;
+    }
+  };
+
+  const formatUpcomingCount = (count: number) => {
+    if (count === 1) return '1 fecha próxima';
+    return `${count} fechas próximas`;
+  };
+
   if (isLoading) {
     return (
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Calendar className="h-5 w-5" />
-            My Tours
+            Mis giras
           </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-center py-4">
             <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-900 dark:border-white mx-auto" />
-            <p className="text-sm text-muted-foreground mt-2">Loading tours...</p>
+            <p className="text-sm text-muted-foreground mt-2">Cargando giras...</p>
           </div>
         </CardContent>
       </Card>
@@ -53,15 +72,15 @@ export const MyToursSection = () => {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Calendar className="h-5 w-5" />
-            My Tours
+            Mis giras
           </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-center py-8">
             <Calendar className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <h3 className="text-lg font-medium mb-2">No Active Tours</h3>
+            <h3 className="text-lg font-medium mb-2">Sin giras activas</h3>
             <p className="text-muted-foreground">
-              You're not currently assigned to any active tours.
+              Actualmente no estás asignado a ninguna gira activa.
             </p>
           </div>
         </CardContent>
@@ -74,7 +93,7 @@ export const MyToursSection = () => {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Calendar className="h-5 w-5" />
-          My Tours
+          Mis giras
           <Badge variant="outline">{activeTours.length}</Badge>
         </CardTitle>
       </CardHeader>
@@ -89,14 +108,14 @@ export const MyToursSection = () => {
               <CardHeader className="pb-3">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <div 
-                      className="w-3 h-3 rounded-full" 
+                    <div
+                      className="w-3 h-3 rounded-full"
                       style={{ backgroundColor: tour.color }}
                     />
                     <h4 className="font-medium">{tour.name}</h4>
                   </div>
                   <Badge variant="outline">
-                    {tour.upcoming_dates} upcoming
+                    {formatUpcomingCount(tour.upcoming_dates)}
                   </Badge>
                 </div>
                 {tour.description && (
@@ -107,7 +126,7 @@ export const MyToursSection = () => {
                 <div className="flex flex-wrap items-center gap-4 text-sm">
                   <div className="flex items-center gap-1">
                     {getDepartmentIcon(tour.assignment_department)}
-                    <span className="capitalize">{tour.assignment_department}</span>
+                    <span className="capitalize">{getDepartmentLabel(tour.assignment_department)}</span>
                   </div>
                   <div className="flex items-center gap-1">
                     <User className="h-4 w-4" />
@@ -117,7 +136,7 @@ export const MyToursSection = () => {
                     <div className="flex items-center gap-1">
                       <Calendar className="h-4 w-4" />
                       <span>
-                        {format(new Date(tour.start_date), 'MMM d')} - {format(new Date(tour.end_date), 'MMM d, yyyy')}
+                        {format(new Date(tour.start_date), "d 'de' MMM", { locale: es })} - {format(new Date(tour.end_date), "d 'de' MMM, yyyy", { locale: es })}
                       </span>
                     </div>
                   )}
@@ -129,7 +148,7 @@ export const MyToursSection = () => {
                 )}
                 <div className="mt-3">
                   <Button variant="outline" size="sm" className="w-full">
-                    View Tour Details
+                    Ver detalles de la gira
                   </Button>
                 </div>
               </CardContent>

--- a/src/components/technician/TimeSpanSelector.tsx
+++ b/src/components/technician/TimeSpanSelector.tsx
@@ -8,28 +8,37 @@ interface TimeSpanSelectorProps {
 
 export const TimeSpanSelector = ({ value, onValueChange, viewMode }: TimeSpanSelectorProps) => {
   const getDisplayText = () => {
-    const prefix = viewMode === 'upcoming' ? 'Next' : 'Past';
+    if (viewMode === 'upcoming') {
+      switch (value) {
+        case "1week": return "Próxima semana";
+        case "2weeks": return "Próximas 2 semanas";
+        case "1month": return "Próximo mes";
+        case "3months": return "Próximos 3 meses";
+        default: return "Próxima semana";
+      }
+    }
+
     switch (value) {
-      case "1week": return `${prefix} Week`;
-      case "2weeks": return `${prefix} 2 Weeks`;
-      case "1month": return `${prefix} Month`;
-      case "3months": return `${prefix} 3 Months`;
-      default: return `${prefix} Week`;
+      case "1week": return "Semana pasada";
+      case "2weeks": return "Últimas 2 semanas";
+      case "1month": return "Mes pasado";
+      case "3months": return "Últimos 3 meses";
+      default: return "Semana pasada";
     }
   };
 
   return (
     <Select value={value} onValueChange={onValueChange}>
       <SelectTrigger className="w-[180px]">
-        <SelectValue placeholder="Select time span">
+        <SelectValue placeholder="Selecciona el periodo">
           {getDisplayText()}
         </SelectValue>
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="1week">{viewMode === 'upcoming' ? 'Next' : 'Past'} Week</SelectItem>
-        <SelectItem value="2weeks">{viewMode === 'upcoming' ? 'Next' : 'Past'} 2 Weeks</SelectItem>
-        <SelectItem value="1month">{viewMode === 'upcoming' ? 'Next' : 'Past'} Month</SelectItem>
-        <SelectItem value="3months">{viewMode === 'upcoming' ? 'Next' : 'Past'} 3 Months</SelectItem>
+        <SelectItem value="1week">{viewMode === 'upcoming' ? 'Próxima semana' : 'Semana pasada'}</SelectItem>
+        <SelectItem value="2weeks">{viewMode === 'upcoming' ? 'Próximas 2 semanas' : 'Últimas 2 semanas'}</SelectItem>
+        <SelectItem value="1month">{viewMode === 'upcoming' ? 'Próximo mes' : 'Mes pasado'}</SelectItem>
+        <SelectItem value="3months">{viewMode === 'upcoming' ? 'Próximos 3 meses' : 'Últimos 3 meses'}</SelectItem>
       </SelectContent>
     </Select>
   );

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -188,7 +188,7 @@ const TechnicianDashboard = () => {
         return transformedJobs || [];
       } catch (error) {
         console.error("Error fetching assignments:", error);
-        toast.error("Failed to load assignments");
+        toast.error("No se pudieron cargar las asignaciones");
         return [];
       }
     },
@@ -213,10 +213,10 @@ const TechnicianDashboard = () => {
       setIsRefreshing(true);
       console.log("Manually refreshing assignments data");
       await refetch();
-      toast.success("Assignments refreshed successfully");
+      toast.success("Asignaciones actualizadas correctamente");
     } catch (error) {
       console.error("Error refreshing assignments:", error);
-      toast.error("Failed to refresh assignments");
+      toast.error("No se pudieron actualizar las asignaciones");
     } finally {
       setIsRefreshing(false);
     }
@@ -234,14 +234,14 @@ const TechnicianDashboard = () => {
   return (
     <div className="w-full max-w-full space-y-4 md:space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <h1 className="text-xl md:text-2xl font-semibold">Technician Dashboard</h1>
+        <h1 className="text-xl md:text-2xl font-semibold">Panel de Técnicos</h1>
         <div className="flex items-center gap-2 flex-wrap w-full sm:w-auto">
           <Button
             variant="outline"
             size="icon"
             onClick={handleRefresh}
             disabled={isLoading || isRefreshing}
-            title="Refresh assignments"
+            title="Actualizar asignaciones"
             className="shrink-0"
           >
             <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
@@ -253,7 +253,7 @@ const TechnicianDashboard = () => {
               onClick={() => setViewMode('upcoming')}
               className="text-xs sm:text-sm"
             >
-              Upcoming
+              Próximas
             </Button>
             <Button
               variant={viewMode === 'past' ? 'default' : 'outline'}
@@ -261,7 +261,7 @@ const TechnicianDashboard = () => {
               onClick={() => setViewMode('past')}
               className="text-xs sm:text-sm"
             >
-              Past
+              Pasadas
             </Button>
           </div>
           <div className="flex items-center gap-2">
@@ -289,15 +289,15 @@ const TechnicianDashboard = () => {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Calendar className="h-5 w-5" />
-            My Availability
+            Mi disponibilidad
           </CardTitle>
         </CardHeader>
         <CardContent className="flex items-center justify-between gap-3">
           <div className="text-sm text-muted-foreground">
-            Manage your unavailability blocks so managers don’t assign overlapping jobs.
+            Gestiona tus bloques de indisponibilidad para que los gestores no asignen trabajos solapados.
           </div>
           <Button onClick={() => navigate('/dashboard/unavailability')}>
-            Manage Unavailability
+            Gestionar indisponibilidad
           </Button>
         </CardContent>
       </Card>
@@ -306,7 +306,7 @@ const TechnicianDashboard = () => {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Calendar className="h-5 w-5" />
-            My {viewMode === 'upcoming' ? 'Upcoming' : 'Past'} Assignments
+            Mis asignaciones {viewMode === 'upcoming' ? 'próximas' : 'pasadas'}
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -318,7 +318,7 @@ const TechnicianDashboard = () => {
                   assignments={assignments}
                   loading={isLoading}
                   onRefresh={handleRefresh}
-                  techName={userDepartment ? `${userDepartment} Technician` : 'Technician'}
+                  techName={userDepartment ? `Técnico de ${userDepartment}` : 'Técnico'}
                 />
               </div>
               {/* Mobile view */}
@@ -327,7 +327,7 @@ const TechnicianDashboard = () => {
                   assignments={assignments} 
                   loading={isLoading} 
                   onRefresh={handleRefresh}
-                  techName={userDepartment ? `${userDepartment} Technician` : 'Technician'}
+                  techName={userDepartment ? `Técnico de ${userDepartment}` : 'Técnico'}
                 />
               </div>
             </>
@@ -336,7 +336,7 @@ const TechnicianDashboard = () => {
               assignments={assignments} 
               loading={isLoading} 
               onRefresh={handleRefresh}
-              techName={userDepartment ? `${userDepartment} Technician` : 'Technician'}
+              techName={userDepartment ? `Técnico de ${userDepartment}` : 'Técnico'}
             />
           )}
         </CardContent>


### PR DESCRIPTION
## Summary
- translate the technician dashboard screen to Spanish, including refreshed controls and availability guidance
- localize technician-related components such as time span selector, tour widgets, and messaging dialogs with Spanish labels and toasts
- update supporting dialogs like tour rates and job details with Spanish copy, localized date formatting, and button text

## Testing
- npm run lint *(fails: missing @eslint/js dependency in project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68efc58d832c832fb41d788e2a6e9712