### PR TITLE
Redesign wallboard UI: increase text sizes, add pagination, redesign calendar

### DIFF
--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -44,6 +44,19 @@ export const ThemeToggle = ({
     updatePreferences({ dark_mode: newDarkMode })
   }
 
+  // Global keyboard shortcut: Ctrl+Shift+D (Cmd+Shift+D on Mac)
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key === 'D') {
+        event.preventDefault()
+        toggleDarkMode()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [toggleDarkMode])
+
   const isIconDisplay = display === "icon"
   const iconSizeClass = isIconDisplay ? "h-5 w-5" : "h-4 w-4"
   const computedAriaLabel = isIconDisplay

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,6 +41,12 @@ export default {
       },
     },
     extend: {
+      // Extended font sizes for wallboard
+      fontSize: {
+        '38': ['38px', { lineHeight: '1.2' }],
+        '32': ['32px', { lineHeight: '1.2' }],
+        '30': ['30px', { lineHeight: '1.2' }],
+      },
       // Extended spacing scale including common gaps and iOS safe area tokens
       spacing: {
         18: "4.5rem",


### PR DESCRIPTION
Major changes:
- Add custom font sizes (38px, 32px, 30px) to Tailwind config for wallboard readability
- Redesign calendar to show current month only with compact 8 jobs per cell layout
- Add pagination to JobsOverview, Crew, Docs, and Logistics panels
- Increase ticker font size from 20px (text-xl) to 30px (text-30)
- Update all panel text sizes to 38px for main content (job titles, names, etc.)
- Add automatic pagination rotation that cycles through pages before switching panels
- Add keyboard shortcut (Ctrl+Shift+D / Cmd+Shift+D) for dark mode toggle
- Update calendar to show compact job cards with status dots and department info
- Maintain responsive grid layouts with larger, more readable text

Note: Weather API infrastructure already exists in job details dialogs