### PR TITLE
Fix wallboard preset panel ordering fallback

### DIFF
--- a/src/pages/WallboardPresets.tsx
+++ b/src/pages/WallboardPresets.tsx
@@ -50,8 +50,10 @@ function normaliseOrder(order?: string[] | null): PanelKey[] {
       seen.add(key);
     }
   });
-  const missing = DEFAULT_ORDER.filter((key) => !seen.has(key));
-  return filtered.length ? [...filtered, ...missing] : [...DEFAULT_ORDER];
+  if (filtered.length === 0) {
+    return [...DEFAULT_ORDER];
+  }
+  return filtered;
 }
 
 function clampNumber(value: number, min: number, max: number, fallback: number) {


### PR DESCRIPTION
## Summary
- adjust wallboard preset panel ordering normalization to only fall back to the default order when no stored panels are valid

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68fff9b3a1b0832fb0cfcd9e1c4851f5