### PR TITLE
Add target date fallback for single-day staffing requests

### DIFF
--- a/src/components/matrix/OptimizedAssignmentMatrix.tsx
+++ b/src/components/matrix/OptimizedAssignmentMatrix.tsx
@@ -1016,7 +1016,8 @@ export const OptimizedAssignmentMatrix = ({
                     return;
                   }
                 }
-                sendStaffingEmail(({ job_id: jobId, profile_id: profileId, phase: 'offer', role, message, channel: via, single_day: true, dates: selectedDates } as any), {
+                const targetDate = selectedDates[0];
+                sendStaffingEmail(({ job_id: jobId, profile_id: profileId, phase: 'offer', role, message, channel: via, single_day: true, dates: selectedDates, target_date: targetDate } as any), {
                   onSuccess: (data: any) => {
                     const ch = data?.channel || via;
                     toast({ title: 'Offer sent', description: `${role} offer sent via ${ch} (${selectedDates.length} day${selectedDates.length>1?'s':''}).` });
@@ -1198,7 +1199,8 @@ export const OptimizedAssignmentMatrix = ({
                     toast({ title: 'Select date(s)', description: 'Choose at least one date within the job span.', variant: 'destructive' });
                     return;
                   }
-                  sendStaffingEmail(({ job_id: jobId, profile_id: profileId, phase: 'availability', channel: via, single_day: true, dates } as any), {
+                  const targetDate = dates[0];
+                  sendStaffingEmail(({ job_id: jobId, profile_id: profileId, phase: 'availability', channel: via, single_day: true, dates, target_date: targetDate } as any), {
                     onSuccess: (data: any) => {
                       setAvailabilitySending(false);
                       setAvailabilityDialog(null);

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -72,12 +72,11 @@ serve(async (req) => {
     const datesArrayRaw: unknown = (body as any)?.dates;
     const desiredChannel = (typeof channel === 'string' && channel.toLowerCase() === 'whatsapp') ? 'whatsapp' : 'email';
     const rawTargetDate = typeof target_date === 'string' && target_date ? target_date : null;
-    const normalizedTargetDate = rawTargetDate ? (() => {
+    let normalizedTargetDate = rawTargetDate ? (() => {
       const parsed = new Date(rawTargetDate);
       if (Number.isNaN(parsed.getTime())) return null;
       return parsed.toISOString().split('T')[0];
     })() : null;
-    const isSingleDayRequest = Boolean(single_day) && Boolean(normalizedTargetDate);
     const normalizedDates: string[] = Array.isArray(datesArrayRaw)
       ? Array.from(new Set((datesArrayRaw as any[])
         .map((d) => {
@@ -88,6 +87,10 @@ serve(async (req) => {
         })
         .filter((d): d is string => typeof d === 'string')))
       : [];
+    if (!normalizedTargetDate && single_day && normalizedDates.length === 1) {
+      normalizedTargetDate = normalizedDates[0];
+    }
+    const isSingleDayRequest = Boolean(single_day) && Boolean(normalizedTargetDate);
     
     // Enhanced validation logging
     console.log('🔍 VALIDATING FIELDS:', {


### PR DESCRIPTION
## Summary
- ensure single-day offer and availability payloads from the matrix pass the selected target_date
- add a backend fallback so single-day requests infer the target_date from provided dates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690cc0c53b3c832fafa8506881db6d5f