### PR TITLE
Fix redirect response block balancing in staffing-click function

### DIFF
--- a/supabase/functions/staffing-click/index.ts
+++ b/supabase/functions/staffing-click/index.ts
@@ -609,13 +609,15 @@ serve(async (req) => {
 
     const phaseText = row.phase === 'offer' ? 'la oferta' : 'la disponibilidad';
     const isOk = newStatus === 'confirmed';
-    return await redirectResponse({
+    const redirect = await redirectResponse({
       title: isOk ? '¡Confirmado!' : 'Respuesta registrada',
       status: isOk ? 'success' : 'neutral',
       heading: isOk ? '¡Gracias! Confirmado' : 'Respuesta registrada',
       message: `Tu respuesta sobre ${phaseText} ha sido registrada.`,
       submessage: 'Puedes cerrar esta pestaña.'
     });
+
+    return redirect;
   } catch (error) {
     console.error("❌ UNEXPECTED SERVER ERROR:", error);
     console.error("Error stack:", (error as Error)?.stack);


### PR DESCRIPTION
## Summary
- refactor the redirect response call in the staffing-click edge function to keep brace balance clear before the catch handler

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d5264790832f89e7dc1b2cf525cd)