### PR TITLE
Add wallboard configuration link to announcements page

### DIFF
--- a/src/pages/Announcements.tsx
+++ b/src/pages/Announcements.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { supabase } from '@/lib/supabase';
 import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Button } from '@/components/ui/button';
@@ -137,9 +138,14 @@ export default function Announcements() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Announcements (Ticker)</h1>
-        <p className="text-muted-foreground">Messages shown in the wallboard ticker. Newest first. Toggle Active to show/hide.</p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Announcements (Ticker)</h1>
+          <p className="text-muted-foreground">Messages shown in the wallboard ticker. Newest first. Toggle Active to show/hide.</p>
+        </div>
+        <Button asChild variant="outline" className="w-full sm:w-auto">
+          <Link to="/management/wallboard-presets">Configure wallboards</Link>
+        </Button>
       </div>
 
       <div className="border rounded-md p-4 space-y-3">


### PR DESCRIPTION
## Summary
- import the React Router Link to support navigation from announcements
- add a configurable wallboard button next to the announcements header
- ensure the new control stacks on small screens for better responsiveness

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffbb60f2d4832fa71d94c35a64b6a2