### PR TITLE
Add single_day_date to Supabase job assignments types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2668,6 +2668,7 @@ export type Database = {
           job_id: string
           lights_role: string | null
           response_time: string | null
+          single_day_date: string | null
           single_day: boolean
           sound_role: string | null
           status: Database["public"]["Enums"]["assignment_status"] | null
@@ -2682,6 +2683,7 @@ export type Database = {
           job_id: string
           lights_role?: string | null
           response_time?: string | null
+          single_day_date?: string | null
           single_day?: boolean
           sound_role?: string | null
           status?: Database["public"]["Enums"]["assignment_status"] | null
@@ -2696,6 +2698,7 @@ export type Database = {
           job_id?: string
           lights_role?: string | null
           response_time?: string | null
+          single_day_date?: string | null
           single_day?: boolean
           sound_role?: string | null
           status?: Database["public"]["Enums"]["assignment_status"] | null


### PR DESCRIPTION
## Summary
- add the single_day_date column to the job_assignments Row, Insert, and Update typings so the Supabase client accepts the new field

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6903a71c97dc832faf43bf875e83d0a1