### PR TITLE
Update Flex URLs to use detail view anchors

### DIFF
--- a/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
+++ b/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
@@ -16,54 +16,54 @@ describe('buildFlexUrl', () => {
   it('should build financial document URL for presupuesto', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.presupuesto);
     expect(url).toContain(
-      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/header`
+      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/detail`
     );
-    expect(url).toContain('/header');
+    expect(url).toContain('/detail');
   });
 
   it('should build financial document URL for presupuestoDryHire', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.presupuestoDryHire);
     expect(url).toContain(
-      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/header`
+      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/detail`
     );
-    expect(url).toContain('/header');
+    expect(url).toContain('/detail');
   });
 
   it('should build financial document URL for hojaGastos', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.hojaGastos);
     expect(url).toContain(
-      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.expenseSheet}/header`
+      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.expenseSheet}/detail`
     );
   });
 
   it('should build contact-list URL for crewCall', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.crewCall);
-    expect(url).toContain('#element/test-element-id/view/contact-list/header');
+    expect(url).toContain('#element/test-element-id/view/contact-list/detail');
   });
 
   it('should build equipment-list URL for pullSheet', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.pullSheet);
-    expect(url).toContain('#element/test-element-id/view/equipment-list/header');
+    expect(url).toContain('#element/test-element-id/view/equipment-list/detail');
   });
 
   it('should build simple element URL for mainFolder', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.mainFolder);
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
   });
 
   it('should build simple element URL for subFolder', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.subFolder);
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
   });
 
   it('should build simple element URL when no definitionId provided', () => {
     const url = buildFlexUrl('test-element-id');
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
   });
 
   it('should build simple element URL for unknown definitionId', () => {
     const url = buildFlexUrl('test-element-id', 'unknown-definition-id');
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
   });
 
   it('should throw error for empty elementId', () => {
@@ -209,7 +209,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
       folderType: 'dryhire',
     });
 
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -218,7 +218,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
       folderType: 'tourdate',
     });
 
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -227,7 +227,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
       jobType: 'dryhire',
     });
 
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -236,7 +236,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
       jobType: 'tourdate',
     });
 
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -261,7 +261,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
 
     const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token');
 
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
   });
 
   it('should not fetch when no context is provided that enables optimization', async () => {
@@ -277,7 +277,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
     // When no context that enables optimization is provided, fetch should be called
     const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {});
 
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
     expect(global.fetch).toHaveBeenCalled();
   });
 
@@ -311,7 +311,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
       jobType: 'dryhire',
     });
 
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -320,7 +320,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
 
     const url = await buildFlexUrlWithTypeDetection('test-element-id', '');
 
-    expect(url).toContain('#element/test-element-id/view/simple-element/header');
+    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
   });
 
   it('should use viewHint when provided in context', async () => {
@@ -337,7 +337,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
       viewHint: 'equipment-list',
     });
 
-    expect(url).toContain('#equipment-list/test-element-id/view/simple-element/header');
+    expect(url).toContain('#equipment-list/test-element-id/view/simple-element/detail');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -346,7 +346,7 @@ describe('buildFlexUrlWithTypeDetection', () => {
       viewHint: 'remote-file-list',
     });
 
-    expect(url).toContain('#remote-file-list/test-element-id/view/simple-element/header');
+    expect(url).toContain('#remote-file-list/test-element-id/view/simple-element/detail');
     expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/flex-folders/__tests__/flexUrlResolver.test.ts
+++ b/src/utils/flex-folders/__tests__/flexUrlResolver.test.ts
@@ -40,7 +40,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node);
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('simple-id')}/view/simple-element/header`
+      `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('simple-id')}/view/simple-element/detail`
     );
     expect(invokeMock()).not.toHaveBeenCalled();
     expect(getFetchMock()).not.toHaveBeenCalled();
@@ -56,7 +56,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node);
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#fin-doc/${encodeURIComponent('fin-doc-id')}/doc-view/${FLEX_VIEW_IDS.FIN_DOC}/header`
+      `${FLEX_UI_BASE_URL}#fin-doc/${encodeURIComponent('fin-doc-id')}/doc-view/${FLEX_VIEW_IDS.FIN_DOC}/detail`
     );
   });
 
@@ -69,7 +69,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node);
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#contact-list/${encodeURIComponent('crew-id')}/view/${FLEX_VIEW_IDS.CREW_CALL}/header`
+      `${FLEX_UI_BASE_URL}#contact-list/${encodeURIComponent('crew-id')}/view/${FLEX_VIEW_IDS.CREW_CALL}/detail`
     );
   });
 
