### PR TITLE
Validate direct message deletions before updating UI

### DIFF
--- a/src/components/messages/hooks/useDirectMessageOperations.ts
+++ b/src/components/messages/hooks/useDirectMessageOperations.ts
@@ -17,14 +17,18 @@ export const useDirectMessageOperations = (
   const handleDeleteMessage = async (messageId: string) => {
     try {
       console.log("Deleting direct message:", messageId);
-      const { error } = await supabase
+      const { data: deleted, error } = await supabase
         .from('direct_messages')
         .delete()
-        .eq('id', messageId);
+        .eq('id', messageId)
+        .select('id');
 
       if (error) throw error;
+      if (!deleted || deleted.length === 0) {
+        throw new Error('No rows deleted. You may not have permission to delete this direct message.');
+      }
 
-      setMessages(messages.filter(message => message.id !== messageId));
+      setMessages(prevMessages => prevMessages.filter(message => message.id !== messageId));
       // Notify other UI to refresh direct messages state
       try {
         window.dispatchEvent(new Event('direct_messages_invalidated'));


### PR DESCRIPTION
## Summary
- request deleted row IDs when removing direct messages and surface failures when no rows are affected
- update the local cache with a functional state setter to avoid stale deletions

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911b051d0b0832fa257e3f7c24ad278)