### PR TITLE
Fix Array.from null error in CorporateEmailComposer

### DIFF
--- a/src/components/emails/CorporateEmailComposer.tsx
+++ b/src/components/emails/CorporateEmailComposer.tsx
@@ -400,8 +400,7 @@ export function CorporateEmailComposer() {
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-[400px] p-0" align="start">
-              {recipientPopoverOpen && (
-                <Command>
+              <Command>
                 <CommandInput
                   placeholder="Buscar por nombre, email o departamento..."
                   value={recipientSearch}
@@ -474,7 +473,6 @@ export function CorporateEmailComposer() {
                   })}
                 </CommandGroup>
               </Command>
-              )}
             </PopoverContent>
           </Popover>
         </div>


### PR DESCRIPTION
Remove conditional rendering of Command component inside PopoverContent.
The cmdk library requires a stable DOM structure during mount and fails
when Command is conditionally rendered within a Dialog/Popover. The
Popover component already handles visibility control, making the
conditional rendering unnecessary.

Fixes: TypeError: Array.from requires an array-like object - not null or undefined