### PR TITLE
Refine project management layout for mobile filters and responsive list

### DIFF
--- a/src/components/project-management/DepartmentTabs.tsx
+++ b/src/components/project-management/DepartmentTabs.tsx
@@ -1,17 +1,13 @@
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { JobCardNew } from "@/components/jobs/cards/JobCardNew";
 import { Department } from "@/types/department";
-import { Loader2 } from "lucide-react";
-import { isToday, isWithinInterval, startOfDay, endOfDay } from "date-fns";
+import { ProjectManagementJobList } from "./ProjectManagementJobList";
 
 interface DepartmentTabsProps {
   selectedDepartment: Department;
   onDepartmentChange: (value: string) => void;
   jobs: any[];
   jobsLoading: boolean;
-  onDeleteDocument?: (jobId: string, document: any) => void;
-  userRole?: string | null;
   highlightToday?: boolean;
 }
 
@@ -20,23 +16,8 @@ export const DepartmentTabs = ({
   onDepartmentChange,
   jobs,
   jobsLoading,
-  onDeleteDocument,
-  userRole,
   highlightToday = false
 }: DepartmentTabsProps) => {
-  
-  // Check if a job is happening today
-  const isJobToday = (job: any) => {
-    const today = new Date();
-    const jobStart = new Date(job.start_time);
-    const jobEnd = new Date(job.end_time);
-    
-    return isWithinInterval(today, {
-      start: startOfDay(jobStart),
-      end: endOfDay(jobEnd)
-    });
-  };
-
   return (
     <Tabs value={selectedDepartment} onValueChange={onDepartmentChange} className="mt-4">
       <TabsList className="grid w-full grid-cols-3 lg:w-[400px]">
@@ -47,42 +28,11 @@ export const DepartmentTabs = ({
 
       {["sound", "lights", "video"].map((dept) => (
         <TabsContent key={dept} value={dept}>
-          {jobsLoading ? (
-            <div className="flex justify-center">
-              <Loader2 className="h-6 w-6 animate-spin" />
-            </div>
-          ) : jobs.length === 0 ? (
-            <p className="text-center text-muted-foreground">No jobs found</p>
-          ) : (
-            <div className="space-y-4">
-              {jobs.map((job) => {
-                const shouldHighlight = highlightToday && isJobToday(job);
-                return (
-                  <div 
-                    key={job.id}
-                    className={`transition-all duration-300 ${
-                      shouldHighlight 
-                        ? 'ring-2 ring-primary ring-offset-2 shadow-lg scale-[1.02]' 
-                        : ''
-                    }`}
-                  >
-                    <JobCardNew
-                      job={job}
-                      onEditClick={() => {}}
-                      onDeleteClick={() => {}}
-                      onJobClick={() => {}}
-                      department={dept as Department}
-                      userRole={userRole}
-                      onDeleteDocument={onDeleteDocument}
-                      showUpload={true}
-                      showManageArtists={true}
-                      isProjectManagementPage={true}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          )}
+          <ProjectManagementJobList
+            jobs={jobs}
+            jobsLoading={jobsLoading}
+            highlightToday={highlightToday}
+          />
         </TabsContent>
       ))}
     </Tabs>

--- a/src/components/project-management/MobileProjectFilters.tsx
+++ b/src/components/project-management/MobileProjectFilters.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { Filter, Search, Loader2 } from "lucide-react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { JobTypeFilter } from "./JobTypeFilter";
+import { StatusFilter } from "./StatusFilter";
+
+interface MobileProjectFiltersProps {
+  allJobTypes: string[];
+  selectedJobTypes: string[];
+  onTypeToggle: (type: string) => void;
+  allJobStatuses: string[];
+  selectedJobStatuses: string[];
+  onStatusSelection: (status: string) => void;
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
+  jobsLoading: boolean;
+}
+
+export const MobileProjectFilters: React.FC<MobileProjectFiltersProps> = ({
+  allJobTypes,
+  selectedJobTypes,
+  onTypeToggle,
+  allJobStatuses,
+  selectedJobStatuses,
+  onStatusSelection,
+  searchQuery,
+  onSearchQueryChange,
+  jobsLoading,
+}) => {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <Filter className="h-4 w-4" />
+          Filters
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="bottom" className="space-y-6">
+        <SheetHeader className="text-left">
+          <SheetTitle className="text-base font-semibold">Filters</SheetTitle>
+        </SheetHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-muted-foreground">Search</label>
+            <div className="relative">
+              <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchQuery}
+                onChange={(event) => onSearchQueryChange(event.target.value)}
+                placeholder="Search projects..."
+                className="pl-8"
+              />
+              {jobsLoading && (
+                <Loader2 className="absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <span className="text-sm font-medium text-muted-foreground">Job Types</span>
+            <JobTypeFilter
+              allJobTypes={allJobTypes}
+              selectedJobTypes={selectedJobTypes}
+              onTypeToggle={onTypeToggle}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <span className="text-sm font-medium text-muted-foreground">Status</span>
+            <StatusFilter
+              allJobStatuses={allJobStatuses}
+              selectedJobStatuses={selectedJobStatuses}
+              onStatusSelection={onStatusSelection}
+            />
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default MobileProjectFilters;

--- a/src/components/project-management/ProjectManagementJobList.tsx
+++ b/src/components/project-management/ProjectManagementJobList.tsx
@@ -1,0 +1,101 @@
+import React, { useMemo } from "react";
+import { format } from "date-fns";
+import { Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { ToolResponsiveTable, type ToolResponsiveColumn } from "@/components/shared/tooling";
+import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
+import { isWithinInterval, startOfDay, endOfDay } from "date-fns";
+
+interface ProjectManagementJobListProps {
+  jobs: any[];
+  jobsLoading: boolean;
+  highlightToday?: boolean;
+}
+
+const isJobToday = (job: any) => {
+  if (!job?.start_time || !job?.end_time) return false;
+
+  const now = new Date();
+  const start = startOfDay(new Date(job.start_time));
+  const end = endOfDay(new Date(job.end_time));
+
+  return isWithinInterval(now, { start, end });
+};
+
+export const ProjectManagementJobList: React.FC<ProjectManagementJobListProps> = ({
+  jobs,
+  jobsLoading,
+  highlightToday = false,
+}) => {
+  const columns = useMemo<ToolResponsiveColumn<any>[]>(
+    () => [
+      {
+        key: "project",
+        header: "Project",
+        render: (job) => (
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium text-foreground">{job.title || "Untitled job"}</span>
+              {job.job_type && (
+                <Badge variant="outline" className="capitalize">
+                  {job.job_type}
+                </Badge>
+              )}
+              {highlightToday && isJobToday(job) && (
+                <Badge className="bg-primary text-primary-foreground">Today</Badge>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-x-2 text-xs text-muted-foreground">
+              {job.client && <span>{job.client}</span>}
+              {job.location?.name && <span>• {job.location.name}</span>}
+            </div>
+          </div>
+        ),
+      },
+      {
+        key: "schedule",
+        header: "Schedule",
+        render: (job) => {
+          const start = job.start_time ? format(new Date(job.start_time), "dd MMM yyyy HH:mm") : "TBD";
+          const end = job.end_time ? format(new Date(job.end_time), "dd MMM yyyy HH:mm") : "TBD";
+
+          return (
+            <div className="space-y-1 text-sm">
+              <div>{start}</div>
+              <div className="text-xs text-muted-foreground">to {end}</div>
+            </div>
+          );
+        },
+      },
+      {
+        key: "status",
+        header: "Status",
+        render: (job) => <JobStatusBadge status={job.status} />,
+      },
+    ],
+    [highlightToday]
+  );
+
+  if (jobsLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!jobs?.length) {
+    return <p className="text-center text-sm text-muted-foreground">No jobs found</p>;
+  }
+
+  return (
+    <ToolResponsiveTable
+      columns={columns}
+      data={jobs}
+      getRowKey={(job) => job.id}
+      gridColumnsMobile={1}
+    />
+  );
+};
+
+export default ProjectManagementJobList;


### PR DESCRIPTION
## Summary
- add a MobileProjectFilters sheet to gather search and filter controls for narrow viewports
- refactor the ProjectManagement page into header/content subcomponents with mobile-aware layout
- replace the department job cards with a responsive job list that shows cards on mobile and a table on desktop

## Testing
- npm run build *(fails: vite command not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68faa4d3ca14832f8ebde17b61ef59e0