### PR TITLE
Allow completed standalone jobs in rates approvals

### DIFF
--- a/src/services/ratesService.ts
+++ b/src/services/ratesService.ts
@@ -227,7 +227,7 @@ export async function fetchRatesApprovals(): Promise<RatesApprovalRow[]> {
     .select('id, title, start_time, end_time, job_type, status, rates_approved, tour_id')
     .neq('job_type', 'tourdate')
     .neq('job_type', 'dryhire')
-    .eq('status', 'Confirmado')
+    .in('status', ['Confirmado', 'Completado'])
     .order('start_time', { ascending: true });
 
   if (jobsError2) throw jobsError2;


### PR DESCRIPTION
## Summary
- update the standalone jobs query so approvals include both confirmed and completed statuses while keeping cancelled and dry-hire jobs excluded

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69011912a2f4832fbc1c9995d5be34b3