### PR TITLE
Keep job matrix visible during background fetches

### DIFF
--- a/src/components/matrix/PerformanceIndicator.tsx
+++ b/src/components/matrix/PerformanceIndicator.tsx
@@ -1,23 +1,26 @@
 import React from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { TrendingUp, Clock, Database, Zap } from 'lucide-react';
+import { TrendingUp, Clock, Database, Zap, RefreshCw } from 'lucide-react';
 
 interface PerformanceIndicatorProps {
   assignmentCount: number;
   availabilityCount: number;
   cellCount: number;
-  isLoading: boolean;
+  isInitialLoading: boolean;
+  isFetching: boolean;
 }
 
 export const PerformanceIndicator = ({
   assignmentCount,
   availabilityCount,
   cellCount,
-  isLoading
+  isInitialLoading,
+  isFetching,
 }: PerformanceIndicatorProps) => {
   const getPerformanceStatus = () => {
-    if (isLoading) return { color: 'secondary', icon: Clock, text: 'Loading...' };
+    if (isInitialLoading) return { color: 'secondary', icon: Clock, text: 'Loading...' };
+    if (isFetching) return { color: 'secondary', icon: RefreshCw, text: 'Refreshing...' };
     if (cellCount > 50000) return { color: 'destructive', icon: TrendingUp, text: 'Heavy Load' };
     if (cellCount > 10000) return { color: 'warning', icon: Zap, text: 'Optimized' };
     return { color: 'success', icon: Zap, text: 'Fast' };


### PR DESCRIPTION
## Summary
- retain job query results while date range refetches by enabling keepPreviousData and exposing initial/fetching flags
- keep the assignment matrix rendered during background refetches and show a lightweight fetching badge instead
- update PerformanceIndicator to understand the refined loading states

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc2437cdc832f920d2414fe4e9640)