### PR TITLE
Add About card to mobile tray

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -314,6 +314,8 @@ const Layout = () => {
           onSignOut={handleSignOut}
           isLoggingOut={isLoggingOut}
           notificationProps={notificationProps}
+          userRole={userRole ?? undefined}
+          userEmail={session.user?.email ?? undefined}
         />
       )}
     </SidebarProvider>

--- a/src/components/layout/MobileActionTray.tsx
+++ b/src/components/layout/MobileActionTray.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils"
 import { NavigationItem } from "./SidebarNavigation"
 import { ThemeToggle } from "./ThemeToggle"
 import { NotificationBadge } from "./NotificationBadge"
+import { AboutCard } from "./AboutCard"
 
 interface MobileActionTrayProps {
   trayItems: NavigationItem[]
@@ -22,6 +23,8 @@ interface MobileActionTrayProps {
     userRole: string
     userDepartment: string | null
   }
+  userRole?: string
+  userEmail?: string
 }
 
 export const MobileActionTray = ({
@@ -30,6 +33,8 @@ export const MobileActionTray = ({
   onSignOut,
   isLoggingOut,
   notificationProps,
+  userRole,
+  userEmail,
 }: MobileActionTrayProps) => {
   const [open, setOpen] = useState(false)
   const { pathname } = useLocation()
@@ -63,6 +68,9 @@ export const MobileActionTray = ({
                 className="w-full justify-start"
               />
             )}
+            <div className="rounded-2xl border border-border/60 bg-muted/40 p-1">
+              <AboutCard userRole={userRole} userEmail={userEmail} />
+            </div>
             {trayItems.length > 0 && (
               <>
                 <Separator className="bg-border/60" />

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -16,6 +16,8 @@ interface MobileNavBarProps {
     userRole: string
     userDepartment: string | null
   }
+  userRole?: string
+  userEmail?: string
 }
 
 export const MobileNavBar = ({
@@ -24,6 +26,8 @@ export const MobileNavBar = ({
   onSignOut,
   isLoggingOut,
   notificationProps,
+  userRole,
+  userEmail,
 }: MobileNavBarProps) => {
   const { pathname } = useLocation()
   const hasNavigation = primaryItems.length > 0 || trayItems.length > 0
@@ -70,6 +74,8 @@ export const MobileNavBar = ({
             onSignOut={onSignOut}
             isLoggingOut={isLoggingOut}
             notificationProps={notificationProps}
+            userRole={userRole}
+            userEmail={userEmail}
             renderTrigger={(open) => (
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- pass the authenticated user role and email from the layout into the mobile navigation tray
- render the About card inside the mobile action tray so it shows the changelog on handheld devices

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb43a066e8832f8c0c79b3136830af