### PR TITLE
Improve mobile responsiveness of lights page layouts

### DIFF
--- a/src/components/lights/LightsHeader.tsx
+++ b/src/components/lights/LightsHeader.tsx
@@ -12,16 +12,16 @@ interface LightsHeaderProps {
 
 export const LightsHeader = ({ onCreateJob, department = "Lights", canCreate = true }: LightsHeaderProps) => {
   return (
-    <div className="flex justify-between items-center">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <h1 className="text-2xl font-semibold">Departmento de {department}</h1>
-      <div className="flex gap-2">
-        <div className="flex">
+      <div className="flex w-full sm:w-auto flex-wrap gap-2 sm:justify-end">
+        <div className="flex w-full sm:w-auto flex-col sm:flex-row gap-2 sm:gap-0">
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button 
+                <Button
                   onClick={() => onCreateJob()}
-                  className="gap-2 rounded-r-none"
+                  className="w-full sm:w-auto gap-2 sm:rounded-r-none"
                   aria-label="Create job"
                   disabled={!canCreate}
                 >
@@ -36,7 +36,7 @@ export const LightsHeader = ({ onCreateJob, department = "Lights", canCreate = t
           </TooltipProvider>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" className="px-2 rounded-l-none" disabled={!canCreate} aria-label="Choose preset">
+              <Button variant="outline" className="w-full sm:w-auto px-2 sm:rounded-l-none" disabled={!canCreate} aria-label="Choose preset">
                 <ChevronDown className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>

--- a/src/pages/Lights.tsx
+++ b/src/pages/Lights.tsx
@@ -153,7 +153,7 @@ const Lights = () => {
   };
 
   return (
-    <div className="max-w-7xl mx-auto space-y-6">
+    <div className="max-w-7xl mx-auto px-3 py-4 sm:px-6 sm:py-6 space-y-6">
       <LightsHeader 
         onCreateJob={(preset) => { setPresetJobType(preset); setIsJobDialogOpen(true); }}
         department="Luces"
@@ -182,35 +182,35 @@ const Lights = () => {
         </div>
       </div>
 
-      <div className="flex gap-4 justify-end mt-4">
-        <Button 
-          variant="outline" 
+      <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 items-stretch sm:items-center sm:justify-end mt-4">
+        <Button
+          variant="outline"
           onClick={() => navigate('/lights-disponibilidad')}
-          className="flex items-center gap-2"
+          className="w-full sm:w-auto flex items-center gap-2"
         >
           <Calendar className="h-4 w-4" />
           Disponibilidad
         </Button>
-        <Button 
-          variant="outline" 
+        <Button
+          variant="outline"
           onClick={() => navigate('/lights-pesos-tool')}
-          className="flex items-center gap-2"
+          className="w-full sm:w-auto flex items-center gap-2"
         >
           <Scale className="h-4 w-4" />
           Calculadora de Peso
         </Button>
-        <Button 
-          variant="outline" 
+        <Button
+          variant="outline"
           onClick={() => navigate('/lights-consumos-tool')}
-          className="flex items-center gap-2"
+          className="w-full sm:w-auto flex items-center gap-2"
         >
           <Zap className="h-4 w-4" />
           Calculadora de Potencia
         </Button>
-        <Button 
-          variant="outline" 
+        <Button
+          variant="outline"
           onClick={() => navigate('/lights-memoria-tecnica')}
-          className="flex items-center gap-2"
+          className="w-full sm:w-auto flex items-center gap-2"
         >
           <FileText className="h-4 w-4" />
           Memoria Técnica


### PR DESCRIPTION
## Summary
- add responsive padding to the lights page container and make quick action buttons stack on small screens
- update the lights header layout so the controls wrap with full-width buttons on mobile while preserving desktop styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901c41c6378832fa92fd06ce51ae6e2