### PR TITLE
Render tray navigation items in mobile action sheet

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -307,7 +307,6 @@ const Layout = () => {
         <MobileNavBar
           primaryItems={primaryItems}
           trayItems={trayItems}
-          navigationProps={navigationProps}
           onSignOut={handleSignOut}
           isLoggingOut={isLoggingOut}
           notificationProps={notificationProps}

--- a/src/components/layout/MobileActionTray.tsx
+++ b/src/components/layout/MobileActionTray.tsx
@@ -1,16 +1,19 @@
 import { useState } from "react"
+import { Link, useLocation } from "react-router-dom"
 import { LogOut } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { cn } from "@/lib/utils"
 
-import { SidebarNavigation, SidebarNavigationProps } from "./SidebarNavigation"
+import { NavigationItem } from "./SidebarNavigation"
 import { ThemeToggle } from "./ThemeToggle"
 import { NotificationBadge } from "./NotificationBadge"
 
 interface MobileActionTrayProps {
-  navigationProps: SidebarNavigationProps
+  trayItems: NavigationItem[]
   renderTrigger: (open: boolean) => React.ReactNode
   onSignOut: () => Promise<void> | void
   isLoggingOut: boolean
@@ -22,13 +25,14 @@ interface MobileActionTrayProps {
 }
 
 export const MobileActionTray = ({
-  navigationProps,
+  trayItems,
   renderTrigger,
   onSignOut,
   isLoggingOut,
   notificationProps,
 }: MobileActionTrayProps) => {
   const [open, setOpen] = useState(false)
+  const { pathname } = useLocation()
 
   const handleNavigate = () => {
     setOpen(false)
@@ -59,8 +63,49 @@ export const MobileActionTray = ({
                 className="w-full justify-start"
               />
             )}
-            <Separator className="bg-border/60" />
-            <SidebarNavigation {...navigationProps} onNavigate={handleNavigate} />
+            {trayItems.length > 0 && (
+              <>
+                <Separator className="bg-border/60" />
+                <div className="grid grid-cols-2 gap-2">
+                  {trayItems.map((item) => {
+                    const Icon = item.icon
+                    const isActive = item.isActive(pathname)
+
+                    return (
+                      <Button
+                        key={item.id}
+                        variant="ghost"
+                        className={cn(
+                          "h-full justify-center gap-2 rounded-2xl border border-border/60 bg-muted/40 px-3 py-3 text-xs font-semibold text-muted-foreground transition-colors hover:border-border hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                          isActive && "border-primary/60 bg-primary/10 text-primary",
+                        )}
+                        data-active={isActive}
+                        asChild
+                      >
+                        <Link
+                          to={item.to}
+                          onClick={handleNavigate}
+                          aria-label={item.label}
+                          aria-current={isActive ? "page" : undefined}
+                          className="flex h-full flex-col items-center justify-center gap-2"
+                        >
+                          <Icon className="h-5 w-5" aria-hidden="true" />
+                          <span className="text-center leading-tight">{item.mobileLabel}</span>
+                          {item.badge && (
+                            <Badge
+                              variant="secondary"
+                              className="rounded-full px-2 py-0 text-[10px] font-semibold"
+                            >
+                              {item.badge}
+                            </Badge>
+                          )}
+                        </Link>
+                      </Button>
+                    )
+                  })}
+                </div>
+              </>
+            )}
             <Separator className="bg-border/60" />
             <Button
               type="button"

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -3,16 +3,12 @@ import { MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-import {
-  NavigationItem,
-  SidebarNavigationProps,
-} from "./SidebarNavigation"
+import { NavigationItem } from "./SidebarNavigation"
 import { MobileActionTray } from "./MobileActionTray"
 
 interface MobileNavBarProps {
   primaryItems: NavigationItem[]
   trayItems: NavigationItem[]
-  navigationProps: SidebarNavigationProps
   onSignOut: () => Promise<void> | void
   isLoggingOut: boolean
   notificationProps?: {
@@ -25,13 +21,13 @@ interface MobileNavBarProps {
 export const MobileNavBar = ({
   primaryItems,
   trayItems,
-  navigationProps,
   onSignOut,
   isLoggingOut,
   notificationProps,
 }: MobileNavBarProps) => {
   const { pathname } = useLocation()
   const hasNavigation = primaryItems.length > 0 || trayItems.length > 0
+  const shouldShowTrayTrigger = trayItems.length > 0
 
   if (!hasNavigation) {
     return null
@@ -68,25 +64,27 @@ export const MobileNavBar = ({
             </Link>
           )
         })}
-        <MobileActionTray
-          navigationProps={navigationProps}
-          onSignOut={onSignOut}
-          isLoggingOut={isLoggingOut}
-          notificationProps={notificationProps}
-          renderTrigger={(open) => (
-            <button
-              type="button"
-              aria-label="Más opciones"
-              className={cn(
-                "flex min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-2 text-[11px] font-semibold text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                (open || activeInTray) && "bg-primary/10 text-primary",
-              )}
-            >
-              <MoreHorizontal className="h-5 w-5" aria-hidden="true" />
-              <span className="max-w-[5rem] truncate">Más</span>
-            </button>
-          )}
-        />
+        {shouldShowTrayTrigger && (
+          <MobileActionTray
+            trayItems={trayItems}
+            onSignOut={onSignOut}
+            isLoggingOut={isLoggingOut}
+            notificationProps={notificationProps}
+            renderTrigger={(open) => (
+              <button
+                type="button"
+                aria-label="Más opciones"
+                className={cn(
+                  "flex min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-2 text-[11px] font-semibold text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                  (open || activeInTray) && "bg-primary/10 text-primary",
+                )}
+              >
+                <MoreHorizontal className="h-5 w-5" aria-hidden="true" />
+                <span className="max-w-[5rem] truncate">Más</span>
+              </button>
+            )}
+          />
+        )}
       </div>
     </nav>
   )

--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useMemo, type ReactNode } from "react"
 import { Link, useLocation } from "react-router-dom"
 import type { LucideIcon } from "lucide-react"
 import {
@@ -47,6 +47,7 @@ export interface NavigationItem {
   mobilePriority?: number
   mobileSlot: "primary" | "secondary"
   isActive: (pathname: string) => boolean
+  badge?: ReactNode
 }
 
 type LabelSource = string | ((context: NavigationContext) => string | null)


### PR DESCRIPTION
## Summary
- render mobile tray items directly in the action sheet using compact icon buttons that support optional badges
- only show the “Más” trigger when tray items exist and ensure leftover navigation routes surface through the sheet
- simplify mobile navbar props and extend navigation item typing for future badge support

## Testing
- npm run lint *(fails: missing @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb38b06d48832f8bf208dc586c4b2b