### PR TITLE
Clarify tour rate multiplier base display

### DIFF
--- a/src/components/dashboard/TechnicianTourRates.tsx
+++ b/src/components/dashboard/TechnicianTourRates.tsx
@@ -221,6 +221,14 @@ export const TechnicianTourRates: React.FC = () => {
                   const baseDayAmount = quote.base_day_eur ?? 0;
                   const extrasAmount = quote.extras_total_eur ?? 0;
                   const perJobMultiplier = getPerJobMultiplier(quote);
+                  const breakdownBase = quote.breakdown?.after_discount ?? quote.breakdown?.base_calculation;
+                  const hasValidMultiplier = typeof perJobMultiplier === 'number' && perJobMultiplier > 0;
+                  const preMultiplierBase =
+                    breakdownBase ?? (hasValidMultiplier ? baseDayAmount / perJobMultiplier : baseDayAmount);
+                  const formattedMultiplier = formatMultiplier(perJobMultiplier);
+                  const trimmedMultiplier = formattedMultiplier.startsWith('×')
+                    ? formattedMultiplier.slice(1)
+                    : formattedMultiplier;
                   return (
                     <div
                       key={quote.job_id}
@@ -255,13 +263,14 @@ export const TechnicianTourRates: React.FC = () => {
                       <div className="sm:text-right">
                         <div className="font-semibold text-lg">{formatCurrency(displayTotal)}</div>
                         <div className="text-xs text-muted-foreground">
-                          Base {formatCurrency(baseDayAmount)}
-                          {quote.is_tour_team_member && shouldDisplayMultiplier(perJobMultiplier) && (
+                          {quote.is_tour_team_member && shouldDisplayMultiplier(perJobMultiplier) ? (
                             <span>
-                              {' '}
-                              {formatMultiplier(perJobMultiplier)} ({quote.week_count}{' '}
+                              Base {formatCurrency(preMultiplierBase)} × {trimmedMultiplier} ={' '}
+                              {formatCurrency(baseDayAmount)} ({quote.week_count}{' '}
                               {quote.week_count === 1 ? 'fecha' : 'fechas'})
                             </span>
+                          ) : (
+                            <span>Base {formatCurrency(baseDayAmount)}</span>
                           )}
                           {extrasAmount > 0 && (
                             <span className="block text-green-600 mt-1">+ Extras {formatCurrency(extrasAmount)}</span>

--- a/src/components/tours/TourRatesManagerDialog.tsx
+++ b/src/components/tours/TourRatesManagerDialog.tsx
@@ -436,6 +436,15 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                 const errorCode = q.breakdown?.error as string | undefined;
                 const house = q.is_house_tech;
                 const perJobMultiplier = getPerJobMultiplier(q);
+                const breakdownBase = q.breakdown?.after_discount ?? q.breakdown?.base_calculation;
+                const baseDayAmount = q.base_day_eur ?? 0;
+                const hasValidMultiplier = typeof perJobMultiplier === 'number' && perJobMultiplier > 0;
+                const preMultiplierBase =
+                  breakdownBase ?? (hasValidMultiplier ? baseDayAmount / perJobMultiplier : baseDayAmount);
+                const formattedMultiplier = formatMultiplier(perJobMultiplier);
+                const trimmedMultiplier = formattedMultiplier.startsWith('×')
+                  ? formattedMultiplier.slice(1)
+                  : formattedMultiplier;
 
                 return (
                   <Card key={q.technician_id + q.job_id}>
@@ -454,12 +463,15 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                         <div className="text-right flex flex-col items-end gap-2">
                           <div className="font-semibold">{formatCurrency(q.total_with_extras_eur || q.total_eur)}</div>
                           <div className="text-xs text-muted-foreground">
-                            Base {formatCurrency(q.base_day_eur)}{' '}
-                            {shouldDisplayMultiplier(perJobMultiplier)
-                              ? `${formatMultiplier(perJobMultiplier)}${
-                                  q.week_count > 1 ? ` (${q.week_count} fechas en la semana)` : ''
-                                }`
-                              : ''}
+                            {shouldDisplayMultiplier(perJobMultiplier) ? (
+                              <>
+                                Base {formatCurrency(preMultiplierBase)} × {trimmedMultiplier} ={' '}
+                                {formatCurrency(baseDayAmount)}
+                                {q.week_count > 1 ? ` (${q.week_count} fechas en la semana)` : ''}
+                              </>
+                            ) : (
+                              <>Base {formatCurrency(baseDayAmount)}</>
+                            )}
                           </div>
                           <Button
                             size="sm"


### PR DESCRIPTION
## Summary
- derive the pre-multiplier base amount for tour rate quotes using the discount breakdown or multiplier fallback
- display the "Base × multiplier = total" copy in manager, job panel, and technician dashboards when multipliers apply while keeping the single base view otherwise

## Testing
- npm run test -- --runInBand *(fails: vitest: not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690b85dd1ab4832fa096f6fbd1d2a180