### PR TITLE
Add SoundVision review system with aggregated ratings

### DIFF
--- a/src/components/soundvision/SoundVisionReviewDialog.tsx
+++ b/src/components/soundvision/SoundVisionReviewDialog.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { SoundVisionFile } from '@/hooks/useSoundVisionFiles';
+import { useSoundVisionFileReviews } from '@/hooks/useSoundVisionFileReviews';
+import { StarRating } from './StarRating';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Loader2, Trash2 } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { toast } from 'sonner';
+
+interface SoundVisionReviewDialogProps {
+  file: SoundVisionFile;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const SoundVisionReviewDialog = ({ file, open, onOpenChange }: SoundVisionReviewDialogProps) => {
+  const {
+    reviews,
+    currentUserReview,
+    userId,
+    isLoading,
+    createReview,
+    updateReview,
+    deleteReview,
+  } = useSoundVisionFileReviews(file.id);
+
+  const [rating, setRating] = useState<number>(0);
+  const [reviewText, setReviewText] = useState('');
+
+  const isSaving = createReview.isPending || updateReview.isPending;
+  const isDeleting = deleteReview.isPending;
+
+  useEffect(() => {
+    if (!open) return;
+    if (currentUserReview) {
+      setRating(currentUserReview.rating);
+      setReviewText(currentUserReview.review ?? '');
+    } else {
+      setRating(0);
+      setReviewText('');
+    }
+  }, [currentUserReview, open]);
+
+  const reviewStats = useMemo(() => {
+    const count = reviews.length;
+    const total = reviews.reduce((sum, review) => sum + review.rating, 0);
+    return {
+      count,
+      average: count > 0 ? total / count : null,
+    };
+  }, [reviews]);
+
+  const averageText = useMemo(() => {
+    if (reviewStats.count > 0 && reviewStats.average !== null) {
+      return `${reviewStats.average.toFixed(1)} / 5 · ${reviewStats.count} ${
+        reviewStats.count === 1 ? 'reseña' : 'reseñas'
+      }`;
+    }
+
+    if (file.ratings_count > 0 && file.average_rating !== null) {
+      return `${file.average_rating.toFixed(1)} / 5 · ${file.ratings_count} ${
+        file.ratings_count === 1 ? 'reseña' : 'reseñas'
+      }`;
+    }
+
+    return 'Sin reseñas registradas';
+  }, [file.average_rating, file.ratings_count, reviewStats]);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!userId) {
+      toast.error('Debes iniciar sesión para dejar una reseña.');
+      return;
+    }
+
+    if (rating < 1) {
+      toast.error('Selecciona una valoración entre 1 y 5 estrellas.');
+      return;
+    }
+
+    const payload = {
+      rating,
+      review: reviewText.trim() ? reviewText.trim() : undefined,
+    };
+
+    try {
+      if (currentUserReview) {
+        await updateReview.mutateAsync({
+          reviewId: currentUserReview.id,
+          rating: payload.rating,
+          review: payload.review,
+        });
+      } else {
+        await createReview.mutateAsync(payload);
+      }
+    } catch (error) {
+      console.error('Error saving review', error);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!currentUserReview) return;
+    try {
+      await deleteReview.mutateAsync(currentUserReview.id);
+    } catch (error) {
+      console.error('Error deleting review', error);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Reseñas para {file.file_name}</DialogTitle>
+          <DialogDescription>
+            <div className="mt-2 flex flex-col gap-2">
+              <div className="flex items-center gap-2 text-sm">
+                <StarRating value={reviewStats.average ?? file.average_rating ?? 0} readOnly />
+                <span className="text-muted-foreground">{averageText}</span>
+              </div>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">Tu valoración</p>
+                {currentUserReview && (
+                  <Badge variant="secondary">Última actualización {formatDistanceToNow(new Date(currentUserReview.updated_at), { addSuffix: true, locale: es })}</Badge>
+                )}
+              </div>
+              <StarRating value={rating} onChange={setRating} readOnly={!userId || isSaving || isDeleting} size="lg" />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="soundvision-review-text">
+                Comentarios (opcional)
+              </label>
+              <Textarea
+                id="soundvision-review-text"
+                placeholder="Comparte detalles útiles sobre este archivo..."
+                value={reviewText}
+                onChange={(event) => setReviewText(event.target.value)}
+                disabled={!userId || isSaving || isDeleting}
+                rows={4}
+              />
+              {!userId && (
+                <p className="text-xs text-muted-foreground">Inicia sesión para dejar una reseña.</p>
+              )}
+            </div>
+            <DialogFooter className="flex items-center justify-between gap-4">
+              {currentUserReview ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                  className="text-destructive"
+                >
+                  {isDeleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                  <span className="ml-2">Eliminar reseña</span>
+                </Button>
+              ) : (
+                <span />
+              )}
+              <Button type="submit" disabled={!userId || isSaving || isDeleting}>
+                {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                {currentUserReview ? 'Actualizar reseña' : 'Publicar reseña'}
+              </Button>
+            </DialogFooter>
+          </form>
+
+          <div className="space-y-3">
+            <p className="text-sm font-medium">Todas las reseñas</p>
+            {isLoading ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-6 w-6 animate-spin text-primary" />
+              </div>
+            ) : reviews.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Todavía no hay reseñas para este archivo.</p>
+            ) : (
+              <div className="space-y-3 max-h-80 overflow-y-auto pr-1">
+                {reviews.map((review) => (
+                  <div key={review.id} className="rounded-lg border p-3 space-y-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <p className="text-sm font-medium">
+                          {review.reviewer
+                            ? `${review.reviewer.first_name ?? ''} ${review.reviewer.last_name ?? ''}`.trim() || 'Usuario'
+                            : 'Usuario'}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatDistanceToNow(new Date(review.updated_at), { addSuffix: true, locale: es })}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <StarRating value={review.rating} readOnly size="sm" />
+                        {review.is_initial && <Badge variant="outline">Inicial</Badge>}
+                      </div>
+                    </div>
+                    {review.review && (
+                      <p className="text-sm text-muted-foreground whitespace-pre-line">{review.review}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/soundvision/StarRating.tsx
+++ b/src/components/soundvision/StarRating.tsx
@@ -1,0 +1,62 @@
+import { cn } from '@/lib/utils';
+import { Star } from 'lucide-react';
+import { useMemo } from 'react';
+
+type StarRatingSize = 'sm' | 'md' | 'lg';
+
+interface StarRatingProps {
+  value: number;
+  onChange?: (value: number) => void;
+  readOnly?: boolean;
+  size?: StarRatingSize;
+  className?: string;
+  label?: string;
+}
+
+const sizeMap: Record<StarRatingSize, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+};
+
+export const StarRating = ({
+  value,
+  onChange,
+  readOnly = false,
+  size = 'md',
+  className,
+  label,
+}: StarRatingProps) => {
+  const stars = useMemo(() => [1, 2, 3, 4, 5], []);
+
+  const handleClick = (starValue: number) => {
+    if (readOnly || !onChange) return;
+    onChange(starValue);
+  };
+
+  return (
+    <div className={cn('flex items-center gap-1', className)} aria-label={label ?? 'Valoración'}>
+      {stars.map((star) => {
+        const active = value >= star;
+        return (
+          <button
+            key={star}
+            type="button"
+            disabled={readOnly}
+            onClick={() => handleClick(star)}
+            className={cn(
+              'transition-colors disabled:cursor-default',
+              readOnly ? 'cursor-default' : 'cursor-pointer'
+            )}
+          >
+            <Star
+              className={cn(sizeMap[size], active ? 'fill-yellow-400 text-yellow-500' : 'text-muted-foreground')}
+              aria-hidden="true"
+            />
+            <span className="sr-only">{`${star} estrella${star > 1 ? 's' : ''}`}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/soundvision/VenueMetadataForm.tsx
+++ b/src/components/soundvision/VenueMetadataForm.tsx
@@ -24,7 +24,7 @@ export interface VenueFormData {
 }
 
 interface VenueMetadataFormProps {
-  form: UseFormReturn<VenueFormData>;
+  form: UseFormReturn<VenueFormData & Record<string, unknown>>;
 }
 
 interface PlaceResult {

--- a/src/hooks/useSoundVisionFileReviews.ts
+++ b/src/hooks/useSoundVisionFileReviews.ts
@@ -1,0 +1,182 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+export interface SoundVisionFileReview {
+  id: string;
+  file_id: string;
+  reviewer_id: string;
+  rating: number;
+  review: string | null;
+  is_initial: boolean;
+  created_at: string;
+  updated_at: string;
+  reviewer?: {
+    id: string;
+    first_name: string | null;
+    last_name: string | null;
+    role: string | null;
+  } | null;
+}
+
+interface ReviewsQueryResult {
+  reviews: SoundVisionFileReview[];
+  currentUserReview: SoundVisionFileReview | null;
+  userId: string | null;
+}
+
+export const useSoundVisionFileReviews = (fileId: string | null | undefined) => {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<ReviewsQueryResult>({
+    queryKey: ['soundvision-file-reviews', fileId],
+    enabled: Boolean(fileId),
+    queryFn: async () => {
+      if (!fileId) {
+        return { reviews: [], currentUserReview: null, userId: null };
+      }
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        return { reviews: [], currentUserReview: null, userId: null };
+      }
+
+      const { data, error } = await supabase
+        .from('soundvision_file_reviews')
+        .select(
+          `id, file_id, reviewer_id, rating, review, is_initial, created_at, updated_at,
+          reviewer:profiles(id, first_name, last_name, role)`
+        )
+        .eq('file_id', fileId)
+        .order('updated_at', { ascending: false });
+
+      if (error) throw error;
+
+      const reviews = (data ?? []).map((entry) => ({
+        id: entry.id,
+        file_id: entry.file_id,
+        reviewer_id: entry.reviewer_id,
+        rating: entry.rating,
+        review: entry.review,
+        is_initial: entry.is_initial,
+        created_at: entry.created_at,
+        updated_at: entry.updated_at,
+        reviewer: entry.reviewer ?? null,
+      }));
+
+      const currentUserReview = reviews.find((review) => review.reviewer_id === user.id) ?? null;
+
+      return { reviews, currentUserReview, userId: user.id };
+    },
+  });
+
+  const invalidateCaches = (fileIdToInvalidate?: string) => {
+    if (!fileIdToInvalidate) return;
+    queryClient.invalidateQueries({ queryKey: ['soundvision-file-reviews', fileIdToInvalidate] });
+    queryClient.invalidateQueries({ queryKey: ['soundvision-files'] });
+  };
+
+  const createReview = useMutation({
+    mutationFn: async ({ rating, review }: { rating: number; review?: string }) => {
+      if (!fileId) throw new Error('Archivo no válido');
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) throw new Error('Usuario no autenticado');
+
+      const { error } = await supabase.from('soundvision_file_reviews').insert({
+        file_id: fileId,
+        reviewer_id: user.id,
+        rating,
+        review: review ?? null,
+      });
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      if (fileId) {
+        invalidateCaches(fileId);
+      }
+      toast.success('Reseña guardada correctamente');
+    },
+    onError: (error) => {
+      console.error('Error creating review:', error);
+      toast.error(error.message || 'No se pudo guardar la reseña');
+    },
+  });
+
+  const updateReview = useMutation({
+    mutationFn: async ({
+      reviewId,
+      rating,
+      review,
+    }: {
+      reviewId: string;
+      rating: number;
+      review?: string;
+    }) => {
+      if (!fileId) throw new Error('Archivo no válido');
+
+      const { error } = await supabase
+        .from('soundvision_file_reviews')
+        .update({
+          rating,
+          review: review ?? null,
+        })
+        .eq('id', reviewId);
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      if (fileId) {
+        invalidateCaches(fileId);
+      }
+      toast.success('Reseña actualizada correctamente');
+    },
+    onError: (error) => {
+      console.error('Error updating review:', error);
+      toast.error(error.message || 'No se pudo actualizar la reseña');
+    },
+  });
+
+  const deleteReview = useMutation({
+    mutationFn: async (reviewId: string) => {
+      if (!fileId) throw new Error('Archivo no válido');
+
+      const { error } = await supabase
+        .from('soundvision_file_reviews')
+        .delete()
+        .eq('id', reviewId);
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      if (fileId) {
+        invalidateCaches(fileId);
+      }
+      toast.success('Reseña eliminada correctamente');
+    },
+    onError: (error) => {
+      console.error('Error deleting review:', error);
+      toast.error(error.message || 'No se pudo eliminar la reseña');
+    },
+  });
+
+  return {
+    reviews: query.data?.reviews ?? [],
+    currentUserReview: query.data?.currentUserReview ?? null,
+    userId: query.data?.userId ?? null,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    createReview,
+    updateReview,
+    deleteReview,
+    refetch: query.refetch,
+    query,
+  };
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4415,37 +4415,49 @@ export type Database = {
       }
       soundvision_files: {
         Row: {
+          average_rating: number | null
           file_name: string
           file_path: string
           file_size: number
           file_type: string
           id: string
+          last_reviewed_at: string | null
           metadata: Json | null
           notes: string | null
+          rating_total: number
+          ratings_count: number
           uploaded_at: string
           uploaded_by: string
           venue_id: string
         }
         Insert: {
+          average_rating?: number | null
           file_name: string
           file_path: string
           file_size: number
           file_type: string
           id?: string
+          last_reviewed_at?: string | null
           metadata?: Json | null
           notes?: string | null
+          rating_total?: number
+          ratings_count?: number
           uploaded_at?: string
           uploaded_by: string
           venue_id: string
         }
         Update: {
+          average_rating?: number | null
           file_name?: string
           file_path?: string
           file_size?: number
           file_type?: string
           id?: string
+          last_reviewed_at?: string | null
           metadata?: Json | null
           notes?: string | null
+          rating_total?: number
+          ratings_count?: number
           uploaded_at?: string
           uploaded_by?: string
           venue_id?: string
@@ -4456,6 +4468,61 @@ export type Database = {
             columns: ["venue_id"]
             isOneToOne: false
             referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      soundvision_file_reviews: {
+        Row: {
+          created_at: string
+          file_id: string
+          id: string
+          is_initial: boolean
+          rating: number
+          review: string | null
+          reviewer_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          file_id: string
+          id?: string
+          is_initial?: boolean
+          rating: number
+          review?: string | null
+          reviewer_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          file_id?: string
+          id?: string
+          is_initial?: boolean
+          rating?: number
+          review?: string | null
+          reviewer_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "soundvision_file_reviews_file_id_fkey"
+            columns: ["file_id"]
+            isOneToOne: false
+            referencedRelation: "soundvision_files"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "soundvision_file_reviews_reviewer_id_fkey"
+            columns: ["reviewer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "soundvision_file_reviews_reviewer_id_fkey"
+            columns: ["reviewer_id"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -6274,6 +6341,10 @@ export type Database = {
         }[]
       }
       get_current_user_role: { Args: never; Returns: string }
+      is_management_or_admin: {
+        Args: { p_user_id: string }
+        Returns: boolean
+      }
       get_job_total_amounts: {
         Args: { _job_id: string; _user_role?: string }
         Returns: {

--- a/supabase/migrations/20260209090000_add_soundvision_reviews.sql
+++ b/supabase/migrations/20260209090000_add_soundvision_reviews.sql
@@ -1,0 +1,146 @@
+-- Adds review aggregation columns and review table for SoundVision files
+
+-- Add cached aggregate columns to soundvision_files
+ALTER TABLE public.soundvision_files
+  ADD COLUMN IF NOT EXISTS average_rating NUMERIC(3,2),
+  ADD COLUMN IF NOT EXISTS ratings_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS rating_total INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_reviewed_at TIMESTAMP WITH TIME ZONE;
+
+-- Create soundvision_file_reviews table
+CREATE TABLE IF NOT EXISTS public.soundvision_file_reviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  file_id UUID NOT NULL REFERENCES public.soundvision_files(id) ON DELETE CASCADE,
+  reviewer_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  rating SMALLINT NOT NULL CHECK (rating BETWEEN 1 AND 5),
+  review TEXT,
+  is_initial BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  CONSTRAINT soundvision_file_reviews_unique_reviewer UNIQUE (file_id, reviewer_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_soundvision_file_reviews_file_id
+  ON public.soundvision_file_reviews(file_id);
+
+CREATE INDEX IF NOT EXISTS idx_soundvision_file_reviews_reviewer_id
+  ON public.soundvision_file_reviews(reviewer_id);
+
+-- Enable RLS
+ALTER TABLE public.soundvision_file_reviews ENABLE ROW LEVEL SECURITY;
+
+-- Helper expression to detect management roles
+CREATE OR REPLACE FUNCTION public.is_management_or_admin(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles
+    WHERE profiles.id = p_user_id
+      AND profiles.role IN ('admin', 'management')
+  );
+$$;
+
+-- RLS Policies
+CREATE POLICY soundvision_file_reviews_select_authenticated
+  ON public.soundvision_file_reviews FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY soundvision_file_reviews_insert_self_or_management
+  ON public.soundvision_file_reviews FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    reviewer_id = auth.uid()
+    OR public.is_management_or_admin(auth.uid())
+  );
+
+CREATE POLICY soundvision_file_reviews_update_self_or_management
+  ON public.soundvision_file_reviews FOR UPDATE
+  TO authenticated
+  USING (
+    reviewer_id = auth.uid()
+    OR public.is_management_or_admin(auth.uid())
+  )
+  WITH CHECK (
+    reviewer_id = auth.uid()
+    OR public.is_management_or_admin(auth.uid())
+  );
+
+CREATE POLICY soundvision_file_reviews_delete_self_or_management
+  ON public.soundvision_file_reviews FOR DELETE
+  TO authenticated
+  USING (
+    reviewer_id = auth.uid()
+    OR public.is_management_or_admin(auth.uid())
+  );
+
+-- Trigger to maintain updated_at on reviews
+CREATE OR REPLACE FUNCTION public.touch_soundvision_file_reviews_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_soundvision_file_reviews_updated_at ON public.soundvision_file_reviews;
+CREATE TRIGGER trg_soundvision_file_reviews_updated_at
+  BEFORE UPDATE ON public.soundvision_file_reviews
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_soundvision_file_reviews_updated_at();
+
+-- Trigger function to refresh aggregates
+CREATE OR REPLACE FUNCTION public.refresh_soundvision_file_review_stats()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_file_id UUID;
+BEGIN
+  v_file_id := COALESCE(NEW.file_id, OLD.file_id);
+
+  UPDATE public.soundvision_files f
+  SET
+    ratings_count = stats.review_count,
+    rating_total = stats.rating_sum,
+    average_rating = CASE WHEN stats.review_count > 0
+      THEN ROUND(stats.rating_sum::NUMERIC / stats.review_count, 2)
+      ELSE NULL
+    END,
+    last_reviewed_at = stats.last_reviewed_at
+  FROM (
+    SELECT
+      file_id,
+      COUNT(*) AS review_count,
+      COALESCE(SUM(rating), 0) AS rating_sum,
+      MAX(updated_at) AS last_reviewed_at
+    FROM public.soundvision_file_reviews
+    WHERE file_id = v_file_id
+    GROUP BY file_id
+  ) AS stats
+  WHERE f.id = stats.file_id;
+
+  IF NOT FOUND THEN
+    UPDATE public.soundvision_files
+    SET
+      ratings_count = 0,
+      rating_total = 0,
+      average_rating = NULL,
+      last_reviewed_at = NULL
+    WHERE id = v_file_id;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_soundvision_file_reviews_refresh_stats ON public.soundvision_file_reviews;
+CREATE TRIGGER trg_soundvision_file_reviews_refresh_stats
+  AFTER INSERT OR UPDATE OR DELETE ON public.soundvision_file_reviews
+  FOR EACH ROW
+  EXECUTE FUNCTION public.refresh_soundvision_file_review_stats();


### PR DESCRIPTION
## Summary
- add a Supabase migration that introduces cached rating columns, a soundvision_file_reviews table, and triggers/policies for keeping aggregates in sync
- extend the upload workflow to optionally seed an initial review and expose the new rating metadata to client hooks
- build review hooks and UI (star rating, review dialog, list/map updates) so users can read and manage SoundVision file reviews

## Testing
- npm run lint -- --max-warnings=0 *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f93df21d3c832fba3c5a2c4a4e2bea