### PR TITLE
Guard Command primitive for SSR environments

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -10,14 +10,8 @@ const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
 >(({ className, ...props }, ref) => {
-  const [mounted, setMounted] = React.useState(false);
-
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted) {
-    return null;
+  if (typeof window === "undefined") {
+    return null
   }
 
   return (


### PR DESCRIPTION
## Summary
- guard the Command wrapper so it only skips rendering when `window` is unavailable, keeping cmdk refs during client renders

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913b44013e0832f80afb448af4fad63)