### PR TITLE
Add personnel work order flex folder and persistence

### DIFF
--- a/src/components/flex/FlexFolderPicker.tsx
+++ b/src/components/flex/FlexFolderPicker.tsx
@@ -70,6 +70,7 @@ const DEPARTMENT_SECTIONS: Record<DepartmentKey, DepartmentSection> = {
   personnel: {
     label: "Personal",
     items: [
+      { key: "workOrder", label: "Orden de Trabajo" },
       { key: "gastosDePersonal", label: "Gastos de Personal" },
       { key: "crewCallSound", label: "Crew Call Sonido" },
       { key: "crewCallLights", label: "Crew Call Luces" },
@@ -120,7 +121,7 @@ const DEFAULT_SELECTIONS: Record<DepartmentKey, SubfolderKey[]> = {
     "presupuestosRecibidos",
     "hojaGastos",
   ],
-  personnel: ["gastosDePersonal", "crewCallSound", "crewCallLights"],
+  personnel: ["workOrder", "gastosDePersonal", "crewCallSound", "crewCallLights"],
   comercial: [
     "extrasSound",
     "presupuestoSound",

--- a/src/utils/flex-folders/types.ts
+++ b/src/utils/flex-folders/types.ts
@@ -18,6 +18,7 @@ export type SubfolderKey =
   | "pullSheetTP" // Tour Pack pull sheet (sound)
   | "pullSheetPA" // PA pull sheet (sound, hidden by tour-pack-only)
   | "gastosDePersonal" // Personnel: “Gastos de Personal - ${job.title}”
+  | "workOrder" // Personnel: “Orden de Trabajo - ${job.title}”
   | "crewCallSound" // Personnel: Crew Call Sonido
   | "crewCallLights" // Personnel: Crew Call Luces
   | "extrasSound" // Comercial extras for sound


### PR DESCRIPTION
## Summary
- add work-order option to personnel flex folder configuration
- create and persist personnel work-order folders for jobs while reusing existing metadata
- register work-order folders in flex_folders for reuse and prevent duplicates

## Testing
- npm run lint *(fails: missing @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f53f0153cc832fb1fb54d6cbc80fd9