### PR TITLE
Add row deletion controls to calculator tables

### DIFF
--- a/src/pages/ConsumosTool.tsx
+++ b/src/pages/ConsumosTool.tsx
@@ -157,6 +157,16 @@ const ConsumosTool: React.FC = () => {
     }));
   };
 
+  const removeRow = (index: number) => {
+    setCurrentTable((prev) => {
+      const filteredRows = prev.rows.filter((_, i) => i !== index);
+      return {
+        ...prev,
+        rows: filteredRows.length > 0 ? filteredRows : [{ quantity: '', componentId: '', watts: '' }],
+      };
+    });
+  };
+
   const updateInput = (index: number, field: keyof TableRow, value: string) => {
     const newRows = [...currentTable.rows];
     if (field === 'componentId' && value) {
@@ -855,6 +865,7 @@ const ConsumosTool: React.FC = () => {
                     <th className="px-4 py-3 text-left font-medium text-sm">Quantity</th>
                     <th className="px-4 py-3 text-left font-medium text-sm">Component</th>
                     <th className="px-4 py-3 text-left font-medium text-sm">Watts (per unit)</th>
+                    <th className="w-12 px-4 py-3 text-left font-medium text-sm">&nbsp;</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -889,8 +900,20 @@ const ConsumosTool: React.FC = () => {
                       <td className="p-4">
                         <Input type="number" value={row.watts} readOnly className="w-full min-w-[120px] bg-muted" />
                       </td>
-                    </tr>
-                  ))}
+                      <td className="p-4">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeRow(index)}
+                          className="text-destructive hover:text-destructive"
+                          aria-label="Delete row"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </td>
+                  </tr>
+                ))}
                 </tbody>
               </table>
             </div>

--- a/src/pages/LightsConsumosTool.tsx
+++ b/src/pages/LightsConsumosTool.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { FileText, ArrowLeft } from 'lucide-react';
+import { FileText, ArrowLeft, Trash2 } from 'lucide-react';
 import { exportToPDF } from '@/utils/pdfExport';
 import { useJobSelection, JobSelection } from '@/hooks/useJobSelection';
 import { useToast } from '@/hooks/use-toast';
@@ -157,6 +157,16 @@ const LightsConsumosTool: React.FC = () => {
       ...prev,
       rows: [...prev.rows, { quantity: '', componentId: '', watts: '' }],
     }));
+  };
+
+  const removeRow = (index: number) => {
+    setCurrentTable((prev) => {
+      const filteredRows = prev.rows.filter((_, i) => i !== index);
+      return {
+        ...prev,
+        rows: filteredRows.length > 0 ? filteredRows : [{ quantity: '', componentId: '', watts: '' }],
+      };
+    });
   };
 
   const updateInput = (index: number, field: keyof TableRow, value: string) => {
@@ -601,6 +611,7 @@ const LightsConsumosTool: React.FC = () => {
                   <th className="px-4 py-3 text-left font-medium">Cantidad</th>
                   <th className="px-4 py-3 text-left font-medium">Componente</th>
                   <th className="px-4 py-3 text-left font-medium">Vatios (por unidad)</th>
+                  <th className="w-12 px-4 py-3 text-left font-medium">&nbsp;</th>
                 </tr>
               </thead>
               <tbody>
@@ -639,6 +650,18 @@ const LightsConsumosTool: React.FC = () => {
                         readOnly
                         className="w-full bg-muted"
                       />
+                    </td>
+                    <td className="p-4">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeRow(index)}
+                        className="text-destructive hover:text-destructive"
+                        aria-label="Eliminar fila"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </td>
                   </tr>
                 ))}

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { FileText, ArrowLeft, Save } from 'lucide-react';
+import { FileText, ArrowLeft, Save, Trash2 } from 'lucide-react';
 import { exportToPDF } from '@/utils/pdfExport';
 import { useJobSelection, JobSelection } from '@/hooks/useJobSelection';
 import { useToast } from '@/hooks/use-toast';
@@ -335,6 +335,16 @@ const PesosTool: React.FC = () => {
       ...prev,
       rows: [...prev.rows, { quantity: '', componentId: '', weight: '' }],
     }));
