### PR TITLE
Fix timesheet select columns for payout emails

### DIFF
--- a/src/lib/job-payout-email.ts
+++ b/src/lib/job-payout-email.ts
@@ -166,9 +166,7 @@ async function fetchLpoMap(
 async function fetchTimesheets(client: SupabaseClient, jobId: string): Promise<any[]> {
   const { data, error } = await client
     .from('timesheets')
-    .select(
-      'technician_id, job_id, date, amount_breakdown, amount_breakdown_visible, approved_by_manager'
-    )
+    .select('technician_id, job_id, date, amount_breakdown, approved_by_manager')
     .eq('job_id', jobId)
     .eq('approved_by_manager', true);
   if (error) throw error;


### PR DESCRIPTION
## Summary
- remove the non-existent `amount_breakdown_visible` column from the direct timesheets query so payout emails rely on fields that exist on the table

## Testing
- not run (requires Supabase access for integration email flow)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f93760cc0832fa8df8578784d1aec)