### PR TITLE
Optimize RLS auth performance by wrapping auth functions in subqueries

### DIFF
--- a/supabase/migrations/20251113000000_optimize_rls_auth_performance.sql
+++ b/supabase/migrations/20251113000000_optimize_rls_auth_performance.sql
@@ -1603,3 +1603,114 @@ using (
     where p.id = (select auth.uid()) and p.role in ('admin', 'management')
   )
 );
+
+drop policy if exists "Users can view accommodations from their hojas de ruta" on public.hoja_de_ruta_accommodations;
+create policy "Users can view accommodations from their hojas de ruta"
+on public.hoja_de_ruta_accommodations
+for select
+using (
+  hoja_de_ruta_id in (
+    select h.id from public.hoja_de_ruta h
+    where h.created_by = (select auth.uid()) or h.approved_by = (select auth.uid())
+  )
+);
+
+-- =====================================================================
+-- HOJA_DE_RUTA_ROOM_ASSIGNMENTS TABLE
+-- =====================================================================
+
+drop policy if exists "Users can view room assignments from their accommodations" on public.hoja_de_ruta_room_assignments;
+create policy "Users can view room assignments from their accommodations"
+on public.hoja_de_ruta_room_assignments
+for select
+using (
+  accommodation_id in (
+    select a.id from public.hoja_de_ruta_accommodations a
+    join public.hoja_de_ruta h on a.hoja_de_ruta_id = h.id
+    where h.created_by = (select auth.uid()) or h.approved_by = (select auth.uid())
+  )
+);
+
+drop policy if exists "Users can create room assignments for their accommodations" on public.hoja_de_ruta_room_assignments;
+create policy "Users can create room assignments for their accommodations"
+on public.hoja_de_ruta_room_assignments
+for insert
+with check (
+  accommodation_id in (
+    select a.id from public.hoja_de_ruta_accommodations a
+    join public.hoja_de_ruta h on a.hoja_de_ruta_id = h.id
+    where h.created_by = (select auth.uid())
+  )
+);
+
+drop policy if exists "Users can update room assignments for their accommodations" on public.hoja_de_ruta_room_assignments;
+create policy "Users can update room assignments for their accommodations"
+on public.hoja_de_ruta_room_assignments
+for update
+using (
+  accommodation_id in (
+    select a.id from public.hoja_de_ruta_accommodations a
+    join public.hoja_de_ruta h on a.hoja_de_ruta_id = h.id
+    where h.created_by = (select auth.uid())
+  )
+);
+
+drop policy if exists "Users can delete room assignments for their accommodations" on public.hoja_de_ruta_room_assignments;
+create policy "Users can delete room assignments for their accommodations"
+on public.hoja_de_ruta_room_assignments
+for delete
+using (
+  accommodation_id in (
+    select a.id from public.hoja_de_ruta_accommodations a
+    join public.hoja_de_ruta h on a.hoja_de_ruta_id = h.id
+    where h.created_by = (select auth.uid())
+  )
+);
+
+-- =====================================================================
+-- HOJA_DE_RUTA_TRAVEL_ARRANGEMENTS TABLE
+-- =====================================================================
+
+drop policy if exists "Users can view travel arrangements from their hojas de ruta" on public.hoja_de_ruta_travel_arrangements;
+create policy "Users can view travel arrangements from their hojas de ruta"
+on public.hoja_de_ruta_travel_arrangements
+for select
+using (
+  hoja_de_ruta_id in (
+    select h.id from public.hoja_de_ruta h
+    where h.created_by = (select auth.uid()) or h.approved_by = (select auth.uid())
+  )
+);
+
+drop policy if exists "Users can create travel arrangements for their hojas de ruta" on public.hoja_de_ruta_travel_arrangements;
+create policy "Users can create travel arrangements for their hojas de ruta"
+on public.hoja_de_ruta_travel_arrangements
+for insert
+with check (
+  hoja_de_ruta_id in (
+    select h.id from public.hoja_de_ruta h
+    where h.created_by = (select auth.uid())
+  )
+);
+
+drop policy if exists "Users can update travel arrangements for their hojas de ruta" on public.hoja_de_ruta_travel_arrangements;
+create policy "Users can update travel arrangements for their hojas de ruta"
+on public.hoja_de_ruta_travel_arrangements
+for update
+using (
+  hoja_de_ruta_id in (
+    select h.id from public.hoja_de_ruta h
+    where h.created_by = (select auth.uid())
+  )
+);
+
+drop policy if exists "Users can delete travel arrangements for their hojas de ruta" on public.hoja_de_ruta_travel_arrangements;
+create policy "Users can delete travel arrangements for their hojas de ruta"
+on public.hoja_de_ruta_travel_arrangements
+for delete
+using (
+  hoja_de_ruta_id in (
+    select h.id from public.hoja_de_ruta h
+    where h.created_by = (select auth.uid())
+  )
+);


### PR DESCRIPTION
Fix 100+ RLS policies to prevent auth function re-evaluation per row.
Wraps auth.uid(), auth.role() calls in (select ...) subqueries as per
Supabase performance best practices.

This resolves all auth_rls_initplan linter warnings by ensuring auth
functions are evaluated once per query instead of per row, significantly
improving query performance at scale.

Affected tables:
- skills, profile_skills, stock_movements, technician_work_records
- messages, direct_messages, transport_requests, transport_request_items
- tour_timeline_events, tour_travel_segments, tour_accommodations
- tour_schedule_templates, rate_extras_2025, job_rate_extras
- lights_job_tasks, video_job_tasks, sound_job_tasks
- technician_availability, timesheets, app_changelog
- soundvision_files, soundvision_file_reviews, venues
- job_assignments, jobs, equipment, job_documents, job_required_roles
- job_whatsapp_groups, job_whatsapp_group_requests
- push_cron_execution_log, push_cron_config, push_notification_schedules
- notification_subscriptions, technician_fridge, profiles
- staffing_requests, rate_cards_2025, rate_cards_tour_2025
- sub_rentals, presets, preset_items, day_preset_assignments
- morning_summary_subscriptions, tours, house_tech_rates
- festival_artist_files, festival_artists, global_stock_entries
- vacation_requests, hoja_de_ruta_restaurants, hoja_de_ruta_accommodations