### PR TITLE
Notify task assignment/completion through push

### DIFF
--- a/supabase/functions/push/index.ts
+++ b/supabase/functions/push/index.ts
@@ -427,6 +427,24 @@ async function handleBroadcast(
       text = `Has sido asignado a "${jobTitle || 'Trabajo'}".`;
     }
     addUsers([body.recipient_id]);
+  } else if (type === 'task.assigned') {
+    const taskLabel = body.task_type ? `la tarea "${body.task_type}"` : 'una tarea';
+    const jobLabel = jobTitle || 'Trabajo';
+    title = 'Tarea asignada';
+    text = recipName
+      ? `${actor} asignó ${taskLabel} a ${recipName} en "${jobLabel}".`
+      : `${actor} asignó ${taskLabel} en "${jobLabel}".`;
+    url = body.url || (jobId ? `/job-management/${jobId}` : url);
+    addUsers([body.recipient_id]);
+  } else if (type === 'task.completed') {
+    const taskLabel = body.task_type ? `la tarea "${body.task_type}"` : 'una tarea';
+    const jobLabel = jobTitle || 'Trabajo';
+    title = 'Tarea completada';
+    text = recipName
+      ? `${actor} marcó como completada ${taskLabel} de ${recipName} en "${jobLabel}".`
+      : `${actor} marcó como completada ${taskLabel} en "${jobLabel}".`;
+    url = body.url || (jobId ? `/job-management/${jobId}` : url);
+    addUsers([body.recipient_id]);
   } else if (type === 'flex.folders.created') {
     title = 'Carpetas Flex creadas';
     text = jobTitle
@@ -541,6 +559,8 @@ async function handleBroadcast(
       ...('changes' in body ? { changes: body.changes } : {}),
       ...('message_preview' in body ? { messagePreview: body.message_preview } : {}),
       ...('message_id' in body ? { messageId: body.message_id } : {}),
+      ...('task_id' in body ? { taskId: body.task_id } : {}),
+      ...('task_type' in body ? { taskType: body.task_type } : {}),
     },
   };
 


### PR DESCRIPTION
## Summary
- send push notifications after assigning a task and when marking one as completed so both actor and assignee are included
- update the push edge function to localize task assignment/completion messages, target the job management view, and expose task metadata

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe5ee1c998832fbe73a14ada0003b1