+  };
+
+  const removeRow = (index: number) => {
+    setCurrentTable((prev) => {
+      const filteredRows = prev.rows.filter((_, i) => i !== index);
+      return {
+        ...prev,
+        rows: filteredRows.length > 0 ? filteredRows : [{ quantity: '', componentId: '', weight: '' }],
+      };
+    });
   };
 
   const updateInput = (index: number, field: keyof TableRow, value: string) => {
@@ -943,6 +953,7 @@ const PesosTool: React.FC = () => {
                   <th className="px-4 py-3 text-left font-medium">Quantity</th>
                   <th className="px-4 py-3 text-left font-medium">Component</th>
                   <th className="px-4 py-3 text-left font-medium">Weight (per unit)</th>
+                  <th className="w-12 px-4 py-3 text-left font-medium">&nbsp;</th>
                 </tr>
               </thead>
               <tbody>
@@ -976,6 +987,18 @@ const PesosTool: React.FC = () => {
                     </td>
                     <td className="p-4">
                       <Input type="number" value={row.weight} readOnly className="w-full bg-muted" />
+                    </td>
+                    <td className="p-4">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeRow(index)}
+                        className="text-destructive hover:text-destructive"
+                        aria-label="Delete row"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </td>
                   </tr>
                 ))}

--- a/src/pages/VideoConsumosTool.tsx
+++ b/src/pages/VideoConsumosTool.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { FileText, ArrowLeft } from 'lucide-react';
+import { FileText, ArrowLeft, Trash2 } from 'lucide-react';
 import { exportToPDF } from '@/utils/pdfExport';
 import { useJobSelection } from '@/hooks/useJobSelection';
 import { useToast } from '@/hooks/use-toast';
@@ -189,6 +189,16 @@ const VideoConsumosTool: React.FC = () => {
       ...prev,
       rows: [...prev.rows, { quantity: '', componentId: '', watts: '' }],
     }));
+  };
+
+  const removeRow = (index: number) => {
+    setCurrentTable((prev) => {
+      const filteredRows = prev.rows.filter((_, i) => i !== index);
+      return {
+        ...prev,
+        rows: filteredRows.length > 0 ? filteredRows : [{ quantity: '', componentId: '', watts: '' }],
+      };
+    });
   };
 
   const updateInput = (index: number, field: keyof TableRow, value: string) => {
@@ -697,6 +707,7 @@ const VideoConsumosTool: React.FC = () => {
                   <th className="px-4 py-3 text-left font-medium">Quantity</th>
                   <th className="px-4 py-3 text-left font-medium">Component</th>
                   <th className="px-4 py-3 text-left font-medium">Watts (per unit)</th>
+                  <th className="w-12 px-4 py-3 text-left font-medium">&nbsp;</th>
                 </tr>
               </thead>
               <tbody>
@@ -730,6 +741,18 @@ const VideoConsumosTool: React.FC = () => {
                     </td>
                     <td className="p-4">
                       <Input type="number" value={row.watts} readOnly className="w-full bg-muted" />
+                    </td>
+                    <td className="p-4">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeRow(index)}
+                        className="text-destructive hover:text-destructive"
+                        aria-label="Delete row"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </td>
                   </tr>
                 ))}

--- a/src/pages/VideoPesosTool.tsx
+++ b/src/pages/VideoPesosTool.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
-import { FileText, ArrowLeft } from 'lucide-react';
+import { FileText, ArrowLeft, Trash2 } from 'lucide-react';
 import { exportToPDF } from '@/utils/pdfExport';
 import { useJobSelection } from '@/hooks/useJobSelection';
 import { useToast } from '@/hooks/use-toast';
@@ -119,6 +119,16 @@ const VideoPesosTool: React.FC = () => {
       ...prev,
       rows: [...prev.rows, { quantity: '', componentId: '', weight: '' }],
     }));
+  };
+
+  const removeRow = (index: number) => {
+    setCurrentTable((prev) => {
+      const filteredRows = prev.rows.filter((_, i) => i !== index);
+      return {
+        ...prev,
+        rows: filteredRows.length > 0 ? filteredRows : [{ quantity: '', componentId: '', weight: '' }],
+      };
+    });
   };
 
   const updateInput = (index: number, field: keyof TableRow, value: string) => {
@@ -477,6 +487,7 @@ const VideoPesosTool: React.FC = () => {
                   <th className="px-4 py-3 text-left font-medium">Quantity</th>
                   <th className="px-4 py-3 text-left font-medium">Component</th>
                   <th className="px-4 py-3 text-left font-medium">Weight (per unit)</th>
+                  <th className="w-12 px-4 py-3 text-left font-medium">&nbsp;</th>
                 </tr>
               </thead>
               <tbody>
@@ -510,6 +521,18 @@ const VideoPesosTool: React.FC = () => {
                     </td>
                     <td className="p-4">
                       <Input type="number" value={row.weight} readOnly className="w-full bg-muted" />
+                    </td>
+                    <td className="p-4">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeRow(index)}
+                        className="text-destructive hover:text-destructive"
+                        aria-label="Delete row"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- add reusable row removal helpers in each calculator tool to keep tables editable
- render destructive delete controls on every row, ensuring at least one blank row remains and calculations keep using the updated data

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_690a444134dc832fa830c435d7073a0a