### PR TITLE
feat: extend mobile liquid glass surfaces

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,21 @@
+# Design System Notes
+
+## Liquid Glass Components
+
+We provide glassified primitives for mobile-first surfaces through the `@/components/ui/glass` entry point. These wrappers respect `useGlassOnMobile` heuristics and the `mobile_glass_ui` feature flag so the experience can be rolled out gradually.
+
+- **`GlassSurface`** – Low-level wrapper around `liquid-glass-react`. Accepts the same shader props plus:
+  - `contentClassName` / `fallbackClassName` for styling inner content.
+  - `mobileOptions` to forward feature-flag and device heuristics (e.g. `{ featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 }`).
+  - `variant` (`"light" | "dark"`) to adapt the translucent palette.
+- **`GlassCard`, `GlassButton`, `GlassSheetContent`** – Convenience components that embed `GlassSurface` into shadcn primitives. All expose `mobileOptions` and `glassSurfaceClassName`/`glassContentClassName` hooks for fine tuning.
+- **Dialogs, sheets, drawers, toasts** – Pass the `glass` prop with optional `glassSurfaceProps` to opt into the frosted treatment (e.g. `<DialogContent glass glassSurfaceProps={{ displacementScale: 0.34 }} />`).
+
+### Rollout guidance
+
+1. Default to the glass variants on mobile layouts (`GlassCard`, `GlassButton`, `GlassSurface`) and set `mobileOptions={{ featureFlag: "mobile_glass_ui" }}`. Desktop surfaces may pass `allowDesktop: true` when parity is required.
+2. Keep layered content readable by balancing `displacementScale` (`0.2–0.4` for scrolling lists) and `blurAmount` (`16–22` for dialogs/sheets).
+3. Provide tactile fallbacks inside `fallbackClassName` when the shader is disabled (reduced motion, low-memory devices, or the feature flag off).
+4. Use utility overlays (thin left accents, gradient backgrounds) inside the `GlassSurface` content block instead of mutating the shader directly.
+
+Refer to `src/components/dashboard/MobileDayCalendar.tsx` and `src/components/personal/MobilePersonalCalendar.tsx` for examples of real-world integration.

--- a/src/components/dashboard/MobileDayCalendar.tsx
+++ b/src/components/dashboard/MobileDayCalendar.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -51,6 +49,7 @@ import {
 import { formatInJobTimezone, isJobOnDate } from "@/utils/timezoneUtils";
 import { useMobileDayCalendarSubscriptions } from "@/hooks/useMobileRealtimeSubscriptions";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { GlassButton, GlassCard, GlassSurface } from "@/components/ui/glass";
 
 interface MobileDayCalendarProps {
   date: Date | undefined;
@@ -255,13 +254,24 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
   };
 
   return (
-    <Card className="h-full flex flex-col">
+    <GlassCard
+      className="h-full flex flex-col"
+      glassSurfaceClassName="h-full"
+      glassContentClassName="flex flex-col"
+      mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+    >
       <CardContent className="flex-grow p-4">
         {/* Header with navigation */}
         <div className="flex items-center justify-between mb-4">
-          <Button variant="ghost" size="sm" onClick={navigateToPrevious} className="p-2">
+          <GlassButton
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            onClick={navigateToPrevious}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <ChevronLeft className="h-4 w-4" />
-          </Button>
+          </GlassButton>
           
           <div className="text-center flex-1">
             <div className="text-lg font-semibold">
@@ -276,36 +286,59 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
           </div>
           
           <div className="flex gap-1">
-            <Button variant="outline" size="sm" onClick={navigateToToday}>
+            <GlassButton
+              variant="outline"
+              size="sm"
+              onClick={navigateToToday}
+              mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+            >
               <Target className="h-4 w-4" />
-            </Button>
-            
+            </GlassButton>
+
             <Popover>
               <PopoverTrigger asChild>
-                <Button variant="outline" size="sm">
+                <GlassButton
+                  variant="outline"
+                  size="sm"
+                  mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+                >
                   <Calendar className="h-4 w-4" />
-                </Button>
+                </GlassButton>
               </PopoverTrigger>
-              <PopoverContent className="w-auto p-0 pointer-events-auto" align="end">
-                <CalendarComponent
-                  mode="single"
-                  selected={currentDate}
-                  onSelect={(date) => {
-                    if (date) {
-                      setCurrentDate(date);
-                      onDateSelect(date);
-                    }
-                  }}
-                  initialFocus
+              <PopoverContent className="w-auto border-0 bg-transparent p-0 shadow-none" align="end">
+                <GlassSurface
                   className="pointer-events-auto"
-                />
+                  contentClassName="p-2"
+                  mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+                  displacementScale={0.38}
+                  blurAmount={18}
+                >
+                  <CalendarComponent
+                    mode="single"
+                    selected={currentDate}
+                    onSelect={(date) => {
+                      if (date) {
+                        setCurrentDate(date);
+                        onDateSelect(date);
+                      }
+                    }}
+                    initialFocus
+                    className="pointer-events-auto"
+                  />
+                </GlassSurface>
               </PopoverContent>
             </Popover>
           </div>
-          
-          <Button variant="ghost" size="sm" onClick={navigateToNext} className="p-2">
+
+          <GlassButton
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            onClick={navigateToNext}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <ChevronRight className="h-4 w-4" />
-          </Button>
+          </GlassButton>
         </div>
 
         {/* Action buttons */}
@@ -314,7 +347,12 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
             {distinctJobTypes.length > 0 && onJobTypeSelection ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="outline" size="sm">
+                  <GlassButton
+                    variant="outline"
+                    size="sm"
+                    className="min-w-[92px]"
+                    mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+                  >
                     <Filter className="h-4 w-4 mr-1" />
                     Types
                     {selectedJobTypes.length > 0 && selectedJobTypes.length < distinctJobTypes.length && (
@@ -322,23 +360,31 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
                         {selectedJobTypes.length}
                       </Badge>
                     )}
-                  </Button>
+                  </GlassButton>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent 
-                  align="start" 
-                  className="w-48 z-50 bg-background border shadow-lg"
-                  sideOffset={4}
+                <DropdownMenuContent
+                  align="start"
+                  className="z-50 w-52 border-0 bg-transparent p-0 shadow-none"
+                  sideOffset={6}
                 >
-                  {distinctJobTypes.map((type) => (
-                    <DropdownMenuCheckboxItem
-                      key={type}
-                      checked={selectedJobTypes.length === 0 || selectedJobTypes.includes(type)}
-                      onCheckedChange={() => onJobTypeSelection(type)}
-                      className="capitalize"
-                    >
-                      {type}
-                    </DropdownMenuCheckboxItem>
-                  ))}
+                  <GlassSurface
+                    className="overflow-hidden"
+                    contentClassName="flex flex-col py-2"
+                    mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+                    displacementScale={0.32}
+                    blurAmount={16}
+                  >
+                    {distinctJobTypes.map((type) => (
+                      <DropdownMenuCheckboxItem
+                        key={type}
+                        checked={selectedJobTypes.length === 0 || selectedJobTypes.includes(type)}
+                        onCheckedChange={() => onJobTypeSelection(type)}
+                        className="capitalize px-3"
+                      >
+                        {type}
+                      </DropdownMenuCheckboxItem>
+                    ))}
+                  </GlassSurface>
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : null}
@@ -346,7 +392,12 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
             {distinctJobStatuses.length > 0 && onJobStatusSelection ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="outline" size="sm">
+                  <GlassButton
+                    variant="outline"
+                    size="sm"
+                    className="min-w-[92px]"
+                    mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+                  >
                     <Filter className="h-4 w-4 mr-1" />
                     Status
                     {selectedJobStatuses.length > 0 && selectedJobStatuses.length < distinctJobStatuses.length && (
@@ -354,32 +405,45 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
                         {selectedJobStatuses.length}
                       </Badge>
                     )}
-                  </Button>
+                  </GlassButton>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent 
-                  align="start" 
-                  className="w-48 z-50 bg-background border shadow-lg"
-                  sideOffset={4}
+                <DropdownMenuContent
+                  align="start"
+                  className="z-50 w-52 border-0 bg-transparent p-0 shadow-none"
+                  sideOffset={6}
                 >
-                  {distinctJobStatuses.map((status) => (
-                    <DropdownMenuCheckboxItem
-                      key={status}
-                      checked={selectedJobStatuses.length === 0 || selectedJobStatuses.includes(status)}
-                      onCheckedChange={() => onJobStatusSelection(status)}
-                      className="capitalize"
-                    >
-                      {status}
-                    </DropdownMenuCheckboxItem>
-                  ))}
+                  <GlassSurface
+                    className="overflow-hidden"
+                    contentClassName="flex flex-col py-2"
+                    mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+                    displacementScale={0.32}
+                    blurAmount={16}
+                  >
+                    {distinctJobStatuses.map((status) => (
+                      <DropdownMenuCheckboxItem
+                        key={status}
+                        checked={selectedJobStatuses.length === 0 || selectedJobStatuses.includes(status)}
+                        onCheckedChange={() => onJobStatusSelection(status)}
+                        className="capitalize px-3"
+                      >
+                        {status}
+                      </DropdownMenuCheckboxItem>
+                    ))}
+                  </GlassSurface>
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : null}
           </div>
-          
-          <Button variant="outline" size="sm" onClick={() => setShowPrintDialog(true)}>
+
+          <GlassButton
+            variant="outline"
+            size="sm"
+            onClick={() => setShowPrintDialog(true)}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <Printer className="h-4 w-4 mr-1" />
             Print
-          </Button>
+          </GlassButton>
         </div>
 
         {/* Jobs area */}
@@ -407,6 +471,6 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
           selectedJobTypes={selectedJobTypes}
         />
       </CardContent>
-    </Card>
+    </GlassCard>
   );
 };

