### PR TITLE
Update social sharing meta image

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="author" content="Sector Pro" />
     
     <!-- Standard Open Graph -->
-    <meta property="og:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/XMySaAljG7POoEqYmtp38WkrHF32/social-images/social-1760691485006-2f12a6ef-587b-4049-ad53-d83fb94064e3.png">
+    <meta property="og:image" content="/og-image.png">
     
     <!-- iOS/iPhone Specific -->
     <link rel="icon" type="image/x-icon" href="https://storage.googleapis.com/gpt-engineer-file-uploads/XMySaAljG7POoEqYmtp38WkrHF32/uploads/1760691504578-2f12a6ef-587b-4049-ad53-d83fb94064e3.png">
@@ -23,7 +23,7 @@
   <meta name="twitter:title" content="Sector Pro">
   <meta property="og:description" content="Sector Pro - Area Tecnica">
   <meta name="twitter:description" content="Sector Pro - Area Tecnica">
-  <meta name="twitter:image" content="https://storage.googleapis.com/gpt-engineer-file-uploads/XMySaAljG7POoEqYmtp38WkrHF32/social-images/social-1760691485006-2f12a6ef-587b-4049-ad53-d83fb94064e3.png">
+  <meta name="twitter:image" content="/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta property="og:type" content="website">
 </head>


### PR DESCRIPTION
## Summary
- point the Open Graph and Twitter card meta tags to the existing `/og-image.png` asset in `public`
- ensure social scrapers will load the corporate image shipped with the project instead of the temporary hosted file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffd1dc5050832f84eebd90ba5cadc7