### PR TITLE
Add SoundVision download tracking and rating eligibility guard

### DIFF
--- a/src/components/soundvision/SoundVisionFilesList.tsx
+++ b/src/components/soundvision/SoundVisionFilesList.tsx
@@ -25,7 +25,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { formatDistanceToNow } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { StarRating } from './StarRating';
 import { SoundVisionReviewDialog } from './SoundVisionReviewDialog';
 
@@ -55,6 +55,21 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
   const downloadFile = useDownloadSoundVisionFile();
 
   const canDelete = canDeleteSoundVisionFiles(profile?.role);
+  const isManagement = useMemo(
+    () => profile?.role === 'admin' || profile?.role === 'management',
+    [profile?.role]
+  );
+
+  useEffect(() => {
+    if (!selectedFile) return;
+    const updated = files.find((file) => file.id === selectedFile.id);
+    if (updated && updated !== selectedFile) {
+      setSelectedFile(updated);
+    }
+  }, [files, selectedFile]);
+
+  const canOpenReviews = (file: SoundVisionFile) =>
+    isManagement || file.hasDownloaded || file.hasReviewed;
 
   if (files.length === 0) {
     return (
@@ -118,6 +133,8 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                 variant={file.hasReviewed ? 'secondary' : 'outline'}
                 onClick={() => setSelectedFile(file)}
                 className="flex-1"
+                disabled={!canOpenReviews(file)}
+                title={!canOpenReviews(file) ? 'Descarga el archivo para poder valorarlo.' : undefined}
               >
                 <StarIcon className="h-4 w-4 mr-1" />
                 Reseñas
@@ -132,6 +149,11 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                 <Download className="h-4 w-4 mr-1" />
                 Descargar
               </Button>
+              {!canOpenReviews(file) && (
+                <p className="w-full text-xs text-muted-foreground">
+                  Descarga el archivo para poder dejar una reseña.
+                </p>
+              )}
               {canDelete && (
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
@@ -210,6 +232,8 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                       size="sm"
                       variant={file.hasReviewed ? 'secondary' : 'outline'}
                       onClick={() => setSelectedFile(file)}
+                      disabled={!canOpenReviews(file)}
+                      title={!canOpenReviews(file) ? 'Descarga el archivo para poder valorarlo.' : undefined}
                     >
                       <StarIcon className="h-4 w-4 mr-1" />
                       Reseñas
@@ -223,6 +247,11 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
                       <Download className="h-4 w-4 mr-1" />
                       Descargar
                     </Button>
+                    {!canOpenReviews(file) && (
+                      <p className="text-xs text-muted-foreground w-full text-right">
+                        Descarga el archivo para poder dejar una reseña.
+                      </p>
+                    )}
                     {canDelete && (
                       <AlertDialog>
                         <AlertDialogTrigger asChild>
@@ -262,6 +291,7 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
               setSelectedFile(null);
             }
           }}
+          currentUserRole={profile?.role ?? null}
         />
       )}
     </>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4413,6 +4413,55 @@ export type Database = {
           },
         ]
       }