--- a/src/components/dashboard/MobileJobCard.tsx
+++ b/src/components/dashboard/MobileJobCard.tsx
@@ -1,6 +1,4 @@
 import React, { useState } from 'react';
-import { Card } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
@@ -38,6 +36,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useFlexUuidLazy } from "@/hooks/useFlexUuidLazy";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useQueryClient } from "@tanstack/react-query";
+import { GlassButton, GlassCard, GlassSurface } from "@/components/ui/glass";
 
 interface MobileJobCardProps {
   job: any;
@@ -96,7 +95,6 @@ export function MobileJobCard({
 
   const {
     appliedBorderColor,
-    appliedBgColor,
     assignments,
     documents,
     soundTaskDialogOpen,
@@ -270,185 +268,199 @@ export function MobileJobCard({
 
   return (
     <>
-      <Card
+      <GlassCard
         className={cn(
           "mb-3 transition-all duration-200",
-          !isHouseTech && !isJobBeingDeleted && "cursor-pointer hover:shadow-md",
-          isJobBeingDeleted && "opacity-50 pointer-events-none"
+          !isHouseTech && !isJobBeingDeleted && "cursor-pointer hover:-translate-y-0.5",
+          isJobBeingDeleted && "pointer-events-none opacity-60"
         )}
+        glassSurfaceClassName="relative overflow-hidden"
+        glassContentClassName="flex flex-col"
+        mobileOptions={{ featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 }}
         onClick={handleJobCardClick}
-        style={{
-          borderLeftColor: appliedBorderColor,
-          backgroundColor: appliedBgColor,
-          borderLeftWidth: '4px'
-        }}
       >
-        {isJobBeingDeleted && (
-          <div className="absolute inset-0 bg-black bg-opacity-20 flex items-center justify-center z-10 rounded">
-            <div className="bg-background px-3 py-2 rounded shadow-lg">
-              <span className="text-sm font-medium">Deleting job...</span>
-            </div>
-          </div>
-        )}
+        <div className="relative flex flex-col rounded-2xl p-4">
+          <div
+            aria-hidden
+            className="absolute left-0 top-3 bottom-3 w-1.5 rounded-full"
+            style={{ backgroundColor: appliedBorderColor || 'hsl(var(--primary))' }}
+          />
 
-        <div className="p-4">
+          {isJobBeingDeleted && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-black/30">
+              <div className="rounded-lg bg-background/80 px-3 py-2 text-sm font-medium shadow-lg">
+                Deleting job...
+              </div>
+            </div>
+          )}
+
+          <div className="relative z-[1]">
           <div className="flex items-start justify-between mb-2">
             <div className="flex items-center gap-2">
               {/* Actions menu - moved to left */}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button 
-                    variant="ghost" 
-                    size="sm" 
-                    className="h-8 w-8 p-0"
+                  <GlassButton
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9"
+                    mobileOptions={{ featureFlag: "mobile_glass_ui" }}
                     onClick={(e) => e.stopPropagation()}
                   >
                     <MoreVertical className="h-4 w-4" />
-                  </Button>
+                  </GlassButton>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent 
-                  align="end" 
-                  side="top" 
-                  sideOffset={-4} 
+                <DropdownMenuContent
+                  align="end"
+                  side="top"
+                  sideOffset={-4}
                   collisionPadding={-8}
                   avoidCollisions={true}
-                  className="w-48 bg-popover border shadow-md z-50"
+                  className="z-50 w-52 border-0 bg-transparent p-0 shadow-none"
                 >
-                  <DropdownMenuItem onClick={handleDateTypeBadgeClick}>
-                    <Calendar className="mr-2 h-4 w-4" />
-                    Change Date Type
-                  </DropdownMenuItem>
+                  <GlassSurface
+                    className="overflow-hidden"
+                    contentClassName="flex flex-col py-2"
+                    mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+                    displacementScale={0.35}
+                    blurAmount={18}
+                    variant="dark"
+                  >
+                    <DropdownMenuItem onClick={handleDateTypeBadgeClick}>
+                      <Calendar className="mr-2 h-4 w-4" />
+                      Change Date Type
+                    </DropdownMenuItem>
 
-                  <DropdownMenuItem 
-                    onClick={(e) => { e.stopPropagation(); handleFlexClick(); }}
-                    disabled={isLoadingFlexUuid}
-                  >
-                    {getFlexIcon()}
-                    {getFlexMenuText()}
-                  </DropdownMenuItem>
-                  
-                  <DropdownMenuSeparator />
-                  
-                  {/* View Details - for technicians and house techs */}
-                  {(userRole === 'technician' || userRole === 'house_tech') && (
-                    <DropdownMenuItem 
+                    <DropdownMenuItem
+                      onClick={(e) => { e.stopPropagation(); handleFlexClick(); }}
+                      disabled={isLoadingFlexUuid}
+                    >
+                      {getFlexIcon()}
+                      {getFlexMenuText()}
+                    </DropdownMenuItem>
+
+                    <DropdownMenuSeparator />
+
+                    {/* View Details - for technicians and house techs */}
+                    {(userRole === 'technician' || userRole === 'house_tech') && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setJobDetailsDialogOpen(true);
+                        }}
+                      >
+                        <FileText className="mr-2 h-4 w-4" />
+                        View Details
+                      </DropdownMenuItem>
+                    )}
+
+                    <DropdownMenuItem
                       onClick={(e) => {
                         e.stopPropagation();
-                        setJobDetailsDialogOpen(true);
+                        setAssignmentDialogOpen(true);
                       }}
                     >
-                      <FileText className="mr-2 h-4 w-4" />
-                      View Details
+                      <Users className="mr-2 h-4 w-4" />
+                      Assign Users
                     </DropdownMenuItem>
-                  )}
-                  
-                  <DropdownMenuItem 
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setAssignmentDialogOpen(true);
-                    }}
-                  >
-                    <Users className="mr-2 h-4 w-4" />
-                    Assign Users
-                  </DropdownMenuItem>
-                  
-                  <DropdownMenuItem onClick={handleTimesheetClick}>
-                    <Clock className="mr-2 h-4 w-4" />
-                    Timesheets
-                  </DropdownMenuItem>
-                  
-                  {isFestival && canManageArtists && (
-                    <DropdownMenuItem onClick={handleFestivalArtistsClick}>
-                      <Star className="mr-2 h-4 w-4" />
-                      Manage Artists
+
+                    <DropdownMenuItem onClick={handleTimesheetClick}>
+                      <Clock className="mr-2 h-4 w-4" />
+                      Timesheets
                     </DropdownMenuItem>
-                  )}
-                  
-                  <DropdownMenuSeparator />
-                  
-                  {canUploadDocuments && (
-                    <DropdownMenuItem asChild>
-                      <label className="cursor-pointer">
-                        <FileUp className="mr-2 h-4 w-4" />
-                        Upload Document
-                        <input
-                          type="file"
-                          className="hidden"
-                          multiple
-                          onChange={handleFileUpload}
-                        />
-                      </label>
-                    </DropdownMenuItem>
-                  )}
-                  
-                  {canCreateFlexFolders && (
-                    <DropdownMenuItem 
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        console.log("MobileJobCard: Create Flex Folders clicked", { 
-                          canCreateFlexFolders, 
-                          isCreatingFolders, 
-                          isFoldersLoading, 
-                          foldersAreCreated,
-                          jobId: job.id 
-                        });
-                        createFlexFoldersHandler(e);
-                      }}
-                      disabled={isCreatingFolders || isFoldersLoading || foldersAreCreated}
-                    >
-                      {isCreatingFolders ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      ) : (
-                        <FolderPlus className="mr-2 h-4 w-4" />
-                      )}
-                      {isCreatingFolders ? 'Creating...' : foldersAreCreated ? 'Flex Folders Created' : 'Create Flex Folders'}
-                    </DropdownMenuItem>
-                  )}
-                  
-                  {!isMobile && (
-                    <DropdownMenuItem 
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        createLocalFoldersHandler(e);
-                      }}
-                      disabled={isCreatingLocalFolders}
-                    >
-                      <HardDrive className="mr-2 h-4 w-4" />
-                      {isCreatingLocalFolders ? 'Creating...' : 'Create Local Folders'}
-                    </DropdownMenuItem>
-                  )}
-                  
-                  <DropdownMenuSeparator />
-                  
-                  {/* View Details - for technicians and house techs */}
-                  {(userRole === 'technician' || userRole === 'house_tech') && (
-                    <DropdownMenuItem 
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setJobDetailsDialogOpen(true);
-                      }}
-                    >
-                      <FileText className="mr-2 h-4 w-4" />
-                      View Details
-                    </DropdownMenuItem>
-                  )}
-                  
-                  {canEditJobs && (
-                    <DropdownMenuItem onClick={handleEditButtonClick}>
-                      <Edit className="mr-2 h-4 w-4" />
-                      Edit Job
-                    </DropdownMenuItem>
-                  )}
-                  
-                  {["admin", "management"].includes(userRole || "") && (
-                    <DropdownMenuItem 
-                      onClick={handleDeleteClick}
-                      className="text-destructive focus:text-destructive"
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Delete Job
-                    </DropdownMenuItem>
-                  )}
+
+                    {isFestival && canManageArtists && (
+                      <DropdownMenuItem onClick={handleFestivalArtistsClick}>
+                        <Star className="mr-2 h-4 w-4" />
+                        Manage Artists
+                      </DropdownMenuItem>
+                    )}
+
+                    <DropdownMenuSeparator />
+
+                    {canUploadDocuments && (
+                      <DropdownMenuItem asChild>
+                        <label className="cursor-pointer">
+                          <FileUp className="mr-2 h-4 w-4" />
+                          Upload Document
+                          <input
+                            type="file"
+                            className="hidden"
+                            multiple
+                            onChange={handleFileUpload}
+                          />
+                        </label>
+                      </DropdownMenuItem>
+                    )}
+
+                    {canCreateFlexFolders && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          console.log("MobileJobCard: Create Flex Folders clicked", {
+                            canCreateFlexFolders,
+                            isCreatingFolders,
+                            isFoldersLoading,
+                            foldersAreCreated,
+                            jobId: job.id
+                          });
+                          createFlexFoldersHandler(e);
+                        }}
+                        disabled={isCreatingFolders || isFoldersLoading || foldersAreCreated}
+                      >
+                        {isCreatingFolders ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                          <FolderPlus className="mr-2 h-4 w-4" />
+                        )}
+                        {isCreatingFolders ? 'Creating...' : foldersAreCreated ? 'Flex Folders Created' : 'Create Flex Folders'}
+                      </DropdownMenuItem>
+                    )}
+
+                    {!isMobile && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          createLocalFoldersHandler(e);
+                        }}
+                        disabled={isCreatingLocalFolders}
+                      >
+                        <HardDrive className="mr-2 h-4 w-4" />
+                        {isCreatingLocalFolders ? 'Creating...' : 'Create Local Folders'}
+                      </DropdownMenuItem>
+                    )}
+
+                    <DropdownMenuSeparator />
+
+                    {(userRole === 'technician' || userRole === 'house_tech') && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setJobDetailsDialogOpen(true);
+                        }}
+                      >
+                        <FileText className="mr-2 h-4 w-4" />
+                        View Details
+                      </DropdownMenuItem>
+                    )}
+
+                    {canEditJobs && (
+                      <DropdownMenuItem onClick={handleEditButtonClick}>
+                        <Edit className="mr-2 h-4 w-4" />
+                        Edit Job
+                      </DropdownMenuItem>
+                    )}
+
+                    {["admin", "management"].includes(userRole || "") && (
+                      <DropdownMenuItem
+                        onClick={handleDeleteClick}
+                        className="text-destructive focus:text-destructive"
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Delete Job
+                      </DropdownMenuItem>
+                    )}
+                  </GlassSurface>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
@@ -488,17 +500,25 @@ export function MobileJobCard({
             ))}
           </div>
         </div>
