### PR TITLE
Add flex folder workflow documentation

### DIFF
--- a/docs/flex-folder-workflows.md
+++ b/docs/flex-folder-workflows.md
@@ -1,0 +1,43 @@
+# Flex Folder Creation Workflows Audit
+
+## Overview
+This document summarizes how Flex folders are provisioned for jobs, tours, and tour dates in the application. It captures entry points, supporting utilities, Supabase functions, and database side effects so future updates can maintain parity across workflows.
+
+## Job Flex Folder Creation
+
+### Entry Points in the UI
+* **Job cards (dashboard & jobs list).** Both `Dashboard JobCardNew` and the job card used in the jobs list expose "Create Flex folders" actions. Each checks for an existing `flex_folders` row for the job, builds the Flex timestamps/document number, and then calls the shared creation helper before marking `jobs.flex_folders_created` and refreshing queries.【F:src/components/dashboard/JobCardNew.tsx†L516-L583】【F:src/components/jobs/cards/JobCardNew.tsx†L523-L583】
+* **Shared job action hook.** `useJobActions` provides the same creation routine for components that rely on the hook (including legacy card implementations). It prevents duplicate requests, invokes the helper, updates the job record, and fires a push notification broadcast.【F:src/hooks/useJobActions.ts†L100-L141】
+* **Tour-date automation hook.** `useTourDateFlexFolders` bulk-creates folders for every tour date by locating its associated job and reusing the job helper. It maintains mutation state, updates `jobs.flex_folders_created`, and invalidates both job and tour-date queries.【F:src/hooks/useTourDateFlexFolders.ts†L8-L158】
+
+### Core Helper: `createAllFoldersForJob`
+The heavy lifting lives in `src/utils/flex-folders/folders.ts`. The helper orchestrates Flex API calls and local persistence with nuanced handling per job type.【F:src/utils/flex-folders/folders.ts†L245-L740】 Key behaviors:
+
+* **Dry hire jobs.** Resolve the department-specific monthly parent folder, create the dry hire subfolder plus a linked "Presupuesto" child, and register the Flex element in `flex_folders` as a `dryhire` row.【F:src/utils/flex-folders/folders.ts†L200-L242】
+* **Tour date jobs.** Require existing tour root folders, look up selected departments, and create department subfolders beneath the tour’s saved Flex IDs. Each folder is stored locally (`folder_type: "tourdate"`) and optional structures (hoja info, documentación técnica, pull sheets, crew calls, etc.) are gated by department selections and UI options.【F:src/utils/flex-folders/folders.ts†L252-L533】 Crew call elements update `flex_crew_calls` so the job retains pointers back to Flex.【F:src/utils/flex-folders/folders.ts†L506-L533】
+* **Standard jobs.** Create the main event folder, persist it (`folder_type: "main_event"`), and then iterate per department. The helper respects department enablement, provisions specialty elements (hoja info, documentación técnica, presupuestos, gastos, comercial extras, crew calls), and writes the relationships into `flex_folders` with `folder_type: "department"` for traceability.【F:src/utils/flex-folders/folders.ts†L538-L737】
+
+All branches call the shared `createFlexFolder` fetch wrapper (Flex API `POST /element`) and rely on `supabase` inserts to mirror the Flex hierarchy locally.【F:src/utils/flex-folders/api.ts†L1-L28】【F:src/utils/flex-folders/folders.ts†L556-L609】
+
+### Legacy Helper
+`src/utils/flexFolders.ts` still exports a simplified `createAllFoldersForJob` that only seeds static Flex element IDs into the database without calling the Flex API. Some components (e.g., `useJobActions`) still import this legacy module, so the codebase currently mixes the old stub with the new API-driven helper.【F:src/utils/flexFolders.ts†L1-L52】【F:src/hooks/useJobActions.ts†L3-L16】
+
+## Tour and Tour-Date Flex Folder Workflows
+
+### Supabase Edge Function (`create-flex-folders`)
+Tours can trigger folder creation via the edge function at `supabase/functions/create-flex-folders/index.ts`:
+
+* **Root folders.** The function determines enabled departments from tour jobs, creates the main folder plus department subfolders in Flex, persists created IDs back onto the `tours` row, and logs management-visible activity events.【F:supabase/functions/create-flex-folders/index.ts†L138-L235】
+* **Date folders.** When asked to build tour-date folders, it enumerates dates, creates a date folder under the tour’s main element, conditionally creates department folders beneath each date, and inserts a `flex_folders` record tied to the `tour_date_id`. It also broadcasts a `flex.tourdate_folder.created` push notification and logs activity.【F:supabase/functions/create-flex-folders/index.ts†L237-L378】
+
+The UI wires into this function through `createTourRootFolders` and `createTourDateFolders` utilities, which invoke the function with the appropriate payload and bubble errors to the calling components.【F:src/utils/tourFolders.ts†L14-L63】 `TourCard` exposes these flows to users, blocking date-folder creation until root folders exist.【F:src/components/tours/TourCard.tsx†L110-L160】
+
+### Manual Root Folder Creation
+For cases where Flex access must be proxied differently, `createTourRootFoldersManual` calls the `secure-flex-api` function to create the main tour folder plus department subfolders, mirrors auxiliary elements (hoja info, documentación técnica, etc.), persists IDs into both `tours` and `flex_folders`, and returns the collected metadata.【F:src/utils/tourFolders.ts†L66-L286】 This path mirrors the job folder structure to keep numbering and subfolders consistent.
+
+### Tour-Date Jobs via UI Hook
+When a user opts to generate folders for individual tour dates from the management dialog, the `useTourDateFlexFolders` hook described above executes the job helper for each date, ensuring tour-level jobs gain the same folder structure as stand-alone jobs.【F:src/hooks/useTourDateFlexFolders.ts†L13-L158】
+
+## Observations
+* The repository still exports two differently implemented `createAllFoldersForJob` helpers (one API-driven, one legacy). Aligning all imports on the modern helper would avoid silent no-op behavior when only the database stub runs.【F:src/utils/flex-folders/folders.ts†L245-L740】【F:src/utils/flexFolders.ts†L1-L52】
+* Each workflow writes to the `flex_folders` table to mirror remote structure, so any schema changes should remain backward compatible with these inserts (job, dryhire, tourdate, and tour department folder types).【F:src/utils/flex-folders/folders.ts†L232-L239】【F:supabase/functions/create-flex-folders/index.ts†L292-L301】


### PR DESCRIPTION
## Summary
- add documentation describing job, tour, and tour-date Flex folder creation flows
- capture key UI entry points, helper utilities, and Supabase functions involved in folder provisioning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f49f25ce98832fa4c2185c68e475a0