### PR TITLE
Add push notification for technician visibility removal

### DIFF
--- a/src/components/jobs/cards/JobCardDocuments.tsx
+++ b/src/components/jobs/cards/JobCardDocuments.tsx
@@ -97,19 +97,17 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
         .eq('id', doc.id);
       if (error) throw error;
       // Realtime subscription in parent hook will refresh the list
-      if (next) {
-        try {
-          // Notify assigned technicians about new tech-visible document
-          void supabase.functions.invoke('push', {
-            body: {
-              action: 'broadcast',
-              type: 'document.tech_visible.enabled',
-              doc_id: doc.id,
-              file_name: doc.file_name,
-            }
-          });
-        } catch {}
-      }
+      try {
+        // Notify assigned technicians about document visibility updates
+        void supabase.functions.invoke('push', {
+          body: {
+            action: 'broadcast',
+            type: next ? 'document.tech_visible.enabled' : 'document.tech_visible.disabled',
+            doc_id: doc.id,
+            file_name: doc.file_name,
+          }
+        });
+      } catch {}
     } catch (err: any) {
       console.error('Error toggling document visibility:', err);
       alert(`Error updating visibility: ${err.message}`);

--- a/supabase/functions/push/index.ts
+++ b/supabase/functions/push/index.ts
@@ -419,6 +419,11 @@ async function handleBroadcast(
     const fname = body.file_name || 'documento';
     text = `Nuevo documento visible: "${fname}" en "${jobTitle || 'Trabajo'}".`;
     addUsers(Array.from(participants));
+  } else if (type === 'document.tech_visible.disabled') {
+    title = 'Documento oculto para técnicos';
+    const fname = body.file_name || 'documento';
+    text = `El documento "${fname}" dejó de estar visible en "${jobTitle || 'Trabajo'}".`;
+    addUsers(Array.from(participants));
   } else if (type === 'staffing.availability.sent') {
     title = 'Solicitud de disponibilidad enviada';
     text = `${actor} envió solicitud a ${recipName || 'técnico'} (${ch}).`;


### PR DESCRIPTION
## Summary
- add broadcast handling for the `document.tech_visible.disabled` push type
- send visibility change pushes whenever a document is toggled for technicians

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ffa4cf4ae8832faed054a5ad2f39cb