+      soundvision_file_downloads: {
+        Row: {
+          downloaded_at: string
+          file_id: string
+          id: string
+          ip_address: string | null
+          profile_id: string
+          user_agent: string | null
+        }
+        Insert: {
+          downloaded_at?: string
+          file_id: string
+          id?: string
+          ip_address?: string | null
+          profile_id: string
+          user_agent?: string | null
+        }
+        Update: {
+          downloaded_at?: string
+          file_id?: string
+          id?: string
+          ip_address?: string | null
+          profile_id?: string
+          user_agent?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "soundvision_file_downloads_file_id_fkey"
+            columns: ["file_id"]
+            isOneToOne: false
+            referencedRelation: "soundvision_files"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "soundvision_file_downloads_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "soundvision_file_downloads_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       soundvision_files: {
         Row: {
           average_rating: number | null

--- a/supabase/migrations/20260210120000_add_soundvision_file_downloads.sql
+++ b/supabase/migrations/20260210120000_add_soundvision_file_downloads.sql
@@ -1,0 +1,84 @@
+-- Create table to track SoundVision file downloads
+CREATE TABLE IF NOT EXISTS public.soundvision_file_downloads (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  file_id uuid NOT NULL REFERENCES public.soundvision_files(id) ON DELETE CASCADE,
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  downloaded_at timestamptz NOT NULL DEFAULT now(),
+  ip_address inet,
+  user_agent text,
+  UNIQUE (file_id, profile_id)
+);
+
+-- Enable row level security
+ALTER TABLE public.soundvision_file_downloads ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to view their own download records, management/admin can view all
+DROP POLICY IF EXISTS soundvision_file_downloads_select_self_or_management ON public.soundvision_file_downloads;
+CREATE POLICY soundvision_file_downloads_select_self_or_management
+  ON public.soundvision_file_downloads FOR SELECT
+  TO authenticated
+  USING (
+    profile_id = auth.uid()
+    OR public.is_management_or_admin(auth.uid())
+  );
+
+-- Allow users to insert download records for themselves
+DROP POLICY IF EXISTS soundvision_file_downloads_insert_self ON public.soundvision_file_downloads;
+CREATE POLICY soundvision_file_downloads_insert_self
+  ON public.soundvision_file_downloads FOR INSERT
+  TO authenticated
+  WITH CHECK (profile_id = auth.uid());
+
+-- Allow users to delete their own records and management/admin to manage all records
+DROP POLICY IF EXISTS soundvision_file_downloads_delete_self_or_management ON public.soundvision_file_downloads;
+CREATE POLICY soundvision_file_downloads_delete_self_or_management
+  ON public.soundvision_file_downloads FOR DELETE
+  TO authenticated
+  USING (
+    profile_id = auth.uid()
+    OR public.is_management_or_admin(auth.uid())
+  );
+
+-- Update review policies to enforce download requirement before inserting/updating reviews
+DROP POLICY IF EXISTS soundvision_file_reviews_insert_self_or_management ON public.soundvision_file_reviews;
+CREATE POLICY soundvision_file_reviews_insert_self_or_management
+  ON public.soundvision_file_reviews FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.is_management_or_admin(auth.uid())
+    OR (
+      reviewer_id = auth.uid()
+      AND EXISTS (
+        SELECT 1
+        FROM public.soundvision_file_downloads d
+        WHERE d.file_id = soundvision_file_reviews.file_id
+          AND d.profile_id = auth.uid()
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS soundvision_file_reviews_update_self_or_management ON public.soundvision_file_reviews;
+CREATE POLICY soundvision_file_reviews_update_self_or_management
+  ON public.soundvision_file_reviews FOR UPDATE
+  TO authenticated
+  USING (
+    reviewer_id = auth.uid()
+    OR public.is_management_or_admin(auth.uid())
+  )
+  WITH CHECK (
+    public.is_management_or_admin(auth.uid())
+    OR (
+      reviewer_id = auth.uid()
+      AND EXISTS (
+        SELECT 1
+        FROM public.soundvision_file_downloads d
+        WHERE d.file_id = soundvision_file_reviews.file_id
+          AND d.profile_id = auth.uid()
+      )
+    )
+  );
+
+-- Helpful indexes for queries
+CREATE INDEX IF NOT EXISTS idx_soundvision_file_downloads_file_id ON public.soundvision_file_downloads(file_id);
+CREATE INDEX IF NOT EXISTS idx_soundvision_file_downloads_profile_id ON public.soundvision_file_downloads(profile_id);
+CREATE INDEX IF NOT EXISTS idx_soundvision_file_downloads_downloaded_at ON public.soundvision_file_downloads(downloaded_at DESC);


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates the soundvision_file_downloads table, indexes, and review policies that require a recorded download before non-management users can review
- extend the Supabase client types and SoundVision hooks to track per-user downloads, record them after storage downloads, and surface helpful errors
- update the SoundVision file list and review dialog UI to disable ratings until a download is recorded and guide users to download first

## Testing
- npm run lint *(fails: missing @eslint/js package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f941a97818832fbfbbd807c12ebaa9