@@ -82,7 +82,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node);
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#expense-sheet/${encodeURIComponent('expense-id')}/view/${FLEX_VIEW_IDS.EXPENSE_SHEET}/header`
+      `${FLEX_UI_BASE_URL}#expense-sheet/${encodeURIComponent('expense-id')}/view/${FLEX_VIEW_IDS.EXPENSE_SHEET}/detail`
     );
   });
 
@@ -95,7 +95,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node);
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#remote-file-list/${encodeURIComponent('remote-id')}/view/${FLEX_VIEW_IDS.REMOTE_FILE_LIST}/header`
+      `${FLEX_UI_BASE_URL}#remote-file-list/${encodeURIComponent('remote-id')}/view/${FLEX_VIEW_IDS.REMOTE_FILE_LIST}/detail`
     );
   });
 
@@ -108,7 +108,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node);
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#equipment-list/${encodeURIComponent('equipment-id')}/view/${FLEX_VIEW_IDS.EQUIPMENT_LIST}/header`
+      `${FLEX_UI_BASE_URL}#equipment-list/${encodeURIComponent('equipment-id')}/view/${FLEX_VIEW_IDS.EQUIPMENT_LIST}/detail`
     );
   });
 
@@ -120,7 +120,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node, { jobType: 'dryhire' });
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('dryhire-folder-id')}/view/simple-element/header`
+      `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('dryhire-folder-id')}/view/simple-element/detail`
     );
     expect(getFetchMock()).not.toHaveBeenCalled();
   });
@@ -134,7 +134,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node, { jobType: 'tourdate' });
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('tourdate-folder-id')}/view/simple-element/header`
+      `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('tourdate-folder-id')}/view/simple-element/detail`
     );
     expect(getFetchMock()).not.toHaveBeenCalled();
   });
