### PR TITLE
Fix SoundVision document path handling

### DIFF
--- a/src/components/dashboard/JobCardNew.tsx
+++ b/src/components/dashboard/JobCardNew.tsx
@@ -21,7 +21,7 @@ import {
   Card 
 } from "@/components/ui/card";
 import { canCreateFolders, canDeleteDocuments, canEditJobs as canEditJobsPerm, canManageFestivalArtists as canManageFestivalArtistsPerm, canUploadDocuments as canUploadDocumentsPerm } from "@/utils/permissions";
-import { createSignedUrl, resolveJobDocBucket } from "@/utils/jobDocuments";
+import { createSignedUrl, resolveJobDocLocation } from "@/utils/jobDocuments";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Plane, Wrench, Star, Moon, Mic, Loader2, FileText, Archive } from "lucide-react";
@@ -803,9 +803,10 @@ export function JobCardNew({
     if (!window.confirm("Are you sure you want to delete this document?")) return;
     try {
       console.log("Starting document deletion:", doc);
+      const { bucket, path } = resolveJobDocLocation(doc.file_path);
       const { error: storageError } = await supabase.storage
-        .from(resolveJobDocBucket(doc.file_path))
-        .remove([doc.file_path]);
+        .from(bucket)
+        .remove([path]);
       
       if (storageError) {
         console.error("Storage deletion error:", storageError);

--- a/src/components/dashboard/JobDocuments.tsx
+++ b/src/components/dashboard/JobDocuments.tsx
@@ -9,7 +9,7 @@ import { Department } from "@/types/department";
 import { SubscriptionIndicator } from "../ui/subscription-indicator";
 import { useEffect, useState } from "react";
 import { useTableSubscription } from "@/hooks/useTableSubscription";
-import { resolveJobDocBucket } from "@/utils/jobDocuments";
+import { resolveJobDocLocation } from "@/utils/jobDocuments";
 
 interface JobDocument {
   id: string;
@@ -47,9 +47,10 @@ export const JobDocuments = ({
     try {
       console.log('Starting download for document:', jobDocument.file_name);
 
+      const { bucket, path } = resolveJobDocLocation(jobDocument.file_path);
       const { data, error } = await supabase.storage
-        .from(resolveJobDocBucket(jobDocument.file_path))
-        .download(jobDocument.file_path);
+        .from(bucket)
+        .download(path);
 
       if (error) {
         console.error('Download error:', error);
@@ -80,9 +81,10 @@ export const JobDocuments = ({
     try {
       console.log('Starting view for document:', jobDocument.file_name);
       
+      const { bucket, path } = resolveJobDocLocation(jobDocument.file_path);
       const { data: { signedUrl }, error } = await supabase.storage
-        .from(resolveJobDocBucket(jobDocument.file_path))
-        .createSignedUrl(jobDocument.file_path, 60);
+        .from(bucket)
+        .createSignedUrl(path, 60);
 
       if (error) {
         console.error('View error:', error);

--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -39,7 +39,7 @@ import { useJobRatesApproval } from '@/hooks/useJobRatesApproval';
 import { useJobApprovalStatus } from '@/hooks/useJobApprovalStatus';
 import { toast } from 'sonner';
 import { syncFlexWorkOrdersForJob } from '@/services/flexWorkOrders';
-import { resolveJobDocBucket } from '@/utils/jobDocuments';
+import { resolveJobDocLocation } from '@/utils/jobDocuments';
 import { mergePDFs } from '@/utils/pdf/pdfMerge';
 import { generateTimesheetPDF } from '@/utils/timesheet-pdf';
 import { generateJobPayoutPDF } from '@/utils/rates-pdf-export';
@@ -359,10 +359,10 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
 
   const handleDownloadDocument = async (doc: any) => {
     try {
-      const bucket = resolveJobDocBucket(doc.file_path);
+      const { bucket, path } = resolveJobDocLocation(doc.file_path);
       const { data } = await supabase.storage
         .from(bucket)
-        .createSignedUrl(doc.file_path, 3600);
+        .createSignedUrl(path, 3600);
 
       if (data?.signedUrl) {
         const link = document.createElement('a');
@@ -379,10 +379,10 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
 
   const handleViewDocument = async (doc: any) => {
     try {
-      const bucket = resolveJobDocBucket(doc.file_path);
+      const { bucket, path } = resolveJobDocLocation(doc.file_path);
       const { data, error } = await supabase.storage
         .from(bucket)
-        .createSignedUrl(doc.file_path, 3600);
+        .createSignedUrl(path, 3600);
 
       if (error) throw error;
 

--- a/src/components/jobs/cards/JobCardDocuments.tsx
+++ b/src/components/jobs/cards/JobCardDocuments.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Eye, Download, Trash2 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { supabase } from "@/lib/supabase";
-import { resolveJobDocBucket } from "@/utils/jobDocuments";
+import { resolveJobDocLocation } from "@/utils/jobDocuments";
 
 export interface JobDocument {
   id: string;
@@ -38,13 +38,13 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
   const handleViewDocument = async (doc: JobDocument) => {
     try {
       console.log("Attempting to view document:", doc);
-      const bucket = resolveJobDocBucket(doc.file_path);
+      const { bucket, path } = resolveJobDocLocation(doc.file_path);
       const { data, error } = await supabase.storage
         .from(bucket)
-        .createSignedUrl(doc.file_path, 60);
+        .createSignedUrl(path, 60);
 
       if (error || !data?.signedUrl) {
-        console.error("Error creating signed URL:", error || 'No signedUrl returned', { bucket, path: doc.file_path });
+        console.error("Error creating signed URL:", error || 'No signedUrl returned', { bucket, path });
         throw error || new Error('Failed to generate signed URL');
       }
 
@@ -60,13 +60,13 @@ export const JobCardDocuments: React.FC<JobCardDocumentsProps> = ({
     try {
       console.log('Starting download for document:', doc.file_name);
 
-      const bucket = resolveJobDocBucket(doc.file_path);
+      const { bucket, path } = resolveJobDocLocation(doc.file_path);
       const { data, error } = await supabase.storage
         .from(bucket)
-        .createSignedUrl(doc.file_path, 60);
-      
+        .createSignedUrl(path, 60);
+
       if (error || !data?.signedUrl) {
-        console.error('Error creating signed URL for download:', error || 'No signedUrl returned', { bucket, path: doc.file_path });
+        console.error('Error creating signed URL for download:', error || 'No signedUrl returned', { bucket, path });
         throw error || new Error('Failed to generate download URL');
       }
       

--- a/src/hooks/useJobCard.ts
+++ b/src/hooks/useJobCard.ts
@@ -6,7 +6,7 @@ import { useToast } from '@/hooks/use-toast';
 import { JobDocument } from '@/components/jobs/cards/JobCardDocuments';
 import { Department } from '@/types/department';
 import { useDeletionState } from './useDeletionState';
-import { resolveJobDocBucket } from '@/utils/jobDocuments';
+import { resolveJobDocLocation } from '@/utils/jobDocuments';
 
 export const useJobCard = (job: any, department: Department, userRole: string | null, onEditClick?: (job: any) => void, onDeleteClick?: (jobId: string) => void, onJobClick?: (jobId: string) => void) => {
   const { toast } = useToast();
@@ -220,10 +220,10 @@ export const useJobCard = (job: any, department: Department, userRole: string | 
     if (!window.confirm("Are you sure you want to delete this document?")) return;
     try {
       console.log("useJobCard: Starting document deletion:", doc);
-      const bucket = resolveJobDocBucket(doc.file_path);
+      const { bucket, path } = resolveJobDocLocation(doc.file_path);
       const { error: storageError } = await supabase.storage
         .from(bucket)
-        .remove([doc.file_path]);
+        .remove([path]);
       
       if (storageError) {
         console.error("Storage deletion error:", storageError);

--- a/src/hooks/useJobManagement.ts
+++ b/src/hooks/useJobManagement.ts
@@ -6,7 +6,7 @@ import { Department } from "@/types/department";
 import { JobDocument } from "@/types/job";
 import { useCallback } from "react";
 import { deleteJobOptimistically } from "@/services/optimisticJobDeletionService";
-import { resolveJobDocBucket } from "@/utils/jobDocuments";
+import { resolveJobDocLocation } from "@/utils/jobDocuments";
 
 export const useJobManagement = (
   selectedDepartment: Department,
@@ -98,10 +98,10 @@ export const useJobManagement = (
       console.log("useJobManagement: Deleting document:", document);
 
       // Delete from storage
-      const bucket = resolveJobDocBucket(document.file_path);
+      const { bucket, path } = resolveJobDocLocation(document.file_path);
       const { error: storageError } = await supabase.storage
         .from(bucket)
-        .remove([document.file_path]);
+        .remove([path]);
 
       if (storageError) throw storageError;
 

--- a/src/hooks/useOptimisticJobManagement.ts
+++ b/src/hooks/useOptimisticJobManagement.ts
@@ -6,7 +6,7 @@ import { Department } from "@/types/department";
 import { JobDocument } from "@/types/job";
 import { useCallback } from "react";
 import { deleteJobOptimistically } from "@/services/optimisticJobDeletionService";
-import { resolveJobDocBucket } from "@/utils/jobDocuments";
+import { resolveJobDocLocation } from "@/utils/jobDocuments";
 
 export const useOptimisticJobManagement = (
   selectedDepartment: Department,
@@ -99,10 +99,10 @@ export const useOptimisticJobManagement = (
       console.log("useOptimisticJobManagement: Deleting document:", document);
 
       // Delete from storage
-      const bucket = resolveJobDocBucket(document.file_path);
+      const { bucket, path } = resolveJobDocLocation(document.file_path);
       const { error: storageError } = await supabase.storage
         .from(bucket)
-        .remove([document.file_path]);
+        .remove([path]);
 
       if (storageError) throw storageError;
 

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -6,7 +6,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import { createQueryKey } from '@/lib/optimized-react-query';
 import { useRequiredRoleSummary } from '@/hooks/useJobRequiredRoles';
-import { resolveJobDocBucket } from '@/utils/jobDocuments';
+import { resolveJobDocLocation } from '@/utils/jobDocuments';
 
 export const useOptimizedJobCard = (
   job: any,
@@ -280,9 +280,10 @@ export const useOptimizedJobCard = (
     if (!window.confirm('Are you sure you want to delete this document?')) return;
 
     try {
+      const { bucket, path } = resolveJobDocLocation(doc.file_path);
       const { error: storageError } = await supabase.storage
-        .from(resolveJobDocBucket(doc.file_path))
-        .remove([doc.file_path]);
+        .from(bucket)
+        .remove([path]);
       
       if (storageError) throw storageError;
 

--- a/src/pages/FestivalManagement.tsx
+++ b/src/pages/FestivalManagement.tsx
@@ -28,7 +28,7 @@ import { FlexFolderPicker } from "@/components/flex/FlexFolderPicker";
 import { createAllFoldersForJob, openFlexElement } from "@/utils/flex-folders";
 import type { CreateFoldersOptions } from "@/utils/flex-folders";
 import { JobPresetManagerDialog } from "@/components/jobs/JobPresetManagerDialog";
-import { resolveJobDocBucket } from "@/utils/jobDocuments";
+import { resolveJobDocLocation } from "@/utils/jobDocuments";
 import { TechnicianIncidentReportDialog } from "@/components/incident-reports/TechnicianIncidentReportDialog";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -147,7 +147,7 @@ const FestivalManagement = () => {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const resolveJobDocumentBucket = useCallback((path: string) => resolveJobDocBucket(path), []);
+  const resolveJobDocumentLocation = useCallback((path: string) => resolveJobDocLocation(path), []);
 
   const fetchJobDetails = useCallback(async (options?: { silent?: boolean }) => {
     const silent = options?.silent ?? false;
@@ -383,9 +383,10 @@ const FestivalManagement = () => {
 
   const handleJobDocumentView = useCallback(async (docEntry: JobDocumentEntry) => {
     try {
+      const { bucket, path } = resolveJobDocumentLocation(docEntry.file_path);
       const { data, error } = await supabase.storage
-        .from(resolveJobDocumentBucket(docEntry.file_path))
-        .createSignedUrl(docEntry.file_path, 3600);
+        .from(bucket)
+        .createSignedUrl(path, 3600);
 
       if (error) throw error;
 
@@ -400,13 +401,14 @@ const FestivalManagement = () => {
         variant: 'destructive',
       });
     }
-  }, [resolveJobDocumentBucket, toast]);
+  }, [resolveJobDocumentLocation, toast]);
 
   const handleJobDocumentDownload = useCallback(async (docEntry: JobDocumentEntry) => {
     try {
+      const { bucket, path } = resolveJobDocumentLocation(docEntry.file_path);
       const { data, error } = await supabase.storage
-        .from(resolveJobDocumentBucket(docEntry.file_path))
-        .download(docEntry.file_path);
+        .from(bucket)
+        .download(path);
 
       if (error) throw error;
 
@@ -426,7 +428,7 @@ const FestivalManagement = () => {
         variant: 'destructive',
       });
     }
-  }, [resolveJobDocumentBucket, toast]);
+  }, [resolveJobDocumentLocation, toast]);
 
   const handleRiderView = useCallback(async (file: ArtistRiderFile) => {
     try {

--- a/src/utils/jobDocuments.ts
+++ b/src/utils/jobDocuments.ts
@@ -2,23 +2,35 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 
 const DEPT_PREFIXES = new Set(['sound','lights','video','production','logistics','administrative']);
 
-export const resolveJobDocBucket = (path: string) => {
-  const first = (path || '').split('/')[0];
+export const resolveJobDocLocation = (path: string) => {
+  const normalized = (path || '').replace(/^\/+/, '');
+  const segments = normalized.split('/');
+  const first = segments[0] ?? '';
   if (first === 'soundvision-files') {
-    return 'soundvision-files';
+    const sanitizedPath = segments.slice(1).join('/');
+    return {
+      bucket: 'soundvision-files',
+      path: sanitizedPath,
+    } as const;
   }
-  return DEPT_PREFIXES.has(first) ? 'job_documents' : 'job-documents';
+
+  return {
+    bucket: DEPT_PREFIXES.has(first) ? 'job_documents' : 'job-documents',
+    path: normalized,
+  } as const;
 };
+
+export const resolveJobDocBucket = (path: string) => resolveJobDocLocation(path).bucket;
 
 export const createSignedUrl = async (
   supabase: SupabaseClient,
   filePath: string,
   expiresInSeconds = 60
 ): Promise<string> => {
-  const bucket = resolveJobDocBucket(filePath);
+  const { bucket, path } = resolveJobDocLocation(filePath);
   const { data, error } = await supabase.storage
     .from(bucket)
-    .createSignedUrl(filePath, expiresInSeconds);
+    .createSignedUrl(path, expiresInSeconds);
   if (error) throw error;
   if (!data?.signedUrl) throw new Error('Failed to generate signed URL');
   return data.signedUrl as string;


### PR DESCRIPTION
## Summary
- add a resolveJobDocLocation helper that returns the storage bucket and sanitized path for job documents
- update document viewers, downloaders, and deleters to use the sanitized path when talking to Supabase storage
- ensure job management hooks consistently rely on the new helper when removing documents

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4a7cd3f4832fb5bc542306c788a5)