### PR TITLE
Add push notification for logistics transport requests

### DIFF
--- a/src/components/logistics/TransportRequestDialog.tsx
+++ b/src/components/logistics/TransportRequestDialog.tsx
@@ -113,6 +113,22 @@ export function TransportRequestDialog({
           const { error: itemsErr } = await supabase.from('transport_request_items').insert(toInsert);
           if (itemsErr) throw itemsErr;
         }
+        try {
+          const { error: pushError } = await supabase.functions.invoke('push', {
+            body: {
+              action: 'broadcast',
+              type: 'logistics.transport.requested',
+              job_id: jobId,
+              department,
+              request_id,
+            },
+          });
+          if (pushError) {
+            console.error('Failed to invoke push notification for transport request', pushError);
+          }
+        } catch (pushError) {
+          console.error('Unexpected error invoking push notification for transport request', pushError);
+        }
       }
 
       toast({ title: 'Transport request saved' });


### PR DESCRIPTION
## Summary
- trigger the push function when a new transport request is inserted from the job dialog
- extend the push broadcast handler to send logistics transport notifications to the correct audience

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff9efeed18832f9bf2934fb8ab63b7