### PR TITLE
Handle auto-populated power requirements

### DIFF
--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -260,7 +260,14 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     }
 
     try {
-      await autoPopulateFromJob();
+      const autoPopulatedData = await autoPopulateFromJob();
+
+      if (autoPopulatedData?.powerRequirements) {
+        setEventData((prev) => ({
+          ...prev,
+          powerRequirements: autoPopulatedData.powerRequirements,
+        }));
+      }
     } catch (error) {
       console.error("Error loading job data:", error);
       toast({


### PR DESCRIPTION
## Summary
- capture the data returned from autoPopulateFromJob when loading job data
- update the Hoja de Ruta form state with any auto-populated power requirements text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f914cb10c0832f9c1cce55958eca79