### PR TITLE
Scope Flex crew sync by department

### DIFF
--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -376,7 +376,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
       setIsSyncing(true);
       toast({ title: 'Syncing', description: 'Syncing crew to Flex…' });
       const { data, error } = await supabase.functions.invoke('sync-flex-crew-for-job', {
-        body: { job_id: jobId }
+        body: { job_id: jobId, departments: [dept] }
       });
       if (error) {
         console.error('Flex sync error:', error);

--- a/src/components/jobs/JobAssignments.tsx
+++ b/src/components/jobs/JobAssignments.tsx
@@ -90,7 +90,7 @@ export const JobAssignments = ({ jobId, department, userRole }: JobAssignmentsPr
       setIsSyncing(true);
       toast.info('Syncing crew to Flex…');
       const { data, error } = await supabase.functions.invoke('sync-flex-crew-for-job', {
-        body: { job_id: jobId }
+        body: { job_id: jobId, departments: [department] }
       });
       if (error) {
         console.error('Flex sync error:', error);


### PR DESCRIPTION
## Summary
- include the current department when syncing job assignments to Flex from the assignments list
- ensure the job assignment dialog also scopes Flex sync requests to the selected department

## Testing
- not run (requires Flex/Supabase integration for verification)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69135684ce54832f8c5056f9111ff524)