### PR TITLE
Allow technician dashboard to display invited assignments

### DIFF
--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -120,6 +120,7 @@ const TechnicianDashboard = () => {
             sound_role,
             lights_role,
             video_role,
+            status,
             assigned_at,
             jobs (
               id,
@@ -143,7 +144,7 @@ const TechnicianDashboard = () => {
             )
           `)
           .eq('technician_id', user.id)
-          .eq('status', 'confirmed');
+          .or('status.is.null,status.eq.confirmed,status.eq.invited');
 
         if (viewMode === 'upcoming') {
           // Show upcoming and ongoing jobs
@@ -181,6 +182,7 @@ const TechnicianDashboard = () => {
               technician_id: assignment.technician_id,
               department,
               role: assignment.sound_role || assignment.lights_role || assignment.video_role || "Assigned",
+              status: assignment.status,
               jobs: assignment.jobs
             };
           });


### PR DESCRIPTION
## Summary
- expand technician dashboard assignment query to include invited or unset statuses so tour date cards render
- expose the assignment status in the transformed technician assignment data for downstream use

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68f39f5f5f20832f8880bad4ee54ba4b