### PR TITLE
Add comercial extras defaults in Flex folder picker

### DIFF
--- a/src/components/flex/FlexFolderPicker.tsx
+++ b/src/components/flex/FlexFolderPicker.tsx
@@ -71,7 +71,18 @@ const DEPARTMENT_SECTIONS: Record<DepartmentKey, DepartmentSection> = {
   },
   comercial: {
     label: "Comercial",
-    items: [],
+    items: [
+      {
+        key: "extrasSound",
+        label: "Extras Sonido",
+        description: "Genera el presupuesto de extras para el equipo de sonido.",
+      },
+      {
+        key: "extrasLights",
+        label: "Extras Luces",
+        description: "Genera el presupuesto de extras para el equipo de luces.",
+      },
+    ],
   },
 };
 
@@ -92,7 +103,7 @@ const DEFAULT_SELECTIONS: Record<DepartmentKey, SubfolderKey[]> = {
     "hojaGastos",
   ],
   personnel: ["gastosDePersonal", "crewCallSound", "crewCallLights"],
-  comercial: [],
+  comercial: ["extrasSound", "extrasLights"],
 };
 
 const departmentEntries = Object.entries(DEPARTMENT_SECTIONS) as [


### PR DESCRIPTION
## Summary
- add the Comercial extras folders to the picker with descriptive labels
- enable Extras Sonido and Extras Luces in the default Comercial selection

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68f4143b8ef8832f94b3e13dccbad4fa