### PR TITLE
Refresh rates PDF branding and logo handling

### DIFF
--- a/src/components/jobs/JobPayoutTotalsPanel.tsx
+++ b/src/components/jobs/JobPayoutTotalsPanel.tsx
@@ -94,7 +94,7 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
             onClick={async () => {
               const { data: jobData } = await supabase
                 .from('jobs')
-                .select('id, title, start_time')
+                .select('id, title, start_time, tour_id')
                 .eq('id', jobId)
                 .single();
               

--- a/src/components/tours/TourRatesManagerDialog.tsx
+++ b/src/components/tours/TourRatesManagerDialog.tsx
@@ -38,7 +38,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
     queryFn: async () => {
       const { data, error } = await supabase
         .from('jobs')
-        .select('id, title, start_time, end_time, job_type')
+        .select('id, title, start_time, end_time, job_type, tour_id')
         .eq('tour_id', tourId)
         .eq('job_type', 'tourdate')
         .order('start_time', { ascending: true });


### PR DESCRIPTION
## Summary
- restyle rate, tour summary, and payout PDFs with the corporate red header/footer treatment shared with timesheet exports
- resolve tour or job branding logos via existing fetch helpers and render them with company fallbacks inside each PDF
- include tour identifiers in job queries so the PDF generators can locate associated branding

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_69011054e8dc832f8de8ecb9fd52ce01