### PR TITLE
Handle open-ended assignments in personal calendar

### DIFF
--- a/src/components/personal/__tests__/MobilePersonalCalendar.test.tsx
+++ b/src/components/personal/__tests__/MobilePersonalCalendar.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import type { ReactNode } from 'react';
+
+vi.mock('../hooks/usePersonalCalendarData', () => ({
+  usePersonalCalendarData: vi.fn(),
+}));
+
+vi.mock('../hooks/useTechnicianAvailability', () => ({
+  useTechnicianAvailability: vi.fn(),
+}));
+
+vi.mock('../TechContextMenu', () => ({
+  TechContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/dashboard/PrintDialog', () => ({
+  PrintDialog: () => null,
+  PrintSettings: {} as any,
+}));
+
+import { usePersonalCalendarData } from '../hooks/usePersonalCalendarData';
+import { useTechnicianAvailability } from '../hooks/useTechnicianAvailability';
+import { MobilePersonalCalendar } from '../MobilePersonalCalendar';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MobilePersonalCalendar', () => {
+  it('lists technician on weekend when assignment has only start time', () => {
+    const jobStart = '2024-05-18T11:00:00.000Z';
+
+    const mockedUsePersonalCalendarData = usePersonalCalendarData as unknown as Mock;
+    const mockedUseTechnicianAvailability = useTechnicianAvailability as unknown as Mock;
+
+    mockedUsePersonalCalendarData.mockReturnValue({
+      houseTechs: [
+        {
+          id: 'tech-1',
+          first_name: 'Alex',
+          last_name: 'Johnson',
+          department: 'sound',
+          phone: '555-0101',
+        },
+      ],
+      assignments: [
+        {
+          technician_id: 'tech-1',
+          sound_role: 'foh',
+          lights_role: null,
+          video_role: null,
+          job: {
+            id: 'job-1',
+            title: 'Main Event',
+            color: '#123456',
+            start_time: jobStart,
+            end_time: jobStart,
+            status: 'scheduled',
+            location: { name: 'Auditorium' },
+          },
+        },
+      ],
+      vacationPeriods: [],
+      isLoading: false,
+    });
+
+    mockedUseTechnicianAvailability.mockReturnValue({
+      updateAvailability: vi.fn(),
+      removeAvailability: vi.fn(),
+      getAvailabilityStatus: vi.fn(() => null),
+      isLoading: false,
+    });
+
+    render(
+      <MobilePersonalCalendar
+        date={new Date('2024-05-18T00:00:00.000Z')}
+        onDateSelect={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Alex Johnson')).toBeInTheDocument();
+    expect(screen.getByText('On job')).toBeInTheDocument();
+  });
+});

--- a/src/components/personal/__tests__/PersonalCalendar.test.tsx
+++ b/src/components/personal/__tests__/PersonalCalendar.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('../hooks/usePersonalCalendarData', () => ({
+  usePersonalCalendarData: vi.fn(),
+}));
+
+vi.mock('../hooks/useTechnicianAvailability', () => ({
+  useTechnicianAvailability: vi.fn(),
+}));
+
+import { usePersonalCalendarData } from '../hooks/usePersonalCalendarData';
+import { useTechnicianAvailability } from '../hooks/useTechnicianAvailability';
+import { PersonalCalendar } from '../PersonalCalendar';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PersonalCalendar', () => {
+  it('renders technician assignment on weekend when job only has start time', () => {
+    const jobStart = '2024-05-18T09:00:00.000Z';
+
+    const mockedUsePersonalCalendarData = usePersonalCalendarData as unknown as Mock;
+    const mockedUseTechnicianAvailability = useTechnicianAvailability as unknown as Mock;
+
+    mockedUsePersonalCalendarData.mockReturnValue({
+      houseTechs: [
+        {
+          id: 'tech-1',
+          first_name: 'Alex',
+          last_name: 'Johnson',
+          department: 'sound',
+          phone: '555-0101',
+        },
+      ],
+      assignments: [
+        {
+          technician_id: 'tech-1',
+          sound_role: 'foh',
+          lights_role: null,
+          video_role: null,
+          job: {
+            id: 'job-1',
+            title: 'Main Event',
+            color: '#123456',
+            start_time: jobStart,
+            end_time: jobStart,
+            status: 'scheduled',
+            location: { name: 'Auditorium' },
+          },
+        },
+      ],
+      vacationPeriods: [],
+      isLoading: false,
+    });
+
+    mockedUseTechnicianAvailability.mockReturnValue({
+      updateAvailability: vi.fn(),
+      removeAvailability: vi.fn(),
+      getAvailabilityStatus: vi.fn(() => null),
+      isLoading: false,
+    });
+
+    render(
+      <PersonalCalendar
+        date={new Date('2024-05-01T00:00:00.000Z')}
+        onDateSelect={vi.fn()}
+      />
+    );
+
+    const findDayCell = (dayLabel: string) => {
+      const daySpans = screen.getAllByText(dayLabel);
+      const currentMonthSpan = daySpans.find(span => {
+        const cell = span.closest('div.p-2');
+        return cell && !cell.className.includes('text-muted-foreground/50');
+      });
+      const cell = currentMonthSpan?.closest('div.p-2');
+      if (!cell) {
+        throw new Error(`Day cell for ${dayLabel} not found`);
+      }
+      return cell as HTMLElement;
+    };
+
+    const saturdayCell = findDayCell('18');
+    const sundayCell = findDayCell('19');
+
+    expect(within(saturdayCell).getByText('AJ')).toBeInTheDocument();
+    expect(() => within(sundayCell).getByText('AJ')).toThrow();
+  });
+});

