### PR TITLE
Validate bulk technician availability selections

### DIFF
--- a/src/components/matrix/MarkUnavailableDialog.tsx
+++ b/src/components/matrix/MarkUnavailableDialog.tsx
@@ -70,10 +70,14 @@ export const MarkUnavailableDialog = ({
       // Include additional dates from multi-select matching this technician
       for (const key of selectedCells) {
         // Keys are formatted as `${technicianId}-yyyy-MM-dd`
-        if (key.startsWith(`${technicianId}-`)) {
-          const parts = key.split('-');
-          const d = parts.slice(1).join('-'); // yyyy-MM-dd
-          if (d && d.length === 10) selectedDates.add(d);
+        const prefix = `${technicianId}-`;
+        if (!key.startsWith(prefix)) continue;
+
+        const datePortion = key.slice(prefix.length);
+        const isValidDateKey = /^\d{4}-\d{2}-\d{2}$/.test(datePortion);
+
+        if (isValidDateKey) {
+          selectedDates.add(datePortion);
         }
       }
 


### PR DESCRIPTION
## Summary
- replace the bulk date extraction with prefix slicing and regex validation to avoid malformed entries
- retain the primary selected date so single-day updates continue working

## Testing
- npm run test -- --run *(fails: vitest not found because dependencies are not installed in the environment)*
- npm install *(fails: dependency conflict between vite@6.3.3 and lovable-tagger@1.1.3 peer requirement)*

------
https://chatgpt.com/codex/tasks/task_e_690cc3a32528832f9e97fcb95a4deaab