### PR TITLE
Fix job details dialog tab state management

### DIFF
--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -286,6 +286,20 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
     }
   }, [showTourRatesTab, showExtrasTab, selectedTab]);
 
+  // Reset selectedTab if user is on a dryhire-excluded tab when isDryhire is true
+  useEffect(() => {
+    if (isDryhire && ['location', 'personnel', 'documents', 'restaurants', 'extras'].includes(selectedTab)) {
+      setSelectedTab('info');
+    }
+  }, [isDryhire, selectedTab]);
+
+  // Reset selectedTab to 'info' when dialog opens to ensure clean state
+  useEffect(() => {
+    if (open) {
+      setSelectedTab('info');
+    }
+  }, [open]);
+
   // Rider files for the artists of this job (2-step to be RLS-friendly)
   const { data: riderFiles = [], isLoading: isRidersLoading } = useQuery({
     queryKey: ['job-rider-files', job.id, artistIdList],


### PR DESCRIPTION
Add useEffect hooks to properly manage selectedTab state:
1. Reset to 'info' when dialog opens (prevents stale tab state)
2. Reset to 'info' when on dryhire-excluded tab (prevents invalid tab selection)

This fixes the issue where tabs (location, personnel, documents, restaurants)
would fail to render when:
- Tab state persisted from previous dialog open
- User was on a tab that became hidden due to job type change
- Dialog opened with selectedTab pointing to non-existent tab

Ensures all tabs load correctly by maintaining valid tab state at all times.