--- a/src/components/personal/hooks/__tests__/usePersonalCalendarData.test.ts
+++ b/src/components/personal/hooks/__tests__/usePersonalCalendarData.test.ts
@@ -1,0 +1,180 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  interface QueryResponse {
+    data: any;
+    error: any;
+  }
+
+  const createQueryBuilder = (response: QueryResponse, terminalMethod: 'order' | 'or' | 'lte') => {
+    const builder: any = {};
+    builder.select = vi.fn(() => builder);
+    builder.in = vi.fn(() => builder);
+    builder.eq = vi.fn(() => builder);
+    builder.gte = vi.fn(() => builder);
+    builder.lte = vi.fn(() => (terminalMethod === 'lte' ? Promise.resolve(response) : builder));
+    builder.order = vi.fn(() => (terminalMethod === 'order' ? Promise.resolve(response) : builder));
+    builder.or = vi.fn(() => (terminalMethod === 'or' ? Promise.resolve(response) : builder));
+    return builder;
+  };
+
+  const profilesResponse = {
+    data: [
+      {
+        id: 'tech-1',
+        first_name: 'Alex',
+        last_name: 'Johnson',
+        department: 'sound',
+        phone: '555-0101',
+      },
+    ],
+    error: null,
+  };
+
+  const jobAssignmentsResponse = {
+    data: [
+      {
+        technician_id: 'tech-1',
+        sound_role: 'foh',
+        lights_role: null,
+        video_role: null,
+        jobs: {
+          id: 'job-1',
+          title: 'Main Event',
+          color: '#123456',
+          start_time: '2024-05-20T10:00:00.000Z',
+          end_time: null,
+          status: 'scheduled',
+          locations: [
+            { name: 'Auditorium' },
+          ],
+        },
+      },
+    ],
+    error: null,
+  };
+
+  const vacationResponse = {
+    data: [],
+    error: null,
+  };
+
+  const profilesQuery = createQueryBuilder(profilesResponse, 'order');
+  const jobAssignmentsQuery = createQueryBuilder(jobAssignmentsResponse, 'or');
+  const vacationQuery = createQueryBuilder(vacationResponse, 'lte');
+
+  const jobAssignmentsOrMock = jobAssignmentsQuery.or as ReturnType<typeof vi.fn>;
+
+  const subscriptionA = { id: 'assignment-channel' };
+  const subscriptionB = { id: 'availability-channel' };
+
+  const removeChannelMock = vi.fn();
+  const subscriptions = [subscriptionA, subscriptionB];
+  const channelMock = vi.fn(() => {
+    const callIndex = channelMock.mock.calls.length;
+    const subscription = subscriptions[callIndex - 1] ?? { id: `channel-${callIndex}` };
+    return {
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnValue(subscription),
+    };
+  });
+
+  const fromMock = vi.fn((table: string) => {
+    switch (table) {
+      case 'profiles':
+        return profilesQuery;
+      case 'job_assignments':
+        return jobAssignmentsQuery;
+      case 'availability_schedules':
+        return vacationQuery;
+      default:
+        throw new Error(`Unexpected table requested: ${table}`);
+    }
+  });
+
+  return {
+    profilesResponse,
+    jobAssignmentsResponse,
+    vacationResponse,
+    profilesQuery,
+    jobAssignmentsQuery,
+    vacationQuery,
+    jobAssignmentsOrMock,
+    subscriptionA,
+    subscriptionB,
+    removeChannelMock,
+    channelMock,
+    fromMock,
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: hoisted.fromMock,
+    channel: hoisted.channelMock,
+    removeChannel: hoisted.removeChannelMock,
+  },
+  checkNetworkConnection: vi.fn(),
+  getRealtimeConnectionStatus: vi.fn(),
+  ensureRealtimeConnection: vi.fn(),
+  monitorConnectionHealth: vi.fn(),
+  forceRefreshSubscriptions: vi.fn(),
+}));
+
+const {
+  profilesResponse,
+  jobAssignmentsResponse,
+  vacationResponse,
+  profilesQuery,
+  jobAssignmentsQuery,
+  vacationQuery,
+  jobAssignmentsOrMock,
+  subscriptionA,
+  subscriptionB,
+  removeChannelMock,
+  channelMock,
+  fromMock,
+} = hoisted;
+
+import { usePersonalCalendarData } from '../usePersonalCalendarData';
+
+describe('usePersonalCalendarData', () => {
+  beforeEach(() => {
+    profilesQuery.select.mockClear();
+    profilesQuery.in.mockClear();
+    profilesQuery.eq.mockClear();
+    profilesQuery.order.mockClear();
+
+    jobAssignmentsQuery.select.mockClear();
+    jobAssignmentsQuery.in.mockClear();
+    jobAssignmentsQuery.lte.mockClear();
+    jobAssignmentsQuery.or.mockClear();
+
+    vacationQuery.select.mockClear();
+    vacationQuery.in.mockClear();
+    vacationQuery.eq.mockClear();
+    vacationQuery.gte.mockClear();
+    vacationQuery.lte.mockClear();
+
+    fromMock.mockClear();
+    channelMock.mockClear();
+    removeChannelMock.mockClear();
+  });
+
+  it('returns assignments with fallback end_time when job end_time is null', async () => {
+    const currentMonth = new Date('2024-05-01T00:00:00.000Z');
+    const { result, unmount } = renderHook(() => usePersonalCalendarData(currentMonth));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.assignments).toHaveLength(1);
+    const assignment = result.current.assignments[0];
+    expect(assignment.job.end_time).toBe(jobAssignmentsResponse.data[0].jobs.start_time);
+    expect(jobAssignmentsOrMock).toHaveBeenCalledWith(expect.stringContaining('jobs.end_time.is.null'));
+
+    unmount();
+    expect(removeChannelMock).toHaveBeenCalledWith(subscriptionA);
+    expect(removeChannelMock).toHaveBeenCalledWith(subscriptionB);
+  });
+});

