### PR TITLE
Ensure rate PDFs use dedicated company footer logo

### DIFF
--- a/src/utils/pdf/logoUtils.ts
+++ b/src/utils/pdf/logoUtils.ts
@@ -2,6 +2,15 @@
 import { supabase } from '@/lib/supabase';
 import { logoUrlCache } from '@/lib/logo-url-cache';
 
+const COMPANY_LOGO_BUCKET = 'company-assets';
+const COMPANY_LOGO_PATH = 'sector-pro-logo.png';
+const COMPANY_LOGO_FALLBACK_PATHS = [
+  '/sector pro logo.png',
+  '/sector-pro-logo.png',
+  '/sector%20pro%20logo.png',
+  '/lovable-uploads/ce3ff31a-4cc5-43c8-b5bb-a4056d3735e4.png',
+];
+
 const inflight = new Map<string, Promise<string | undefined>>();
 const withInflight = (bucket: string, path: string, fn: () => Promise<string | undefined>) => {
   const key = `${bucket}:${path}`;
@@ -170,27 +179,113 @@ export const fetchJobLogo = async (jobId: string): Promise<string | undefined> =
       console.log("Found festival logo for job:", jobId);
       return festivalLogo;
     }
-    
+
     // If no festival logo, check if it's a tour date job and get the tour logo
     const { data: jobData, error: jobError } = await supabase
       .from("jobs")
       .select("tour_id")
       .eq("id", jobId)
       .maybeSingle();
-      
+
     if (jobError) {
       console.error("Error fetching job data:", jobError);
       return undefined;
     }
-    
+
     if (jobData?.tour_id) {
       // Fetch the tour logo
       return await fetchTourLogo(jobData.tour_id);
     }
-    
+
     return undefined;
   } catch (err) {
     console.error("Error in job logo fetch:", err);
     return undefined;
   }
+};
+
+const loadImageElement = (src: string): Promise<HTMLImageElement | null> => {
+  return new Promise((resolve) => {
+    if (!src || typeof Image === 'undefined') {
+      resolve(null);
+      return;
+    }
+
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = (error) => {
+      console.warn('Failed to load company logo from', src, error);
+      resolve(null);
+    };
+    img.src = src;
+  });
+};
+
+const blobToDataUrl = (blob: Blob): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
+    reader.readAsDataURL(blob);
+  });
+};
+
+let companyLogoPromise: Promise<HTMLImageElement | null> | null = null;
+
+const fetchCompanyLogoFromStorage = async (): Promise<HTMLImageElement | null> => {
+  try {
+    const { data, error } = await supabase.storage
+      .from(COMPANY_LOGO_BUCKET)
+      .download(COMPANY_LOGO_PATH);
+
+    if (!error && data) {
+      const dataUrl = await blobToDataUrl(data);
+      const image = await loadImageElement(dataUrl);
+      if (image) return image;
+    }
+  } catch (error) {
+    console.warn('Error downloading company logo:', error);
+  }
+
+  try {
+    const { data: signedData, error: signedError } = await supabase.storage
+      .from(COMPANY_LOGO_BUCKET)
+      .createSignedUrl(COMPANY_LOGO_PATH, 60 * 60);
+
+    if (!signedError && signedData?.signedUrl) {
+      const image = await loadImageElement(signedData.signedUrl);
+      if (image) return image;
+    }
+  } catch (error) {
+    console.warn('Error fetching signed URL for company logo:', error);
+  }
+
+  return null;
+};
+
+export const getCompanyLogo = async (): Promise<HTMLImageElement | null> => {
+  if (companyLogoPromise) return companyLogoPromise;
+
+  companyLogoPromise = (async () => {
+    if (typeof window === 'undefined' || typeof Image === 'undefined') {
+      return null;
+    }
+
+    const storageLogo = await fetchCompanyLogoFromStorage();
+    if (storageLogo) return storageLogo;
+
+    for (const path of COMPANY_LOGO_FALLBACK_PATHS) {
+      const image = await loadImageElement(path);
+      if (image) return image;
+    }
+
+    return null;
+  })();
+
+  companyLogoPromise.catch(() => {
+    companyLogoPromise = null;
+  });
+
+  return companyLogoPromise;
 };


### PR DESCRIPTION
## Summary
- add a company-logo loader that reads from Supabase storage with public fallbacks
- update rate PDF generators to fetch the company logo alongside tour/job branding and use it in the footer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901257ab0f8832f85ef7c3479ab5474