### PR TITLE
Increase mobile sheet CTA z-index

### DIFF
--- a/src/pages/TechnicianUnavailability.tsx
+++ b/src/pages/TechnicianUnavailability.tsx
@@ -277,7 +277,7 @@ export default function TechnicianUnavailability() {
       )}
 
       <div className="md:hidden">
-        <div className="fixed inset-x-0 bottom-0 z-20 bg-background/95 px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="fixed inset-x-0 bottom-0 z-50 bg-background/95 px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <Button className="w-full" onClick={() => setOpen(true)}>
             Añadir bloqueo
           </Button>


### PR DESCRIPTION
## Summary
- raise the fixed mobile add-block button stacking context so it sits above the bottom navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb5b2d5e68832fbbf815fd44796d17