### PR TITLE
Ensure mobile action tray trigger always visible on mobile

### DIFF
--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -31,7 +31,9 @@ export const MobileNavBar = ({
 }: MobileNavBarProps) => {
   const { pathname } = useLocation()
   const hasNavigation = primaryItems.length > 0 || trayItems.length > 0
-  const shouldShowTrayTrigger = trayItems.length > 0
+  // Always render the tray trigger so persistent actions like Sign Out and About
+  // remain accessible for all roles, even when there are no additional tray items.
+  const shouldShowTrayTrigger = true
 
   if (!hasNavigation) {
     return null


### PR DESCRIPTION
## Summary
- always render the mobile action tray trigger so mobile users can reach global actions like About and Sign Out

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb49e7bec8832fa7c4eca19b4bd1ee