### PR TITLE
Allow technicians to read job locations and restore document visibility

### DIFF
--- a/src/utils/hoja-de-ruta/pdf-upload.ts
+++ b/src/utils/hoja-de-ruta/pdf-upload.ts
@@ -76,7 +76,8 @@ export const uploadPdfToJob = async (jobId: string, pdfBlob: Blob, fileName: str
         file_type: 'application/pdf',
         file_size: pdfBlob.size,
         uploaded_by: (await supabase.auth.getUser()).data.user?.id,
-        original_type: 'pdf'
+        original_type: 'pdf',
+        visible_to_tech: true
       });
 
     if (insertError) {

--- a/src/utils/jobDocumentsUpload.ts
+++ b/src/utils/jobDocumentsUpload.ts
@@ -74,6 +74,7 @@ export const uploadJobPdfWithCleanup = async (
         file_size: pdfBlob.size,
         uploaded_by: userRes?.user?.id || null,
         original_type: 'pdf',
+        visible_to_tech: true,
       });
     if (insertError) throw insertError;
 

--- a/src/utils/pdf-generator.ts
+++ b/src/utils/pdf-generator.ts
@@ -25,7 +25,8 @@ export const uploadPdfToJob = async (
       file_name: fileName,
       file_path: data.path,
       file_type: "application/pdf",
-      original_type: 'pdf'
+      original_type: 'pdf',
+      visible_to_tech: true,
     });
 
     if (docError) throw docError;

--- a/supabase/migrations/20251115120000_adjust_locations_policy_for_techs.sql
+++ b/supabase/migrations/20251115120000_adjust_locations_policy_for_techs.sql
@@ -1,0 +1,30 @@
+-- Allow technicians assigned to a job to read its location details
+-- in addition to the existing admin/management/wallboard access.
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'locations'
+      and policyname = 'wb_locations_select'
+  ) then
+    drop policy wb_locations_select on public.locations;
+  end if;
+
+  create policy wb_locations_select on public.locations
+    for select to authenticated
+    using (
+      public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'wallboard'::text])
+      or exists (
+        select 1
+        from public.jobs j
+        join public.job_assignments ja on ja.job_id = j.id
+        where j.location_id = locations.id
+          and ja.technician_id = auth.uid()
+          and coalesce(ja.status, 'accepted') <> 'declined'
+      )
+    );
+end;
+$$;

--- a/supabase/migrations/20251115121000_job_documents_default_visible.sql
+++ b/supabase/migrations/20251115121000_job_documents_default_visible.sql
@@ -1,0 +1,9 @@
+-- Ensure existing job documents remain visible to technicians and default
+-- new uploads to technician-visible unless explicitly hidden.
+
+alter table if exists public.job_documents
+  alter column visible_to_tech set default true;
+
+update public.job_documents
+set visible_to_tech = true
+where visible_to_tech = false;


### PR DESCRIPTION
## Summary
- expand the locations select policy so assigned technicians can load job venue details
- default job documents to technician-visible and backfill existing rows to restore access
- ensure all job document uploads explicitly flag files as visible to technicians

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e74f8cd64832f86ff4861ed4c7e29)