### PR TITLE
Fix sync flex work order secret retrieval

### DIFF
--- a/supabase/functions/sync-flex-work-orders/index.ts
+++ b/supabase/functions/sync-flex-work-orders/index.ts
@@ -150,18 +150,32 @@ async function ensureFlexAuthToken(req: Request): Promise<string | null> {
   let token = Deno.env.get("X_AUTH_TOKEN") ?? "";
   if (token) return token;
 
+  const authorization = req.headers.get("authorization") ?? req.headers.get("Authorization");
+  if (!authorization) {
+    console.error("sync-flex-work-orders: Authorization header missing, cannot load Flex token from secret");
+    return null;
+  }
+
   try {
     const res = await fetch(new URL(req.url).origin + "/functions/v1/get-secret", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key: "X_AUTH_TOKEN" })
+      headers: {
+        "Content-Type": "application/json",
+        ...(authorization ? { Authorization: authorization } : {})
+      },
+      body: JSON.stringify({ secretName: "X_AUTH_TOKEN" })
     });
     if (res.ok) {
       const json = await res.json().catch(() => ({}));
       token = (json as any)?.X_AUTH_TOKEN ?? token;
+    } else {
+      const errTxt = await res.text().catch(() => "");
+      console.error(
+        `sync-flex-work-orders: failed to retrieve Flex token (${res.status}) ${errTxt}`.trim()
+      );
     }
-  } catch (_err) {
-    // ignore and fall through
+  } catch (err) {
+    console.error("sync-flex-work-orders: error retrieving Flex token", err);
   }
 
   return token || null;


### PR DESCRIPTION
## Summary
- update the sync flex work orders function to forward caller authorization and request the proper secret payload when falling back to get-secret
- log missing authorization headers and non-successful responses so token lookup failures are easier to diagnose

## Testing
- not run (edge function change)


------
https://chatgpt.com/codex/tasks/task_e_68f5222fd6c8832fb7a7ac09d2bc8c0e