### PR TITLE
Traducir Festival Management completo al español

### DIFF
--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -36,7 +36,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
         console.error("Error fetching files:", error);
         toast({
           title: "Error",
-          description: "Failed to fetch files",
+          description: "No se pudieron obtener los archivos",
           variant: "destructive",
         });
         return;
@@ -47,7 +47,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       console.error("Error fetching files:", error);
       toast({
         title: "Error",
-        description: "Failed to fetch files",
+        description: "No se pudieron obtener los archivos",
         variant: "destructive",
       });
     }
@@ -95,8 +95,8 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       }
 
       toast({
-        title: "Success",
-        description: "File uploaded successfully",
+        title: "Éxito",
+        description: "Archivo cargado correctamente",
       });
 
       fetchFiles();
@@ -104,7 +104,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       console.error("Error uploading file:", error);
       toast({
         title: "Error",
-        description: "Failed to upload file",
+        description: "No se pudo cargar el archivo",
         variant: "destructive",
       });
     } finally {
@@ -138,8 +138,8 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       }
 
       toast({
-        title: "Success",
-        description: "File deleted successfully",
+        title: "Éxito",
+        description: "Archivo eliminado correctamente",
       });
 
       fetchFiles();
@@ -147,7 +147,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       console.error("Error deleting file:", error);
       toast({
         title: "Error",
-        description: "Failed to delete file",
+        description: "No se pudo eliminar el archivo",
         variant: "destructive",
       });
     } finally {
@@ -177,7 +177,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       console.error("Error downloading file:", error);
       toast({
         title: "Error",
-        description: "Failed to download file",
+        description: "No se pudo descargar el archivo",
         variant: "destructive",
       });
     }
@@ -198,7 +198,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       console.error("Error getting file URL:", error);
       toast({
         title: "Error",
-        description: "Failed to view file",
+        description: "No se pudo ver el archivo",
         variant: "destructive",
       });
     }
@@ -209,12 +209,12 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="max-w-2xl">
           <DialogHeader>
-            <DialogTitle>Manage Files</DialogTitle>
+            <DialogTitle>Gestionar Archivos</DialogTitle>
           </DialogHeader>
 
           <div className="space-y-4">
             <div>
-              <Label htmlFor="file-upload">Upload File</Label>
+              <Label htmlFor="file-upload">Cargar Archivo</Label>
               <div className="mt-1 flex items-center gap-4">
                 <Input
                   id="file-upload"
@@ -228,9 +228,9 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
             </div>
 
             <div className="border rounded-lg p-4">
