### PR TITLE
Fix PushNotificationMatrix overlapping mobile nav bar

### DIFF
--- a/src/components/settings/PushNotificationMatrix.tsx
+++ b/src/components/settings/PushNotificationMatrix.tsx
@@ -327,7 +327,7 @@ export function PushNotificationMatrix() {
 
   if (isMobile) {
     return (
-      <Collapsible open={isOpen} onOpenChange={setIsOpen} className="fixed bottom-0 left-0 right-0 z-50">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen} className="fixed bottom-[calc(4rem+env(safe-area-inset-bottom))] left-0 right-0 z-30">
         <Card className="rounded-t-lg rounded-b-none border-x-0 border-b-0 shadow-lg">
           <CollapsibleTrigger asChild>
             <CardHeader className="cursor-pointer hover:bg-accent/50 transition-colors pb-3">
@@ -348,7 +348,7 @@ export function PushNotificationMatrix() {
             </CardHeader>
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <CardContent className="max-h-[70vh] overflow-y-auto pt-0">
+            <CardContent className="max-h-[60vh] overflow-y-auto pt-0">
               {loading ? (
                 <div className="p-4 text-sm text-muted-foreground">Loading…</div>
               ) : (


### PR DESCRIPTION
Adjusted the mobile collapsible push routing matrix positioning and z-index to prevent it from covering the mobile navigation bar:
- Changed z-index from z-50 to z-30 (below nav bar's z-40)
- Positioned matrix above nav bar using bottom-[calc(4rem+env(safe-area-inset-bottom))]
- Reduced max-h from 70vh to 60vh for better viewport usage

This ensures the nav bar remains accessible when the matrix is open.