### PR TITLE
Fix job extras mutation payload destructuring

### DIFF
--- a/src/hooks/useJobExtras.ts
+++ b/src/hooks/useJobExtras.ts
@@ -49,7 +49,14 @@ export function useUpsertJobExtra() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ jobId, technicianId, extraType, approvedQuantity, requestedQuantity }: SubmitJobExtraPayload) => {
+    mutationFn: async ({
+      jobId,
+      technicianId,
+      extraType,
+      approvedQuantity,
+      requestedQuantity,
+      hasExistingRow,
+    }: SubmitJobExtraPayload) => {
       const { data: auth } = await supabase.auth.getUser();
       const now = new Date().toISOString();
       const hasChange = approvedQuantity !== requestedQuantity;


### PR DESCRIPTION
## Summary
- include `hasExistingRow` in the job extras mutation payload destructuring to allow the guard clause to compile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3d77fd3e4832f82b7592a40a7722e