### PR TITLE
Use subfolder definition for comercial extras

### DIFF
--- a/src/utils/flex-folders/folders.ts
+++ b/src/utils/flex-folders/folders.ts
@@ -137,7 +137,7 @@ export async function createAllFoldersForJob(
       const extrasName = `Extras ${baseName} - ${deptLabel}`;
 
       const extrasPayload = {
-        definitionId: FLEX_FOLDER_IDS.presupuesto,
+        definitionId: FLEX_FOLDER_IDS.subFolder,
         parentElementId,
         open: true,
         locked: false,


### PR DESCRIPTION
## Summary
- update comercial extras folder creation to use the standard subfolder definition while retaining department-specific metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4963ac1d0832f9df3182cd5e9dbd7