### PR TITLE
Display non-autonomo technician indicators in payouts and rate PDFs

### DIFF
--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { JobPayoutTotalsPanel } from '../JobPayoutTotalsPanel';
+import { NO_AUTONOMO_LABEL } from '@/utils/autonomo';
+
+const useJobPayoutTotalsMock = vi.fn();
+
+vi.mock('@/hooks/useJobPayoutTotals', () => ({
+  useJobPayoutTotals: (...args: any[]) => useJobPayoutTotalsMock(...args),
+}));
+
+const useQueryMock = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (options: any) => useQueryMock(options),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {},
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+describe('JobPayoutTotalsPanel autonomo badge', () => {
+  beforeEach(() => {
+    useJobPayoutTotalsMock.mockReturnValue({
+      data: [
+        {
+          technician_id: 'tech-1',
+          job_id: 'job-1',
+          timesheets_total_eur: 100,
+          extras_total_eur: 0,
+          total_eur: 100,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: any[] }) => {
+      const key = queryKey[0];
+      if (key === 'flex-work-orders-by-job') {
+        return { data: [], isLoading: false, error: null };
+      }
+      if (key === 'profiles-for-job-payout') {
+        return {
+          data: [
+            {
+              id: 'tech-1',
+              first_name: 'Ana',
+              last_name: 'Lopez',
+              email: 'ana@example.com',
+              autonomo: false,
+            },
+          ],
+          isLoading: false,
+          error: null,
+        };
+      }
+      if (key === 'job-payout-metadata') {
+        return {
+          data: {
+            id: 'job-1',
+            title: 'Job Uno',
+            start_time: '2024-01-01T00:00:00Z',
+            tour_id: null,
+            rates_approved: true,
+          },
+          isLoading: false,
+          error: null,
+        };
+      }
+      return { data: undefined, isLoading: false, error: null };
+    });
+  });
+
+  it('renders the non-autonomo badge when the flag is false', () => {
+    render(<JobPayoutTotalsPanel jobId="job-1" />);
+
+    expect(screen.getByText(NO_AUTONOMO_LABEL)).toBeInTheDocument();
+  });
+});

--- a/src/components/tours/__tests__/TourRatesPanel.autonomo.test.tsx
+++ b/src/components/tours/__tests__/TourRatesPanel.autonomo.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TourRatesPanel } from '../TourRatesPanel';
+import { NO_AUTONOMO_LABEL } from '@/utils/autonomo';
+
+const useTourJobRateQuotesMock = vi.fn();
+
+vi.mock('@/hooks/useTourJobRateQuotes', () => ({
+  useTourJobRateQuotes: (...args: any[]) => useTourJobRateQuotesMock(...args),
+}));
+
+const useQueryMock = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (options: any) => useQueryMock(options),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {},
+}));
+
+vi.mock('@/lib/tour-payout-email', () => ({
+  sendTourJobEmails: vi.fn().mockResolvedValue({ success: true, missingEmails: [], context: {} }),
+}));
+
+describe('TourRatesPanel autonomo badge', () => {
+  beforeEach(() => {
+    useTourJobRateQuotesMock.mockReturnValue({
+      data: [
+        {
+          job_id: 'job-1',
+          technician_id: 'tech-1',
+          start_time: '2024-01-01T00:00:00Z',
+          end_time: '2024-01-01T10:00:00Z',
+          job_type: 'show',
+          tour_id: 'tour-1',
+          title: 'Opening Night',
+          is_house_tech: false,
+          is_tour_team_member: true,
+          category: 'audio',
+          base_day_eur: 200,
+          week_count: 1,
+          multiplier: 1,
+          per_job_multiplier: 1,
+          iso_year: 2024,
+          iso_week: 1,
+          total_eur: 200,
+          extras_total_eur: 0,
+          total_with_extras_eur: 200,
+          vehicle_disclaimer: false,
+          breakdown: {
+            after_discount: 200,
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: any[] }) => {
+      const key = queryKey[0];
+      if (key === 'profiles-for-tour-rates') {
+        return {
+          data: [
+            {
+              id: 'tech-1',
+              first_name: 'Ana',
+              last_name: 'Lopez',
+              email: 'ana@example.com',
+              autonomo: false,
+            },
+          ],
+          isLoading: false,
+          error: null,
+        };
+      }
+      if (key === 'tour-rates-job-meta') {
+        return {
+          data: {
+            id: 'job-1',
+            title: 'Opening Night',
+            start_time: '2024-01-01T00:00:00Z',
+            tour_id: 'tour-1',
+            rates_approved: true,
+          },
+          isLoading: false,
+          error: null,
+        };
+      }
+      return { data: undefined, isLoading: false, error: null };
+    });
+  });
+
+  it('shows the non-autonomo badge beside the technician name', () => {
+    render(<TourRatesPanel jobId="job-1" />);
+
+    expect(screen.getByText(NO_AUTONOMO_LABEL)).toBeInTheDocument();
+  });
+});

--- a/src/lib/job-payout-email.ts
+++ b/src/lib/job-payout-email.ts
@@ -8,6 +8,7 @@ export interface TechnicianProfileWithEmail {
   first_name?: string | null;
   last_name?: string | null;
   email?: string | null;
+  autonomo?: boolean | null;
 }
 
 export interface JobPayoutEmailJobDetails {
@@ -25,6 +26,7 @@ export interface JobPayoutEmailAttachment {
   payout: JobPayoutTotals;
   pdfBase64: string;
   filename: string;
+  autonomo?: boolean | null;
 }
 
 export interface JobPayoutEmailContextResult {
@@ -130,14 +132,15 @@ async function fetchProfiles(
 ): Promise<TechnicianProfileWithEmail[]> {
   if (provided) {
     const hasEmailField = provided.every((p) => Object.prototype.hasOwnProperty.call(p, 'email'));
-    if (hasEmailField) {
+    const hasAutonomoField = provided.every((p) => Object.prototype.hasOwnProperty.call(p, 'autonomo'));
+    if (hasEmailField && hasAutonomoField) {
       return provided;
     }
   }
   if (!techIds.length) return provided || [];
   const { data, error } = await client
     .from('profiles')
-    .select('id, first_name, last_name, email')
+    .select('id, first_name, last_name, email, autonomo')
     .in('id', techIds);
   if (error) throw error;
   return (data || []) as TechnicianProfileWithEmail[];
@@ -219,6 +222,7 @@ export async function prepareJobPayoutEmailContext(
       payout,
       pdfBase64,
       filename,
+      autonomo: profile?.autonomo ?? null,
     });
   }
 
@@ -283,6 +287,7 @@ export async function sendJobPayoutEmails(
       },
       pdf_base64: attachment.pdfBase64,
       filename: attachment.filename,
+      autonomo: attachment.autonomo ?? null,
     })),
     missing_emails: context.missingEmails,
     requested_at: new Date().toISOString(),

--- a/src/lib/tour-payout-email.ts
+++ b/src/lib/tour-payout-email.ts
@@ -20,6 +20,7 @@ export interface TourJobEmailAttachment {
   quote: TourJobRateQuote;
   pdfBase64: string;
   filename: string;
+  autonomo?: boolean | null;
 }
 
 export interface TourJobEmailContextResult {
@@ -127,6 +128,7 @@ export async function prepareTourJobEmailContext(
       quote: techQuotes[0],
       pdfBase64,
       filename,
+      autonomo: profile?.autonomo ?? null,
     });
   }
 
