### PR TITLE
Add dry hire presupuesto flex folder creation

### DIFF
--- a/src/utils/flex-folders/constants.ts
+++ b/src/utils/flex-folders/constants.ts
@@ -10,6 +10,7 @@ export const FLEX_FOLDER_IDS = {
   documentacionTecnica: "3787806c-af2d-11df-b8d5-00e08175e43e",
   presupuestosRecibidos: "3787806c-af2d-11df-b8d5-00e08175e43e",
   presupuesto: "9bfb850c-b117-11df-b8d5-00e08175e43e",
+  presupuestoDryHire: "fb8b82c9-41d6-4b8f-99b6-4ab8276d06aa",
   hojaGastos: "566d32e0-1a1e-11e0-a472-00e08175e43e",
   hojaInfoSx: "702029c3-ba89-4304-98fe-fbc6fc695eb0",
   hojaInfoLx: "4db54bad-b5fa-4c1f-85d4-525d991d7b62",

--- a/src/utils/flex-folders/folders.ts
+++ b/src/utils/flex-folders/folders.ts
@@ -170,6 +170,7 @@ export async function createAllFoldersForJob(
       throw new Error(`No parent folder found for month ${monthKey}`);
     }
 
+    const parentDocumentNumber = `${documentNumber}${DEPARTMENT_SUFFIXES[department as Department]}`;
     const dryHireFolderPayload = {
       definitionId: FLEX_FOLDER_IDS.subFolder,
       parentElementId: parentFolderId,
@@ -180,12 +181,27 @@ export async function createAllFoldersForJob(
       plannedEndDate: formattedEndDate,
       locationId: FLEX_FOLDER_IDS.location,
       departmentId: DEPARTMENT_IDS[department as Department],
-      documentNumber: `${documentNumber}${DEPARTMENT_SUFFIXES[department as Department]}`,
+      documentNumber: parentDocumentNumber,
       personResponsibleId: RESPONSIBLE_PERSON_IDS[department as Department],
     };
 
     console.log("Creating dryhire folder with payload:", dryHireFolderPayload);
     const dryHireFolder = await createFlexFolder(dryHireFolderPayload);
+
+    const dryHireDocumentSuffix = department === "sound" ? "SDH" : "LDH";
+    await createFlexFolder({
+      definitionId: FLEX_FOLDER_IDS.presupuestoDryHire,
+      parentElementId: dryHireFolder.elementId,
+      open: true,
+      locked: false,
+      name: dryHireFolderPayload.name,
+      plannedStartDate: dryHireFolderPayload.plannedStartDate,
+      plannedEndDate: dryHireFolderPayload.plannedEndDate,
+      locationId: dryHireFolderPayload.locationId,
+      departmentId: dryHireFolderPayload.departmentId,
+      documentNumber: `${parentDocumentNumber}${dryHireDocumentSuffix}`,
+      personResponsibleId: dryHireFolderPayload.personResponsibleId,
+    });
 
     await supabase
       .from("flex_folders")


### PR DESCRIPTION
## Summary
- add the presupuestoDryHire flex folder definition id to the constants list
- automatically create a dry hire presupuesto folder beneath the generated dry hire folder with an SDH/LDH document number suffix

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f413ccb710832fa131f6a724a47474