@@ -161,7 +161,7 @@ describe('resolveFlexUrl', () => {
     const url = await resolveFlexUrl(node);
 
     expect(url).toBe(
-      `${FLEX_UI_BASE_URL}#fin-doc/${encodeURIComponent('metadata-id')}/doc-view/${FLEX_VIEW_IDS.FIN_DOC}/header`
+      `${FLEX_UI_BASE_URL}#fin-doc/${encodeURIComponent('metadata-id')}/doc-view/${FLEX_VIEW_IDS.FIN_DOC}/detail`
     );
 
     expect(invokeMock()).toHaveBeenCalledTimes(1);

--- a/src/utils/flex-folders/__tests__/openFlexElement.test.ts
+++ b/src/utils/flex-folders/__tests__/openFlexElement.test.ts
@@ -39,7 +39,7 @@ describe('openFlexElement', () => {
 
   it('should open a placeholder window synchronously', async () => {
     (resolverModule.resolveFlexUrl as any).mockResolvedValue(
-      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header'
+      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail'
     );
 
     await openFlexElement({
@@ -51,7 +51,7 @@ describe('openFlexElement', () => {
   });
 
   it('should resolve URL via resolver and navigate placeholder window', async () => {
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrl').mockResolvedValue(mockUrl);
 
     await openFlexElement({
@@ -81,7 +81,7 @@ describe('openFlexElement', () => {
 
     // Verify fallback URL was used
     expect(mockPlaceholderWindow.location.href).toBe(
-      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header'
+      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail'
     );
 
     // Verify warning callback was called
@@ -101,7 +101,7 @@ describe('openFlexElement', () => {
 
     // Verify fallback URL was used
     expect(mockPlaceholderWindow.location.href).toBe(
-      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header'
+      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail'
     );
 
     // Verify warning callback was called
@@ -114,7 +114,7 @@ describe('openFlexElement', () => {
 
     // Resolver returns a valid URL
     vi.spyOn(resolverModule, 'resolveFlexUrl').mockResolvedValue(
-      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header'
+      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail'
     );
 
     const onError = vi.fn();
@@ -129,7 +129,7 @@ describe('openFlexElement', () => {
   });
 
   it('should pass context to resolver', async () => {
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrl').mockResolvedValue(mockUrl);
 
     const context = {
@@ -151,7 +151,7 @@ describe('openFlexElement', () => {
 
   it('should handle window.close gracefully when setting location fails', async () => {
     vi.spyOn(resolverModule, 'resolveFlexUrl').mockResolvedValue(
-      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header'
+      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail'
     );
 
     // Make setting location.href throw
@@ -245,7 +245,7 @@ describe('openFlexElement', () => {
   });
 
   it('should handle dryhire context with proper URL format', async () => {
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-dryhire-id/view/simple-element/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-dryhire-id/view/simple-element/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrl').mockResolvedValue(mockUrl);
 
     await openFlexElement({
@@ -267,7 +267,7 @@ describe('openFlexElement', () => {
   });
 
   it('should handle tourdate context with proper URL format', async () => {
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-tourdate-id/view/simple-element/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-tourdate-id/view/simple-element/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrl').mockResolvedValue(mockUrl);
 
     await openFlexElement({

--- a/src/utils/flex-folders/__tests__/openFlexElementSync.test.ts
+++ b/src/utils/flex-folders/__tests__/openFlexElementSync.test.ts
@@ -54,7 +54,7 @@ describe('openFlexElementSync', () => {
   });
 
   it('should create and click an anchor element with correct attributes', () => {
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrlSync').mockReturnValue(mockUrl);
 
     openFlexElementSync({
@@ -77,7 +77,7 @@ describe('openFlexElementSync', () => {
   });
 
   it('should build URL with domainId and definitionId', () => {
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrlSync').mockReturnValue(mockUrl);
 
     openFlexElementSync({
@@ -159,7 +159,7 @@ describe('openFlexElementSync', () => {
 
     // Verify fallback URL was used
     expect(mockAnchor.href).toBe(
-      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header'
+      'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail'
     );
 
     // Verify anchor was clicked
@@ -189,7 +189,7 @@ describe('openFlexElementSync', () => {
   });
 
   it('should handle financial document with definitionId', () => {
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#fin-doc/test-id/doc-view/ca6b072c-b122-11df-b8d5-00e08175e43e/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#fin-doc/test-id/doc-view/ca6b072c-b122-11df-b8d5-00e08175e43e/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrlSync').mockReturnValue(mockUrl);
 
     openFlexElementSync({
@@ -209,7 +209,7 @@ describe('openFlexElementSync', () => {
 
   it('should log comprehensive debug information', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrlSync').mockReturnValue(mockUrl);
 
     openFlexElementSync({
@@ -249,7 +249,7 @@ describe('openFlexElementSync', () => {
   });
 
   it('should set anchor style to display none', () => {
-    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/header';
+    const mockUrl = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#element/test-id/view/simple-element/detail';
     vi.spyOn(resolverModule, 'resolveFlexUrlSync').mockReturnValue(mockUrl);
 
     openFlexElementSync({

--- a/src/utils/flex-folders/__tests__/urlBuilder.test.ts
+++ b/src/utils/flex-folders/__tests__/urlBuilder.test.ts
@@ -5,52 +5,52 @@ import { FLEX_CONFIG } from '../config';
 describe('buildFlexUrlByIntent', () => {
   it('should build simple-element URL', () => {
     const url = buildFlexUrlByIntent('simple-element', 'test-id');
-    expect(url).toContain('#element/test-id/view/simple-element/header');
+    expect(url).toContain('#element/test-id/view/simple-element/detail');
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
   it('should build fin-doc URL', () => {
     const url = buildFlexUrlByIntent('fin-doc', 'test-id');
     expect(url).toContain('#fin-doc/test-id/doc-view/');
-    expect(url).toContain('/header');
+    expect(url).toContain('/detail');
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
   it('should build expense-sheet URL', () => {
     const url = buildFlexUrlByIntent('expense-sheet', 'test-id');
     expect(url).toBe(
-      `https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#fin-doc/test-id/doc-view/${FLEX_CONFIG.viewIds.expenseSheet}/header`
+      `https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop#fin-doc/test-id/doc-view/${FLEX_CONFIG.viewIds.expenseSheet}/detail`
     );
   });
 
   it('should build contact-list URL', () => {
     const url = buildFlexUrlByIntent('contact-list', 'test-id');
-    expect(url).toContain('#element/test-id/view/contact-list/header');
+    expect(url).toContain('#element/test-id/view/contact-list/detail');
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
   it('should build equipment-list URL', () => {
     const url = buildFlexUrlByIntent('equipment-list', 'test-id');
-    expect(url).toContain('#element/test-id/view/equipment-list/header');
+    expect(url).toContain('#element/test-id/view/equipment-list/detail');
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
   it('should build remote-file-list URL', () => {
     const url = buildFlexUrlByIntent('remote-file-list', 'test-id');
-    expect(url).toContain('#element/test-id/view/remote-file-list/header');
+    expect(url).toContain('#element/test-id/view/remote-file-list/detail');
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
   it('should accept custom viewId for fin-doc', () => {
     const customViewId = 'custom-view-id';
     const url = buildFlexUrlByIntent('fin-doc', 'test-id', customViewId);
-    expect(url).toContain(`#fin-doc/test-id/doc-view/${customViewId}/header`);
+    expect(url).toContain(`#fin-doc/test-id/doc-view/${customViewId}/detail`);
   });
 
   it('should accept custom viewId for contact-list', () => {
     const customViewId = 'custom-view-id';
     const url = buildFlexUrlByIntent('contact-list', 'test-id', customViewId);
-    expect(url).toContain(`#element/test-id/view/${customViewId}/header`);
+    expect(url).toContain(`#element/test-id/view/${customViewId}/detail`);
   });
 
   it('should throw error for empty elementId', () => {

--- a/src/utils/flex-folders/urlBuilder.ts
+++ b/src/utils/flex-folders/urlBuilder.ts
@@ -12,12 +12,12 @@ import { FlexLinkIntent } from './intentDetection';
  * @remarks
  * This is the core URL builder that all other functions should use.
  * It handles the different URL schemas based on intent:
- * - simple-element: #element/{id}/view/simple-element/header
- * - fin-doc: #fin-doc/{id}/doc-view/{viewId}/header
- * - expense-sheet: #fin-doc/{id}/doc-view/{expenseViewId}/header
- * - contact-list: #element/{id}/view/contact-list/header
- * - equipment-list: #element/{id}/view/equipment-list/header
- * - remote-file-list: #element/{id}/view/remote-file-list/header
+ * - simple-element: #element/{id}/view/simple-element/detail
+ * - fin-doc: #fin-doc/{id}/doc-view/{viewId}/detail
+ * - expense-sheet: #fin-doc/{id}/doc-view/{expenseViewId}/detail
+ * - contact-list: #element/{id}/view/contact-list/detail
+ * - equipment-list: #element/{id}/view/equipment-list/detail
+ * - remote-file-list: #element/{id}/view/remote-file-list/detail
  */
 export function buildFlexUrlByIntent(
   intent: FlexLinkIntent,
@@ -35,38 +35,38 @@ export function buildFlexUrlByIntent(
 
   switch (intent) {
     case 'simple-element':
-      return `${baseUrl}#element/${elementId}/view/simple-element/header`;
+      return `${baseUrl}#element/${elementId}/view/simple-element/detail`;
 
     case 'fin-doc': {
       const finDocViewId = viewId || getFlexViewId('presupuesto');
-      return `${baseUrl}#fin-doc/${elementId}/doc-view/${finDocViewId}/header`;
+      return `${baseUrl}#fin-doc/${elementId}/doc-view/${finDocViewId}/detail`;
     }
 
     case 'expense-sheet': {
       const expenseSheetViewId = viewId || getFlexViewId('expenseSheet');
-      return `${baseUrl}#fin-doc/${elementId}/doc-view/${expenseSheetViewId}/header`;
+      return `${baseUrl}#fin-doc/${elementId}/doc-view/${expenseSheetViewId}/detail`;
     }
 
     case 'contact-list': {
       const contactViewName = viewId || 'contact-list';
-      return `${baseUrl}#element/${elementId}/view/${contactViewName}/header`;
+      return `${baseUrl}#element/${elementId}/view/${contactViewName}/detail`;
     }
 
     case 'equipment-list': {
       const equipmentViewName = viewId || 'equipment-list';
-      return `${baseUrl}#element/${elementId}/view/${equipmentViewName}/header`;
+      return `${baseUrl}#element/${elementId}/view/${equipmentViewName}/detail`;
     }
 
     case 'remote-file-list': {
       const remoteFileViewName = viewId || 'remote-file-list';
-      return `${baseUrl}#element/${elementId}/view/${remoteFileViewName}/header`;
+      return `${baseUrl}#element/${elementId}/view/${remoteFileViewName}/detail`;
     }
 
     default: {
       // TypeScript exhaustiveness check
       const _exhaustive: never = intent;
       console.warn('[urlBuilder] Unknown intent, using simple-element fallback:', intent);
-      return `${baseUrl}#element/${elementId}/view/simple-element/header`;
+      return `${baseUrl}#element/${elementId}/view/simple-element/detail`;
     }
   }
 }


### PR DESCRIPTION
## Summary
- update the Flex URL builder to return detail anchors for all intents and refresh inline documentation
- update the flex folders unit tests to assert the new /detail hashes

## Testing
- npm run test -- --run src/utils/flex-folders/__tests__/urlBuilder.test.ts *(fails: vitest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68fe17ad0194832f9192c2755e586cee