### PR TITLE
Add comercial extras folder creation logic

### DIFF
--- a/src/utils/flex-folders/constants.ts
+++ b/src/utils/flex-folders/constants.ts
@@ -9,6 +9,7 @@ export const FLEX_FOLDER_IDS = {
   mainResponsible: "4bc2df20-e700-11ea-97d0-2a0a4490a7fb",
   documentacionTecnica: "3787806c-af2d-11df-b8d5-00e08175e43e",
   presupuestosRecibidos: "3787806c-af2d-11df-b8d5-00e08175e43e",
+  presupuesto: "9bfb850c-b117-11df-b8d5-00e08175e43e",
   hojaGastos: "566d32e0-1a1e-11e0-a472-00e08175e43e",
   hojaInfoSx: "702029c3-ba89-4304-98fe-fbc6fc695eb0",
   hojaInfoLx: "4db54bad-b5fa-4c1f-85d4-525d991d7b62",

--- a/src/utils/flex-folders/types.ts
+++ b/src/utils/flex-folders/types.ts
@@ -19,7 +19,9 @@ export type SubfolderKey =
   | "pullSheetPA" // PA pull sheet (sound, hidden by tour-pack-only)
   | "gastosDePersonal" // Personnel: “Gastos de Personal - ${job.title}”
   | "crewCallSound" // Personnel: Crew Call Sonido
-  | "crewCallLights"; // Personnel: Crew Call Luces
+  | "crewCallLights" // Personnel: Crew Call Luces
+  | "extrasSound" // Comercial extras for sound
+  | "extrasLights"; // Comercial extras for lights
 
 export type CreateFoldersOptions = Partial<Record<DepartmentKey, SubfolderKey[]>>;
 


### PR DESCRIPTION
## Summary
- add the Flex presupuesto folder id constant and expose new comercial extras subfolder keys
- create shared helper to add sonido and luces extras under comercial departments for tour and standard jobs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f412509698832fbc6c3c9ee7e27e0d