### PR TITLE
Gate technician payouts on tour and extras approval

### DIFF
--- a/src/components/dashboard/TechnicianTourRates.tsx
+++ b/src/components/dashboard/TechnicianTourRates.tsx
@@ -9,13 +9,23 @@ import { es } from "date-fns/locale";
 import { useTechnicianTourRateQuotes } from "@/hooks/useTourJobRateQuotes";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useTourRatesApprovalMap } from "@/hooks/useTourRatesApproval";
+import { useJobRatesApprovalMap } from "@/hooks/useJobRatesApproval";
+import type { TourJobRateQuote } from "@/types/tourRates";
 
 export const TechnicianTourRates: React.FC = () => {
   const { data: quotes, isLoading, error } = useTechnicianTourRateQuotes();
   const { userRole } = useOptimizedAuth();
   // Always compute tourIds and call the hook (it self-disables when empty)
-  const tourIds = Array.from(new Set((quotes || []).map(q => q.tour_id).filter(Boolean))) as string[];
-  const { data: approvalMap } = useTourRatesApprovalMap(tourIds);
+  const tourIds = useMemo(
+    () => Array.from(new Set((quotes || []).map(q => q.tour_id).filter(Boolean))) as string[],
+    [quotes]
+  );
+  const jobIds = useMemo(
+    () => Array.from(new Set((quotes || []).map(q => q.job_id).filter(Boolean))) as string[],
+    [quotes]
+  );
+  const { data: tourApprovalMap } = useTourRatesApprovalMap(tourIds);
+  const { data: jobApprovalMap } = useJobRatesApprovalMap(jobIds);
   // Local state/hooks must not be behind conditional returns
   const [expanded, setExpanded] = useState(true);
 
@@ -83,8 +93,33 @@ export const TechnicianTourRates: React.FC = () => {
 
   const activeWeekIndex = activeWeekKey ? allowedWeekKeys.indexOf(activeWeekKey) : -1;
   const selectedQuotes = activeWeekKey ? weekGroups[activeWeekKey] ?? [] : [];
-  const approvedQuotes = selectedQuotes.filter(q => !q.tour_id || (approvalMap?.get(q.tour_id) ?? false));
-  const pendingQuotes = selectedQuotes.filter(q => q.tour_id && !(approvalMap?.get(q.tour_id) ?? false));
+  const quoteHasExtras = (quote: TourJobRateQuote) => {
+    if ((quote.extras_total_eur ?? 0) > 0) {
+      return true;
+    }
+    return quote.extras?.items?.some(item => item.quantity > 0 && item.amount_eur > 0) ?? false;
+  };
+
+  const isQuoteApproved = (quote: TourJobRateQuote) => {
+    const tourApproved = !quote.tour_id || (tourApprovalMap?.get(quote.tour_id) ?? false);
+    if (!tourApproved) {
+      return false;
+    }
+
+    const extrasPresent = quoteHasExtras(quote);
+    if (!extrasPresent) {
+      return true;
+    }
+
+    if (!quote.job_id) {
+      return false;
+    }
+
+    return jobApprovalMap?.get(quote.job_id) ?? false;
+  };
+
+  const approvedQuotes = selectedQuotes.filter((quote) => isQuoteApproved(quote));
+  const pendingQuotes = selectedQuotes.filter((quote) => !isQuoteApproved(quote));
   const isHouseTech = (quotes && quotes[0]) ? quotes[0].is_house_tech : false;
 
   return (
@@ -171,57 +206,78 @@ export const TechnicianTourRates: React.FC = () => {
             </div>
           )}
 
-          <div className="space-y-3">
-            {approvedQuotes.length > 0 ? (
-              approvedQuotes.map((quote) => (
-                <div key={quote.job_id} className="flex flex-col gap-3 rounded-lg border border-muted bg-muted/40 p-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-medium leading-tight">{quote.title}</span>
-                      {quote.category && (
-                        <Badge variant="outline" className="text-xs">
-                          {quote.category.charAt(0).toUpperCase() + quote.category.slice(1)}
-                        </Badge>
-                      )}
-                      {quote.is_house_tech && (
-                        <Badge variant="secondary" className="text-xs">Tarifa fija</Badge>
-                      )}
-                      {quote.is_tour_team_member && quote.multiplier > 1 && (
-                        <Badge variant="outline" className="text-xs">
-                          Multiplicador semanal ×{quote.multiplier}
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="text-sm text-muted-foreground mt-1">
-                      {format(new Date(quote.start_time), "EEEE, d 'de' MMM, yyyy", { locale: es })}
-                    </div>
-                    {!quote.is_tour_team_member && (
-                      <div className="text-xs text-muted-foreground mt-2">
-                        Multiplicador de gira no aplicado: no formas parte del equipo de la gira para este recorrido.
+            <div className="space-y-3">
+              {approvedQuotes.length > 0 ? (
+                approvedQuotes.map((quote) => {
+                  const displayTotal = quote.total_with_extras_eur ?? quote.total_eur ?? 0;
+                  const baseDayAmount = quote.base_day_eur ?? 0;
+                  const extrasAmount = quote.extras_total_eur ?? 0;
+                  return (
+                    <div
+                      key={quote.job_id}
+                      className="flex flex-col gap-3 rounded-lg border border-muted bg-muted/40 p-3 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div className="flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium leading-tight">{quote.title}</span>
+                          {quote.category && (
+                            <Badge variant="outline" className="text-xs">
+                              {quote.category.charAt(0).toUpperCase() + quote.category.slice(1)}
+                            </Badge>
+                          )}
+                          {quote.is_house_tech && (
+                            <Badge variant="secondary" className="text-xs">Tarifa fija</Badge>
+                          )}
+                          {quote.is_tour_team_member && quote.multiplier > 1 && (
+                            <Badge variant="outline" className="text-xs">
+                              Multiplicador semanal ×{quote.multiplier}
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="text-sm text-muted-foreground mt-1">
+                          {format(new Date(quote.start_time), "EEEE, d 'de' MMM, yyyy", { locale: es })}
+                        </div>
+                        {!quote.is_tour_team_member && (
+                          <div className="text-xs text-muted-foreground mt-2">
+                            Multiplicador de gira no aplicado: no formas parte del equipo de la gira para este recorrido.
+                          </div>
+                        )}
                       </div>
-                    )}
-                  </div>
-                  <div className="sm:text-right">
-                    <div className="font-semibold text-lg">{formatCurrency(quote.total_eur)}</div>
-                    <div className="text-xs text-muted-foreground">
-                      Base {formatCurrency(quote.base_day_eur)}
-                      {quote.is_tour_team_member && quote.multiplier > 1 && (
-                        <span> × {quote.multiplier} ({quote.week_count} {quote.week_count === 1 ? 'fecha' : 'fechas'})</span>
-                      )}
+                      <div className="sm:text-right">
+                        <div className="font-semibold text-lg">{formatCurrency(displayTotal)}</div>
+                        <div className="text-xs text-muted-foreground">
+                          Base {formatCurrency(baseDayAmount)}
+                          {quote.is_tour_team_member && quote.multiplier > 1 && (
+                            <span> × {quote.multiplier} ({quote.week_count} {quote.week_count === 1 ? 'fecha' : 'fechas'})</span>
+                          )}
+                          {extrasAmount > 0 && (
+                            <span className="block text-green-600 mt-1">+ Extras {formatCurrency(extrasAmount)}</span>
+                          )}
+                        </div>
+                      </div>
                     </div>
-                  </div>
+                  );
+                })
+              ) : (
+                <div className="text-sm text-muted-foreground">
+                  {pendingQuotes.length > 0
+                    ? 'Las tarifas de esta semana están pendientes de aprobación de la gira o de los extras.'
+                    : 'No hay tarifas de gira registradas para esta semana.'}
                 </div>
-              ))
-            ) : (
-              <div className="text-sm text-muted-foreground">
-                {pendingQuotes.length > 0 ? 'Las tarifas de esta semana están pendientes de aprobación.' : 'No hay tarifas de gira registradas para esta semana.'}
-              </div>
-            )}
-          </div>
+              )}
+            </div>
 
-          <div className="border-t pt-3 text-xs text-muted-foreground">
-            Los importes mostrados son por fecha de gira. Usa la paginación para revisar recorridos pasados o futuros.
-          </div>
+            {pendingQuotes.length > 0 && (
+              <Alert>
+                <AlertDescription>
+                  Algunas fechas no se muestran hasta que la dirección apruebe la tarifa base del tour y los extras correspondientes.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="border-t pt-3 text-xs text-muted-foreground">
+              Los importes mostrados son por fecha de gira. Usa la paginación para revisar recorridos pasados o futuros.
+            </div>
             </>
           )}
         </CardContent>


### PR DESCRIPTION
## Summary
- require both tour-level rate approval and per-date extras approval before surfacing technician tour totals
- extend the technician tour rates panel to hide unapproved dates, surface extras in the breakdown, and warn when amounts remain pending

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68f3b7897ec4832fa287ae17d5d1d295