### PR TITLE
Support single-day job assignments across workflows

### DIFF
--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -71,6 +71,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
           job_assignments(
             job_id, technician_id, assigned_by, assigned_at,
             sound_role, lights_role, video_role, status,
+            single_day, assignment_date,
             profiles(id, first_name, last_name, department, role)
           ),
           job_documents(id, file_name, file_path, uploaded_at, file_size, visible_to_tech, read_only, template_type),
@@ -756,6 +757,11 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                           <p className="text-sm text-muted-foreground">
                             {assignment.profiles?.department || 'Externo'}
                           </p>
+                          {assignment.single_day && (
+                            <p className="text-xs text-muted-foreground">
+                              Solo día: {assignment.assignment_date ? format(new Date(assignment.assignment_date), 'PPP', { locale: es }) : 'Sin fecha definida'}
+                            </p>
+                          )}
                         </div>
                         <div className="flex gap-1">
                           {assignment.sound_role && (

--- a/src/features/staffing/hooks/useStaffing.ts
+++ b/src/features/staffing/hooks/useStaffing.ts
@@ -52,7 +52,7 @@ export function useStaffingStatus(jobId: string, profileId: string) {
 export function useSendStaffingEmail() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (payload: { job_id: string, profile_id: string, phase: 'availability'|'offer', role?: string | null, message?: string | null, channel?: 'email' | 'whatsapp' }) => {
+    mutationFn: async (payload: { job_id: string, profile_id: string, phase: 'availability'|'offer', role?: string | null, message?: string | null, channel?: 'email' | 'whatsapp', target_date?: string | null, single_day?: boolean }) => {
       console.log('🚀 SENDING STAFFING EMAIL:', {
         payload,
         job_id_type: typeof payload.job_id,

--- a/src/hooks/useAvailableTechnicians.ts
+++ b/src/hooks/useAvailableTechnicians.ts
@@ -19,6 +19,7 @@ interface UseAvailableTechniciansOptions {
   jobId: string;
   jobStartTime: string;
   jobEndTime: string;
+  assignmentDate?: string | null;
   enabled?: boolean;
 }
 
@@ -27,13 +28,14 @@ export function useAvailableTechnicians({
   jobId,
   jobStartTime,
   jobEndTime,
+  assignmentDate,
   enabled = true
 }: UseAvailableTechniciansOptions) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const queryClient = useQueryClient();
 
   const query = useQuery({
-    queryKey: ["available-technicians", department, jobId, jobStartTime, jobEndTime],
+    queryKey: ["available-technicians", department, jobId, jobStartTime, jobEndTime, assignmentDate ?? null],
     queryFn: async () => {
       if (!department || !jobId || !jobStartTime || !jobEndTime) {
         return [];
@@ -44,7 +46,8 @@ export function useAvailableTechnicians({
           department,
           jobId,
           jobStartTime,
-          jobEndTime
+          jobEndTime,
+          assignmentDate
         );
         
         console.log(`Found ${technicians.length} available ${department} technicians for job ${jobId}`);
@@ -108,7 +111,7 @@ export function useAvailableTechnicians({
       console.log('Cleaning up technician availability subscription');
       supabase.removeChannel(channel);
     };
-  }, [enabled, department, jobId, jobStartTime, jobEndTime, queryClient]);
+  }, [enabled, department, jobId, jobStartTime, jobEndTime, assignmentDate, queryClient]);
 
   const handleManualRefresh = async () => {
     setIsRefreshing(true);

--- a/src/hooks/useJobAssignmentsRealtime.ts
+++ b/src/hooks/useJobAssignmentsRealtime.ts
@@ -101,7 +101,12 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
 
   const { manageFlexCrewAssignment } = useFlexCrewAssignments();
 
-  const addAssignment = async (technicianId: string, soundRole: string, lightsRole: string) => {
+  const addAssignment = async (
+    technicianId: string,
+    soundRole: string,
+    lightsRole: string,
+    options?: { singleDay?: boolean; assignmentDate?: string | null }
+  ) => {
     try {
       // Optimistic cache update for 'jobs' list so cards update instantly
       queryClient.setQueryData(['jobs'], (old: any) => {
@@ -113,6 +118,8 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
             technician_id: technicianId,
             sound_role: soundRole !== 'none' ? soundRole : null,
             lights_role: lightsRole !== 'none' ? lightsRole : null,
+            single_day: options?.singleDay ?? false,
+            assignment_date: options?.assignmentDate ?? null,
             profiles: { first_name: '', last_name: '' },
           };
           const current = Array.isArray(j.job_assignments) ? j.job_assignments : [];
@@ -129,6 +136,8 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
           lights_role: lightsRole !== 'none' ? lightsRole : null,
           assigned_by: (await supabase.auth.getUser()).data.user?.id,
           assigned_at: new Date().toISOString(),
+          single_day: options?.singleDay ?? false,
+          assignment_date: options?.singleDay ? options?.assignmentDate ?? null : null,
         });
 
       if (error) {

--- a/src/hooks/useOptimizedMatrixData.ts
+++ b/src/hooks/useOptimizedMatrixData.ts
@@ -23,6 +23,8 @@ interface AssignmentWithJob {
   video_role?: string;
   status: string;
   assigned_at: string;
+  single_day?: boolean;
+  assignment_date?: string | null;
   job: {
     id: string;
     title: string;
@@ -75,6 +77,8 @@ export const useOptimizedMatrixData = ({ technicians, dates, jobs }: OptimizedMa
               video_role,
               status,
               assigned_at,
+              single_day,
+              assignment_date,
               jobs!job_id (
                 id,
                 title,
@@ -110,6 +114,8 @@ export const useOptimizedMatrixData = ({ technicians, dates, jobs }: OptimizedMa
           video_role: item.video_role,
           status: item.status,
           assigned_at: item.assigned_at,
+          single_day: item.single_day,
+          assignment_date: item.assignment_date,
           job: Array.isArray(item.jobs) ? item.jobs[0] : item.jobs
         })).filter(item => item.job); // Filter out items without job data
         

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2661,11 +2661,13 @@ export type Database = {
       }
       job_assignments: {
         Row: {
+          assignment_date: string | null
           assigned_at: string
           assigned_by: string | null
           assignment_source: string | null
           job_id: string
           lights_role: string | null
+          single_day: boolean
           response_time: string | null
           sound_role: string | null
           status: Database["public"]["Enums"]["assignment_status"] | null
@@ -2673,11 +2675,13 @@ export type Database = {
           video_role: string | null
         }
         Insert: {
+          assignment_date?: string | null
           assigned_at?: string
           assigned_by?: string | null
           assignment_source?: string | null
           job_id: string
           lights_role?: string | null
+          single_day?: boolean
           response_time?: string | null
           sound_role?: string | null
           status?: Database["public"]["Enums"]["assignment_status"] | null
@@ -2685,11 +2689,13 @@ export type Database = {
           video_role?: string | null
         }
         Update: {
+          assignment_date?: string | null
           assigned_at?: string
           assigned_by?: string | null
           assignment_source?: string | null
           job_id?: string
           lights_role?: string | null
+          single_day?: boolean
           response_time?: string | null
           sound_role?: string | null
           status?: Database["public"]["Enums"]["assignment_status"] | null

--- a/src/types/assignment.ts
+++ b/src/types/assignment.ts
@@ -4,9 +4,11 @@ export interface Assignment {
   technician_id: string;
   assigned_by: string | null;
   assigned_at: string;
+  assignment_date: string | null;
   sound_role: string | null;
   lights_role: string | null;
   video_role: string | null;
+  single_day: boolean;
   profiles: {
     first_name: string;
     nickname?: string | null;

--- a/supabase/migrations/20250719090000_add_single_day_assignments.sql
+++ b/supabase/migrations/20250719090000_add_single_day_assignments.sql
@@ -1,0 +1,20 @@
+alter table public.job_assignments
+  add column if not exists single_day boolean not null default false,
+  add column if not exists assignment_date date;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'job_assignments_single_day_check'
+      and conrelid = 'public.job_assignments'::regclass
+  ) then
+    alter table public.job_assignments
+      add constraint job_assignments_single_day_check
+      check (single_day = false or assignment_date is not null);
+  end if;
+end $$;
+
+create index if not exists job_assignments_assignment_date_idx
+  on public.job_assignments (assignment_date);


### PR DESCRIPTION
## Summary
- add single-day assignment controls and display to the job assignment dialog while filtering availability by the chosen date
- persist per-day assignment metadata, update technician availability checks, and expose new fields to matrix data consumers
- propagate single-day context through staffing emails, push notifications, and database schema updates

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6900a5512d30832f9f761e6c2aa4eb68