### PR TITLE
Translate SoundVision file database to Spanish

### DIFF
--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -132,7 +132,7 @@ export const SidebarNavigation = ({ userRole, userDepartment }: SidebarNavigatio
               }`}
             >
               <Database className="h-4 w-4" />
-              <span>SoundVision Files</span>
+              <span>Archivos SoundVision</span>
             </Button>
           </Link>
         )}

--- a/src/components/soundvision/SoundVisionDatabaseDialog.tsx
+++ b/src/components/soundvision/SoundVisionDatabaseDialog.tsx
@@ -37,16 +37,16 @@ export const SoundVisionDatabaseDialog = () => {
   return (
     <div className="space-y-4">
       <div>
-        <h1 className="text-3xl font-bold">SoundVision File Database</h1>
+        <h1 className="text-3xl font-bold">Base de datos de archivos SoundVision</h1>
         <p className="text-muted-foreground mt-2">
-          Upload, browse, and download venue-specific SoundVision files
+          Sube, explora y descarga archivos SoundVision específicos de cada recinto
         </p>
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="browse">Browse Files</TabsTrigger>
-          <TabsTrigger value="upload">Upload New File</TabsTrigger>
+          <TabsTrigger value="browse">Explorar archivos</TabsTrigger>
+          <TabsTrigger value="upload">Subir nuevo archivo</TabsTrigger>
         </TabsList>
 
         <TabsContent value="browse" className="space-y-4 mt-4">

--- a/src/components/soundvision/SoundVisionFileUploader.tsx
+++ b/src/components/soundvision/SoundVisionFileUploader.tsx
@@ -63,7 +63,7 @@ export const SoundVisionFileUploader = ({ onUploadComplete }: SoundVisionFileUpl
 
   const onSubmit = (data: VenueFormData) => {
     if (!selectedFile) {
-      alert('Please select a file');
+      alert('Por favor, selecciona un archivo');
       return;
     }
 
@@ -119,21 +119,21 @@ export const SoundVisionFileUploader = ({ onUploadComplete }: SoundVisionFileUpl
               onClick={() => setSelectedFile(null)}
               disabled={isUploading}
             >
-              Remove
+              Quitar
             </Button>
           </div>
         ) : (
           <>
             <Upload className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
             <p className="text-lg font-medium mb-2">
-              Drag and drop your SoundVision file here
+              Arrastra y suelta aquí tu archivo de SoundVision
             </p>
             <p className="text-sm text-muted-foreground mb-4">
-              Supported formats: {ALLOWED_FILE_TYPES.join(', ')} (Max 100MB)
+              Formatos admitidos: {ALLOWED_FILE_TYPES.join(', ')} (Máx. 100 MB)
             </p>
             <label htmlFor="file-input">
               <Button variant="outline" asChild>
-                <span>Browse Files</span>
+                <span>Buscar archivos</span>
               </Button>
               <input
                 id="file-input"
@@ -155,7 +155,7 @@ export const SoundVisionFileUploader = ({ onUploadComplete }: SoundVisionFileUpl
       {isUploading && (
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
-            <span>Uploading...</span>
+            <span>Subiendo...</span>
             <span>{progress}%</span>
           </div>
           <Progress value={progress} />
@@ -172,7 +172,7 @@ export const SoundVisionFileUploader = ({ onUploadComplete }: SoundVisionFileUpl
             className="w-full"
             disabled={!selectedFile || isUploading}
           >
-            Upload File
+            Subir archivo
           </Button>
         </form>
       </Form>

--- a/src/components/soundvision/SoundVisionFilesList.tsx
+++ b/src/components/soundvision/SoundVisionFilesList.tsx
@@ -23,6 +23,7 @@ import { useDeleteSoundVisionFile, useDownloadSoundVisionFile, SoundVisionFile }
 import { canDeleteSoundVisionFiles } from '@/utils/permissions';
 import { supabase } from '@/integrations/supabase/client';
 import { formatDistanceToNow } from 'date-fns';
+import { es } from 'date-fns/locale';
 import { useQuery } from '@tanstack/react-query';
 
 interface SoundVisionFilesListProps {
@@ -54,8 +55,8 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
   if (files.length === 0) {
     return (
       <div className="text-center py-12 text-muted-foreground">
-        <p className="text-lg mb-2">No files found</p>
-        <p className="text-sm">Try adjusting your search filters</p>
+        <p className="text-lg mb-2">No se encontraron archivos</p>
+        <p className="text-sm">Intenta ajustar los filtros de búsqueda</p>
       </div>
     );
   }
@@ -82,7 +83,12 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
               </div>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Calendar className="h-3 w-3" />
-                <span>{formatDistanceToNow(new Date(file.uploaded_at), { addSuffix: true })}</span>
+                <span>
+                  {formatDistanceToNow(new Date(file.uploaded_at), {
+                    addSuffix: true,
+                    locale: es,
+                  })}
+                </span>
               </div>
             </div>
             <div className="flex gap-2">
@@ -94,7 +100,7 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                 className="flex-1"
               >
                 <Download className="h-4 w-4 mr-1" />
-                Download
+                Descargar
               </Button>
               {canDelete && (
                 <AlertDialog>
@@ -105,15 +111,15 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                   </AlertDialogTrigger>
                   <AlertDialogContent>
                     <AlertDialogHeader>
-                      <AlertDialogTitle>Delete File</AlertDialogTitle>
+                      <AlertDialogTitle>Eliminar archivo</AlertDialogTitle>
                       <AlertDialogDescription>
-                        Are you sure you want to delete "{file.file_name}"? This action cannot be undone.
+                        ¿Seguro que quieres eliminar "{file.file_name}"? Esta acción no se puede deshacer.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
                       <AlertDialogAction onClick={() => deleteFile.mutate(file.id)}>
-                        Delete
+                        Eliminar
                       </AlertDialogAction>
                     </AlertDialogFooter>
                   </AlertDialogContent>
@@ -129,12 +135,12 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Venue</TableHead>
-              <TableHead>Location</TableHead>
-              <TableHead>File Name</TableHead>
-              <TableHead>Uploaded By</TableHead>
-              <TableHead>Upload Date</TableHead>
-              <TableHead className="text-right">Actions</TableHead>
+              <TableHead>Recinto</TableHead>
+              <TableHead>Ubicación</TableHead>
+              <TableHead>Nombre del archivo</TableHead>
+              <TableHead>Subido por</TableHead>
+              <TableHead>Fecha de subida</TableHead>
+              <TableHead className="text-right">Acciones</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -149,7 +155,10 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                   {file.uploader?.first_name} {file.uploader?.last_name}
                 </TableCell>
                 <TableCell>
-                  {formatDistanceToNow(new Date(file.uploaded_at), { addSuffix: true })}
+                  {formatDistanceToNow(new Date(file.uploaded_at), {
+                    addSuffix: true,
+                    locale: es,
+                  })}
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex gap-2 justify-end">
@@ -160,7 +169,7 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                       disabled={downloadFile.isPending}
                     >
                       <Download className="h-4 w-4 mr-1" />
-                      Download
+                      Descargar
                     </Button>
                     {canDelete && (
                       <AlertDialog>
@@ -171,15 +180,15 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                         </AlertDialogTrigger>
                         <AlertDialogContent>
                           <AlertDialogHeader>
-                            <AlertDialogTitle>Delete File</AlertDialogTitle>
+                            <AlertDialogTitle>Eliminar archivo</AlertDialogTitle>
                             <AlertDialogDescription>
-                              Are you sure you want to delete "{file.file_name}"? This action cannot be undone.
+                              ¿Seguro que quieres eliminar "{file.file_name}"? Esta acción no se puede deshacer.
                             </AlertDialogDescription>
                           </AlertDialogHeader>
                           <AlertDialogFooter>
-                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogCancel>Cancelar</AlertDialogCancel>
                             <AlertDialogAction onClick={() => deleteFile.mutate(file.id)}>
-                              Delete
+                              Eliminar
                             </AlertDialogAction>
                           </AlertDialogFooter>
                         </AlertDialogContent>

--- a/src/components/soundvision/SoundVisionMap.tsx
+++ b/src/components/soundvision/SoundVisionMap.tsx
@@ -56,12 +56,12 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
 
         if (tokenError) {
           console.error('Token fetch error:', tokenError);
-          throw new Error(`Failed to fetch Mapbox token: ${tokenError.message}`);
+          throw new Error(`Error al obtener el token de Mapbox: ${tokenError.message}`);
         }
 
         if (!data?.token) {
           console.error('No token in response:', data);
-          throw new Error('Mapbox token not found in response');
+          throw new Error('No se encontró el token de Mapbox en la respuesta');
         }
 
         console.log('Mapbox token retrieved successfully');
@@ -106,9 +106,9 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
           if (!isMounted || hasShownError.current || mapHasLoaded) return;
           hasShownError.current = true;
           console.error('Mapbox error:', event.error);
-          setError('Failed to load map data. Please try again later.');
+          setError('No se pudieron cargar los datos del mapa. Inténtalo de nuevo más tarde.');
           setIsLoading(false);
-          toast.error('Failed to load map data');
+          toast.error('No se pudieron cargar los datos del mapa');
         });
 
         const handleResize = () => mapInstance.resize();
@@ -120,9 +120,9 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
       } catch (err) {
         if (!isMounted) return;
         console.error('Error initializing map:', err);
-        setError('Failed to load map. Please check your connection.');
+        setError('No se pudo cargar el mapa. Revisa tu conexión.');
         setIsLoading(false);
-        toast.error('Failed to initialize map');
+        toast.error('No se pudo iniciar el mapa');
       }
     };
 
@@ -181,6 +181,7 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
       el.style.cursor = 'pointer';
       el.style.boxShadow = '0 2px 8px rgba(0,0,0,0.3)';
 
+      const archivosDisponibles = fileCount === 1 ? 'archivo disponible' : 'archivos disponibles';
       const popupContent = `
         <div style="padding: 8px; min-width: 200px;">
           <h3 style="font-weight: bold; margin-bottom: 4px; color: hsl(var(--foreground));">${venue.name}</h3>
