### PR TITLE
Add job payout email workflow

### DIFF
--- a/docs/rates-extras-workflow.md
+++ b/docs/rates-extras-workflow.md
@@ -31,7 +31,9 @@ The application supports two pay-processing paths: **regular jobs** (single-day 
 
 4. **Job Approval & Visibility**
    - A management toggle (`rates_approved`) on each job governs when technicians can view totals and extras. Until it is set true, technicians see a “pending approval” notice in job totals, even if timesheets were approved. 【F:src/components/jobs/JobDetailsDialog.tsx†L398-L444】【F:src/components/timesheet/MyJobTotal.tsx†L70-L90】
-   - Once approved, technicians can see their aggregated totals, which combine approved timesheet amounts and extras from the `v_job_tech_payout_2025` view. 【F:src/hooks/useJobPayoutTotals.ts†L5-L24】【F:src/components/timesheet/MyJobTotal.tsx†L94-L137】
+- Once approved, technicians can see their aggregated totals, which combine approved timesheet amounts and extras from the `v_job_tech_payout_2025` view. 【F:src/hooks/useJobPayoutTotals.ts†L5-L24】【F:src/components/timesheet/MyJobTotal.tsx†L94-L137】
+- Managers pueden enviar los resúmenes de pagos directamente por correo electrónico una vez aprobadas las tarifas. El diálogo de detalles del trabajo muestra un aviso inmediato tras pulsar “Aprobar” y el panel de totales incorpora la acción “Enviar por correo”, que genera PDFs por técnico y llama a la nueva función Edge `send-job-payout-email`. Las tarjetas resaltan a los técnicos sin correo para evitar omisiones. 【F:src/components/jobs/JobDetailsDialog.tsx†L520-L609】【F:src/components/jobs/JobPayoutTotalsPanel.tsx†L1-L347】【F:supabase/functions/send-job-payout-email/index.ts†L1-L176】
+- Configure `BREVO_API_KEY`, `BREVO_FROM`, and optional `PAYOUT_EMAIL_BCC` so the email function can authenticate with Brevo and copy administration on each payout message. 【F:supabase/functions/send-job-payout-email/index.ts†L1-L176】
 
 5. **Aggregation & Dashboard Display**
    - The dashboard aggregates job totals across all approved jobs, separating pending and approved amounts. Multi-day jobs are rolled up automatically by the payout view, and managers can access detailed breakdowns in job management screens. 【F:src/components/dashboard/MyJobTotalsSection.tsx†L105-L215】【F:src/hooks/useJobTotals.ts†L5-L33】

--- a/src/lib/job-payout-email.ts
+++ b/src/lib/job-payout-email.ts
@@ -1,0 +1,302 @@
+import { format } from 'date-fns';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { JobPayoutTotals } from '@/types/jobExtras';
+import { generateJobPayoutPDF, TimesheetLine } from '@/utils/rates-pdf-export';
+
+export interface TechnicianProfileWithEmail {
+  id: string;
+  first_name?: string | null;
+  last_name?: string | null;
+  email?: string | null;
+}
+
+export interface JobPayoutEmailJobDetails {
+  id: string;
+  title: string;
+  start_time: string;
+  tour_id?: string | null;
+  rates_approved?: boolean | null;
+}
+
+export interface JobPayoutEmailAttachment {
+  technician_id: string;
+  email?: string | null;
+  full_name: string;
+  payout: JobPayoutTotals;
+  pdfBase64: string;
+  filename: string;
+}
+
+export interface JobPayoutEmailContextResult {
+  job: JobPayoutEmailJobDetails;
+  payouts: JobPayoutTotals[];
+  profiles: TechnicianProfileWithEmail[];
+  lpoMap?: Map<string, string | null>;
+  timesheetMap: Map<string, TimesheetLine[]>;
+  attachments: JobPayoutEmailAttachment[];
+  missingEmails: string[];
+}
+
+export interface JobPayoutEmailInput {
+  jobId: string;
+  supabase: SupabaseClient;
+  payouts?: JobPayoutTotals[];
+  profiles?: TechnicianProfileWithEmail[];
+  lpoMap?: Map<string, string | null>;
+  jobDetails?: JobPayoutEmailJobDetails | null;
+}
+
+function sanitizeForFilename(value: string) {
+  return value
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  const arrayBuffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+function buildTimesheetMap(rows: any[]): Map<string, TimesheetLine[]> {
+  const map = new Map<string, TimesheetLine[]>();
+  rows.forEach((row) => {
+    const breakdown = (row.amount_breakdown || row.amount_breakdown_visible || {}) as Record<string, any>;
+    const line: TimesheetLine = {
+      date: row.date ?? null,
+      hours_rounded: Number(breakdown.hours_rounded ?? breakdown.worked_hours_rounded ?? 0) || 0,
+      base_day_eur: breakdown.base_day_eur != null ? Number(breakdown.base_day_eur) : undefined,
+      plus_10_12_hours: breakdown.plus_10_12_hours != null ? Number(breakdown.plus_10_12_hours) : undefined,
+      plus_10_12_amount_eur:
+        breakdown.plus_10_12_amount_eur != null ? Number(breakdown.plus_10_12_amount_eur) : undefined,
+      overtime_hours: breakdown.overtime_hours != null ? Number(breakdown.overtime_hours) : undefined,
+      overtime_hour_eur: breakdown.overtime_hour_eur != null ? Number(breakdown.overtime_hour_eur) : undefined,
+      overtime_amount_eur:
+        breakdown.overtime_amount_eur != null ? Number(breakdown.overtime_amount_eur) : undefined,
+      total_eur: breakdown.total_eur != null ? Number(breakdown.total_eur) : undefined,
+    };
+
+    const existing = map.get(row.technician_id) || [];
+    existing.push(line);
+    map.set(row.technician_id, existing);
+  });
+  return map;
+}
+
+async function fetchJobDetails(
+  client: SupabaseClient,
+  jobId: string,
+  provided?: JobPayoutEmailJobDetails | null
+): Promise<JobPayoutEmailJobDetails> {
+  if (provided) return provided;
+  const { data, error } = await client
+    .from('jobs')
+    .select('id, title, start_time, tour_id, rates_approved')
+    .eq('id', jobId)
+    .maybeSingle();
+  if (error || !data) {
+    throw error || new Error('Job not found');
+  }
+  return data as JobPayoutEmailJobDetails;
+}
+
+async function fetchPayouts(
+  client: SupabaseClient,
+  jobId: string,
+  provided?: JobPayoutTotals[]
+): Promise<JobPayoutTotals[]> {
+  if (provided && provided.length) return provided;
+  const { data, error } = await client
+    .from('v_job_tech_payout_2025')
+    .select('*')
+    .eq('job_id', jobId);
+  if (error) throw error;
+  return (data || []) as JobPayoutTotals[];
+}
+
+async function fetchProfiles(
+  client: SupabaseClient,
+  techIds: string[],
+  provided?: TechnicianProfileWithEmail[]
+): Promise<TechnicianProfileWithEmail[]> {
+  if (provided) {
+    const hasEmailField = provided.every((p) => Object.prototype.hasOwnProperty.call(p, 'email'));
+    if (hasEmailField) {
+      return provided;
+    }
+  }
+  if (!techIds.length) return provided || [];
+  const { data, error } = await client
+    .from('profiles')
+    .select('id, first_name, last_name, email')
+    .in('id', techIds);
+  if (error) throw error;
+  return (data || []) as TechnicianProfileWithEmail[];
+}
+
+async function fetchLpoMap(
+  client: SupabaseClient,
+  jobId: string,
+  technicianIds: string[],
+  provided?: Map<string, string | null>
+): Promise<Map<string, string | null>> {
+  if (provided) return provided;
+  if (!technicianIds.length) return new Map();
+  const { data, error } = await client
+    .from('flex_work_orders')
+    .select('technician_id, lpo_number')
+    .eq('job_id', jobId)
+    .in('technician_id', technicianIds);
+  if (error) throw error;
+  return new Map((data || []).map((row: any) => [row.technician_id, row.lpo_number || null]));
+}
+
+async function fetchTimesheets(client: SupabaseClient, jobId: string): Promise<any[]> {
+  const { data, error } = await client
+    .from('timesheets')
+    .select(
+      'technician_id, job_id, date, amount_breakdown, amount_breakdown_visible, approved_by_manager'
+    )
+    .eq('job_id', jobId)
+    .eq('approved_by_manager', true);
+  if (error) throw error;
+  if (data && data.length) return data as any[];
+  const { data: rpcData, error: rpcError } = await client.rpc('get_timesheet_amounts_visible');
+  if (rpcError) throw rpcError;
+  return ((rpcData as any[]) || []).filter(
+    (row) => row.job_id === jobId && row.approved_by_manager === true
+  );
+}
+
+export async function prepareJobPayoutEmailContext(
+  input: JobPayoutEmailInput
+): Promise<JobPayoutEmailContextResult> {
+  const { jobId, supabase, jobDetails: providedJob, payouts: providedPayouts, profiles: providedProfiles, lpoMap: providedLpoMap } =
+    input;
+  const job = await fetchJobDetails(supabase, jobId, providedJob);
+  const payouts = await fetchPayouts(supabase, jobId, providedPayouts);
+  const technicianIds = Array.from(new Set(payouts.map((p) => p.technician_id).filter(Boolean)));
+  const profiles = await fetchProfiles(supabase, technicianIds, providedProfiles);
+  const lpoMap = await fetchLpoMap(supabase, jobId, technicianIds, providedLpoMap);
+  const timesheetRows = await fetchTimesheets(supabase, jobId);
+  const timesheetMap = buildTimesheetMap(timesheetRows);
+
+  const profileMap = new Map(profiles.map((p) => [p.id, p]));
+  const attachments: JobPayoutEmailAttachment[] = [];
+  for (const payout of payouts) {
+    const profile = profileMap.get(payout.technician_id);
+    const fullName = `${profile?.first_name ?? ''} ${profile?.last_name ?? ''}`.trim() || payout.technician_id;
+    const perTechMap = new Map<string, TimesheetLine[]>([
+      [payout.technician_id, timesheetMap.get(payout.technician_id) || []],
+    ]);
+    const blob = (await generateJobPayoutPDF(
+      [payout],
+      job,
+      profiles,
+      lpoMap,
+      perTechMap,
+      { download: false }
+    )) as Blob | void;
+    if (!blob) continue;
+    const pdfBase64 = await blobToBase64(blob);
+    const jobSlug = sanitizeForFilename(job.title || job.id);
+    const techSlug = sanitizeForFilename(fullName);
+    const datePart = format(new Date(), 'yyyy-MM-dd');
+    const filename = `pago_${jobSlug || job.id}_${techSlug || payout.technician_id}_${datePart}.pdf`;
+    attachments.push({
+      technician_id: payout.technician_id,
+      email: profile?.email ?? null,
+      full_name: fullName,
+      payout,
+      pdfBase64,
+      filename,
+    });
+  }
+
+  const missingEmails = attachments
+    .filter((attachment) => !attachment.email)
+    .map((attachment) => attachment.technician_id);
+
+  return {
+    job,
+    payouts,
+    profiles,
+    lpoMap,
+    timesheetMap,
+    attachments,
+    missingEmails,
+  };
+}
+
+export interface SendJobPayoutEmailsResult {
+  success: boolean;
+  missingEmails: string[];
+  response?: any;
+  error?: any;
+  context: JobPayoutEmailContextResult;
+}
+
+export interface SendJobPayoutEmailsInput extends JobPayoutEmailInput {
+  existingContext?: JobPayoutEmailContextResult;
+}
+
+export async function sendJobPayoutEmails(
+  input: SendJobPayoutEmailsInput
+): Promise<SendJobPayoutEmailsResult> {
+  const context =
+    input.existingContext ?? (await prepareJobPayoutEmailContext(input));
+  const recipients = context.attachments.filter((attachment) => attachment.email);
+
+  if (!recipients.length) {
+    return {
+      success: false,
+      missingEmails: context.missingEmails,
+      context,
+      error: new Error('No technicians with email available'),
+    };
+  }
+
+  const payload = {
+    job: {
+      id: context.job.id,
+      title: context.job.title,
+      start_time: context.job.start_time,
+      tour_id: context.job.tour_id ?? null,
+    },
+    technicians: recipients.map((attachment) => ({
+      technician_id: attachment.technician_id,
+      email: attachment.email,
+      full_name: attachment.full_name,
+      totals: {
+        timesheets_total_eur: attachment.payout.timesheets_total_eur,
+        extras_total_eur: attachment.payout.extras_total_eur,
+        total_eur: attachment.payout.total_eur,
+      },
+      pdf_base64: attachment.pdfBase64,
+      filename: attachment.filename,
+    })),
+    missing_emails: context.missingEmails,
+    requested_at: new Date().toISOString(),
+  };
+
+  const { data, error } = await input.supabase.functions.invoke('send-job-payout-email', {
+    body: payload,
+  });
+
+  return {
+    success: !error && data?.success !== false,
+    missingEmails: context.missingEmails,
+    response: data,
+    error,
+    context,
+  };
+}

--- a/src/utils/rates-pdf-export.ts
+++ b/src/utils/rates-pdf-export.ts
@@ -6,7 +6,7 @@ import { TourJobRateQuote } from '@/types/tourRates';
 import { formatCurrency } from '@/lib/utils';
 import { fetchJobLogo, fetchTourLogo, getCompanyLogo } from '@/utils/pdf/logoUtils';
 
-interface TechnicianProfile {
+export interface TechnicianProfile {
   id: string;
   first_name?: string | null;
   last_name?: string | null;
@@ -14,7 +14,7 @@ interface TechnicianProfile {
   role?: string | null;
 }
 
-interface JobDetails {
+export interface JobDetails {
   id: string;
   title: string;
   start_time: string;
@@ -47,7 +47,7 @@ interface PayoutData {
   vehicle_disclaimer_text?: string;
 }
 
-interface TimesheetLine {
+export interface TimesheetLine {
   date?: string | null;
   hours_rounded?: number;
   base_day_eur?: number;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -20,3 +20,6 @@ verify_jwt = false
 
 [functions.push]
 verify_jwt = true
+
+[functions.send-job-payout-email]
+verify_jwt = true

--- a/supabase/functions/send-job-payout-email/index.ts
+++ b/supabase/functions/send-job-payout-email/index.ts
@@ -1,0 +1,188 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+const corsHeaders: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const BREVO_KEY = Deno.env.get("BREVO_API_KEY") ?? "";
+const BREVO_FROM = Deno.env.get("BREVO_FROM") ?? "";
+const ADMIN_BCC = Deno.env.get("PAYOUT_EMAIL_BCC") ?? "";
+
+interface JobMetadata {
+  id: string;
+  title: string;
+  start_time?: string;
+  tour_id?: string | null;
+}
+
+interface TechnicianPayload {
+  technician_id: string;
+  email: string;
+  full_name?: string;
+  totals?: {
+    timesheets_total_eur?: number;
+    extras_total_eur?: number;
+    total_eur?: number;
+  };
+  pdf_base64: string;
+  filename?: string;
+}
+
+interface JobPayoutRequestBody {
+  job?: JobMetadata;
+  technicians?: TechnicianPayload[];
+  missing_emails?: string[];
+  requested_at?: string;
+}
+
+function formatCurrency(amount?: number) {
+  return new Intl.NumberFormat('es-ES', {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+  }).format(Number(amount ?? 0));
+}
+
+function formatJobDate(dateIso?: string) {
+  if (!dateIso) return 'sin fecha';
+  const parsed = new Date(dateIso);
+  if (Number.isNaN(parsed.getTime())) return 'sin fecha';
+  return new Intl.DateTimeFormat('es-ES', { dateStyle: 'long' }).format(parsed);
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  }
+
+  if (!BREVO_KEY || !BREVO_FROM) {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Email channel not configured',
+        missing_env: [
+          ...(BREVO_KEY ? [] : ['BREVO_API_KEY']),
+          ...(BREVO_FROM ? [] : ['BREVO_FROM']),
+        ],
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
+  try {
+    const body = (await req.json()) as JobPayoutRequestBody;
+    console.log('[send-job-payout-email] Incoming payload', JSON.stringify(body, null, 2));
+
+    if (!body || !body.job || !body.job.id) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Missing job metadata' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (!Array.isArray(body.technicians) || body.technicians.length === 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'No technician payloads received' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const results: Array<{ technician_id: string; sent: boolean; error?: string }> = [];
+
+    for (const tech of body.technicians) {
+      const trimmedEmail = (tech.email || '').trim();
+      const pdfBase64 = (tech.pdf_base64 || '').trim();
+
+      if (!trimmedEmail) {
+        results.push({ technician_id: tech.technician_id, sent: false, error: 'missing_email' });
+        continue;
+      }
+      if (!pdfBase64) {
+        results.push({ technician_id: tech.technician_id, sent: false, error: 'missing_pdf' });
+        continue;
+      }
+
+      const subject = `Resumen de pagos · ${body.job.title}`;
+      const htmlContent = `
+        <p>Hola ${tech.full_name || 'equipo'},</p>
+        <p>Adjuntamos tu resumen de pagos correspondiente al trabajo <strong>${body.job.title}</strong>, programado para el <strong>${formatJobDate(body.job.start_time)}</strong>.</p>
+        <p>Totales registrados:</p>
+        <ul>
+          <li>Partes aprobados: <strong>${formatCurrency(tech.totals?.timesheets_total_eur)}</strong></li>
+          <li>Extras: <strong>${formatCurrency(tech.totals?.extras_total_eur)}</strong></li>
+          <li>Total general: <strong>${formatCurrency(tech.totals?.total_eur)}</strong></li>
+        </ul>
+        <p>Si detectas alguna incidencia puedes responder a este mensaje o contactar con administración.</p>
+        <p>Saludos,<br/>Área Técnica</p>
+      `;
+
+      const emailPayload: Record<string, unknown> = {
+        sender: { email: BREVO_FROM, name: 'Área Técnica' },
+        to: [{ email: trimmedEmail, name: tech.full_name || undefined }],
+        subject,
+        htmlContent,
+        attachments: [
+          {
+            content: pdfBase64,
+            name: tech.filename || `pago_${body.job.id}_${tech.technician_id}.pdf`,
+          },
+        ],
+      };
+
+      if (ADMIN_BCC) {
+        emailPayload['bcc'] = [{ email: ADMIN_BCC }];
+      }
+
+      try {
+        const sendRes = await fetch('https://api.brevo.com/v3/smtp/email', {
+          method: 'POST',
+          headers: {
+            'api-key': BREVO_KEY,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(emailPayload),
+        });
+
+        if (!sendRes.ok) {
+          const errText = await sendRes.text();
+          console.error('[send-job-payout-email] Brevo error', sendRes.status, errText);
+          results.push({ technician_id: tech.technician_id, sent: false, error: errText || sendRes.statusText });
+        } else {
+          results.push({ technician_id: tech.technician_id, sent: true });
+        }
+      } catch (err) {
+        console.error('[send-job-payout-email] Failed to send email', err);
+        results.push({ technician_id: tech.technician_id, sent: false, error: (err as Error).message });
+      }
+    }
+
+    const success = results.every((r) => r.sent);
+    return new Response(
+      JSON.stringify({
+        success,
+        results,
+        job: body.job,
+        missing_emails: body.missing_emails || [],
+        requested_at: body.requested_at || new Date().toISOString(),
+      }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (err) {
+    console.error('[send-job-payout-email] Unexpected error', err);
+    return new Response(
+      JSON.stringify({ success: false, error: (err as Error).message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a shared helper to prepare per-technician payout PDFs/base64 blobs, highlight missing addresses, and expose an "Enviar por correo" action in the totals panel
- prompt managers to send payout emails immediately after approving rates in the job dialog while reusing the new helper
- create the `send-job-payout-email` Edge Function, wire it into Supabase config, and document the new email workflow and configuration

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_690148f6d0f4832fb577d71163f6af37