### PR TITLE
Align flex folder URL builder with shared schema

### DIFF
--- a/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
+++ b/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
@@ -7,6 +7,7 @@ import {
   getElementDetails,
 } from '../buildFlexUrl';
 import { FLEX_FOLDER_IDS } from '../constants';
+import { FLEX_CONFIG } from '../config';
 
 // Mock fetch globally
 global.fetch = vi.fn();
@@ -14,31 +15,35 @@ global.fetch = vi.fn();
 describe('buildFlexUrl', () => {
   it('should build financial document URL for presupuesto', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.presupuesto);
-    expect(url).toContain('#fin-doc/test-element-id/doc-view/');
+    expect(url).toContain(
+      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/header`
+    );
     expect(url).toContain('/header');
   });
 
   it('should build financial document URL for presupuestoDryHire', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.presupuestoDryHire);
-    expect(url).toContain('#fin-doc/test-element-id/doc-view/');
+    expect(url).toContain(
+      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/header`
+    );
     expect(url).toContain('/header');
   });
 
   it('should build financial document URL for hojaGastos', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.hojaGastos);
-    expect(url).toContain('#fin-doc/test-element-id/doc-view/');
-    expect(url).toContain('/header');
+    expect(url).toContain(
+      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.expenseSheet}/header`
+    );
   });
 
   it('should build contact-list URL for crewCall', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.crewCall);
-    expect(url).toContain('#contact-list/test-element-id/view/');
-    expect(url).toContain('/detail');
+    expect(url).toContain('#element/test-element-id/view/contact-list/header');
   });
 
   it('should build equipment-list URL for pullSheet', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.pullSheet);
-    expect(url).toContain('#equipment-list/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/equipment-list/header');
   });
 
   it('should build simple element URL for mainFolder', () => {

--- a/src/utils/flex-folders/__tests__/urlBuilder.test.ts
+++ b/src/utils/flex-folders/__tests__/urlBuilder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildFlexUrlByIntent } from '../urlBuilder';
+import { FLEX_CONFIG } from '../config';
 
 describe('buildFlexUrlByIntent', () => {
   it('should build simple-element URL', () => {
@@ -15,22 +16,28 @@ describe('buildFlexUrlByIntent', () => {
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
+  it('should build expense-sheet URL', () => {
+    const url = buildFlexUrlByIntent('expense-sheet', 'test-id');
+    expect(url).toBe(
+      `https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#fin-doc/test-id/doc-view/${FLEX_CONFIG.viewIds.expenseSheet}/header`
+    );
+  });
+
   it('should build contact-list URL', () => {
     const url = buildFlexUrlByIntent('contact-list', 'test-id');
-    expect(url).toContain('#contact-list/test-id/view/');
-    expect(url).toContain('/detail');
+    expect(url).toContain('#element/test-id/view/contact-list/header');
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
   it('should build equipment-list URL', () => {
     const url = buildFlexUrlByIntent('equipment-list', 'test-id');
-    expect(url).toContain('#equipment-list/test-id/view/simple-element/header');
+    expect(url).toContain('#element/test-id/view/equipment-list/header');
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
   it('should build remote-file-list URL', () => {
     const url = buildFlexUrlByIntent('remote-file-list', 'test-id');
-    expect(url).toContain('#remote-file-list/test-id/view/simple-element/header');
+    expect(url).toContain('#element/test-id/view/remote-file-list/header');
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
@@ -43,7 +50,7 @@ describe('buildFlexUrlByIntent', () => {
   it('should accept custom viewId for contact-list', () => {
     const customViewId = 'custom-view-id';
     const url = buildFlexUrlByIntent('contact-list', 'test-id', customViewId);
-    expect(url).toContain(`#contact-list/test-id/view/${customViewId}/detail`);
+    expect(url).toContain(`#element/test-id/view/${customViewId}/header`);
   });
 
   it('should throw error for empty elementId', () => {

--- a/src/utils/flex-folders/config.ts
+++ b/src/utils/flex-folders/config.ts
@@ -9,6 +9,7 @@ export const FLEX_CONFIG = {
   viewIds: {
     presupuesto: 'ca6b072c-b122-11df-b8d5-00e08175e43e',
     crewCall: '139e2f60-8d20-11e2-b07f-00e08175e43e',
+    expenseSheet: '566d32e0-1a1e-11e0-a472-00e08175e43e',
   },
 } as const;
 

--- a/src/utils/flex-folders/intentDetection.ts
+++ b/src/utils/flex-folders/intentDetection.ts
@@ -7,6 +7,7 @@ import { FLEX_FOLDER_IDS } from './constants';
 export type FlexLinkIntent =
   | 'simple-element'    // Folders, subfolders, dryhire, tourdate
   | 'fin-doc'           // Financial documents (presupuesto, hojaGastos, ordenes)
+  | 'expense-sheet'     // Expense sheet documents
   | 'contact-list'      // Crew call/contact list
   | 'equipment-list'    // Pull sheet/equipment list
   | 'remote-file-list'; // Remote file list
@@ -42,6 +43,8 @@ export interface IntentDetectionContext {
 }
 
 // Financial documents that use the #fin-doc URL schema
+const EXPENSE_SHEET_DEFINITION_IDS = [FLEX_FOLDER_IDS.hojaGastos];
+
 const FINANCIAL_DOCUMENT_DEFINITION_IDS = [
   FLEX_FOLDER_IDS.presupuesto,
   FLEX_FOLDER_IDS.presupuestoDryHire,
@@ -90,14 +93,18 @@ export function detectFlexLinkIntent(context?: IntentDetectionContext): FlexLink
 
   // Check definitionId
   if (context.definitionId) {
+    if (EXPENSE_SHEET_DEFINITION_IDS.includes(context.definitionId)) {
+      return 'expense-sheet';
+    }
+
     if (CREW_CALL_DEFINITION_IDS.includes(context.definitionId)) {
       return 'contact-list';
     }
-    
+
     if (EQUIPMENT_LIST_DEFINITION_IDS.includes(context.definitionId)) {
       return 'equipment-list';
     }
-    
+
     if (FINANCIAL_DOCUMENT_DEFINITION_IDS.includes(context.definitionId)) {
       return 'fin-doc';
     }
@@ -108,6 +115,10 @@ export function detectFlexLinkIntent(context?: IntentDetectionContext): FlexLink
   }
 
   // Check domainId from tree API
+  if (context.domainId === 'expense-sheet') {
+    return 'expense-sheet';
+  }
+
   if (context.domainId === 'simple-project-element') {
     return 'simple-element';
   }

--- a/src/utils/flex-folders/urlBuilder.ts
+++ b/src/utils/flex-folders/urlBuilder.ts
@@ -14,9 +14,10 @@ import { FlexLinkIntent } from './intentDetection';
  * It handles the different URL schemas based on intent:
  * - simple-element: #element/{id}/view/simple-element/header
  * - fin-doc: #fin-doc/{id}/doc-view/{viewId}/header
- * - contact-list: #contact-list/{id}/view/{viewId}/detail
- * - equipment-list: #equipment-list/{id}/view/simple-element/header
- * - remote-file-list: #remote-file-list/{id}/view/simple-element/header
+ * - expense-sheet: #fin-doc/{id}/doc-view/{expenseViewId}/header
+ * - contact-list: #element/{id}/view/contact-list/header
+ * - equipment-list: #element/{id}/view/equipment-list/header
+ * - remote-file-list: #element/{id}/view/remote-file-list/header
  */
 export function buildFlexUrlByIntent(
   intent: FlexLinkIntent,
@@ -41,16 +42,25 @@ export function buildFlexUrlByIntent(
       return `${baseUrl}#fin-doc/${elementId}/doc-view/${finDocViewId}/header`;
     }
 
-    case 'contact-list': {
-      const contactViewId = viewId || getFlexViewId('crewCall');
-      return `${baseUrl}#contact-list/${elementId}/view/${contactViewId}/detail`;
+    case 'expense-sheet': {
+      const expenseSheetViewId = viewId || getFlexViewId('expenseSheet');
+      return `${baseUrl}#fin-doc/${elementId}/doc-view/${expenseSheetViewId}/header`;
     }
 
-    case 'equipment-list':
-      return `${baseUrl}#equipment-list/${elementId}/view/simple-element/header`;
+    case 'contact-list': {
+      const contactViewName = viewId || 'contact-list';
+      return `${baseUrl}#element/${elementId}/view/${contactViewName}/header`;
+    }
 
-    case 'remote-file-list':
-      return `${baseUrl}#remote-file-list/${elementId}/view/simple-element/header`;
+    case 'equipment-list': {
+      const equipmentViewName = viewId || 'equipment-list';
+      return `${baseUrl}#element/${elementId}/view/${equipmentViewName}/header`;
+    }
+
+    case 'remote-file-list': {
+      const remoteFileViewName = viewId || 'remote-file-list';
+      return `${baseUrl}#element/${elementId}/view/${remoteFileViewName}/header`;
+    }
 
     default: {
       // TypeScript exhaustiveness check


### PR DESCRIPTION
## Summary
- align the flex folder URL builder with the shared library, including the new expense-sheet intent and element-based hash fragments for list views
- extend the flex configuration and detection logic to surface the expense sheet view id when needed
- refresh unit tests to assert the updated fragments for financial, expense, contact, equipment, and remote list URLs

## Testing
- npx vitest --run --reporter=basic *(fails: missing local vitest dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd3ae63128832f979ba6e3f48ffb88