@@ -195,6 +197,7 @@ export async function sendTourJobEmails(
         },
         pdf_base64: attachment.pdfBase64,
         filename: attachment.filename,
+        autonomo: attachment.autonomo ?? null,
       };
     }),
     missing_emails: context.missingEmails,

--- a/src/utils/__tests__/autonomo.test.ts
+++ b/src/utils/__tests__/autonomo.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { appendAutonomoLabel, getAutonomoBadgeLabel, NO_AUTONOMO_LABEL } from '@/utils/autonomo';
+
+describe('autonomo helpers', () => {
+  it('returns the badge label only when autonomo is false', () => {
+    expect(getAutonomoBadgeLabel(true)).toBeNull();
+    expect(getAutonomoBadgeLabel(undefined)).toBeNull();
+    expect(getAutonomoBadgeLabel(null)).toBeNull();
+    expect(getAutonomoBadgeLabel(false)).toBe(NO_AUTONOMO_LABEL);
+  });
+
+  it('appends the label on a new line by default when not autonomo', () => {
+    expect(appendAutonomoLabel('Ana Lopez', true)).toBe('Ana Lopez');
+    expect(appendAutonomoLabel('Ana Lopez', false)).toBe(`Ana Lopez\n${NO_AUTONOMO_LABEL}`);
+  });
+
+  it('can append the label inline when requested', () => {
+    expect(appendAutonomoLabel('Ana Lopez', false, { multiline: false })).toBe(
+      `Ana Lopez (${NO_AUTONOMO_LABEL})`
+    );
+  });
+});

