### PR TITLE
feat: support single-day job assignments

### DIFF
--- a/src/components/jobs/JobAssignments.tsx
+++ b/src/components/jobs/JobAssignments.tsx
@@ -10,6 +10,7 @@ import { SubscriptionIndicator } from "../ui/subscription-indicator";
 import { useJobAssignmentsRealtime } from "@/hooks/useJobAssignmentsRealtime";
 import { useEffect, useState } from "react";
 import { labelForCode } from '@/utils/roles';
+import { format } from "date-fns";
 
 interface JobAssignmentsProps {
   jobId: string;
@@ -201,10 +202,19 @@ export const JobAssignments = ({ jobId, department, userRole }: JobAssignmentsPr
           >
             <div className="flex items-center gap-2">
               <User className="h-4 w-4" />
-              <span className="font-medium">
-                {assignment.profiles.first_name} {assignment.profiles.last_name}
-              </span>
-              <span className="text-xs">({displayRole})</span>
+              <div className="flex flex-col">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">
+                    {assignment.profiles.first_name} {assignment.profiles.last_name}
+                  </span>
+                  <span className="text-xs">({displayRole})</span>
+                </div>
+                {assignment.single_day && assignment.single_day_date && (
+                  <span className="text-xs text-muted-foreground">
+                    Single-day: {format(new Date(`${assignment.single_day_date}T00:00:00`), "PPP")}
+                  </span>
+                )}
+              </div>
             </div>
             {userRole !== 'logistics' && (
               <Button

--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -773,6 +773,11 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                               Vídeo: {labelForCode(assignment.video_role)}
                             </Badge>
                           )}
+                          {assignment.single_day && assignment.single_day_date && (
+                            <Badge variant="secondary" className="text-xs">
+                              Single-day: {format(new Date(`${assignment.single_day_date}T00:00:00`), "PPP")}
+                            </Badge>
+                          )}
                         </div>
                       </div>
                     ))}

--- a/src/components/jobs/cards/JobCardAssignments.tsx
+++ b/src/components/jobs/cards/JobCardAssignments.tsx
@@ -5,6 +5,7 @@ import { Users } from "lucide-react";
 import { Department } from "@/types/department";
 import { labelForCode } from '@/utils/roles';
 import { formatUserName } from '@/utils/userName';
+import { format } from "date-fns";
 
 interface JobCardAssignmentsProps {
   assignments: any[];
@@ -43,13 +44,14 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
         : assignment.external_technician_name || 'Unknown';
       
       const isFromTour = assignment.assignment_source === 'tour';
-      
+
       return {
         id: assignment.technician_id || assignment.id,
         name,
         role: role ? labelForCode(role) : null,
         isFromTour,
-        isExternal: !assignment.profiles && assignment.external_technician_name
+        isExternal: !assignment.profiles && assignment.external_technician_name,
+        singleDayDate: assignment.single_day && assignment.single_day_date ? assignment.single_day_date : null,
       };
     })
     .filter(Boolean);
@@ -63,14 +65,15 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
       <Users className="h-4 w-4 text-muted-foreground" />
       <div className="flex flex-wrap gap-1">
         {assignedTechnicians.map((tech, index) => (
-          <Badge 
-            key={tech.id || index} 
-            variant={tech.isFromTour ? "outline" : "secondary"} 
+          <Badge
+            key={tech.id || index}
+            variant={tech.isFromTour ? "outline" : "secondary"}
             className={`text-xs ${tech.isFromTour ? 'border-blue-300 text-blue-700' : ''}`}
           >
             {tech.name} {tech.role && `(${tech.role})`}
             {tech.isFromTour && ' 🎪'}
             {tech.isExternal && ' 👤'}
+            {tech.singleDayDate && ` • Single-day ${format(new Date(`${tech.singleDayDate}T00:00:00`), "MMM d")}`}
           </Badge>
         ))}
       </div>