@@ -188,7 +189,7 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
             ${[venue.city, venue.state_region, venue.country].filter(Boolean).join(', ')}
           </p>
           <p style="font-size: 0.875rem; color: hsl(var(--muted-foreground));">
-            <strong>${fileCount}</strong> file${fileCount !== 1 ? 's' : ''} available
+            <strong>${fileCount}</strong> ${archivosDisponibles}
           </p>
         </div>
       `;
@@ -209,7 +210,7 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
 
     if (venueMap.size === 0) {
       if (previousVenueCount.current !== 0) {
-        toast.info('No venues with coordinates to display');
+        toast.info('No hay recintos con coordenadas para mostrar');
       }
       previousVenueCount.current = 0;
       return;
@@ -220,7 +221,8 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
     }
 
     if (venueMap.size !== previousVenueCount.current) {
-      toast.success(`Map loaded with ${venueMap.size} venue location${venueMap.size === 1 ? '' : 's'}`);
+      const textoUbicaciones = venueMap.size === 1 ? 'ubicación' : 'ubicaciones';
+      toast.success(`Mapa cargado con ${venueMap.size} ${textoUbicaciones} de recintos`);
     }
 
     previousVenueCount.current = venueMap.size;
@@ -230,7 +232,7 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
     return (
       <div className="w-full h-full flex items-center justify-center bg-muted/20 rounded-lg border">
         <div className="text-center p-6">
-          <p className="text-destructive font-medium mb-2">Map Error</p>
+          <p className="text-destructive font-medium mb-2">Error del mapa</p>
           <p className="text-sm text-muted-foreground">{error}</p>
         </div>
       </div>
@@ -243,7 +245,7 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
         <div className="absolute inset-0 flex items-center justify-center bg-background/80 backdrop-blur-sm z-10 rounded-lg">
           <div className="flex items-center gap-2">
             <Loader2 className="h-6 w-6 animate-spin text-primary" />
-            <span className="text-sm text-muted-foreground">Loading map...</span>
+            <span className="text-sm text-muted-foreground">Cargando mapa...</span>
           </div>
         </div>
       )}

--- a/src/components/soundvision/SoundVisionSearchFilters.tsx
+++ b/src/components/soundvision/SoundVisionSearchFilters.tsx
@@ -52,7 +52,7 @@ export const SoundVisionSearchFilters = ({
       <div className="relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
-          placeholder="Search by venue name or file name..."
+          placeholder="Buscar por nombre de recinto o archivo..."
           value={searchTerm}
           onChange={(e) => onSearchChange(e.target.value)}
           className="pl-10"
@@ -63,22 +63,22 @@ export const SoundVisionSearchFilters = ({
       <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
         <Select value={fileType} onValueChange={onFileTypeChange}>
           <SelectTrigger>
-            <SelectValue placeholder="All Types" />
+            <SelectValue placeholder="Todos los tipos" />
           </SelectTrigger>
           <SelectContent className="bg-popover z-50">
-            <SelectItem value="all">All Types</SelectItem>
-            <SelectItem value=".xmlp">.xmlp (Project)</SelectItem>
-            <SelectItem value=".xmls">.xmls (Scene)</SelectItem>
-            <SelectItem value=".xmlc">.xmlc (Configuration)</SelectItem>
+            <SelectItem value="all">Todos los tipos</SelectItem>
+            <SelectItem value=".xmlp">.xmlp (Proyecto)</SelectItem>
+            <SelectItem value=".xmls">.xmls (Escena)</SelectItem>
+            <SelectItem value=".xmlc">.xmlc (Configuración)</SelectItem>
           </SelectContent>
         </Select>
 
         <Select value={city} onValueChange={onCityChange}>
           <SelectTrigger>
-            <SelectValue placeholder="All Cities" />
+            <SelectValue placeholder="Todas las ciudades" />
           </SelectTrigger>
           <SelectContent className="bg-popover z-50">
-            <SelectItem value="all">All Cities</SelectItem>
+            <SelectItem value="all">Todas las ciudades</SelectItem>
             {cities.map((c) => (
               <SelectItem key={c} value={c}>
                 {c}
@@ -89,10 +89,10 @@ export const SoundVisionSearchFilters = ({
 
         <Select value={country} onValueChange={onCountryChange}>
           <SelectTrigger>
-            <SelectValue placeholder="All Countries" />
+            <SelectValue placeholder="Todos los países" />
           </SelectTrigger>
           <SelectContent className="bg-popover z-50">
-            <SelectItem value="all">All Countries</SelectItem>
+            <SelectItem value="all">Todos los países</SelectItem>
             {countries.map((c) => (
               <SelectItem key={c} value={c}>
                 {c}
@@ -103,10 +103,10 @@ export const SoundVisionSearchFilters = ({
 
         <Select value={stateRegion} onValueChange={onStateRegionChange}>
           <SelectTrigger>
-            <SelectValue placeholder="All States/Regions" />
+            <SelectValue placeholder="Todas las provincias/regiones" />
           </SelectTrigger>
           <SelectContent className="bg-popover z-50">
-            <SelectItem value="all">All States/Regions</SelectItem>
+            <SelectItem value="all">Todas las provincias/regiones</SelectItem>
             {stateRegions.map((s) => (
               <SelectItem key={s} value={s}>
                 {s}
@@ -117,7 +117,7 @@ export const SoundVisionSearchFilters = ({
 
         {hasActiveFilters && (
           <Button variant="outline" onClick={onClearFilters} className="w-full">
-            Clear Filters
+            Limpiar filtros
           </Button>
         )}
       </div>

--- a/src/components/soundvision/VenueMetadataForm.tsx
+++ b/src/components/soundvision/VenueMetadataForm.tsx
@@ -67,12 +67,12 @@ export const VenueMetadataForm = ({ form }: VenueMetadataFormProps) => {
         name="venueName"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>Venue Name *</FormLabel>
+            <FormLabel>Nombre del recinto *</FormLabel>
             <FormControl>
               <PlaceAutocomplete
                 value={field.value}
                 onSelect={handlePlaceSelect}
-                placeholder="Search for venue..."
+                placeholder="Buscar recinto..."
                 onInputChange={field.onChange}
               />
             </FormControl>
@@ -87,7 +87,7 @@ export const VenueMetadataForm = ({ form }: VenueMetadataFormProps) => {
           name="venueCity"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>City *</FormLabel>
+              <FormLabel>Ciudad *</FormLabel>
               <FormControl>
                 <Input {...field} placeholder="Madrid" />
               </FormControl>
@@ -101,7 +101,7 @@ export const VenueMetadataForm = ({ form }: VenueMetadataFormProps) => {
           name="venueStateRegion"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>State/Region</FormLabel>
+              <FormLabel>Provincia/Región</FormLabel>
               <FormControl>
                 <Input {...field} placeholder="Community of Madrid" />
               </FormControl>
@@ -116,7 +116,7 @@ export const VenueMetadataForm = ({ form }: VenueMetadataFormProps) => {
         name="venueCountry"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>Country *</FormLabel>
+            <FormLabel>País *</FormLabel>
             <FormControl>
               <Input {...field} placeholder="Spain" />
             </FormControl>
@@ -130,7 +130,7 @@ export const VenueMetadataForm = ({ form }: VenueMetadataFormProps) => {
         name="venueCapacity"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>Venue Capacity (optional)</FormLabel>
+            <FormLabel>Aforo del recinto (opcional)</FormLabel>
             <FormControl>
               <Input {...field} type="number" placeholder="5000" />
             </FormControl>
@@ -144,9 +144,13 @@ export const VenueMetadataForm = ({ form }: VenueMetadataFormProps) => {
         name="venueNotes"
         render={({ field }) => (
           <FormItem>
-            <FormLabel>Additional Notes (optional)</FormLabel>
+            <FormLabel>Notas adicionales (opcional)</FormLabel>
             <FormControl>
-              <Textarea {...field} placeholder="Any additional information about the venue setup..." rows={3} />
+              <Textarea
+                {...field}
+                placeholder="Información adicional sobre el montaje del recinto..."
+                rows={3}
+              />
             </FormControl>
             <FormMessage />
           </FormItem>

--- a/src/hooks/useSoundVisionFiles.ts
+++ b/src/hooks/useSoundVisionFiles.ts
@@ -136,11 +136,11 @@ export const useDeleteSoundVisionFile = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['soundvision-files'] });
-      toast.success('File deleted successfully');
+      toast.success('Archivo eliminado correctamente');
     },
     onError: (error) => {
       console.error('Error deleting file:', error);
-      toast.error('Failed to delete file');
+      toast.error('No se pudo eliminar el archivo');
     },
   });
 };
@@ -166,7 +166,7 @@ export const useDownloadSoundVisionFile = () => {
     },
     onError: (error) => {
       console.error('Error downloading file:', error);
-      toast.error('Failed to download file');
+      toast.error('No se pudo descargar el archivo');
     },
   });
 };

--- a/src/hooks/useSoundVisionUpload.ts
+++ b/src/hooks/useSoundVisionUpload.ts
@@ -49,7 +49,7 @@ export const useSoundVisionUpload = () => {
       const {
         data: { user },
       } = await supabase.auth.getUser();
-      if (!user) throw new Error('User not authenticated');
+      if (!user) throw new Error('Usuario no autenticado');
 
       // Create database record
       const { error: dbError } = await supabase.from('soundvision_files').insert({
@@ -68,12 +68,12 @@ export const useSoundVisionUpload = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['soundvision-files'] });
       queryClient.invalidateQueries({ queryKey: ['venues'] });
-      toast.success('File uploaded successfully');
+      toast.success('Archivo subido correctamente');
       setProgress(0);
     },
     onError: (error) => {
       console.error('Error uploading file:', error);
-      toast.error(error.message || 'Failed to upload file');
+      toast.error(error.message || 'No se pudo subir el archivo');
       setProgress(0);
     },
   });

--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -289,7 +289,7 @@ const Sound = () => {
               onClick={() => setShowSoundVisionDatabase(true)}
             >
               <Database className="h-4 w-4 sm:h-6 sm:w-6" />
-              <span className="text-center leading-tight">SoundVision Files</span>
+              <span className="text-center leading-tight">Archivos SoundVision</span>
             </Button>
            </div>
          </div>

--- a/src/pages/SoundVisionFiles.tsx
+++ b/src/pages/SoundVisionFiles.tsx
@@ -16,7 +16,7 @@ const SoundVisionFiles = () => {
       <div className="container mx-auto px-4 py-6 max-w-7xl h-[calc(100vh-6rem)] flex items-center justify-center">
         <div className="flex items-center gap-2">
           <Loader2 className="h-6 w-6 animate-spin text-primary" />
-          <span className="text-muted-foreground">Loading SoundVision files...</span>
+          <span className="text-muted-foreground">Cargando archivos de SoundVision...</span>
         </div>
       </div>
     );

--- a/src/utils/soundvisionFileValidation.ts
+++ b/src/utils/soundvisionFileValidation.ts
@@ -1,9 +1,9 @@
-// L-Acoustics SoundVision file validation utilities
+// Utilidades de validación de archivos SoundVision de L-Acoustics
 
-// L-Acoustics Soundvision file types:
-// .xmlp - Project file (full Soundvision project)
-// .xmls - Scene file (venue/geometry context)
-// .xmlc - Configuration file (exports like speaker positions)
+// Tipos de archivos SoundVision de L-Acoustics:
+// .xmlp - Archivo de proyecto (proyecto SoundVision completo)
+// .xmls - Archivo de escena (contexto de recinto/geometría)
+// .xmlc - Archivo de configuración (exportaciones como posiciones de altavoces)
 export const ALLOWED_FILE_TYPES = ['.xmlp', '.xmls', '.xmlc'];
 export const ALLOWED_MIME_TYPES = [
   'application/xml',
@@ -18,28 +18,28 @@ export interface FileValidationResult {
 }
 
 export const validateFile = (file: File): FileValidationResult => {
-  // Check file size
+  // Comprobar el tamaño del archivo
   if (file.size > MAX_FILE_SIZE) {
     return {
       valid: false,
-      error: `File size exceeds 100MB limit (${(file.size / 1024 / 1024).toFixed(2)}MB)`,
+      error: `El tamaño del archivo supera el límite de 100 MB (${(file.size / 1024 / 1024).toFixed(2)} MB)`,
     };
   }
 
-  // Check file extension
+  // Comprobar la extensión del archivo
   const extension = file.name.toLowerCase().match(/\.[^.]+$/)?.[0];
   if (!extension || !ALLOWED_FILE_TYPES.includes(extension)) {
     return {
       valid: false,
-      error: `Invalid file type. Allowed types: ${ALLOWED_FILE_TYPES.join(', ')}`,
+      error: `Tipo de archivo no válido. Tipos permitidos: ${ALLOWED_FILE_TYPES.join(', ')}`,
     };
   }
 
-  // Check MIME type (if available)
+  // Comprobar el tipo MIME (si está disponible)
   if (file.type && !ALLOWED_MIME_TYPES.includes(file.type)) {
     return {
       valid: false,
-      error: `Invalid MIME type: ${file.type}`,
+      error: `Tipo MIME no válido: ${file.type}`,
     };
   }
 
@@ -47,7 +47,7 @@ export const validateFile = (file: File): FileValidationResult => {
 };
 
 export const sanitizeFileName = (fileName: string): string => {
-  // Remove path traversal attempts
+  // Eliminar intentos de recorridos de ruta
   const sanitized = fileName
     .replace(/\.\./g, '')
     .replace(/[/\\]/g, '_')


### PR DESCRIPTION
## Summary
- translate the SoundVision database interface labels, dialogs, and actions to Spanish
- localize SoundVision file validation messages, map toasts, and uploader notifications
- update supporting hooks and navigation entries to keep terminology consistent across the app

## Testing
- npm run lint *(fails: missing @eslint/js package)*

------
https://chatgpt.com/codex/tasks/task_e_68f8fcd52ad8832fb5d0b46877b24457