--- a/src/components/personal/hooks/usePersonalCalendarData.ts
+++ b/src/components/personal/hooks/usePersonalCalendarData.ts
@@ -73,6 +73,9 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
 
         // Fetch job assignments for house techs within date range
         console.log('PersonalCalendar: Fetching job assignments...');
+        const startIso = startDate.toISOString();
+        const endIso = endDate.toISOString();
+
         const { data: assignmentsData, error: assignmentsError } = await supabase
           .from('job_assignments')
           .select(`
@@ -93,8 +96,8 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
             )
           `)
           .in('technician_id', (techsData || []).map(tech => tech.id))
-          .gte('jobs.start_time', startDate.toISOString())
-          .lte('jobs.end_time', endDate.toISOString());
+          .lte('jobs.start_time', endIso)
+          .or(`jobs.end_time.is.null,jobs.end_time.gte.${startIso}`);
 
         if (assignmentsError) {
           console.error('PersonalCalendar: Error fetching assignments:', assignmentsError);
@@ -147,7 +150,7 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
               title: jobData.title,
               color: jobData.color,
               start_time: jobData.start_time,
-              end_time: jobData.end_time,
+              end_time: jobData.end_time ?? jobData.start_time,
               status: jobData.status,
               location: jobData.locations && Array.isArray(jobData.locations) && jobData.locations.length > 0 
                 ? { name: jobData.locations[0].name } 


### PR DESCRIPTION
## Summary
- extend the personal calendar Supabase query to include open-ended jobs by bounding start times and allowing null end times when they overlap the selected window
- fall back to a job's start timestamp when the Supabase payload omits `end_time` so downstream calendar math stays valid
- add regression tests for the hook plus the desktop and mobile calendars to confirm a one-day job without an end time still renders

## Testing
- `npx vitest run src/components/personal/hooks/__tests__/usePersonalCalendarData.test.ts src/components/personal/__tests__/PersonalCalendar.test.tsx src/components/personal/__tests__/MobilePersonalCalendar.test.tsx`
- `npm test` *(fails because of unrelated suites that already error when their module mocks are hoisted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c1ec130c832f83fd15834d5a816d)