### PR TITLE
Fix staffing matrix not updating after email confirmation

### DIFF
--- a/src/features/staffing/hooks/useStaffingRealtime.ts
+++ b/src/features/staffing/hooks/useStaffingRealtime.ts
@@ -104,6 +104,7 @@ export function useStaffingRealtime() {
       console.log('🔄 Invalidating matrix queries')
       qc.invalidateQueries({ queryKey: ['assignment-matrix'] })
       qc.invalidateQueries({ queryKey: ['optimized-matrix-assignments'] })
+      qc.invalidateQueries({ queryKey: ['staffing-matrix'] })
     }
       
     return () => { 


### PR DESCRIPTION
Add missing ['staffing-matrix'] query invalidation to ensure the matrix UI
updates automatically when technicians confirm offers via email links.

The realtime subscription was working correctly but only invalidated
['assignment-matrix'] and ['optimized-matrix-assignments']. The matrix
status badges use ['staffing-matrix'] which was only invalidated as a
fallback via activity_log events.

Now all staffing_requests updates will properly invalidate the matrix
status query, ensuring immediate UI updates without page refresh.