### PR TITLE
Tighten SoundVision file access policies

### DIFF
--- a/supabase/migrations/20250718120000_update_soundvision_file_policies.sql
+++ b/supabase/migrations/20250718120000_update_soundvision_file_policies.sql
@@ -1,0 +1,66 @@
+BEGIN;
+
+DROP POLICY IF EXISTS "soundvision_files_select_authenticated" ON public.soundvision_files;
+CREATE POLICY "soundvision_files_select_authenticated"
+  ON public.soundvision_files FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND (
+          profiles.role IN ('admin', 'management')
+          OR COALESCE(profiles.soundvision_access_enabled, false)
+          OR (profiles.role = 'house_tech' AND profiles.department = 'sound')
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "soundvision_files_insert_authorized" ON public.soundvision_files;
+CREATE POLICY "soundvision_files_insert_authorized"
+  ON public.soundvision_files FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND (
+          profiles.role IN ('admin', 'management')
+          OR COALESCE(profiles.soundvision_access_enabled, false)
+          OR (profiles.role = 'house_tech' AND profiles.department = 'sound')
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "soundvision_files_update_owner_or_management" ON public.soundvision_files;
+CREATE POLICY "soundvision_files_update_authorized"
+  ON public.soundvision_files FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND (
+          profiles.role IN ('admin', 'management')
+          OR COALESCE(profiles.soundvision_access_enabled, false)
+          OR (profiles.role = 'house_tech' AND profiles.department = 'sound')
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND (
+          profiles.role IN ('admin', 'management')
+          OR COALESCE(profiles.soundvision_access_enabled, false)
+          OR (profiles.role = 'house_tech' AND profiles.department = 'sound')
+        )
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary
- replace the `soundvision_files_select_authenticated` policy so only admins, management, flagged profiles, or sound house techs can read files
- align the insert and update policies to enforce the same access requirements for writes

## Testing
- npm run lint *(fails: missing local dependency installation due to peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68f948f3d254832fbc337d72b6e58e2f