### PR TITLE
Add comercial presupuesto folder options

### DIFF
--- a/src/components/flex/FlexFolderPicker.tsx
+++ b/src/components/flex/FlexFolderPicker.tsx
@@ -78,9 +78,21 @@ const DEPARTMENT_SECTIONS: Record<DepartmentKey, DepartmentSection> = {
         description: "Genera el presupuesto de extras para el equipo de sonido.",
       },
       {
+        key: "presupuestoSound",
+        label: "Presupuesto Sonido",
+        description:
+          "Crea el presupuesto principal para sonido usando el nombre del departamento/fecha en lugar de Comercial.",
+      },
+      {
         key: "extrasLights",
         label: "Extras Luces",
         description: "Genera el presupuesto de extras para el equipo de luces.",
+      },
+      {
+        key: "presupuestoLights",
+        label: "Presupuesto Luces",
+        description:
+          "Crea el presupuesto principal para luces usando el nombre del departamento/fecha en lugar de Comercial.",
       },
     ],
   },
@@ -103,7 +115,12 @@ const DEFAULT_SELECTIONS: Record<DepartmentKey, SubfolderKey[]> = {
     "hojaGastos",
   ],
   personnel: ["gastosDePersonal", "crewCallSound", "crewCallLights"],
-  comercial: ["extrasSound", "extrasLights"],
+  comercial: [
+    "extrasSound",
+    "presupuestoSound",
+    "extrasLights",
+    "presupuestoLights",
+  ],
 };
 
 const departmentEntries = Object.entries(DEPARTMENT_SECTIONS) as [

--- a/src/utils/flex-folders/folders.ts
+++ b/src/utils/flex-folders/folders.ts
@@ -126,22 +126,28 @@ export async function createAllFoldersForJob(
     const parentDoc = parentDocumentNumber ?? "";
     const deptLabel = "Comercial";
     const replacements = [
-      { key: "extrasSound" as const, label: "Sonido", dept: "sound" as const, suffix: "SQT" },
-      { key: "extrasLights" as const, label: "Luces", dept: "lights" as const, suffix: "LQT" },
+      {
+        label: "Sonido",
+        dept: "sound" as const,
+        suffix: "SQT",
+        extrasKey: "extrasSound" as const,
+        presupuestoKey: "presupuestoSound" as const,
+      },
+      {
+        label: "Luces",
+        dept: "lights" as const,
+        suffix: "LQT",
+        extrasKey: "extrasLights" as const,
+        presupuestoKey: "presupuestoLights" as const,
+      },
     ];
 
     for (const extra of replacements) {
-      if (!shouldCreateItem("comercial", extra.key, options)) continue;
-
       const baseName = parentName.replace(/Comercial/gi, extra.label);
-      const extrasName = `Extras ${baseName} - ${deptLabel}`;
-
-      const extrasPayload = {
-        definitionId: FLEX_FOLDER_IDS.subFolder,
+      const sharedPayload = {
         parentElementId,
         open: true,
         locked: false,
-        name: extrasName,
         plannedStartDate: formattedStartDate,
         plannedEndDate: formattedEndDate,
         locationId: FLEX_FOLDER_IDS.location,
@@ -150,7 +156,27 @@ export async function createAllFoldersForJob(
         personResponsibleId: RESPONSIBLE_PERSON_IDS[extra.dept as Department],
       };
 
-      await createFlexFolder(extrasPayload);
+      if (shouldCreateItem("comercial", extra.extrasKey, options)) {
+        const extrasName = `Extras ${baseName} - ${deptLabel}`;
+        const extrasPayload = {
+          definitionId: FLEX_FOLDER_IDS.subFolder,
+          name: extrasName,
+          ...sharedPayload,
+        };
+
+        await createFlexFolder(extrasPayload);
+      }
+
+      if (shouldCreateItem("comercial", extra.presupuestoKey, options)) {
+        const presupuestoName = `Presupuesto ${baseName}`;
+        const presupuestoPayload = {
+          definitionId: FLEX_FOLDER_IDS.presupuesto,
+          name: presupuestoName,
+          ...sharedPayload,
+        };
+
+        await createFlexFolder(presupuestoPayload);
+      }
     }
   };
 

--- a/src/utils/flex-folders/types.ts
+++ b/src/utils/flex-folders/types.ts
@@ -21,7 +21,9 @@ export type SubfolderKey =
   | "crewCallSound" // Personnel: Crew Call Sonido
   | "crewCallLights" // Personnel: Crew Call Luces
   | "extrasSound" // Comercial extras for sound
-  | "extrasLights"; // Comercial extras for lights
+  | "extrasLights" // Comercial extras for lights
+  | "presupuestoSound" // Comercial presupuesto for sound
+  | "presupuestoLights"; // Comercial presupuesto for lights
 
 export type CreateFoldersOptions = Partial<Record<DepartmentKey, SubfolderKey[]>>;
 


### PR DESCRIPTION
## Summary
- add SubfolderKey entries for comercial presupuesto folders
- update the Flex folder picker to expose the new presupuesto checkboxes by default
- create presupuesto elements that mirror the extras metadata while renaming Comercial to the target department/date

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f496fcb290832f89e1785be955e8c1