### PR TITLE
Add SoundVision access flag handling to auth and UI

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -39,6 +39,7 @@ const Layout = () => {
     session,
     userRole,
     userDepartment,
+    hasSoundVisionAccess,
     isLoading,
     logout
   } = useOptimizedAuth();
@@ -107,7 +108,11 @@ const Layout = () => {
           <SidebarContent>
             <SidebarGroup>
               <SidebarGroupContent>
-                <SidebarNavigation userRole={userRole} />
+                <SidebarNavigation
+                  userRole={userRole}
+                  userDepartment={userDepartment}
+                  hasSoundVisionAccess={hasSoundVisionAccess}
+                />
               </SidebarGroupContent>
             </SidebarGroup>
           </SidebarContent>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -36,6 +36,7 @@ const Layout = () => {
     session,
     userRole,
     userDepartment,
+    hasSoundVisionAccess,
     isLoading,
     logout
   } = useOptimizedAuth();
@@ -93,7 +94,11 @@ const Layout = () => {
           <SidebarContent>
             <SidebarGroup>
               <SidebarGroupContent>
-                <SidebarNavigation userRole={userRole} userDepartment={userDepartment} />
+                <SidebarNavigation
+                  userRole={userRole}
+                  userDepartment={userDepartment}
+                  hasSoundVisionAccess={hasSoundVisionAccess}
+                />
               </SidebarGroupContent>
             </SidebarGroup>
           </SidebarContent>

--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -26,9 +26,10 @@ import { SidebarNavigationSkeleton } from './SidebarNavigationSkeleton';
 interface SidebarNavigationProps {
   userRole: string | null;
   userDepartment?: string | null;
+  hasSoundVisionAccess: boolean;
 }
 
-export const SidebarNavigation = ({ userRole, userDepartment }: SidebarNavigationProps) => {
+export const SidebarNavigation = ({ userRole, userDepartment, hasSoundVisionAccess }: SidebarNavigationProps) => {
   const location = useLocation();
   console.log('Current user role in navigation:', userRole);
   console.log('Current user department in navigation:', userDepartment);
@@ -38,16 +39,6 @@ export const SidebarNavigation = ({ userRole, userDepartment }: SidebarNavigatio
   
   // Management users have access to everything
   const isManagementUser = userRole === 'management';
-  
-  // Check if user is in sound department
-  const isSoundDepartment = userDepartment?.toLowerCase() === 'sound';
-
-  // Check if user is house tech from sound department
-  const isSoundHouseTech = userRole === 'house_tech' && isSoundDepartment;
-  
-  // Check if user is in lights department
-  const isLightsDepartment = userDepartment?.toLowerCase() === 'lights';
-  const isLightsHouseTech = userRole === 'house_tech' && isLightsDepartment;
 
   // Show skeleton instead of nothing while role loads
   if (!userRole) {
@@ -122,8 +113,8 @@ export const SidebarNavigation = ({ userRole, userDepartment }: SidebarNavigatio
           </Link>
         )}
 
-        {/* SoundVision Files - for sound department technicians/house techs only */}
-        {isTechnicianOrHouseTech && isSoundDepartment && (
+        {/* SoundVision Files - gated by dedicated access flag */}
+        {hasSoundVisionAccess && (
           <Link to="/soundvision-files">
             <Button
               variant="ghost"

--- a/src/pages/SoundVisionFiles.tsx
+++ b/src/pages/SoundVisionFiles.tsx
@@ -2,16 +2,29 @@ import { Card } from '@/components/ui/card';
 import { SoundVisionDatabaseDialog } from '@/components/soundvision/SoundVisionDatabaseDialog';
 import { SoundVisionMap } from '@/components/soundvision/SoundVisionMap';
 import { useSoundVisionFiles } from '@/hooks/useSoundVisionFiles';
-import { useRoleGuard } from '@/hooks/useRoleGuard';
+import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getDashboardPath } from '@/utils/roleBasedRouting';
+import type { UserRole } from '@/types/user';
 import { Loader2 } from 'lucide-react';
 
 const SoundVisionFiles = () => {
-  // Protect this page - only allow sound department technicians and house techs
-  useRoleGuard(['technician', 'house_tech'], 'sound');
+  const { hasSoundVisionAccess, isLoading, userRole } = useOptimizedAuth();
+  const navigate = useNavigate();
 
-  const { data: files = [], isLoading } = useSoundVisionFiles();
+  useEffect(() => {
+    if (isLoading) return;
 
-  if (isLoading) {
+    if (!hasSoundVisionAccess) {
+      const fallbackPath = getDashboardPath(userRole ? (userRole as UserRole) : null);
+      navigate(fallbackPath, { replace: true });
+    }
+  }, [hasSoundVisionAccess, isLoading, navigate, userRole]);
+
+  const { data: files = [], isLoading: isFilesLoading } = useSoundVisionFiles();
+
+  if (isLoading || !hasSoundVisionAccess || isFilesLoading) {
     return (
       <div className="container mx-auto px-4 py-6 max-w-7xl h-[calc(100vh-6rem)] flex items-center justify-center">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- extend the optimized auth provider to pull the SoundVision access flag, cache it, and expose a derived `hasSoundVisionAccess`
- wire the new flag through the layout navigation and SoundVision files route guard so only authorized users see or reach the feature
- update the sound department page to hide the SoundVision dialog launcher when access is not granted

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f944e0a3b8832f964a7302caf58d45