### PR TITLE
Fix ICS calendar URL authentication by adding apikey parameter

### DIFF
--- a/docs/tech-calendar-ics.md
+++ b/docs/tech-calendar-ics.md
@@ -6,8 +6,8 @@ This Edge Function exposes a read‑only, per‑technician iCalendar (ICS) feed 
 Function
 --------
 - Path: `supabase/functions/tech-calendar-ics/index.ts`
-- URL: `${SUPABASE_URL}/functions/v1/tech-calendar-ics?tid=<profile_id>&token=<calendar_ics_token>`
- - Public access: `supabase/functions/tech-calendar-ics/config.toml` sets `verify_jwt = false` so Google/Apple can fetch without auth headers.
+- URL: `${SUPABASE_URL}/functions/v1/tech-calendar-ics?tid=<profile_id>&token=<calendar_ics_token>&apikey=<anon_key>`
+ - Public access: `supabase/functions/tech-calendar-ics/config.toml` sets `verify_jwt = false` so Google/Apple can fetch without auth headers. The anon key is included as a query parameter to bypass Supabase's infrastructure authentication.
 
 Security
 --------
@@ -24,6 +24,7 @@ Parameters
 ----------
 - `tid` (required): Profile UUID of the technician.
 - `token` (required): Secret token from `profiles.calendar_ics_token`.
+- `apikey` (required): Supabase anon key for authentication bypass.
 - `back` (optional): Days back to include (default 90, max 365).
 - `fwd` (optional): Days forward to include (default 365, max 730).
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -11,7 +11,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Department } from "@/types/department";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Loader2, Save, UserCircle, AlertTriangle, Calendar as CalendarIcon, Copy, RefreshCcw } from "lucide-react";
-import { SUPABASE_URL } from "@/lib/api-config";
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/api-config";
 import { FolderStructureEditor, type FolderStructure } from "@/components/profile/FolderStructureEditor";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { MorningSummarySubscription } from "@/components/settings/MorningSummarySubscription";
@@ -169,7 +169,7 @@ export const Profile = () => {
   };
 
   const icsUrl = profile?.calendar_ics_token
-    ? `${SUPABASE_URL}/functions/v1/tech-calendar-ics?tid=${profile.id}&token=${profile.calendar_ics_token}&back=90&fwd=365`
+    ? `${SUPABASE_URL}/functions/v1/tech-calendar-ics?tid=${profile.id}&token=${profile.calendar_ics_token}&apikey=${SUPABASE_ANON_KEY}&back=90&fwd=365`
     : '';
 
   const handlePasswordChange = async () => {


### PR DESCRIPTION
Calendar apps (Google Calendar, Apple Calendar, etc.) cannot send custom
HTTP headers when fetching ICS feeds. Even with verify_jwt=false, Supabase
requires the apikey for authentication. This change adds the anon key as a
query parameter to allow calendar apps to successfully fetch the ICS feed.

Changes:
- Add apikey parameter to ICS URL in Profile.tsx
- Import SUPABASE_ANON_KEY in Profile component
- Update documentation to reflect the new parameter

Fixes: 401 error when calendar apps try to fetch ICS feeds