### PR TITLE
Batch job requirements save and stateful editor

### DIFF
--- a/src/components/jobs/JobRequirementsEditor.tsx
+++ b/src/components/jobs/JobRequirementsEditor.tsx
@@ -4,8 +4,13 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Input } from '@/components/ui/input'
-import { useJobRequiredRoles, useUpsertJobRequiredRole, useDeleteJobRequiredRole } from '@/hooks/useJobRequiredRoles'
-import { roleOptionsForDiscipline, labelForCode } from '@/types/roles'
+import {
+  useJobRequiredRoles,
+  useSaveJobRequirements,
+  type JobRequiredRoleRow,
+  type JobRequiredRoleInput,
+} from '@/hooks/useJobRequiredRoles'
+import { roleOptionsForDiscipline } from '@/types/roles'
 
 interface JobRequirementsEditorProps {
   open: boolean
@@ -14,85 +19,257 @@ interface JobRequirementsEditorProps {
   departments: string[]
 }
 
-export const JobRequirementsEditor: React.FC<JobRequirementsEditorProps> = ({ open, onOpenChange, jobId, departments }) => {
-  const { data: rows = [] } = useJobRequiredRoles(jobId)
-  const { mutateAsync: upsert, isPending: saving } = useUpsertJobRequiredRole()
-  const { mutateAsync: remove, isPending: deleting } = useDeleteJobRequiredRole()
+type EditableRowStatus = 'clean' | 'new' | 'updated'
 
-  const byDept = React.useMemo(() => {
-    const m = new Map<string, Array<any>>()
-    ;(rows || []).forEach((r) => {
-      const list = m.get(r.department) ?? []
-      list.push(r)
-      m.set(r.department, list)
-    })
-    return m
+interface EditableRow
+  extends Pick<JobRequiredRoleRow, 'id' | 'job_id' | 'department' | 'role_code' | 'quantity' | 'notes'> {
+  localId: string
+  status: EditableRowStatus
+}
+
+const createEditableRow = (row: JobRequiredRoleRow): EditableRow => ({
+  localId: row.id,
+  id: row.id,
+  job_id: row.job_id,
+  department: row.department,
+  role_code: row.role_code,
+  quantity: row.quantity,
+  notes: row.notes,
+  status: 'clean',
+})
+
+const createLocalId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `tmp-${Math.random().toString(36).slice(2, 11)}`
+
+export const JobRequirementsEditor: React.FC<JobRequirementsEditorProps> = ({ open, onOpenChange, jobId, departments }) => {
+  const { data: rows = [], isLoading } = useJobRequiredRoles(jobId)
+  const {
+    mutateAsync: saveChanges,
+    isPending: saving,
+    reset: resetSave,
+  } = useSaveJobRequirements()
+  const [editableRows, setEditableRows] = React.useState<EditableRow[]>([])
+  const [deletedIds, setDeletedIds] = React.useState<string[]>([])
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+
+  const resetStateFromServer = React.useCallback(() => {
+    const next = (rows || []).map(createEditableRow)
+    setEditableRows(next)
+    setDeletedIds([])
   }, [rows])
 
-  const handleAdd = async (dept: string) => {
-    const opts = roleOptionsForDiscipline(dept)
-    const defaultCode = opts[0]?.code || ''
+  const isDirty = React.useMemo(
+    () =>
+      deletedIds.length > 0 ||
+      editableRows.some((row) => row.status === 'new' || row.status === 'updated'),
+    [editableRows, deletedIds],
+  )
+
+  React.useEffect(() => {
+    if (!open) return
+    if (isDirty) return
+    resetStateFromServer()
+  }, [open, rows, isDirty, resetStateFromServer])
+
+  const rowsByDepartment = React.useMemo(() => {
+    const map = new Map<string, EditableRow[]>()
+    departments.forEach((dept) => map.set(dept, []))
+    editableRows.forEach((row) => {
+      const list = map.get(row.department) ?? []
+      list.push(row)
+      map.set(row.department, list)
+    })
+    return map
+  }, [editableRows, departments])
+
+  const handleAdd = (dept: string) => {
+    if (!jobId) return
+    const options = roleOptionsForDiscipline(dept)
+    const defaultCode = options[0]?.code ?? ''
     if (!defaultCode) return
-    await upsert({ job_id: jobId, department: dept, role_code: defaultCode, quantity: 1, notes: null })
+
+    const newRow: EditableRow = {
+      localId: createLocalId(),
+      id: undefined,
+      job_id: jobId,
+      department: dept,
+      role_code: defaultCode,
+      quantity: 1,
+      notes: null,
+      status: 'new',
+    }
+
+    setEditableRows((prev) => [...prev, newRow])
   }
 
-  const handleRoleChange = async (r: any, newCode: string) => {
-    await upsert({ id: r.id, job_id: r.job_id, department: r.department, role_code: newCode, quantity: r.quantity, notes: r.notes })
+  const markRowUpdated = (localId: string, updater: (row: EditableRow) => EditableRow) => {
+    setEditableRows((prev) =>
+      prev.map((row) => {
+        if (row.localId !== localId) return row
+        const updatedRow = updater(row)
+        const nextStatus: EditableRowStatus = row.status === 'new' ? 'new' : 'updated'
+        return { ...updatedRow, status: nextStatus }
+      }),
+    )
   }
 
-  const handleQtyChange = async (r: any, q: number) => {
-    const next = Number.isFinite(q) && q >= 0 ? Math.floor(q) : 0
-    await upsert({ id: r.id, job_id: r.job_id, department: r.department, role_code: r.role_code, quantity: next, notes: r.notes })
+  const handleRoleChange = (localId: string, newCode: string) => {
+    markRowUpdated(localId, (row) => ({ ...row, role_code: newCode }))
   }
 
-  const handleDelete = async (r: any) => {
-    await remove({ id: r.id, job_id: r.job_id })
+  const handleQtyChange = (localId: string, value: number) => {
+    const next = Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0
+    markRowUpdated(localId, (row) => ({ ...row, quantity: next }))
+  }
+
+  const handleDelete = (row: EditableRow) => {
+    setEditableRows((prev) => prev.filter((item) => item.localId !== row.localId))
+    if (row.id) {
+      setDeletedIds((prev) => [...prev, row.id!])
+    }
+  }
+
+  const handleCancel = () => {
+    resetStateFromServer()
+    setErrorMessage(null)
+    resetSave()
+  }
+
+  const handleSave = async () => {
+    if (!jobId) return
+
+    const inserts = editableRows
+      .filter((row) => row.status === 'new')
+      .map<JobRequiredRoleInput>((row) => ({
+        job_id: row.job_id,
+        department: row.department,
+        role_code: row.role_code,
+        quantity: row.quantity,
+        notes: row.notes,
+      }))
+
+    const updates = editableRows
+      .filter((row) => row.status === 'updated' && row.id)
+      .map((row) => ({
+        id: row.id!,
+        job_id: row.job_id,
+        department: row.department,
+        role_code: row.role_code,
+        quantity: row.quantity,
+        notes: row.notes,
+      }))
+
+    if (inserts.length === 0 && updates.length === 0 && deletedIds.length === 0) return
+
+    try {
+      const result = await saveChanges({
+        jobId,
+        inserts,
+        updates,
+        deletes: deletedIds,
+      })
+
+      setEditableRows((prev) => {
+        const updatedMap = new Map(result.updated.map((row) => [row.id, row]))
+        const existing = prev
+          .filter((row) => row.status !== 'new')
+          .map((row) => {
+            if (row.id && result.deleted.includes(row.id)) {
+              return null
+            }
+            if (row.id && updatedMap.has(row.id)) {
+              return createEditableRow(updatedMap.get(row.id)!)
+            }
+            return { ...row, status: 'clean' as EditableRowStatus, localId: row.id ?? row.localId }
+          })
+          .filter((row): row is EditableRow => row !== null)
+
+        const inserted = result.inserted.map(createEditableRow)
+        return [...existing, ...inserted]
+      })
+
+      setDeletedIds([])
+      setErrorMessage(null)
+    } catch (err) {
+      console.error(err)
+      const message = err instanceof Error ? err.message : 'Failed to save job requirements.'
+      setErrorMessage(message)
+    }
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Required Crew</DialogTitle>
-        </DialogHeader>
+      <DialogContent className="max-w-2xl space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <DialogHeader>
+            <DialogTitle>Required Crew</DialogTitle>
+            {isLoading && <p className="text-sm text-muted-foreground">Loading requirements…</p>}
+          </DialogHeader>
+          <div className="flex items-center gap-2 pt-2">
+            <Button variant="outline" size="sm" onClick={handleCancel} disabled={saving}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={!isDirty || saving}>
+              Save
+            </Button>
+          </div>
+        </div>
+        {errorMessage && <div className="text-sm text-destructive">{errorMessage}</div>}
         <div className="space-y-6">
-          {departments.map((dept) => (
-            <div key={dept} className="border rounded-md p-3">
-              <div className="flex items-center justify-between mb-2">
-                <div className="font-medium capitalize">{dept}</div>
-                <Button size="sm" variant="outline" onClick={() => handleAdd(dept)} disabled={saving}>Add Role</Button>
+          {departments.map((dept) => {
+            const deptRows = rowsByDepartment.get(dept) ?? []
+            return (
+              <div key={dept} className="border rounded-md p-3">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="font-medium capitalize">{dept}</div>
+                  <Button size="sm" variant="outline" onClick={() => handleAdd(dept)} disabled={saving}>
+                    Add Role
+                  </Button>
+                </div>
+                <div className="space-y-2">
+                  {deptRows.map((row) => (
+                    <div key={row.localId} className="grid grid-cols-12 gap-2 items-center">
+                      <div className="col-span-7">
+                        <Label className="sr-only">Role</Label>
+                        <Select value={row.role_code} onValueChange={(value) => handleRoleChange(row.localId, value)}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a role" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {roleOptionsForDiscipline(dept).map((opt) => (
+                              <SelectItem key={opt.code} value={opt.code}>
+                                {opt.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="col-span-3">
+                        <Label className="sr-only">Qty</Label>
+                        <Input
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={row.quantity}
+                          onChange={(event) => handleQtyChange(row.localId, Number(event.target.value))}
+                        />
+                      </div>
+                      <div className="col-span-2 flex justify-end">
+                        <Button variant="destructive" size="sm" onClick={() => handleDelete(row)} disabled={saving}>
+                          Delete
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                  {deptRows.length === 0 && (
+                    <div className="text-sm text-muted-foreground">No roles configured</div>
+                  )}
+                </div>
               </div>
-              <div className="space-y-2">
-                {(byDept.get(dept) || []).map((r) => (
-                  <div key={r.id} className="grid grid-cols-12 gap-2 items-center">
-                    <div className="col-span-7">
-                      <Label className="sr-only">Role</Label>
-                      <Select defaultValue={r.role_code} onValueChange={(v) => handleRoleChange(r, v)}>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select a role" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {roleOptionsForDiscipline(dept).map((opt) => (
-                            <SelectItem key={opt.code} value={opt.code}>{opt.label}</SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="col-span-3">
-                      <Label className="sr-only">Qty</Label>
-                      <Input type="number" min={0} step={1} defaultValue={r.quantity} onBlur={(e) => handleQtyChange(r, Number(e.target.value))} />
-                    </div>
-                    <div className="col-span-2 flex justify-end">
-                      <Button variant="destructive" size="sm" onClick={() => handleDelete(r)} disabled={deleting}>Delete</Button>
-                    </div>
-                  </div>
-                ))}
-                {(byDept.get(dept) || []).length === 0 && (
-                  <div className="text-sm text-muted-foreground">No roles configured</div>
-                )}
-              </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/hooks/useJobRequiredRoles.ts
+++ b/src/hooks/useJobRequiredRoles.ts
@@ -22,6 +22,30 @@ export interface RequiredRoleSummaryItem {
   roles: Array<{ role_code: string; quantity: number; notes?: string | null }>
 }
 
+export type JobRequiredRoleInput = Omit<
+  JobRequiredRoleRow,
+  'id' | 'created_at' | 'updated_at' | 'created_by' | 'updated_by'
+>
+
+type JobRequiredRoleUpdate = Pick<
+  JobRequiredRoleRow,
+  'id' | 'job_id' | 'department' | 'role_code' | 'quantity' | 'notes'
+>
+
+export interface SaveJobRequirementsPayload {
+  jobId: string
+  inserts: JobRequiredRoleInput[]
+  updates: JobRequiredRoleUpdate[]
+  deletes: string[]
+}
+
+interface SaveJobRequirementsResult {
+  jobId: string
+  inserted: JobRequiredRoleRow[]
+  updated: JobRequiredRoleRow[]
+  deleted: string[]
+}
+
 function parseSummaryRow(row: any): RequiredRoleSummaryItem | null {
   if (!row) return null
   const roles = Array.isArray(row.roles)
@@ -84,179 +108,186 @@ export function useRequiredRoleSummary(jobId: string) {
   return { ...q, byDepartment }
 }
 
-export function useUpsertJobRequiredRole() {
+async function fetchDepartmentRoleSummaries(jobId: string): Promise<RequiredRoleSummaryItem[]> {
+  const { data: summaryData, error: summaryError } = await supabase
+    .from('job_required_roles_summary')
+    .select('department, total_required, roles')
+    .eq('job_id', jobId)
+
+  if (summaryError) throw summaryError
+
+  const summaryItems = (summaryData || [])
+    .map(parseSummaryRow)
+    .filter(Boolean) as RequiredRoleSummaryItem[]
+
+  return summaryItems
+}
+
+async function broadcastJobRequirementsUpdate(
+  jobId: string,
+  changeSummary: SaveJobRequirementsResult,
+) {
+  try {
+    const { data: sessionData } = await supabase.auth.getSession()
+    const actorId = sessionData?.session?.user?.id ?? null
+
+    const summaryItems = await fetchDepartmentRoleSummaries(jobId)
+
+    const departmentRoles = summaryItems.map((item) => ({
+      department: item.department,
+      total_required: item.total_required,
+      roles: item.roles.map((role) => ({
+        role_code: role.role_code,
+        quantity: role.quantity,
+        notes: role.notes ?? null,
+      })),
+    }))
+
+    const activityPayload = {
+      department_roles: departmentRoles,
+      last_change: {
+        type: 'batch' as const,
+        created: changeSummary.inserted.map((row) => ({
+          id: row.id,
+          department: row.department,
+          role_code: row.role_code,
+          quantity: row.quantity,
+        })),
+        updated: changeSummary.updated.map((row) => ({
+          id: row.id,
+          department: row.department,
+          role_code: row.role_code,
+          quantity: row.quantity,
+        })),
+        deleted: changeSummary.deleted,
+      },
+    }
+
+    const activityResult = await supabase.rpc('log_activity', {
+      _code: 'job.requirements.updated',
+      _job_id: jobId,
+      _entity_type: 'job_required_roles',
+      _entity_id:
+        changeSummary.inserted[0]?.id ??
+        changeSummary.updated[0]?.id ??
+        changeSummary.deleted[0] ??
+        jobId,
+      _payload: activityPayload,
+    })
+
+    if (activityResult.error) {
+      console.warn('Failed to record job requirements activity:', activityResult.error)
+    }
+
+    const pushResult = await supabase.functions.invoke('push', {
+      body: {
+        action: 'broadcast',
+        type: 'job.requirements.updated',
+        job_id: jobId,
+        actor_id: actorId ?? undefined,
+        department_roles: departmentRoles,
+      },
+    })
+
+    if (pushResult.error) {
+      console.warn('Failed to invoke job requirements push:', pushResult.error)
+    }
+  } catch (err) {
+    console.warn('Failed to broadcast job requirements update:', err)
+  }
+}
+
+export function useSaveJobRequirements() {
   const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: async (payload: Omit<JobRequiredRoleRow, 'id' | 'created_at' | 'updated_at' | 'created_by' | 'updated_by'> & { id?: string }) => {
-      const { id, ...rest } = payload
-      if (id) {
+  return useMutation<SaveJobRequirementsResult, unknown, SaveJobRequirementsPayload>({
+    mutationFn: async ({ jobId, inserts, updates, deletes }) => {
+      const inserted: JobRequiredRoleRow[] = []
+      const updated: JobRequiredRoleRow[] = []
+
+      if (inserts.length > 0) {
         const { data, error } = await supabase
           .from('job_required_roles')
-          .update(rest)
-          .eq('id', id)
+          .insert(inserts)
           .select('*')
-          .single()
         if (error) throw error
-        return { row: data as JobRequiredRoleRow, action: 'updated' as const }
-      } else {
-        const { data, error } = await supabase
-          .from('job_required_roles')
-          .insert(rest)
-          .select('*')
-          .single()
-        if (error) throw error
-        return { row: data as JobRequiredRoleRow, action: 'created' as const }
+        inserted.push(...((data || []) as JobRequiredRoleRow[]))
       }
+
+      if (updates.length > 0) {
+        const { data, error } = await supabase
+          .from('job_required_roles')
+          .upsert(updates, { onConflict: 'id' })
+          .select('*')
+        if (error) throw error
+        updated.push(...((data || []) as JobRequiredRoleRow[]))
+      }
+
+      if (deletes.length > 0) {
+        const { error } = await supabase
+          .from('job_required_roles')
+          .delete()
+          .in('id', deletes)
+        if (error) throw error
+      }
+
+      return { jobId, inserted, updated, deleted: deletes }
     },
-    onSuccess: ({ row, action }) => {
-      queryClient.invalidateQueries({ queryKey: ['job-required-roles', row.job_id] })
-      queryClient.invalidateQueries({ queryKey: ['job-required-summary', row.job_id] })
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['job-required-roles', result.jobId] })
+      queryClient.invalidateQueries({ queryKey: ['job-required-summary', result.jobId] })
       queryClient.invalidateQueries({ queryKey: ['jobs'] })
-      void (async () => {
-        try {
-          const jobId = row.job_id
-          const { data: sessionData } = await supabase.auth.getSession()
-          const actorId = sessionData?.session?.user?.id ?? null
 
-          const { data: summaryData, error: summaryError } = await supabase
-            .from('job_required_roles_summary')
-            .select('department, total_required, roles')
-            .eq('job_id', jobId)
+      void broadcastJobRequirementsUpdate(result.jobId, result)
+    },
+  })
+}
 
-          if (summaryError) throw summaryError
+export function useUpsertJobRequiredRole() {
+  const saveMutation = useSaveJobRequirements()
+  return useMutation({
+    mutationFn: async (
+      payload: JobRequiredRoleInput & { id?: string },
+    ) => {
+      const { id, ...rest } = payload
+      const result = await saveMutation.mutateAsync({
+        jobId: rest.job_id,
+        inserts: id ? [] : [rest],
+        updates: id
+          ? [
+              {
+                id,
+                ...rest,
+              },
+            ]
+          : [],
+        deletes: [],
+      })
 
-          const summaryItems = (summaryData || [])
-            .map(parseSummaryRow)
-            .filter(Boolean) as RequiredRoleSummaryItem[]
+      if (id) {
+        const row = result.updated.find((item) => item.id === id)
+        if (!row) throw new Error('Failed to update job required role')
+        return { row, action: 'updated' as const }
+      }
 
-          const departmentRoles = summaryItems.map((item) => ({
-            department: item.department,
-            total_required: item.total_required,
-            roles: item.roles.map((role) => ({
-              role_code: role.role_code,
-              quantity: role.quantity,
-              notes: role.notes ?? null,
-            })),
-          }))
-
-          const activityPayload = {
-            department_roles: departmentRoles,
-            last_change: {
-              type: action,
-              department: row.department,
-              role_code: row.role_code,
-              quantity: row.quantity,
-            },
-          }
-
-          const activityResult = await supabase.rpc('log_activity', {
-            _code: 'job.requirements.updated',
-            _job_id: jobId,
-            _entity_type: 'job_required_roles',
-            _entity_id: row.id,
-            _payload: activityPayload,
-          })
-
-          if (activityResult.error) {
-            console.warn('Failed to record job requirements activity:', activityResult.error)
-          }
-
-          const pushResult = await supabase.functions.invoke('push', {
-            body: {
-              action: 'broadcast',
-              type: 'job.requirements.updated',
-              job_id: jobId,
-              actor_id: actorId ?? undefined,
-              department_roles: departmentRoles,
-            },
-          })
-
-          if (pushResult.error) {
-            console.warn('Failed to invoke job requirements push:', pushResult.error)
-          }
-        } catch (err) {
-          console.warn('Failed to broadcast job requirements update:', err)
-        }
-      })()
+      const row = result.inserted[0]
+      if (!row) throw new Error('Failed to create job required role')
+      return { row, action: 'created' as const }
     },
   })
 }
 
 export function useDeleteJobRequiredRole() {
-  const queryClient = useQueryClient()
+  const saveMutation = useSaveJobRequirements()
   return useMutation({
     mutationFn: async ({ id, job_id }: { id: string; job_id: string }) => {
-      const { error } = await supabase.from('job_required_roles').delete().eq('id', id)
-      if (error) throw error
+      await saveMutation.mutateAsync({
+        jobId: job_id,
+        inserts: [],
+        updates: [],
+        deletes: [id],
+      })
+
       return { id, job_id }
-    },
-    onSuccess: ({ job_id, id }) => {
-      queryClient.invalidateQueries({ queryKey: ['job-required-roles', job_id] })
-      queryClient.invalidateQueries({ queryKey: ['job-required-summary', job_id] })
-      queryClient.invalidateQueries({ queryKey: ['jobs'] })
-      void (async () => {
-        try {
-          const { data: sessionData } = await supabase.auth.getSession()
-          const actorId = sessionData?.session?.user?.id ?? null
-
-          const { data: summaryData, error: summaryError } = await supabase
-            .from('job_required_roles_summary')
-            .select('department, total_required, roles')
-            .eq('job_id', job_id)
-
-          if (summaryError) throw summaryError
-
-          const summaryItems = (summaryData || [])
-            .map(parseSummaryRow)
-            .filter(Boolean) as RequiredRoleSummaryItem[]
-
-          const departmentRoles = summaryItems.map((item) => ({
-            department: item.department,
-            total_required: item.total_required,
-            roles: item.roles.map((role) => ({
-              role_code: role.role_code,
-              quantity: role.quantity,
-              notes: role.notes ?? null,
-            })),
-          }))
-
-          const activityPayload = {
-            department_roles: departmentRoles,
-            last_change: {
-              type: 'deleted',
-              deleted_role_id: id,
-            },
-          }
-
-          const activityResult = await supabase.rpc('log_activity', {
-            _code: 'job.requirements.updated',
-            _job_id: job_id,
-            _entity_type: 'job_required_roles',
-            _entity_id: id,
-            _payload: activityPayload,
-          })
-
-          if (activityResult.error) {
-            console.warn('Failed to record job requirements activity:', activityResult.error)
-          }
-
-          const pushResult = await supabase.functions.invoke('push', {
-            body: {
-              action: 'broadcast',
-              type: 'job.requirements.updated',
-              job_id,
-              actor_id: actorId ?? undefined,
-              department_roles: departmentRoles,
-            },
-          })
-
-          if (pushResult.error) {
-            console.warn('Failed to invoke job requirements push:', pushResult.error)
-          }
-        } catch (err) {
-          console.warn('Failed to broadcast job requirements deletion:', err)
-        }
-      })()
     },
   })
 }


### PR DESCRIPTION
## Summary
- keep job requirements editing local to the dialog with save/cancel controls and staged changes
- add a batched `useSaveJobRequirements` helper that persists inserts, updates, and deletions before logging and broadcasting
- update legacy upsert/delete hooks to delegate to the new batch save logic

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*
- npm run build *(fails: vite: not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912596d6ed4832fb43b777d19593488)