### PR TITLE
Propagate Flex view hints to selectors

### DIFF
--- a/src/components/flex/FlexElementSelectorDialog.tsx
+++ b/src/components/flex/FlexElementSelectorDialog.tsx
@@ -94,10 +94,12 @@ export const FlexElementSelectorDialog: React.FC<
       documentNumber: node.documentNumber,
       domainId: node.domainId,
       definitionId: node.definitionId,
+      schemaId: node.schemaId,
+      viewHint: node.viewHint,
       depth: node.depth,
       node,
     });
-    
+
     onSelect(node.elementId, node);
     onOpenChange(false);
     setSearchQuery("");

--- a/src/components/jobs/cards/JobCardActions.tsx
+++ b/src/components/jobs/cards/JobCardActions.tsx
@@ -20,7 +20,65 @@ import {
   createTourdateFilterPredicate,
   getElementTree,
   openFlexElement,
+  type FlatElementNode,
+  type FlexLinkIntent,
 } from "@/utils/flex-folders";
+
+function mapViewHintToIntent(viewHint?: string | null): FlexLinkIntent | "auto" | undefined {
+  if (!viewHint || typeof viewHint !== "string") {
+    return undefined;
+  }
+
+  const normalized = viewHint.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+
+  if (normalized === "auto") {
+    return "auto";
+  }
+
+  const canonical = normalized.replace(/[\s_]+/g, "-");
+
+  switch (canonical) {
+    case "contact-list":
+    case "contactlist":
+    case "crew-call":
+    case "crewcall":
+    case "crew-list":
+    case "crewlist":
+      return "contact-list";
+    case "equipment-list":
+    case "equipmentlist":
+    case "pull-sheet":
+    case "pullsheet":
+    case "pull-list":
+    case "pulllist":
+      return "equipment-list";
+    case "remote-file-list":
+    case "remotefilelist":
+    case "remote-files":
+    case "remotefiles":
+    case "remote-files-list":
+      return "remote-file-list";
+    case "expense-sheet":
+    case "expensesheet":
+    case "expense":
+      return "expense-sheet";
+    case "fin-doc":
+    case "financial-document":
+    case "financial-doc":
+    case "financialdoc":
+    case "presupuesto":
+      return "fin-doc";
+    case "simple-element":
+    case "folder":
+    case "element":
+      return "simple-element";
+    default:
+      return undefined;
+  }
+}
 
 interface JobCardActionsProps {
   job: any;
@@ -574,7 +632,7 @@ export const JobCardActions: React.FC<JobCardActionsProps> = ({
     }
   };
 
-  const handleFlexElementSelect = React.useCallback((elementId: string, node?: any) => {
+  const handleFlexElementSelect = React.useCallback((elementId: string, node?: FlatElementNode) => {
     // Synchronous navigation path to preserve user gesture
     console.log(`[JobCardActions] Opening Flex element from selector`, {
       elementId,
@@ -588,6 +646,8 @@ export const JobCardActions: React.FC<JobCardActionsProps> = ({
       node,
       domainId: node?.domainId,
       definitionId: node?.definitionId,
+      schemaId: node?.schemaId,
+      viewHint: node?.viewHint,
       displayName: node?.displayName,
       documentNumber: node?.documentNumber,
       jobType: job.job_type,
@@ -624,6 +684,8 @@ export const JobCardActions: React.FC<JobCardActionsProps> = ({
       context: {
         definitionId: node?.definitionId,
         domainId: node?.domainId,
+        schemaId: node?.schemaId,
+        viewHint: mapViewHintToIntent(node?.viewHint),
         jobType: job.job_type,
       },
       onError: (error) => {

--- a/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
+++ b/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { JobCardActions } from '../JobCardActions';
+import type { FlatElementNode } from '@/utils/flex-folders';
 import * as resolveFlexUrl from '@/utils/flex-folders/resolveFlexUrl';
 import * as useFlexUuidModule from '@/hooks/useFlexUuid';
 import * as flexMainFolderId from '@/utils/flexMainFolderId';
@@ -454,6 +455,47 @@ describe('JobCardActions', () => {
       });
 
       expect(result).toBeNull();
+    });
+
+    it('forwards viewHint aliases and schemaId when selecting a node', () => {
+      vi.spyOn(flexMainFolderId, 'getMainFlexElementIdSync').mockReturnValue({
+        elementId: 'main-element-id',
+        department: 'sound',
+      });
+
+      const props = {
+        ...defaultProps,
+        foldersAreCreated: true,
+      };
+
+      render(<JobCardActions {...props} />);
+
+      expect(FlexElementSelectorDialogMock).toHaveBeenCalled();
+
+      const dialogProps = FlexElementSelectorDialogMock.mock.calls[0][0];
+      const node: FlatElementNode = {
+        elementId: 'crew-call-element',
+        displayName: 'Crew Call',
+        depth: 1,
+        domainId: 'contact-list',
+        parentElementId: 'main-element-id',
+        schemaId: 'crew-call-schema',
+        viewHint: 'crew-call',
+      };
+
+      dialogProps.onSelect(node.elementId, node);
+
+      expect(openFlexElementMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          elementId: 'crew-call-element',
+          context: expect.objectContaining({
+            schemaId: 'crew-call-schema',
+            viewHint: 'contact-list',
+            domainId: 'contact-list',
+            jobType: props.job.job_type,
+          }),
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- normalize Flex tree nodes to carry schemaId and viewHint metadata across flatten/search helpers
- plumb the metadata through the selector dialog and job card handler so openFlexElement can infer intents locally
- add a regression test ensuring crew-call view hints map to contact-list intents when selecting nodes

## Testing
- npm test src/components/jobs/cards/__tests__/JobCardActions.test.tsx *(fails: vitest binary missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124af8eb6c832fac0356cdcbab93de)