### PR TITLE
Add autonomo flag to technician profile exports

### DIFF
--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -50,6 +50,7 @@ interface TechnicianProfile {
   first_name?: string | null;
   last_name?: string | null;
   department?: string | null;
+  autonomo?: boolean | null;
 }
 
 type SupabaseClientLike = typeof supabase;
@@ -73,7 +74,7 @@ export const enrichTimesheetsWithProfiles = async (
 
   const { data: profiles, error } = await client
     .from('profiles')
-    .select('id, first_name, last_name, department')
+    .select('id, first_name, last_name, department, autonomo')
     .in('id', technicianIds);
 
   if (error) {
@@ -815,7 +816,7 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
                             if (missingProfileIds.length) {
                               const { data: extraProfiles, error: extraProfilesError } = await supabase
                                 .from('profiles')
-                                .select('id, first_name, last_name, department')
+                                .select('id, first_name, last_name, department, autonomo')
                                 .in('id', missingProfileIds);
 
                               if (extraProfilesError) {

--- a/src/components/jobs/__tests__/JobDetailsDialog.timesheet-pdf.test.ts
+++ b/src/components/jobs/__tests__/JobDetailsDialog.timesheet-pdf.test.ts
@@ -61,7 +61,13 @@ describe('JobDetailsDialog timesheet enrichment', () => {
         select: vi.fn(() => ({
           in: vi.fn(async () => ({
             data: [
-              { id: 'tech-1', first_name: 'Alice', last_name: 'Doe', department: 'Audio' },
+              {
+                id: 'tech-1',
+                first_name: 'Alice',
+                last_name: 'Doe',
+                department: 'Audio',
+                autonomo: false,
+              },
             ],
             error: null,
           })),
@@ -89,6 +95,9 @@ describe('JobDetailsDialog timesheet enrichment', () => {
 
     expect(profileMap.size).toBe(1);
     expect(enrichedTimesheets[0].technician).toMatchObject({ first_name: 'Alice', last_name: 'Doe' });
+    expect(profileMap.get('tech-1')).toMatchObject({ autonomo: false });
+    const payoutProfiles = Array.from(profileMap.values());
+    expect(payoutProfiles[0]).toMatchObject({ autonomo: false });
 
     await generateTimesheetPDF({
       job: {

--- a/src/types/timesheet.ts
+++ b/src/types/timesheet.ts
@@ -66,6 +66,7 @@ export interface Timesheet {
     last_name: string;
     email: string;
     department: string;
+    autonomo?: boolean | null;
   };
 }
 


### PR DESCRIPTION
## Summary
- include the autonomo field when loading technician profiles for timesheets and payouts
- propagate the autonomo flag through technician maps and payout profile exports
- update typing and tests to cover non-autónomo technicians

## Testing
- npm run test -- JobDetailsDialog.timesheet-pdf.test.ts *(fails: vitest not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8a91cc4c832fa1f9412af73532ba)