### PR TITLE
Fix crew call contact list URL generation

### DIFF
--- a/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
+++ b/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
@@ -38,7 +38,7 @@ describe('buildFlexUrl', () => {
 
   it('should build contact-list URL for crewCall', () => {
     const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.crewCall);
-    expect(url).toContain('#element/test-element-id/view/contact-list/detail');
+    expect(url).toContain(`#contact-list/test-element-id/view/${FLEX_CONFIG.viewIds.crewCall}/detail`);
   });
 
   it('should build equipment-list URL for pullSheet', () => {

--- a/src/utils/flex-folders/__tests__/urlBuilder.test.ts
+++ b/src/utils/flex-folders/__tests__/urlBuilder.test.ts
@@ -25,7 +25,7 @@ describe('buildFlexUrlByIntent', () => {
 
   it('should build contact-list URL', () => {
     const url = buildFlexUrlByIntent('contact-list', 'test-id');
-    expect(url).toContain('#element/test-id/view/contact-list/detail');
+    expect(url).toContain(`#contact-list/test-id/view/${FLEX_CONFIG.viewIds.crewCall}/detail`);
     expect(url).toContain('https://sectorpro.flexrentalsolutions.com');
   });
 
@@ -50,7 +50,7 @@ describe('buildFlexUrlByIntent', () => {
   it('should accept custom viewId for contact-list', () => {
     const customViewId = 'custom-view-id';
     const url = buildFlexUrlByIntent('contact-list', 'test-id', customViewId);
-    expect(url).toContain(`#element/test-id/view/${customViewId}/detail`);
+    expect(url).toContain(`#contact-list/test-id/view/${customViewId}/detail`);
   });
 
   it('should throw error for empty elementId', () => {

--- a/src/utils/flex-folders/urlBuilder.ts
+++ b/src/utils/flex-folders/urlBuilder.ts
@@ -15,7 +15,7 @@ import { FlexLinkIntent } from './intentDetection';
  * - simple-element: #element/{id}/view/simple-element/detail
  * - fin-doc: #fin-doc/{id}/doc-view/{viewId}/detail
  * - expense-sheet: #fin-doc/{id}/doc-view/{expenseViewId}/detail
- * - contact-list: #element/{id}/view/contact-list/detail
+ * - contact-list: #contact-list/{id}/view/{crewCallViewId}/detail
  * - equipment-list: #element/{id}/view/equipment-list/detail
  * - remote-file-list: #element/{id}/view/remote-file-list/detail
  */
@@ -48,8 +48,8 @@ export function buildFlexUrlByIntent(
     }
 
     case 'contact-list': {
-      const contactViewName = viewId || 'contact-list';
-      return `${baseUrl}#element/${elementId}/view/${contactViewName}/detail`;
+      const contactViewId = viewId || getFlexViewId('crewCall');
+      return `${baseUrl}#contact-list/${elementId}/view/${contactViewId}/detail`;
     }
 
     case 'equipment-list': {


### PR DESCRIPTION
## Summary
- update the contact-list intent URL builder to emit the #contact-list route with the crew call view id
- refresh flex-folder unit tests to cover the corrected contact-list prefix and detail suffix

## Testing
- npm run test -- --run src/utils/flex-folders/__tests__/urlBuilder.test.ts src/utils/flex-folders/__tests__/buildFlexUrl.test.ts *(fails: local vitest binary unavailable because dependency installation requires external downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68fe187281c8832f9093f435a672618a