--- a/src/components/matrix/OptimizedMatrixCell.tsx
+++ b/src/components/matrix/OptimizedMatrixCell.tsx
@@ -405,13 +405,18 @@ export const OptimizedMatrixCell = memo(({
           >
             {assignment.job?.title || 'Assignment'}
           </div>
-          <div 
+          <div
             className={cn('text-xs truncate', assignment.status === 'confirmed' ? '' : 'text-muted-foreground')}
             style={{ color: assignment.status === 'confirmed' ? confirmedSubTextColor : undefined }}
           >
             {labelForCode(assignment.sound_role || assignment.lights_role || assignment.video_role)}
           </div>
-          
+          {assignment.single_day && assignment.single_day_date && (
+            <div className="text-[10px] text-muted-foreground truncate">
+              Single-day: {format(new Date(`${assignment.single_day_date}T00:00:00`), 'MMM d')}
+            </div>
+          )}
+
           {/* Status Actions */}
           {assignment.status === 'invited' && (
             <div className="flex gap-1 mt-1">
@@ -629,6 +634,11 @@ export const OptimizedMatrixCell = memo(({
               <div className="text-muted-foreground">
                 {labelForCode(assignment.sound_role || assignment.lights_role || assignment.video_role)}
               </div>
+              {assignment.single_day && assignment.single_day_date && (
+                <div className="text-muted-foreground">
+                  Single-day: {format(new Date(`${assignment.single_day_date}T00:00:00`), 'MMM d')}
+                </div>
+              )}
               <div className={`capitalize ${assignment.status === 'confirmed' ? 'text-green-600' : assignment.status === 'declined' ? 'text-red-600' : 'text-yellow-600'}`}>
                 {assignment.status}
               </div>

--- a/src/hooks/__tests__/useJobAssignmentsRealtime.test.ts
+++ b/src/hooks/__tests__/useJobAssignmentsRealtime.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { buildAssignmentInsertPayload } from '../useJobAssignmentsRealtime';
+
+describe('buildAssignmentInsertPayload', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('normalizes role values and defaults single-day fields', () => {
+    const fixedDate = new Date('2025-03-01T12:00:00Z');
+    vi.useFakeTimers().setSystemTime(fixedDate);
+
+    const payload = buildAssignmentInsertPayload(
+      'job-1',
+      'tech-1',
+      'none',
+      'lx-main',
+      'manager-1',
+      undefined
+    );
+
+    expect(payload).toMatchObject({
+      job_id: 'job-1',
+      technician_id: 'tech-1',
+      sound_role: null,
+      lights_role: 'lx-main',
+      assigned_by: 'manager-1',
+      single_day: false,
+      single_day_date: null,
+    });
+    expect(payload.assigned_at).toBe(fixedDate.toISOString());
+  });
+
+  it('captures single-day metadata when provided', () => {
+    const fixedDate = new Date('2025-04-15T08:30:00Z');
+    vi.useFakeTimers().setSystemTime(fixedDate);
+
+    const payload = buildAssignmentInsertPayload(
+      'job-2',
+      'tech-99',
+      'mix',
+      'none',
+      'manager-2',
+      {
+        singleDay: true,
+        singleDayDate: '2025-04-20',
+      }
+    );
+
+    expect(payload).toMatchObject({
+      job_id: 'job-2',
+      technician_id: 'tech-99',
+      sound_role: 'mix',
+      lights_role: null,
+      assigned_by: 'manager-2',
+      single_day: true,
+      single_day_date: '2025-04-20',
+    });
+    expect(payload.assigned_at).toBe(fixedDate.toISOString());
+  });
+});

--- a/src/hooks/__tests__/useOptimizedMatrixData.test.ts
+++ b/src/hooks/__tests__/useOptimizedMatrixData.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { buildAssignmentDateMap } from '../useOptimizedMatrixData';
+
+const createDate = (iso: string) => new Date(`${iso}T00:00:00Z`);
+
+describe('buildAssignmentDateMap', () => {
+  it('maps multi-day assignments across the visible range', () => {
+    const assignments: any[] = [
+      {
+        job_id: 'job-a',
+        technician_id: 'tech-a',
+        sound_role: 'mix',
+        single_day: false,
+        single_day_date: null,
+        job: {
+          id: 'job-a',
+          title: 'Main Show',
+          start_time: '2025-03-01T08:00:00Z',
+          end_time: '2025-03-03T23:00:00Z',
+        },
+      },
+      {
+        job_id: 'job-b',
+        technician_id: 'tech-b',
+        lights_role: 'lx-lead',
+        single_day: true,
+        single_day_date: '2025-03-02',
+        job: {
+          id: 'job-b',
+          title: 'Support Day',
+          start_time: '2025-03-02T09:00:00Z',
+          end_time: '2025-03-02T18:00:00Z',
+        },
+      },
+    ];
+
+    const dates = [createDate('2025-03-01'), createDate('2025-03-02'), createDate('2025-03-03')];
+    const map = buildAssignmentDateMap(assignments as any, dates);
+
+    expect(map.get('tech-a-2025-03-01')).toBe(assignments[0]);
+    expect(map.get('tech-a-2025-03-02')).toBe(assignments[0]);
+    expect(map.get('tech-a-2025-03-03')).toBe(assignments[0]);
+
+    expect(map.get('tech-b-2025-03-02')).toBe(assignments[1]);
+    expect(map.get('tech-b-2025-03-01')).toBeUndefined();
+    expect(map.get('tech-b-2025-03-03')).toBeUndefined();
+  });
+});

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -58,8 +58,10 @@ export const useOptimizedJobs = (
         job_assignments(
           technician_id,
           sound_role,
-          lights_role, 
+          lights_role,
           video_role,
+          single_day,
+          single_day_date,
           status,
           assigned_at,
           profiles!inner(

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2667,6 +2667,8 @@ export type Database = {
           job_id: string
           lights_role: string | null
           response_time: string | null
+          single_day: boolean | null
+          single_day_date: string | null
           sound_role: string | null
           status: Database["public"]["Enums"]["assignment_status"] | null
           technician_id: string
@@ -2679,6 +2681,8 @@ export type Database = {
           job_id: string
           lights_role?: string | null
           response_time?: string | null
+          single_day?: boolean | null
+          single_day_date?: string | null
           sound_role?: string | null
           status?: Database["public"]["Enums"]["assignment_status"] | null
           technician_id: string
@@ -2691,6 +2695,8 @@ export type Database = {
           job_id?: string
           lights_role?: string | null
           response_time?: string | null
+          single_day?: boolean | null
+          single_day_date?: string | null
           sound_role?: string | null
           status?: Database["public"]["Enums"]["assignment_status"] | null
           technician_id?: string

--- a/src/types/assignment.ts
+++ b/src/types/assignment.ts
@@ -7,6 +7,8 @@ export interface Assignment {
   sound_role: string | null;
   lights_role: string | null;
   video_role: string | null;
+  single_day?: boolean | null;
+  single_day_date?: string | null;
   profiles: {
     first_name: string;
     nickname?: string | null;

--- a/supabase/migrations/20260301000000_add_single_day_assignment_support.sql
+++ b/supabase/migrations/20260301000000_add_single_day_assignment_support.sql
@@ -1,0 +1,66 @@
+-- Add single-day assignment tracking to job_assignments
+ALTER TABLE IF EXISTS public.job_assignments
+  ADD COLUMN IF NOT EXISTS single_day boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS single_day_date date;
+
+COMMENT ON COLUMN public.job_assignments.single_day IS 'True when the assignment only covers a single job date';
+COMMENT ON COLUMN public.job_assignments.single_day_date IS 'Specific job date covered when single_day is true';
+
+-- Ensure legacy rows have deterministic values
+UPDATE public.job_assignments
+SET single_day = COALESCE(single_day, false)
+WHERE single_day IS NULL;
+
+-- Update timesheet auto-generation to respect the single-day flag
+CREATE OR REPLACE FUNCTION public.create_timesheets_for_assignment()
+RETURNS TRIGGER AS $$
+DECLARE
+    job_start_date date;
+    job_end_date date;
+    current_date date;
+BEGIN
+    -- When explicitly marked as single-day, only create a timesheet for that date
+    IF COALESCE(NEW.single_day, false) = true AND NEW.single_day_date IS NOT NULL THEN
+        INSERT INTO timesheets (
+            job_id,
+            technician_id,
+            date,
+            created_by
+        ) VALUES (
+            NEW.job_id,
+            NEW.technician_id,
+            NEW.single_day_date,
+            NEW.assigned_by
+        )
+        ON CONFLICT (job_id, technician_id, date) DO NOTHING;
+
+        RETURN NEW;
+    END IF;
+
+    -- Fallback to legacy behaviour (cover full job range)
+    SELECT DATE(start_time), DATE(end_time)
+    INTO job_start_date, job_end_date
+    FROM jobs
+    WHERE id = NEW.job_id;
+
+    current_date := job_start_date;
+    WHILE current_date <= job_end_date LOOP
+        INSERT INTO timesheets (
+            job_id,
+            technician_id,
+            date,
+            created_by
+        ) VALUES (
+            NEW.job_id,
+            NEW.technician_id,
+            current_date,
+            NEW.assigned_by
+        )
+        ON CONFLICT (job_id, technician_id, date) DO NOTHING;
+
+        current_date := current_date + INTERVAL '1 day';
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- add a single-day toggle with job-date picker to the assignment dialog and thread the selected date through addAssignment
- persist single-day metadata in Supabase (schema/types and timesheet trigger) and surface it across job detail/card views and the matrix
- add regression tests covering the assignment payload builder and matrix date-mapping helper

## Testing
- npm test -- --run *(fails: vitest binary missing and npm install blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6900a7233234832f976c4e620fa0e369