### PR TITLE
Ensure Hoja de Ruta auto-populated data updates form state

### DIFF
--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -260,7 +260,14 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     }
 
     try {
-      await autoPopulateFromJob();
+      const autoPopulatedData = await autoPopulateFromJob();
+
+      if (autoPopulatedData && Object.keys(autoPopulatedData).length > 0) {
+        setEventData(prev => ({
+          ...prev,
+          ...autoPopulatedData,
+        }));
+      }
     } catch (error) {
       console.error("Error loading job data:", error);
       toast({


### PR DESCRIPTION
## Summary
- merge the auto-populated job data into the Hoja de Ruta form state after loading so saved power requirements appear in the form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f90f7b001c832faed1522521740b4d