### PR TITLE
feat: proxy place search through edge function

### DIFF
--- a/src/components/jobs/CreateJobDialog.tsx
+++ b/src/components/jobs/CreateJobDialog.tsx
@@ -328,7 +328,7 @@ export const CreateJobDialog = ({ open, onOpenChange, currentDepartment, initial
                   name: result.name,
                   address: result.address,
                   coordinates: result.coordinates,
-                  place_id: undefined, // PlaceAutocomplete doesn't provide place_id
+                  place_id: result.place_id,
                 });
               }}
               placeholder="Enter venue location"

--- a/src/components/maps/PlaceAutocomplete.tsx
+++ b/src/components/maps/PlaceAutocomplete.tsx
@@ -29,6 +29,19 @@ interface PredictionItem {
   formatted_address: string;
 }
 
+type PlaceSearchResponse = {
+  suggestions?: PredictionItem[];
+};
+
+type PlaceDetailsResponse = {
+  place?: {
+    place_id?: string;
+    name?: string;
+    formatted_address?: string;
+    coordinates?: { lat: number; lng: number };
+  };
+};
+
 export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
   value,
   onSelect,
@@ -42,7 +55,6 @@ export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
   const [suggestions, setSuggestions] = useState<PredictionItem[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [apiKey, setApiKey] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<number | undefined>(undefined);
   const cacheRef = useRef<Record<string, PredictionItem[]>>({});
@@ -51,28 +63,6 @@ export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
   useEffect(() => {
     setInputValue(value || '');
   }, [value]);
-
-  // Fetch Google Maps API key securely (with retry support)
-  const fetchApiKey = async (): Promise<string | null> => {
-    try {
-      const { data, error } = await supabase.functions.invoke('get-google-maps-key');
-      if (error) {
-        console.error('Failed to fetch Google Maps API key:', error);
-        return null;
-      }
-      if (data?.apiKey) {
-        setApiKey(data.apiKey);
-        return data.apiKey as string;
-      }
-    } catch (err) {
-      console.error('Error fetching API key:', err);
-    }
-    return null;
-  };
-
-  useEffect(() => {
-    fetchApiKey();
-  }, []);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -85,10 +75,8 @@ export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
   }, []);
 
   const searchPlaces = async (query: string) => {
-    // Ensure API key is available (retry on demand)
-    const key = apiKey || (await fetchApiKey());
-    if (!key || !query || query.length < 2) {
-      console.log('PlacesAutocomplete: Search conditions not met:', { hasApiKey: !!key, query, queryLength: query?.length || 0 });
+    if (!query || query.length < 2) {
+      console.log('PlacesAutocomplete: Search conditions not met:', { query, queryLength: query?.length || 0 });
       setSuggestions([]);
       setShowSuggestions(false);
       return;
@@ -108,77 +96,23 @@ export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
     console.log('PlacesAutocomplete: Starting API search...');
 
     try {
-      // Try Places Text Search first (good for establishments)
-      console.log('PlacesAutocomplete: Trying text search...');
-      const textSearchRes = await fetch('https://places.googleapis.com/v1/places:searchText', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Goog-Api-Key': key,
-          'X-Goog-FieldMask': 'places.id,places.displayName,places.formattedAddress,places.location,places.types',
-        },
-        body: JSON.stringify({
-          textQuery: query,
-          maxResultCount: 6,
-        }),
+      const { data, error } = await supabase.functions.invoke<PlaceSearchResponse>('place-search', {
+        body: { type: 'search', query },
       });
 
-      console.log('PlacesAutocomplete: Text search response status:', textSearchRes.status);
-
-      if (textSearchRes.ok) {
-        const data = await textSearchRes.json();
-        console.log('PlacesAutocomplete: Text search data:', data);
-        if (data.places && data.places.length > 0) {
-          const results: PredictionItem[] = data.places.map((p: any) => ({
-            place_id: p.id,
-            name: p.displayName?.text || p.formattedAddress,
-            formatted_address: p.formattedAddress || '',
-          }));
-          console.log('PlacesAutocomplete: Text search results:', results);
-          cacheRef.current[query] = results;
-          setSuggestions(results);
-          setShowSuggestions(true);
-          setIsLoading(false);
-          return;
-        }
-      }
-
-      // Fallback to Autocomplete API for broader matches (establishments + addresses)
-      console.log('PlacesAutocomplete: Trying autocomplete...');
-      const acRes = await fetch('https://places.googleapis.com/v1/places:autocomplete', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Goog-Api-Key': key,
-          'X-Goog-FieldMask': 'suggestions.placePrediction.placeId,suggestions.placePrediction.text,suggestions.placePrediction.structuredFormat',
-        },
-          body: JSON.stringify({
-            input: query,
-            maxResultCount: 6,
-          }),
-      });
-
-      console.log('PlacesAutocomplete: Autocomplete response status:', acRes.status);
-
-      if (acRes.ok) {
-        const data = await acRes.json();
-        console.log('PlacesAutocomplete: Autocomplete data:', data);
-        const results: PredictionItem[] = (data.suggestions || [])
-          .filter((s: any) => s.placePrediction)
-          .map((s: any) => ({
-            place_id: s.placePrediction.placeId,
-            name: s.placePrediction.structuredFormat?.mainText?.text || s.placePrediction.text?.text,
-            formatted_address: s.placePrediction.structuredFormat?.secondaryText?.text || '',
-          }));
-        console.log('PlacesAutocomplete: Autocomplete results:', results);
-        cacheRef.current[query] = results;
-        setSuggestions(results);
-        setShowSuggestions(results.length > 0);
-      } else {
-        console.error('Places Autocomplete API error:', acRes.status);
+      if (error) {
+        console.error('PlacesAutocomplete: place-search function error:', error);
         setSuggestions([]);
         setShowSuggestions(false);
+        return;
       }
+
+      const suggestions: PredictionItem[] = Array.isArray(data?.suggestions) ? data.suggestions : [];
+      console.log('PlacesAutocomplete: Received suggestions from edge function:', suggestions);
+
+      cacheRef.current[query] = suggestions;
+      setSuggestions(suggestions);
+      setShowSuggestions(suggestions.length > 0);
     } catch (e) {
       console.error('Error searching places:', e);
       setSuggestions([]);
@@ -192,40 +126,27 @@ export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
   const getPlaceDetails = async (placeId: string, fallbackName: string, fallbackAddress?: string) => {
     console.log('PlacesAutocomplete: Getting place details for:', { placeId, fallbackName, fallbackAddress });
     
-    const key = apiKey || (await fetchApiKey());
-    if (!key) {
-      console.log('PlacesAutocomplete: No API key after retry, using fallback data');
-      onSelect({ name: fallbackName, address: fallbackAddress || '', place_id: placeId });
-      return;
-    }
-    
     try {
       onBusyChange?.(true);
-      const res = await fetch(`https://places.googleapis.com/v1/places/${placeId}`, {
-        headers: {
-          'X-Goog-Api-Key': key,
-          'X-Goog-FieldMask': 'id,displayName,formattedAddress,location',
-        },
+      const { data, error } = await supabase.functions.invoke<PlaceDetailsResponse>('place-search', {
+        body: { type: 'details', placeId },
       });
-      
-      console.log('PlacesAutocomplete: Place details response status:', res.status);
-      
-      if (!res.ok) throw new Error(`Place Details API error: ${res.status}`);
-      
-      const place = await res.json();
-      console.log('PlacesAutocomplete: Place details data:', place);
-      
-      const coordinates = place.location
-        ? { lat: place.location.latitude, lng: place.location.longitude }
-        : undefined;
-        
+
+      if (error) {
+        console.error('PlacesAutocomplete: place-search details error:', error);
+        throw error;
+      }
+
+      const place = data?.place;
+      console.log('PlacesAutocomplete: Place details data from edge function:', place);
+
       const result: PlaceAutocompleteResult = {
-        name: place.displayName?.text || fallbackName,
-        address: place.formattedAddress || fallbackAddress || '',
-        coordinates,
-        place_id: placeId,
+        name: place?.name || fallbackName,
+        address: place?.formatted_address || fallbackAddress || '',
+        coordinates: place?.coordinates,
+        place_id: place?.place_id || placeId,
       };
-      
+
       console.log('PlacesAutocomplete: Calling onSelect with:', result);
       onSelect(result);
       setInputValue(result.name);
@@ -274,7 +195,7 @@ export const PlaceAutocomplete: React.FC<PlaceAutocompleteProps> = ({
               e.stopPropagation();
             }
           }}
-          onFocus={() => { if (!apiKey) { fetchApiKey(); } if (suggestions.length > 0) setShowSuggestions(true); }}
+          onFocus={() => { if (suggestions.length > 0) setShowSuggestions(true); }}
         />
         <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
         <div className="absolute right-3 top-1/2 -translate-y-1/2">

--- a/supabase/functions/place-search/index.ts
+++ b/supabase/functions/place-search/index.ts
@@ -1,0 +1,231 @@
+// Edge Function: place-search
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+type SearchRequestBody = {
+  type: 'search';
+  query?: string;
+  languageCode?: string;
+  regionCode?: string;
+};
+
+type DetailsRequestBody = {
+  type: 'details';
+  placeId?: string;
+};
+
+type RequestBody = SearchRequestBody | DetailsRequestBody;
+
+type Suggestion = {
+  place_id: string;
+  name: string;
+  formatted_address: string;
+};
+
+type PlaceDetails = {
+  place_id: string;
+  name: string;
+  formatted_address: string;
+  coordinates?: { lat: number; lng: number };
+};
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const apiKey = Deno.env.get('GOOGLE_MAPS_API_KEY');
+    if (!apiKey) {
+      console.error('place-search: GOOGLE_MAPS_API_KEY missing');
+      return new Response(JSON.stringify({ error: 'API key not available' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const body = (await req.json()) as Partial<RequestBody> | null;
+    console.log('place-search: incoming body', body);
+
+    if (!body || typeof body !== 'object' || !('type' in body)) {
+      return new Response(JSON.stringify({ error: 'Invalid request body' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (body.type === 'search') {
+      const query = body.query?.trim();
+      if (!query || query.length < 2) {
+        console.warn('place-search: query missing or too short', { query });
+        return new Response(JSON.stringify({ suggestions: [] }), {
+          status: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const languageCode = body.languageCode || 'es';
+      const regionCode = body.regionCode || 'ES';
+
+      // Try Places Text Search first
+      const textSearchResponse = await fetch('https://places.googleapis.com/v1/places:searchText', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': apiKey,
+          'X-Goog-FieldMask': 'places.id,places.displayName,places.formattedAddress',
+        },
+        body: JSON.stringify({
+          textQuery: query,
+          maxResultCount: 6,
+          languageCode,
+          regionCode,
+        }),
+      });
+
+      if (!textSearchResponse.ok) {
+        const txt = await textSearchResponse.text().catch(() => '');
+        console.error('place-search: text search error', textSearchResponse.status, txt);
+      } else {
+        const data = await textSearchResponse.json();
+        console.log('place-search: text search results', data?.places?.length ?? 0);
+        if (Array.isArray(data?.places) && data.places.length > 0) {
+          const suggestions: Suggestion[] = data.places.map((p: any) => ({
+            place_id: p.id,
+            name: p.displayName?.text ?? p.formattedAddress ?? query,
+            formatted_address: p.formattedAddress ?? '',
+          }));
+
+          return new Response(JSON.stringify({ suggestions }), {
+            status: 200,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          });
+        }
+      }
+
+      // Fallback to Autocomplete
+      const autocompleteResponse = await fetch('https://places.googleapis.com/v1/places:autocomplete', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': apiKey,
+          'X-Goog-FieldMask': 'suggestions.placePrediction.placeId,suggestions.placePrediction.text,suggestions.placePrediction.structuredFormat',
+        },
+        body: JSON.stringify({
+          input: query,
+          maxResultCount: 6,
+          languageCode,
+          regionCode,
+        }),
+      });
+
+      if (!autocompleteResponse.ok) {
+        const txt = await autocompleteResponse.text().catch(() => '');
+        console.error('place-search: autocomplete error', autocompleteResponse.status, txt);
+        return new Response(JSON.stringify({
+          error: 'Google Places autocomplete error',
+          status: autocompleteResponse.status,
+          details: txt || 'Unknown error',
+        }), {
+          status: 502,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const autocompleteData = await autocompleteResponse.json();
+      console.log('place-search: autocomplete suggestions', autocompleteData?.suggestions?.length ?? 0);
+      const suggestions: Suggestion[] = Array.isArray(autocompleteData?.suggestions)
+        ? autocompleteData.suggestions
+            .filter((s: any) => s?.placePrediction?.placeId)
+            .map((s: any) => ({
+              place_id: s.placePrediction.placeId,
+              name:
+                s.placePrediction.structuredFormat?.mainText?.text ??
+                s.placePrediction.text?.text ??
+                query,
+              formatted_address:
+                s.placePrediction.structuredFormat?.secondaryText?.text ??
+                s.placePrediction.text?.text ??
+                '',
+            }))
+        : [];
+
+      return new Response(JSON.stringify({ suggestions }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (body.type === 'details') {
+      const placeId = body.placeId?.trim();
+      if (!placeId) {
+        return new Response(JSON.stringify({ error: 'placeId is required' }), {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const detailsResponse = await fetch(`https://places.googleapis.com/v1/places/${placeId}`, {
+        method: 'GET',
+        headers: {
+          'X-Goog-Api-Key': apiKey,
+          'X-Goog-FieldMask': 'id,displayName,formattedAddress,location',
+        },
+      });
+
+      if (!detailsResponse.ok) {
+        const txt = await detailsResponse.text().catch(() => '');
+        console.error('place-search: details error', detailsResponse.status, txt);
+        return new Response(JSON.stringify({
+          error: 'Google Places details error',
+          status: detailsResponse.status,
+          details: txt || 'Unknown error',
+        }), {
+          status: 502,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      const place = await detailsResponse.json();
+      console.log('place-search: details retrieved', place?.id);
+      const result: PlaceDetails = {
+        place_id: place?.id ?? placeId,
+        name: place?.displayName?.text ?? '',
+        formatted_address: place?.formattedAddress ?? '',
+        coordinates: place?.location
+          ? {
+              lat: place.location.latitude,
+              lng: place.location.longitude,
+            }
+          : undefined,
+      };
+
+      return new Response(JSON.stringify({ place: result }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: 'Unsupported request type' }), {
+      status: 400,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('place-search: unexpected error', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a `place-search` Edge Function that proxies Google Places text search, autocomplete, and details calls with server-side logging and error handling
- refactor the PlaceAutocomplete component to consume the new edge function and simplify client-side logic while keeping caching and busy-state feedback
- persist the returned Google place identifier when creating jobs so downstream logic can reuse it

## Testing
- npm run lint *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_69050b94489c832fb0ea8ededc0667ba