--- a/src/utils/__tests__/rates-pdf-export.test.ts
+++ b/src/utils/__tests__/rates-pdf-export.test.ts
@@ -38,8 +38,8 @@ describe('generateRateQuotePDF', () => {
     };
 
     const profiles: TechnicianProfile[] = [
-      { id: 'tech-1', first_name: 'Ana', last_name: 'Lopez' },
-      { id: 'tech-2', first_name: 'Luis', last_name: 'Martin' },
+      { id: 'tech-1', first_name: 'Ana', last_name: 'Lopez', autonomo: false },
+      { id: 'tech-2', first_name: 'Luis', last_name: 'Martin', autonomo: true },
     ];
 
     const quotes: TourJobRateQuote[] = [
@@ -108,6 +108,7 @@ describe('generateRateQuotePDF', () => {
 
     const mainTable = autoTableCalls[0];
     expect(mainTable.head[0][2]).toBe('Base (calc.)');
+    expect(mainTable.body[0][0]).toContain('No autónomo – €30 descuento');
     expect(mainTable.body[0][2]).toBe('180 € ×1,25 = 225 €');
     expect(mainTable.body[1][2]).toBe('150 €');
   });

--- a/src/utils/autonomo.ts
+++ b/src/utils/autonomo.ts
@@ -1,0 +1,20 @@
+export const NO_AUTONOMO_LABEL = 'No autónomo – €30 descuento';
+
+export const isAutonomo = (value?: boolean | null): boolean => value !== false;
+
+export const getAutonomoBadgeLabel = (value?: boolean | null): string | null =>
+  isAutonomo(value) ? null : NO_AUTONOMO_LABEL;
+
+export const appendAutonomoLabel = (
+  base: string,
+  value?: boolean | null,
+  options?: { multiline?: boolean }
+): string => {
+  if (isAutonomo(value)) return base;
+  const label = NO_AUTONOMO_LABEL;
+  if (options?.multiline === false) {
+    return `${base} (${label})`;
+  }
+  // Default to multiline to align with PDF tables where additional lines are clearer.
+  return `${base}\n${label}`;
+};


### PR DESCRIPTION
## Summary
- surface the autonomo flag in job payout and tour rate panels and show a clear badge when a technician is not autonomo
- extend job/tour email context builders and PDF exports to propagate autonomo metadata and annotate rate tables accordingly
- introduce shared autonomo helpers plus focused unit tests covering the badge/label formatting and new UI states

## Testing
- npx vitest run *(fails: existing suite contains unrelated environment-sensitive tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6f3cde50832f9d5adf43aba8aa9c)