### PR TITLE
feat: extend flex folder picker options

### DIFF
--- a/src/utils/flex-folders/folders.ts
+++ b/src/utils/flex-folders/folders.ts
@@ -1,7 +1,11 @@
 import { format } from "date-fns";
 import { supabase } from "@/lib/supabase";
 import { Department } from "@/types/department";
-import { CreateFoldersOptions, DepartmentKey, SubfolderKey } from "./types";
+import {
+  CreateFoldersOptions,
+  DepartmentKey,
+  SubfolderKey,
+} from "./types";
 import { createFlexFolder } from "./api";
 import {
   FLEX_FOLDER_IDS,
@@ -100,7 +104,8 @@ function shouldCreateItem(
   options?: CreateFoldersOptions
 ): boolean {
   if (!options || options[dept] === undefined) return true;
-  const list = options[dept]!;
+  const list = options[dept]?.subfolders;
+  if (!list) return true;
   return list.includes(key);
 }
 

--- a/src/utils/flex-folders/types.ts
+++ b/src/utils/flex-folders/types.ts
@@ -25,7 +25,27 @@ export type SubfolderKey =
   | "presupuestoSound" // Comercial presupuesto for sound
   | "presupuestoLights"; // Comercial presupuesto for lights
 
-export type CreateFoldersOptions = Partial<Record<DepartmentKey, SubfolderKey[]>>;
+export interface CustomPullsheetSettings {
+  enabled: boolean;
+  name: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface ExtrasPresupuestoSettings {
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface DepartmentSelectionOptions {
+  subfolders: SubfolderKey[];
+  customPullsheet?: CustomPullsheetSettings;
+  extrasPresupuesto?: ExtrasPresupuestoSettings;
+}
+
+export type CreateFoldersOptions = Partial<
+  Record<DepartmentKey, DepartmentSelectionOptions>
+>;
 
 // Helper to express “all defaults for a department”
 export type DepartmentDefaultSelector = (dept: DepartmentKey) => SubfolderKey[];


### PR DESCRIPTION
## Summary
- initialize the flex folder picker state with department defaults and preserve selections for submission
- add controlled inputs for custom pull sheet metadata on technical departments and extras presupuesto date ranges
- update folder option typing and helpers to accept structured selection data

## Testing
- npm run lint *(fails: missing @eslint/js in the eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68f4cf57b5e8832facc1f746e6bec2de