### PR TITLE
Support metadata for Flex folder selections

### DIFF
--- a/src/utils/flex-folders/folders.ts
+++ b/src/utils/flex-folders/folders.ts
@@ -5,6 +5,7 @@ import {
   CreateFoldersOptions,
   DepartmentKey,
   SubfolderKey,
+  getSubfolderSelectionSummary,
 } from "./types";
 import { createFlexFolder } from "./api";
 import {
@@ -104,9 +105,10 @@ function shouldCreateItem(
   options?: CreateFoldersOptions
 ): boolean {
   if (!options || options[dept] === undefined) return true;
-  const list = options[dept]?.subfolders;
-  if (!list) return true;
-  return list.includes(key);
+  const selection = options[dept];
+  const { keys, hasExplicitSelection } = getSubfolderSelectionSummary(selection);
+  if (!hasExplicitSelection) return true;
+  return keys.includes(key);
 }
 
 /**

--- a/src/utils/flex-folders/types.ts
+++ b/src/utils/flex-folders/types.ts
@@ -25,20 +25,28 @@ export type SubfolderKey =
   | "presupuestoSound" // Comercial presupuesto for sound
   | "presupuestoLights"; // Comercial presupuesto for lights
 
+export interface FlexFolderMetadataEntry {
+  name: string;
+  plannedStartDate?: string;
+  plannedEndDate?: string;
+}
+
 export interface CustomPullsheetSettings {
   enabled: boolean;
   name: string;
   startDate?: string;
   endDate?: string;
+  entries?: FlexFolderMetadataEntry[];
 }
 
 export interface ExtrasPresupuestoSettings {
   startDate?: string;
   endDate?: string;
+  entries?: FlexFolderMetadataEntry[];
 }
 
 export interface DepartmentSelectionOptions {
-  subfolders: SubfolderKey[];
+  subfolders?: SubfolderKey[];
   customPullsheet?: CustomPullsheetSettings;
   extrasPresupuesto?: ExtrasPresupuestoSettings;
 }
@@ -46,6 +54,283 @@ export interface DepartmentSelectionOptions {
 export type CreateFoldersOptions = Partial<
   Record<DepartmentKey, DepartmentSelectionOptions>
 >;
+
+const cloneMetadataEntries = (
+  entries?: FlexFolderMetadataEntry[]
+): FlexFolderMetadataEntry[] | undefined =>
+  entries?.map(entry => ({
+    name: entry.name,
+    plannedStartDate: entry.plannedStartDate,
+    plannedEndDate: entry.plannedEndDate,
+  }));
+
+export const sanitizeMetadataEntries = (
+  entries?: FlexFolderMetadataEntry[]
+): FlexFolderMetadataEntry[] => {
+  if (!entries) return [];
+
+  return entries
+    .map(entry => ({
+      name: entry.name?.trim?.() ?? entry.name ?? "",
+      plannedStartDate: entry.plannedStartDate || undefined,
+      plannedEndDate: entry.plannedEndDate || undefined,
+    }))
+    .filter(
+      entry =>
+        Boolean(entry.name) ||
+        Boolean(entry.plannedStartDate) ||
+        Boolean(entry.plannedEndDate)
+    );
+};
+
+export const cloneDepartmentSelectionOptions = (
+  selection?: DepartmentSelectionOptions
+): DepartmentSelectionOptions | undefined => {
+  if (!selection) return undefined;
+
+  const cloned: DepartmentSelectionOptions = {};
+
+  if (selection.subfolders) {
+    cloned.subfolders = [...selection.subfolders];
+  }
+
+  if (selection.customPullsheet) {
+    cloned.customPullsheet = {
+      ...selection.customPullsheet,
+      entries: cloneMetadataEntries(selection.customPullsheet.entries),
+    };
+  }
+
+  if (selection.extrasPresupuesto) {
+    cloned.extrasPresupuesto = {
+      ...selection.extrasPresupuesto,
+      entries: cloneMetadataEntries(selection.extrasPresupuesto.entries),
+    };
+  }
+
+  return cloned;
+};
+
+export const cloneOptions = (
+  options?: CreateFoldersOptions
+): CreateFoldersOptions => {
+  if (!options) return {};
+
+  const cloned: CreateFoldersOptions = {};
+
+  for (const [dept, value] of Object.entries(options) as [
+    DepartmentKey,
+    DepartmentSelectionOptions | undefined,
+  ][]) {
+    const clonedSelection = cloneDepartmentSelectionOptions(value);
+    if (clonedSelection) {
+      cloned[dept] = clonedSelection;
+    }
+  }
+
+  return cloned;
+};
+
+export interface SubfolderSelectionSummary {
+  keys: SubfolderKey[];
+  hasExplicitSelection: boolean;
+}
+
+export const getSubfolderSelectionSummary = (
+  selection?: DepartmentSelectionOptions
+): SubfolderSelectionSummary => {
+  const keys = selection?.subfolders ? [...selection.subfolders] : [];
+  return {
+    keys,
+    hasExplicitSelection: Array.isArray(selection?.subfolders),
+  };
+};
+
+export const getDepartmentCustomPullsheetMetadata = (
+  selection?: DepartmentSelectionOptions
+): FlexFolderMetadataEntry[] => {
+  const entries = selection?.customPullsheet?.entries;
+  if (entries && entries.length > 0) {
+    return entries.map(entry => ({ ...entry }));
+  }
+
+  const legacy = selection?.customPullsheet;
+  if (!legacy) return [];
+
+  const name = legacy.name?.trim?.() ?? legacy.name ?? "";
+  const startDate = legacy.startDate || undefined;
+  const endDate = legacy.endDate || undefined;
+
+  if (!legacy.enabled && !name && !startDate && !endDate) {
+    return [];
+  }
+
+  const metadata: FlexFolderMetadataEntry = {
+    name,
+    plannedStartDate: startDate,
+    plannedEndDate: endDate,
+  };
+
+  if (!metadata.name && !metadata.plannedStartDate && !metadata.plannedEndDate) {
+    return [];
+  }
+
+  return [metadata];
+};
+
+export const getDepartmentExtrasPresupuestoMetadata = (
+  selection?: DepartmentSelectionOptions
+): FlexFolderMetadataEntry[] => {
+  const entries = selection?.extrasPresupuesto?.entries;
+  if (entries && entries.length > 0) {
+    return entries.map(entry => ({ ...entry }));
+  }
+
+  const legacy = selection?.extrasPresupuesto;
+  if (!legacy) return [];
+
+  const startDate = legacy.startDate || undefined;
+  const endDate = legacy.endDate || undefined;
+
+  if (!startDate && !endDate) {
+    return [];
+  }
+
+  return [
+    {
+      name: "",
+      plannedStartDate: startDate,
+      plannedEndDate: endDate,
+    },
+  ];
+};
+
+export const setDepartmentCustomPullsheetMetadata = (
+  selection: DepartmentSelectionOptions | undefined,
+  entries: FlexFolderMetadataEntry[]
+): DepartmentSelectionOptions => {
+  const base = cloneDepartmentSelectionOptions(selection) ?? {};
+  const sanitized = sanitizeMetadataEntries(entries);
+
+  if (!base.customPullsheet) {
+    base.customPullsheet = {
+      enabled: sanitized.length > 0,
+      name: "",
+    };
+  } else {
+    base.customPullsheet = {
+      ...base.customPullsheet,
+    };
+  }
+
+  if (sanitized.length > 0) {
+    base.customPullsheet.entries = sanitized;
+  } else {
+    delete base.customPullsheet.entries;
+  }
+
+  return base;
+};
+
+export const setDepartmentExtrasPresupuestoMetadata = (
+  selection: DepartmentSelectionOptions | undefined,
+  entries: FlexFolderMetadataEntry[]
+): DepartmentSelectionOptions => {
+  const base = cloneDepartmentSelectionOptions(selection) ?? {};
+  const sanitized = sanitizeMetadataEntries(entries);
+
+  if (!base.extrasPresupuesto) {
+    base.extrasPresupuesto = {};
+  }
+
+  if (sanitized.length > 0) {
+    base.extrasPresupuesto.entries = sanitized;
+  } else {
+    delete base.extrasPresupuesto.entries;
+  }
+
+  return base;
+};
+
+export const getCustomPullsheetMetadataForDepartment = (
+  options: CreateFoldersOptions | undefined,
+  dept: DepartmentKey
+): FlexFolderMetadataEntry[] =>
+  getDepartmentCustomPullsheetMetadata(options?.[dept]);
+
+export const setCustomPullsheetMetadataForDepartment = (
+  options: CreateFoldersOptions | undefined,
+  dept: DepartmentKey,
+  entries: FlexFolderMetadataEntry[]
+): CreateFoldersOptions => {
+  const base = cloneOptions(options);
+  base[dept] = setDepartmentCustomPullsheetMetadata(base[dept], entries);
+  return base;
+};
+
+export const getExtrasPresupuestoMetadataForDepartment = (
+  options: CreateFoldersOptions | undefined,
+  dept: DepartmentKey
+): FlexFolderMetadataEntry[] =>
+  getDepartmentExtrasPresupuestoMetadata(options?.[dept]);
+
+export const setExtrasPresupuestoMetadataForDepartment = (
+  options: CreateFoldersOptions | undefined,
+  dept: DepartmentKey,
+  entries: FlexFolderMetadataEntry[]
+): CreateFoldersOptions => {
+  const base = cloneOptions(options);
+  base[dept] = setDepartmentExtrasPresupuestoMetadata(base[dept], entries);
+  return base;
+};
+
+export const sanitizeCustomPullsheetSettings = (
+  value?: CustomPullsheetSettings
+): CustomPullsheetSettings | undefined => {
+  if (!value) return undefined;
+
+  const enabled = Boolean(value.enabled);
+  const name = value.name?.trim?.() ?? value.name ?? "";
+  const startDate = value.startDate || undefined;
+  const endDate = value.endDate || undefined;
+  const entries = sanitizeMetadataEntries(value.entries);
+
+  if (!enabled && !name && !startDate && !endDate && entries.length === 0) {
+    return undefined;
+  }
+
+  const sanitized: CustomPullsheetSettings = {
+    enabled,
+    name,
+  };
+
+  if (startDate) sanitized.startDate = startDate;
+  if (endDate) sanitized.endDate = endDate;
+  if (entries.length > 0) sanitized.entries = entries;
+
+  return sanitized;
+};
+
+export const sanitizeExtrasPresupuestoSettings = (
+  value?: ExtrasPresupuestoSettings
+): ExtrasPresupuestoSettings | undefined => {
+  if (!value) return undefined;
+
+  const startDate = value.startDate || undefined;
+  const endDate = value.endDate || undefined;
+  const entries = sanitizeMetadataEntries(value.entries);
+
+  if (!startDate && !endDate && entries.length === 0) {
+    return undefined;
+  }
+
+  const sanitized: ExtrasPresupuestoSettings = {};
+  if (startDate) sanitized.startDate = startDate;
+  if (endDate) sanitized.endDate = endDate;
+  if (entries.length > 0) sanitized.entries = entries;
+
+  return sanitized;
+};
 
 // Helper to express “all defaults for a department”
 export type DepartmentDefaultSelector = (dept: DepartmentKey) => SubfolderKey[];


### PR DESCRIPTION
## Summary
- add metadata entry types and helper utilities so CreateFoldersOptions can carry structured pullsheet and extras presupuesto details
- update FlexFolderPicker sanitization and persistence logic to preserve metadata alongside subfolder toggles
- adjust Flex folder creation helpers to consume the new selection summary utilities for backward-compatible behavior

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f4d1c299fc832f969c7d6048b3e5c8