### PR TITLE
Adjust mobile unavailability CTA placement

### DIFF
--- a/src/pages/TechnicianUnavailability.tsx
+++ b/src/pages/TechnicianUnavailability.tsx
@@ -277,7 +277,9 @@ export default function TechnicianUnavailability() {
       )}
 
       <div className="md:hidden">
-        <div className="fixed inset-x-0 bottom-0 z-50 bg-background/95 px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div
+          className="fixed inset-x-0 bottom-20 z-40 bg-background/95 px-4 pb-4 pt-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/60 supports-[bottom:env(safe-area-inset-bottom)]:bottom-[calc(env(safe-area-inset-bottom)+5rem)]"
+        >
           <Button className="w-full" onClick={() => setOpen(true)}>
             Añadir bloqueo
           </Button>


### PR DESCRIPTION
## Summary
- reposition the mobile unavailability call-to-action so it sits above the navigation bar instead of covering it
- add a safe-area-aware bottom offset while preserving the existing visual treatment

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68fb5ab79444832fac271d6b33297dbe