### PR TITLE
Add rejection metadata support to timesheets

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -5184,6 +5184,9 @@ export type Database = {
           job_id: string
           notes: string | null
           overtime_hours: number | null
+          rejected_at: string | null
+          rejected_by: string | null
+          rejection_reason: string | null
           signature_data: string | null
           signed_at: string | null
           start_time: string | null
@@ -5208,6 +5211,9 @@ export type Database = {
           job_id: string
           notes?: string | null
           overtime_hours?: number | null
+          rejected_at?: string | null
+          rejected_by?: string | null
+          rejection_reason?: string | null
           signature_data?: string | null
           signed_at?: string | null
           start_time?: string | null
@@ -5232,6 +5238,9 @@ export type Database = {
           job_id?: string
           notes?: string | null
           overtime_hours?: number | null
+          rejected_at?: string | null
+          rejected_by?: string | null
+          rejection_reason?: string | null
           signature_data?: string | null
           signed_at?: string | null
           start_time?: string | null
@@ -5240,6 +5249,20 @@ export type Database = {
           updated_at?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "timesheets_rejected_by_fkey"
+            columns: ["rejected_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "timesheets_rejected_by_fkey"
+            columns: ["rejected_by"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "fk_timesheets_technician_id"
             columns: ["technician_id"]

--- a/src/types/timesheet.ts
+++ b/src/types/timesheet.ts
@@ -15,8 +15,8 @@ export interface Timesheet {
   created_by?: string;
   approved_by?: string;
   approved_at?: string;
-  rejected_at?: string;
-  rejected_by?: string;
+  rejected_at?: string | null;
+  rejected_by?: string | null;
   rejection_reason?: string | null;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20250918113631_5c446413-1d00-4b44-a196-c11a940988a0.sql
+++ b/supabase/migrations/20250918113631_5c446413-1d00-4b44-a196-c11a940988a0.sql
@@ -22,6 +22,9 @@ RETURNS TABLE(
   created_by uuid,
   approved_by uuid,
   approved_at timestamp with time zone,
+  rejected_at timestamp with time zone,
+  rejected_by uuid,
+  rejection_reason text,
   created_at timestamp with time zone,
   updated_at timestamp with time zone,
   category text,
@@ -47,7 +50,7 @@ BEGIN
 
   -- Return timesheets with visibility rules applied
   RETURN QUERY 
-  SELECT 
+  SELECT
     t.id,
     t.job_id,
     t.technician_id,
@@ -63,6 +66,9 @@ BEGIN
     t.created_by,
     t.approved_by,
     t.approved_at,
+    t.rejected_at,
+    t.rejected_by,
+    t.rejection_reason,
     t.created_at,
     t.updated_at,
     t.category,

--- a/supabase/migrations/20260308000000_timesheets_add_rejection_fields.sql
+++ b/supabase/migrations/20260308000000_timesheets_add_rejection_fields.sql
@@ -1,0 +1,11 @@
+-- Add rejection metadata to timesheets
+ALTER TABLE public.timesheets
+  ADD COLUMN IF NOT EXISTS rejected_at timestamptz,
+  ADD COLUMN IF NOT EXISTS rejected_by uuid REFERENCES public.profiles (id),
+  ADD COLUMN IF NOT EXISTS rejection_reason text;
+
+COMMENT ON COLUMN public.timesheets.rejected_at IS 'Timestamp when the timesheet was rejected.';
+COMMENT ON COLUMN public.timesheets.rejected_by IS 'Profile that rejected the timesheet.';
+COMMENT ON COLUMN public.timesheets.rejection_reason IS 'Optional explanation provided when rejecting the timesheet.';
+
+CREATE INDEX IF NOT EXISTS timesheets_rejected_by_idx ON public.timesheets (rejected_by);


### PR DESCRIPTION
## Summary
- add a migration that introduces rejection metadata columns and supporting comments/index on public.timesheets
- expose the new rejection fields from get_timesheet_amounts_visible so RPC consumers can read them
- regenerate Supabase timesheet typings and align the frontend Timesheet interface with the new nullable fields

## Testing
- ⚠️ `npm run lint` *(fails: Cannot find package '@eslint/js' in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9bde25b4832f9be571831c3b6cdc)