### PR TITLE
Fix Mapbox token fetch logic in scheduling dialog

### DIFF
--- a/src/components/tours/TourSchedulingDialog.tsx
+++ b/src/components/tours/TourSchedulingDialog.tsx
@@ -74,7 +74,7 @@ export const TourSchedulingDialog: React.FC<TourSchedulingDialogProps> = ({
 
   // Pre-fetch Mapbox token to avoid connection contention
   useEffect(() => {
-    if (open && !mapboxToken && !isLoadingMapboxToken) {
+    if (open && !mapboxToken && !isLoadingMapboxToken && !mapboxTokenError) {
       const fetchMapboxToken = async () => {
         setIsLoadingMapboxToken(true);
         setMapboxTokenError(null);
@@ -104,10 +104,19 @@ export const TourSchedulingDialog: React.FC<TourSchedulingDialogProps> = ({
           setIsLoadingMapboxToken(false);
         }
       };
-      
+
       fetchMapboxToken();
     }
-  }, [open, mapboxToken, isLoadingMapboxToken, toast]);
+  }, [open, mapboxTokenError]);
+
+  // Reset Mapbox state when the dialog closes
+  useEffect(() => {
+    if (!open) {
+      setMapboxToken(null);
+      setMapboxTokenError(null);
+      setIsLoadingMapboxToken(false);
+    }
+  }, [open]);
 
   // Load tour data and associated hoja de ruta records
   useEffect(() => {
@@ -443,6 +452,7 @@ export const TourSchedulingDialog: React.FC<TourSchedulingDialogProps> = ({
                       <Button 
                         size="sm" 
                         onClick={() => {
+                          setIsLoadingMapboxToken(false);
                           setMapboxToken(null);
                           setMapboxTokenError(null);
                         }}


### PR DESCRIPTION
## Summary
- prevent premature exits when pre-fetching the Mapbox token by tightening the dialog effect condition
- reset Mapbox token state when the dialog closes and when the retry button is pressed to allow refetching

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69039fde2970832faa4051228b0fb405