### PR TITLE
Handle per-date conflicts before auto-assigning staffing batches

### DIFF
--- a/supabase/functions/staffing-click/__tests__/conflictUtils.test.ts
+++ b/supabase/functions/staffing-click/__tests__/conflictUtils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { detectConflictForAssignment, type AssignmentCoverage, type JobTimeInfo } from '../conflictUtils.ts';
+
+const makeDayWindow = (date: string, jobId: number, jobTitle: string | null = null): AssignmentCoverage => {
+  const start = new Date(`${date}T00:00:00.000Z`);
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  return {
+    window: { kind: 'day', start, end },
+    meta: { job_id: jobId, job_title: jobTitle, assignment_date: date },
+  };
+};
+
+describe('detectConflictForAssignment', () => {
+  const jobInfo: JobTimeInfo = {
+    title: 'Lighting Gig',
+    start: new Date('2024-05-01T08:00:00.000Z'),
+    end: new Date('2024-05-03T02:00:00.000Z'),
+    rawStart: '2024-05-01T08:00:00.000Z',
+    rawEnd: '2024-05-03T02:00:00.000Z',
+  };
+
+  it('flags a conflicting single-day assignment while allowing other days to proceed', () => {
+    const existingAssignments: AssignmentCoverage[] = [
+      makeDayWindow('2024-05-02', 77, 'Soundcheck'),
+    ];
+    const processed: string[] = [];
+    const skipped: string[] = [];
+    for (const day of ['2024-05-01', '2024-05-02', '2024-05-03']) {
+      const result = detectConflictForAssignment({
+        targetDate: day,
+        existingAssignmentWindows: existingAssignments,
+        jobInfo,
+        jobId: 55,
+        jobStartTime: jobInfo.rawStart,
+        jobEndTime: jobInfo.rawEnd,
+      });
+      if (result.conflict) {
+        skipped.push(day);
+      } else {
+        processed.push(day);
+      }
+    }
+
+    expect(skipped).toEqual(['2024-05-02']);
+    expect(processed).toEqual(['2024-05-01', '2024-05-03']);
+  });
+
+  it('produces detailed conflict metadata when overlap occurs', () => {
+    const result = detectConflictForAssignment({
+      targetDate: '2024-05-02',
+      existingAssignmentWindows: [makeDayWindow('2024-05-02', 99, 'Main Stage')],
+      jobInfo,
+      jobId: 55,
+      jobStartTime: jobInfo.rawStart,
+      jobEndTime: jobInfo.rawEnd,
+    });
+
+    expect(result.conflict).toBe(true);
+    if (result.conflict) {
+      expect(result.meta).toMatchObject({
+        request_job_id: 55,
+        request_single_day: true,
+        request_window_type: 'day',
+        request_assignment_date: '2024-05-02',
+        conflicting_job_id: 99,
+        conflicting_job_title: 'Main Stage',
+        conflicting_window_type: 'day',
+        conflicting_assignment_date: '2024-05-02',
+      });
+    }
+  });
+});

--- a/supabase/functions/staffing-click/conflictUtils.ts
+++ b/supabase/functions/staffing-click/conflictUtils.ts
@@ -1,0 +1,98 @@
+export type DayWindow = { kind: 'day'; start: Date; end: Date };
+export type RangeWindow = { kind: 'range'; start: Date; end: Date };
+export type TimeWindow = DayWindow | RangeWindow;
+
+export type AssignmentCoverageMeta = {
+  job_id: number;
+  job_title: string | null;
+  assignment_date?: string;
+  start_time?: string | null;
+  end_time?: string | null;
+};
+
+export type AssignmentCoverage = {
+  window: TimeWindow;
+  meta: AssignmentCoverageMeta;
+};
+
+export type JobTimeInfo = {
+  title: string | null;
+  start: Date | null;
+  end: Date | null;
+  rawStart: string | null;
+  rawEnd: string | null;
+};
+
+export type ConflictContext = {
+  targetDate: string | null;
+  existingAssignmentWindows: AssignmentCoverage[];
+  jobInfo: JobTimeInfo | undefined;
+  jobId: number;
+  jobStartTime: string | null;
+  jobEndTime: string | null;
+};
+
+export type ConflictResult =
+  | { conflict: false }
+  | { conflict: true; meta: Record<string, unknown> };
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function windowsIntersect(a: TimeWindow, b: TimeWindow) {
+  return a.start.getTime() < b.end.getTime() && b.start.getTime() < a.end.getTime();
+}
+
+export function computeRequestWindow(targetDate: string | null, jobInfo: JobTimeInfo | undefined): TimeWindow | null {
+  if (targetDate) {
+    const dayStart = new Date(targetDate);
+    if (Number.isNaN(dayStart.getTime())) return null;
+    return { kind: 'day', start: dayStart, end: new Date(dayStart.getTime() + DAY_MS) };
+  }
+  if (!jobInfo || !jobInfo.start || !jobInfo.end) return null;
+  if (jobInfo.start.getTime() >= jobInfo.end.getTime()) return null;
+  return { kind: 'range', start: jobInfo.start, end: jobInfo.end };
+}
+
+export function detectConflictForAssignment(context: ConflictContext): ConflictResult {
+  const { targetDate, existingAssignmentWindows, jobInfo, jobId, jobStartTime, jobEndTime } = context;
+  if (existingAssignmentWindows.length === 0) {
+    return { conflict: false };
+  }
+
+  const requestWindow = computeRequestWindow(targetDate, jobInfo);
+  if (!requestWindow) {
+    return { conflict: false };
+  }
+
+  const conflicting = existingAssignmentWindows.find((existing) => windowsIntersect(requestWindow, existing.window));
+  if (!conflicting) {
+    return { conflict: false };
+  }
+
+  const conflictMeta: Record<string, unknown> = {
+    request_job_id: jobId,
+    request_single_day: !!targetDate,
+    request_window_type: requestWindow.kind,
+    conflicting_job_id: conflicting.meta.job_id,
+    conflicting_job_title: conflicting.meta.job_title,
+    conflicting_window_type: conflicting.window.kind,
+  };
+
+  if (targetDate) {
+    conflictMeta.request_assignment_date = targetDate;
+  } else {
+    conflictMeta.request_job_start = jobStartTime ?? null;
+    conflictMeta.request_job_end = jobEndTime ?? null;
+  }
+
+  if (conflicting.meta.assignment_date) {
+    conflictMeta.conflicting_assignment_date = conflicting.meta.assignment_date;
+  }
+
+  if (conflicting.meta.start_time || conflicting.meta.end_time) {
+    conflictMeta.conflicting_job_start = conflicting.meta.start_time ?? null;
+    conflictMeta.conflicting_job_end = conflicting.meta.end_time ?? null;
+  }
+
+  return { conflict: true, meta: conflictMeta };
+}


### PR DESCRIPTION
## Summary
- move the conflict detection out of the upsert helper so each batch row or single-day request logs its own clash and continues processing remaining dates
- centralize the overlap calculation in a reusable `detectConflictForAssignment` helper for consistent metadata
- add a regression-style Vitest that simulates a mixed batch to confirm only the conflicting date is skipped

## Testing
- npm test -- --run *(fails: vitest binary unavailable because dependencies could not be installed in the offline environment)*
- npm install --legacy-peer-deps *(fails: onnxruntime binary download blocked by environment network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cc385614832fb7daf2bbb61e3ddf)