### PR TITLE
Add shared technician conflict detection to assignment flows

### DIFF
--- a/src/components/matrix/__tests__/AssignJobDialog.test.tsx
+++ b/src/components/matrix/__tests__/AssignJobDialog.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AssignJobDialog } from '../AssignJobDialog';
+
+const useQueryMock = vi.fn();
+const checkTimeConflictMock = vi.fn();
+const insertMock = vi.fn();
+const deleteMock = vi.fn();
+const fromMock = vi.fn();
+const authGetUserMock = vi.fn();
+const functionsInvokeMock = vi.fn();
+const toastFn = Object.assign(vi.fn(), {
+  error: vi.fn(),
+  success: vi.fn(),
+});
+
+type TechnicianJobConflict = {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+};
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: useQueryMock,
+  };
+});
+
+vi.mock('@/utils/technicianAvailability', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/technicianAvailability')>('@/utils/technicianAvailability');
+  return {
+    ...actual,
+    checkTimeConflict: checkTimeConflictMock,
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: fromMock,
+    auth: {
+      getUser: authGetUserMock,
+    },
+    functions: {
+      invoke: functionsInvokeMock,
+    },
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: toastFn,
+}));
+
+const baseJob = {
+  id: 'job-1',
+  title: 'Main Event',
+  start_time: '2024-05-01T10:00:00Z',
+  end_time: '2024-05-02T02:00:00Z',
+  status: 'scheduled',
+};
+
+const defaultTechnician = {
+  first_name: 'Pat',
+  last_name: 'Jones',
+  department: 'sound',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useQueryMock.mockReturnValue({ data: defaultTechnician });
+  insertMock.mockResolvedValue({ error: null });
+  deleteMock.mockResolvedValue({ error: null });
+  fromMock.mockImplementation((table: string) => {
+    if (table === 'job_assignments') {
+      return {
+        insert: insertMock,
+        delete: deleteMock,
+      };
+    }
+    return {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+  authGetUserMock.mockResolvedValue({ data: { user: { id: 'manager-1' } } });
+  functionsInvokeMock.mockResolvedValue({ data: null, error: null });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AssignJobDialog conflict handling', () => {
+  it('prompts for confirmation when a conflict is detected before proceeding', async () => {
+    const conflict: TechnicianJobConflict = {
+      id: 'conflict-1',
+      title: 'Overlapping Show',
+      start_time: '2024-05-01T08:00:00Z',
+      end_time: '2024-05-01T20:00:00Z',
+    };
+    checkTimeConflictMock.mockResolvedValue(conflict);
+
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <AssignJobDialog
+        open
+        onClose={onClose}
+        technicianId="tech-1"
+        date={new Date('2024-05-01T00:00:00Z')}
+        availableJobs={[baseJob]}
+        preSelectedJobId="job-1"
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /choose a role/i }));
+    await user.click(screen.getByText(/foh/i));
+
+    await user.click(screen.getByRole('button', { name: /assign job/i }));
+
+    expect(await screen.findByText(/potential scheduling conflict/i)).toBeInTheDocument();
+    expect(checkTimeConflictMock).toHaveBeenCalledWith('tech-1', 'job-1');
+    expect(insertMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /go back/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/potential scheduling conflict/i)).not.toBeInTheDocument();
+    });
+    expect(insertMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /assign job/i }));
+    expect(await screen.findByText(/potential scheduling conflict/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /proceed anyway/i }));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+    expect(checkTimeConflictMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates the assignment immediately when no conflict exists', async () => {
+    checkTimeConflictMock.mockResolvedValue(null);
+
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <AssignJobDialog
+        open
+        onClose={onClose}
+        technicianId="tech-2"
+        date={new Date('2024-06-01T00:00:00Z')}
+        availableJobs={[baseJob]}
+        preSelectedJobId="job-1"
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /choose a role/i }));
+    await user.click(screen.getByText(/foh/i));
+
+    await user.click(screen.getByRole('button', { name: /assign job/i }));
+
+    await waitFor(() => {
+      expect(insertMock).toHaveBeenCalledTimes(1);
+    });
+    expect(checkTimeConflictMock).toHaveBeenCalledWith('tech-2', 'job-1');
+    expect(screen.queryByText(/potential scheduling conflict/i)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract the technician scheduling conflict helper into the shared technician availability utilities and reuse it inside the optimized matrix
- update the Assign Job dialog to run the shared conflict check, require confirmation through an alert dialog when overlaps are found, and proceed only after explicit approval
- add interaction tests that cover the conflict warning workflow and the successful assignment path with no conflicts

## Testing
- npm test *(fails: vitest binary missing before dependencies are installed)*
- npm install --legacy-peer-deps *(fails: onnxruntime download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_690ccb331338832f9e48b87c4904f1a2