### PR TITLE
Plan tour rate multiplier override feature

### DIFF
--- a/src/components/jobs/JobExtrasEditor.tsx
+++ b/src/components/jobs/JobExtrasEditor.tsx
@@ -6,12 +6,12 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Plus, Minus, Euro, AlertCircle } from 'lucide-react';
-import { useJobExtras, useUpsertJobExtra, useReviewJobExtra } from '@/hooks/useJobExtras';
-import { 
-  JobExtraType, 
-  EXTRA_TYPE_LABELS, 
+import { useJobExtras, useUpsertJobExtra } from '@/hooks/useJobExtras';
+import {
+  JobExtraType,
+  EXTRA_TYPE_LABELS,
   EXTRA_TYPE_LIMITS,
-  JobExtra 
+  JobExtra
 } from '@/types/jobExtras';
 import { formatCurrency } from '@/lib/utils';
 import { useRateExtrasCatalog } from '@/hooks/useRateExtrasCatalog';
@@ -36,118 +36,61 @@ export function JobExtrasEditor({
   const { data: jobExtras = [], isLoading } = useJobExtras(jobId, technicianId);
   const { data: catalog = [], isLoading: catalogLoading } = useRateExtrasCatalog();
   const upsertJobExtra = useUpsertJobExtra();
-  const reviewJobExtra = useReviewJobExtra();
 
-  const [pendingChanges, setPendingChanges] = useState<Partial<Record<JobExtraType, number>>>({});
+  const [editingQuantities, setEditingQuantities] = useState<Partial<Record<JobExtraType, number>>>({});
 
   const findExtra = (extraType: JobExtraType): JobExtra | undefined =>
     jobExtras.find(e => e.extra_type === extraType);
 
-  const getApprovedQuantity = (extraType: JobExtraType): number => {
+  const getCurrentQuantity = (extraType: JobExtraType): number => {
     return findExtra(extraType)?.quantity ?? 0;
   };
 
-  const getPendingQuantity = (extraType: JobExtraType): number | null => {
-    const value = findExtra(extraType)?.pending_quantity;
-    return typeof value === 'number' ? value : null;
+  const getDisplayQuantity = (extraType: JobExtraType): number => {
+    // Show editing quantity if currently being edited, otherwise show saved quantity
+    return editingQuantities[extraType] ?? getCurrentQuantity(extraType);
   };
 
-  const getInputQuantity = (extraType: JobExtraType): number => {
-    if (pendingChanges[extraType] !== undefined) {
-      return pendingChanges[extraType] as number;
-    }
-    const pending = getPendingQuantity(extraType);
-    if (pending !== null && pending !== undefined) {
-      return pending;
-    }
-    return getApprovedQuantity(extraType);
-  };
-
-  // Update quantity locally
+  // Update quantity locally (for live preview)
   const updateQuantity = (extraType: JobExtraType, quantity: number) => {
     const maxQuantity = EXTRA_TYPE_LIMITS[extraType];
     const clampedQuantity = Math.max(0, Math.min(quantity, maxQuantity));
-    const baseline = getPendingQuantity(extraType);
-    const approved = getApprovedQuantity(extraType);
-    const reference = baseline !== null && baseline !== undefined ? baseline : approved;
-
-    setPendingChanges(prev => {
-      const next = { ...prev };
-      if (clampedQuantity === reference) {
-        delete next[extraType];
-      } else {
-        next[extraType] = clampedQuantity;
-      }
-      return next;
-    });
+    setEditingQuantities(prev => ({
+      ...prev,
+      [extraType]: clampedQuantity,
+    }));
   };
 
-  // Save changes to database
-  const saveChanges = async () => {
+  // Save a single extra immediately
+  const saveExtra = async (extraType: JobExtraType, quantity: number) => {
     try {
-      for (const [extraType, quantity] of Object.entries(pendingChanges)) {
-        const typedExtra = extraType as JobExtraType;
-        if (quantity === undefined) continue;
-
-        const existing = findExtra(typedExtra);
-        const baseline = existing?.pending_quantity ?? existing?.quantity ?? 0;
-        if (quantity === baseline) continue;
-        if (!existing && quantity === 0) continue;
-
-        await upsertJobExtra.mutateAsync({
-          jobId,
-          technicianId,
-          extraType: typedExtra,
-          approvedQuantity: existing?.quantity ?? 0,
-          requestedQuantity: quantity,
-          hasExistingRow: Boolean(existing),
-        });
-      }
-      setPendingChanges({} as Partial<Record<JobExtraType, number>>);
+      await upsertJobExtra.mutateAsync({
+        jobId,
+        technicianId,
+        extraType,
+        quantity,
+      });
+      // Clear editing state after successful save
+      setEditingQuantities(prev => {
+        const next = { ...prev };
+        delete next[extraType];
+        return next;
+      });
     } catch (error) {
-      console.error('Error saving job extras:', error);
+      console.error('Error saving job extra:', error);
     }
   };
 
-  const handleApprove = (extraType: JobExtraType) => {
-    reviewJobExtra.approve.mutate({ jobId, technicianId, extraType });
-  };
-
-  const handleReject = (extraType: JobExtraType) => {
-    const reason = window.prompt('Reason for rejecting this extra?');
-    const trimmed = reason?.trim();
-    reviewJobExtra.reject.mutate({
-      jobId,
-      technicianId,
-      extraType,
-      reason: trimmed ? trimmed : undefined,
-    });
-  };
-
-  // Check if there are unsaved changes
-  const hasChanges = Object.entries(pendingChanges).some(([extraType, quantity]) => {
-    if (quantity === undefined) return false;
-    const typedExtra = extraType as JobExtraType;
-    const existing = findExtra(typedExtra);
-    const baseline = existing?.pending_quantity ?? existing?.quantity ?? 0;
-    return quantity !== baseline;
-  });
-
-  // Get unit amount for extra type (from rate catalog - hardcoded for now)
+  // Get unit amount for extra type from catalog
   function getUnitAmount(extraType: JobExtraType): number {
-    const defaults = {
-      travel_half: 50,
-      travel_full: 100,
-      day_off: 100,
-    } as const;
-    const row = catalog?.find(r => r.extra_type === extraType);
-    return row?.amount_eur ?? defaults[extraType];
+    const catalogItem = catalog?.find(r => r.extra_type === extraType);
+    return catalogItem?.amount_eur ?? 0;
   }
 
-  // Calculate total extras amount (approved only)
+  // Calculate total extras amount
   const totalExtrasAmount = (Object.keys(EXTRA_TYPE_LABELS) as JobExtraType[])
     .reduce((total, extraType) => {
-      const quantity = getApprovedQuantity(extraType);
+      const quantity = getCurrentQuantity(extraType);
       const unitAmount = getUnitAmount(extraType);
       return total + (quantity * unitAmount);
     }, 0);
@@ -175,32 +118,13 @@ export function JobExtrasEditor({
       </CardHeader>
       <CardContent className="space-y-4">
         {(Object.keys(EXTRA_TYPE_LABELS) as JobExtraType[]).map((extraType) => {
-          const existing = findExtra(extraType);
-          const inputQuantity = getInputQuantity(extraType);
-          const approvedQuantity = getApprovedQuantity(extraType);
-          const pendingQuantity = getPendingQuantity(extraType);
-          const hasPending = pendingQuantity !== null && pendingQuantity !== approvedQuantity;
-          const isRejected = existing?.status === 'rejected';
+          const currentQuantity = getCurrentQuantity(extraType);
+          const displayQuantity = getDisplayQuantity(extraType);
+          const hasUnsavedChange = editingQuantities[extraType] !== undefined;
           const maxQuantity = EXTRA_TYPE_LIMITS[extraType];
           const unitAmount = getUnitAmount(extraType);
-          const approvedTotal = approvedQuantity * unitAmount;
-          const proposedTotal = inputQuantity * unitAmount;
-          const status = existing?.status ?? (approvedQuantity > 0 ? 'approved' : 'empty');
-          const statusText = status === 'pending'
-            ? 'Pending approval'
-            : status === 'approved'
-              ? 'Approved'
-              : status === 'rejected'
-                ? 'Rejected'
-                : 'Not set';
-          const statusVariant = status === 'approved'
-            ? 'outline'
-            : status === 'pending'
-              ? 'secondary'
-              : status === 'rejected'
-                ? 'destructive'
-                : 'secondary';
-          const isReviewing = reviewJobExtra.approve.isPending || reviewJobExtra.reject.isPending;
+          const currentTotal = currentQuantity * unitAmount;
+          const displayTotal = displayQuantity * unitAmount;
 
           return (
             <div key={extraType} className="space-y-2">
@@ -212,32 +136,13 @@ export function JobExtrasEditor({
                   <Badge variant="outline" className="text-xs">
                     {formatCurrency(unitAmount)} each
                   </Badge>
-                  <Badge variant={statusVariant} className="text-xs capitalize">
-                    {statusText}
-                  </Badge>
+                  {currentQuantity > 0 && (
+                    <Badge variant="secondary" className="text-xs">
+                      Current: {currentQuantity}
+                    </Badge>
+                  )}
                 </div>
               </div>
-
-              {(approvedQuantity > 0 || hasPending) && (
-                <div className="text-xs text-muted-foreground flex flex-wrap gap-2">
-                  {approvedQuantity > 0 && (
-                    <span>
-                      Approved: {approvedQuantity} ({formatCurrency(approvedTotal)})
-                    </span>
-                  )}
-                  {hasPending && pendingQuantity !== null && (
-                    <span className="text-amber-600">
-                      Pending: {pendingQuantity} ({formatCurrency(pendingQuantity * unitAmount)})
-                    </span>
-                  )}
-                </div>
-              )}
-
-              {isRejected && existing?.rejection_reason && (
-                <div className="text-xs text-destructive">
-                  Last rejection: {existing.rejection_reason}
-                </div>
-              )}
 
               {isManager ? (
                 <div className="space-y-2">
@@ -245,8 +150,8 @@ export function JobExtrasEditor({
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => updateQuantity(extraType, inputQuantity - 1)}
-                      disabled={inputQuantity <= 0}
+                      onClick={() => updateQuantity(extraType, displayQuantity - 1)}
+                      disabled={displayQuantity <= 0 || upsertJobExtra.isPending}
                     >
                       <Minus className="h-3 w-3" />
                     </Button>
@@ -255,45 +160,54 @@ export function JobExtrasEditor({
                       type="number"
                       min="0"
                       max={maxQuantity}
-                      value={inputQuantity}
+                      value={displayQuantity}
                       onChange={(e) => updateQuantity(extraType, parseInt(e.target.value) || 0)}
+                      onBlur={() => {
+                        // Auto-save on blur if value changed
+                        if (hasUnsavedChange) {
+                          saveExtra(extraType, displayQuantity);
+                        }
+                      }}
+                      onKeyDown={(e) => {
+                        // Save on Enter key
+                        if (e.key === 'Enter' && hasUnsavedChange) {
+                          saveExtra(extraType, displayQuantity);
+                        }
+                      }}
+                      disabled={upsertJobExtra.isPending}
                       className="w-20 text-center"
                     />
 
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => updateQuantity(extraType, inputQuantity + 1)}
-                      disabled={inputQuantity >= maxQuantity}
+                      onClick={() => {
+                        const newQuantity = displayQuantity + 1;
+                        updateQuantity(extraType, newQuantity);
+                        // Auto-save immediately when using +/- buttons
+                        saveExtra(extraType, newQuantity);
+                      }}
+                      disabled={displayQuantity >= maxQuantity || upsertJobExtra.isPending}
                     >
                       <Plus className="h-3 w-3" />
                     </Button>
 
                     <Badge variant="secondary" className="ml-auto">
-                      {formatCurrency(proposedTotal)}
+                      {formatCurrency(displayTotal)}
                     </Badge>
                   </div>
 
                   <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                     <span>Max {maxQuantity}</span>
-                    {existing?.status === 'pending' && hasPending && (
-                      <div className="flex items-center gap-2 ml-auto">
-                        <Button
-                          size="sm"
-                          onClick={() => handleApprove(extraType)}
-                          disabled={isReviewing}
-                        >
-                          {reviewJobExtra.approve.isPending ? 'Approving…' : 'Approve'}
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleReject(extraType)}
-                          disabled={isReviewing}
-                        >
-                          {reviewJobExtra.reject.isPending ? 'Rejecting…' : 'Reject'}
-                        </Button>
-                      </div>
+                    {hasUnsavedChange && (
+                      <Button
+                        size="sm"
+                        variant="default"
+                        onClick={() => saveExtra(extraType, displayQuantity)}
+                        disabled={upsertJobExtra.isPending}
+                      >
+                        {upsertJobExtra.isPending ? 'Saving...' : 'Save'}
+                      </Button>
                     )}
                   </div>
                 </div>
@@ -301,24 +215,14 @@ export function JobExtrasEditor({
                 <div className="space-y-1">
                   <div className="flex items-center justify-between">
                     <span className="text-sm">
-                      {approvedQuantity > 0 ? `${approvedQuantity} × ${formatCurrency(unitAmount)}` : 'None'}
+                      {currentQuantity > 0 ? `${currentQuantity} × ${formatCurrency(unitAmount)}` : 'None'}
                     </span>
-                    {approvedQuantity > 0 && (
+                    {currentQuantity > 0 && (
                       <Badge variant="secondary">
-                        {formatCurrency(approvedTotal)}
+                        {formatCurrency(currentTotal)}
                       </Badge>
                     )}
                   </div>
-                  {hasPending && pendingQuantity !== null && (
-                    <div className="text-xs text-amber-600">
-                      Pending review: {pendingQuantity} ({formatCurrency(pendingQuantity * unitAmount)})
-                    </div>
-                  )}
-                  {isRejected && existing?.rejection_reason && (
-                    <div className="text-xs text-destructive">
-                      Last rejection: {existing.rejection_reason}
-                    </div>
-                  )}
                 </div>
               )}
             </div>
@@ -344,16 +248,6 @@ export function JobExtrasEditor({
               {vehicleDisclaimerText}
             </p>
           </div>
-        )}
-        
-        {isManager && hasChanges && (
-          <Button
-            onClick={saveChanges}
-            disabled={upsertJobExtra.isPending}
-            className="w-full"
-          >
-            {upsertJobExtra.isPending ? 'Submitting…' : 'Submit changes for approval'}
-          </Button>
         )}
       </CardContent>
     </Card>

--- a/src/hooks/useJobAssignments.ts
+++ b/src/hooks/useJobAssignments.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateJobAssignmentMultiplierOverride } from '@/lib/supabase/queries/jobAssignments';
+import { toast } from 'sonner';
+
+interface UpdateMultiplierOverrideParams {
+  jobId: string;
+  technicianId: string;
+  useTourMultipliers: boolean;
+}
+
+/**
+ * Hook to update the tour multiplier override flag for a job assignment
+ * Forces tour multiplier calculation even if tech is not in tour_assignments table
+ */
+export function useUpdateMultiplierOverride() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ jobId, technicianId, useTourMultipliers }: UpdateMultiplierOverrideParams) =>
+      updateJobAssignmentMultiplierOverride(jobId, technicianId, useTourMultipliers),
+
+    onSuccess: (data, variables) => {
+      // Invalidate all rate quote queries to trigger recalculation
+      queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes'] });
+      queryClient.invalidateQueries({ queryKey: ['technician-tour-rate-quotes'] });
+      queryClient.invalidateQueries({ queryKey: ['manager-job-quotes'] });
+      queryClient.invalidateQueries({ queryKey: ['job-tech-payout'] });
+
+      // Show success message
+      toast.success(
+        variables.useTourMultipliers
+          ? 'Multiplicadores tour activados'
+          : 'Multiplicadores tour desactivados'
+      );
+    },
+
+    onError: (error) => {
+      console.error('Failed to update multiplier override:', error);
+      toast.error('Error al actualizar multiplicadores');
+    },
+  });
+}

--- a/src/hooks/useManagerJobQuotes.ts
+++ b/src/hooks/useManagerJobQuotes.ts
@@ -104,16 +104,16 @@ export function useManagerJobQuotes(jobId?: string, jobType?: string, tourId?: s
         is_house_tech: false,
         is_tour_team_member: false,
         category: '',
-        base_day_eur: Number(p.timesheets_total_eur || 0),
+        base_day_eur: Number(p.timesheets_total_eur || 0), // Timesheets total (base from worked hours)
         week_count: 1,
         multiplier: 1,
         per_job_multiplier: 1,
         iso_year: null,
         iso_week: null,
-        total_eur: Number(p.total_eur || 0),
+        total_eur: Number(p.timesheets_total_eur || 0), // Base total (same as timesheets for non-tour jobs)
         extras: undefined,
         extras_total_eur: Number(p.extras_total_eur || 0),
-        total_with_extras_eur: Number(p.total_eur || 0),
+        total_with_extras_eur: Number(p.total_eur || 0), // Total including extras
         breakdown: {},
       })) as TourJobRateQuote[];
     },

--- a/src/lib/supabase/queries/jobAssignments.ts
+++ b/src/lib/supabase/queries/jobAssignments.ts
@@ -1,0 +1,49 @@
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * Update the tour multiplier override flag for a specific job assignment
+ * @param jobId - The job ID
+ * @param technicianId - The technician ID
+ * @param useTourMultipliers - Whether to force tour multipliers for this assignment
+ * @returns The updated job assignment
+ */
+export async function updateJobAssignmentMultiplierOverride(
+  jobId: string,
+  technicianId: string,
+  useTourMultipliers: boolean
+) {
+  const { data, error } = await supabase
+    .from('job_assignments')
+    .update({
+      use_tour_multipliers: useTourMultipliers,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('job_id', jobId)
+    .eq('technician_id', technicianId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+/**
+ * Get the tour multiplier override status for a specific job assignment
+ * @param jobId - The job ID
+ * @param technicianId - The technician ID
+ * @returns Whether the override is enabled
+ */
+export async function getJobAssignmentMultiplierOverride(
+  jobId: string,
+  technicianId: string
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('job_assignments')
+    .select('use_tour_multipliers')
+    .eq('job_id', jobId)
+    .eq('technician_id', technicianId)
+    .single();
+
+  if (error) throw error;
+  return data?.use_tour_multipliers ?? false;
+}

--- a/src/types/jobExtras.ts
+++ b/src/types/jobExtras.ts
@@ -5,13 +5,7 @@ export interface JobExtra {
   technician_id: string;
   extra_type: JobExtraType;
   quantity: number;
-  pending_quantity?: number | null;
-  status?: 'pending' | 'approved' | 'rejected';
-  submitted_at?: string | null;
-  submitted_by?: string | null;
-  approved_at?: string | null;
-  approved_by?: string | null;
-  rejection_reason?: string | null;
+  status?: 'approved'; // Always approved for manager-only workflow
   amount_override_eur?: number;
   updated_by?: string;
   updated_at: string;

--- a/src/types/tourRates.ts
+++ b/src/types/tourRates.ts
@@ -10,6 +10,7 @@ export interface TourJobRateQuote {
   title: string;
   is_house_tech: boolean;
   is_tour_team_member?: boolean;
+  use_tour_multipliers?: boolean; // Override flag to force tour multipliers even if not tour-wide assigned
   category: string;
   base_day_eur: number;
   week_count: number;

--- a/supabase/migrations/20251105160000_add_tour_multiplier_override.sql
+++ b/supabase/migrations/20251105160000_add_tour_multiplier_override.sql
@@ -1,0 +1,15 @@
+-- Add tour multiplier override flag to job_assignments
+-- Allows forcing tour multiplier calculation for specific job+tech assignments
+-- even when the tech is not assigned tour-wide in tour_assignments table
+
+-- Add the override column
+ALTER TABLE job_assignments
+ADD COLUMN IF NOT EXISTS use_tour_multipliers BOOLEAN DEFAULT FALSE;
+
+-- Add index for efficient querying
+CREATE INDEX IF NOT EXISTS idx_job_assignments_use_tour_multipliers
+ON job_assignments(use_tour_multipliers) WHERE use_tour_multipliers = TRUE;
+
+-- Add comment explaining the column's purpose
+COMMENT ON COLUMN job_assignments.use_tour_multipliers IS
+'Override flag to force tour multiplier calculation even if tech is not in tour_assignments table. Used for edge cases where tech only works specific dates but should still receive tour multipliers.';

--- a/supabase/migrations/20251105170000_update_tour_multiplier_with_override.sql
+++ b/supabase/migrations/20251105170000_update_tour_multiplier_with_override.sql
@@ -1,0 +1,281 @@
+-- Update compute_tour_job_rate_quote_2025 to check for multiplier override flag
+-- Allows forcing tour multiplier calculation via job_assignments.use_tour_multipliers
+
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  tour_group uuid;
+  cat text;
+  house boolean := false;
+  is_autonomo boolean := true;
+  autonomo_discount numeric := 0;
+  base_day_before_discount numeric;
+  base_after_discount numeric(10,2);
+  team_member boolean := false;
+  has_override boolean := false;
+  base numeric(10,2);
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  tour_date_type text := NULL;
+  rehearsal_flat_rate numeric := NULL;
+BEGIN
+  -- Fetch job info
+  SELECT job_type, start_time, tour_id
+  INTO jtype, st, tour_group
+  FROM jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  -- Check for rehearsal tour date type
+  SELECT td.tour_date_type INTO tour_date_type
+  FROM tour_dates td
+  JOIN jobs j ON j.tour_date_id = td.id
+  WHERE j.id = _job_id
+  LIMIT 1;
+
+  -- Check if house tech and autonomo status
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END
+  INTO house, is_autonomo
+  FROM profiles
+  WHERE id = _tech_id;
+
+  -- Handle rehearsal flat rate for tour dates
+  IF tour_date_type = 'rehearsal' THEN
+    IF house THEN
+      -- Check for custom house tech rehearsal rate
+      SELECT rehearsal_day_eur INTO rehearsal_flat_rate
+      FROM house_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      -- Technician rehearsal: €180 base
+      rehearsal_flat_rate := 180.00;
+      base_day_before_discount := 180.00;
+
+      -- Apply autonomo discount if applicable
+      IF NOT is_autonomo THEN
+        autonomo_discount := 30.00;
+        rehearsal_flat_rate := rehearsal_flat_rate - autonomo_discount;
+      END IF;
+    END IF;
+  END IF;
+
+  -- If rehearsal flat rate applies, return early
+  IF rehearsal_flat_rate IS NOT NULL THEN
+    extras := extras_total_for_job_tech(_job_id, _tech_id);
+    extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+    final_total := ROUND(rehearsal_flat_rate + extras_total, 2);
+    disclaimer := needs_vehicle_disclaimer(_tech_id);
+
+    RETURN jsonb_build_object(
+      'job_id', _job_id,
+      'technician_id', _tech_id,
+      'is_rehearsal_flat_rate', true,
+      'rehearsal_rate_eur', ROUND(rehearsal_flat_rate, 2),
+      'autonomo_discount_eur', ROUND(autonomo_discount, 2),
+      'base_day_before_discount_eur', ROUND(COALESCE(base_day_before_discount, rehearsal_flat_rate), 2),
+      'base_day_eur', ROUND(rehearsal_flat_rate, 2),
+      'total_eur', ROUND(rehearsal_flat_rate, 2),
+      'extras', extras,
+      'extras_total_eur', ROUND(extras_total, 2),
+      'total_with_extras_eur', ROUND(final_total, 2),
+      'vehicle_disclaimer', disclaimer,
+      'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+      'category', 'rehearsal',
+      'breakdown', jsonb_build_object('notes', ARRAY['Rehearsal flat rate applied'])
+    );
+  END IF;
+
+  -- Normal tour rate calculation continues...
+  -- Resolve category (non-house)
+  IF NOT house THEN
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+  END IF;
+
+  -- Base rate lookup
+  IF house THEN
+    SELECT base_day_eur INTO base
+    FROM house_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF base IS NULL THEN
+      RETURN jsonb_build_object('error','house_rate_missing','profile_id',_tech_id);
+    END IF;
+  ELSE
+    SELECT base_day_eur INTO base
+    FROM rate_cards_tour_2025
+    WHERE category = cat;
+
+    IF base IS NULL THEN
+      RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+    END IF;
+  END IF;
+
+  base_day_before_discount := base;
+
+  -- Apply autonomo discount for non-house technicians BEFORE multipliers
+  IF NOT house AND NOT is_autonomo THEN
+    autonomo_discount := 30;
+    base := base - autonomo_discount;
+  END IF;
+
+  base_after_discount := base;
+
+  -- NEW: Check for override flag first
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(ja.use_tour_multipliers, FALSE)
+    INTO has_override
+    FROM job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+  END IF;
+
+  -- Determine if technician belongs to the tour team OR has override enabled
+  IF tour_group IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM tour_assignments ta
+      WHERE ta.tour_id = tour_group
+        AND ta.technician_id = _tech_id
+    ) OR has_override  -- NEW: Include override check
+    INTO team_member;
+  END IF;
+
+  -- Multiplier logic: Count TOUR DATES in the week and check if tech is assigned to all
+  SELECT iso_year, iso_week INTO y, w
+  FROM iso_year_week_madrid(st);
+
+  IF team_member THEN
+    DECLARE
+      total_tour_dates int;
+      tech_assigned_dates int;
+    BEGIN
+      -- Count total tour dates for this tour in the same ISO week
+      SELECT count(DISTINCT j.id) INTO total_tour_dates
+      FROM jobs j
+      WHERE j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status NOT IN ('cancelled', 'deleted')
+        AND (SELECT iso_year FROM iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM iso_year_week_madrid(j.start_time)) = w;
+
+      -- Count how many of those dates this specific technician is assigned to
+      SELECT count(DISTINCT j.id) INTO tech_assigned_dates
+      FROM jobs j
+      JOIN job_assignments a ON a.job_id = j.id
+      WHERE a.technician_id = _tech_id
+        AND j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status NOT IN ('cancelled', 'deleted')
+        AND (SELECT iso_year FROM iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM iso_year_week_madrid(j.start_time)) = w;
+
+      -- Only apply multiplier if technician is assigned to ALL tour dates in the week
+      IF tech_assigned_dates = total_tour_dates THEN
+        cnt := total_tour_dates;
+
+        IF cnt <= 1 THEN
+          mult := 1.5;
+          per_job_multiplier := 1.5;
+        ELSIF cnt = 2 THEN
+          mult := 2.25;
+          per_job_multiplier := 1.125;
+        ELSE
+          mult := 1.0;
+          per_job_multiplier := 1.0;
+        END IF;
+      ELSE
+        -- Tech is not assigned to all dates, use default multiplier
+        cnt := tech_assigned_dates;
+        mult := 1.0;
+        per_job_multiplier := 1.0;
+      END IF;
+    END;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+  END IF;
+
+  -- Apply multiplier per job
+  base := ROUND(base * per_job_multiplier, 2);
+
+  extras := extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(base + extras_total, 2);
+
+  disclaimer := needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,  -- NEW: Include override flag in response
+    'category', cat,
+    'base_day_eur', base,
+    'autonomo_discount_eur', ROUND(autonomo_discount, 2),
+    'base_day_before_discount_eur', ROUND(base_day_before_discount, 2),
+    'week_count', cnt,
+    'multiplier', mult,
+    'per_job_multiplier', ROUND(per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', ROUND(base, 2),
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', ROUND(final_total, 2),
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', ROUND(base_day_before_discount, 2),
+      'autonomo_discount', ROUND(autonomo_discount, 2),
+      'after_discount', ROUND(base_after_discount, 2),
+      'multiplier', mult,
+      'per_job_multiplier', ROUND(per_job_multiplier, 3),
+      'final_base', ROUND(base, 2)
+    )
+  );
+END;
+$function$;


### PR DESCRIPTION
This commit implements two major improvements to the tour rates system:

**1. Tour Multiplier Override (Per-Tech Per-Date)**
- Added `use_tour_multipliers` boolean column to job_assignments table
- Updated RPC function to check override flag when calculating multipliers
- Managers can now force tour multipliers for specific techs on specific dates
- Useful for edge cases where techs only work selected dates but should receive multipliers
- Added checkbox UI in TourRatesManagerDialog with tooltip explanation
- Only shows for non-tour-team members on tour dates

**2. Fixed Extras System**
- Simplified extras workflow to manager-only (removed approval workflow)
- Extras are now set directly by managers, no pending/approval states needed
- Updated useJobExtras hook to perform direct upserts
- Simplified JobExtrasEditor component: removed approval UI, auto-save on change
- Updated types to remove approval workflow fields
- Fixed non-tour job base calculation bug in useManagerJobQuotes
- RLS policies already correct (managers write, techs read-only)

Files changed:
- Database: 2 new migrations for multiplier override column and RPC update
- Backend: New query functions and mutation hook for override toggle
- Frontend: Updated TourRatesManagerDialog with checkbox, simplified JobExtrasEditor
- Types: Added use_tour_multipliers to TourJobRateQuote, simplified JobExtra