### PR TITLE
Fix Command component to avoid cmdk null reference error

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -10,16 +10,6 @@ const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
 >(({ className, ...props }, ref) => {
-  const [mounted, setMounted] = React.useState(false);
-
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted) {
-    return null;
-  }
-
   return (
     <CommandPrimitive
       ref={ref}


### PR DESCRIPTION
## Summary
- render the Command primitive immediately so cmdk always receives a mounted root element

## Testing
- npm test *(fails: vitest not found in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913b44013e0832f80afb448af4fad63)