### PR TITLE
Auto-attach SoundVision templates and flag them as read-only

### DIFF
--- a/src/components/dashboard/JobCardNew.tsx
+++ b/src/components/dashboard/JobCardNew.tsx
@@ -64,6 +64,9 @@ export interface JobDocument {
   file_name: string;
   file_path: string;
   uploaded_at: string;
+  visible_to_tech?: boolean;
+  read_only?: boolean;
+  template_type?: string | null;
 }
 
 export interface JobCardNewProps {
@@ -751,6 +754,14 @@ export function JobCardNew({
   };
 
   const handleDeleteDocument = async (doc: JobDocument) => {
+    if (doc.read_only) {
+      toast({
+        title: "Cannot delete read-only document",
+        description: "Template documents are attached automatically and cannot be removed manually.",
+        variant: "destructive",
+      });
+      return;
+    }
     if (!window.confirm("Are you sure you want to delete this document?")) return;
     try {
       console.log("Starting document deletion:", doc);
@@ -1149,56 +1160,66 @@ export function JobCardNew({
                   <div className="mt-4 space-y-2">
                     <div className="text-xs sm:text-sm font-medium">Documents</div>
                     <div className="space-y-2">
-                      {documents.map((doc) => (
-                        <div
-                          key={doc.id}
-                          className="flex items-center justify-between p-2 rounded-md bg-accent/20 hover:bg-accent/30 transition-colors"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <div className="flex flex-col min-w-0 flex-1 mr-2">
-                            <span className="text-xs sm:text-sm font-medium truncate" title={doc.file_name}>
-                              {doc.file_name}
-                            </span>
-                            <span className="text-xs text-muted-foreground">
-                              Uploaded {format(new Date(doc.uploaded_at), "MMM d, yyyy")}
-                            </span>
-                          </div>
-                          <div className="flex gap-1 shrink-0">
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => handleViewDocument(doc)}
-                              title="View"
-                              disabled={isJobBeingDeleted}
-                              className="h-7 w-7 sm:h-8 sm:w-8"
-                            >
-                              <Eye className="h-3 w-3 sm:h-4 sm:w-4" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => handleDownload(doc)}
-                              title="Download"
-                              disabled={isJobBeingDeleted}
-                              className="h-7 w-7 sm:h-8 sm:w-8"
-                            >
-                              <Download className="h-3 w-3 sm:h-4 sm:w-4" />
-                            </Button>
-                            {canDeleteDocuments(userRole) && (
+                      {documents.map((doc) => {
+                        const isTemplate = doc.template_type === 'soundvision';
+                        const isReadOnly = Boolean(doc.read_only);
+                        return (
+                          <div
+                            key={doc.id}
+                            className="flex items-center justify-between p-2 rounded-md bg-accent/20 hover:bg-accent/30 transition-colors"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <div className="flex flex-col min-w-0 flex-1 mr-2">
+                              <span className="text-xs sm:text-sm font-medium truncate flex items-center gap-2" title={doc.file_name}>
+                                {doc.file_name}
+                                {isTemplate && (
+                                  <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                                    Template SoundVision File
+                                  </Badge>
+                                )}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                Uploaded {format(new Date(doc.uploaded_at), "MMM d, yyyy")}
+                                {isReadOnly && <span className="ml-2 italic">Read-only</span>}
+                              </span>
+                            </div>
+                            <div className="flex gap-1 shrink-0">
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                onClick={() => handleDeleteDocument(doc)}
-                                title="Delete"
+                                onClick={() => handleViewDocument(doc)}
+                                title="View"
                                 disabled={isJobBeingDeleted}
                                 className="h-7 w-7 sm:h-8 sm:w-8"
                               >
-                                <Trash2 className="h-3 w-3 sm:h-4 sm:w-4" />
+                                <Eye className="h-3 w-3 sm:h-4 sm:w-4" />
                               </Button>
-                            )}
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleDownload(doc)}
+                                title="Download"
+                                disabled={isJobBeingDeleted}
+                                className="h-7 w-7 sm:h-8 sm:w-8"
+                              >
+                                <Download className="h-3 w-3 sm:h-4 sm:w-4" />
+                              </Button>
+                              {canDeleteDocuments(userRole) && !isReadOnly && (
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  onClick={() => handleDeleteDocument(doc)}
+                                  title="Delete"
+                                  disabled={isJobBeingDeleted}
+                                  className="h-7 w-7 sm:h-8 sm:w-8"
+                                >
+                                  <Trash2 className="h-3 w-3 sm:h-4 sm:w-4" />
+                                </Button>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                     </div>
                   </div>
                 )}

--- a/src/components/jobs/cards/JobCardDocuments.tsx
+++ b/src/components/jobs/cards/JobCardDocuments.tsx
@@ -2,9 +2,11 @@
 import React from 'react';
 import { format } from "date-fns";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Eye, Download, Trash2 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { supabase } from "@/lib/supabase";
+import { resolveJobDocBucket } from "@/utils/jobDocuments";
 
 export interface JobDocument {
   id: string;
@@ -12,6 +14,8 @@ export interface JobDocument {
   file_path: string;
   uploaded_at: string;
   visible_to_tech?: boolean;
+  read_only?: boolean;
+  template_type?: string | null;
 }
 
 interface JobCardDocumentsProps {
@@ -31,16 +35,10 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
     return null;
   }
 
-  const resolveBucket = (path: string) => {
-    const first = (path || '').split('/')[0];
-    const dept = new Set(['sound','lights','video','production','logistics','administrative']);
-    return dept.has(first) ? 'job_documents' : 'job-documents';
-  };
-
   const handleViewDocument = async (doc: JobDocument) => {
     try {
       console.log("Attempting to view document:", doc);
-      const bucket = resolveBucket(doc.file_path);
+      const bucket = resolveJobDocBucket(doc.file_path);
       const { data, error } = await supabase.storage
         .from(bucket)
         .createSignedUrl(doc.file_path, 60);
@@ -61,8 +59,8 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
   const handleDownload = async (doc: JobDocument) => {
     try {
       console.log('Starting download for document:', doc.file_name);
-      
-      const bucket = resolveBucket(doc.file_path);
+
+      const bucket = resolveJobDocBucket(doc.file_path);
       const { data, error } = await supabase.storage
         .from(bucket)
         .createSignedUrl(doc.file_path, 60);
@@ -88,6 +86,9 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
   };
 
   const handleToggleVisibility = async (doc: JobDocument) => {
+    if (doc.read_only) {
+      return;
+    }
     try {
       const next = !Boolean(doc.visible_to_tech);
       const { error } = await supabase
@@ -119,15 +120,23 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
     <div className="mt-2 space-y-2">
       {showTitle && <div className="text-sm font-medium">Documents</div>}
       <div className="space-y-2">
-        {documents.map((doc) => (
-          <div
-            key={doc.id}
-            className="flex items-center justify-between p-2 rounded-md bg-accent/20 hover:bg-accent/30 transition-colors"
-            onClick={(e) => e.stopPropagation()}
-          >
+        {documents.map((doc) => {
+          const isTemplate = doc.template_type === 'soundvision';
+          const isReadOnly = Boolean(doc.read_only);
+          return (
+            <div
+              key={doc.id}
+              className="flex items-center justify-between p-2 rounded-md bg-accent/20 hover:bg-accent/30 transition-colors"
+              onClick={(e) => e.stopPropagation()}
+            >
             <div className="flex flex-col">
               <span className="text-sm font-medium flex items-center gap-2">
                 {doc.file_name}
+                {isTemplate && (
+                  <Badge variant="outline" className="text-[10px] font-semibold uppercase tracking-wide">
+                    Template SoundVision File
+                  </Badge>
+                )}
                 {['admin','management'].includes(userRole || '') && (
                   <span className={`text-[10px] px-1.5 py-0.5 rounded ${doc.visible_to_tech ? 'bg-green-500/20 text-green-800 dark:text-green-200' : 'bg-muted text-muted-foreground'}`}>
                     {doc.visible_to_tech ? 'Tech-visible' : 'Hidden from tech'}
@@ -136,6 +145,9 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
               </span>
               <span className="text-xs text-muted-foreground">
                 Uploaded {format(new Date(doc.uploaded_at), "MMM d, yyyy")}
+                {isReadOnly && (
+                  <span className="ml-2 italic">Read-only</span>
+                )}
               </span>
             </div>
             <div className="flex gap-2">
@@ -145,6 +157,7 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
                   <Switch
                     checked={Boolean(doc.visible_to_tech)}
                     onCheckedChange={() => handleToggleVisibility(doc)}
+                    disabled={isReadOnly}
                   />
                 </div>
               )}
@@ -164,7 +177,7 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
               >
                 <Download className="h-4 w-4" />
               </Button>
-              {['admin', 'management'].includes(userRole || '') && (
+              {['admin', 'management'].includes(userRole || '') && !isReadOnly && (
                 <Button
                   variant="ghost"
                   size="icon"
@@ -175,8 +188,9 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
                 </Button>
               )}
             </div>
-          </div>
-        ))}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/soundvision/SoundVisionFileUploader.tsx
+++ b/src/components/soundvision/SoundVisionFileUploader.tsx
@@ -174,6 +174,9 @@ export const SoundVisionFileUploader = ({ onUploadComplete }: SoundVisionFileUpl
           >
             Subir archivo
           </Button>
+          <p className="text-xs italic text-muted-foreground text-center">
+            Por favor, sube preferiblemente archivos .xmls de SoundVision para asegurar la mejor compatibilidad y reutilización.
+          </p>
         </form>
       </Form>
     </div>

--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { format } from "date-fns";
 import { formatInJobTimezone } from "@/utils/timezoneUtils";
@@ -197,22 +198,36 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
                   </Button>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="space-y-1 mt-1">
-                  {jobData.job_documents.map((doc: any) => (
-                    <div key={doc.id} className="flex items-center justify-between gap-2 p-2 bg-secondary/20 rounded text-xs">
-                      <div className="flex-1 min-w-0">
-                        <p className="truncate font-medium">{doc.file_name}</p>
-                        <p className="text-muted-foreground text-xs">{doc.uploaded_at && format(new Date(doc.uploaded_at), "dd/MM/yyyy")}</p>
+                  {jobData.job_documents.map((doc: any) => {
+                    const isTemplate = doc.template_type === 'soundvision';
+                    const isReadOnly = Boolean(doc.read_only);
+                    return (
+                      <div key={doc.id} className="flex items-center justify-between gap-2 p-2 bg-secondary/20 rounded text-xs">
+                        <div className="flex-1 min-w-0">
+                          <p className="truncate font-medium flex items-center gap-2">
+                            {doc.file_name}
+                            {isTemplate && (
+                              <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                                Template SoundVision File
+                              </Badge>
+                            )}
+                          </p>
+                          <p className="text-muted-foreground text-xs">
+                            {doc.uploaded_at && format(new Date(doc.uploaded_at), "dd/MM/yyyy")}
+                            {isReadOnly && <span className="ml-1 italic">Solo lectura</span>}
+                          </p>
+                        </div>
+                        <div className="flex gap-1 flex-shrink-0">
+                          <Button onClick={() => handleViewDocument(doc)} variant="ghost" size="sm" className="h-6 w-6 p-0" title={`Ver ${doc.file_name}`} disabled={documentLoading.has(doc.id)}>
+                            {documentLoading.has(doc.id) ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Eye className="h-3 w-3" />}
+                          </Button>
+                          <Button onClick={() => handleDownload(doc)} variant="ghost" size="sm" className="h-6 w-6 p-0" title={`Descargar ${doc.file_name}`} disabled={documentLoading.has(doc.id)}>
+                            {documentLoading.has(doc.id) ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Download className="h-3 w-3" />}
+                          </Button>
+                        </div>
                       </div>
-                      <div className="flex gap-1 flex-shrink-0">
-                        <Button onClick={() => handleViewDocument(doc)} variant="ghost" size="sm" className="h-6 w-6 p-0" title={`Ver ${doc.file_name}`} disabled={documentLoading.has(doc.id)}>
-                          {documentLoading.has(doc.id) ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Eye className="h-3 w-3" />}
-                        </Button>
-                        <Button onClick={() => handleDownload(doc)} variant="ghost" size="sm" className="h-6 w-6 p-0" title={`Descargar ${doc.file_name}`} disabled={documentLoading.has(doc.id)}>
-                          {documentLoading.has(doc.id) ? <RefreshCw className="h-3 w-3 animate-spin" /> : <Download className="h-3 w-3" />}
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </CollapsibleContent>
               </Collapsible>
             </div>

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -6,6 +6,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import { createQueryKey } from '@/lib/optimized-react-query';
 import { useRequiredRoleSummary } from '@/hooks/useJobRequiredRoles';
+import { resolveJobDocBucket } from '@/utils/jobDocuments';
 
 export const useOptimizedJobCard = (
   job: any,
@@ -248,11 +249,15 @@ export const useOptimizedJobCard = (
   }, [job.id, department]);
 
   const handleDeleteDocument = useCallback(async (doc: any) => {
+    if (doc?.read_only) {
+      console.error('Attempted to delete read-only document', doc);
+      return;
+    }
     if (!window.confirm('Are you sure you want to delete this document?')) return;
-    
+
     try {
       const { error: storageError } = await supabase.storage
-        .from('job_documents')
+        .from(resolveJobDocBucket(doc.file_path))
         .remove([doc.file_path]);
       
       if (storageError) throw storageError;

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -77,7 +77,9 @@ export const useOptimizedJobs = (
           file_type,
           file_size,
           visible_to_tech,
-          uploaded_at
+          uploaded_at,
+          read_only,
+          template_type
         ),
         flex_folders(
           id,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2811,8 +2811,10 @@ export type Database = {
           original_type: string | null
           preview_generated_at: string | null
           preview_url: string | null
+          read_only: boolean
           uploaded_at: string
           uploaded_by: string | null
+          template_type: string | null
           visible_to_tech: boolean
         }
         Insert: {
@@ -2826,8 +2828,10 @@ export type Database = {
           original_type?: string | null
           preview_generated_at?: string | null
           preview_url?: string | null
+          read_only?: boolean
           uploaded_at?: string
           uploaded_by?: string | null
+          template_type?: string | null
           visible_to_tech?: boolean
         }
         Update: {
@@ -2841,8 +2845,10 @@ export type Database = {
           original_type?: string | null
           preview_generated_at?: string | null
           preview_url?: string | null
+          read_only?: boolean
           uploaded_at?: string
           uploaded_by?: string | null
+          template_type?: string | null
           visible_to_tech?: boolean
         }
         Relationships: [

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -134,13 +134,15 @@ const TechnicianDashboard = () => {
               color,
               status,
               location:locations(name),
-              job_documents(
-                id,
-                file_name,
-                file_path,
-                visible_to_tech,
-                uploaded_at
-              )
+            job_documents(
+              id,
+              file_name,
+              file_path,
+              visible_to_tech,
+              uploaded_at,
+              read_only,
+              template_type
+            )
             )
           `)
           .eq('technician_id', user.id)

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -3,6 +3,9 @@ export interface JobDocument {
   file_name: string;
   file_path: string;
   uploaded_at: string;
+  visible_to_tech?: boolean;
+  read_only?: boolean;
+  template_type?: string | null;
 }
 
 export type JobType = "single" | "tour" | "tourdate" | "festival" | "dryhire";

--- a/src/utils/jobDocuments.ts
+++ b/src/utils/jobDocuments.ts
@@ -4,6 +4,9 @@ const DEPT_PREFIXES = new Set(['sound','lights','video','production','logistics'
 
 export const resolveJobDocBucket = (path: string) => {
   const first = (path || '').split('/')[0];
+  if (first === 'soundvision-files') {
+    return 'soundvision-files';
+  }
   return DEPT_PREFIXES.has(first) ? 'job_documents' : 'job-documents';
 };
 

--- a/supabase/migrations/20251107120000_add_soundvision_template_autolink.sql
+++ b/supabase/migrations/20251107120000_add_soundvision_template_autolink.sql
@@ -1,0 +1,157 @@
+-- Add read-only/template metadata to job documents
+ALTER TABLE public.job_documents
+  ADD COLUMN IF NOT EXISTS read_only boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS template_type text;
+
+-- Ensure only one template entry per job for a given template_type
+CREATE UNIQUE INDEX IF NOT EXISTS job_documents_unique_template
+  ON public.job_documents (job_id, template_type)
+  WHERE template_type IS NOT NULL;
+
+-- Helper function to normalize text for comparisons
+CREATE OR REPLACE FUNCTION public.normalize_text_for_match(input text)
+RETURNS text
+LANGUAGE sql
+AS $$
+  SELECT CASE
+    WHEN input IS NULL THEN NULL
+    ELSE lower(regexp_replace(input, '[^a-z0-9]', '', 'g'))
+  END;
+$$;
+
+-- Function to automatically attach SoundVision templates based on job location
+CREATE OR REPLACE FUNCTION public.attach_soundvision_template()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  loc RECORD;
+  matching RECORD;
+  existing RECORD;
+  prefixed_path text;
+BEGIN
+  -- Remove template if location cleared
+  IF NEW.location_id IS NULL THEN
+    DELETE FROM public.job_documents
+    WHERE job_id = NEW.id
+      AND template_type = 'soundvision';
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO loc
+  FROM public.locations
+  WHERE id = NEW.location_id;
+
+  IF NOT FOUND THEN
+    RETURN NEW;
+  END IF;
+
+  -- 1. Match by Google Place ID
+  IF loc.google_place_id IS NOT NULL THEN
+    SELECT svf.*, v.* INTO matching
+    FROM public.soundvision_files svf
+    JOIN public.venues v ON v.id = svf.venue_id
+    WHERE v.google_place_id = loc.google_place_id
+    ORDER BY svf.uploaded_at DESC
+    LIMIT 1;
+  END IF;
+
+  -- 2. Match by normalized address
+  IF matching IS NULL AND loc.formatted_address IS NOT NULL THEN
+    SELECT svf.*, v.* INTO matching
+    FROM public.soundvision_files svf
+    JOIN public.venues v ON v.id = svf.venue_id
+    WHERE normalize_text_for_match(v.full_address) = normalize_text_for_match(loc.formatted_address)
+    ORDER BY svf.uploaded_at DESC
+    LIMIT 1;
+  END IF;
+
+  -- 3. Match by venue name + city/state inside formatted address
+  IF matching IS NULL THEN
+    SELECT svf.*, v.* INTO matching
+    FROM public.soundvision_files svf
+    JOIN public.venues v ON v.id = svf.venue_id
+    WHERE lower(v.name) = lower(loc.name)
+      AND (
+        (v.city IS NULL OR (loc.formatted_address IS NOT NULL AND loc.formatted_address ILIKE '%' || v.city || '%'))
+      )
+      AND (
+        (v.state_region IS NULL OR (loc.formatted_address IS NOT NULL AND loc.formatted_address ILIKE '%' || v.state_region || '%'))
+      )
+    ORDER BY svf.uploaded_at DESC
+    LIMIT 1;
+  END IF;
+
+  -- No matching template found; ensure any stale template is removed
+  IF matching IS NULL THEN
+    DELETE FROM public.job_documents
+    WHERE job_id = NEW.id
+      AND template_type = 'soundvision';
+    RETURN NEW;
+  END IF;
+
+  prefixed_path := 'soundvision-files/' || matching.file_path;
+
+  -- Find existing template document for this job
+  SELECT * INTO existing
+  FROM public.job_documents
+  WHERE job_id = NEW.id
+    AND template_type = 'soundvision'
+  LIMIT 1;
+
+  IF existing IS NULL THEN
+    INSERT INTO public.job_documents (
+      job_id,
+      file_name,
+      file_path,
+      file_size,
+      file_type,
+      uploaded_by,
+      visible_to_tech,
+      read_only,
+      template_type,
+      has_preview,
+      original_type
+    )
+    VALUES (
+      NEW.id,
+      matching.file_name,
+      prefixed_path,
+      matching.file_size,
+      matching.file_type,
+      matching.uploaded_by,
+      true,
+      true,
+      'soundvision',
+      false,
+      'soundvision-template'
+    );
+  ELSE
+    IF existing.file_path <> prefixed_path OR NOT existing.read_only THEN
+      UPDATE public.job_documents
+      SET
+        file_name = matching.file_name,
+        file_path = prefixed_path,
+        file_size = matching.file_size,
+        file_type = matching.file_type,
+        uploaded_at = now(),
+        uploaded_by = matching.uploaded_by,
+        visible_to_tech = true,
+        read_only = true,
+        template_type = 'soundvision',
+        original_type = 'soundvision-template'
+      WHERE id = existing.id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_jobs_attach_soundvision ON public.jobs;
+CREATE TRIGGER trg_jobs_attach_soundvision
+AFTER INSERT OR UPDATE OF location_id ON public.jobs
+FOR EACH ROW
+EXECUTE FUNCTION public.attach_soundvision_template();


### PR DESCRIPTION
## Summary
- add a database migration that auto-attaches matching SoundVision files to jobs and marks them as read-only templates
- update job document handling across dashboards, detail views, and technician cards to badge SoundVision templates, disable destructive actions, and support the soundvision-files bucket
- add the required Spanish disclaimer beneath the SoundVision uploader to encourage .xmls submissions

## Testing
- npm run lint *(fails: requires @eslint/js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f9084dec00832f9b0fadbdaac434ca