-      </Card>
+      </GlassCard>
 
       {/* Date Type Dialog */}
       <Dialog open={dateTypeDialogOpen} onOpenChange={setDateTypeDialogOpen}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent
+          className="sm:max-w-md"
+          glass
+          glassSurfaceProps={{
+            mobileOptions: { featureFlag: "mobile_glass_ui" },
+            displacementScale: 0.4,
+            blurAmount: 20,
+          }}
+        >
           <DialogHeader>
             <DialogTitle>Change Date Type</DialogTitle>
           </DialogHeader>
           <div className="grid gap-2">
             {DATE_TYPE_OPTIONS.map((option) => (
-              <Button
+              <GlassButton
                 key={option.value}
                 variant={selectedDateType === option.value ? "default" : "outline"}
                 className="justify-start"
@@ -510,7 +530,7 @@ export function MobileJobCard({
               >
                 <span className="mr-2">{option.emoji}</span>
                 {option.label}
-              </Button>
+              </GlassButton>
             ))}
           </div>
         </DialogContent>

--- a/src/components/jobs/EditJobDialog.tsx
+++ b/src/components/jobs/EditJobDialog.tsx
@@ -268,7 +268,15 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
   return (
     <>
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] md:max-h-none md:h-auto overflow-y-auto md:overflow-visible">
+      <DialogContent
+        className="max-h-[90vh] md:max-h-none md:h-auto overflow-y-auto md:overflow-visible"
+        glass
+        glassSurfaceProps={{
+          mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+          displacementScale: 0.34,
+          blurAmount: 20,
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Edit Job</DialogTitle>
         </DialogHeader>

--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -317,7 +317,15 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[625px]">
+      <DialogContent
+        className="sm:max-w-[625px]"
+        glass
+        glassSurfaceProps={{
+          mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+          displacementScale: 0.36,
+          blurAmount: 18,
+        }}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center justify-between">
             <span>Manage {currentDepartment} Assignments</span>

--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -321,7 +321,15 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
   if (isJobLoading) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-4xl max-h-[80vh]">
+        <DialogContent
+          className="max-w-4xl max-h-[80vh]"
+          glass
+          glassSurfaceProps={{
+            mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+            displacementScale: 0.32,
+            blurAmount: 20,
+          }}
+        >
           <div className="flex items-center justify-center h-32">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
           </div>
@@ -344,7 +352,15 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[80vh]">
+      <DialogContent
+        className="max-w-4xl max-h-[80vh]"
+        glass
+        glassSurfaceProps={{
+          mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+          displacementScale: 0.32,
+          blurAmount: 20,
+        }}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Calendar className="h-5 w-5" />

--- a/src/components/lights/LightsTaskDialog.tsx
+++ b/src/components/lights/LightsTaskDialog.tsx
@@ -281,7 +281,15 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="p-4 w-[95vw] max-w-[800px] max-h-[80vh] overflow-y-auto">
+      <DialogContent
+        className="p-4 w-[95vw] max-w-[800px] max-h-[80vh] overflow-y-auto"
+        glass
+        glassSurfaceProps={{
+          mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+          displacementScale: 0.36,
+          blurAmount: 20,
+        }}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Table className="h-5 w-5" />

--- a/src/components/logistics/LogisticsEventCard.tsx
+++ b/src/components/logistics/LogisticsEventCard.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { Package, PackageCheck, Truck } from "lucide-react";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
+import { GlassSurface } from "@/components/ui/glass";
 
 interface LogisticsEventCardProps {
   event: any;
@@ -42,25 +43,39 @@ export const LogisticsEventCard = ({
   };
 
   return (
-    <div
+    <GlassSurface
       onClick={onClick}
-      style={{
-        borderColor: borderColor,
-        backgroundColor: getBgColor(),
-      }}
       className={cn(
-        "p-2 bg-card border rounded-md cursor-pointer hover:shadow-md transition-shadow",
+        "relative cursor-pointer overflow-hidden border border-white/10",
+        variant === "calendar" ? "rounded-lg px-3 py-2" : "rounded-xl",
         className
       )}
+      contentClassName={cn(
+        "relative z-[1]",
+        variant === "calendar" ? "flex items-center gap-2" : "flex flex-col gap-2 p-3"
+      )}
+      mobileOptions={{ featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 }}
+      displacementScale={compact ? 0.18 : variant === "calendar" ? 0.2 : 0.32}
+      blurAmount={compact ? 10 : variant === "calendar" ? 12 : 18}
+      fallbackClassName={cn(
+        "relative overflow-hidden border",
+        variant === "calendar" ? "rounded-lg px-3 py-2" : "rounded-xl p-3"
+      )}
+      style={{
+        backgroundImage: getBgColor() ? `linear-gradient(135deg, ${getBgColor()}, transparent)` : undefined,
+      }}
     >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-2 left-0 w-1 rounded-full"
+        style={{ backgroundColor: borderColor }}
+      />
       {variant === "calendar" ? (
-        <div className="flex items-center gap-2">
-          <span className="text-xs">{event.title || event.job?.title}</span>
-        </div>
+        <span className="text-xs font-medium">{event.title || event.job?.title}</span>
       ) : (
         <>
           <div className="flex items-center justify-between gap-2">
-            <Badge 
+            <Badge
               variant={event.event_type === 'load' ? 'default' : 'secondary'}
               className="flex items-center gap-1"
             >
@@ -76,19 +91,19 @@ export const LogisticsEventCard = ({
               <span className="capitalize">{event.transport_type}</span>
             </Badge>
           </div>
-          
-          <h3 className="font-medium mt-2">{event.title || event.job?.title}</h3>
-          <div className="text-sm text-muted-foreground mt-1">
+
+          <h3 className="mt-2 font-medium">{event.title || event.job?.title}</h3>
+          <div className="mt-1 text-sm text-muted-foreground">
             {format(new Date(`2000-01-01T${event.event_time}`), 'HH:mm')}
           </div>
 
           {event.license_plate && (
-            <div className="text-sm text-muted-foreground mt-1">
+            <div className="mt-1 text-sm text-muted-foreground">
               {event.license_plate}
             </div>
           )}
 
-          <div className="flex flex-wrap gap-1 mt-1">
+          <div className="mt-1 flex flex-wrap gap-1">
             {event.departments?.map((dept: any) => (
               <Badge key={dept.department} variant="secondary" className="text-xs">
                 {dept.department}
@@ -97,12 +112,12 @@ export const LogisticsEventCard = ({
           </div>
 
           {event.loading_bay && (
-            <div className="text-sm text-muted-foreground mt-2">
+            <div className="mt-2 text-sm text-muted-foreground">
               Loading Bay: {event.loading_bay}
             </div>
           )}
         </>
       )}
-    </div>
+    </GlassSurface>
   );
 };

--- a/src/components/logistics/LogisticsEventDialog.tsx
+++ b/src/components/logistics/LogisticsEventDialog.tsx
@@ -294,7 +294,15 @@ export const LogisticsEventDialog = ({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-h-[90vh] md:max-h-none md:h-auto overflow-y-auto md:overflow-visible">
+      <DialogContent
+        className="max-h-[90vh] md:max-h-none md:h-auto overflow-y-auto md:overflow-visible"
+        glass
+        glassSurfaceProps={{
+          mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+          displacementScale: 0.34,
+          blurAmount: 22,
+        }}
+      >
           <DialogHeader>
             <DialogTitle>
               {selectedEvent ? "Edit Logistics Event" : "Create Logistics Event"}

--- a/src/components/logistics/MobileLogisticsCalendar.tsx
+++ b/src/components/logistics/MobileLogisticsCalendar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { GlassButton, GlassCard } from "@/components/ui/glass";
 import { Calendar, ChevronLeft, ChevronRight, Plus, Printer } from "lucide-react";
 import { PrintDialog, PrintSettings } from "@/components/dashboard/PrintDialog";
 import { format, addDays, subDays, isToday, isSameDay, isValid } from "date-fns";
@@ -120,60 +120,86 @@ export const MobileLogisticsCalendar: React.FC<MobileLogisticsCalendarProps> = (
   };
 
   return (
-    <Card className="h-full flex flex-col">
+    <GlassCard
+      className="h-full flex flex-col"
+      glassSurfaceClassName="h-full"
+      glassContentClassName="flex flex-col"
+      mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+    >
       <CardHeader className="pb-4">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg font-bold">Logistics</CardTitle>
-          <Button
+          <GlassButton
             onClick={handleAddEvent}
             size="sm"
             className="flex items-center gap-2"
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
           >
             <Plus className="h-4 w-4" />
             Add Event
-          </Button>
+          </GlassButton>
         </div>
-        
+
         <div className="flex items-center justify-between">
-          <Button variant="ghost" size="icon" onClick={navigateToPrevious}>
+          <GlassButton
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            onClick={navigateToPrevious}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <ChevronLeft className="h-4 w-4" />
-          </Button>
-          
+          </GlassButton>
+
           <div className="flex items-center gap-2">
             <Calendar className="h-4 w-4 mr-1" />
-            <span className={cn(
-              "font-medium",
-              isToday(currentDate) && "text-primary"
-                        )}>
+            <span
+              className={cn(
+                "font-medium",
+                isToday(currentDate) && "text-primary"
+              )}
+            >
               {format(currentDate, "EEE, MMM d")}
             </span>
           </div>
-          
-          <Button variant="ghost" size="icon" onClick={navigateToNext}>
+
+          <GlassButton
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            onClick={navigateToNext}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <ChevronRight className="h-4 w-4" />
-          </Button>
+          </GlassButton>
         </div>
-        
+
         {/* Action buttons */}
         <div className="flex items-center justify-between">
           <div /> {/* Spacer */}
-          
-          <Button variant="outline" size="sm" onClick={() => setShowPrintDialog(true)}>
+
+          <GlassButton
+            variant="outline"
+            size="sm"
+            onClick={() => setShowPrintDialog(true)}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <Printer className="h-4 w-4 mr-1" />
             Print
-          </Button>
-          
-          <Button 
-            variant="outline" 
-            size="sm" 
+          </GlassButton>
+
+          <GlassButton
+            variant="outline"
+            size="sm"
             onClick={navigateToToday}
             className={cn(
               isToday(currentDate) && "bg-primary text-primary-foreground"
             )}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
           >
             <Calendar className="h-4 w-4 mr-1" />
             Today
-          </Button>
+          </GlassButton>
         </div>
       </CardHeader>
 
@@ -219,6 +245,6 @@ export const MobileLogisticsCalendar: React.FC<MobileLogisticsCalendarProps> = (
         currentMonth={currentDate}
         selectedJobTypes={[]}
       />
-    </Card>
+    </GlassCard>
   );
 };

--- a/src/components/personal/MobilePersonalCalendar.tsx
+++ b/src/components/personal/MobilePersonalCalendar.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calendar, ChevronLeft, ChevronRight, Users, Warehouse, Briefcase, Sun, CalendarOff, Car, Thermometer, Printer } from "lucide-react";
 import { PrintDialog, PrintSettings } from "@/components/dashboard/PrintDialog";
 import { format, addDays, subDays, isToday, isSameDay, isWithinInterval } from "date-fns";
@@ -10,6 +9,7 @@ import { TechContextMenu } from "./TechContextMenu";
 import { usePersonalCalendarData } from "./hooks/usePersonalCalendarData";
 import { useTechnicianAvailability } from "./hooks/useTechnicianAvailability";
 import { TechDetailModal } from "./TechDetailModal";
+import { GlassButton, GlassCard } from "@/components/ui/glass";
 
 interface MobilePersonalCalendarProps {
   date: Date;
@@ -262,7 +262,12 @@ export const MobilePersonalCalendar: React.FC<MobilePersonalCalendarProps> = ({
 
   if (houseTechs.length === 0) {
     return (
-      <Card className="h-full flex flex-col">
+      <GlassCard
+        className="h-full flex flex-col"
+        glassSurfaceClassName="h-full"
+        glassContentClassName="flex flex-col"
+        mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+      >
         <CardHeader className="pb-4">
           <CardTitle className="text-lg font-bold">House Techs</CardTitle>
         </CardHeader>
@@ -273,23 +278,34 @@ export const MobilePersonalCalendar: React.FC<MobilePersonalCalendarProps> = ({
             Make sure there are users with the 'house_tech' role
           </p>
         </CardContent>
-      </Card>
+      </GlassCard>
     );
   }
 
   return (
     <div className="w-full max-w-[480px] mx-auto sm:max-w-lg">
-      <Card className="h-full flex flex-col">
+      <GlassCard
+        className="h-full flex flex-col"
+        glassSurfaceClassName="h-full"
+        glassContentClassName="flex flex-col"
+        mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+      >
         <CardHeader className="px-2 sm:px-4 py-3">
           <div className="flex items-center justify-between">
             <CardTitle className="text-lg font-bold">House Technicians</CardTitle>
           </div>
-        
+
         <div className="flex items-center justify-between">
-          <Button variant="ghost" size="icon" onClick={navigateToPrevious}>
+          <GlassButton
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            onClick={navigateToPrevious}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <ChevronLeft className="h-4 w-4" />
-          </Button>
-          
+          </GlassButton>
+
           <div className="flex items-center gap-2">
             <Calendar className="h-4 w-4 mr-1" />
             <span className={cn(
@@ -299,40 +315,53 @@ export const MobilePersonalCalendar: React.FC<MobilePersonalCalendarProps> = ({
               {format(currentDate, "EEE, MMM d")}
             </span>
           </div>
-          
-          <Button variant="ghost" size="icon" onClick={navigateToNext}>
+
+          <GlassButton
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9"
+            onClick={navigateToNext}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <ChevronRight className="h-4 w-4" />
-          </Button>
+          </GlassButton>
         </div>
-        
+
         {/* Action buttons */}
         <div className="flex items-center justify-between">
-          <Button 
-            variant="outline" 
+          <GlassButton
+            variant="outline"
             size="sm"
             onClick={() => setSelectedDepartment(null)}
             disabled={!selectedDepartment}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
           >
             <Users className="h-4 w-4 mr-1" />
             {selectedDepartment ? `${selectedDepartment}` : 'All Depts'}
-          </Button>
-          
-          <Button variant="outline" size="sm" onClick={() => setShowPrintDialog(true)}>
+          </GlassButton>
+
+          <GlassButton
+            variant="outline"
+            size="sm"
+            onClick={() => setShowPrintDialog(true)}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
+          >
             <Printer className="h-4 w-4 mr-1" />
             Print
-          </Button>
-          
-          <Button 
-            variant="outline" 
-            size="sm" 
+          </GlassButton>
+
+          <GlassButton
+            variant="outline"
+            size="sm"
             onClick={navigateToToday}
             className={cn(
               isToday(currentDate) && "bg-primary text-primary-foreground"
             )}
+            mobileOptions={{ featureFlag: "mobile_glass_ui" }}
           >
             <Calendar className="h-4 w-4 mr-1" />
             Today
-          </Button>
+          </GlassButton>
         </div>
 
         {/* Personnel Summary Section - Moved to header */}
@@ -484,7 +513,7 @@ export const MobilePersonalCalendar: React.FC<MobilePersonalCalendarProps> = ({
           onAvailabilityRemove={(techId, d) => handleAvailabilityRemove(techId, d)}
         />
       )}
-    </Card>
+      </GlassCard>
     </div>
   );
 };

--- a/src/components/personal/TechContextMenu.tsx
+++ b/src/components/personal/TechContextMenu.tsx
@@ -11,6 +11,7 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
 import { Calendar, Plane, Stethoscope, CalendarOff, Warehouse } from 'lucide-react';
+import { GlassSurface } from '@/components/ui/glass';
 
 interface TechContextMenuProps {
   children: React.ReactNode;
@@ -45,40 +46,56 @@ export const TechContextMenu: React.FC<TechContextMenuProps> = ({
       <ContextMenuTrigger asChild>
         {children}
       </ContextMenuTrigger>
-      <ContextMenuContent className="w-56">
-        <ContextMenuSub>
-          <ContextMenuSubTrigger>
-            <Calendar className="mr-2 h-4 w-4" />
-            Mark as Unavailable
-          </ContextMenuSubTrigger>
-          <ContextMenuSubContent className="w-48">
-            <ContextMenuItem onClick={() => handleUnavailable('vacation')}>
+      <ContextMenuContent className="w-56 border-0 bg-transparent p-0 shadow-none">
+        <GlassSurface
+          className="overflow-hidden"
+          contentClassName="flex flex-col py-2"
+          mobileOptions={{ featureFlag: 'mobile_glass_ui', minimumDeviceMemory: 3 }}
+          displacementScale={0.28}
+          blurAmount={16}
+        >
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
               <Calendar className="mr-2 h-4 w-4" />
-              Vacation
-            </ContextMenuItem>
-            <ContextMenuItem onClick={() => handleUnavailable('travel')}>
-              <Plane className="mr-2 h-4 w-4" />
-              Travel
-            </ContextMenuItem>
-            <ContextMenuItem onClick={() => handleUnavailable('sick')}>
-              <Stethoscope className="mr-2 h-4 w-4" />
-              Sick Day
-            </ContextMenuItem>
-            <ContextMenuItem onClick={() => handleUnavailable('day_off')}>
-              <CalendarOff className="mr-2 h-4 w-4" />
-              Day Off
-            </ContextMenuItem>
-            <ContextMenuItem onClick={() => handleUnavailable('warehouse')}>
-              <Warehouse className="mr-2 h-4 w-4" />
-              Mark as In Warehouse
-            </ContextMenuItem>
-          </ContextMenuSubContent>
-        </ContextMenuSub>
-        <ContextMenuSeparator />
-        <ContextMenuItem onClick={handleRemoveAvailability}>
-          <Calendar className="mr-2 h-4 w-4" />
-          Remove Override
-        </ContextMenuItem>
+              Mark as Unavailable
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent className="w-48 border-0 bg-transparent p-0 shadow-none">
+              <GlassSurface
+                className="overflow-hidden"
+                contentClassName="flex flex-col py-2"
+                mobileOptions={{ featureFlag: 'mobile_glass_ui', minimumDeviceMemory: 3 }}
+                displacementScale={0.24}
+                blurAmount={14}
+              >
+                <ContextMenuItem onClick={() => handleUnavailable('vacation')}>
+                  <Calendar className="mr-2 h-4 w-4" />
+                  Vacation
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleUnavailable('travel')}>
+                  <Plane className="mr-2 h-4 w-4" />
+                  Travel
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleUnavailable('sick')}>
+                  <Stethoscope className="mr-2 h-4 w-4" />
+                  Sick Day
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleUnavailable('day_off')}>
+                  <CalendarOff className="mr-2 h-4 w-4" />
+                  Day Off
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => handleUnavailable('warehouse')}>
+                  <Warehouse className="mr-2 h-4 w-4" />
+                  Mark as In Warehouse
+                </ContextMenuItem>
+              </GlassSurface>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+          <ContextMenuSeparator />
+          <ContextMenuItem onClick={handleRemoveAvailability}>
+            <Calendar className="mr-2 h-4 w-4" />
+            Remove Override
+          </ContextMenuItem>
+        </GlassSurface>
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/personal/TechDetailModal.tsx
+++ b/src/components/personal/TechDetailModal.tsx
@@ -2,12 +2,12 @@
 import React from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { format } from 'date-fns';
 import { formatInJobTimezone } from '@/utils/timezoneUtils';
 import { MapPin, Clock, User, Phone, Briefcase, Calendar, Plane, Stethoscope, Home, X, Warehouse } from 'lucide-react';
 import { labelForCode } from '@/utils/roles';
 import { formatUserName } from '@/utils/userName';
+import { GlassButton } from '@/components/ui/glass';
 
 interface TechDetailModalProps {
   open: boolean;
@@ -104,7 +104,15 @@ export const TechDetailModal: React.FC<TechDetailModalProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
+      <DialogContent
+        className="max-w-sm"
+        glass
+        glassSurfaceProps={{
+          mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+          displacementScale: 0.36,
+          blurAmount: 20,
+        }}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <User className="h-4 w-4 text-primary" />
@@ -143,14 +151,15 @@ export const TechDetailModal: React.FC<TechDetailModalProps> = ({
                 <p className="text-sm text-muted-foreground">
                   {getAvailabilityStatusText()} on {format(date, 'MMM d, yyyy')}
                 </p>
-                <Button
+                <GlassButton
                   variant="ghost"
                   size="sm"
                   onClick={handleRemoveAvailability}
-                  className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                  mobileOptions={{ featureFlag: "mobile_glass_ui" }}
                 >
                   <X className="h-3 w-3" />
-                </Button>
+                </GlassButton>
               </div>
               <p className="text-xs text-orange-600">Not available for assignment</p>
             </div>
@@ -215,51 +224,56 @@ export const TechDetailModal: React.FC<TechDetailModalProps> = ({
             <div className="border-t pt-3">
               <h5 className="font-medium text-sm mb-2">Mark as Unavailable</h5>
               <div className="grid grid-cols-1 gap-2">
-                <Button
+                <GlassButton
                   variant="outline"
                   size="sm"
                   onClick={() => handleUnavailableClick('vacation')}
                   className="justify-start"
+                  mobileOptions={{ featureFlag: "mobile_glass_ui" }}
                 >
                   <Calendar className="mr-2 h-3 w-3" />
                   Vacation
-                </Button>
-                <Button
+                </GlassButton>
+                <GlassButton
                   variant="outline"
                   size="sm"
                   onClick={() => handleUnavailableClick('travel')}
                   className="justify-start"
+                  mobileOptions={{ featureFlag: "mobile_glass_ui" }}
                 >
                   <Plane className="mr-2 h-3 w-3" />
                   Travel
-                </Button>
-                <Button
+                </GlassButton>
+                <GlassButton
                   variant="outline"
                   size="sm"
                   onClick={() => handleUnavailableClick('sick')}
                   className="justify-start"
+                  mobileOptions={{ featureFlag: "mobile_glass_ui" }}
                 >
                   <Stethoscope className="mr-2 h-3 w-3" />
                   Sick Day
-                </Button>
-                <Button
+                </GlassButton>
+                <GlassButton
                   variant="outline"
                   size="sm"
                   onClick={() => handleUnavailableClick('day_off')}
                   className="justify-start"
+                  mobileOptions={{ featureFlag: "mobile_glass_ui" }}
                 >
                   <Home className="mr-2 h-3 w-3" />
                   Day Off
-                </Button>
-                <Button
+                </GlassButton>
+                <GlassButton
                   variant="outline"
                   size="sm"
                   onClick={() => handleUnavailableClick('warehouse')}
                   className="justify-start"
+                  mobileOptions={{ featureFlag: "mobile_glass_ui" }}
                 >
                   <Warehouse className="mr-2 h-3 w-3" />
                   Mark as In Warehouse
-                </Button>
+                </GlassButton>
               </div>
             </div>
           )}

--- a/src/components/sound/SoundTaskDialog.tsx
+++ b/src/components/sound/SoundTaskDialog.tsx
@@ -382,7 +382,15 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
 
    return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-full max-w-4xl h-[90vh] flex flex-col p-0">
+      <DialogContent
+        className="w-full max-w-4xl h-[90vh] flex flex-col p-0"
+        glass
+        glassSurfaceProps={{
+          mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+          displacementScale: 0.38,
+          blurAmount: 22,
+        }}
+      >
         <DialogHeader className="px-4 py-2 flex flex-row items-center justify-between border-b">
           <DialogTitle className="flex items-center gap-2">
             <Table className="h-5 w-5" />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,6 +3,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { GlassSurface, type GlassSurfaceProps } from "@/components/ui/glass"
 
 const Dialog = DialogPrimitive.Root
 
@@ -27,28 +28,71 @@ const DialogOverlay = React.forwardRef<
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  glass?: boolean
+  glassSurfaceProps?: Partial<GlassSurfaceProps>
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
+  DialogContentProps
+>(({ className, children, glass = false, glassSurfaceProps, ...props }, ref) => {
+  const {
+    className: surfaceClassName,
+    contentClassName: surfaceContentClassName,
+    mobileOptions,
+    displacementScale,
+    blurAmount,
+    cornerRadius,
+    variant,
+    disabled,
+    ...surfaceRest
+  } = glassSurfaceProps ?? {}
+
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          glass && "border-0 bg-transparent p-0 shadow-none",
+          className
+        )}
+        {...props}
+      >
+        {glass ? (
+          <GlassSurface
+            {...surfaceRest}
+            variant={variant ?? "dark"}
+            displacementScale={displacementScale ?? 0.52}
+            blurAmount={blurAmount ?? 26}
+            cornerRadius={cornerRadius ?? 26}
+            mobileOptions={{ allowDesktop: true, ...mobileOptions }}
+            className={cn("h-full w-full", surfaceClassName)}
+            contentClassName={cn("relative flex h-full w-full flex-col gap-4 p-6", surfaceContentClassName)}
+            disabled={disabled}
+          >
+            {children}
+            <DialogPrimitive.Close className="absolute right-4 top-4 inline-flex size-8 items-center justify-center rounded-full border border-white/20 bg-black/40 text-white shadow-lg backdrop-blur focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          </GlassSurface>
+        ) : (
+          <>
+            {children}
+            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          </>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+})
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
 import { cn } from "@/lib/utils"
+import { GlassSurface, type GlassSurfaceProps } from "@/components/ui/glass"
 
 const Drawer = ({
   shouldScaleBackground = true,
@@ -32,25 +33,62 @@ const DrawerOverlay = React.forwardRef<
 ))
 DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
 
+interface DrawerContentProps
+  extends React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> {
+  glass?: boolean
+  glassSurfaceProps?: Partial<GlassSurfaceProps>
+}
+
 const DrawerContent = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DrawerPortal>
-    <DrawerOverlay />
-    <DrawerPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
-        className
-      )}
-      {...props}
-    >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
-      {children}
-    </DrawerPrimitive.Content>
-  </DrawerPortal>
-))
+  DrawerContentProps
+>(({ className, children, glass = false, glassSurfaceProps, ...props }, ref) => {
+  const {
+    className: surfaceClassName,
+    contentClassName: surfaceContentClassName,
+    mobileOptions,
+    displacementScale,
+    blurAmount,
+    cornerRadius,
+    variant,
+    disabled,
+    ...surfaceRest
+  } = glassSurfaceProps ?? {}
+
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+          glass && "border-0 bg-transparent shadow-none",
+          className,
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+        {glass ? (
+          <GlassSurface
+            {...surfaceRest}
+            variant={variant ?? "dark"}
+            displacementScale={displacementScale ?? 0.48}
+            blurAmount={blurAmount ?? 22}
+            cornerRadius={cornerRadius ?? 28}
+            mobileOptions={{ allowDesktop: true, ...mobileOptions }}
+            className={cn("mt-2 h-full w-full", surfaceClassName)}
+            contentClassName={cn("relative flex h-full w-full flex-col gap-4 p-6", surfaceContentClassName)}
+            disabled={disabled}
+          >
+            {children}
+          </GlassSurface>
+        ) : (
+          children
+        )}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+})
 DrawerContent.displayName = "DrawerContent"
 
 const DrawerHeader = ({

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react"
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { GlassSurface, type GlassSurfaceProps } from "@/components/ui/glass"
 
 const Sheet = SheetPrimitive.Root
 
@@ -49,27 +50,70 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-  VariantProps<typeof sheetVariants> { }
+    VariantProps<typeof sheetVariants> {
+  glass?: boolean
+  glassSurfaceProps?: Partial<GlassSurfaceProps>
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
+>(({ side = "right", className, children, glass = false, glassSurfaceProps, ...props }, ref) => {
+  const {
+    className: surfaceClassName,
+    contentClassName: surfaceContentClassName,
+    mobileOptions,
+    displacementScale,
+    blurAmount,
+    cornerRadius,
+    variant,
+    disabled,
+    ...surfaceRest
+  } = glassSurfaceProps ?? {}
+
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(
+          sheetVariants({ side }),
+          glass && "border-0 bg-transparent p-0 shadow-none",
+          className,
+        )}
+        {...props}
+      >
+        {glass ? (
+          <GlassSurface
+            {...surfaceRest}
+            variant={variant ?? "dark"}
+            displacementScale={displacementScale ?? 0.5}
+            blurAmount={blurAmount ?? 24}
+            cornerRadius={cornerRadius ?? (side === "bottom" || side === "top" ? 24 : 28)}
+            mobileOptions={{ allowDesktop: true, ...mobileOptions }}
+            className={cn("h-full w-full", surfaceClassName)}
+            contentClassName={cn("relative flex h-full w-full flex-col gap-4 p-6", surfaceContentClassName)}
+            disabled={disabled}
+          >
+            {children}
+            <SheetPrimitive.Close className="absolute right-4 top-4 inline-flex size-8 items-center justify-center rounded-full border border-white/20 bg-black/35 text-white shadow-lg backdrop-blur focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </SheetPrimitive.Close>
+          </GlassSurface>
+        ) : (
+          <>
+            {children}
+            <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+              <X className="h-4 w-4" />
+              <span className="sr-only">Close</span>
+            </SheetPrimitive.Close>
+          </>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+})
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -4,6 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { GlassSurface, type GlassSurfaceProps } from "@/components/ui/glass"
 
 const ToastProvider = ToastPrimitives.Provider
 
@@ -38,17 +39,64 @@ const toastVariants = cva(
   }
 )
 
+interface ToastPropsInternal
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root>,
+    VariantProps<typeof toastVariants> {
+  glass?: boolean
+  glassSurfaceProps?: Partial<GlassSurfaceProps>
+}
+
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
-    VariantProps<typeof toastVariants>
->(({ className, variant, ...props }, ref) => {
+  ToastPropsInternal
+>(({ className, variant, glass = false, glassSurfaceProps, children, ...props }, ref) => {
+  const {
+    className: surfaceClassName,
+    contentClassName: surfaceContentClassName,
+    mobileOptions,
+    displacementScale,
+    blurAmount,
+    cornerRadius,
+    variant: surfaceVariant,
+    disabled,
+    ...surfaceRest
+  } = glassSurfaceProps ?? {}
+
+  if (!glass) {
+    return (
+      <ToastPrimitives.Root
+        ref={ref}
+        className={cn(toastVariants({ variant }), className)}
+        {...props}
+      >
+        {children}
+      </ToastPrimitives.Root>
+    )
+  }
+
   return (
     <ToastPrimitives.Root
       ref={ref}
-      className={cn(toastVariants({ variant }), className)}
+      className={cn(
+        "pointer-events-auto relative w-full border-0 bg-transparent p-0 shadow-none",
+        className,
+      )}
       {...props}
-    />
+    >
+      <GlassSurface
+        {...surfaceRest}
+        variant={surfaceVariant ?? "dark"}
+        displacementScale={displacementScale ?? 0.48}
+        blurAmount={blurAmount ?? 20}
+        cornerRadius={cornerRadius ?? 20}
+        mobileOptions={{ allowDesktop: true, ...mobileOptions }}
+        className={cn("w-full", surfaceClassName)}
+        contentClassName={cn("relative flex w-full items-start gap-3 p-4", surfaceContentClassName)}
+        disabled={disabled}
+      >
+        {children}
+      </GlassSurface>
+    </ToastPrimitives.Root>
   )
 })
 Toast.displayName = ToastPrimitives.Root.displayName

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -15,8 +15,17 @@ export function Toaster() {
     <ToastProvider>
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
-          <Toast key={id} {...props}>
-            <div className="grid gap-1">
+          <Toast
+            key={id}
+            glass
+            glassSurfaceProps={{
+              mobileOptions: { allowDesktop: true },
+              displacementScale: 0.42,
+              blurAmount: 18,
+            }}
+            {...props}
+          >
+            <div className="grid gap-1 text-sm">
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && (
                 <ToastDescription>{description}</ToastDescription>

--- a/src/components/video/VideoTaskDialog.tsx
+++ b/src/components/video/VideoTaskDialog.tsx
@@ -281,7 +281,15 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="p-4 w-[95vw] max-w-[800px] max-h-[80vh] overflow-y-auto">
+      <DialogContent
+        className="p-4 w-[95vw] max-w-[800px] max-h-[80vh] overflow-y-auto"
+        glass
+        glassSurfaceProps={{
+          mobileOptions: { featureFlag: "mobile_glass_ui", minimumDeviceMemory: 3 },
+          displacementScale: 0.36,
+          blurAmount: 20,
+        }}
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Table className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- wrap mobile calendar, job, and logistics surfaces in glass primitives gated by the `mobile_glass_ui` flag
- update modal, sheet, drawer, and toast infrastructure to support frosted glass variants and apply them across task dialogs
- document usage patterns for the liquid glass primitives in the design system guide

## Testing
- `npm run lint` *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3e7f413b0832fb14d340ee93bb11e