### PR TITLE
Add revert helper for timesheet approvals

### DIFF
--- a/src/components/timesheet/TimesheetView.tsx
+++ b/src/components/timesheet/TimesheetView.tsx
@@ -39,7 +39,7 @@ interface TimesheetViewProps {
 export const TimesheetView = ({ jobId, jobTitle, canManage = false }: TimesheetViewProps) => {
   // Ensure userRole is initialized before passing into hooks that depend on it
   const { user, userRole } = useOptimizedAuth();
-  const { timesheets, isLoading, createTimesheet, updateTimesheet, submitTimesheet, approveTimesheet, rejectTimesheet, signTimesheet, deleteTimesheet, deleteTimesheets, recalcTimesheet, refetch } = useTimesheets(jobId, { userRole });
+  const { timesheets, isLoading, createTimesheet, updateTimesheet, submitTimesheet, approveTimesheet, rejectTimesheet, signTimesheet, deleteTimesheet, deleteTimesheets, recalcTimesheet, revertTimesheet, refetch } = useTimesheets(jobId, { userRole });
   const { assignments } = useJobAssignmentsRealtime(jobId);
   const { toast } = useToast();
   const [selectedDate, setSelectedDate] = useState(format(new Date(), 'yyyy-MM-dd'));
@@ -660,7 +660,7 @@ export const TimesheetView = ({ jobId, jobTitle, canManage = false }: TimesheetV
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => submitTimesheet(timesheet.id)}
+                          onClick={() => revertTimesheet(timesheet.id)}
                           disabled={isBulkUpdating}
                           className="border-orange-500 text-orange-600 hover:bg-orange-50"
                         >

--- a/src/hooks/useTimesheets.ts
+++ b/src/hooks/useTimesheets.ts
@@ -364,6 +364,30 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
     return updated;
   };
 
+  const revertTimesheet = async (timesheetId: string) => {
+    const updated = await updateTimesheet(
+      timesheetId,
+      {
+        status: 'submitted',
+        approved_by_manager: false,
+        approved_by: null,
+        approved_at: null,
+        rejected_at: null,
+        rejected_by: null,
+        rejection_reason: null
+      },
+      true
+    );
+
+    if (updated) {
+      await fetchTimesheets();
+      toast.success('Timesheet approval reverted');
+      invalidateApprovalContext();
+    }
+
+    return updated;
+  };
+
   const approveTimesheet = async (timesheetId: string) => {
     const currentUser = (await supabase.auth.getUser()).data.user;
     // Mark as approved (manager) and recompute
@@ -511,6 +535,7 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
     signTimesheet,
     deleteTimesheet,
     deleteTimesheets,
-    recalcTimesheet
+    recalcTimesheet,
+    revertTimesheet
   };
 };


### PR DESCRIPTION
## Summary
- add a revertTimesheet helper in the timesheets hook that resets approval metadata before refreshing state
- wire the management revert action in TimesheetView to use the new helper instead of resubmitting

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f8d7bf710832f81e771c6adf4bb97)