-              <h3 className="font-medium mb-2">Files</h3>
+              <h3 className="font-medium mb-2">Archivos</h3>
               {files.length === 0 ? (
-                <p className="text-sm text-muted-foreground">No files uploaded yet.</p>
+                <p className="text-sm text-muted-foreground">Aún no se han cargado archivos.</p>
               ) : (
                 <div className="space-y-2">
                   {files.map((file) => (
@@ -248,7 +248,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
                             variant="ghost"
                             size="sm"
                             onClick={() => handleViewFile(file)}
-                            title="View file"
+                            title="Ver archivo"
                           >
                             <Eye className="h-4 w-4" />
                           </Button>
@@ -257,7 +257,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
                           variant="ghost"
                           size="sm"
                           onClick={() => downloadFile(file)}
-                          title="Download file"
+                          title="Descargar archivo"
                         >
                           <Upload className="h-4 w-4" />
                         </Button>
@@ -268,7 +268,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
                             setSelectedFile(file);
                             setDeleteDialogOpen(true);
                           }}
-                          title="Delete file"
+                          title="Eliminar archivo"
                         >
                           <Trash2 className="h-4 w-4 text-destructive" />
                         </Button>
@@ -285,14 +285,14 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete File</AlertDialogTitle>
+            <AlertDialogTitle>Eliminar Archivo</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to delete this file? This action cannot be undone.
+              ¿Está seguro que desea eliminar este archivo? Esta acción no se puede deshacer.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleFileDelete}>Delete</AlertDialogAction>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleFileDelete}>Eliminar</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/festival/ArtistForm.tsx
+++ b/src/components/festival/ArtistForm.tsx
@@ -94,7 +94,7 @@ export const ArtistForm = () => {
     if (!token) {
       toast({
         title: "Error",
-        description: "Invalid form URL",
+        description: "URL de formulario inválida",
         variant: "destructive",
       });
       return;
@@ -110,21 +110,21 @@ export const ArtistForm = () => {
         .single();
 
       if (formError) {
-        throw new Error('Invalid form link');
+        throw new Error('Enlace de formulario inválido');
       }
 
       if (!formInfo) {
-        throw new Error('Form not found');
+        throw new Error('Formulario no encontrado');
       }
 
       // Check if form is expired
       if (new Date(formInfo.expires_at) < new Date()) {
-        throw new Error('This form link has expired');
+        throw new Error('Este enlace de formulario ha expirado');
       }
 
       // Check if form is already completed
       if (formInfo.status !== 'pending') {
-        throw new Error('This form has already been submitted');
+        throw new Error('Este formulario ya ha sido enviado');
       }
 
       // Ensure wired_mics is properly serialized
@@ -211,8 +211,8 @@ export const ArtistForm = () => {
       if (updateFormError) throw updateFormError;
 
       toast({
-        title: "Success",
-        description: "Form submitted successfully",
+        title: "Éxito",
+        description: "Formulario enviado correctamente",
       });
 
       // Redirect to a thank you page
@@ -232,15 +232,15 @@ export const ArtistForm = () => {
   return (
     <div className="min-h-screen bg-background p-6">
       <div className="max-w-4xl mx-auto space-y-8">
-        <h1 className="text-2xl font-bold">Artist Technical Requirements Form</h1>
-        
+        <h1 className="text-2xl font-bold">Formulario de Requerimientos Técnicos del Artista</h1>
+
         <form onSubmit={handleSubmit} className="space-y-8">
           <div className="grid gap-6">
             {/* Basic Info */}
             <div className="space-y-4">
-              <h2 className="text-xl font-semibold">Basic Information</h2>
+              <h2 className="text-xl font-semibold">Información Básica</h2>
               <div className="space-y-2">
-                <Label>Artist/Band Name</Label>
+                <Label>Nombre del Artista/Banda</Label>
                 <Input
                   type="text"
                   value={formData.name || ""}
@@ -251,7 +251,7 @@ export const ArtistForm = () => {
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Show Start Time</Label>
+                  <Label>Hora de Inicio del Show</Label>
                   <Input
                     type="time"
                     value={formData.show_start || ""}
@@ -259,7 +259,7 @@ export const ArtistForm = () => {
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label>Show End Time</Label>
+                  <Label>Hora de Fin del Show</Label>
                   <Input
                     type="time"
                     value={formData.show_end || ""}
@@ -270,18 +270,18 @@ export const ArtistForm = () => {
 
               <div className="space-y-4">
                 <div className="flex items-center space-x-2">
-                  <Checkbox 
+                  <Checkbox
                     id="soundcheck"
                     checked={formData.soundcheck}
                     onCheckedChange={(checked) => setFormData(prev => ({ ...prev, soundcheck: !!checked }))}
                   />
-                  <Label htmlFor="soundcheck">Soundcheck Required</Label>
+                  <Label htmlFor="soundcheck">Requiere Soundcheck</Label>
                 </div>
 
                 {formData.soundcheck && (
                   <div className="grid grid-cols-2 gap-4 ml-6">
                     <div className="space-y-2">
-                      <Label>Soundcheck Start</Label>
+                      <Label>Inicio del Soundcheck</Label>
                       <Input
                         type="time"
                         value={formData.soundcheck_start || ""}
@@ -289,7 +289,7 @@ export const ArtistForm = () => {
                       />
                     </div>
                     <div className="space-y-2">
-                      <Label>Soundcheck End</Label>
+                      <Label>Fin del Soundcheck</Label>
                       <Input
                         type="time"
                         value={formData.soundcheck_end || ""}
@@ -300,37 +300,37 @@ export const ArtistForm = () => {
                 )}
 
                 <div className="flex items-center space-x-2">
-                  <Checkbox 
+                  <Checkbox
                     id="after-midnight"
                     checked={formData.isaftermidnight}
                     onCheckedChange={(checked) => setFormData(prev => ({ ...prev, isaftermidnight: !!checked }))}
                   />
-                  <Label htmlFor="after-midnight">Show is after midnight</Label>
+                  <Label htmlFor="after-midnight">El show es después de medianoche</Label>
                 </div>
 
                 <div className="flex items-center space-x-2">
-                  <Checkbox 
+                  <Checkbox
                     id="rider-missing"
                     checked={formData.rider_missing}
                     onCheckedChange={(checked) => setFormData(prev => ({ ...prev, rider_missing: !!checked }))}
                   />
-                  <Label htmlFor="rider-missing">Rider is missing</Label>
+                  <Label htmlFor="rider-missing">El rider está faltando</Label>
                 </div>
               </div>
             </div>
 
             {/* FOH Console Section */}
             <div className="space-y-4">
-              <h2 className="text-xl font-semibold">FOH Console</h2>
+              <h2 className="text-xl font-semibold">Console FOH</h2>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Console Model</Label>
+                  <Label>Modelo de Console</Label>
                   <Select
                     value={formData.foh_console || ""}
                     onValueChange={(value) => setFormData(prev => ({ ...prev, foh_console: value }))}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select console" />
+                      <SelectValue placeholder="Seleccionar console" />
                     </SelectTrigger>
                     <SelectContent>
                       {fohOptions.map((option) => (
@@ -342,7 +342,7 @@ export const ArtistForm = () => {
                   </Select>
                 </div>
                 <div className="space-y-2">
-                  <Label>Provided By</Label>
+                  <Label>Proporcionado Por</Label>
                   <Select
                     value={formData.foh_console_provided_by || "festival"}
                     onValueChange={(value: "festival" | "band") => setFormData(prev => ({ ...prev, foh_console_provided_by: value }))}
@@ -352,33 +352,33 @@ export const ArtistForm = () => {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="festival">Festival</SelectItem>
-                      <SelectItem value="band">Band</SelectItem>
+                      <SelectItem value="band">Banda</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
               </div>
               <div className="flex items-center space-x-2">
-                <Checkbox 
+                <Checkbox
                   id="foh-tech"
                   checked={formData.foh_tech}
                   onCheckedChange={(checked) => setFormData(prev => ({ ...prev, foh_tech: !!checked }))}
                 />
-                <Label htmlFor="foh-tech">FOH Technician Required</Label>
+                <Label htmlFor="foh-tech">Requiere Técnico FOH</Label>
               </div>
             </div>
 
             {/* Monitor Console Section */}
             <div className="space-y-4">
-              <h2 className="text-xl font-semibold">Monitor Console</h2>
+              <h2 className="text-xl font-semibold">Console de Monitor</h2>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Console Model</Label>
+                  <Label>Modelo de Console</Label>
                   <Select
                     value={formData.mon_console || ""}
                     onValueChange={(value) => setFormData(prev => ({ ...prev, mon_console: value }))}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select console" />
+                      <SelectValue placeholder="Seleccionar console" />
                     </SelectTrigger>
                     <SelectContent>
                       {monOptions.map((option) => (
@@ -390,7 +390,7 @@ export const ArtistForm = () => {
                   </Select>
                 </div>
                 <div className="space-y-2">
-                  <Label>Provided By</Label>
+                  <Label>Proporcionado Por</Label>
                   <Select
                     value={formData.mon_console_provided_by || "festival"}
                     onValueChange={(value: "festival" | "band") => setFormData(prev => ({ ...prev, mon_console_provided_by: value }))}
@@ -400,18 +400,18 @@ export const ArtistForm = () => {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="festival">Festival</SelectItem>
-                      <SelectItem value="band">Band</SelectItem>
+                      <SelectItem value="band">Banda</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
               </div>
               <div className="flex items-center space-x-2">
-                <Checkbox 
+                <Checkbox
                   id="mon-tech"
                   checked={formData.mon_tech}
                   onCheckedChange={(checked) => setFormData(prev => ({ ...prev, mon_tech: !!checked }))}
                 />
-                <Label htmlFor="mon-tech">Monitor Technician Required</Label>
+                <Label htmlFor="mon-tech">Requiere Técnico de Monitor</Label>
               </div>
             </div>
 
@@ -431,18 +431,18 @@ export const ArtistForm = () => {
 
             {/* Notes Section */}
             <div className="space-y-2">
-              <Label>Additional Notes</Label>
+              <Label>Notas Adicionales</Label>
               <Input
                 type="text"
                 value={formData.notes || ""}
                 onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
-                placeholder="Any additional requirements or comments"
+                placeholder="Cualquier requerimiento o comentario adicional"
               />
             </div>
           </div>
 
           <Button type="submit" disabled={isLoading} className="w-full">
-            {isLoading ? "Submitting..." : "Submit Form"}
+            {isLoading ? "Enviando..." : "Enviar Formulario"}
           </Button>
         </form>
       </div>

--- a/src/components/festival/ArtistFormLinkDialog.tsx
+++ b/src/components/festival/ArtistFormLinkDialog.tsx
@@ -29,7 +29,7 @@ export const ArtistFormLinkDialog = ({
     if (!artistId) {
       toast({
         title: "Error",
-        description: "Artist ID is required to generate a form link.",
+        description: "Se requiere el ID del artista para generar un enlace de formulario.",
         variant: "destructive",
       });
       return;
@@ -76,16 +76,16 @@ export const ArtistFormLinkDialog = ({
 
       const formUrl = `${window.location.origin}/festival/artist-form/${data.token}`;
       setFormLink(formUrl);
-      
+
       toast({
-        title: "Link generated",
-        description: "New form link has been generated successfully.",
+        title: "Enlace generado",
+        description: "El nuevo enlace de formulario ha sido generado correctamente.",
       });
     } catch (error: any) {
       console.error('Error generating form link:', error);
       toast({
         title: "Error",
-        description: "Failed to generate form link.",
+        description: "No se pudo generar el enlace del formulario.",
         variant: "destructive",
       });
     } finally {
@@ -97,13 +97,13 @@ export const ArtistFormLinkDialog = ({
     try {
       await navigator.clipboard.writeText(formLink);
       toast({
-        title: "Copied",
-        description: "Link copied to clipboard",
+        title: "Copiado",
+        description: "Enlace copiado al portapapeles",
       });
     } catch (error) {
       toast({
         title: "Error",
-        description: "Failed to copy link",
+        description: "No se pudo copiar el enlace",
         variant: "destructive",
       });
     }
@@ -139,7 +139,7 @@ export const ArtistFormLinkDialog = ({
           setFormLink("");
           toast({
             title: "Error",
-            description: "Failed to check existing form link.",
+            description: "No se pudo verificar el enlace de formulario existente.",
             variant: "destructive",
           });
         }
@@ -153,9 +153,9 @@ export const ArtistFormLinkDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>Form Link for {artistName}</DialogTitle>
+          <DialogTitle>Enlace de Formulario para {artistName}</DialogTitle>
         </DialogHeader>
-        
+
         <div className="space-y-4 mt-4">
           {formLink ? (
             <>
@@ -169,7 +169,7 @@ export const ArtistFormLinkDialog = ({
                   variant="outline"
                   size="icon"
                   onClick={copyToClipboard}
-                  title="Copy link"
+                  title="Copiar enlace"
                 >
                   <Copy className="h-4 w-4" />
                 </Button>
@@ -180,7 +180,7 @@ export const ArtistFormLinkDialog = ({
                 disabled={isLoading}
               >
                 <RefreshCcw className="h-4 w-4 mr-2" />
-                Generate New Link
+                Generar Nuevo Enlace
               </Button>
             </>
           ) : (
@@ -189,7 +189,7 @@ export const ArtistFormLinkDialog = ({
               className="w-full"
               disabled={isLoading}
             >
-              Generate Link
+              Generar Enlace
             </Button>
           )}
         </div>

--- a/src/components/festival/ArtistFormLinksDialog.tsx
+++ b/src/components/festival/ArtistFormLinksDialog.tsx
@@ -70,7 +70,7 @@ export const ArtistFormLinksDialog = ({
       console.error('Error fetching artist links:', error);
       toast({
         title: "Error",
-        description: "Failed to fetch artist links",
+        description: "No se pudieron obtener los enlaces de artistas",
         variant: "destructive",
       });
     } finally {
@@ -112,14 +112,14 @@ export const ArtistFormLinksDialog = ({
 
       await fetchArtistLinks();
       toast({
-        title: "Success",
-        description: "Generated missing links successfully",
+        title: "Éxito",
+        description: "Enlaces faltantes generados correctamente",
       });
     } catch (error) {
       console.error('Error generating links:', error);
       toast({
         title: "Error",
-        description: "Failed to generate links",
+        description: "No se pudieron generar los enlaces",
         variant: "destructive",
       });
     } finally {
@@ -135,14 +135,14 @@ export const ArtistFormLinksDialog = ({
       return acc;
     }, {} as Record<string, ArtistLinkData[]>);
 
-    let text = `Artist Form Links - ${format(new Date(selectedDate), 'dd/MM/yyyy')}\n\n`;
+    let text = `Enlaces de Formularios de Artistas - ${format(new Date(selectedDate), 'dd/MM/yyyy')}\n\n`;
 
     Object.entries(groupedByStage).forEach(([stage, artists]) => {
       text += `${stage}:\n`;
       artists.forEach(artist => {
-        const link = artist.token 
+        const link = artist.token
           ? `${window.location.origin}/festival/artist-form/${artist.token}`
-          : 'No link generated yet';
+          : 'Enlace aún no generado';
         text += `${artist.name} - ${link}\n`;
       });
       text += '\n';
@@ -150,26 +150,26 @@ export const ArtistFormLinksDialog = ({
 
     navigator.clipboard.writeText(text);
     toast({
-      title: "Copied",
-      description: "All links copied to clipboard",
+      title: "Copiado",
+      description: "Todos los enlaces copiados al portapapeles",
     });
   };
 
   const copyStageLinks = (stage: number) => {
     const stageArtists = artistLinks.filter(a => a.stage === stage);
     let text = `Stage ${stage} - ${format(new Date(selectedDate), 'dd/MM/yyyy')}\n\n`;
-    
+
     stageArtists.forEach(artist => {
-      const link = artist.token 
+      const link = artist.token
         ? `${window.location.origin}/festival/artist-form/${artist.token}`
-        : 'No link generated yet';
+        : 'Enlace aún no generado';
       text += `${artist.name} - ${link}\n`;
     });
 
     navigator.clipboard.writeText(text);
     toast({
-      title: "Copied",
-      description: `Stage ${stage} links copied to clipboard`,
+      title: "Copiado",
+      description: `Enlaces del Stage ${stage} copiados al portapapeles`,
     });
   };
 
@@ -191,18 +191,18 @@ export const ArtistFormLinksDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Artist Form Links - {format(new Date(selectedDate), 'dd/MM/yyyy')}</DialogTitle>
+          <DialogTitle>Enlaces de Formularios de Artistas - {format(new Date(selectedDate), 'dd/MM/yyyy')}</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-6">
           <div className="flex justify-between items-center">
             <Button onClick={generateLinks} disabled={isGenerating}>
               <RefreshCcw className={`h-4 w-4 mr-2 ${isGenerating ? 'animate-spin' : ''}`} />
-              Generate Missing Links
+              Generar Enlaces Faltantes
             </Button>
             <Button onClick={copyAllLinks}>
               <Copy className="h-4 w-4 mr-2" />
-              Copy All Links
+              Copiar Todos los Enlaces
             </Button>
           </div>
 
@@ -212,7 +212,7 @@ export const ArtistFormLinksDialog = ({
                 <h3 className="text-lg font-semibold">Stage {stage}</h3>
                 <Button variant="outline" size="sm" onClick={() => copyStageLinks(stage)}>
                   <Copy className="h-4 w-4 mr-2" />
-                  Copy Stage Links
+                  Copiar Enlaces del Stage
                 </Button>
               </div>
               <div className="border rounded-lg divide-y">
@@ -225,11 +225,11 @@ export const ArtistFormLinksDialog = ({
                         {artist.token ? (
                           <>
                             {artist.status === 'expired' && (
-                              <Badge variant="destructive">Expired</Badge>
+                              <Badge variant="destructive">Expirado</Badge>
                             )}
                             {artist.expires_at && isAfter(new Date(artist.expires_at), new Date()) && (
                               <Badge variant="secondary">
-                                Expires {format(new Date(artist.expires_at), 'dd/MM/yyyy')}
+                                Expira {format(new Date(artist.expires_at), 'dd/MM/yyyy')}
                               </Badge>
                             )}
                             <Button
@@ -239,8 +239,8 @@ export const ArtistFormLinksDialog = ({
                                 const link = `${window.location.origin}/festival/artist-form/${artist.token}`;
                                 navigator.clipboard.writeText(link);
                                 toast({
-                                  title: "Copied",
-                                  description: "Link copied to clipboard",
+                                  title: "Copiado",
+                                  description: "Enlace copiado al portapapeles",
                                 });
                               }}
                             >
@@ -248,7 +248,7 @@ export const ArtistFormLinksDialog = ({
                             </Button>
                           </>
                         ) : (
-                          <Badge variant="outline">No link generated</Badge>
+                          <Badge variant="outline">Sin enlace generado</Badge>
                         )}
                       </div>
                     </div>

--- a/src/components/festival/ArtistFormSubmissionDialog.tsx
+++ b/src/components/festival/ArtistFormSubmissionDialog.tsx
@@ -74,18 +74,18 @@ export const ArtistFormSubmissionDialog = ({
     try {
       // Create PDF
       const doc = new jsPDF();
-      
+
       // Add title
       doc.setFontSize(20);
-      doc.text("Artist Form Submission", 20, 20);
-      
+      doc.text("Envío de Formulario de Artista", 20, 20);
+
       // Add submission date
       doc.setFontSize(12);
-      doc.text(`Submitted on: ${format(new Date(submission.submitted_at), 'PPpp')}`, 20, 35);
-      
+      doc.text(`Enviado el: ${format(new Date(submission.submitted_at), 'PPpp')}`, 20, 35);
+
       // Add form data
       doc.setFontSize(14);
-      doc.text("Form Data:", 20, 50);
+      doc.text("Datos del Formulario:", 20, 50);
       
       // Convert form data to formatted text
       const formDataText = Object.entries(submission.form_data)
@@ -101,24 +101,24 @@ export const ArtistFormSubmissionDialog = ({
       if (submission.notes) {
         const yPos = 65 + (splitText.length * 7);
         doc.setFontSize(14);
-        doc.text("Notes:", 20, yPos);
+        doc.text("Notas:", 20, yPos);
         doc.setFontSize(12);
         const splitNotes = doc.splitTextToSize(submission.notes, 170);
         doc.text(splitNotes, 20, yPos + 10);
       }
 
       // Save the PDF
-      doc.save("form_submission.pdf");
+      doc.save("envio_formulario.pdf");
 
       toast({
-        title: "Success",
-        description: "Form submission downloaded successfully",
+        title: "Éxito",
+        description: "Envío de formulario descargado correctamente",
       });
     } catch (error) {
       console.error('Error downloading submission:', error);
       toast({
         title: "Error",
-        description: "Could not download the form submission",
+        description: "No se pudo descargar el envío del formulario",
         variant: "destructive",
       });
     }
@@ -128,7 +128,7 @@ export const ArtistFormSubmissionDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl max-h-[80vh] flex flex-col">
         <DialogHeader className="flex flex-row items-center justify-between">
-          <DialogTitle>Form Submission Details</DialogTitle>
+          <DialogTitle>Detalles del Envío del Formulario</DialogTitle>
           {submission && (
             <Button
               variant="outline"
@@ -137,7 +137,7 @@ export const ArtistFormSubmissionDialog = ({
               className="ml-auto"
             >
               <Download className="h-4 w-4 mr-2" />
-              Download PDF
+              Descargar PDF
             </Button>
           )}
         </DialogHeader>
@@ -148,17 +148,17 @@ export const ArtistFormSubmissionDialog = ({
           </div>
         ) : !submission ? (
           <div className="text-center p-4 text-muted-foreground">
-            No submission found for this artist.
+            No se encontró envío para este artista.
           </div>
         ) : (
           <ScrollArea className="flex-1">
             <div className="space-y-4 p-4">
               <div className="text-sm text-muted-foreground">
-                Submitted on: {format(new Date(submission.submitted_at), 'PPpp')}
+                Enviado el: {format(new Date(submission.submitted_at), 'PPpp')}
               </div>
-              
+
               <div className="space-y-4">
-                <h3 className="text-lg font-semibold">Submitted Data</h3>
+                <h3 className="text-lg font-semibold">Datos Enviados</h3>
                 <pre className="bg-muted p-4 rounded-lg overflow-auto whitespace-pre-wrap">
                   {JSON.stringify(submission.form_data, null, 2)}
                 </pre>
@@ -166,7 +166,7 @@ export const ArtistFormSubmissionDialog = ({
 
               {submission.notes && (
                 <div className="space-y-2">
-                  <h3 className="text-lg font-semibold">Notes</h3>
+                  <h3 className="text-lg font-semibold">Notas</h3>
                   <p className="text-muted-foreground">{submission.notes}</p>
                 </div>
               )}

--- a/src/components/festival/ArtistManagementDialog.tsx
+++ b/src/components/festival/ArtistManagementDialog.tsx
@@ -50,7 +50,7 @@ export const ArtistManagementDialog = ({
       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto w-[95vw] sm:w-full">
         <DialogHeader>
           <DialogTitle>
-            {artist ? "Edit Artist" : "Add Artist"}
+            {artist ? "Editar Artista" : "Agregar Artista"}
           </DialogTitle>
         </DialogHeader>
         <ArtistManagementForm

--- a/src/components/festival/ArtistManagementForm.tsx
+++ b/src/components/festival/ArtistManagementForm.tsx
@@ -152,7 +152,7 @@ export const ArtistManagementForm = ({
             console.error("Error fetching artist:", error);
             toast({
               title: "Error",
-              description: "Could not load artist details",
+              description: "No se pudieron cargar los detalles del artista",
               variant: "destructive",
             });
           } else if (data) {
@@ -162,7 +162,7 @@ export const ArtistManagementForm = ({
           console.error("Error fetching artist:", error);
           toast({
             title: "Error",
-            description: "Could not load artist details",
+            description: "No se pudieron cargar los detalles del artista",
             variant: "destructive",
           });
         } finally {
@@ -185,20 +185,20 @@ export const ArtistManagementForm = ({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <BasicInfoSection 
-        formData={formData as any} 
+      <BasicInfoSection
+        formData={formData as any}
         onChange={updateFormData}
         gearSetup={combinedSetup?.globalSetup || null}
       />
 
-      <ConsoleSetupSection 
-        formData={formData as any} 
+      <ConsoleSetupSection
+        formData={formData as any}
         onChange={updateFormData}
         gearSetup={combinedSetup?.globalSetup || null}
       />
 
-      <WirelessSetupSection 
-        formData={formData as any} 
+      <WirelessSetupSection
+        formData={formData as any}
         onChange={updateFormData}
         gearSetup={combinedSetup?.globalSetup || null}
       />
@@ -210,31 +210,31 @@ export const ArtistManagementForm = ({
         onWiredMicsChange={(mics) => updateFormData({ wired_mics: mics })}
       />
 
-      <MonitorSetupSection 
-        formData={formData as any} 
+      <MonitorSetupSection
+        formData={formData as any}
         onChange={updateFormData}
         gearSetup={combinedSetup?.globalSetup || null}
       />
 
-      <ExtraRequirementsSection 
-        formData={formData as any} 
+      <ExtraRequirementsSection
+        formData={formData as any}
         onChange={updateFormData}
         gearSetup={combinedSetup?.globalSetup || null}
       />
 
-      <InfrastructureSection 
-        formData={formData as any} 
+      <InfrastructureSection
+        formData={formData as any}
         onChange={updateFormData}
         gearSetup={combinedSetup?.globalSetup || null}
       />
 
-      <NotesSection 
-        formData={formData as any} 
+      <NotesSection
+        formData={formData as any}
         onChange={updateFormData}
       />
 
       <Button type="submit" disabled={isSubmitting} className="w-full">
-        {isSubmitting ? "Saving..." : artist ? "Update Artist" : "Add Artist"}
+        {isSubmitting ? "Guardando..." : artist ? "Actualizar Artista" : "Agregar Artista"}
       </Button>
     </form>
   );

--- a/src/components/festival/ArtistRequirementsForm.tsx
+++ b/src/components/festival/ArtistRequirementsForm.tsx
@@ -59,7 +59,7 @@ export const ArtistRequirementsForm = () => {
       if (!token) {
         toast({
           title: "Error",
-          description: "Invalid form token",
+          description: "Token de formulario inválido",
           variant: "destructive"
         });
         return;
@@ -76,16 +76,16 @@ export const ArtistRequirementsForm = () => {
         if (!formInfo) {
           toast({
             title: "Error",
-            description: "Invalid form token",
+            description: "Token de formulario inválido",
             variant: "destructive"
           });
           return;
         }
-        
+
         if (formInfo.status === 'completed') {
           toast({
-            title: "Form Already Submitted",
-            description: "This form has already been completed.",
+            title: "Formulario Ya Enviado",
+            description: "Este formulario ya ha sido completado.",
             variant: "destructive"
           });
           return;
@@ -104,7 +104,7 @@ export const ArtistRequirementsForm = () => {
         if (!artistData) {
           toast({
             title: "Error",
-            description: "Artist not found",
+            description: "Artista no encontrado",
             variant: "destructive"
           });
           return;
@@ -155,7 +155,7 @@ export const ArtistRequirementsForm = () => {
         console.error('Error fetching form data:', error);
         toast({
           title: "Error",
-          description: "Could not load form data. Please try again later.",
+          description: "No se pudieron cargar los datos del formulario. Por favor intente más tarde.",
           variant: "destructive"
         });
       } finally {
@@ -184,8 +184,8 @@ export const ArtistRequirementsForm = () => {
           const newData = payload.new as FormData;
           if (newData && newData.status === 'completed') {
             toast({
-              title: "Form Status Updated",
-              description: "Your form has been submitted successfully",
+              title: "Estado del Formulario Actualizado",
+              description: "Su formulario ha sido enviado correctamente",
             });
             navigate('/festival/form-submitted');
           }
@@ -212,11 +212,11 @@ export const ArtistRequirementsForm = () => {
 
       if (formError) throw formError;
       if (!formInfo) {
-        throw new Error('Form not found');
+        throw new Error('Formulario no encontrado');
       }
 
       if (formInfo.status === 'completed') {
-        throw new Error('This form has already been submitted');
+        throw new Error('Este formulario ya ha sido enviado');
       }
 
       const { error: submissionError } = await supabase
@@ -239,8 +239,8 @@ export const ArtistRequirementsForm = () => {
       if (updateError) throw updateError;
 
       toast({
-        title: "Success",
-        description: "Your technical requirements have been submitted successfully.",
+        title: "Éxito",
+        description: "Sus requerimientos técnicos han sido enviados correctamente.",
       });
 
       navigate('/festival/form-submitted');
@@ -248,7 +248,7 @@ export const ArtistRequirementsForm = () => {
       console.error('Error submitting form:', error);
       toast({
         title: "Error",
-        description: error.message || "Could not submit form. Please try again later.",
+        description: error.message || "No se pudo enviar el formulario. Por favor intente más tarde.",
         variant: "destructive"
       });
     } finally {
@@ -286,51 +286,51 @@ export const ArtistRequirementsForm = () => {
           
           <Card>
             <CardHeader>
-              <CardTitle>Artist Technical Requirements Form</CardTitle>
+              <CardTitle>Formulario de Requerimientos Técnicos del Artista</CardTitle>
             </CardHeader>
             <CardContent>
               <form onSubmit={handleSubmit} className="space-y-8">
-                <BasicInfoSection 
-                  formData={formData} 
+                <BasicInfoSection
+                  formData={formData}
                   onChange={handleFormChange}
                 />
 
-                <ConsoleSetupSection 
-                  formData={formData} 
-                  onChange={handleFormChange} 
+                <ConsoleSetupSection
+                  formData={formData}
+                  onChange={handleFormChange}
                   gearSetup={gearSetup}
                 />
 
-                <ArtistWirelessSetupSection 
-                  formData={formData} 
+                <ArtistWirelessSetupSection
+                  formData={formData}
                   onChange={handleFormChange}
                 />
 
-                <MonitorSetupSection 
-                  formData={formData} 
-                  onChange={handleFormChange} 
+                <MonitorSetupSection
+                  formData={formData}
+                  onChange={handleFormChange}
                   gearSetup={gearSetup}
                 />
 
-                <ExtraRequirementsSection 
-                  formData={formData} 
-                  onChange={handleFormChange} 
+                <ExtraRequirementsSection
+                  formData={formData}
+                  onChange={handleFormChange}
                   gearSetup={gearSetup}
                 />
 
-                <InfrastructureSection 
-                  formData={formData} 
-                  onChange={handleFormChange} 
+                <InfrastructureSection
+                  formData={formData}
+                  onChange={handleFormChange}
                   gearSetup={gearSetup}
                 />
 
-                <NotesSection 
-                  formData={formData} 
+                <NotesSection
+                  formData={formData}
                   onChange={handleFormChange}
                 />
 
                 <Button type="submit" disabled={isLoading} className="w-full">
-                  {isLoading ? "Submitting..." : "Submit Requirements"}
+                  {isLoading ? "Enviando..." : "Enviar Requerimientos"}
                 </Button>
               </form>
             </CardContent>

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -253,13 +253,14 @@ export const ArtistTable = ({
     if (artist.other_infrastructure) {
       infraItems.push(artist.other_infrastructure);
     }
-    
-    return infraItems.length > 0 ? infraItems.join(", ") : "None";
+
+
+    return infraItems.length > 0 ? infraItems.join(", ") : "Ninguno";
   };
 
   // Helper function to truncate notes for display
   const formatNotes = (notes?: string) => {
-    if (!notes || notes.trim() === '') return "No notes";
+    if (!notes || notes.trim() === '') return "Sin notas";
     return notes.length > 50 ? `${notes.substring(0, 50)}...` : notes;
   };
 
@@ -281,7 +282,7 @@ export const ArtistTable = ({
   // Apply chronological sorting to filtered artists using imported utility
   const sortedFilteredArtists = sortArtistsChronologically(filteredArtists as any) as Artist[];
   const handleDeleteClick = async (artist: Artist) => {
-    if (window.confirm(`Are you sure you want to delete ${artist.name}?`)) {
+    if (window.confirm(`¿Estás seguro de que quieres eliminar ${artist.name}?`)) {
       setDeletingArtistId(artist.id);
       await onDeleteArtist(artist);
       setDeletingArtistId(null);
@@ -292,14 +293,14 @@ export const ArtistTable = ({
     quantity: number;
     exclusive_use?: boolean;
   }> = []) => {
-    if (mics.length === 0) return "None";
+    if (mics.length === 0) return "Ninguno";
     return mics.map(mic => {
       const exclusiveIndicator = mic.exclusive_use ? " (E)" : "";
       return `${mic.quantity}x ${mic.model}${exclusiveIndicator}`;
     }).join(", ");
   };
   const formatWirelessSystems = (systems: any[] = [], isIEM = false) => {
-    if (systems.length === 0) return "None";
+    if (systems.length === 0) return "Ninguno";
     return systems.map(system => {
       if (isIEM) {
         // For IEM: show channels and beltpacks
@@ -433,11 +434,12 @@ export const ArtistTable = ({
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-      
-      toast.success(`PDF generated for ${artist.name}`);
+
+
+      toast.success(`PDF generado para ${artist.name}`);
     } catch (error) {
       console.error('Error generating PDF:', error);
-      toast.error('Failed to generate PDF');
+      toast.error('Error al generar PDF');
     } finally {
       setPrintingArtistId(null);
     }
@@ -457,7 +459,7 @@ export const ArtistTable = ({
     return <div className="w-full">
         <div className="flex items-center justify-center py-8">
           <Loader2 className="h-8 w-8 animate-spin" />
-          <span className="ml-2">Loading artists...</span>
+          <span className="ml-2">Cargando artistas...</span>
         </div>
       </div>;
   }
@@ -468,11 +470,11 @@ export const ArtistTable = ({
           {/* Header */}
           <div className="flex items-center justify-between py-4 px-2">
             <h2 className="text-xl md:text-2xl font-semibold leading-none tracking-tight">
-              Artist Schedule ({sortedFilteredArtists.length} artists)
+              Cronograma de artistas ({sortedFilteredArtists.length} artistas)
             </h2>
             <Button variant="outline" size="sm" onClick={handleViewLinks} className="hidden md:flex">
               <ExternalLink className="h-4 w-4 mr-2" />
-              View All Links
+              Ver todos los enlaces
             </Button>
             <Button variant="outline" size="icon" onClick={handleViewLinks} className="md:hidden">
               <ExternalLink className="h-4 w-4" />
@@ -484,25 +486,25 @@ export const ArtistTable = ({
             <Table className="w-full min-w-full">
               <TableHeader>
                 <TableRow>
-                  <TableHead className="min-w-[140px]">Artist</TableHead>
+                  <TableHead className="min-w-[140px]">Artista</TableHead>
                   <TableHead className="min-w-[80px]">Stage</TableHead>
-                  <TableHead className="min-w-[100px]">Show Time</TableHead>
+                  <TableHead className="min-w-[100px]">Hora del show</TableHead>
                   <TableHead className="min-w-[100px]">Soundcheck</TableHead>
-                  <TableHead className="min-w-[200px]">Consoles</TableHead>
+                  <TableHead className="min-w-[200px]">Consolas</TableHead>
                   <TableHead className="min-w-[180px]">Wireless/IEM</TableHead>
                   <TableHead className="min-w-[140px]">
                     <div className="flex items-center gap-1">
                       <Mic className="h-4 w-4" />
-                      Microphones
+                      Micrófonos
                     </div>
                   </TableHead>
-                  <TableHead className="min-w-[80px]">Monitors</TableHead>
-                  <TableHead className="min-w-[160px]">Infrastructure</TableHead>
+                  <TableHead className="min-w-[80px]">Monitores</TableHead>
+                  <TableHead className="min-w-[160px]">Infraestructura</TableHead>
                   <TableHead className="min-w-[80px]">Extras</TableHead>
-                  <TableHead className="min-w-[120px]">Notes</TableHead>
-                  <TableHead className="min-w-[80px]">Status</TableHead>
-                  <TableHead className="min-w-[100px]">Gear Status</TableHead>
-                  <TableHead className="min-w-[200px]">Actions</TableHead>
+                  <TableHead className="min-w-[120px]">Notas</TableHead>
+                  <TableHead className="min-w-[80px]">Estado</TableHead>
+                  <TableHead className="min-w-[100px]">Estado del equipo</TableHead>
+                  <TableHead className="min-w-[200px]">Acciones</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -514,7 +516,7 @@ export const ArtistTable = ({
                       <TableCell className="min-w-[140px]">
                         <div className="space-y-1">
                           <div className="font-medium">{artist.name}</div>
-                          {artist.isaftermidnight && <Badge variant="outline" className="text-xs bg-blue-700">After Midnight</Badge>}
+                          {artist.isaftermidnight && <Badge variant="outline" className="text-xs bg-blue-700">Después de medianoche</Badge>}
                         </div>
                       </TableCell>
                       <TableCell className="min-w-[80px]">
@@ -528,7 +530,7 @@ export const ArtistTable = ({
                       <TableCell className="min-w-[100px]">
                         {artist.soundcheck ? (
                           <div className="text-sm">
-                            <Badge variant="secondary">Yes</Badge>
+                            <Badge variant="secondary">Sí</Badge>
                             <div className="text-xs text-muted-foreground">
                               {artist.soundcheck_start} - {artist.soundcheck_end}
                             </div>
@@ -541,22 +543,22 @@ export const ArtistTable = ({
                       <TableCell className="min-w-[200px]">
                         <div className="text-sm space-y-1">
                           <div className="flex items-center gap-1 flex-wrap">
-                            <span>FOH: {artist.foh_console || "Not specified"}</span>
+                            <span>FOH: {artist.foh_console || "No especificado"}</span>
                             {artist.foh_console_provided_by && (
                               <Badge variant="outline" className={`text-xs ${getProviderBadge(artist.foh_console_provided_by)}`}>
                                 {artist.foh_console_provided_by}
                               </Badge>
                             )}
-                            {artist.foh_tech && <Badge variant="outline" className="text-xs">Tech</Badge>}
+                            {artist.foh_tech && <Badge variant="outline" className="text-xs">Técnico</Badge>}
                           </div>
                           <div className="flex items-center gap-1 flex-wrap">
-                            <span>MON: {artist.mon_console || "Not specified"}</span>
+                            <span>MON: {artist.mon_console || "No especificado"}</span>
                             {artist.mon_console_provided_by && (
                               <Badge variant="outline" className={`text-xs ${getProviderBadge(artist.mon_console_provided_by)}`}>
                                 {artist.mon_console_provided_by}
                               </Badge>
                             )}
-                            {artist.mon_tech && <Badge variant="outline" className="text-xs">Tech</Badge>}
+                            {artist.mon_tech && <Badge variant="outline" className="text-xs">Técnico</Badge>}
                           </div>
                         </div>
                       </TableCell>
@@ -617,7 +619,7 @@ export const ArtistTable = ({
                             <Badge variant="secondary">{artist.monitors_quantity}x</Badge>
                           </div>
                         ) : (
-                          <Badge variant="outline">None</Badge>
+                          <Badge variant="outline">Ninguno</Badge>
                         )}
                       </TableCell>
 
@@ -632,10 +634,10 @@ export const ArtistTable = ({
                             </TooltipTrigger>
                             <TooltipContent>
                               <div className="max-w-sm">
-                                <p className="font-medium">Infrastructure Requirements:</p>
+                                <p className="font-medium">Requisitos de infraestructura:</p>
                                 <p>{formatInfrastructure(artist)}</p>
                                 {artist.infrastructure_provided_by && (
-                                  <p className="text-xs mt-1">Provided by: {artist.infrastructure_provided_by}</p>
+                                  <p className="text-xs mt-1">Provisto por: {artist.infrastructure_provided_by}</p>
                                 )}
                               </div>
                             </TooltipContent>
@@ -667,19 +669,19 @@ export const ArtistTable = ({
                             </TooltipTrigger>
                             <TooltipContent>
                               <div className="max-w-sm">
-                                <p className="font-medium">Notes:</p>
+                                <p className="font-medium">Notas:</p>
                                 <p className="whitespace-pre-wrap">{artist.notes}</p>
                               </div>
                             </TooltipContent>
                           </Tooltip>
                         ) : (
-                          <span className="text-xs text-muted-foreground">No notes</span>
+                          <span className="text-xs text-muted-foreground">Sin notas</span>
                         )}
                       </TableCell>
-                      
+
                       <TableCell className="min-w-[80px]">
                         <Badge variant={artist.rider_missing ? "destructive" : "default"}>
-                          {artist.rider_missing ? "Missing" : "Complete"}
+                          {artist.rider_missing ? "Faltante" : "Completo"}
                         </Badge>
                       </TableCell>
 
@@ -689,7 +691,7 @@ export const ArtistTable = ({
                           <GearMismatchIndicator mismatches={gearComparison.mismatches} compact />
                         ) : (
                           <Badge variant="outline" className="text-xs">
-                            No Setup
+                            Sin configuración
                           </Badge>
                         )}
                       </TableCell>
@@ -734,16 +736,16 @@ export const ArtistTable = ({
                       <div className="flex items-center gap-2 mt-1 flex-wrap">
                         <Badge variant="outline" className="text-xs">{getStageDisplayName(artist.stage)}</Badge>
                         <Badge variant={artist.rider_missing ? "destructive" : "default"} className="text-xs">
-                          {artist.rider_missing ? "Missing" : "Complete"}
+                          {artist.rider_missing ? "Faltante" : "Completo"}
                         </Badge>
-                        {artist.isaftermidnight && <Badge variant="outline" className="text-xs bg-blue-700">After Midnight</Badge>}
+                        {artist.isaftermidnight && <Badge variant="outline" className="text-xs bg-blue-700">Después de medianoche</Badge>}
                       </div>
                     </div>
                   </div>
 
                   {/* Show Time */}
                   <div className="space-y-1">
-                    <div className="text-sm font-medium">Show Time</div>
+                    <div className="text-sm font-medium">Hora del show</div>
                     <div className="text-sm">{artist.show_start} - {artist.show_end}</div>
                   </div>
 
@@ -757,27 +759,27 @@ export const ArtistTable = ({
 
                   {/* Consoles */}
                   <div className="space-y-1">
-                    <div className="text-sm font-medium">Consoles</div>
+                    <div className="text-sm font-medium">Consolas</div>
                     <div className="text-sm space-y-1">
                       <div className="flex items-center gap-1 flex-wrap">
                         <span className="text-xs text-muted-foreground">FOH:</span>
-                        <span>{artist.foh_console || "Not specified"}</span>
+                        <span>{artist.foh_console || "No especificado"}</span>
                         {artist.foh_console_provided_by && (
                           <Badge variant="outline" className={`text-xs ${getProviderBadge(artist.foh_console_provided_by)}`}>
                             {artist.foh_console_provided_by}
                           </Badge>
                         )}
-                        {artist.foh_tech && <Badge variant="outline" className="text-xs">Tech</Badge>}
+                        {artist.foh_tech && <Badge variant="outline" className="text-xs">Técnico</Badge>}
                       </div>
                       <div className="flex items-center gap-1 flex-wrap">
                         <span className="text-xs text-muted-foreground">MON:</span>
-                        <span>{artist.mon_console || "Not specified"}</span>
+                        <span>{artist.mon_console || "No especificado"}</span>
                         {artist.mon_console_provided_by && (
                           <Badge variant="outline" className={`text-xs ${getProviderBadge(artist.mon_console_provided_by)}`}>
                             {artist.mon_console_provided_by}
                           </Badge>
                         )}
-                        {artist.mon_tech && <Badge variant="outline" className="text-xs">Tech</Badge>}
+                        {artist.mon_tech && <Badge variant="outline" className="text-xs">Técnico</Badge>}
                       </div>
                     </div>
                   </div>
@@ -816,7 +818,7 @@ export const ArtistTable = ({
                   <div className="space-y-1">
                     <div className="text-sm font-medium flex items-center gap-1">
                       <Mic className="h-4 w-4" />
-                      Microphones
+                      Micrófonos
                     </div>
                     <div className="flex items-center gap-2 flex-wrap">
                       <Badge variant={
@@ -840,19 +842,19 @@ export const ArtistTable = ({
 
                   {/* Monitors */}
                   <div className="space-y-1">
-                    <div className="text-sm font-medium">Monitors</div>
+                    <div className="text-sm font-medium">Monitores</div>
                     <div>
                       {artist.monitors_enabled ? (
                         <Badge variant="secondary">{artist.monitors_quantity}x</Badge>
                       ) : (
-                        <Badge variant="outline">None</Badge>
+                        <Badge variant="outline">Ninguno</Badge>
                       )}
                     </div>
                   </div>
 
                   {/* Infrastructure */}
                   <div className="space-y-1">
-                    <div className="text-sm font-medium">Infrastructure</div>
+                    <div className="text-sm font-medium">Infraestructura</div>
                     <div className="text-xs text-muted-foreground">
                       {formatInfrastructure(artist)}
                     </div>
@@ -870,7 +872,7 @@ export const ArtistTable = ({
                       <div className="flex flex-wrap gap-1">
                         {artist.extras_sf && <Badge variant="outline" className="text-xs">Side Fill</Badge>}
                         {artist.extras_df && <Badge variant="outline" className="text-xs">Drum Fill</Badge>}
-                        {artist.extras_djbooth && <Badge variant="outline" className="text-xs">DJ Booth</Badge>}
+                        {artist.extras_djbooth && <Badge variant="outline" className="text-xs">Cabina DJ</Badge>}
                       </div>
                     </div>
                   )}
@@ -878,7 +880,7 @@ export const ArtistTable = ({
                   {/* Notes */}
                   {artist.notes && artist.notes.trim() !== '' && (
                     <div className="space-y-1">
-                      <div className="text-sm font-medium">Notes</div>
+                      <div className="text-sm font-medium">Notas</div>
                       <div className="text-xs text-muted-foreground whitespace-pre-wrap">{artist.notes}</div>
                     </div>
                   )}
@@ -886,7 +888,7 @@ export const ArtistTable = ({
                   {/* Gear Status */}
                   {gearComparison && (
                     <div className="space-y-1">
-                      <div className="text-sm font-medium">Gear Status</div>
+                      <div className="text-sm font-medium">Estado del equipo</div>
                       <GearMismatchIndicator mismatches={gearComparison.mismatches} compact />
                     </div>
                   )}
@@ -895,23 +897,23 @@ export const ArtistTable = ({
                   <div className="flex items-center justify-end gap-2 pt-2 border-t">
                     <Button variant="ghost" size="sm" onClick={() => handleGenerateLink(artist)}>
                       <Link className="h-4 w-4 mr-1" />
-                      <span className="text-xs">Link</span>
+                      <span className="text-xs">Enlace</span>
                     </Button>
                     <Button variant="ghost" size="sm" onClick={() => handleManageFiles(artist)}>
                       <FileText className="h-4 w-4 mr-1" />
-                      <span className="text-xs">Files</span>
+                      <span className="text-xs">Archivos</span>
                     </Button>
                     <Button variant="ghost" size="sm" onClick={() => handlePrintArtist(artist)} disabled={printingArtistId === artist.id}>
                       {printingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Printer className="h-4 w-4 mr-1" />}
-                      <span className="text-xs">Print</span>
+                      <span className="text-xs">Imprimir</span>
                     </Button>
                     <Button variant="ghost" size="sm" onClick={() => onEditArtist(artist)}>
                       <Pencil className="h-4 w-4 mr-1" />
-                      <span className="text-xs">Edit</span>
+                      <span className="text-xs">Editar</span>
                     </Button>
                     <Button variant="ghost" size="sm" onClick={() => handleDeleteClick(artist)} disabled={deletingArtistId === artist.id}>
                       {deletingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4 mr-1" />}
-                      <span className="text-xs">Delete</span>
+                      <span className="text-xs">Eliminar</span>
                     </Button>
                   </div>
                 </div>
@@ -921,7 +923,7 @@ export const ArtistTable = ({
 
           {sortedFilteredArtists.length === 0 && !isLoading && (
             <div className="text-center py-8 text-muted-foreground">
-              No artists found matching the current filters.
+              No se encontraron artistas con los filtros actuales.
             </div>
           )}
         </div>

--- a/src/components/festival/ArtistTableFilters.tsx
+++ b/src/components/festival/ArtistTableFilters.tsx
@@ -32,25 +32,25 @@ export const ArtistTableFilters = ({
     <div className="space-y-4 mb-4">
       <div className={`grid grid-cols-1 md:grid-cols-2 ${gridCols} gap-4`}>
         <div>
-          <Label htmlFor="search" className="text-sm">Search Artist</Label>
+          <Label htmlFor="search" className="text-sm">Buscar artista</Label>
           <Input
             id="search"
-            placeholder="Search by name..."
+            placeholder="Buscar por nombre..."
             value={searchTerm}
             onChange={(e) => onSearchChange(e.target.value)}
             className="h-10"
           />
         </div>
-        
+
         {!hideStageFilter && (
           <div>
-            <Label htmlFor="stage" className="text-sm">Filter by Stage</Label>
+            <Label htmlFor="stage" className="text-sm">Filtrar por Stage</Label>
             <Select value={stageFilter} onValueChange={onStageFilterChange}>
               <SelectTrigger id="stage" className="h-10">
-                <SelectValue placeholder="All Stages" />
+                <SelectValue placeholder="Todos los Stages" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All Stages</SelectItem>
+                <SelectItem value="all">Todos los Stages</SelectItem>
                 <SelectItem value="1">Stage 1</SelectItem>
                 <SelectItem value="2">Stage 2</SelectItem>
                 <SelectItem value="3">Stage 3</SelectItem>
@@ -60,30 +60,30 @@ export const ArtistTableFilters = ({
         )}
 
         <div>
-          <Label htmlFor="equipment" className="text-sm">Filter by Equipment</Label>
+          <Label htmlFor="equipment" className="text-sm">Filtrar por equipo</Label>
           <Select value={equipmentFilter} onValueChange={onEquipmentFilterChange}>
             <SelectTrigger id="equipment" className="h-10">
-              <SelectValue placeholder="All Equipment" />
+              <SelectValue placeholder="Todo el equipo" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">All Equipment</SelectItem>
+              <SelectItem value="all">Todo el equipo</SelectItem>
               <SelectItem value="wireless">Wireless</SelectItem>
               <SelectItem value="iem">IEM</SelectItem>
-              <SelectItem value="monitors">Monitors</SelectItem>
+              <SelectItem value="monitors">Monitores</SelectItem>
             </SelectContent>
           </Select>
         </div>
 
         <div>
-          <Label htmlFor="rider" className="text-sm">Filter by Rider Status</Label>
+          <Label htmlFor="rider" className="text-sm">Filtrar por estado del rider</Label>
           <Select value={riderFilter} onValueChange={onRiderFilterChange}>
             <SelectTrigger id="rider" className="h-10">
-              <SelectValue placeholder="All Riders" />
+              <SelectValue placeholder="Todos los riders" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">All Riders</SelectItem>
-              <SelectItem value="complete">Rider Complete</SelectItem>
-              <SelectItem value="missing">Rider Missing</SelectItem>
+              <SelectItem value="all">Todos los riders</SelectItem>
+              <SelectItem value="complete">Rider completo</SelectItem>
+              <SelectItem value="missing">Rider faltante</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/components/festival/ArtistTablePrintDialog.tsx
+++ b/src/components/festival/ArtistTablePrintDialog.tsx
@@ -150,7 +150,7 @@ export const ArtistTablePrintDialog = ({
       
       if (filteredArtists.length === 0) {
         console.warn('No artists match the filter criteria');
-        toast.error('No artists found for the selected criteria');
+        toast.error('No se encontraron artistas para los criterios seleccionados');
         return;
       }
 
@@ -306,7 +306,7 @@ export const ArtistTablePrintDialog = ({
       });
 
       const pdfData: ArtistTablePdfData = {
-        jobTitle: jobTitle || 'Festival Schedule',
+        jobTitle: jobTitle || 'Cronograma del festival',
         date: selectedDate,
         stage: stageFilter !== 'all' ? stageFilter : undefined,
         stageNames: stageNames,
@@ -340,13 +340,14 @@ export const ArtistTablePrintDialog = ({
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-      
-      toast.success('Artist schedule PDF generated successfully');
+
+
+      toast.success('PDF del cronograma de artistas generado exitosamente');
       setDialogOpen(false);
     } catch (error) {
       console.error('Error generating artist schedule PDF:', error);
       console.error('Error stack:', error.stack);
-      toast.error('Failed to generate PDF');
+      toast.error('Error al generar PDF');
     } finally {
       setIsGenerating(false);
     }
@@ -356,27 +357,27 @@ export const ArtistTablePrintDialog = ({
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <DialogContent className="sm:max-w-[425px] w-[95vw]">
         <DialogHeader>
-          <DialogTitle>Print Artist Schedule</DialogTitle>
+          <DialogTitle>Imprimir cronograma de artistas</DialogTitle>
           <DialogDescription>
-            Generate a PDF of the current artist schedule.
+            Generar un PDF del cronograma de artistas actual.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
           <div className="grid grid-cols-1 sm:grid-cols-4 items-center gap-2 sm:gap-4">
             <Label htmlFor="name" className="sm:text-right">
-              Job Title
+              Título del trabajo
             </Label>
-            <Input id="name" value={jobTitle || 'Festival Schedule'} className="sm:col-span-3" disabled />
+            <Input id="name" value={jobTitle || 'Cronograma del festival'} className="sm:col-span-3" disabled />
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-4 items-center gap-2 sm:gap-4">
             <Label htmlFor="username" className="sm:text-right">
-              Date
+              Fecha
             </Label>
             <Input id="username" value={selectedDate} className="sm:col-span-3" disabled />
           </div>
           <div className="flex items-start space-x-2 pt-2">
-            <Checkbox 
-              id="gear-conflicts" 
+            <Checkbox
+              id="gear-conflicts"
               checked={includeGearConflicts}
               onCheckedChange={(checked) => {
                 setIncludeGearConflicts(checked === true);
@@ -384,17 +385,17 @@ export const ArtistTablePrintDialog = ({
               className="mt-1"
             />
             <Label htmlFor="gear-conflicts" className="text-sm font-medium leading-normal cursor-pointer">
-              Include gear conflicts summary
+              Incluir resumen de conflictos de equipo
             </Label>
           </div>
         </div>
         <Button onClick={handleTablePrint} disabled={isGenerating || isLoading} className="w-full">
           {(isGenerating || isLoading) ? (
             <>
-              Generating <Loader2 className="ml-2 h-4 w-4 animate-spin" />
+              Generando <Loader2 className="ml-2 h-4 w-4 animate-spin" />
             </>
           ) : (
-            "Generate PDF"
+            "Generar PDF"
           )}
         </Button>
       </DialogContent>

--- a/src/components/festival/CopyArtistsDialog.tsx
+++ b/src/components/festival/CopyArtistsDialog.tsx
@@ -84,7 +84,7 @@ export const CopyArtistsDialog = ({
       setFestivals(data || []);
     } catch (error) {
       console.error("Error loading festivals:", error);
-      toast.error("Failed to load festivals");
+      toast.error("Error al cargar festivales");
     } finally {
       setIsLoading(false);
     }
@@ -99,12 +99,12 @@ export const CopyArtistsDialog = ({
         .not("date", "is", null);
 
       if (error) throw error;
-      
+
       const uniqueDates = [...new Set(data?.map(item => item.date) || [])];
       setAvailableDates(uniqueDates.sort());
     } catch (error) {
       console.error("Error loading dates:", error);
-      toast.error("Failed to load available dates");
+      toast.error("Error al cargar fechas disponibles");
     }
   };
 
@@ -123,7 +123,7 @@ export const CopyArtistsDialog = ({
       setSelectedArtists(data?.map(artist => artist.id) || []);
     } catch (error) {
       console.error("Error loading artists:", error);
-      toast.error("Failed to load artists");
+      toast.error("Error al cargar artistas");
     } finally {
       setIsLoading(false);
     }
@@ -155,7 +155,7 @@ export const CopyArtistsDialog = ({
 
   const copyArtists = async () => {
     if (selectedArtists.length === 0) {
-      toast.error("Please select at least one artist to copy");
+      toast.error("Por favor selecciona al menos un artista para copiar");
       return;
     }
 
@@ -202,12 +202,12 @@ export const CopyArtistsDialog = ({
 
       if (insertError) throw insertError;
 
-      toast.success(`Successfully copied ${selectedArtists.length} artist${selectedArtists.length > 1 ? 's' : ''}`);
+      toast.success(`Se copiaron exitosamente ${selectedArtists.length} artista${selectedArtists.length > 1 ? 's' : ''}`);
       onArtistsCopied();
       onOpenChange(false);
     } catch (error) {
       console.error("Error copying artists:", error);
-      toast.error("Failed to copy artists");
+      toast.error("Error al copiar artistas");
     } finally {
       setIsCopying(false);
     }
@@ -219,17 +219,17 @@ export const CopyArtistsDialog = ({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Users className="h-5 w-5" />
-            Copy Artists from Another Festival
+            Copiar artistas de otro festival
           </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-6">
           {/* Festival Selection */}
           <div className="space-y-2">
-            <Label>Select Source Festival</Label>
+            <Label>Seleccionar festival de origen</Label>
             <Select onValueChange={handleFestivalChange} disabled={isLoading}>
               <SelectTrigger className="h-10">
-                <SelectValue placeholder="Choose a festival to copy from..." />
+                <SelectValue placeholder="Elegir festival del que copiar..." />
               </SelectTrigger>
               <SelectContent>
                 {festivals.map(festival => (
@@ -250,10 +250,10 @@ export const CopyArtistsDialog = ({
           {/* Date Selection */}
           {selectedFestival && availableDates.length > 0 && (
             <div className="space-y-2">
-              <Label>Select Source Date</Label>
+              <Label>Seleccionar fecha de origen</Label>
               <Select onValueChange={setSelectedSourceDate}>
                 <SelectTrigger className="h-10">
-                  <SelectValue placeholder="Choose a date..." />
+                  <SelectValue placeholder="Elegir fecha..." />
                 </SelectTrigger>
                 <SelectContent>
                    {availableDates.map(date => (
@@ -269,51 +269,51 @@ export const CopyArtistsDialog = ({
           {/* Copy Options */}
           {artists.length > 0 && (
             <div className="space-y-4">
-              <Label className="text-base font-medium">Copy Options</Label>
+              <Label className="text-base font-medium">Opciones de copia</Label>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div className="flex items-start space-x-2">
                   <Checkbox
                     id="resetTimes"
                     checked={copyOptions.resetTimes}
-                    onCheckedChange={(checked) => 
+                    onCheckedChange={(checked) =>
                       setCopyOptions(prev => ({ ...prev, resetTimes: !!checked }))
                     }
                     className="mt-1"
                   />
-                  <Label htmlFor="resetTimes" className="text-sm leading-normal cursor-pointer">Reset show times</Label>
+                  <Label htmlFor="resetTimes" className="text-sm leading-normal cursor-pointer">Restablecer horarios del show</Label>
                 </div>
                 <div className="flex items-start space-x-2">
                   <Checkbox
                     id="resetStages"
                     checked={copyOptions.resetStages}
-                    onCheckedChange={(checked) => 
+                    onCheckedChange={(checked) =>
                       setCopyOptions(prev => ({ ...prev, resetStages: !!checked }))
                     }
                     className="mt-1"
                   />
-                  <Label htmlFor="resetStages" className="text-sm leading-normal cursor-pointer">Reset to Stage 1</Label>
+                  <Label htmlFor="resetStages" className="text-sm leading-normal cursor-pointer">Restablecer a Stage 1</Label>
                 </div>
                 <div className="flex items-start space-x-2">
                   <Checkbox
                     id="copyNotes"
                     checked={copyOptions.copyNotes}
-                    onCheckedChange={(checked) => 
+                    onCheckedChange={(checked) =>
                       setCopyOptions(prev => ({ ...prev, copyNotes: !!checked }))
                     }
                     className="mt-1"
                   />
-                  <Label htmlFor="copyNotes" className="text-sm leading-normal cursor-pointer">Copy notes</Label>
+                  <Label htmlFor="copyNotes" className="text-sm leading-normal cursor-pointer">Copiar notas</Label>
                 </div>
                 <div className="flex items-start space-x-2">
                   <Checkbox
                     id="copyTechnicalSpecs"
                     checked={copyOptions.copyTechnicalSpecs}
-                    onCheckedChange={(checked) => 
+                    onCheckedChange={(checked) =>
                       setCopyOptions(prev => ({ ...prev, copyTechnicalSpecs: !!checked }))
                     }
                     className="mt-1"
                   />
-                  <Label htmlFor="copyTechnicalSpecs" className="text-sm leading-normal cursor-pointer">Copy technical specs</Label>
+                  <Label htmlFor="copyTechnicalSpecs" className="text-sm leading-normal cursor-pointer">Copiar especificaciones técnicas</Label>
                 </div>
               </div>
             </div>
@@ -324,10 +324,10 @@ export const CopyArtistsDialog = ({
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <Label className="text-base font-medium">
-                  Select Artists ({selectedArtists.length}/{artists.length})
+                  Seleccionar artistas ({selectedArtists.length}/{artists.length})
                 </Label>
                 <Button variant="outline" size="sm" onClick={handleSelectAll}>
-                  {selectedArtists.length === artists.length ? "Deselect All" : "Select All"}
+                  {selectedArtists.length === artists.length ? "Deseleccionar todo" : "Seleccionar todo"}
                 </Button>
               </div>
               
@@ -364,21 +364,21 @@ export const CopyArtistsDialog = ({
           {selectedFestival && availableDates.length === 0 && !isLoading && (
             <div className="text-center py-8 text-muted-foreground">
               <Users className="h-12 w-12 mx-auto mb-4 opacity-50" />
-              <p>No artists found in the selected festival.</p>
+              <p>No se encontraron artistas en el festival seleccionado.</p>
             </div>
           )}
         </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
+            Cancelar
           </Button>
           <Button
             onClick={copyArtists}
             disabled={selectedArtists.length === 0 || isCopying}
             className="min-w-24"
           >
-            {isCopying ? "Copying..." : `Copy ${selectedArtists.length} Artist${selectedArtists.length !== 1 ? 's' : ''}`}
+            {isCopying ? "Copiando..." : `Copiar ${selectedArtists.length} artista${selectedArtists.length !== 1 ? 's' : ''}`}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/festival/FestivalDateNavigation.tsx
+++ b/src/components/festival/FestivalDateNavigation.tsx
@@ -164,7 +164,7 @@ export const FestivalDateNavigation = ({
     return (
       <div className="flex items-center justify-center p-8 text-center text-muted-foreground border rounded-md">
         <div>
-          <p>No {showOnlyShowDates ? 'show/key' : ''} dates found for this week.</p>
+          <p>No se encontraron fechas {showOnlyShowDates ? 'de show/clave' : ''} para esta semana.</p>
           <div className="flex items-center justify-center gap-2 mt-4">
             <Button
               variant="outline"
@@ -172,7 +172,7 @@ export const FestivalDateNavigation = ({
               onClick={() => setShowOnlyShowDates(false)}
               disabled={!showOnlyShowDates}
             >
-              Show All Dates
+              Mostrar todas las fechas
             </Button>
             <Button
               variant="outline"
@@ -180,7 +180,7 @@ export const FestivalDateNavigation = ({
               onClick={() => setViewMode('all')}
               disabled={viewMode === 'all'}
             >
-              Show All Weeks
+              Mostrar todas las semanas
             </Button>
           </div>
         </div>
@@ -196,15 +196,15 @@ export const FestivalDateNavigation = ({
           {isLongFestival && (
             <>
               <div className="flex items-center gap-2">
-                <Label htmlFor="view-mode" className="text-sm whitespace-nowrap">View:</Label>
+                <Label htmlFor="view-mode" className="text-sm whitespace-nowrap">Vista:</Label>
                 <Switch
                   id="view-mode"
                   checked={viewMode === 'week'}
                   onCheckedChange={(checked) => setViewMode(checked ? 'week' : 'all')}
                 />
-                <span className="text-sm">{viewMode === 'week' ? 'Week' : 'All'}</span>
+                <span className="text-sm">{viewMode === 'week' ? 'Semana' : 'Todo'}</span>
               </div>
-              
+
               <div className="flex items-center gap-2">
                 <Filter className="h-4 w-4" />
                 <Switch
@@ -212,7 +212,7 @@ export const FestivalDateNavigation = ({
                   checked={showOnlyShowDates}
                   onCheckedChange={setShowOnlyShowDates}
                 />
-                <Label htmlFor="show-filter" className="text-sm whitespace-nowrap">Key dates only</Label>
+                <Label htmlFor="show-filter" className="text-sm whitespace-nowrap">Solo fechas clave</Label>
               </div>
             </>
           )}
@@ -226,7 +226,7 @@ export const FestivalDateNavigation = ({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="all">All Stages</SelectItem>
+                  <SelectItem value="all">Todos los Stages</SelectItem>
                   {Array.from({ length: maxStages }, (_, i) => i + 1).map((stage) => (
                     <SelectItem key={stage} value={stage.toString()}>
                       Stage {stage}
@@ -271,7 +271,7 @@ export const FestivalDateNavigation = ({
             <PopoverTrigger asChild>
               <Button variant="outline" size="sm" className="h-10 hidden sm:flex">
                 <Calendar className="h-4 w-4 mr-2" />
-                Jump to Date
+                Ir a fecha
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0" align="end">
@@ -279,8 +279,8 @@ export const FestivalDateNavigation = ({
                 mode="single"
                 selected={new Date(selectedDate)}
                 onSelect={handleDateJump}
-                disabled={(date) => 
-                  !jobDates.some(jobDate => 
+                disabled={(date) =>
+                  !jobDates.some(jobDate =>
                     format(jobDate, 'yyyy-MM-dd') === format(date, 'yyyy-MM-dd')
                   )
                 }
@@ -339,9 +339,9 @@ export const FestivalDateNavigation = ({
                       </TooltipTrigger>
                       <TooltipContent>
                         <div className="text-center">
-                          <p>Festival day runs from {dayStartTime} to {dayStartTime} the next day</p>
-                          <p>Date: {formattedDateValue}</p>
-                          <p>Type: {dateTypes[`${jobId}-${formattedDateValue}`] || 'Not set'}</p>
+                          <p>El día del festival es de {dayStartTime} a {dayStartTime} del día siguiente</p>
+                          <p>Fecha: {formattedDateValue}</p>
+                          <p>Tipo: {dateTypes[`${jobId}-${formattedDateValue}`] || 'No configurado'}</p>
                         </div>
                       </TooltipContent>
                     </Tooltip>

--- a/src/components/festival/FestivalGearSetupForm.tsx
+++ b/src/components/festival/FestivalGearSetupForm.tsx
@@ -208,7 +208,7 @@ export const FestivalGearSetupForm = ({
         console.error('Error fetching festival gear setup:', error);
         toast({
           title: "Error",
-          description: "Failed to load gear setup.",
+          description: "Error al cargar la configuración de equipamiento.",
           variant: "destructive"
         });
       } finally {
@@ -413,16 +413,16 @@ export const FestivalGearSetupForm = ({
 
       onSave?.();
       toast({
-        title: "Success",
-        description: isPrimaryStage 
-          ? "Global gear setup has been saved." 
-          : `Stage ${stageNumber} setup has been saved.`,
+        title: "Éxito",
+        description: isPrimaryStage
+          ? "La configuración de equipamiento global ha sido guardada."
+          : `La configuración de Stage ${stageNumber} ha sido guardada.`,
       });
     } catch (error) {
       console.error('Error saving festival gear setup:', error);
       toast({
         title: "Error",
-        description: "Failed to save festival gear setup.",
+        description: "Error al guardar la configuración de equipamiento del festival.",
         variant: "destructive",
       });
     } finally {
@@ -430,11 +430,11 @@ export const FestivalGearSetupForm = ({
     }
   };
 
-  const alertText = isPrimaryStage 
-    ? "You are editing the default stage setup. These settings will be used as defaults for all stages."
-    : hasStageSpecificSetup 
-      ? `This stage has a custom gear setup that differs from the global configuration.`
-      : `This stage is currently using the global setup. Any changes will create a custom setup for Stage ${stageNumber}.`;
+  const alertText = isPrimaryStage
+    ? "Está editando la configuración de stage predeterminada. Esta configuración se utilizará como predeterminada para todos los stages."
+    : hasStageSpecificSetup
+      ? `Este stage tiene una configuración de equipamiento personalizada que difiere de la configuración global.`
+      : `Este stage está usando actualmente la configuración global. Cualquier cambio creará una configuración personalizada para Stage ${stageNumber}.`;
 
   const alertVariant = isPrimaryStage ? "default" : hasStageSpecificSetup ? "info" : "default";
 
@@ -511,9 +511,9 @@ export const FestivalGearSetupForm = ({
         />
 
         <div className="space-y-4">
-          <h3 className="text-lg font-semibold">Microphone Requirements Analysis</h3>
+          <h3 className="text-lg font-semibold">Análisis de Requisitos de Micrófonos</h3>
           <p className="text-sm text-muted-foreground">
-            Calculate wired microphone needs based on artist requirements and show schedules.
+            Calcule las necesidades de micrófonos cableados basándose en los requisitos de los artistas y los horarios de shows.
           </p>
           <MicrophoneNeedsCalculator jobId={jobId} />
         </div>
@@ -529,7 +529,7 @@ export const FestivalGearSetupForm = ({
         <Accordion type="multiple" defaultValue={["consoles", "wireless"]} className="space-y-4">
           <AccordionItem value="consoles" className="border rounded-lg px-4">
             <AccordionTrigger className="text-base font-semibold hover:no-underline">
-              Console Configuration
+              Configuración de Console
             </AccordionTrigger>
             <AccordionContent>
               <FestivalConsoleSetupSection
@@ -541,7 +541,7 @@ export const FestivalGearSetupForm = ({
 
           <AccordionItem value="wireless" className="border rounded-lg px-4">
             <AccordionTrigger className="text-base font-semibold hover:no-underline">
-              Wireless Setup
+              Configuración de Wireless
             </AccordionTrigger>
             <AccordionContent>
               <WirelessSetupSection
@@ -553,7 +553,7 @@ export const FestivalGearSetupForm = ({
 
           <AccordionItem value="mics" className="border rounded-lg px-4">
             <AccordionTrigger className="text-base font-semibold hover:no-underline">
-              Microphone Kit
+              Kit de Micrófonos
             </AccordionTrigger>
             <AccordionContent>
               <FestivalMicKitConfig
@@ -570,7 +570,7 @@ export const FestivalGearSetupForm = ({
 
           <AccordionItem value="monitors" className="border rounded-lg px-4">
             <AccordionTrigger className="text-base font-semibold hover:no-underline">
-              Monitor Setup
+              Configuración de Monitor
             </AccordionTrigger>
             <AccordionContent>
               <MonitorSetupSection
@@ -583,7 +583,7 @@ export const FestivalGearSetupForm = ({
 
           <AccordionItem value="extras" className="border rounded-lg px-4">
             <AccordionTrigger className="text-base font-semibold hover:no-underline">
-              Extra Requirements
+              Requisitos Adicionales
             </AccordionTrigger>
             <AccordionContent>
               <ExtraRequirementsSection
@@ -596,7 +596,7 @@ export const FestivalGearSetupForm = ({
 
           <AccordionItem value="infrastructure" className="border rounded-lg px-4">
             <AccordionTrigger className="text-base font-semibold hover:no-underline">
-              Infrastructure
+              Infraestructura
             </AccordionTrigger>
             <AccordionContent>
               <InfrastructureSection
@@ -609,12 +609,12 @@ export const FestivalGearSetupForm = ({
 
           <AccordionItem value="analysis" className="border rounded-lg px-4">
             <AccordionTrigger className="text-base font-semibold hover:no-underline">
-              Microphone Analysis
+              Análisis de Micrófonos
             </AccordionTrigger>
             <AccordionContent>
               <div className="space-y-4">
                 <p className="text-sm text-muted-foreground">
-                  Calculate wired microphone needs based on artist requirements and show schedules.
+                  Calcule las necesidades de micrófonos cableados basándose en los requisitos de los artistas y los horarios de shows.
                 </p>
                 <MicrophoneNeedsCalculator jobId={jobId} />
               </div>
@@ -623,7 +623,7 @@ export const FestivalGearSetupForm = ({
 
           <AccordionItem value="notes" className="border rounded-lg px-4">
             <AccordionTrigger className="text-base font-semibold hover:no-underline">
-              Notes
+              Notas
             </AccordionTrigger>
             <AccordionContent>
               <NotesSection
@@ -637,12 +637,12 @@ export const FestivalGearSetupForm = ({
 
       <Button type="submit" disabled={isLoading} className="w-full">
         <Save className="h-4 w-4 mr-2" />
-        {isLoading ? "Saving..." : (
-          isPrimaryStage 
-            ? "Save Global Setup" 
-            : hasStageSpecificSetup 
-              ? `Update Stage ${stageNumber} Setup` 
-              : `Create Custom Setup for Stage ${stageNumber}`
+        {isLoading ? "Guardando..." : (
+          isPrimaryStage
+            ? "Guardar Configuración Global"
+            : hasStageSpecificSetup
+              ? `Actualizar Configuración de Stage ${stageNumber}`
+              : `Crear Configuración Personalizada para Stage ${stageNumber}`
         )}
       </Button>
     </form>

--- a/src/components/festival/FestivalLogoManager.tsx
+++ b/src/components/festival/FestivalLogoManager.tsx
@@ -81,8 +81,8 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
 
     if (!file.type.startsWith('image/')) {
       toast({
-        title: "Invalid file type",
-        description: "Please upload an image file",
+        title: "Tipo de archivo inválido",
+        description: "Por favor sube un archivo de imagen",
         variant: "destructive",
       });
       return;
@@ -90,8 +90,8 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
 
     if (!user) {
       toast({
-        title: "Authentication required",
-        description: "You must be logged in to upload logos",
+        title: "Autenticación requerida",
+        description: "Debes iniciar sesión para subir logos",
         variant: "destructive",
       });
       return;
@@ -187,12 +187,12 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
       }
 
       toast({
-        title: "Success",
-        description: "Festival logo has been updated",
+        title: "Éxito",
+        description: "El logo del festival ha sido actualizado",
       });
     } catch (error: any) {
       console.error('Error uploading logo:', error);
-      const errorMessage = error.message || "Could not upload logo";
+      const errorMessage = error.message || "No se pudo subir el logo";
       setErrorDetails(errorMessage);
       toast({
         title: "Error",
@@ -209,8 +209,8 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
     
     if (!user) {
       toast({
-        title: "Authentication required",
-        description: "You must be logged in to delete logos",
+        title: "Autenticación requerida",
+        description: "Debes iniciar sesión para eliminar logos",
         variant: "destructive",
       });
       return;
@@ -262,15 +262,15 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
         setLogoUrl(null);
 
         toast({
-          title: "Success",
-          description: "Festival logo has been removed",
+          title: "Éxito",
+          description: "El logo del festival ha sido eliminado",
         });
       } else {
         console.log("No logo found to delete");
       }
     } catch (error: any) {
       console.error('Error deleting logo:', error);
-      const errorMessage = error.message || "Could not delete logo";
+      const errorMessage = error.message || "No se pudo eliminar el logo";
       setErrorDetails(errorMessage);
       toast({
         title: "Error",
@@ -338,7 +338,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
         >
           <label htmlFor="logo-upload" className="cursor-pointer">
             <Upload className="h-4 w-4 mr-2" />
-            {isUploading ? "Uploading..." : "Upload Logo"}
+            {isUploading ? "Subiendo..." : "Subir Logo"}
           </label>
         </Button>
       </div>

--- a/src/components/festival/FestivalManagementWrapper.tsx
+++ b/src/components/festival/FestivalManagementWrapper.tsx
@@ -45,11 +45,11 @@ export function FestivalManagementWrapper() {
           if (fullRecoverySuccess) {
             console.log('Full connection recovery succeeded, retrying fetch');
             refetch();
-            toast.success('Connection restored');
+            toast.success('Conexión restaurada');
           } else {
             console.log('All recovery attempts failed');
-            toast.error('Connection issues persist', {
-              description: 'Please check your network connection and try again'
+            toast.error('Problemas de conexión persisten', {
+              description: 'Por favor, verifica tu conexión de red e intenta de nuevo'
             });
           }
         }
@@ -60,14 +60,14 @@ export function FestivalManagementWrapper() {
   }, [isError, isPaused, refetch, recoverConnection]);
 
   const handleRetry = async () => {
-    toast.info('Reconnecting...');
-    
+    toast.info('Reconectando...');
+
     try {
       await recoverConnection();
       await refetch();
     } catch (error) {
       console.error('Error during retry:', error);
-      toast.error('Retry failed');
+      toast.error('Error al reintentar');
     }
   };
 
@@ -76,7 +76,7 @@ export function FestivalManagementWrapper() {
       <TimeoutLoader
         isLoading={isLoading}
         isError={false}
-        message="Loading festival details..."
+        message="Cargando detalles del festival..."
         timeout={5000}
       />
     );
@@ -86,21 +86,21 @@ export function FestivalManagementWrapper() {
     return (
       <div className="flex flex-col items-center justify-center min-h-[50vh] max-w-md mx-auto text-center p-4 md:p-6">
         <AlertTriangle className="h-10 w-10 md:h-12 md:w-12 text-destructive mb-3 md:mb-4" />
-        <h2 className="text-lg md:text-xl font-bold">Error Loading Festival</h2>
+        <h2 className="text-lg md:text-xl font-bold">Error al cargar festival</h2>
         <p className="text-sm md:text-base text-muted-foreground mt-2 mb-3 md:mb-4">
-          {error instanceof Error ? error.message : 'Failed to load festival data'}
+          {error instanceof Error ? error.message : 'No se pudo cargar los datos del festival'}
         </p>
         <p className="text-xs md:text-sm text-muted-foreground mb-4 md:mb-6">
-          Connection status: {connectionStatus}
+          Estado de la conexión: {connectionStatus}
         </p>
-        <Button 
-          onClick={handleRetry} 
+        <Button
+          onClick={handleRetry}
           variant="default"
           size="sm"
           className="flex items-center gap-2"
         >
           <RefreshCw className="h-4 w-4" />
-          Reconnect & Retry
+          Reconectar e Reintentar
         </Button>
       </div>
     );
@@ -109,9 +109,9 @@ export function FestivalManagementWrapper() {
   if (!festival) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[50vh] p-4 text-center">
-        <h2 className="text-lg md:text-xl font-bold">Festival Not Found</h2>
+        <h2 className="text-lg md:text-xl font-bold">Festival no encontrado</h2>
         <p className="text-sm md:text-base text-muted-foreground mt-2">
-          The requested festival could not be found or may have been deleted.
+          No se pudo encontrar el festival solicitado o puede haber sido eliminado.
         </p>
       </div>
     );

--- a/src/components/festival/FestivalWeatherSection.tsx
+++ b/src/components/festival/FestivalWeatherSection.tsx
@@ -73,7 +73,7 @@ export const FestivalWeatherSection: React.FC<FestivalWeatherSectionProps> = ({
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
               <CloudIcon className="h-4 w-4 sm:h-5 sm:w-5" />
-              Weather Forecast
+              Pronóstico del Tiempo
             </CardTitle>
             {canFetchWeather && (
               <Button
@@ -88,7 +88,7 @@ export const FestivalWeatherSection: React.FC<FestivalWeatherSectionProps> = ({
                 ) : (
                   <RefreshCw className="h-4 w-4" />
                 )}
-                {isLoading ? 'Loading...' : 'Refresh'}
+                {isLoading ? 'Cargando...' : 'Actualizar'}
               </Button>
             )}
           </div>
@@ -97,7 +97,7 @@ export const FestivalWeatherSection: React.FC<FestivalWeatherSectionProps> = ({
           {!canFetchWeather ? (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <AlertCircle className="h-4 w-4" />
-              Weather forecast requires venue location and event dates
+              El pronóstico del tiempo requiere ubicación del lugar y fechas del evento
             </div>
           ) : error ? (
             <div className="flex items-center gap-2 text-sm text-destructive">
@@ -107,7 +107,7 @@ export const FestivalWeatherSection: React.FC<FestivalWeatherSectionProps> = ({
           ) : isLoading ? (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
-              Fetching weather forecast...
+              Obteniendo pronóstico del tiempo...
             </div>
           ) : weatherData && weatherData.length > 0 ? (
             <div className="space-y-2 sm:space-y-3">
@@ -122,7 +122,7 @@ export const FestivalWeatherSection: React.FC<FestivalWeatherSectionProps> = ({
                       <div className="text-xs sm:text-sm text-muted-foreground">
                         {Math.round(weather.maxTemp)}°C / {Math.round(weather.minTemp)}°C
                         {weather.precipitationProbability > 0 && (
-                          <span>, {weather.precipitationProbability}% rain</span>
+                          <span>, {weather.precipitationProbability}% lluvia</span>
                         )}
                       </div>
                     </div>
@@ -132,16 +132,16 @@ export const FestivalWeatherSection: React.FC<FestivalWeatherSectionProps> = ({
               
               <div className="text-xs text-muted-foreground mt-4 space-y-1">
                 <p>
-                  <strong>Tip:</strong> Weather data is fetched from Open-Meteo and updates automatically.
+                  <strong>Consejo:</strong> Los datos del tiempo se obtienen de Open-Meteo y se actualizan automáticamente.
                 </p>
                 {lastFetch && (
-                  <p>Last updated: {lastFetch.toLocaleString()}</p>
+                  <p>Última actualización: {lastFetch.toLocaleString()}</p>
                 )}
               </div>
             </div>
           ) : (
             <div className="text-sm text-muted-foreground">
-              Weather data not available for the selected dates and location.
+              Datos del tiempo no disponibles para las fechas y ubicación seleccionadas.
             </div>
           )}
         </CardContent>

--- a/src/components/festival/FormStatusBadge.tsx
+++ b/src/components/festival/FormStatusBadge.tsx
@@ -11,11 +11,11 @@ export const FormStatusBadge = ({ status, className }: FormStatusBadgeProps) => 
   const getStatusDetails = (status: string) => {
     switch (status) {
       case 'pending':
-        return { label: 'Pending', variant: 'secondary' as const };
+        return { label: 'Pendiente', variant: 'secondary' as const };
       case 'submitted':
-        return { label: 'Submitted', variant: 'default' as const };
+        return { label: 'Enviado', variant: 'default' as const };
       case 'expired':
-        return { label: 'Expired', variant: 'destructive' as const };
+        return { label: 'Expirado', variant: 'destructive' as const };
       default:
         return { label: status, variant: 'secondary' as const };
     }

--- a/src/components/festival/FormSubmitted.tsx
+++ b/src/components/festival/FormSubmitted.tsx
@@ -6,9 +6,9 @@ export const FormSubmitted = () => {
     <div className="min-h-screen bg-background flex items-center justify-center p-6">
       <div className="max-w-md mx-auto text-center space-y-4">
         <CheckCircle className="h-16 w-16 mx-auto text-green-500" />
-        <h1 className="text-2xl font-bold">Form Submitted Successfully</h1>
+        <h1 className="text-2xl font-bold">Formulario Enviado Correctamente</h1>
         <p className="text-muted-foreground">
-          Thank you for submitting your technical requirements. The festival team will review your submission.
+          Gracias por enviar sus requerimientos técnicos. El equipo del festival revisará su envío.
         </p>
       </div>
     </div>

--- a/src/components/festival/GearMismatchIndicator.tsx
+++ b/src/components/festival/GearMismatchIndicator.tsx
@@ -17,20 +17,20 @@ export const GearMismatchIndicator = ({ mismatches, compact = false }: GearMisma
       </Badge>
     ) : (
       <Badge variant="secondary" className="bg-green-100 text-green-800">
-        No Issues
+        Sin problemas
       </Badge>
     );
   }
 
   const errors = mismatches.filter(m => m.severity === 'error');
   const warnings = mismatches.filter(m => m.severity === 'warning');
-  
+
   const tooltipContent = (
     <div className="max-w-sm space-y-2">
-      <p className="font-medium">Equipment Issues:</p>
+      <p className="font-medium">Problemas de equipo:</p>
       {errors.length > 0 && (
         <div>
-          <p className="text-red-600 font-medium text-xs">Errors ({errors.length}):</p>
+          <p className="text-red-600 font-medium text-xs">Errores ({errors.length}):</p>
           {errors.map((error, index) => (
             <div key={index} className="text-xs">
               <p className="text-red-600">• {error.message}</p>
@@ -41,7 +41,7 @@ export const GearMismatchIndicator = ({ mismatches, compact = false }: GearMisma
       )}
       {warnings.length > 0 && (
         <div>
-          <p className="text-orange-600 font-medium text-xs">Warnings ({warnings.length}):</p>
+          <p className="text-orange-600 font-medium text-xs">Advertencias ({warnings.length}):</p>
           {warnings.map((warning, index) => (
             <div key={index} className="text-xs">
               <p className="text-orange-600">• {warning.message}</p>
@@ -86,13 +86,13 @@ export const GearMismatchIndicator = ({ mismatches, compact = false }: GearMisma
           {errors.length > 0 && (
             <Badge variant="destructive" className="text-xs">
               <XCircle className="h-3 w-3 mr-1" />
-              {errors.length} Error{errors.length !== 1 ? 's' : ''}
+              {errors.length} Error{errors.length !== 1 ? 'es' : ''}
             </Badge>
           )}
           {warnings.length > 0 && (
             <Badge variant="outline" className="text-xs bg-orange-100 text-orange-800 border-orange-300">
               <AlertTriangle className="h-3 w-3 mr-1" />
-              {warnings.length} Warning{warnings.length !== 1 ? 's' : ''}
+              {warnings.length} Advertencia{warnings.length !== 1 ? 's' : ''}
             </Badge>
           )}
         </div>

--- a/src/components/festival/ViewFileDialog.tsx
+++ b/src/components/festival/ViewFileDialog.tsx
@@ -44,8 +44,8 @@ export const ViewFileDialog = ({ open, onOpenChange, file, url }: ViewFileDialog
           {!isImage && !isPDF && (
             <div className="text-center py-8">
               <p className="text-muted-foreground">
-                Preview is not available for this file type.
-                Please download the file to view it.
+                La vista previa no está disponible para este tipo de archivo.
+                Por favor descargue el archivo para verlo.
               </p>
             </div>
           )}

--- a/src/components/festival/form/sections/ArtistWirelessSetupSection.tsx
+++ b/src/components/festival/form/sections/ArtistWirelessSetupSection.tsx
@@ -17,13 +17,13 @@ export const ArtistWirelessSetupSection = ({ formData, onChange }: ArtistSection
 
   return (
     <div className="space-y-4 border rounded-lg p-4">
-      <h3 className="text-lg font-semibold">RF & Wireless Setup</h3>
+      <h3 className="text-lg font-semibold">Configuración RF & Wireless</h3>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <div className="space-y-4">
           <WirelessConfig
             systems={formData.wireless_systems || []}
             onChange={handleWirelessChange}
-            label="Wireless Systems"
+            label="Sistemas Wireless"
             includeQuantityTypes={true}
           />
         </div>
@@ -31,7 +31,7 @@ export const ArtistWirelessSetupSection = ({ formData, onChange }: ArtistSection
           <WirelessConfig
             systems={formData.iem_systems || []}
             onChange={handleIEMChange}
-            label="IEM Systems"
+            label="Sistemas IEM"
             includeQuantityTypes={true}
             isIEM={true}
           />

--- a/src/components/festival/form/sections/BasicInfoSection.tsx
+++ b/src/components/festival/form/sections/BasicInfoSection.tsx
@@ -11,21 +11,21 @@ export const BasicInfoSection = ({ formData, onChange, gearSetup }: ArtistSectio
 
   return (
     <div className="space-y-4 border rounded-lg p-4">
-      <h3 className="text-lg font-semibold">Basic Information</h3>
-      
+      <h3 className="text-lg font-semibold">Información Básica</h3>
+
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <Label>Artist/Band Name</Label>
-          <Input 
-            value={formData.name || ""} 
+          <Label>Nombre del Artista/Banda</Label>
+          <Input
+            value={formData.name || ""}
             onChange={(e) => onChange({ name: e.target.value })}
-            placeholder="Enter artist name"
+            placeholder="Ingrese el nombre del artista"
           />
         </div>
         <div>
           <Label>Stage</Label>
-          <Select 
-            value={formData.stage?.toString() || "1"} 
+          <Select
+            value={formData.stage?.toString() || "1"}
             onValueChange={(value) => onChange({ stage: parseInt(value) })}
           >
             <SelectTrigger>
@@ -43,28 +43,28 @@ export const BasicInfoSection = ({ formData, onChange, gearSetup }: ArtistSectio
       </div>
 
       <div>
-        <Label>Date</Label>
-        <Input 
+        <Label>Fecha</Label>
+        <Input
           type="date"
-          value={formData.date || ""} 
+          value={formData.date || ""}
           onChange={(e) => onChange({ date: e.target.value })}
         />
       </div>
 
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <Label>Show Start</Label>
-          <Input 
+          <Label>Inicio del Show</Label>
+          <Input
             type="time"
-            value={formData.show_start || ""} 
+            value={formData.show_start || ""}
             onChange={(e) => onChange({ show_start: e.target.value })}
           />
         </div>
         <div>
-          <Label>Show End</Label>
-          <Input 
+          <Label>Fin del Show</Label>
+          <Input
             type="time"
-            value={formData.show_end || ""} 
+            value={formData.show_end || ""}
             onChange={(e) => onChange({ show_end: e.target.value })}
           />
         </div>
@@ -72,29 +72,29 @@ export const BasicInfoSection = ({ formData, onChange, gearSetup }: ArtistSectio
 
       <div className="space-y-4">
         <div className="flex items-center space-x-2">
-          <Checkbox 
+          <Checkbox
             id="soundcheck"
             checked={formData.soundcheck}
             onCheckedChange={(checked) => onChange({ soundcheck: checked })}
           />
-          <Label htmlFor="soundcheck">Soundcheck Required</Label>
+          <Label htmlFor="soundcheck">Requiere Soundcheck</Label>
         </div>
 
         {formData.soundcheck && (
           <div className="grid grid-cols-2 gap-4 ml-6">
             <div>
-              <Label>Soundcheck Start</Label>
-              <Input 
+              <Label>Inicio del Soundcheck</Label>
+              <Input
                 type="time"
-                value={formData.soundcheck_start || ""} 
+                value={formData.soundcheck_start || ""}
                 onChange={(e) => onChange({ soundcheck_start: e.target.value })}
               />
             </div>
             <div>
-              <Label>Soundcheck End</Label>
-              <Input 
+              <Label>Fin del Soundcheck</Label>
+              <Input
                 type="time"
-                value={formData.soundcheck_end || ""} 
+                value={formData.soundcheck_end || ""}
                 onChange={(e) => onChange({ soundcheck_end: e.target.value })}
               />
             </div>
@@ -104,21 +104,21 @@ export const BasicInfoSection = ({ formData, onChange, gearSetup }: ArtistSectio
 
       <div className="space-y-4">
         <div className="flex items-center space-x-2">
-          <Checkbox 
+          <Checkbox
             id="after-midnight"
             checked={formData.isaftermidnight}
             onCheckedChange={(checked) => onChange({ isaftermidnight: checked })}
           />
-          <Label htmlFor="after-midnight">Show is after midnight</Label>
+          <Label htmlFor="after-midnight">El show es después de medianoche</Label>
         </div>
 
         <div className="flex items-center space-x-2">
-          <Checkbox 
+          <Checkbox
             id="rider-missing"
             checked={formData.rider_missing}
             onCheckedChange={(checked) => onChange({ rider_missing: checked })}
           />
-          <Label htmlFor="rider-missing">Rider is missing</Label>
+          <Label htmlFor="rider-missing">El rider está faltando</Label>
         </div>
       </div>
     </div>

--- a/src/components/festival/form/sections/ConsoleSetupSection.tsx
+++ b/src/components/festival/form/sections/ConsoleSetupSection.tsx
@@ -30,20 +30,20 @@ export const ConsoleSetupSection = ({ formData, onChange }: ArtistSectionProps) 
 
   return (
     <div className="space-y-4 border rounded-lg p-4">
-      <h3 className="text-lg font-semibold">Console Setup</h3>
-      
+      <h3 className="text-lg font-semibold">Configuración de Consoles</h3>
+
       {/* FOH Console */}
       <div className="space-y-4">
-        <h4 className="font-medium">FOH Console</h4>
+        <h4 className="font-medium">Console FOH</h4>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <Label>Console Model</Label>
+            <Label>Modelo de Console</Label>
             <Select
               value={formData.foh_console || ""}
               onValueChange={(value) => onChange({ foh_console: value })}
             >
               <SelectTrigger>
-                <SelectValue placeholder="Select console" />
+                <SelectValue placeholder="Seleccionar console" />
               </SelectTrigger>
               <SelectContent>
                 {fohOptions.map((option) => (
@@ -55,7 +55,7 @@ export const ConsoleSetupSection = ({ formData, onChange }: ArtistSectionProps) 
             </Select>
           </div>
           <div>
-            <Label>Provided By</Label>
+            <Label>Proporcionado Por</Label>
             <Select
               value={formData.foh_console_provided_by || "festival"}
               onValueChange={(value) => onChange({ foh_console_provided_by: value })}
@@ -65,33 +65,33 @@ export const ConsoleSetupSection = ({ formData, onChange }: ArtistSectionProps) 
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="festival">Festival</SelectItem>
-                <SelectItem value="band">Band</SelectItem>
+                <SelectItem value="band">Banda</SelectItem>
               </SelectContent>
             </Select>
           </div>
         </div>
         <div className="flex items-center space-x-2">
-          <Checkbox 
+          <Checkbox
             id="foh-tech"
             checked={formData.foh_tech}
             onCheckedChange={(checked) => onChange({ foh_tech: checked })}
           />
-          <Label htmlFor="foh-tech">FOH Technician Required</Label>
+          <Label htmlFor="foh-tech">Requiere Técnico FOH</Label>
         </div>
       </div>
 
       {/* Monitor Console */}
       <div className="space-y-4">
-        <h4 className="font-medium">Monitor Console</h4>
+        <h4 className="font-medium">Console de Monitor</h4>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <Label>Console Model</Label>
+            <Label>Modelo de Console</Label>
             <Select
               value={formData.mon_console || ""}
               onValueChange={(value) => onChange({ mon_console: value })}
             >
               <SelectTrigger>
-                <SelectValue placeholder="Select console" />
+                <SelectValue placeholder="Seleccionar console" />
               </SelectTrigger>
               <SelectContent>
                 {monOptions.map((option) => (
@@ -103,7 +103,7 @@ export const ConsoleSetupSection = ({ formData, onChange }: ArtistSectionProps) 
             </Select>
           </div>
           <div>
-            <Label>Provided By</Label>
+            <Label>Proporcionado Por</Label>
             <Select
               value={formData.mon_console_provided_by || "festival"}
               onValueChange={(value) => onChange({ mon_console_provided_by: value })}
@@ -113,18 +113,18 @@ export const ConsoleSetupSection = ({ formData, onChange }: ArtistSectionProps) 
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="festival">Festival</SelectItem>
-                <SelectItem value="band">Band</SelectItem>
+                <SelectItem value="band">Banda</SelectItem>
               </SelectContent>
             </Select>
           </div>
         </div>
         <div className="flex items-center space-x-2">
-          <Checkbox 
+          <Checkbox
             id="mon-tech"
             checked={formData.mon_tech}
             onCheckedChange={(checked) => onChange({ mon_tech: checked })}
           />
-          <Label htmlFor="mon-tech">Monitor Technician Required</Label>
+          <Label htmlFor="mon-tech">Requiere Técnico de Monitor</Label>
         </div>
       </div>
     </div>

--- a/src/components/festival/form/sections/ExtraRequirementsSection.tsx
+++ b/src/components/festival/form/sections/ExtraRequirementsSection.tsx
@@ -8,25 +8,25 @@ import { SectionProps } from "@/types/festival-form";
 export const ExtraRequirementsSection = ({ formData, onChange, gearSetup }: SectionProps) => {
   return (
     <div className="space-y-4 border rounded-lg p-3 md:p-4">
-      <h3 className="text-base md:text-lg font-semibold">Extra Requirements</h3>
+      <h3 className="text-base md:text-lg font-semibold">Requerimientos Adicionales</h3>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
         <div className="space-y-3">
           <div className="flex items-center gap-2">
             <h4 className="text-sm md:text-base font-medium">Side Fill</h4>
             {gearSetup && !gearSetup.has_side_fills && formData.extras_sf && (
-              <Badge variant="secondary" className="text-xs">Not Available</Badge>
+              <Badge variant="secondary" className="text-xs">No Disponible</Badge>
             )}
           </div>
           <RadioGroup
             value={formData.extras_sf ? "yes" : "no"}
-            onValueChange={(value) => 
+            onValueChange={(value) =>
               onChange({ extras_sf: value === "yes" })
             }
             className="flex flex-col space-y-1"
           >
             <div className="flex items-center space-x-2">
               <RadioGroupItem value="yes" id="sf-yes" />
-              <Label htmlFor="sf-yes" className="text-sm md:text-base">Yes</Label>
+              <Label htmlFor="sf-yes" className="text-sm md:text-base">Sí</Label>
             </div>
             <div className="flex items-center space-x-2">
               <RadioGroupItem value="no" id="sf-no" />
@@ -34,24 +34,24 @@ export const ExtraRequirementsSection = ({ formData, onChange, gearSetup }: Sect
             </div>
           </RadioGroup>
         </div>
-        
+
         <div className="space-y-3">
           <div className="flex items-center gap-2">
             <h4 className="text-sm md:text-base font-medium">Drum Fill</h4>
             {gearSetup && !gearSetup.has_drum_fills && formData.extras_df && (
-              <Badge variant="secondary" className="text-xs">Not Available</Badge>
+              <Badge variant="secondary" className="text-xs">No Disponible</Badge>
             )}
           </div>
           <RadioGroup
             value={formData.extras_df ? "yes" : "no"}
-            onValueChange={(value) => 
+            onValueChange={(value) =>
               onChange({ extras_df: value === "yes" })
             }
             className="flex flex-col space-y-1"
           >
             <div className="flex items-center space-x-2">
               <RadioGroupItem value="yes" id="df-yes" />
-              <Label htmlFor="df-yes" className="text-sm md:text-base">Yes</Label>
+              <Label htmlFor="df-yes" className="text-sm md:text-base">Sí</Label>
             </div>
             <div className="flex items-center space-x-2">
               <RadioGroupItem value="no" id="df-no" />
@@ -59,24 +59,24 @@ export const ExtraRequirementsSection = ({ formData, onChange, gearSetup }: Sect
             </div>
           </RadioGroup>
         </div>
-        
+
         <div className="space-y-3">
           <div className="flex items-center gap-2">
             <h4 className="text-sm md:text-base font-medium">DJ Booth</h4>
             {gearSetup && !gearSetup.has_dj_booths && formData.extras_djbooth && (
-              <Badge variant="secondary" className="text-xs">Not Available</Badge>
+              <Badge variant="secondary" className="text-xs">No Disponible</Badge>
             )}
           </div>
           <RadioGroup
             value={formData.extras_djbooth ? "yes" : "no"}
-            onValueChange={(value) => 
+            onValueChange={(value) =>
               onChange({ extras_djbooth: value === "yes" })
             }
             className="flex flex-col space-y-1"
           >
             <div className="flex items-center space-x-2">
               <RadioGroupItem value="yes" id="djbooth-yes" />
-              <Label htmlFor="djbooth-yes" className="text-sm md:text-base">Yes</Label>
+              <Label htmlFor="djbooth-yes" className="text-sm md:text-base">Sí</Label>
             </div>
             <div className="flex items-center space-x-2">
               <RadioGroupItem value="no" id="djbooth-no" />
@@ -86,7 +86,7 @@ export const ExtraRequirementsSection = ({ formData, onChange, gearSetup }: Sect
         </div>
       </div>
       <div>
-        <Label htmlFor="extras-wired" className="text-sm md:text-base">Additional Wired Requirements</Label>
+        <Label htmlFor="extras-wired" className="text-sm md:text-base">Requerimientos Cableados Adicionales</Label>
         <Input
           id="extras-wired"
           value={formData.extras_wired || ''}

--- a/src/components/festival/form/sections/FestivalConsoleSetupSection.tsx
+++ b/src/components/festival/form/sections/FestivalConsoleSetupSection.tsx
@@ -16,18 +16,18 @@ interface FestivalConsoleSetupSectionProps {
 export const FestivalConsoleSetupSection = ({ formData, onChange }: FestivalConsoleSetupSectionProps) => {
   return (
     <div className="space-y-4 md:space-y-6 border rounded-lg p-3 md:p-4">
-      <h3 className="text-base md:text-lg font-semibold">Console Configuration</h3>
-      
+      <h3 className="text-base md:text-lg font-semibold">Configuración de Consoles</h3>
+
       <ConsoleConfig
         consoles={formData.foh_consoles}
         onChange={(consoles) => onChange({ foh_consoles: consoles })}
-        label="FOH Consoles"
+        label="Consoles FOH"
       />
-      
+
       <ConsoleConfig
         consoles={formData.mon_consoles}
         onChange={(consoles) => onChange({ mon_consoles: consoles })}
-        label="Monitor Consoles"
+        label="Consoles de Monitor"
       />
     </div>
   );

--- a/src/components/festival/form/sections/InfrastructureSection.tsx
+++ b/src/components/festival/form/sections/InfrastructureSection.tsx
@@ -11,7 +11,7 @@ export const InfrastructureSection = ({ formData, onChange, gearSetup }: Section
 
   return (
     <div className="space-y-4 border rounded-lg p-3 md:p-4">
-      <h3 className="text-base md:text-lg font-semibold">Infrastructure</h3>
+      <h3 className="text-base md:text-lg font-semibold">Infraestructura</h3>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {/* CAT6 */}
@@ -141,7 +141,7 @@ export const InfrastructureSection = ({ formData, onChange, gearSetup }: Section
         {/* Analog Lines */}
         <div className="space-y-2">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-            <Label htmlFor="infra-analog" className="text-sm md:text-base">Analog Lines</Label>
+            <Label htmlFor="infra-analog" className="text-sm md:text-base">Líneas Analógicas</Label>
             <QuantityInput
               id="infra-analog"
               label=""
@@ -157,14 +157,14 @@ export const InfrastructureSection = ({ formData, onChange, gearSetup }: Section
       </div>
 
       <div>
-        <Label htmlFor="other-infrastructure">Other Infrastructure Requirements</Label>
+        <Label htmlFor="other-infrastructure">Otros Requerimientos de Infraestructura</Label>
         <Input
           id="other-infrastructure"
           value={formData.other_infrastructure || ''}
           onChange={(e) => onChange({
             other_infrastructure: e.target.value
           })}
-          placeholder="Enter any additional infrastructure requirements"
+          placeholder="Ingrese cualquier requerimiento de infraestructura adicional"
         />
       </div>
     </div>

--- a/src/components/festival/form/sections/MicKitSection.tsx
+++ b/src/components/festival/form/sections/MicKitSection.tsx
@@ -27,13 +27,13 @@ export const MicKitSection = ({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Microphone Kit</CardTitle>
+        <CardTitle>Kit de Micrófonos</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
         <ProviderSelector
           value={micKit}
           onChange={onMicKitChange}
-          label="Microphone Kit Provider"
+          label="Proveedor del Kit de Micrófonos"
           id="mic-kit"
           showMixed={true}
         />
@@ -42,12 +42,12 @@ export const MicKitSection = ({
           <div className="space-y-3">
             <div>
               <h3 className="text-sm font-semibold mb-2">
-                {micKit === 'mixed' ? "Festival-Provided Wired Microphones" : "Required Wired Microphones"}
+                {micKit === 'mixed' ? "Micrófonos Cableados Proporcionados por el Festival" : "Micrófonos Cableados Requeridos"}
               </h3>
               <p className="text-sm text-muted-foreground mb-4">
                 {micKit === 'mixed'
-                  ? "Select only the microphones that the festival will provide. The band will provide any additional microphones."
-                  : "Select the wired microphones you need for your performance."
+                  ? "Seleccione solo los micrófonos que el festival proporcionará. La banda proporcionará cualquier micrófono adicional."
+                  : "Seleccione los micrófonos cableados que necesita para su presentación."
                 }
               </p>
             </div>
@@ -64,7 +64,7 @@ export const MicKitSection = ({
         {micKit === 'band' && (
           <div className="p-4 bg-muted rounded-lg">
             <p className="text-sm text-muted-foreground">
-              The band will provide their own microphone kit.
+              La banda proporcionará su propio kit de micrófonos.
             </p>
           </div>
         )}
@@ -72,8 +72,8 @@ export const MicKitSection = ({
         {micKit === 'mixed' && (
           <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
             <p className="text-sm text-blue-700">
-              Mixed microphone setup: Enter only the microphones that the festival will provide.
-              The band will provide any additional microphones they need.
+              Configuración mixta de micrófonos: Ingrese solo los micrófonos que el festival proporcionará.
+              La banda proporcionará cualquier micrófono adicional que necesite.
             </p>
           </div>
         )}

--- a/src/components/festival/form/sections/MonitorSetupSection.tsx
+++ b/src/components/festival/form/sections/MonitorSetupSection.tsx
@@ -11,23 +11,23 @@ export const MonitorSetupSection = ({ formData, onChange, gearSetup }: SectionPr
   return (
     <div className="space-y-4 border rounded-lg p-3 md:p-4">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        <h3 className="text-base md:text-lg font-semibold">Monitor Setup</h3>
+        <h3 className="text-base md:text-lg font-semibold">Configuración de Monitores</h3>
         <div className="flex items-center space-x-2">
           <Switch
             id="monitors-enabled"
             checked={formData.monitors_enabled}
-            onCheckedChange={(checked) => 
+            onCheckedChange={(checked) =>
               onChange({ monitors_enabled: checked, monitors_quantity: checked ? 1 : 0 })
             }
           />
-          <Label htmlFor="monitors-enabled" className="text-sm md:text-base">Enable Stage Monitors</Label>
+          <Label htmlFor="monitors-enabled" className="text-sm md:text-base">Habilitar Monitores de Stage</Label>
         </div>
       </div>
 
       {formData.monitors_enabled && (
         <QuantityInput
           id="monitors-quantity"
-          label="Number of Monitors"
+          label="Número de Monitores"
           value={formData.monitors_quantity || 0}
           onChange={(value) => onChange({ monitors_quantity: value })}
           available={gearSetup?.available_monitors}

--- a/src/components/festival/form/sections/NotesSection.tsx
+++ b/src/components/festival/form/sections/NotesSection.tsx
@@ -6,14 +6,14 @@ import { SectionProps } from "@/types/festival-form";
 export const NotesSection = ({ formData, onChange }: SectionProps) => {
   return (
     <div className="space-y-4 border rounded-lg p-3 md:p-4">
-      <h3 className="text-base md:text-lg font-semibold">Additional Notes</h3>
+      <h3 className="text-base md:text-lg font-semibold">Notas Adicionales</h3>
       <div>
-        <Label htmlFor="notes" className="text-sm md:text-base">Notes</Label>
+        <Label htmlFor="notes" className="text-sm md:text-base">Notas</Label>
         <Textarea
           id="notes"
           value={formData.notes || ""}
           onChange={(e) => onChange({ notes: e.target.value })}
-          placeholder="Enter additional notes about setup, requirements, or restrictions..."
+          placeholder="Ingrese notas adicionales sobre configuración, requerimientos o restricciones..."
           className="h-24 text-sm md:text-base"
         />
       </div>

--- a/src/components/festival/form/sections/WirelessSetupSection.tsx
+++ b/src/components/festival/form/sections/WirelessSetupSection.tsx
@@ -73,37 +73,37 @@ export const WirelessSetupSection = ({ formData, onChange }: ArtistSectionProps)
 
   return (
     <div className="space-y-4 border rounded-lg p-3 md:p-4">
-      <h3 className="text-base md:text-lg font-semibold">RF & Wireless Setup</h3>
-      
+      <h3 className="text-base md:text-lg font-semibold">Configuración RF & Wireless</h3>
+
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-6">
         <div className="space-y-4">
           <WirelessConfig
             systems={formData.wireless_systems || []}
             onChange={handleWirelessChange}
-            label="Wireless Systems"
+            label="Sistemas Wireless"
             includeQuantityTypes={true}
           />
           <ProviderSelector
             value={formData.wireless_provided_by || "festival"}
             onChange={handleWirelessProviderChange}
-            label="Wireless Systems Provided By"
+            label="Sistemas Wireless Proporcionados Por"
             id="wireless-provider"
             showMixed={true}
           />
         </div>
-        
+
         <div className="space-y-4">
           <WirelessConfig
             systems={formData.iem_systems || []}
             onChange={handleIEMChange}
-            label="IEM Systems"
+            label="Sistemas IEM"
             includeQuantityTypes={true}
             isIEM={true}
           />
           <ProviderSelector
             value={formData.iem_provided_by || "festival"}
             onChange={handleIEMProviderChange}
-            label="IEM Systems Provided By"
+            label="Sistemas IEM Proporcionados Por"
             id="iem-provider"
             showMixed={true}
           />

--- a/src/components/festival/form/shared/EquipmentSelect.tsx
+++ b/src/components/festival/form/shared/EquipmentSelect.tsx
@@ -15,7 +15,7 @@ export const EquipmentSelect = ({
   value,
   onChange,
   options,
-  placeholder = "Select equipment",
+  placeholder = "Seleccionar equipo",
   fallbackOptions = [],
   category
 }: EquipmentSelectProps) => {
@@ -43,10 +43,10 @@ export const EquipmentSelect = ({
   return (
     <Select value={value} onValueChange={onChange} disabled={isLoading}>
       <SelectTrigger>
-        <SelectValue placeholder={isLoading ? "Loading..." : placeholder} />
+        <SelectValue placeholder={isLoading ? "Cargando..." : placeholder} />
       </SelectTrigger>
       <SelectContent>
-        {Array.isArray(itemsToRender) && itemsToRender.length > 0 && 
+        {Array.isArray(itemsToRender) && itemsToRender.length > 0 &&
           itemsToRender.map((option) => {
             if (typeof option === 'string') {
               return (
@@ -57,7 +57,7 @@ export const EquipmentSelect = ({
             } else if (option && typeof option === 'object') {
               return (
                 <SelectItem key={option.model} value={option.model}>
-                  {option.model}{option.quantity ? ` (${option.quantity} available)` : ''}
+                  {option.model}{option.quantity ? ` (${option.quantity} disponibles)` : ''}
                 </SelectItem>
               );
             }

--- a/src/components/festival/form/shared/ProviderSelector.tsx
+++ b/src/components/festival/form/shared/ProviderSelector.tsx
@@ -18,12 +18,12 @@ export const ProviderSelector = ({ value, onChange, label, id, showMixed = false
         </div>
         <div className="flex items-center space-x-2">
           <RadioGroupItem value="band" id={`${id}-band`} />
-          <Label htmlFor={`${id}-band`}>Band</Label>
+          <Label htmlFor={`${id}-band`}>Banda</Label>
         </div>
         {showMixed && (
           <div className="flex items-center space-x-2">
             <RadioGroupItem value="mixed" id={`${id}-mixed`} />
-            <Label htmlFor={`${id}-mixed`}>Mixed</Label>
+            <Label htmlFor={`${id}-mixed`}>Mixto</Label>
           </div>
         )}
       </RadioGroup>

--- a/src/components/festival/form/shared/QuantityInput.tsx
+++ b/src/components/festival/form/shared/QuantityInput.tsx
@@ -32,14 +32,14 @@ export const QuantityInput = ({
         />
         {available !== undefined && (
           <Badge variant="secondary">
-            {available} available
+            {available} disponibles
           </Badge>
         )}
       </div>
       {isInvalid && (
         <p className="text-sm text-red-500 flex items-center gap-1 mt-1">
           <AlertCircle className="h-4 w-4" />
-          Exceeds available quantity
+          Excede la cantidad disponible
         </p>
       )}
     </div>

--- a/src/components/festival/gear-setup/ConsoleConfig.tsx
+++ b/src/components/festival/gear-setup/ConsoleConfig.tsx
@@ -49,7 +49,7 @@ export const ConsoleConfig = ({ consoles, onChange, label }: ConsoleConfigProps)
           onClick={addConsole}
         >
           <Plus className="h-4 w-4 mr-2" />
-          Add Console
+          Añadir Console
         </Button>
       </div>
 
@@ -61,7 +61,7 @@ export const ConsoleConfig = ({ consoles, onChange, label }: ConsoleConfigProps)
               onChange={(value) => updateConsole(index, 'model', value)}
               options={[]}
               fallbackOptions={consoleOptions}
-              placeholder="Select console"
+              placeholder="Seleccionar console"
               category={getCategory()}
             />
           </div>

--- a/src/components/festival/gear-setup/FestivalMicKitConfig.tsx
+++ b/src/components/festival/gear-setup/FestivalMicKitConfig.tsx
@@ -36,12 +36,12 @@ export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }
 
   const handleLoadFromAnalysis = async () => {
     if (!analysisData) {
-      toast.error("No analysis data available");
+      toast.error("No hay datos de análisis disponibles");
       return;
     }
 
     if (analysisData.peakRequirements.length === 0) {
-      toast.error(`No microphone requirements found for Stage ${stageNumber}`);
+      toast.error(`No se encontraron requisitos de micrófonos para Stage ${stageNumber}`);
       return;
     }
 
@@ -97,11 +97,11 @@ export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }
       
       onChange(sanitizedMics);
       
-      toast.success(`Loaded ${newRequirements.length} microphone types for Stage ${stageNumber}`);
+      toast.success(`${newRequirements.length} tipos de micrófonos cargados para Stage ${stageNumber}`);
       setAnalysisPreviewOpen(false);
     } catch (error) {
       console.error("Error loading requirements:", error);
-      toast.error("Failed to load microphone requirements");
+      toast.error("Error al cargar los requisitos de micrófonos");
     } finally {
       setIsLoadingRequirements(false);
     }
@@ -128,16 +128,16 @@ export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardTitle>Stage {stageNumber} Microphone Kit</CardTitle>
+          <CardTitle>Kit de Micrófonos Stage {stageNumber}</CardTitle>
           <div className="flex gap-2">
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="sm"
               onClick={handleLoadFromAnalysis}
               disabled={isAnalyzing}
             >
               <Calculator className="h-4 w-4 mr-2" />
-              {isAnalyzing ? "Analyzing..." : "Load from Artist Requirements"}
+              {isAnalyzing ? "Analizando..." : "Cargar desde Requisitos de Artistas"}
             </Button>
           </div>
         </div>
@@ -145,10 +145,10 @@ export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }
       <CardContent>
         <div className="space-y-3">
           <div>
-            <h3 className="text-sm font-semibold mb-2">Available Wired Microphones</h3>
+            <h3 className="text-sm font-semibold mb-2">Micrófonos Cableados Disponibles</h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Configure the microphones available for Stage {stageNumber}. Use the "Load from Artist Requirements"
-              button to automatically calculate peak needs based on artist submissions.
+              Configure los micrófonos disponibles para Stage {stageNumber}. Use el botón "Cargar desde Requisitos de Artistas"
+              para calcular automáticamente las necesidades máximas basadas en las solicitudes de los artistas.
             </p>
           </div>
           <MicrophoneListBuilder

--- a/src/components/festival/gear-setup/InfrastructureConfig.tsx
+++ b/src/components/festival/gear-setup/InfrastructureConfig.tsx
@@ -6,11 +6,11 @@ import { InfrastructureConfigProps } from "@/types/festival-gear";
 export const InfrastructureConfig = ({ data, onChange }: InfrastructureConfigProps) => {
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold">Infrastructure</h3>
-      
+      <h3 className="text-lg font-semibold">Infraestructura</h3>
+
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
-          <Label htmlFor="cat6-runs">CAT6 Runs</Label>
+          <Label htmlFor="cat6-runs">Líneas CAT6</Label>
           <Input
             id="cat6-runs"
             type="number"
@@ -21,7 +21,7 @@ export const InfrastructureConfig = ({ data, onChange }: InfrastructureConfigPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="hma-runs">HMA Runs</Label>
+          <Label htmlFor="hma-runs">Líneas HMA</Label>
           <Input
             id="hma-runs"
             type="number"
@@ -32,7 +32,7 @@ export const InfrastructureConfig = ({ data, onChange }: InfrastructureConfigPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="coax-runs">Coax Runs</Label>
+          <Label htmlFor="coax-runs">Líneas Coax</Label>
           <Input
             id="coax-runs"
             type="number"
@@ -43,7 +43,7 @@ export const InfrastructureConfig = ({ data, onChange }: InfrastructureConfigPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="analog-runs">Analog Runs</Label>
+          <Label htmlFor="analog-runs">Líneas Analógicas</Label>
           <Input
             id="analog-runs"
             type="number"
@@ -54,7 +54,7 @@ export const InfrastructureConfig = ({ data, onChange }: InfrastructureConfigPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="opticalcon-runs">OpticalCon Duo Runs</Label>
+          <Label htmlFor="opticalcon-runs">Líneas OpticalCon Duo</Label>
           <Input
             id="opticalcon-runs"
             type="number"

--- a/src/components/festival/gear-setup/MicrophoneAnalysisPreview.tsx
+++ b/src/components/festival/gear-setup/MicrophoneAnalysisPreview.tsx
@@ -35,7 +35,7 @@ export const MicrophoneAnalysisPreview = ({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Info className="h-5 w-5" />
-            Stage {analysisDetails.stageNumber} Microphone Requirements
+            Requisitos de Micrófonos Stage {analysisDetails.stageNumber}
           </DialogTitle>
         </DialogHeader>
 
@@ -43,35 +43,35 @@ export const MicrophoneAnalysisPreview = ({
           <Alert>
             <CheckCircle className="h-4 w-4" />
             <AlertDescription>
-              Analysis completed for {analysisDetails.totalArtists} artists on Stage {analysisDetails.stageNumber} using festival microphones.
-              Peak requirements calculated considering show schedules and exclusive use constraints.
+              Análisis completado para {analysisDetails.totalArtists} artistas en Stage {analysisDetails.stageNumber} usando micrófonos del festival.
+              Requisitos máximos calculados considerando horarios de shows y restricciones de uso exclusivo.
             </AlertDescription>
           </Alert>
 
           <div className="grid grid-cols-3 gap-4">
             <div className="bg-blue-50 p-4 rounded-lg">
               <div className="text-2xl font-bold text-blue-700">{analysisDetails.stageNumber}</div>
-              <div className="text-sm text-blue-600">Stage Number</div>
+              <div className="text-sm text-blue-600">Número de Stage</div>
             </div>
             <div className="bg-green-50 p-4 rounded-lg">
               <div className="text-2xl font-bold text-green-700">{analysisDetails.totalArtists}</div>
-              <div className="text-sm text-green-600">Artists Analyzed</div>
+              <div className="text-sm text-green-600">Artistas Analizados</div>
             </div>
             <div className="bg-purple-50 p-4 rounded-lg">
               <div className="text-2xl font-bold text-purple-700">{peakRequirements.length}</div>
-              <div className="text-sm text-purple-600">Mic Models Required</div>
+              <div className="text-sm text-purple-600">Modelos de Mic Requeridos</div>
             </div>
           </div>
 
           {peakRequirements.length > 0 ? (
             <div>
-              <h3 className="text-lg font-semibold mb-3">Peak Microphone Requirements for Stage {analysisDetails.stageNumber}</h3>
+              <h3 className="text-lg font-semibold mb-3">Requisitos Máximos de Micrófonos para Stage {analysisDetails.stageNumber}</h3>
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Microphone Model</TableHead>
-                    <TableHead>Quantity</TableHead>
-                    <TableHead>Notes</TableHead>
+                    <TableHead>Modelo de Micrófono</TableHead>
+                    <TableHead>Cantidad</TableHead>
+                    <TableHead>Notas</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -91,27 +91,27 @@ export const MicrophoneAnalysisPreview = ({
             </div>
           ) : (
             <div className="text-center py-8 text-muted-foreground">
-              No microphone requirements found for Stage {analysisDetails.stageNumber}. 
-              Make sure artists on this stage have wired microphones configured with festival kit selected.
+              No se encontraron requisitos de micrófonos para Stage {analysisDetails.stageNumber}.
+              Asegúrese de que los artistas en este stage tengan micrófonos cableados configurados con kit de festival seleccionado.
             </div>
           )}
 
           <div className="bg-yellow-50 p-4 rounded-lg border border-yellow-200">
             <div className="text-sm text-yellow-800">
-              <strong>Note:</strong> These requirements are specific to Stage {analysisDetails.stageNumber} and will be merged with your existing microphone kit. 
-              Quantities for existing models will be updated to the higher value.
+              <strong>Nota:</strong> Estos requisitos son específicos para Stage {analysisDetails.stageNumber} y se fusionarán con su kit de micrófonos existente.
+              Las cantidades para modelos existentes se actualizarán al valor más alto.
             </div>
           </div>
 
           <div className="flex justify-end gap-3">
             <Button variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
+              Cancelar
             </Button>
-            <Button 
-              onClick={onConfirm} 
+            <Button
+              onClick={onConfirm}
               disabled={isLoading || peakRequirements.length === 0}
             >
-              {isLoading ? "Loading..." : "Load Requirements"}
+              {isLoading ? "Cargando..." : "Cargar Requisitos"}
             </Button>
           </div>
         </div>

--- a/src/components/festival/gear-setup/MicrophoneListBuilder.tsx
+++ b/src/components/festival/gear-setup/MicrophoneListBuilder.tsx
@@ -163,33 +163,33 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
       {/* Search Bar */}
       <div className="relative">
         <Label htmlFor="mic-search" className="sr-only">
-          Search microphones
+          Buscar micrófonos
         </Label>
         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500" aria-hidden="true" />
         <Input
           id="mic-search"
           type="text"
-          placeholder="Search microphones..."
+          placeholder="Buscar micrófonos..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="pl-10"
           disabled={readOnly}
-          aria-label="Search available microphones"
+          aria-label="Buscar micrófonos disponibles"
           aria-describedby="mic-search-description"
         />
         <span id="mic-search-description" className="sr-only">
-          Type to filter the list of available microphones. Current total: {totalCount} microphones.
+          Escriba para filtrar la lista de micrófonos disponibles. Total actual: {totalCount} micrófonos.
         </span>
       </div>
 
       {/* Tally Grid */}
-      <div role="region" aria-label="Available microphones">
+      <div role="region" aria-label="Micrófonos disponibles">
         <div className="flex justify-between items-center mb-3">
           <Label className="text-sm font-semibold" id="tally-grid-label">
-            Available Microphones
+            Micrófonos Disponibles
           </Label>
           <span className="text-sm text-gray-500 dark:text-gray-400" aria-live="polite" aria-atomic="true">
-            Click to add • Total: {totalCount}
+            Clic para añadir • Total: {totalCount}
           </span>
         </div>
         <div
@@ -207,14 +207,14 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                 className="relative h-auto py-3 px-4 text-left justify-start"
                 onClick={() => addMicrophone(mic)}
                 disabled={readOnly}
-                aria-label={`Add ${mic}${count > 0 ? `, currently ${count} in list` : ''}`}
+                aria-label={`Añadir ${mic}${count > 0 ? `, actualmente ${count} en la lista` : ''}`}
                 aria-pressed={count > 0}
               >
                 <span className="text-sm truncate flex-1">{mic}</span>
                 {count > 0 && (
                   <span
                     className="ml-2 bg-white dark:bg-gray-800 text-primary dark:text-primary-foreground font-bold px-2 py-0.5 rounded-full text-xs"
-                    aria-label={`${count} units`}
+                    aria-label={`${count} unidades`}
                   >
                     {count}
                   </span>
@@ -225,17 +225,17 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
         </div>
         {filteredMics.length === 0 && (
           <div className="text-center py-8 text-gray-500 dark:text-gray-400" role="status">
-            No microphones found matching "{searchQuery}"
+            No se encontraron micrófonos que coincidan con "{searchQuery}"
           </div>
         )}
       </div>
 
       {/* Entry List */}
       {expandedEntries.length > 0 && (
-        <div role="region" aria-label="Microphone entries">
+        <div role="region" aria-label="Entradas de micrófonos">
           <div className="flex justify-between items-center mb-3">
             <Label className="text-sm font-semibold" id="entries-label">
-              Entries ({expandedEntries.length})
+              Entradas ({expandedEntries.length})
             </Label>
             {!readOnly && (
               <Button
@@ -244,10 +244,10 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                 size="sm"
                 onClick={() => setShowClearDialog(true)}
                 className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-950"
-                aria-label={`Clear all ${expandedEntries.length} microphone entries`}
+                aria-label={`Limpiar todas las ${expandedEntries.length} entradas de micrófonos`}
               >
                 <Trash2 className="h-4 w-4 mr-1" aria-hidden="true" />
-                Clear All
+                Limpiar Todo
               </Button>
             )}
           </div>
@@ -264,8 +264,8 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
               >
                 <div className="flex items-center gap-2 flex-1">
                   <span className="text-sm font-medium">{entry.model}</span>
-                  <span className="text-xs text-gray-500 dark:text-gray-400" aria-label={`Entry ${entry.index + 1} of ${entry.total}`}>
-                    ({entry.index + 1} of {entry.total})
+                  <span className="text-xs text-gray-500 dark:text-gray-400" aria-label={`Entrada ${entry.index + 1} de ${entry.total}`}>
+                    ({entry.index + 1} de {entry.total})
                   </span>
                 </div>
                 {!readOnly && (
@@ -275,7 +275,7 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                     size="sm"
                     onClick={() => removeMicrophone(entry.model)}
                     className="h-8 w-8 p-0"
-                    aria-label={`Remove one ${entry.model} microphone`}
+                    aria-label={`Eliminar un micrófono ${entry.model}`}
                   >
                     <Minus className="h-4 w-4" aria-hidden="true" />
                   </Button>
@@ -288,9 +288,9 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
 
       {/* Summary Panel */}
       {summary.length > 0 && (
-        <div role="region" aria-label="Microphone summary">
+        <div role="region" aria-label="Resumen de micrófonos">
           <Label className="text-sm font-semibold mb-3 block" id="summary-label">
-            Summary
+            Resumen
           </Label>
           <div className="space-y-2 border rounded-lg p-4 bg-blue-50 dark:bg-blue-950" role="list" aria-labelledby="summary-label">
             {summary.map(item => {
@@ -305,9 +305,9 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                           <span
                             className="text-xs bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 px-2 py-0.5 rounded"
                             role="status"
-                            aria-label="Exclusive use required"
+                            aria-label="Se requiere uso exclusivo"
                           >
-                            Exclusive
+                            Exclusivo
                           </span>
                         )}
                       </div>
@@ -315,7 +315,7 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                     <div className="flex items-center gap-2">
                       <span
                         className="text-lg font-bold text-blue-600 dark:text-blue-400"
-                        aria-label={`${item.quantity} units of ${item.model}`}
+                        aria-label={`${item.quantity} unidades de ${item.model}`}
                       >
                         ×{item.quantity}
                       </span>
@@ -327,9 +327,9 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                             size="sm"
                             onClick={() => setEditingModel(item.model)}
                             className="h-8 px-2"
-                            aria-label={`Edit notes for ${item.model}`}
+                            aria-label={`Editar notas para ${item.model}`}
                           >
-                            Notes
+                            Notas
                           </Button>
                           <Button
                             type="button"
@@ -337,7 +337,7 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                             size="sm"
                             onClick={() => removeAllOfModel(item.model)}
                             className="h-8 w-8 p-0 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-950"
-                            aria-label={`Remove all ${item.quantity} ${item.model} microphones`}
+                            aria-label={`Eliminar todos los ${item.quantity} micrófonos ${item.model}`}
                           >
                             <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </Button>
@@ -360,7 +360,7 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                         htmlFor={`exclusive-inline-${item.model}`}
                         className="text-sm font-normal cursor-pointer"
                       >
-                        Exclusive use (cannot be shared with other artists)
+                        Uso exclusivo (no se puede compartir con otros artistas)
                       </Label>
                     </div>
                   )}
@@ -377,15 +377,15 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                     <Dialog open={true} onOpenChange={() => setEditingModel(null)}>
                       <DialogContent>
                         <DialogHeader>
-                          <DialogTitle>Notes for {item.model}</DialogTitle>
+                          <DialogTitle>Notas para {item.model}</DialogTitle>
                           <DialogDescription>
-                            Add any additional notes or special requirements for this microphone
+                            Agregue notas adicionales o requisitos especiales para este micrófono
                           </DialogDescription>
                         </DialogHeader>
                         <div className="py-4">
                           <Textarea
                             id={`notes-${item.model}`}
-                            placeholder="Add any notes about this microphone..."
+                            placeholder="Agregar notas sobre este micrófono..."
                             value={micData?.notes || ''}
                             onChange={(e) =>
                               updateMicDetails(item.model, { notes: e.target.value })
@@ -395,7 +395,7 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
                           />
                         </div>
                         <DialogFooter>
-                          <Button onClick={() => setEditingModel(null)}>Done</Button>
+                          <Button onClick={() => setEditingModel(null)}>Listo</Button>
                         </DialogFooter>
                       </DialogContent>
                     </Dialog>
@@ -405,8 +405,8 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
             })}
             <div className="pt-2 border-t mt-3">
               <div className="flex justify-between items-center font-bold">
-                <span>Total Microphones</span>
-                <span className="text-xl text-blue-600 dark:text-blue-400" aria-label={`Total: ${totalCount} microphones`}>
+                <span>Total de Micrófonos</span>
+                <span className="text-xl text-blue-600 dark:text-blue-400" aria-label={`Total: ${totalCount} micrófonos`}>
                   {totalCount}
                 </span>
               </div>
@@ -419,9 +419,9 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
       {value.length === 0 && (
         <div className="text-center py-12 border-2 border-dashed rounded-lg" role="status">
           <Plus className="h-12 w-12 mx-auto text-gray-400 dark:text-gray-600 mb-3" aria-hidden="true" />
-          <p className="text-gray-600 dark:text-gray-400 font-medium mb-1">No microphones added yet</p>
+          <p className="text-gray-600 dark:text-gray-400 font-medium mb-1">Aún no se han añadido micrófonos</p>
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            Click on a microphone button above to add it to your list
+            Haga clic en un botón de micrófono arriba para agregarlo a su lista
           </p>
         </div>
       )}
@@ -432,19 +432,19 @@ export const MicrophoneListBuilder: React.FC<MicrophoneListBuilderProps> = ({
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-yellow-600 dark:text-yellow-500" />
-              Clear All Microphones?
+              ¿Limpiar Todos los Micrófonos?
             </DialogTitle>
             <DialogDescription>
-              This will remove all {totalCount} microphone{totalCount !== 1 ? 's' : ''} from your list.
-              This action cannot be undone.
+              Esto eliminará {totalCount === 1 ? 'el micrófono' : `los ${totalCount} micrófonos`} de su lista.
+              Esta acción no se puede deshacer.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowClearDialog(false)}>
-              Cancel
+              Cancelar
             </Button>
             <Button variant="destructive" onClick={clearAll}>
-              Clear All
+              Limpiar Todo
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/festival/gear-setup/MicrophoneNeedsCalculator.tsx
+++ b/src/components/festival/gear-setup/MicrophoneNeedsCalculator.tsx
@@ -115,19 +115,19 @@ export const MicrophoneNeedsCalculator = ({ jobId }: MicrophoneNeedsCalculatorPr
         className="w-full"
       >
         <Calculator className="h-4 w-4 mr-2" />
-        Wired Microphone Matrix
+        Matriz de Micrófonos Cableados
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center justify-between">
-              <span>Wired Microphone Requirements Matrix</span>
+              <span>Matriz de Requisitos de Micrófonos Cableados</span>
               <div className="flex gap-2">
                 {validArtists.length > 0 && (
                   <Button onClick={exportMatrixPDF} variant="outline" size="sm">
                     <FileText className="h-4 w-4 mr-2" />
-                    Export Matrix PDF
+                    Exportar Matriz PDF
                   </Button>
                 )}
               </div>
@@ -135,42 +135,42 @@ export const MicrophoneNeedsCalculator = ({ jobId }: MicrophoneNeedsCalculatorPr
           </DialogHeader>
 
           {isLoading ? (
-            <div className="text-center py-8">Loading artist data...</div>
+            <div className="text-center py-8">Cargando datos de artistas...</div>
           ) : validArtists.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
-              No artists found with wired microphone requirements using festival kit.
+              No se encontraron artistas con requisitos de micrófonos cableados usando kit de festival.
               <br />
-              Make sure artists have wired microphones configured with festival kit selected.
+              Asegúrese de que los artistas tengan micrófonos cableados configurados con kit de festival seleccionado.
             </div>
           ) : (
             <div className="space-y-6">
               <div className="text-sm text-muted-foreground">
-                This matrix shows all artists using festival wired microphones. The PDF export will calculate 
-                peak requirements considering show schedules and microphone sharing constraints.
+                Esta matriz muestra todos los artistas que usan micrófonos cableados del festival. La exportación PDF calculará
+                los requisitos máximos considerando los horarios de shows y las restricciones de compartir micrófonos.
               </div>
 
               {/* Summary Statistics */}
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div className="bg-blue-50 p-4 rounded-lg">
                   <div className="text-2xl font-bold text-blue-700">{validArtists.length}</div>
-                  <div className="text-sm text-blue-600">Artists with Wired Mics</div>
+                  <div className="text-sm text-blue-600">Artistas con Micrófonos Cableados</div>
                 </div>
                 <div className="bg-green-50 p-4 rounded-lg">
                   <div className="text-2xl font-bold text-green-700">{microphoneModels.length}</div>
-                  <div className="text-sm text-green-600">Microphone Models</div>
+                  <div className="text-sm text-green-600">Modelos de Micrófonos</div>
                 </div>
                 <div className="bg-purple-50 p-4 rounded-lg">
                   <div className="text-2xl font-bold text-purple-700">
                     {new Set(validArtists.map(a => `${a.date}-${a.stage}`)).size}
                   </div>
-                  <div className="text-sm text-purple-600">Date/Stage Combinations</div>
+                  <div className="text-sm text-purple-600">Combinaciones Fecha/Stage</div>
                 </div>
               </div>
 
               {/* Microphone Models Overview */}
               {microphoneModels.length > 0 && (
                 <div>
-                  <h3 className="text-lg font-semibold mb-3">Microphone Models Required</h3>
+                  <h3 className="text-lg font-semibold mb-3">Modelos de Micrófonos Requeridos</h3>
                   <div className="flex flex-wrap gap-2">
                     {microphoneModels.map((model) => (
                       <Badge key={model} variant="outline" className="text-sm">
@@ -183,15 +183,15 @@ export const MicrophoneNeedsCalculator = ({ jobId }: MicrophoneNeedsCalculatorPr
 
               {/* Artists Preview Table */}
               <div>
-                <h3 className="text-lg font-semibold mb-3">Artists Included in Matrix</h3>
+                <h3 className="text-lg font-semibold mb-3">Artistas Incluidos en la Matriz</h3>
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      <TableHead>Artist</TableHead>
-                      <TableHead>Date</TableHead>
+                      <TableHead>Artista</TableHead>
+                      <TableHead>Fecha</TableHead>
                       <TableHead>Stage</TableHead>
-                      <TableHead>Show Time</TableHead>
-                      <TableHead>Microphones</TableHead>
+                      <TableHead>Hora del Show</TableHead>
+                      <TableHead>Micrófonos</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -217,7 +217,7 @@ export const MicrophoneNeedsCalculator = ({ jobId }: MicrophoneNeedsCalculatorPr
                                   </Badge>
                                   {mic.exclusive_use && (
                                     <Badge variant="destructive" className="text-xs">
-                                      Exclusive
+                                      Exclusivo
                                     </Badge>
                                   )}
                                 </div>
@@ -233,8 +233,8 @@ export const MicrophoneNeedsCalculator = ({ jobId }: MicrophoneNeedsCalculatorPr
 
               <div className="bg-yellow-50 p-4 rounded-lg border border-yellow-200">
                 <div className="text-sm text-yellow-800">
-                  <strong>Note:</strong> The matrix PDF will calculate exact peak requirements by analyzing 
-                  show schedules, exclusive use requirements, and sharing constraints across all dates and stages.
+                  <strong>Nota:</strong> El PDF de la matriz calculará los requisitos máximos exactos analizando
+                  los horarios de shows, requisitos de uso exclusivo y restricciones de compartir en todas las fechas y stages.
                 </div>
               </div>
             </div>

--- a/src/components/festival/gear-setup/StageEquipmentConfig.tsx
+++ b/src/components/festival/gear-setup/StageEquipmentConfig.tsx
@@ -7,11 +7,11 @@ import { StageEquipmentConfigProps } from "@/types/festival-gear";
 export const StageEquipmentConfig = ({ data, onChange }: StageEquipmentConfigProps) => {
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold">Stage Equipment</h3>
+      <h3 className="text-lg font-semibold">Equipamiento de Stage</h3>
 
       <div className="space-y-4">
         <div className="space-y-2">
-          <Label htmlFor="available-monitors">Available Monitors</Label>
+          <Label htmlFor="available-monitors">Monitores Disponibles</Label>
           <Input
             id="available-monitors"
             type="number"
@@ -23,7 +23,7 @@ export const StageEquipmentConfig = ({ data, onChange }: StageEquipmentConfigPro
 
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <Label htmlFor="side-fills">Side Fills Available</Label>
+            <Label htmlFor="side-fills">Side Fills Disponibles</Label>
             <Switch
               id="side-fills"
               checked={data.extras_sf}
@@ -32,7 +32,7 @@ export const StageEquipmentConfig = ({ data, onChange }: StageEquipmentConfigPro
           </div>
 
           <div className="flex items-center justify-between">
-            <Label htmlFor="drum-fills">Drum Fills Available</Label>
+            <Label htmlFor="drum-fills">Drum Fills Disponibles</Label>
             <Switch
               id="drum-fills"
               checked={data.extras_df}
@@ -41,7 +41,7 @@ export const StageEquipmentConfig = ({ data, onChange }: StageEquipmentConfigPro
           </div>
 
           <div className="flex items-center justify-between">
-            <Label htmlFor="dj-booths">DJ Booths Available</Label>
+            <Label htmlFor="dj-booths">Cabinas de DJ Disponibles</Label>
             <Switch
               id="dj-booths"
               checked={data.extras_djbooth}

--- a/src/components/festival/gear-setup/WiredMicConfig.tsx
+++ b/src/components/festival/gear-setup/WiredMicConfig.tsx
@@ -20,11 +20,11 @@ interface WiredMicConfigProps {
   showProvider?: boolean;
 }
 
-export const WiredMicConfig = ({ 
-  mics, 
-  onChange, 
-  label = "Wired Microphones",
-  showProvider = false 
+export const WiredMicConfig = ({
+  mics,
+  onChange,
+  label = "Micrófonos Cableados",
+  showProvider = false
 }: WiredMicConfigProps) => {
   const addMic = () => {
     onChange([...mics, { 
@@ -57,7 +57,7 @@ export const WiredMicConfig = ({
           onClick={addMic}
         >
           <Plus className="h-4 w-4 mr-2" />
-          Add Microphone
+          Añadir Micrófono
         </Button>
       </div>
 
@@ -70,7 +70,7 @@ export const WiredMicConfig = ({
                 onChange={(value) => updateMic(index, 'model', value)}
                 options={[]}
                 fallbackOptions={[]}
-                placeholder="Select microphone"
+                placeholder="Seleccionar micrófono"
                 category="wired_mics"
               />
             </div>
@@ -89,7 +89,7 @@ export const WiredMicConfig = ({
                 onCheckedChange={(checked) => updateMic(index, 'exclusive_use', !!checked)}
               />
               <Label htmlFor={`exclusive-${index}`} className="text-sm">
-                Exclusive
+                Exclusivo
               </Label>
             </div>
             <Button
@@ -105,7 +105,7 @@ export const WiredMicConfig = ({
       ))}
 
       {mics.length === 0 && (
-        <p className="text-sm text-muted-foreground">No wired microphones added yet.</p>
+        <p className="text-sm text-muted-foreground">Aún no se han añadido micrófonos cableados.</p>
       )}
     </div>
   );

--- a/src/components/festival/gear-setup/WirelessConfig.tsx
+++ b/src/components/festival/gear-setup/WirelessConfig.tsx
@@ -79,10 +79,10 @@ export const WirelessConfig = ({
 
   const options = isIEM ? IEM_SYSTEMS : WIRELESS_SYSTEMS;
   const quantityTypeLabels = isIEM ? {
-    hh: "Channels",
+    hh: "Canales",
     bp: "Bodypacks"
   } : {
-    hh: "Handheld",
+    hh: "De Mano",
     bp: "Bodypacks"
   };
 
@@ -104,7 +104,7 @@ export const WirelessConfig = ({
           onClick={addSystem}
         >
           <Plus className="h-4 w-4 mr-2" />
-          Add System
+          Añadir Sistema
         </Button>
       </div>
 
@@ -117,7 +117,7 @@ export const WirelessConfig = ({
                 onChange={(value) => updateSystem(index, 'model', value)}
                 options={[]}
                 fallbackOptions={options}
-                placeholder="Select system"
+                placeholder="Seleccionar sistema"
                 category={getCategory()}
               />
             </div>
@@ -159,17 +159,17 @@ export const WirelessConfig = ({
           </div>
 
           <div>
-            <Label>Frequency Band</Label>
+            <Label>Banda de Frecuencia</Label>
             <Input
               value={system.band || ''}
               onChange={(e) => updateSystem(index, 'band', e.target.value)}
-              placeholder="e.g., G50, H50"
+              placeholder="ej., G50, H50"
             />
           </div>
-          
+
           {!hideProvidedBy && (
             <div>
-              <Label>Provided By</Label>
+              <Label>Proporcionado Por</Label>
               <RadioGroup
                 value={system.provided_by || 'festival'}
                 onValueChange={(value: 'festival' | 'band') => {
@@ -184,7 +184,7 @@ export const WirelessConfig = ({
                 </div>
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="band" id={`${index}-band`} />
-                  <Label htmlFor={`${index}-band`}>Band</Label>
+                  <Label htmlFor={`${index}-band`}>Banda</Label>
                 </div>
               </RadioGroup>
             </div>

--- a/src/components/festival/pdf/PrintOptionsDialog.tsx
+++ b/src/components/festival/pdf/PrintOptionsDialog.tsx
@@ -218,7 +218,7 @@ export const PrintOptionsDialog = ({
 
   const handleDownloadMissingRiderReport = async () => {
     if (!jobId) {
-      toast.error('Job ID is required to generate missing rider report');
+      toast.error('Se requiere el ID del trabajo para generar el reporte de riders faltantes');
       return;
     }
 
@@ -291,16 +291,16 @@ export const PrintOptionsDialog = ({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      toast.success('Missing Rider Report downloaded successfully');
+      toast.success('Reporte de Riders Faltantes descargado exitosamente');
     } catch (error: any) {
       console.error('Error generating Missing Rider Report:', error);
-      toast.error(`Failed to generate Missing Rider Report: ${error.message}`);
+      toast.error(`Error al generar Reporte de Riders Faltantes: ${error.message}`);
     }
   };
 
   const handleDownloadGearSetup = async () => {
     if (!jobId) {
-      toast.error('Job ID is required to generate gear setup report');
+      toast.error('Se requiere el ID del trabajo para generar el reporte de equipamiento');
       return;
     }
 
@@ -341,16 +341,16 @@ export const PrintOptionsDialog = ({
         URL.revokeObjectURL(url);
       }
 
-      toast.success('Gear Setup downloaded successfully');
+      toast.success('Equipamiento descargado exitosamente');
     } catch (error: any) {
       console.error('Error generating Gear Setup:', error);
-      toast.error(`Failed to generate Gear Setup: ${error.message}`);
+      toast.error(`Error al generar Equipamiento: ${error.message}`);
     }
   };
 
   const handleDownloadShiftSchedules = async () => {
     if (!jobId) {
-      toast.error('Job ID is required to generate shift schedules');
+      toast.error('Se requiere el ID del trabajo para generar horarios de turnos');
       return;
     }
 
@@ -396,16 +396,16 @@ export const PrintOptionsDialog = ({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      toast.success('Shift Schedules downloaded successfully');
+      toast.success('Horarios de Turnos descargados exitosamente');
     } catch (error: any) {
       console.error('Error generating Shift Schedules:', error);
-      toast.error(`Failed to generate Shift Schedules: ${error.message}`);
+      toast.error(`Error al generar Horarios de Turnos: ${error.message}`);
     }
   };
 
   const handleDownloadArtistTables = async () => {
     if (!jobId) {
-      toast.error('Job ID is required to generate artist tables');
+      toast.error('Se requiere el ID del trabajo para generar tablas de artistas');
       return;
     }
 
@@ -444,16 +444,16 @@ export const PrintOptionsDialog = ({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      toast.success('Artist Tables downloaded successfully');
+      toast.success('Tablas de Artistas descargadas exitosamente');
     } catch (error: any) {
       console.error('Error generating Artist Tables:', error);
-      toast.error(`Failed to generate Artist Tables: ${error.message}`);
+      toast.error(`Error al generar Tablas de Artistas: ${error.message}`);
     }
   };
 
   const handleDownloadRfIemTable = async () => {
     if (!jobId) {
-      toast.error('Job ID is required to generate RF/IEM table');
+      toast.error('Se requiere el ID del trabajo para generar tabla de RF/IEM');
       return;
     }
 
@@ -491,16 +491,16 @@ export const PrintOptionsDialog = ({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      toast.success('RF/IEM Table downloaded successfully');
+      toast.success('Tabla de RF/IEM descargada exitosamente');
     } catch (error: any) {
       console.error('Error generating RF/IEM Table:', error);
-      toast.error(`Failed to generate RF/IEM Table: ${error.message}`);
+      toast.error(`Error al generar Tabla de RF/IEM: ${error.message}`);
     }
   };
 
   const handleDownloadInfrastructureTable = async () => {
     if (!jobId) {
-      toast.error('Job ID is required to generate infrastructure table');
+      toast.error('Se requiere el ID del trabajo para generar tabla de infraestructura');
       return;
     }
 
@@ -538,16 +538,16 @@ export const PrintOptionsDialog = ({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      toast.success('Infrastructure Table downloaded successfully');
+      toast.success('Tabla de Infraestructura descargada exitosamente');
     } catch (error: any) {
       console.error('Error generating Infrastructure Table:', error);
-      toast.error(`Failed to generate Infrastructure Table: ${error.message}`);
+      toast.error(`Error al generar Tabla de Infraestructura: ${error.message}`);
     }
   };
 
   const handleDownloadWiredMicNeeds = async () => {
     if (!jobId) {
-      toast.error('Job ID is required to generate wired microphone needs');
+      toast.error('Se requiere el ID del trabajo para generar necesidades de micrófonos cableados');
       return;
     }
 
@@ -594,10 +594,10 @@ export const PrintOptionsDialog = ({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      toast.success('Wired Microphone Needs downloaded successfully');
+      toast.success('Necesidades de Micrófonos Cableados descargadas exitosamente');
     } catch (error: any) {
       console.error('Error generating Wired Microphone Needs:', error);
-      toast.error(`Failed to generate Wired Microphone Needs: ${error.message}`);
+      toast.error(`Error al generar Necesidades de Micrófonos Cableados: ${error.message}`);
     }
   };
 
@@ -605,7 +605,7 @@ export const PrintOptionsDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[95vw] sm:max-w-2xl max-h-[90vh] sm:max-h-[90vh] w-[95vw] sm:w-auto overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
-          <DialogTitle className="text-base sm:text-lg">Select Documents to Print</DialogTitle>
+          <DialogTitle className="text-base sm:text-lg">Seleccionar Documentos para Imprimir</DialogTitle>
         </DialogHeader>
         <div className="space-y-4 sm:space-y-6 py-2 sm:py-4">
           <div className="border rounded-lg p-4 bg-blue-50 dark:bg-blue-950/30 dark:border-blue-800">
@@ -613,51 +613,51 @@ export const PrintOptionsDialog = ({
               <Checkbox
                 id="individual-stage-pdfs"
                 checked={options.generateIndividualStagePDFs}
-                onCheckedChange={(checked) => 
+                onCheckedChange={(checked) =>
                   setOptions(prev => ({ ...prev, generateIndividualStagePDFs: checked as boolean }))
                 }
                 className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
               />
-              <Label 
-                htmlFor="individual-stage-pdfs" 
+              <Label
+                htmlFor="individual-stage-pdfs"
                 className="font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
               >
-                Generate Individual Stage PDFs
+                Generar PDFs Individuales por Stage
               </Label>
             </div>
             <p className="text-sm text-muted-foreground pl-6 dark:text-gray-300">
-              {options.generateIndividualStagePDFs 
-                ? "Creates separate PDF documents for each stage containing the selected document types. Downloads as a ZIP file containing individual PDFs for each stage."
-                : "Create a single combined PDF with the selected document types and stages. Use the stage selections below to choose which stages to include for each document type."
+              {options.generateIndividualStagePDFs
+                ? "Crea documentos PDF separados para cada stage conteniendo los tipos de documentos seleccionados. Se descarga como un archivo ZIP con PDFs individuales para cada stage."
+                : "Crear un único PDF combinado con los tipos de documentos y stages seleccionados. Usa las selecciones de stage abajo para elegir qué stages incluir para cada tipo de documento."
               }
             </p>
           </div>
 
           {maxStages > 1 && (
             <div className="border-b pb-4">
-              <h3 className="text-sm font-medium mb-3 dark:text-gray-200">Global Stage Controls</h3>
+              <h3 className="text-sm font-medium mb-3 dark:text-gray-200">Controles Globales de Stage</h3>
               <div className="flex flex-col sm:flex-row gap-2">
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
                   onClick={handleSelectAllStages}
                   className="w-full sm:w-auto"
                 >
-                  Select All Stages
+                  Seleccionar Todos los Stages
                 </Button>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
                   onClick={handleDeselectAllStages}
                   className="w-full sm:w-auto"
                 >
-                  Deselect All Stages
+                  Deseleccionar Todos los Stages
                 </Button>
               </div>
               <p className="text-xs text-muted-foreground mt-2 dark:text-gray-400">
-                {options.generateIndividualStagePDFs 
-                  ? "These controls apply to all sections. Individual PDFs will be generated for stages that have content in each selected document type."
-                  : "These controls apply to all sections that have stage selections."
+                {options.generateIndividualStagePDFs
+                  ? "Estos controles aplican a todas las secciones. Se generarán PDFs individuales para stages que tengan contenido en cada tipo de documento seleccionado."
+                  : "Estos controles aplican a todas las secciones que tienen selecciones de stage."
                 }
               </p>
             </div>
@@ -675,11 +675,11 @@ export const PrintOptionsDialog = ({
                     }
                     className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                   />
-                  <Label 
+                  <Label
                     htmlFor="gear-setup"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                   >
-                    Stage Equipment Setup
+                    Configuración de Equipamiento por Stage
                   </Label>
                 </div>
                 {jobId && (
@@ -708,11 +708,11 @@ export const PrintOptionsDialog = ({
                     }
                     className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                   />
-                  <Label 
+                  <Label
                     htmlFor="shift-schedules"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                   >
-                    Staff Shift Schedules
+                    Horarios de Turnos de Personal
                   </Label>
                 </div>
                 {jobId && (
@@ -741,11 +741,11 @@ export const PrintOptionsDialog = ({
                     }
                     className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                   />
-                  <Label 
+                  <Label
                     htmlFor="artist-tables"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                   >
-                    Artist Schedule Tables
+                    Tablas de Programación de Artistas
                   </Label>
                 </div>
                 {jobId && (
@@ -773,11 +773,11 @@ export const PrintOptionsDialog = ({
                   }
                   className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                 />
-                <Label 
+                <Label
                   htmlFor="artist-requirements"
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                 >
-                  Individual Artist Requirements
+                  Requerimientos Individuales de Artistas
                 </Label>
               </div>
               {options.includeArtistRequirements && maxStages > 1 && renderStageSelections('artistRequirementStages')}
@@ -794,11 +794,11 @@ export const PrintOptionsDialog = ({
                     }
                     className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                   />
-                  <Label 
+                  <Label
                     htmlFor="rf-iem-table"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                   >
-                    Artist RF & IEM Overview
+                    Resumen de RF e IEM de Artistas
                   </Label>
                 </div>
                 {jobId && (
@@ -827,11 +827,11 @@ export const PrintOptionsDialog = ({
                     }
                     className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                   />
-                  <Label 
+                  <Label
                     htmlFor="infrastructure-table"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                   >
-                    Infrastructure Needs Overview
+                    Resumen de Necesidades de Infraestructura
                   </Label>
                 </div>
                 {jobId && (
@@ -860,11 +860,11 @@ export const PrintOptionsDialog = ({
                     }
                     className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                   />
-                  <Label 
+                  <Label
                     htmlFor="wired-mic-needs"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                   >
-                    Wired Microphone Requirements
+                    Requerimientos de Micrófonos Cableados
                   </Label>
                 </div>
                 {jobId && (
@@ -881,7 +881,7 @@ export const PrintOptionsDialog = ({
               </div>
               {options.includeWiredMicNeeds && maxStages > 1 && renderStageSelections('wiredMicNeedsStages')}
               <div className="pl-6 text-sm text-muted-foreground dark:text-gray-300">
-                Detailed microphone inventory requirements and peak usage analysis
+                Requerimientos detallados de inventario de micrófonos y análisis de uso pico
               </div>
             </div>
 
@@ -895,15 +895,15 @@ export const PrintOptionsDialog = ({
                   }
                   className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                 />
-                <Label 
+                <Label
                   htmlFor="weather-prediction"
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                 >
-                  Include Weather Prediction
+                  Incluir Pronóstico del Tiempo
                 </Label>
               </div>
               <div className="pl-6 text-sm text-muted-foreground dark:text-gray-300">
-                Weather forecast for festival dates from Open-Meteo
+                Pronóstico del tiempo para las fechas del festival de Open-Meteo
               </div>
             </div>
 
@@ -918,11 +918,11 @@ export const PrintOptionsDialog = ({
                     }
                     className="data-[state=checked]:bg-primary data-[state=checked]:border-primary dark:border-gray-500 dark:data-[state=checked]:bg-primary dark:data-[state=checked]:border-primary"
                   />
-                  <Label 
+                  <Label
                     htmlFor="missing-rider-report"
                     className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-gray-200"
                   >
-                    Missing Rider Report
+                    Reporte de Riders Faltantes
                   </Label>
                 </div>
                 {jobId && (
@@ -938,25 +938,25 @@ export const PrintOptionsDialog = ({
                 )}
               </div>
               <div className="pl-6 text-sm text-muted-foreground dark:text-gray-300">
-                Summary of all artists with missing technical riders
+                Resumen de todos los artistas con riders técnicos faltantes
               </div>
             </div>
           </div>
 
           <div className="border-t pt-4">
             <div className="bg-muted/50 p-3 rounded-md dark:bg-muted/20">
-              <h4 className="text-xs sm:text-sm font-medium mb-1 dark:text-gray-200">Generated filename:</h4>
+              <h4 className="text-xs sm:text-sm font-medium mb-1 dark:text-gray-200">Nombre de archivo generado:</h4>
               <p className="text-xs sm:text-sm text-muted-foreground font-mono dark:text-gray-300 break-all">{generateFilename()}</p>
             </div>
           </div>
         </div>
         <DialogFooter className="flex-col sm:flex-row gap-2 sm:gap-0">
           <Button variant="outline" onClick={() => onOpenChange(false)} className="w-full sm:w-auto">
-            Cancel
+            Cancelar
           </Button>
           <Button onClick={handleConfirm} className="w-full sm:w-auto">
-            <span className="hidden sm:inline">Generate {options.generateIndividualStagePDFs ? 'Individual Stage PDFs' : 'PDF'}</span>
-            <span className="sm:hidden">Generate</span>
+            <span className="hidden sm:inline">Generar {options.generateIndividualStagePDFs ? 'PDFs Individuales por Stage' : 'PDF'}</span>
+            <span className="sm:hidden">Generar</span>
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/festival/scheduling/CopyShiftsDialog.tsx
+++ b/src/components/festival/scheduling/CopyShiftsDialog.tsx
@@ -29,7 +29,7 @@ export const CopyShiftsDialog = ({
 
   const handleCopy = async () => {
     if (!targetDate) {
-      toast.error("Please select a target date");
+      toast.error("Por favor selecciona una fecha destino");
       return;
     }
 
@@ -58,7 +58,7 @@ export const CopyShiftsDialog = ({
       }
 
       if (!shifts || shifts.length === 0) {
-        toast.error("No shifts found for the selected source date");
+        toast.error("No se encontraron turnos para la fecha de origen seleccionada");
         return;
       }
 
@@ -128,15 +128,15 @@ export const CopyShiftsDialog = ({
       }
 
       console.log("Copy operation completed successfully");
-      toast.success(`Successfully copied ${shifts.length} shifts with all assignments to ${format(new Date(targetDate), 'MMM d, yyyy')}`);
-      
+      toast.success(`Se copiaron exitosamente ${shifts.length} turnos con todas las asignaciones a ${format(new Date(targetDate), 'MMM d, yyyy')}`);
+
       // Call the callback to refresh data
       onShiftsCopied();
       onOpenChange(false);
-      
+
     } catch (error: any) {
       console.error("Error copying shifts:", error);
-      toast.error(`Failed to copy shifts: ${error.message || 'Unknown error'}`);
+      toast.error(`Error al copiar turnos: ${error.message || 'Error desconocido'}`);
     } finally {
       setIsLoading(false);
     }
@@ -146,22 +146,22 @@ export const CopyShiftsDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[95vw] sm:max-w-md max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="text-base sm:text-lg">Copy Shifts to Another Date</DialogTitle>
+          <DialogTitle className="text-base sm:text-lg">Copiar Turnos a Otra Fecha</DialogTitle>
         </DialogHeader>
         <div className="space-y-4 mt-4">
           <div>
             <p className="text-sm text-muted-foreground mb-2">
-              Source date: {format(new Date(sourceDate), 'MMM d, yyyy')}
+              Fecha de origen: {format(new Date(sourceDate), 'MMM d, yyyy')}
             </p>
             <p className="text-xs text-muted-foreground mb-4">
-              This will copy all shifts and their assigned technicians to the target date.
+              Esto copiará todos los turnos y sus técnicos asignados a la fecha destino.
             </p>
             <Select
               value={targetDate}
               onValueChange={setTargetDate}
             >
               <SelectTrigger>
-                <SelectValue placeholder="Select target date" />
+                <SelectValue placeholder="Seleccionar fecha destino" />
               </SelectTrigger>
               <SelectContent>
                 {jobDates.map((date) => {
@@ -182,13 +182,13 @@ export const CopyShiftsDialog = ({
               onClick={() => onOpenChange(false)}
               disabled={isLoading}
             >
-              Cancel
+              Cancelar
             </Button>
             <Button
               onClick={handleCopy}
               disabled={!targetDate || isLoading}
             >
-              {isLoading ? "Copying..." : "Copy Shifts & Assignments"}
+              {isLoading ? "Copiando..." : "Copiar Turnos y Asignaciones"}
             </Button>
           </div>
         </div>

--- a/src/components/festival/scheduling/CreateShiftDialog.tsx
+++ b/src/components/festival/scheduling/CreateShiftDialog.tsx
@@ -23,9 +23,9 @@ interface CreateShiftDialogProps {
 }
 
 const formSchema = z.object({
-  name: z.string().min(1, "Shift name is required"),
-  start_time: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, "Valid time format is required (HH:MM)"),
-  end_time: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, "Valid time format is required (HH:MM)"),
+  name: z.string().min(1, "El nombre del turno es requerido"),
+  start_time: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, "Se requiere formato de hora válido (HH:MM)"),
+  end_time: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, "Se requiere formato de hora válido (HH:MM)"),
   stage: z.string().optional(),
   department: z.string().optional(),
   notes: z.string().optional(),
@@ -90,16 +90,16 @@ export const CreateShiftDialog = ({
       console.log("Shift created successfully:", data);
       form.reset();
       onShiftCreated();
-      
+
       toast({
-        title: "Success",
-        description: "Shift created successfully",
+        title: "Éxito",
+        description: "Turno creado exitosamente",
       });
     } catch (error: any) {
       console.error("Error creating shift:", error);
       toast({
         title: "Error",
-        description: `Could not create shift: ${error.message}`,
+        description: `No se pudo crear el turno: ${error.message}`,
         variant: "destructive",
       });
     } finally {
@@ -111,14 +111,14 @@ export const CreateShiftDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[95vw] sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="text-base sm:text-lg">Create Shift</DialogTitle>
+          <DialogTitle className="text-base sm:text-lg">Crear Turno</DialogTitle>
         </DialogHeader>
         <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4 pt-4">
           <div className="space-y-2">
-            <Label htmlFor="name">Shift Name</Label>
+            <Label htmlFor="name">Nombre del Turno</Label>
             <Input
               id="name"
-              placeholder="Morning Shift, Sound Check, etc."
+              placeholder="Turno Mañana, Soundcheck, etc."
               {...form.register("name")}
             />
             {form.formState.errors.name && (
@@ -137,7 +137,7 @@ export const CreateShiftDialog = ({
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="start_time">Start Time</Label>
+              <Label htmlFor="start_time">Hora de Inicio</Label>
               <Input
                 id="start_time"
                 type="time"
@@ -151,7 +151,7 @@ export const CreateShiftDialog = ({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="end_time">End Time</Label>
+              <Label htmlFor="end_time">Hora de Fin</Label>
               <Input
                 id="end_time"
                 type="time"
@@ -167,10 +167,10 @@ export const CreateShiftDialog = ({
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="stage">Stage (optional)</Label>
+              <Label htmlFor="stage">Stage (opcional)</Label>
               <Select onValueChange={(value) => form.setValue("stage", value)}>
                 <SelectTrigger>
-                  <SelectValue placeholder="Select stage" />
+                  <SelectValue placeholder="Seleccionar stage" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="1">Stage 1</SelectItem>
@@ -182,26 +182,26 @@ export const CreateShiftDialog = ({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="department">Department (optional)</Label>
+              <Label htmlFor="department">Departamento (opcional)</Label>
               <Select onValueChange={(value) => form.setValue("department", value)}>
                 <SelectTrigger>
-                  <SelectValue placeholder="Select department" />
+                  <SelectValue placeholder="Seleccionar departamento" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="sound">Sound</SelectItem>
-                  <SelectItem value="lights">Lights</SelectItem>
+                  <SelectItem value="sound">Sonido</SelectItem>
+                  <SelectItem value="lights">Luces</SelectItem>
                   <SelectItem value="video">Video</SelectItem>
-                  <SelectItem value="logistics">Logistics</SelectItem>
+                  <SelectItem value="logistics">Logística</SelectItem>
                 </SelectContent>
               </Select>
             </div>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="notes">Notes (optional)</Label>
+            <Label htmlFor="notes">Notas (opcional)</Label>
             <Textarea
               id="notes"
-              placeholder="Any additional information about this shift"
+              placeholder="Cualquier información adicional sobre este turno"
               {...form.register("notes")}
             />
           </div>
@@ -212,10 +212,10 @@ export const CreateShiftDialog = ({
               variant="outline"
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              Cancelar
             </Button>
             <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Creating..." : "Create Shift"}
+              {isSubmitting ? "Creando..." : "Crear Turno"}
             </Button>
           </div>
         </form>

--- a/src/components/festival/scheduling/EditShiftDialog.tsx
+++ b/src/components/festival/scheduling/EditShiftDialog.tsx
@@ -22,9 +22,9 @@ interface EditShiftDialogProps {
 }
 
 const formSchema = z.object({
-  name: z.string().min(1, "Shift name is required"),
-  start_time: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, "Valid time format is required (HH:MM)"),
-  end_time: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, "Valid time format is required (HH:MM)"),
+  name: z.string().min(1, "El nombre del turno es requerido"),
+  start_time: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, "Se requiere formato de hora válido (HH:MM)"),
+  end_time: z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, "Se requiere formato de hora válido (HH:MM)"),
   stage: z.string().optional(),
   department: z.string().optional(),
   notes: z.string().optional(),
@@ -78,14 +78,14 @@ export const EditShiftDialog = ({
       onShiftUpdated();
       onOpenChange(false);
       toast({
-        title: "Success",
-        description: "Shift updated successfully",
+        title: "Éxito",
+        description: "Turno actualizado exitosamente",
       });
     } catch (error: any) {
       console.error("Error updating shift:", error);
       toast({
         title: "Error",
-        description: "Could not update shift",
+        description: "No se pudo actualizar el turno",
         variant: "destructive",
       });
     } finally {
@@ -97,14 +97,14 @@ export const EditShiftDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[95vw] sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="text-base sm:text-lg">Edit Shift</DialogTitle>
+          <DialogTitle className="text-base sm:text-lg">Editar Turno</DialogTitle>
         </DialogHeader>
         <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4 pt-4">
           <div className="space-y-2">
-            <Label htmlFor="name">Shift Name</Label>
+            <Label htmlFor="name">Nombre del Turno</Label>
             <Input
               id="name"
-              placeholder="Morning Shift, Sound Check, etc."
+              placeholder="Turno Mañana, Soundcheck, etc."
               {...form.register("name")}
             />
             {form.formState.errors.name && (
@@ -123,7 +123,7 @@ export const EditShiftDialog = ({
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="start_time">Start Time</Label>
+              <Label htmlFor="start_time">Hora de Inicio</Label>
               <Input
                 id="start_time"
                 type="time"
@@ -137,7 +137,7 @@ export const EditShiftDialog = ({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="end_time">End Time</Label>
+              <Label htmlFor="end_time">Hora de Fin</Label>
               <Input
                 id="end_time"
                 type="time"
@@ -153,16 +153,16 @@ export const EditShiftDialog = ({
 
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="stage">Stage (optional)</Label>
-              <Select 
+              <Label htmlFor="stage">Stage (opcional)</Label>
+              <Select
                 defaultValue={form.getValues("stage") || "none"}
                 onValueChange={(value) => form.setValue("stage", value)}
               >
                 <SelectTrigger>
-                  <SelectValue placeholder="Select stage" />
+                  <SelectValue placeholder="Seleccionar stage" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">No stage</SelectItem>
+                  <SelectItem value="none">Sin stage</SelectItem>
                   <SelectItem value="1">Stage 1</SelectItem>
                   <SelectItem value="2">Stage 2</SelectItem>
                   <SelectItem value="3">Stage 3</SelectItem>
@@ -172,30 +172,30 @@ export const EditShiftDialog = ({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="department">Department (optional)</Label>
-              <Select 
+              <Label htmlFor="department">Departamento (opcional)</Label>
+              <Select
                 defaultValue={form.getValues("department") || "none"}
                 onValueChange={(value) => form.setValue("department", value)}
               >
                 <SelectTrigger>
-                  <SelectValue placeholder="Select department" />
+                  <SelectValue placeholder="Seleccionar departamento" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">No department</SelectItem>
-                  <SelectItem value="sound">Sound</SelectItem>
-                  <SelectItem value="lights">Lights</SelectItem>
+                  <SelectItem value="none">Sin departamento</SelectItem>
+                  <SelectItem value="sound">Sonido</SelectItem>
+                  <SelectItem value="lights">Luces</SelectItem>
                   <SelectItem value="video">Video</SelectItem>
-                  <SelectItem value="logistics">Logistics</SelectItem>
+                  <SelectItem value="logistics">Logística</SelectItem>
                 </SelectContent>
               </Select>
             </div>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="notes">Notes (optional)</Label>
+            <Label htmlFor="notes">Notas (opcional)</Label>
             <Textarea
               id="notes"
-              placeholder="Any additional information about this shift"
+              placeholder="Cualquier información adicional sobre este turno"
               {...form.register("notes")}
             />
           </div>
@@ -206,10 +206,10 @@ export const EditShiftDialog = ({
               variant="outline"
               onClick={() => onOpenChange(false)}
             >
-              Cancel
+              Cancelar
             </Button>
             <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Updating..." : "Update Shift"}
+              {isSubmitting ? "Actualizando..." : "Actualizar Turno"}
             </Button>
           </div>
         </form>

--- a/src/components/festival/scheduling/FestivalScheduling.tsx
+++ b/src/components/festival/scheduling/FestivalScheduling.tsx
@@ -138,8 +138,8 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
     setTimeout(async () => {
       await refetch();
       toast({
-        title: "Data refreshed",
-        description: "Shifts and assignments have been updated",
+        title: "Datos actualizados",
+        description: "Los turnos y asignaciones han sido actualizados",
       });
     }, 500);
   };
@@ -165,14 +165,14 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
 
       await refetch();
       toast({
-        title: "Success",
-        description: "Shift deleted successfully",
+        title: "Éxito",
+        description: "Turno eliminado exitosamente",
       });
     } catch (error: any) {
       console.error("Error deleting shift:", error);
       toast({
         title: "Error",
-        description: `Failed to delete shift: ${error.message}`,
+        description: `No se pudo eliminar el turno: ${error.message}`,
         variant: "destructive",
       });
     } finally {
@@ -185,14 +185,14 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
     try {
       await refetch();
       toast({
-        title: "Success",
-        description: "Shifts refreshed successfully",
+        title: "Éxito",
+        description: "Turnos actualizados exitosamente",
       });
     } catch (error) {
       console.error("Error refreshing shifts:", error);
       toast({
         title: "Error",
-        description: "Failed to refresh shifts",
+        description: "No se pudieron actualizar los turnos",
         variant: "destructive",
       });
     } finally {
@@ -205,7 +205,7 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
     return (
       <Card>
         <CardContent className="p-8 text-center">
-          <p className="text-muted-foreground">No dates available for scheduling.</p>
+          <p className="text-muted-foreground">No hay fechas disponibles para programar.</p>
         </CardContent>
       </Card>
     );
@@ -215,27 +215,27 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
     <Card className="mt-4 sm:mt-6">
       <CardHeader className="p-4 sm:p-6">
         <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 sm:gap-4">
-          <CardTitle className="text-base sm:text-lg">Festival Schedule</CardTitle>
+          <CardTitle className="text-base sm:text-lg">Programación del Festival</CardTitle>
           <div className="flex gap-2">
             {!isViewOnly && (
-              <Button 
-                size="sm" 
+              <Button
+                size="sm"
                 onClick={() => setIsCreateShiftOpen(true)}
                 className="flex items-center gap-1"
               >
                 <Plus className="h-4 w-4" />
-                <span className="hidden sm:inline">Create Shift</span>
+                <span className="hidden sm:inline">Crear Turno</span>
               </Button>
             )}
-            <Button 
-              size="sm" 
-              variant="outline" 
+            <Button
+              size="sm"
+              variant="outline"
               className="flex items-center gap-1"
               onClick={handleRefresh}
               disabled={isRefreshing}
             >
               <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
-              <span className="hidden sm:inline">Refresh</span>
+              <span className="hidden sm:inline">Actualizar</span>
             </Button>
           </div>
         </div>
@@ -246,13 +246,13 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
             showRefreshButton
             onRefresh={handleRefresh}
           />
-          <Button 
-            variant="ghost" 
-            size="sm" 
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => setViewMode(viewMode === "list" ? "table" : "list")}
             className="text-xs w-fit"
           >
-            {viewMode === "table" ? "List View" : "Table View"}
+            {viewMode === "table" ? "Vista de Lista" : "Vista de Tabla"}
           </Button>
         </div>
       </CardHeader>
@@ -272,10 +272,10 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
 
           {selectedDate && (
             isLoading ? (
-              <div className="flex justify-center p-8">Loading...</div>
+              <div className="flex justify-center p-8">Cargando...</div>
             ) : shifts.length === 0 ? (
               <div className="text-center p-8 text-muted-foreground">
-                No shifts scheduled for this date. {!isViewOnly && "Click \"Create Shift\" to add one."}
+                No hay turnos programados para esta fecha. {!isViewOnly && "Haz clic en \"Crear Turno\" para añadir uno."}
               </div>
             ) : viewMode === "table" ? (
               <ShiftsTable 

--- a/src/components/festival/scheduling/ManageAssignmentsDialog.tsx
+++ b/src/components/festival/scheduling/ManageAssignmentsDialog.tsx
@@ -154,15 +154,15 @@ export const ManageAssignmentsDialog = ({
       queryClient.invalidateQueries({ queryKey: ["festivalShifts"] });
       onAssignmentsUpdated();
       toast({
-        title: "Success",
-        description: "Technician assigned successfully",
+        title: "Éxito",
+        description: "Técnico asignado exitosamente",
       });
     },
     onError: (error: any) => {
       console.error("Error adding assignment:", error);
       toast({
         title: "Error",
-        description: "Could not assign technician",
+        description: "No se pudo asignar el técnico",
         variant: "destructive",
       });
     },
@@ -185,15 +185,15 @@ export const ManageAssignmentsDialog = ({
       queryClient.invalidateQueries({ queryKey: ["festivalShifts"] });
       onAssignmentsUpdated();
       toast({
-        title: "Success",
-        description: "Technician unassigned successfully",
+        title: "Éxito",
+        description: "Técnico desasignado exitosamente",
       });
     },
     onError: (error: any) => {
       console.error("Error removing assignment:", error);
       toast({
         title: "Error",
-        description: "Could not unassign technician",
+        description: "No se pudo desasignar el técnico",
         variant: "destructive",
       });
     },
@@ -203,7 +203,7 @@ export const ManageAssignmentsDialog = ({
     if ((!technicianId && !externalTechnicianName) || !role) {
       toast({
         title: "Error",
-        description: "Please fill in all required fields",
+        description: "Por favor completa todos los campos requeridos",
         variant: "destructive",
       });
       return;
@@ -229,7 +229,7 @@ export const ManageAssignmentsDialog = ({
       console.error("Error adding assignment:", error);
       toast({
         title: "Error",
-        description: "Could not assign technician",
+        description: "No se pudo asignar el técnico",
         variant: "destructive",
       });
     }
@@ -242,7 +242,7 @@ export const ManageAssignmentsDialog = ({
       console.error("Error removing assignment:", error);
       toast({
         title: "Error",
-        description: "Could not unassign technician",
+        description: "No se pudo desasignar el técnico",
         variant: "destructive",
       });
     }
@@ -253,12 +253,12 @@ export const ManageAssignmentsDialog = ({
       <DialogContent className="max-w-[95vw] sm:max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-base sm:text-lg">
-            {isViewOnly ? "View Staff for" : "Manage Staff for"} {shift.name}
+            {isViewOnly ? "Ver Personal para" : "Gestionar Personal para"} {shift.name}
           </DialogTitle>
           <DialogDescription className="text-sm">
-            {isViewOnly 
-              ? "View staff assigned to this shift" 
-              : "Add or remove staff from this shift"}
+            {isViewOnly
+              ? "Ver personal asignado a este turno"
+              : "Añadir o eliminar personal de este turno"}
           </DialogDescription>
         </DialogHeader>
 
@@ -271,25 +271,25 @@ export const ManageAssignmentsDialog = ({
                     checked={isExternalTechnician}
                     onCheckedChange={setIsExternalTechnician}
                   />
-                  <Label>External Technician</Label>
+                  <Label>Técnico Externo</Label>
                 </div>
 
                 {isExternalTechnician ? (
                   <div className="grid gap-2">
-                    <Label htmlFor="externalTechnician">External Technician Name</Label>
+                    <Label htmlFor="externalTechnician">Nombre del Técnico Externo</Label>
                     <Input
                       id="externalTechnician"
                       value={externalTechnicianName}
                       onChange={(e) => setExternalTechnicianName(e.target.value)}
-                      placeholder="Enter technician name"
+                      placeholder="Ingresar nombre del técnico"
                     />
                   </div>
                 ) : (
                   <div className="grid gap-2">
-                    <Label htmlFor="technician">Technician</Label>
+                    <Label htmlFor="technician">Técnico</Label>
                     <Select onValueChange={setTechnicianId}>
                       <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select a technician" />
+                        <SelectValue placeholder="Seleccionar un técnico" />
                       </SelectTrigger>
                       <SelectContent>
                         {getSortedTechnicians().map((technician) => (
@@ -303,13 +303,13 @@ export const ManageAssignmentsDialog = ({
                 )}
 
                 <div className="grid gap-2">
-                  <Label htmlFor="role">Role</Label>
-                  <Select 
-                    value={role} 
+                  <Label htmlFor="role">Rol</Label>
+                  <Select
+                    value={role}
                     onValueChange={setRole}
                   >
                     <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select a role" />
+                      <SelectValue placeholder="Seleccionar un rol" />
                     </SelectTrigger>
                     <SelectContent>
                       {getRoleOptions(shift.department as Department || "sound").map((code) => (
@@ -321,13 +321,13 @@ export const ManageAssignmentsDialog = ({
                   </Select>
                 </div>
                 <Button onClick={handleAddAssignment} disabled={addAssignmentMutation.isPending}>
-                  {addAssignmentMutation.isPending ? "Assigning..." : "Assign Technician"}
+                  {addAssignmentMutation.isPending ? "Asignando..." : "Asignar Técnico"}
                 </Button>
               </div>
             )}
-            
+
             <div className="space-y-4">
-              <h3 className="text-sm font-medium">Assigned Staff</h3>
+              <h3 className="text-sm font-medium">Personal Asignado</h3>
               {shift.assignments.length > 0 ? (
                 <div className="space-y-2">
                   {shift.assignments.map(assignment => (
@@ -338,27 +338,27 @@ export const ManageAssignmentsDialog = ({
                         - {labelForCode(assignment.role) || assignment.role}
                       </div>
                       {!isViewOnly && (
-                        <Button 
-                          variant="ghost" 
-                          size="sm" 
+                        <Button
+                          variant="ghost"
+                          size="sm"
                           onClick={() => handleRemoveAssignment(assignment.id)}
                         >
-                          Remove
+                          Eliminar
                         </Button>
                       )}
                     </div>
                   ))}
                 </div>
               ) : (
-                <div className="text-sm text-muted-foreground">No staff assigned to this shift yet.</div>
+                <div className="text-sm text-muted-foreground">Aún no hay personal asignado a este turno.</div>
               )}
             </div>
           </div>
         </ScrollArea>
-        
+
         <DialogFooter className="mt-6">
           <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
-            Close
+            Cerrar
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/festival/scheduling/ShiftTimeCalculator.tsx
+++ b/src/components/festival/scheduling/ShiftTimeCalculator.tsx
@@ -55,7 +55,7 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
       <CollapsibleTrigger asChild>
         <Button variant="outline" type="button" className="w-full">
           <Calculator className="h-4 w-4 mr-2" />
-          Shift Time Calculator
+          Calculadora de Horarios de Turnos
         </Button>
       </CollapsibleTrigger>
       
@@ -64,7 +64,7 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
           <CardHeader className="pb-3">
             <CardTitle className="text-sm flex items-center gap-2">
               <Clock className="h-4 w-4" />
-              Calculate Optimal Shift Times
+              Calcular Horarios Óptimos de Turnos
             </CardTitle>
           </CardHeader>
           
@@ -74,9 +74,9 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
               <CollapsibleTrigger asChild>
                 <Button variant="ghost" size="sm" type="button" className="w-full justify-start">
                   <Settings className="h-4 w-4 mr-2" />
-                  Configuration
+                  Configuración
                   {(startTimeBuffer !== 30 || teardownTime !== 4) && (
-                    <Badge variant="secondary" className="ml-2 text-xs">Custom</Badge>
+                    <Badge variant="secondary" className="ml-2 text-xs">Personalizado</Badge>
                   )}
                 </Button>
               </CollapsibleTrigger>
@@ -85,7 +85,7 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
                 <div className="grid grid-cols-2 gap-3">
                   <div className="space-y-2">
                     <Label htmlFor="start-buffer" className="text-xs">
-                      Start Time Buffer (minutes)
+                      Tiempo de Preparación (minutos)
                     </Label>
                     <Input
                       id="start-buffer"
@@ -99,7 +99,7 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="teardown-time" className="text-xs">
-                      Teardown Time (hours)
+                      Tiempo de Desmontaje (horas)
                     </Label>
                     <Input
                       id="teardown-time"
@@ -113,22 +113,22 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
                   </div>
                 </div>
                 <div className="text-xs text-muted-foreground">
-                  Buffer time is added before first soundcheck. Teardown time is added after last show on festival's final day.
+                  El tiempo de preparación se añade antes del primer soundcheck. El tiempo de desmontaje se añade después del último show en el día final del festival.
                 </div>
               </CollapsibleContent>
             </Collapsible>
 
             {isLoading ? (
-              <div className="text-sm text-muted-foreground">Loading artist schedule...</div>
+              <div className="text-sm text-muted-foreground">Cargando programación de artistas...</div>
             ) : (
               <>
                 <div className="space-y-2">
                   <div className="text-sm font-medium">
-                    {stage ? `Stage ${stage} Schedule` : "Festival Schedule"}
+                    {stage ? `Programación Stage ${stage}` : "Programación del Festival"}
                   </div>
                   <div className="text-sm text-muted-foreground flex items-center gap-2">
                     <Users className="h-3 w-3" />
-                    {artists.length} artists scheduled
+                    {artists.length} artistas programados
                   </div>
                   <Badge variant="outline" className="text-xs">
                     {getScheduleSummary()}
@@ -136,17 +136,17 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
                 </div>
 
                 <div className="space-y-2">
-                  <label className="text-sm font-medium">Number of Shifts</label>
+                  <label className="text-sm font-medium">Número de Turnos</label>
                   <Select value={numberOfShifts.toString()} onValueChange={(value) => setNumberOfShifts(parseInt(value))}>
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="2">2 Shifts</SelectItem>
-                      <SelectItem value="3">3 Shifts</SelectItem>
-                      <SelectItem value="4">4 Shifts</SelectItem>
-                      <SelectItem value="5">5 Shifts</SelectItem>
-                      <SelectItem value="6">6 Shifts</SelectItem>
+                      <SelectItem value="2">2 Turnos</SelectItem>
+                      <SelectItem value="3">3 Turnos</SelectItem>
+                      <SelectItem value="4">4 Turnos</SelectItem>
+                      <SelectItem value="5">5 Turnos</SelectItem>
+                      <SelectItem value="6">6 Turnos</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -154,7 +154,7 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
                 {calculatedShifts.length > 0 && (
                   <div className="space-y-3">
                     <div className="text-sm font-medium">
-                      Suggested Shifts (with 1h overlap) - Total: {
+                      Turnos Sugeridos (con solapamiento de 1h) - Total: {
                         Math.round(calculatedShifts.reduce((total, shift) => total + shift.duration, 0) * 10) / 10
                       }h
                     </div>
@@ -182,7 +182,7 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
                             onClick={() => onApplyTimes(shift.start_time, shift.end_time)}
                             className="w-full mt-2"
                           >
-                            Apply to Form
+                            Aplicar al Formulario
                           </Button>
                         </div>
                       ))}
@@ -192,9 +192,9 @@ export const ShiftTimeCalculator = ({ jobId, date, stage, onApplyTimes }: ShiftT
 
                 {artists.length === 0 && (
                   <div className="text-sm text-muted-foreground bg-muted p-3 rounded-lg">
-                    {stage 
-                      ? `No artists scheduled for Stage ${stage} on this date.`
-                      : "No artists scheduled for this date. Add artists first to calculate optimal shift times."
+                    {stage
+                      ? `No hay artistas programados para el Stage ${stage} en esta fecha.`
+                      : "No hay artistas programados para esta fecha. Añade artistas primero para calcular horarios óptimos de turnos."
                     }
                   </div>
                 )}

--- a/src/components/festival/scheduling/ShiftsList.tsx
+++ b/src/components/festival/scheduling/ShiftsList.tsx
@@ -53,7 +53,7 @@ export const ShiftsList = ({
             size="sm"
             onClick={() => setCopyShiftsOpen(true)}
           >
-            Copy Shifts to Another Date
+            Copiar Turnos a Otra Fecha
           </Button>
         )}
       </div>
@@ -71,14 +71,14 @@ export const ShiftsList = ({
                       size="sm"
                       onClick={() => handleEditShift(shift)}
                     >
-                      Edit
+                      Editar
                     </Button>
                     <Button
                       variant="ghost"
                       size="sm"
                       onClick={() => onDeleteShift(shift.id)}
                     >
-                      Delete
+                      Eliminar
                     </Button>
                   </>
                 )}
@@ -87,7 +87,7 @@ export const ShiftsList = ({
                   size="sm"
                   onClick={() => handleManageAssignments(shift)}
                 >
-                  {isViewOnly ? "View Staff" : "Manage Staff"}
+                  {isViewOnly ? "Ver Personal" : "Gestionar Personal"}
                 </Button>
               </div>
             </div>
@@ -95,16 +95,16 @@ export const ShiftsList = ({
           <CardContent className="p-4 pt-0">
             <div className="grid grid-cols-2 gap-2 text-sm">
               <div>
-                <span className="font-medium">Start Time:</span> {shift.start_time}
+                <span className="font-medium">Hora de Inicio:</span> {shift.start_time}
               </div>
               <div>
-                <span className="font-medium">End Time:</span> {shift.end_time}
+                <span className="font-medium">Hora de Fin:</span> {shift.end_time}
               </div>
               <div>
-                <span className="font-medium">Department:</span> {shift.department || "N/A"}
+                <span className="font-medium">Departamento:</span> {shift.department || "N/A"}
               </div>
               <div>
-                <span className="font-medium">Notes:</span> {shift.notes || "N/A"}
+                <span className="font-medium">Notas:</span> {shift.notes || "N/A"}
               </div>
             </div>
           </CardContent>

--- a/src/components/festival/scheduling/ShiftsTable.tsx
+++ b/src/components/festival/scheduling/ShiftsTable.tsx
@@ -125,7 +125,7 @@ export const ShiftsTable = ({
 
   const handleDeleteClick = (e: React.MouseEvent, shiftId: string) => {
     e.stopPropagation();
-    if (confirm("Are you sure you want to delete this shift?")) {
+    if (confirm("¿Estás seguro de que deseas eliminar este turno?")) {
       onDeleteShift(shiftId);
     }
   };
@@ -172,14 +172,14 @@ export const ShiftsTable = ({
       URL.revokeObjectURL(url);
 
       toast({
-        title: "Success",
-        description: "PDF generated successfully",
+        title: "Éxito",
+        description: "PDF generado exitosamente",
       });
     } catch (error) {
       console.error('Error generating PDF:', error);
       toast({
         title: "Error",
-        description: "Could not generate PDF",
+        description: "No se pudo generar el PDF",
         variant: "destructive",
       });
     }
@@ -194,21 +194,21 @@ export const ShiftsTable = ({
         </div>
         <div className="flex gap-2 ml-auto mb-2 print:hidden">
           {!isViewOnly && sortedShifts.length > 0 && jobDates.length > 1 && (
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="sm"
               onClick={() => setIsCopyDialogOpen(true)}
             >
               <Copy className="h-4 w-4 mr-2" />
-              Copy Shifts
+              Copiar Turnos
             </Button>
           )}
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             onClick={handleExportPDF}
           >
             <FileDown className="h-4 w-4 mr-2" />
-            Export to PDF
+            Exportar a PDF
           </Button>
         </div>
       </div>
@@ -216,12 +216,12 @@ export const ShiftsTable = ({
       <Table className="border-collapse border border-border print:border-black">
         <TableHeader>
           <TableRow className="bg-muted print:bg-gray-200">
-            <TableHead className="border border-border print:border-black print:text-black font-medium">Shift</TableHead>
-            <TableHead className="border border-border print:border-black print:text-black font-medium">Time</TableHead>
+            <TableHead className="border border-border print:border-black print:text-black font-medium">Turno</TableHead>
+            <TableHead className="border border-border print:border-black print:text-black font-medium">Horario</TableHead>
             <TableHead className="border border-border print:border-black print:text-black font-medium">Stage</TableHead>
-            <TableHead className="border border-border print:border-black print:text-black font-medium">Department</TableHead>
-            <TableHead className="border border-border print:border-black print:text-black font-medium">Technicians</TableHead>
-            <TableHead className="border border-border print:border-black print:text-black font-medium print:hidden">Actions</TableHead>
+            <TableHead className="border border-border print:border-black print:text-black font-medium">Departamento</TableHead>
+            <TableHead className="border border-border print:border-black print:text-black font-medium">Técnicos</TableHead>
+            <TableHead className="border border-border print:border-black print:text-black font-medium print:hidden">Acciones</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -251,7 +251,7 @@ export const ShiftsTable = ({
                     ))}
                   </ul>
                 ) : (
-                  <span className="text-muted-foreground print:text-gray-500">No technicians assigned</span>
+                  <span className="text-muted-foreground print:text-gray-500">Sin técnicos asignados</span>
                 )}
               </TableCell>
               <TableCell className="border border-border print:hidden">

--- a/src/components/ui/festivals-pagination.tsx
+++ b/src/components/ui/festivals-pagination.tsx
@@ -23,9 +23,9 @@ export const FestivalsPagination = ({
   return (
     <div className="flex flex-col sm:flex-row items-center justify-between gap-4 px-2">
       <div className="text-xs sm:text-sm text-muted-foreground order-2 sm:order-1">
-        Showing {startItem}-{endItem} of {totalItems} festivals
+        Mostrando {startItem}-{endItem} de {totalItems} festivales
       </div>
-      
+
       <div className="flex items-center gap-1 sm:gap-2 order-1 sm:order-2">
         <Button
           variant="outline"
@@ -35,7 +35,7 @@ export const FestivalsPagination = ({
           className="h-9 sm:h-8"
         >
           <ChevronLeft className="h-4 w-4" />
-          <span className="hidden sm:inline">Previous</span>
+          <span className="hidden sm:inline">Anterior</span>
         </Button>
         
         <div className="flex items-center gap-1">
@@ -77,7 +77,7 @@ export const FestivalsPagination = ({
           disabled={currentPage >= totalPages}
           className="h-9 sm:h-8"
         >
-          <span className="hidden sm:inline">Next</span>
+          <span className="hidden sm:inline">Siguiente</span>
           <ChevronRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -445,8 +445,8 @@ const FestivalArtistManagement = () => {
       URL.revokeObjectURL(url);
       
       toast({
-        title: "Success",
-        description: "PDF generated successfully"
+        title: "Éxito",
+        description: "PDF generado exitosamente"
       });
       setIsPrintDialogOpen(false);
     } catch (error) {
@@ -454,7 +454,7 @@ const FestivalArtistManagement = () => {
       console.error('Error stack:', error.stack);
       toast({
         title: "Error",
-        description: "Could not generate PDF",
+        description: "No se pudo generar el PDF",
         variant: "destructive"
       });
     } finally {
@@ -482,7 +482,7 @@ const FestivalArtistManagement = () => {
         console.error("Error fetching all festival artists:", error);
         toast({
           title: "Error",
-          description: "Could not fetch festival artists",
+          description: "No se pudieron obtener los artistas del festival",
           variant: "destructive"
         });
         return;
@@ -490,8 +490,8 @@ const FestivalArtistManagement = () => {
 
       if (!allArtists || allArtists.length === 0) {
         toast({
-          title: "No Data",
-          description: "No artists found for this festival",
+          title: "Sin Datos",
+          description: "No se encontraron artistas para este festival",
           variant: "destructive"
         });
         return;
@@ -530,14 +530,14 @@ const FestivalArtistManagement = () => {
       URL.revokeObjectURL(url);
       
       toast({
-        title: "Success",
-        description: "Full festival schedule PDF generated successfully"
+        title: "Éxito",
+        description: "PDF del horario completo del festival generado exitosamente"
       });
     } catch (error) {
       console.error('Error generating full schedule PDF:', error);
       toast({
         title: "Error",
-        description: "Could not generate full schedule PDF",
+        description: "No se pudo generar el PDF del horario completo",
         variant: "destructive"
       });
     } finally {
@@ -553,8 +553,8 @@ const FestivalArtistManagement = () => {
       <div className="mb-6 px-4 md:px-6">
         <Button variant="ghost" onClick={() => navigate(`/festival-management/${jobId}`)} className="mb-4">
           <ArrowLeft className="h-4 w-4 mr-2" />
-          <span className="hidden sm:inline">Back to Festival Management</span>
-          <span className="sm:hidden">Back</span>
+          <span className="hidden sm:inline">Volver a Gestión de Festival</span>
+          <span className="sm:hidden">Volver</span>
         </Button>
         <div className="flex items-center justify-between gap-2">
           <h1 className="text-xl md:text-2xl font-bold truncate">{jobTitle}</h1>
@@ -565,7 +565,7 @@ const FestivalArtistManagement = () => {
       <Card className="mx-4 md:mx-6">
         <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
           <CardTitle className="flex items-center gap-2">
-            <span className="text-lg md:text-xl">Artist Management</span>
+            <span className="text-lg md:text-xl">Gestión de Artistas</span>
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -574,8 +574,8 @@ const FestivalArtistManagement = () => {
                   </div>
                 </TooltipTrigger>
                 <TooltipContent className="max-w-sm">
-                  <p>Festival days run from {dayStartTime} to {dayStartTime} the next day.</p>
-                  <p>Shows after midnight are included in the previous day's schedule.</p>
+                  <p>Los días del festival van desde las {dayStartTime} hasta las {dayStartTime} del día siguiente.</p>
+                  <p>Los shows después de medianoche se incluyen en el horario del día anterior.</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -584,38 +584,38 @@ const FestivalArtistManagement = () => {
           {/* Desktop buttons */}
           <div className="hidden lg:flex items-center gap-2">
             {showArtistControls && (
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 onClick={() => setIsCopyDialogOpen(true)}
               >
                 <Copy className="h-4 w-4 mr-2" />
-                Copy Artists
+                Copiar Artistas
               </Button>
             )}
-            <Button 
+            <Button
               variant="outline"
               onClick={handlePrintFullSchedule}
               disabled={isFullSchedulePrinting}
             >
               <Printer className="h-4 w-4 mr-2" />
-              {isFullSchedulePrinting ? "Generating..." : "Print Full Schedule"}
+              {isFullSchedulePrinting ? "Generando..." : "Imprimir Horario Completo"}
             </Button>
             <Button onClick={() => {
               setPrintDate(selectedDate);
               setIsPrintDialogOpen(true);
             }}>
               <Printer className="h-4 w-4 mr-2" />
-              Print Day Schedule
+              Imprimir Horario del Día
             </Button>
             {showArtistControls ? (
               <Button onClick={handleAddArtist}>
                 <Plus className="h-4 w-4 mr-2" />
-                Add Artist
+                Añadir Artista
               </Button>
             ) : (
-              <Button disabled title="Artists can only be added on show dates">
+              <Button disabled title="Los artistas solo se pueden añadir en fechas de show">
                 <Plus className="h-4 w-4 mr-2" />
-                Add Artist
+                Añadir Artista
               </Button>
             )}
           </div>
@@ -625,15 +625,15 @@ const FestivalArtistManagement = () => {
             {showArtistControls ? (
               <Button onClick={handleAddArtist} className="flex-1 sm:flex-initial">
                 <Plus className="h-4 w-4 mr-2" />
-                Add Artist
+                Añadir Artista
               </Button>
             ) : (
-              <Button disabled title="Artists can only be added on show dates" className="flex-1 sm:flex-initial">
+              <Button disabled title="Los artistas solo se pueden añadir en fechas de show" className="flex-1 sm:flex-initial">
                 <Plus className="h-4 w-4 mr-2" />
-                Add Artist
+                Añadir Artista
               </Button>
             )}
-            
+
             <Sheet>
               <SheetTrigger asChild>
                 <Button variant="outline" size="icon">
@@ -642,29 +642,29 @@ const FestivalArtistManagement = () => {
               </SheetTrigger>
               <SheetContent side="right" className="w-[300px] sm:w-[400px]">
                 <SheetHeader>
-                  <SheetTitle>Actions</SheetTitle>
+                  <SheetTitle>Acciones</SheetTitle>
                 </SheetHeader>
                 <div className="flex flex-col gap-3 mt-6">
                   {showArtistControls && (
-                    <Button 
-                      variant="outline" 
+                    <Button
+                      variant="outline"
                       onClick={() => setIsCopyDialogOpen(true)}
                       className="justify-start w-full"
                     >
                       <Copy className="h-4 w-4 mr-2" />
-                      Copy Artists
+                      Copiar Artistas
                     </Button>
                   )}
-                  <Button 
+                  <Button
                     variant="outline"
                     onClick={handlePrintFullSchedule}
                     disabled={isFullSchedulePrinting}
                     className="justify-start w-full"
                   >
                     <Printer className="h-4 w-4 mr-2" />
-                    {isFullSchedulePrinting ? "Generating..." : "Print Full Schedule"}
+                    {isFullSchedulePrinting ? "Generando..." : "Imprimir Horario Completo"}
                   </Button>
-                  <Button 
+                  <Button
                     variant="outline"
                     onClick={() => {
                       setPrintDate(selectedDate);
@@ -673,7 +673,7 @@ const FestivalArtistManagement = () => {
                     className="justify-start w-full"
                   >
                     <Printer className="h-4 w-4 mr-2" />
-                    Print Day Schedule
+                    Imprimir Horario del Día
                   </Button>
                 </div>
               </SheetContent>
@@ -730,9 +730,9 @@ const FestivalArtistManagement = () => {
                 </div>
               ) : (
                 <div className="p-8 text-center text-muted-foreground border rounded-md">
-                  <p>This is not configured as a show date.</p>
-                  <p>Artist management is only available on show dates.</p>
-                  <p className="mt-2 text-sm">Right-click on the date tab to change its type.</p>
+                  <p>Esta fecha no está configurada como fecha de show.</p>
+                  <p>La gestión de artistas solo está disponible en fechas de show.</p>
+                  <p className="mt-2 text-sm">Haz clic derecho en la pestaña de fecha para cambiar su tipo.</p>
                 </div>
               )
             )}

--- a/src/pages/FestivalGearManagement.tsx
+++ b/src/pages/FestivalGearManagement.tsx
@@ -176,7 +176,7 @@ const FestivalGearManagement = () => {
         console.error("Error fetching job details:", error);
         toast({
           title: "Error",
-          description: "Could not load festival details",
+          description: "No se pudieron cargar los detalles del festival",
           variant: "destructive",
         });
       } finally {
@@ -218,7 +218,7 @@ const FestivalGearManagement = () => {
       console.error("Error loading gear setup and stages:", error);
       toast({
         title: "Error",
-        description: "Could not load festival gear setup",
+        description: "No se pudo cargar la configuración de equipo del festival",
         variant: "destructive",
       });
     }
@@ -289,14 +289,14 @@ const FestivalGearManagement = () => {
       await fetchAndSyncStageData(newMaxStages);
       
       toast({
-        title: "Success",
-        description: `Updated to ${newMaxStages} stages`,
+        title: "Éxito",
+        description: `Actualizado a ${newMaxStages} escenarios`,
       });
     } catch (error: any) {
       console.error("Error updating max stages:", error);
       toast({
         title: "Error",
-        description: "Could not update stages configuration",
+        description: "No se pudo actualizar la configuración de escenarios",
         variant: "destructive",
       });
     } finally {
@@ -352,14 +352,14 @@ const FestivalGearManagement = () => {
       setEditingStageName("");
 
       toast({
-        title: "Success",
-        description: "Stage name updated",
+        title: "Éxito",
+        description: "Nombre del escenario actualizado",
       });
     } catch (error) {
       console.error("Error updating stage name:", error);
       toast({
         title: "Error",
-        description: "Could not update stage name",
+        description: "No se pudo actualizar el nombre del escenario",
         variant: "destructive",
       });
       
@@ -381,8 +381,8 @@ const FestivalGearManagement = () => {
 
   const handleSave = () => {
     toast({
-      title: "Success",
-      description: "Festival gear setup has been updated.",
+      title: "Éxito",
+      description: "La configuración de equipo del festival ha sido actualizada.",
     });
   };
 
@@ -412,14 +412,14 @@ const FestivalGearManagement = () => {
       URL.revokeObjectURL(url);
       
       toast({
-        title: "Success",
-        description: 'Gear setup documentation generated successfully'
+        title: "Éxito",
+        description: 'Documentación de configuración de equipo generada exitosamente'
       });
     } catch (error: any) {
       console.error('Error generating gear setup PDF:', error);
       toast({
         title: "Error",
-        description: `Failed to generate documentation: ${error.message}`,
+        description: `Error al generar documentación: ${error.message}`,
         variant: "destructive"
       });
     } finally {
@@ -451,14 +451,14 @@ const FestivalGearManagement = () => {
       URL.revokeObjectURL(url);
       
       toast({
-        title: "Success",
-        description: 'Documentation generated successfully'
+        title: "Éxito",
+        description: 'Documentación generada exitosamente'
       });
     } catch (error: any) {
       console.error('Error generating documentation:', error);
       toast({
         title: "Error",
-        description: `Failed to generate documentation: ${error.message}`,
+        description: `Error al generar documentación: ${error.message}`,
         variant: "destructive"
       });
     } finally {
@@ -475,12 +475,12 @@ const FestivalGearManagement = () => {
           className="self-start"
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Festival Management
+          Volver a Gestión de Festival
         </Button>
         <div className="flex flex-col items-start md:items-end md:text-right">
           <h1 className="text-xl md:text-2xl font-bold">{jobTitle}</h1>
           <div className="flex items-center gap-2">
-            <p className="text-sm md:text-base text-muted-foreground">Gear Management</p>
+            <p className="text-sm md:text-base text-muted-foreground">Gestión de Equipo</p>
             <ConnectionIndicator variant="icon" />
           </div>
         </div>
@@ -490,14 +490,14 @@ const FestivalGearManagement = () => {
         <CardHeader>
           <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
             <div className="space-y-2">
-              <CardTitle>Stages Configuration</CardTitle>
+              <CardTitle>Configuración de Escenarios</CardTitle>
               <CardDescription>
-                Configure the stages for your festival. Click on a stage name to edit it.
+                Configura los escenarios para tu festival. Haz clic en el nombre de un escenario para editarlo.
               </CardDescription>
             </div>
             <Button onClick={handleAddStage} size="sm" className="self-start sm:self-auto">
               <Plus className="h-4 w-4 mr-2" />
-              Add Stage
+              Añadir Escenario
             </Button>
           </div>
         </CardHeader>
@@ -513,7 +513,7 @@ const FestivalGearManagement = () => {
                   <span className="truncate max-w-[120px] md:max-w-none">{stage.name}</span>
                   {stageSetups[stage.number] && (
                     <Badge variant="outline" className="ml-1 md:ml-2 bg-blue-100 text-xs">
-                      Custom
+                      Personalizado
                     </Badge>
                   )}
                 </Button>
@@ -523,7 +523,7 @@ const FestivalGearManagement = () => {
                     <Input
                       value={editingStageName}
                       onChange={(e) => setEditingStageName(e.target.value)}
-                      placeholder="Stage name"
+                      placeholder="Nombre del escenario"
                       className="mb-2"
                       onKeyDown={(e) => {
                         if (e.key === 'Enter') handleSaveStageEdit();
@@ -534,11 +534,11 @@ const FestivalGearManagement = () => {
                     <div className="flex gap-2 md:gap-1">
                       <Button size="sm" onClick={handleSaveStageEdit} className="flex-1 md:flex-initial">
                         <Check className="h-3 w-3 mr-2 md:mr-0" />
-                        <span className="md:hidden">Save</span>
+                        <span className="md:hidden">Guardar</span>
                       </Button>
                       <Button size="sm" variant="outline" onClick={handleCancelStageEdit} className="flex-1 md:flex-initial">
                         <X className="h-3 w-3 mr-2 md:mr-0" />
-                        <span className="md:hidden">Cancel</span>
+                        <span className="md:hidden">Cancelar</span>
                       </Button>
                     </div>
                   </div>
@@ -566,8 +566,8 @@ const FestivalGearManagement = () => {
                 <Wrench className="h-4 w-4 md:h-5 md:w-5" />
                 <span className="truncate">{getCurrentStageName(selectedStage)} Gear Setup</span>
               </CardTitle>
-              <Button 
-                onClick={handlePrintGearSetup} 
+              <Button
+                onClick={handlePrintGearSetup}
                 disabled={isPrinting}
                 variant="outline"
                 size="sm"
@@ -578,8 +578,8 @@ const FestivalGearManagement = () => {
                 ) : (
                   <Printer className="h-4 w-4 mr-2" />
                 )}
-                <span className="hidden sm:inline">Print Gear Setup</span>
-                <span className="sm:hidden">Print</span>
+                <span className="hidden sm:inline">Imprimir Configuración de Equipo</span>
+                <span className="sm:hidden">Imprimir</span>
               </Button>
             </div>
           </CardHeader>
@@ -587,7 +587,7 @@ const FestivalGearManagement = () => {
             <div className="mb-4">
               <Alert>
                 <AlertDescription className="text-sm">
-                  Configure the gear setup for {getCurrentStageName(selectedStage)}. This information will be used when artists submit their technical requirements.
+                  Configura el equipo para {getCurrentStageName(selectedStage)}. Esta información se utilizará cuando los artistas envíen sus requerimientos técnicos.
                 </AlertDescription>
               </Alert>
             </div>

--- a/src/pages/FestivalManagement.tsx
+++ b/src/pages/FestivalManagement.tsx
@@ -372,8 +372,8 @@ const FestivalManagement = () => {
     } catch (error: any) {
       console.error('Error fetching documents:', error);
       toast({
-        title: 'Error loading documents',
-        description: error.message || 'We could not load the documents for this job.',
+        title: 'Error al cargar documentos',
+        description: error.message || 'No se pudieron cargar los documentos para este trabajo.',
         variant: 'destructive',
       });
     } finally {
@@ -396,8 +396,8 @@ const FestivalManagement = () => {
     } catch (error: any) {
       console.error('Error viewing document:', error);
       toast({
-        title: 'Unable to open document',
-        description: error.message || 'Please try again in a few moments.',
+        title: 'No se puede abrir el documento',
+        description: error.message || 'Por favor, inténtalo de nuevo en unos momentos.',
         variant: 'destructive',
       });
     }
@@ -423,8 +423,8 @@ const FestivalManagement = () => {
     } catch (error: any) {
       console.error('Error downloading document:', error);
       toast({
-        title: 'Download failed',
-        description: error.message || 'We could not download that file.',
+        title: 'Descarga fallida',
+        description: error.message || 'No se pudo descargar ese archivo.',
         variant: 'destructive',
       });
     }
@@ -444,8 +444,8 @@ const FestivalManagement = () => {
     } catch (error: any) {
       console.error('Error viewing rider:', error);
       toast({
-        title: 'Unable to open rider',
-        description: error.message || 'Please try again later.',
+        title: 'No se puede abrir el rider',
+        description: error.message || 'Por favor, inténtalo de nuevo más tarde.',
         variant: 'destructive',
       });
     }
@@ -470,8 +470,8 @@ const FestivalManagement = () => {
     } catch (error: any) {
       console.error('Error downloading rider:', error);
       toast({
-        title: 'Download failed',
-        description: error.message || 'We could not download that rider file.',
+        title: 'Descarga fallida',
+        description: error.message || 'No se pudo descargar ese archivo de rider.',
         variant: 'destructive',
       });
     }
@@ -580,16 +580,16 @@ const FestivalManagement = () => {
 
           if (existingFolders && existingFolders.length > 0) {
             toast({
-              title: 'Folders already exist',
-              description: 'Flex folders have already been created for this job.',
+              title: 'Las carpetas ya existen',
+              description: 'Ya se han creado carpetas Flex para este trabajo.',
             });
             return;
           }
         } catch (error: any) {
           console.error('Error checking existing folders:', error);
           toast({
-            title: 'Error checking folders',
-            description: error.message || 'Please try again in a moment.',
+            title: 'Error al verificar carpetas',
+            description: error.message || 'Por favor, inténtalo de nuevo en un momento.',
             variant: 'destructive',
           });
           return;
@@ -598,8 +598,8 @@ const FestivalManagement = () => {
 
       if (!job.start_time || !job.end_time) {
         toast({
-          title: 'Missing job dates',
-          description: `Update the job dates before ${flexPickerMode === 'create' ? 'creating' : 'adding'} Flex folders.`,
+          title: 'Fechas del trabajo faltantes',
+          description: `Actualiza las fechas del trabajo antes de ${flexPickerMode === 'create' ? 'crear' : 'añadir'} carpetas Flex.`,
           variant: 'destructive',
         });
         return;
@@ -610,8 +610,8 @@ const FestivalManagement = () => {
 
       if (!isValid(startDate) || !isValid(endDate)) {
         toast({
-          title: 'Invalid job dates',
-          description: 'Please verify the job dates before creating Flex folders.',
+          title: 'Fechas del trabajo inválidas',
+          description: 'Por favor, verifica las fechas del trabajo antes de crear carpetas Flex.',
           variant: 'destructive',
         });
         return;
@@ -625,8 +625,8 @@ const FestivalManagement = () => {
         const formattedEndDate = endDate.toISOString().split('.')[0] + '.000Z';
 
         toast({
-          title: flexPickerMode === 'create' ? 'Creating Flex folders…' : 'Adding Flex folders…',
-          description: flexPickerMode === 'create' ? 'This may take a few seconds.' : 'Selected folders will be created in Flex.',
+          title: flexPickerMode === 'create' ? 'Creando carpetas Flex…' : 'Añadiendo carpetas Flex…',
+          description: flexPickerMode === 'create' ? 'Esto puede tardar unos segundos.' : 'Las carpetas seleccionadas se crearán en Flex.',
         });
 
         await createAllFoldersForJob(
@@ -638,8 +638,8 @@ const FestivalManagement = () => {
         );
 
         toast({
-          title: flexPickerMode === 'create' ? 'Flex folders ready' : 'Flex folders updated',
-          description: flexPickerMode === 'create' ? 'Folders have been created successfully.' : 'Selected folders have been added successfully.',
+          title: flexPickerMode === 'create' ? 'Carpetas Flex listas' : 'Carpetas Flex actualizadas',
+          description: flexPickerMode === 'create' ? 'Las carpetas se han creado exitosamente.' : 'Las carpetas seleccionadas se han añadido exitosamente.',
         });
 
         await Promise.all([
@@ -650,8 +650,8 @@ const FestivalManagement = () => {
       } catch (error: any) {
         console.error('Error adding Flex folders:', error);
         toast({
-          title: 'Flex folder update failed',
-          description: error.message || 'Please try again in a moment.',
+          title: 'Error al actualizar carpetas Flex',
+          description: error.message || 'Por favor, inténtalo de nuevo en un momento.',
           variant: 'destructive',
         });
       } finally {
@@ -663,15 +663,15 @@ const FestivalManagement = () => {
 
   const flexStatus = useMemo(() => {
     if (isFlexLoading) {
-      return { label: 'Checking status…', variant: 'outline' as const };
+      return { label: 'Verificando estado…', variant: 'outline' as const };
     }
     if (flexError) {
-      return { label: 'Flex error', variant: 'destructive' as const };
+      return { label: 'Error de Flex', variant: 'destructive' as const };
     }
     if (folderExists) {
-      return { label: 'Folders ready', variant: 'secondary' as const };
+      return { label: 'Carpetas listas', variant: 'secondary' as const };
     }
-    return { label: 'Folders not created', variant: 'outline' as const };
+    return { label: 'Carpetas no creadas', variant: 'outline' as const };
   }, [isFlexLoading, flexError, folderExists]);
 
   const isSchedulingRoute = location.pathname.includes('/scheduling');
@@ -742,16 +742,16 @@ const FestivalManagement = () => {
       URL.revokeObjectURL(url);
       
       toast({
-        title: "Success",
-        description: options.generateIndividualStagePDFs 
-          ? 'Individual stage PDFs generated successfully'
-          : 'Documentation generated successfully'
+        title: "Éxito",
+        description: options.generateIndividualStagePDFs
+          ? 'PDFs individuales de escenarios generados exitosamente'
+          : 'Documentación generada exitosamente'
       });
     } catch (error: any) {
       console.error('Error generating documentation:', error);
       toast({
         title: "Error",
-        description: `Failed to generate documentation: ${error.message}`,
+        description: `Error al generar documentación: ${error.message}`,
         variant: "destructive"
       });
     } finally {
@@ -765,7 +765,7 @@ const FestivalManagement = () => {
 
   const handleFlexClick = async () => {
     if (isFlexLoading) {
-      toast({ title: "Loading", description: "Please wait while we load the Flex folder..." });
+      toast({ title: "Cargando", description: "Por favor espera mientras cargamos la carpeta Flex..." });
       return;
     }
 
@@ -773,16 +773,16 @@ const FestivalManagement = () => {
       await openFlexElement({
         elementId: flexUuid,
         onError: (error) => {
-          toast({ title: "Error", description: error.message || "Failed to open Flex", variant: "destructive" });
+          toast({ title: "Error", description: error.message || "Error al abrir Flex", variant: "destructive" });
         },
         onWarning: (message) => {
-          toast({ title: "Warning", description: message });
+          toast({ title: "Advertencia", description: message });
         },
       });
     } else if (flexError) {
       toast({ title: "Error", description: flexError, variant: "destructive" });
     } else {
-      toast({ title: "Info", description: "Flex folder not available for this festival" });
+      toast({ title: "Info", description: "Carpeta Flex no disponible para este festival" });
     }
   };
 
@@ -811,16 +811,16 @@ const FestivalManagement = () => {
       if (dbError) throw dbError;
 
       toast({
-        title: "Success",
-        description: "Document uploaded successfully",
+        title: "Éxito",
+        description: "Documento subido exitosamente",
       });
 
       fetchDocuments();
     } catch (error: any) {
       console.error('Error uploading document:', error);
       toast({
-        title: "Upload failed",
-        description: error.message || "Failed to upload document",
+        title: "Error al subir",
+        description: error.message || "Error al subir documento",
         variant: "destructive",
       });
     } finally {
@@ -841,14 +841,14 @@ const FestivalManagement = () => {
       if (error) throw error;
 
       toast({
-        title: "Success",
-        description: data?.message || "Local folders created successfully",
+        title: "Éxito",
+        description: data?.message || "Carpetas locales creadas exitosamente",
       });
     } catch (error: any) {
       console.error('Error creating local folders:', error);
       toast({
         title: "Error",
-        description: error.message || "Failed to create local folders",
+        description: error.message || "Error al crear carpetas locales",
         variant: "destructive",
       });
     } finally {
@@ -872,8 +872,8 @@ const FestivalManagement = () => {
       if (error) throw error;
       setArchiveResult(data);
       toast({
-        title: archiveDryRun ? 'Dry run complete' : 'Archive complete',
-        description: `${data?.uploaded ?? 0} uploaded, ${data?.failed ?? 0} failed`,
+        title: archiveDryRun ? 'Prueba completada' : 'Archivo completado',
+        description: `${data?.uploaded ?? 0} subidos, ${data?.failed ?? 0} fallidos`,
       });
       if (!archiveDryRun && (data?.uploaded ?? 0) > 0) {
         fetchDocuments();
@@ -881,7 +881,7 @@ const FestivalManagement = () => {
     } catch (err: any) {
       console.error('Archive error', err);
       setArchiveError(err?.message || 'Failed to archive');
-      toast({ title: 'Archive failed', description: err?.message || 'Failed to archive', variant: 'destructive' });
+      toast({ title: 'Error al archivar', description: err?.message || 'Error al archivar', variant: 'destructive' });
     } finally {
       setIsArchiving(false);
     }
@@ -909,11 +909,11 @@ const FestivalManagement = () => {
       if (error) throw error;
       setBackfillResult(data);
       setBackfillMessage(`Inserted ${data?.inserted ?? 0}, already ${data?.already ?? 0}`);
-      toast({ title: 'Backfill complete', description: `Inserted ${data?.inserted ?? 0}, already ${data?.already ?? 0}` });
+      toast({ title: 'Relleno completado', description: `Insertados ${data?.inserted ?? 0}, ya existían ${data?.already ?? 0}` });
     } catch (err: any) {
       console.error('Backfill error', err);
       setBackfillMessage(err?.message || 'Backfill failed');
-      toast({ title: 'Backfill failed', description: err?.message || 'Backfill failed', variant: 'destructive' });
+      toast({ title: 'Error al rellenar', description: err?.message || 'Error al rellenar', variant: 'destructive' });
     } finally {
       setIsBackfilling(false);
     }
@@ -927,15 +927,15 @@ const FestivalManagement = () => {
       });
       if (error) throw error;
       toast({
-        title: "Success",
-        description: "WhatsApp group created successfully",
+        title: "Éxito",
+        description: "Grupo de WhatsApp creado exitosamente",
       });
       setIsWhatsappDialogOpen(false);
     } catch (error: any) {
       console.error('Error creating WhatsApp group:', error);
       toast({
         title: "Error",
-        description: error.message || "Failed to create WhatsApp group",
+        description: error.message || "Error al crear grupo de WhatsApp",
         variant: "destructive",
       });
     } finally {
@@ -978,8 +978,8 @@ const FestivalManagement = () => {
       if (error) throw error;
 
       toast({
-        title: "Success",
-        description: "Job deleted successfully",
+        title: "Éxito",
+        description: "Trabajo eliminado exitosamente",
       });
 
       navigate('/project-management');
@@ -987,7 +987,7 @@ const FestivalManagement = () => {
       console.error('Error deleting job:', error);
       toast({
         title: "Error",
-        description: error.message || "Failed to delete job",
+        description: error.message || "Error al eliminar trabajo",
         variant: "destructive",
       });
     } finally {
@@ -1003,15 +1003,15 @@ const FestivalManagement = () => {
   }, [jobId, navigate]);
 
   if (!jobId) {
-    return <div>Job ID is required</div>;
+    return <div>Se requiere ID del trabajo</div>;
   }
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <div>Cargando...</div>;
   }
 
   if (!job) {
-    return <div>Festival not found</div>;
+    return <div>Festival no encontrado</div>;
   }
 
   return (
@@ -1061,7 +1061,7 @@ const FestivalManagement = () => {
                     ) : (
                       <Printer className="h-4 w-4" />
                     )}
-                    <span className="hidden sm:inline">{isPrinting ? 'Generating...' : 'Print'}</span>
+                    <span className="hidden sm:inline">{isPrinting ? 'Generando...' : 'Imprimir'}</span>
                   </Button>
 
                   {(folderExists || isFlexLoading) && (
@@ -1077,7 +1077,7 @@ const FestivalManagement = () => {
                       ) : (
                         <img src={createFolderIcon} alt="Flex" className="h-4 w-4" />
                       )}
-                      <span className="hidden sm:inline">{isFlexLoading ? 'Loading...' : 'Flex'}</span>
+                      <span className="hidden sm:inline">{isFlexLoading ? 'Cargando...' : 'Flex'}</span>
                     </Button>
                   )}
 
@@ -1100,7 +1100,7 @@ const FestivalManagement = () => {
                     onClick={() => setIsDeleteDialogOpen(true)}
                   >
                     <Trash2 className="h-4 w-4" />
-                    <span className="hidden sm:inline">Delete</span>
+                    <span className="hidden sm:inline">Eliminar</span>
                   </Button>
                 </>
               )}
@@ -1122,19 +1122,19 @@ const FestivalManagement = () => {
                   <div className="p-2 rounded-lg bg-blue-500/10 text-blue-500 group-hover:bg-blue-500/20 transition-colors">
                     <Users className="h-5 w-5 md:h-6 md:w-6" />
                   </div>
-                  <span className="group-hover:text-primary transition-colors">Artists</span>
+                  <span className="group-hover:text-primary transition-colors">Artistas</span>
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
                 <div className="flex items-baseline gap-2">
                   <p className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-blue-600 to-blue-400 bg-clip-text text-transparent">{artistCount}</p>
-                  <p className="text-xs md:text-sm text-muted-foreground">Total Artists</p>
+                  <p className="text-xs md:text-sm text-muted-foreground">Total de Artistas</p>
                 </div>
                 <Button className="w-full group-hover:shadow-md transition-shadow" size="sm" onClick={(e) => {
                   e.stopPropagation();
                   navigate(`/festival-management/${jobId}/artists`);
                 }}>
-                  {isViewOnly ? "View Artists" : "Manage Artists"}
+                  {isViewOnly ? "Ver Artistas" : "Gestionar Artistas"}
                 </Button>
               </CardContent>
             </Card>
@@ -1148,18 +1148,18 @@ const FestivalManagement = () => {
                   <div className="p-2 rounded-lg bg-purple-500/10 text-purple-500 group-hover:bg-purple-500/20 transition-colors">
                     <Layout className="h-5 w-5 md:h-6 md:w-6" />
                   </div>
-                  <span className="group-hover:text-primary transition-colors">Stages & Gear</span>
+                  <span className="group-hover:text-primary transition-colors">Escenarios y Equipo</span>
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
                 <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">
-                  Manage stages and technical equipment
+                  Gestiona escenarios y equipo técnico
                 </p>
                 <Button className="w-full group-hover:shadow-md transition-shadow" size="sm" onClick={(e) => {
                   e.stopPropagation();
                   navigate(`/festival-management/${jobId}/gear`);
                 }}>
-                  {isViewOnly ? "View Gear" : "Manage Gear"}
+                  {isViewOnly ? "Ver Equipo" : "Gestionar Equipo"}
                 </Button>
               </CardContent>
             </Card>
@@ -1173,18 +1173,18 @@ const FestivalManagement = () => {
                   <div className="p-2 rounded-lg bg-green-500/10 text-green-500 group-hover:bg-green-500/20 transition-colors">
                     <Calendar className="h-5 w-5 md:h-6 md:w-6" />
                   </div>
-                  <span className="group-hover:text-primary transition-colors">Scheduling</span>
+                  <span className="group-hover:text-primary transition-colors">Planificación</span>
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-3">
                 <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">
-                  Manage shifts and staff assignments
+                  Gestiona turnos y asignaciones de personal
                 </p>
                 <Button className="w-full group-hover:shadow-md transition-shadow" size="sm" onClick={(e) => {
                   e.stopPropagation();
                   navigate(`/festival-management/${jobId}/scheduling`);
                 }}>
-                  {isViewOnly ? "View Schedule" : "Manage Schedule"}
+                  {isViewOnly ? "Ver Planificación" : "Gestionar Planificación"}
                 </Button>
               </CardContent>
             </Card>
@@ -1195,7 +1195,7 @@ const FestivalManagement = () => {
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <CardTitle className="flex items-center gap-2 text-base md:text-lg">
                   <RefreshCw className="h-4 w-4 md:h-5 md:w-5" />
-                  Quick Actions
+                  Acciones Rápidas
                 </CardTitle>
                 <Button
                   variant="outline"
@@ -1212,7 +1212,7 @@ const FestivalManagement = () => {
                   ) : (
                     <RefreshCw className="h-4 w-4" />
                   )}
-                  Refresh Data
+                  Actualizar Datos
                 </Button>
               </div>
             </CardHeader>
@@ -1222,12 +1222,12 @@ const FestivalManagement = () => {
                   <div className="flex items-center justify-between flex-wrap gap-2">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <Users className="h-4 w-4 flex-shrink-0" />
-                      Assignments
+                      Asignaciones
                     </div>
                     <Badge variant="outline" className="text-xs">{humanizeDepartment(assignmentDepartment)}</Badge>
                   </div>
                   <p className="text-xs md:text-sm text-muted-foreground">
-                    Coordinate crew assignments by department.
+                    Coordina asignaciones de crew por departamento.
                   </p>
                   <div className="flex flex-col gap-2">
                     <Select value={assignmentDepartment} onValueChange={(value) => setAssignmentDepartment(value as Department)}>
@@ -1248,7 +1248,7 @@ const FestivalManagement = () => {
                       size="sm"
                       className="w-full"
                     >
-                      Open
+                      Abrir
                     </Button>
                   </div>
                 </div>
@@ -1259,7 +1259,7 @@ const FestivalManagement = () => {
                     Flex Crew Calls
                   </div>
                   <p className="text-xs md:text-sm text-muted-foreground">
-                    Link Sound/Lights crew call element IDs.
+                    Vincula los IDs de elementos de crew call de Sonido/Luces.
                   </p>
                   <div className="flex">
                     {jobId && <CrewCallLinkerDialog jobId={jobId} />}
@@ -1272,10 +1272,10 @@ const FestivalManagement = () => {
                     Timesheets
                   </div>
                   <p className="text-xs md:text-sm text-muted-foreground">
-                    Review and approve crew timesheets for this job.
+                    Revisa y aprueba las hojas de tiempo del crew para este trabajo.
                   </p>
                   <Button onClick={handleNavigateTimesheets} disabled={!jobId} size="sm" className="w-full">
-                    Open Timesheets
+                    Abrir Hojas de Tiempo
                   </Button>
                 </div>
 
@@ -1285,10 +1285,10 @@ const FestivalManagement = () => {
                     Hoja de Ruta
                   </div>
                   <p className="text-xs md:text-sm text-muted-foreground">
-                    Generate and review the roadmap for this job.
+                    Genera y revisa la hoja de ruta para este trabajo.
                   </p>
                   <Button onClick={handleOpenRouteSheet} disabled={!jobId} size="sm" className="w-full">
-                    Open Hoja de Ruta
+                    Abrir Hoja de Ruta
                   </Button>
                 </div>
 
@@ -1301,7 +1301,7 @@ const FestivalManagement = () => {
                     <Badge variant={flexStatus.variant} className="text-xs">{flexStatus.label}</Badge>
                   </div>
                   <p className="text-xs md:text-sm text-muted-foreground">
-                    Keep Flex folders in sync with this job&apos;s data.
+                    Mantén las carpetas de Flex sincronizadas con los datos de este trabajo.
                   </p>
                   <div className="flex flex-col gap-2">
                     <Button
@@ -1313,10 +1313,10 @@ const FestivalManagement = () => {
                       {isCreatingFlexFolders ? (
                         <>
                           <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Creating…
+                          Creando…
                         </>
                       ) : (
-                        'Create / Verify'
+                        'Crear / Verificar'
                       )}
                     </Button>
                     <div className="grid grid-cols-2 gap-2">
@@ -1335,10 +1335,10 @@ const FestivalManagement = () => {
                         {isCreatingFlexFolders ? (
                           <>
                             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            Updating…
+                            Actualizando…
                           </>
                         ) : (
-                          'Add'
+                          'Añadir'
                         )}
                       </Button>
                       <Button
@@ -1347,7 +1347,7 @@ const FestivalManagement = () => {
                         disabled={!canEdit}
                         size="sm"
                       >
-                        View Logs
+                        Ver Registros
                       </Button>
                     </div>
                   </div>
@@ -1361,13 +1361,13 @@ const FestivalManagement = () => {
                 <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3">
                   <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                     <FileText className="h-4 w-4 flex-shrink-0" />
-                    Job Details
+                    Detalles del Trabajo
                   </div>
                   <p className="text-xs md:text-sm text-muted-foreground">
-                    View the complete job configuration and metadata.
+                    Ve la configuración completa del trabajo y sus metadatos.
                   </p>
                   <Button onClick={handleOpenJobDetails} disabled={!job} size="sm" className="w-full">
-                    View Job Details
+                    Ver Detalles del Trabajo
                   </Button>
                 </div>
 
@@ -1376,10 +1376,10 @@ const FestivalManagement = () => {
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-blue-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <Upload className="h-4 w-4 flex-shrink-0 text-blue-500" />
-                      Upload Documents
+                      Subir Documentos
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Upload job documents and technical files.
+                      Sube documentos de trabajo y archivos técnicos.
                     </p>
                     <div className="relative">
                       <input
@@ -1396,10 +1396,10 @@ const FestivalManagement = () => {
                         {isUploadingDocument ? (
                           <>
                             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            Uploading...
+                            Subiendo...
                           </>
                         ) : (
-                          'Choose File'
+                          'Elegir Archivo'
                         )}
                       </Button>
                     </div>
@@ -1411,10 +1411,10 @@ const FestivalManagement = () => {
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-purple-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <FolderPlus className="h-4 w-4 flex-shrink-0 text-purple-500" />
-                      Local Folders
+                      Carpetas Locales
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Create local folder structure for this job.
+                      Crea estructura de carpetas locales para este trabajo.
                     </p>
                     <Button
                       onClick={handleCreateLocalFolders}
@@ -1425,10 +1425,10 @@ const FestivalManagement = () => {
                       {isCreatingLocalFolders ? (
                         <>
                           <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Creating...
+                          Creando...
                         </>
                       ) : (
-                        'Create Folders'
+                        'Crear Carpetas'
                       )}
                     </Button>
                   </div>
@@ -1439,10 +1439,10 @@ const FestivalManagement = () => {
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-orange-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <Archive className="h-4 w-4 flex-shrink-0 text-orange-500" />
-                      Archive to Flex
+                      Archivar en Flex
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Archive documents to Flex Documentación Técnica.
+                      Archiva documentos en Flex Documentación Técnica.
                     </p>
                     <Button
                       onClick={() => setIsArchiveDialogOpen(true)}
@@ -1451,7 +1451,7 @@ const FestivalManagement = () => {
                       className="w-full"
                       variant="outline"
                     >
-                      {isArchiving ? 'Archiving...' : 'Open Archive'}
+                      {isArchiving ? 'Archivando...' : 'Abrir Archivo'}
                     </Button>
                   </div>
                 )}
@@ -1461,10 +1461,10 @@ const FestivalManagement = () => {
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-cyan-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <RotateCw className="h-4 w-4 flex-shrink-0 text-cyan-500" />
-                      Backfill Doc Técnica
+                      Rellenar Doc Técnica
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Find and persist missing technical documentation.
+                      Encuentra y persiste documentación técnica faltante.
                     </p>
                     <Button
                       onClick={() => setIsBackfillDialogOpen(true)}
@@ -1473,7 +1473,7 @@ const FestivalManagement = () => {
                       className="w-full"
                       variant="outline"
                     >
-                      {isBackfilling ? 'Backfilling...' : 'Open Backfill'}
+                      {isBackfilling ? 'Rellenando...' : 'Abrir Relleno'}
                     </Button>
                   </div>
                 )}
@@ -1483,10 +1483,10 @@ const FestivalManagement = () => {
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-green-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <MessageCircle className="h-4 w-4 flex-shrink-0 text-green-500" />
-                      WhatsApp Group
+                      Grupo de WhatsApp
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Create WhatsApp group for job coordination.
+                      Crea grupo de WhatsApp para coordinación del trabajo.
                     </p>
                     <Button
                       onClick={() => setIsWhatsappDialogOpen(true)}
@@ -1494,7 +1494,7 @@ const FestivalManagement = () => {
                       className="w-full"
                       variant="outline"
                     >
-                      Create Group
+                      Crear Grupo
                     </Button>
                   </div>
                 )}
@@ -1507,7 +1507,7 @@ const FestivalManagement = () => {
                       Almacén Sonido
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Send message to warehouse team.
+                      Envía mensaje al equipo de almacén.
                     </p>
                     <Button
                       onClick={() => {
@@ -1518,7 +1518,7 @@ const FestivalManagement = () => {
                       className="w-full"
                       variant="outline"
                     >
-                      Send Message
+                      Enviar Mensaje
                     </Button>
                   </div>
                 )}
@@ -1528,10 +1528,10 @@ const FestivalManagement = () => {
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-indigo-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <Scale className="h-4 w-4 flex-shrink-0 text-indigo-500" />
-                      Pesos Calculator
+                      Calculadora de Pesos
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Calculate weights and load distribution.
+                      Calcula pesos y distribución de carga.
                     </p>
                     <Button
                       onClick={() => navigateToCalculator('pesos')}
@@ -1539,7 +1539,7 @@ const FestivalManagement = () => {
                       className="w-full"
                       variant="outline"
                     >
-                      Open Calculator
+                      Abrir Calculadora
                     </Button>
                   </div>
                 )}
@@ -1549,10 +1549,10 @@ const FestivalManagement = () => {
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-yellow-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <Zap className="h-4 w-4 flex-shrink-0 text-yellow-500" />
-                      Consumos Calculator
+                      Calculadora de Consumos
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Calculate power consumption and requirements.
+                      Calcula consumo y requisitos de energía.
                     </p>
                     <Button
                       onClick={() => navigateToCalculator('consumos')}
@@ -1560,7 +1560,7 @@ const FestivalManagement = () => {
                       className="w-full"
                       variant="outline"
                     >
-                      Open Calculator
+                      Abrir Calculadora
                     </Button>
                   </div>
                 )}
@@ -1570,10 +1570,10 @@ const FestivalManagement = () => {
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-red-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <AlertCircle className="h-4 w-4 flex-shrink-0 text-red-500" />
-                      Incident Report
+                      Reporte de Incidencia
                     </div>
                     <p className="text-xs md:text-sm text-muted-foreground">
-                      Create an incident report for this job.
+                      Crea un reporte de incidencia para este trabajo.
                     </p>
                     <TechnicianIncidentReportDialog job={job} techName={userRole} />
                   </div>
@@ -1594,7 +1594,7 @@ const FestivalManagement = () => {
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <CardTitle className="flex items-center gap-2 text-base md:text-lg">
                   <FileText className="h-4 w-4 md:h-5 md:w-5" />
-                  Documents & Riders
+                  Documentos y Riders
                 </CardTitle>
                 <Button
                   variant="outline"
@@ -1609,7 +1609,7 @@ const FestivalManagement = () => {
                   {isLoadingDocuments ? (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   ) : null}
-                  {isLoadingDocuments ? 'Refreshing…' : 'Refresh'}
+                  {isLoadingDocuments ? 'Actualizando…' : 'Actualizar'}
                 </Button>
               </div>
             </CardHeader>
@@ -1617,14 +1617,14 @@ const FestivalManagement = () => {
               {isLoadingDocuments ? (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  Loading documents…
+                  Cargando documentos…
                 </div>
               ) : (
                 <>
                   <div>
                     <h4 className="text-xs md:text-sm font-semibold text-foreground flex items-center gap-2 mb-3">
                       <FileText className="h-4 w-4 flex-shrink-0" />
-                      Job Documents
+                      Documentos del Trabajo
                     </h4>
                     {jobDocuments.length > 0 ? (
                       <div className="space-y-2">
@@ -1679,7 +1679,7 @@ const FestivalManagement = () => {
                       </div>
                     ) : (
                       <p className="text-xs md:text-sm text-muted-foreground">
-                        No job documents have been uploaded yet.
+                        Aún no se han subido documentos del trabajo.
                       </p>
                     )}
                   </div>
@@ -1687,7 +1687,7 @@ const FestivalManagement = () => {
                   <div>
                     <h4 className="text-xs md:text-sm font-semibold text-foreground flex items-center gap-2 mb-3">
                       <Users className="h-4 w-4 flex-shrink-0" />
-                      Artist Riders
+                      Riders de Artistas
                     </h4>
                     {groupedRiderFiles.length > 0 ? (
                       <div className="space-y-4">
@@ -1737,7 +1737,7 @@ const FestivalManagement = () => {
                       </div>
                     ) : (
                       <p className="text-xs md:text-sm text-muted-foreground">
-                        No artist riders uploaded yet. Riders added through the artist table will appear here automatically.
+                        Aún no se han subido riders de artistas. Los riders añadidos a través de la tabla de artistas aparecerán aquí automáticamente.
                       </p>
                     )}
                   </div>
@@ -1793,12 +1793,12 @@ const FestivalManagement = () => {
       {isSchedulingRoute && (
         <div>
           <div className="mb-4">
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               onClick={() => navigate(`/festival-management/${jobId}`)}
               className="flex items-center gap-1"
             >
-              Back to Festival
+              Volver al Festival
             </Button>
           </div>
           
@@ -1807,9 +1807,9 @@ const FestivalManagement = () => {
           ) : (
             <Card>
               <CardContent className="p-8 text-center">
-                <p className="text-muted-foreground mb-4">No dates available for scheduling. Please update the festival dates first.</p>
+                <p className="text-muted-foreground mb-4">No hay fechas disponibles para planificación. Por favor, actualiza primero las fechas del festival.</p>
                 <Button onClick={() => navigate(`/festival-management/${jobId}`)}>
-                  Go Back
+                  Volver
                 </Button>
               </CardContent>
             </Card>
@@ -1841,22 +1841,22 @@ const FestivalManagement = () => {
       <Dialog open={isArchiveDialogOpen} onOpenChange={setIsArchiveDialogOpen}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>Archive documents to Flex</DialogTitle>
+            <DialogTitle>Archivar documentos en Flex</DialogTitle>
             <DialogDescription>
-              Uploads all job documents to each department's Documentación Técnica in Flex and removes them from Supabase.
+              Sube todos los documentos del trabajo a la Documentación Técnica de cada departamento en Flex y los elimina de Supabase.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
-                <label className="text-sm font-medium">Mode</label>
+                <label className="text-sm font-medium">Modo</label>
                 <select
                   className="w-full h-9 rounded-md border bg-background px-3 text-sm"
                   value={archiveMode}
                   onChange={(e) => setArchiveMode(e.target.value as 'by-prefix' | 'all-tech')}
                 >
-                  <option value="by-prefix">By prefix (default)</option>
-                  <option value="all-tech">All technical depts</option>
+                  <option value="by-prefix">Por prefijo (predeterminado)</option>
+                  <option value="all-tech">Todos los depts. técnicos</option>
                 </select>
               </div>
               <div className="flex items-center gap-2 mt-6 sm:mt-[30px]">
@@ -1866,7 +1866,7 @@ const FestivalManagement = () => {
                   checked={archiveIncludeTemplates}
                   onChange={(e) => setArchiveIncludeTemplates(e.target.checked)}
                 />
-                <label htmlFor="includeTemplates" className="text-sm">Include templates</label>
+                <label htmlFor="includeTemplates" className="text-sm">Incluir templates</label>
               </div>
               <div className="flex items-center gap-2">
                 <input
@@ -1875,13 +1875,13 @@ const FestivalManagement = () => {
                   checked={archiveDryRun}
                   onChange={(e) => setArchiveDryRun(e.target.checked)}
                 />
-                <label htmlFor="dryRun" className="text-sm">Dry run (no delete)</label>
+                <label htmlFor="dryRun" className="text-sm">Prueba (sin eliminar)</label>
               </div>
             </div>
 
             {isArchiving && (
               <div className="flex items-center gap-2 text-sm">
-                <Loader2 className="h-4 w-4 animate-spin" /> Archiving...
+                <Loader2 className="h-4 w-4 animate-spin" /> Archivando...
               </div>
             )}
 
@@ -1891,23 +1891,23 @@ const FestivalManagement = () => {
 
             {archiveResult && (
               <div className="space-y-3">
-                <div className="text-sm">Summary</div>
+                <div className="text-sm">Resumen</div>
                 <div className="grid grid-cols-2 gap-2 text-sm">
-                  <div>Attempted: <span className="font-medium">{archiveResult.attempted ?? 0}</span></div>
-                  <div>Uploaded: <span className="font-medium">{archiveResult.uploaded ?? 0}</span></div>
-                  <div>Skipped: <span className="font-medium">{archiveResult.skipped ?? 0}</span></div>
-                  <div>Failed: <span className="font-medium">{archiveResult.failed ?? 0}</span></div>
+                  <div>Intentados: <span className="font-medium">{archiveResult.attempted ?? 0}</span></div>
+                  <div>Subidos: <span className="font-medium">{archiveResult.uploaded ?? 0}</span></div>
+                  <div>Omitidos: <span className="font-medium">{archiveResult.skipped ?? 0}</span></div>
+                  <div>Fallidos: <span className="font-medium">{archiveResult.failed ?? 0}</span></div>
                 </div>
               </div>
             )}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsArchiveDialogOpen(false)} disabled={isArchiving}>
-              Close
+              Cerrar
             </Button>
             <Button onClick={handleArchiveToFlex} disabled={isArchiving}>
               {isArchiving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
-              {archiveDryRun ? 'Run Dry' : 'Start'}
+              {archiveDryRun ? 'Ejecutar Prueba' : 'Iniciar'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -1917,63 +1917,63 @@ const FestivalManagement = () => {
       <Dialog open={isBackfillDialogOpen} onOpenChange={setIsBackfillDialogOpen}>
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>Backfill Documentación Técnica</DialogTitle>
+            <DialogTitle>Rellenar Documentación Técnica</DialogTitle>
             <DialogDescription>
-              Finds and persists missing Documentación Técnica elements for this job so archiving can target them reliably.
+              Encuentra y persiste elementos de Documentación Técnica faltantes para este trabajo, permitiendo que el archivado los localice de forma fiable.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2 text-sm">
             <div className="grid grid-cols-2 gap-3">
               <label className="flex items-center gap-2">
-                <input type="checkbox" checked={bfSound} onChange={(e) => setBfSound(e.target.checked)} /> Sound
+                <input type="checkbox" checked={bfSound} onChange={(e) => setBfSound(e.target.checked)} /> Sonido
               </label>
               <label className="flex items-center gap-2">
-                <input type="checkbox" checked={bfLights} onChange={(e) => setBfLights(e.target.checked)} /> Lights
+                <input type="checkbox" checked={bfLights} onChange={(e) => setBfLights(e.target.checked)} /> Luces
               </label>
               <label className="flex items-center gap-2">
                 <input type="checkbox" checked={bfVideo} onChange={(e) => setBfVideo(e.target.checked)} /> Video
               </label>
               <label className="flex items-center gap-2">
-                <input type="checkbox" checked={bfProduction} onChange={(e) => setBfProduction(e.target.checked)} /> Production
+                <input type="checkbox" checked={bfProduction} onChange={(e) => setBfProduction(e.target.checked)} /> Producción
               </label>
             </div>
             <div className="mt-2">
-              <div className="text-xs text-muted-foreground mb-1">Manual UUIDs (optional)</div>
+              <div className="text-xs text-muted-foreground mb-1">UUIDs manuales (opcional)</div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
-                  <label className="text-xs">Sound UUID</label>
+                  <label className="text-xs">UUID Sonido</label>
                   <input
                     className="w-full h-8 rounded border px-2 text-xs"
                     value={uuidSound}
                     onChange={(e) => setUuidSound(e.target.value)}
-                    placeholder="paste elementId"
+                    placeholder="pegar elementId"
                   />
                 </div>
                 <div>
-                  <label className="text-xs">Lights UUID</label>
+                  <label className="text-xs">UUID Luces</label>
                   <input
                     className="w-full h-8 rounded border px-2 text-xs"
                     value={uuidLights}
                     onChange={(e) => setUuidLights(e.target.value)}
-                    placeholder="paste elementId"
+                    placeholder="pegar elementId"
                   />
                 </div>
                 <div>
-                  <label className="text-xs">Video UUID</label>
+                  <label className="text-xs">UUID Video</label>
                   <input
                     className="w-full h-8 rounded border px-2 text-xs"
                     value={uuidVideo}
                     onChange={(e) => setUuidVideo(e.target.value)}
-                    placeholder="paste elementId"
+                    placeholder="pegar elementId"
                   />
                 </div>
                 <div>
-                  <label className="text-xs">Production UUID</label>
+                  <label className="text-xs">UUID Producción</label>
                   <input
                     className="w-full h-8 rounded border px-2 text-xs"
                     value={uuidProduction}
                     onChange={(e) => setUuidProduction(e.target.value)}
-                    placeholder="paste elementId"
+                    placeholder="pegar elementId"
                   />
                 </div>
               </div>
@@ -1981,18 +1981,18 @@ const FestivalManagement = () => {
 
             {isBackfilling && (
               <div className="flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" /> Backfilling…
+                <Loader2 className="h-4 w-4 animate-spin" /> Rellenando…
               </div>
             )}
             {backfillMessage && <div className="text-muted-foreground">{backfillMessage}</div>}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsBackfillDialogOpen(false)} disabled={isBackfilling}>
-              Close
+              Cerrar
             </Button>
             <Button onClick={handleBackfill} disabled={isBackfilling}>
               {isBackfilling ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
-              Start
+              Iniciar
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -2002,22 +2002,22 @@ const FestivalManagement = () => {
       <Dialog open={isWhatsappDialogOpen} onOpenChange={setIsWhatsappDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Create WhatsApp Group</DialogTitle>
+            <DialogTitle>Crear Grupo de WhatsApp</DialogTitle>
             <DialogDescription>
-              Create a WhatsApp group for coordinating this job with your team.
+              Crea un grupo de WhatsApp para coordinar este trabajo con tu equipo.
             </DialogDescription>
           </DialogHeader>
           <div className="py-4">
             <p className="text-sm text-muted-foreground">
-              A WhatsApp group will be created with the job title: <span className="font-semibold">{job?.title}</span>
+              Se creará un grupo de WhatsApp con el título del trabajo: <span className="font-semibold">{job?.title}</span>
             </p>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsWhatsappDialogOpen(false)} disabled={isSendingWa}>
-              Cancel
+              Cancelar
             </Button>
             <Button onClick={handleCreateWhatsappGroup} disabled={isSendingWa}>
-              {isSendingWa ? 'Creating...' : 'Create Group'}
+              {isSendingWa ? 'Creando...' : 'Crear Grupo'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -2056,28 +2056,28 @@ const FestivalManagement = () => {
       <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete Job</DialogTitle>
+            <DialogTitle>Eliminar Trabajo</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete this job? This action cannot be undone.
+              ¿Estás seguro de que quieres eliminar este trabajo? Esta acción no se puede deshacer.
             </DialogDescription>
           </DialogHeader>
           <div className="py-4">
             <p className="text-sm">
-              Job: <span className="font-semibold">{job?.title}</span>
+              Trabajo: <span className="font-semibold">{job?.title}</span>
             </p>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)} disabled={isDeleting}>
-              Cancel
+              Cancelar
             </Button>
             <Button variant="destructive" onClick={handleDeleteJob} disabled={isDeleting}>
               {isDeleting ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Deleting...
+                  Eliminando...
                 </>
               ) : (
-                'Delete'
+                'Eliminar'
               )}
             </Button>
           </DialogFooter>

--- a/src/pages/Festivals.tsx
+++ b/src/pages/Festivals.tsx
@@ -179,10 +179,10 @@ const Festivals = () => {
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
       
-      toast.success('Documentation generated successfully');
+      toast.success('Documentación generada exitosamente');
     } catch (error: any) {
       console.error('Error generating documentation:', error);
-      toast.error(`Failed to generate documentation: ${error.message}`);
+      toast.error(`Error al generar documentación: ${error.message}`);
     } finally {
       setIsPrinting(prev => ({ ...prev, [selectedJobForPrint.id]: false }));
     }
@@ -191,23 +191,23 @@ const Festivals = () => {
   // Handle refresh button click with enhanced recovery
   const handleRefreshClick = async () => {
     try {
-      toast.info("Refreshing festival data...");
+      toast.info("Actualizando datos de festivales...");
       
       // First try to ensure realtime connection
       const connectionRestored = await ensureRealtimeConnection();
       
       if (connectionRestored) {
         await refetch();
-        toast.success("Festival data refreshed");
+        toast.success("Datos de festival actualizados");
       } else {
         // If connection couldn't be restored, try the full recovery
         await recoverConnection();
         await refetch();
-        toast.success("Connection restored and data refreshed");
+        toast.success("Conexión restaurada y datos actualizados");
       }
     } catch (error) {
       console.error("Error during refresh:", error);
-      toast.error("Could not refresh data. Please try again.");
+      toast.error("No se pudieron actualizar los datos. Por favor, inténtalo de nuevo.");
     }
   };
 
@@ -219,10 +219,10 @@ const Festivals = () => {
       <Card>
         <CardHeader className="flex flex-col md:flex-row md:items-center justify-between space-y-4 md:space-y-0 pb-2">
           <div className="flex items-center gap-4">
-            <CardTitle className="text-xl md:text-2xl font-bold">Festival Management</CardTitle>
+            <CardTitle className="text-xl md:text-2xl font-bold">Gestión de Festivales</CardTitle>
             <Tent className="h-5 w-5 md:h-6 md:w-6 text-muted-foreground" />
           </div>
-          
+
           <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
             <Button
               variant="outline"
@@ -231,11 +231,11 @@ const Festivals = () => {
               className="w-full sm:w-auto"
             >
               {showCompleted ? <EyeOff className="h-4 w-4 sm:mr-2" /> : <Eye className="h-4 w-4 sm:mr-2" />}
-              <span className="ml-2 sm:ml-0">{showCompleted ? 'Hide Completed' : 'Show Completed'}</span>
+              <span className="ml-2 sm:ml-0">{showCompleted ? 'Ocultar Completados' : 'Mostrar Completados'}</span>
             </Button>
-            <SubscriptionIndicator 
-              tables={['jobs', 'job_assignments', 'job_departments', 'job_date_types', 'festival_logos']} 
-              showRefreshButton 
+            <SubscriptionIndicator
+              tables={['jobs', 'job_assignments', 'job_departments', 'job_date_types', 'festival_logos']}
+              showRefreshButton
               onRefresh={handleRefreshClick}
               showLabel
               className="justify-center sm:justify-start"
@@ -244,41 +244,41 @@ const Festivals = () => {
         </CardHeader>
         <CardContent>
           <p className="text-muted-foreground mb-6">
-            Access and manage all festival-type events in one place.
+            Accede y gestiona todos los eventos tipo festival en un solo lugar.
           </p>
           <Separator className="my-6" />
           
           {isLoading ? (
             <div className="flex flex-col justify-center items-center h-40">
               <Loader2 className="h-8 w-8 animate-spin mb-2 text-primary" />
-              <p className="text-muted-foreground">Loading festivals...</p>
+              <p className="text-muted-foreground">Cargando festivales...</p>
               {connectionStatus !== 'connected' && (
-                <p className="text-amber-500 mt-2">Establishing connection...</p>
+                <p className="text-amber-500 mt-2">Estableciendo conexión...</p>
               )}
             </div>
           ) : isError ? (
             <div className="flex flex-col justify-center items-center h-40 text-center">
               <AlertTriangle className="h-8 w-8 mb-2 text-destructive" />
-              <h3 className="text-lg font-medium text-destructive">Error loading festivals</h3>
+              <h3 className="text-lg font-medium text-destructive">Error al cargar festivales</h3>
               <p className="text-muted-foreground mt-2 max-w-md">
-                {error instanceof Error ? error.message : 'An unknown error occurred'}
+                {error instanceof Error ? error.message : 'Ha ocurrido un error desconocido'}
               </p>
-              <p className="text-sm text-muted-foreground mt-2">Connection status: {connectionStatus}</p>
-              <Button 
-                variant="outline" 
-                size="sm" 
+              <p className="text-sm text-muted-foreground mt-2">Estado de conexión: {connectionStatus}</p>
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={handleRefreshClick}
                 className="mt-4"
               >
                 <RefreshCw className="h-4 w-4 mr-2" />
-                Reconnect & Try Again
+                Reconectar e Intentar de Nuevo
               </Button>
             </div>
           ) : festivalJobs.length === 0 ? (
             <div className="text-center py-10">
-              <h3 className="text-lg font-medium">No festivals found</h3>
+              <h3 className="text-lg font-medium">No se encontraron festivales</h3>
               <p className="text-muted-foreground mt-2">
-                There are currently no festival-type jobs scheduled.
+                Actualmente no hay trabajos tipo festival programados.
               </p>
             </div>
           ) : (
@@ -327,7 +327,7 @@ const Festivals = () => {
                         ) : (
                           <Printer className="h-4 w-4" />
                         )}
-                        <span className="sr-only">Print Documentation</span>
+                        <span className="sr-only">Imprimir Documentación</span>
                       </Button>
                     )}
                   </div>


### PR DESCRIPTION
Traduce toda la interfaz del workflow de Festival Management al español,
manteniendo términos técnicos en inglés según las convenciones del proyecto.

Páginas principales traducidas (4):
- Festivals.tsx - Página de lista de festivales
- FestivalManagement.tsx - Hub de gestión con tarjetas de navegación y acciones rápidas
- FestivalArtistManagement.tsx - Gestión de artistas
- FestivalGearManagement.tsx - Gestión de escenarios y equipo

Componentes core y navegación (3):
- FestivalManagementWrapper.tsx - Componente wrapper
- FestivalDateNavigation.tsx - Navegación por fechas con tipos de día
- festivals-pagination.tsx - Paginación de festivales

Gestión de artistas (21):
- Tabla de artistas con filtros y búsqueda
- Formularios de artistas (público e interno)
- Diálogos de gestión y enlaces de formulario
- Todas las secciones del formulario (info básica, consoles, wireless, IEM, etc.)
- Componentes compartidos (selección de equipo, proveedor, cantidad)
- Estado de formularios y archivos de riders

Gestión de equipo (10):
- Configuración de gear por escenario
- Configuración de consoles (FOH y monitores)
- Configuración de wireless e IEM
- Configuración de micrófonos (kit y cableados)
- Configuración de infraestructura
- Calculadora y análisis de necesidades de micrófonos

Planificación y turnos (8):
- Tabla y lista de turnos
- Creación y edición de turnos
- Copia de turnos entre fechas
- Gestión de asignaciones de personal
- Calculadora de horarios de turnos

Utilidades (5):
- Diálogo de opciones de impresión
- Gestor de logos de festival
- Sección de pronóstico del tiempo
- Indicadores de estado y conflictos
- Utilidades de visualización de archivos

Términos técnicos mantenidos en inglés:
- crew, preset, rider, soundcheck, stage
- wireless, IEM, console, FOH, monitor
- Nombres de equipos y marcas

Total: 57 archivos modificados