### PR TITLE
Add push notifications for job requirements updates

### DIFF
--- a/src/components/settings/PushNotificationMatrix.tsx
+++ b/src/components/settings/PushNotificationMatrix.tsx
@@ -41,6 +41,7 @@ const FALLBACK_EVENTS: EventInfo[] = [
   // Job events
   { code: 'job.created', label: 'Job created' },
   { code: 'job.updated', label: 'Job updated' },
+  { code: 'job.requirements.updated', label: 'Job requirements updated' },
   { code: 'job.deleted', label: '🗑️ Job deleted (CRITICAL)' },
   { code: 'job.status.confirmed', label: 'Job confirmed' },
   { code: 'job.status.cancelled', label: 'Job cancelled' },

--- a/src/features/activity/catalog.ts
+++ b/src/features/activity/catalog.ts
@@ -17,6 +17,14 @@ export const activityCatalogDefaults: Record<string, ActivityCatalogEntry> = {
     toast_enabled: true,
     template: '{actor_name} updated job {job_title}',
   },
+  'job.requirements.updated': {
+    code: 'job.requirements.updated',
+    label: 'Job requirements updated',
+    default_visibility: 'job_participants',
+    severity: 'info',
+    toast_enabled: true,
+    template: '{actor_name} adjusted crew requirements for {job_title}',
+  },
   'job.deleted': {
     code: 'job.deleted',
     label: 'Job deleted',

--- a/src/hooks/useActivityPushFallback.ts
+++ b/src/hooks/useActivityPushFallback.ts
@@ -19,6 +19,7 @@ const COVERED_CODES = new Set<string>([
   'staffing.offer.cancelled',
   'job.status.confirmed',
   'job.status.cancelled',
+  'job.requirements.updated',
   'flex.tourdate_folder.created',
 ])
 

--- a/supabase/migrations/20251115090000_add_job_requirements_push_event.sql
+++ b/supabase/migrations/20251115090000_add_job_requirements_push_event.sql
@@ -1,0 +1,16 @@
+-- Register job requirements updated event for activity log and push routing
+INSERT INTO public.activity_catalog (code, label, default_visibility, severity, toast_enabled, template)
+VALUES (
+  'job.requirements.updated',
+  'Job crew requirements updated',
+  'job_participants',
+  'info',
+  TRUE,
+  '{actor_name} adjusted crew requirements for {job_title}'
+)
+ON CONFLICT (code) DO UPDATE SET
+  label = EXCLUDED.label,
+  default_visibility = EXCLUDED.default_visibility,
+  severity = EXCLUDED.severity,
+  toast_enabled = EXCLUDED.toast_enabled,
+  template = EXCLUDED.template;


### PR DESCRIPTION
## Summary
- add a dedicated `job.requirements.updated` broadcast handler that assembles crew requirement summaries and enriches push payload metadata
- trigger activity logging and push invocation after creating, updating, or deleting job required roles so recipients and feeds stay in sync
- register the new event in the activity catalog and notification preferences matrix for routing management

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' required by eslint.config.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fae9ead9c832f933639e1ad87a9f3)