### PR TITLE
Fix social meta image URL to hosted asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta name="author" content="Sector Pro" />
     
     <!-- Standard Open Graph -->
-    <meta property="og:image" content="/og-image.png">
+    <meta property="og:image" content="https://www.sector-pro.com/8067C0A4-0C71-4CDF-952B-0E699DA25A74.png">
     
     <!-- iOS/iPhone Specific -->
     <link rel="icon" type="image/x-icon" href="https://storage.googleapis.com/gpt-engineer-file-uploads/XMySaAljG7POoEqYmtp38WkrHF32/uploads/1760691504578-2f12a6ef-587b-4049-ad53-d83fb94064e3.png">
@@ -23,7 +23,7 @@
   <meta name="twitter:title" content="Sector Pro">
   <meta property="og:description" content="Sector Pro - Area Tecnica">
   <meta name="twitter:description" content="Sector Pro - Area Tecnica">
-  <meta name="twitter:image" content="/og-image.png">
+  <meta name="twitter:image" content="https://www.sector-pro.com/8067C0A4-0C71-4CDF-952B-0E699DA25A74.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta property="og:type" content="website">
 </head>


### PR DESCRIPTION
## Summary
- update the Open Graph and Twitter meta image URLs to the deployed 8067C0A4 asset so scrapers load the social preview

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffd6b7d0dc832f8e5869df9597e64f