### PR TITLE
Add Flex crew cleanup when removing assignments

### DIFF
--- a/src/utils/flexCrewAssignments.ts
+++ b/src/utils/flexCrewAssignments.ts
@@ -1,0 +1,45 @@
+export type FlexDepartment = 'sound' | 'lights';
+
+type AssignmentLike = {
+  sound_role?: string | null;
+  lights_role?: string | null;
+  job?: { department?: string | null } | null;
+  jobs?: { department?: string | null } | null;
+  department?: string | null;
+} | null | undefined;
+
+const isFlexDepartment = (department: string | null | undefined): department is FlexDepartment => {
+  return department === 'sound' || department === 'lights';
+};
+
+export const determineFlexDepartmentsForAssignment = (
+  assignment: AssignmentLike,
+  fallbackDepartment?: string | null | undefined
+): FlexDepartment[] => {
+  const departments = new Set<FlexDepartment>();
+
+  if (assignment?.sound_role && assignment.sound_role !== 'none') {
+    departments.add('sound');
+  }
+
+  if (assignment?.lights_role && assignment.lights_role !== 'none') {
+    departments.add('lights');
+  }
+
+  if (assignment?.department) {
+    if (isFlexDepartment(assignment.department)) {
+      departments.add(assignment.department);
+    }
+  }
+
+  const jobDepartment = assignment?.job?.department ?? assignment?.jobs?.department;
+  if (isFlexDepartment(jobDepartment)) {
+    departments.add(jobDepartment);
+  }
+
+  if (departments.size === 0 && isFlexDepartment(fallbackDepartment)) {
+    departments.add(fallbackDepartment);
+  }
+
+  return Array.from(departments);
+};


### PR DESCRIPTION
## Summary
- add a shared helper to resolve Flex crew departments from an assignment
- call manage-flex-crew-assignments with action remove when deleting assignments in the matrix cell dialog
- remove Flex crew records during reassignment and manual removal in the assign job dialog before confirming success

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_690cd6850fd0832faa9c8a8345d41575