### PR TITLE
Fix personal calendar single-day assignment date parsing

### DIFF
--- a/src/components/personal/PersonalCalendar.tsx
+++ b/src/components/personal/PersonalCalendar.tsx
@@ -13,6 +13,7 @@ import {
   isToday,
   isSameDay,
   isWithinInterval,
+  parse
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { HouseTechBadge } from "./HouseTechBadge";
@@ -102,7 +103,7 @@ export const PersonalCalendar: React.FC<PersonalCalendarProps> = ({
     return assignments.filter(assignment => {
       // Check if this is a single-day assignment
       if (assignment.single_day && assignment.assignment_date) {
-        const assignmentDate = new Date(assignment.assignment_date);
+        const assignmentDate = parse(assignment.assignment_date, "yyyy-MM-dd", new Date());
         return isSameDay(day, assignmentDate);
       }
       


### PR DESCRIPTION
## Summary
- import the date-fns `parse` helper in the personal calendar component
- parse single-day assignment dates as local dates to avoid timezone shifts when matching days

## Testing
- npm test -- --run Tests/PersonalCalendar *(fails: vitest binary not available because dependencies could not be installed without network access)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913cab28d28832fbe97112afad30bdc)