### PR TITLE
Guard SoundVision data fetching for unauthorized users

### DIFF
--- a/src/hooks/useSoundVisionFiles.ts
+++ b/src/hooks/useSoundVisionFiles.ts
@@ -52,10 +52,21 @@ export interface SoundVisionFileFilters {
   fileType?: string;
 }
 
-export const useSoundVisionFiles = (filters?: SoundVisionFileFilters) => {
+export interface UseSoundVisionFilesOptions {
+  enabled?: boolean;
+}
+
+export const useSoundVisionFiles = (
+  filters?: SoundVisionFileFilters,
+  options?: UseSoundVisionFilesOptions
+) => {
   return useQuery({
     queryKey: ['soundvision-files', filters],
+    enabled: options?.enabled ?? true,
     queryFn: async () => {
+      const { error: accessError } = await supabase.rpc('assert_soundvision_access');
+      if (accessError) throw accessError;
+
       // First get the files with venue data
       const query = supabase
         .from('soundvision_files')

--- a/src/pages/SoundVisionFiles.tsx
+++ b/src/pages/SoundVisionFiles.tsx
@@ -21,7 +21,9 @@ const SoundVisionFiles = () => {
     }
   }, [hasSoundVisionAccess, isLoading]);
 
-  const { data: files = [], isLoading: isFilesLoading } = useSoundVisionFiles();
+  const { data: files = [], isLoading: isFilesLoading } = useSoundVisionFiles(undefined, {
+    enabled: !isLoading && hasSoundVisionAccess,
+  });
 
   if (isLoading) {
     return (

--- a/supabase/migrations/20260215090000_add_assert_soundvision_access_function.sql
+++ b/supabase/migrations/20260215090000_add_assert_soundvision_access_function.sql
@@ -1,0 +1,44 @@
+DROP FUNCTION IF EXISTS public.assert_soundvision_access();
+
+CREATE OR REPLACE FUNCTION public.assert_soundvision_access()
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text;
+  v_department text;
+  v_has_flag boolean;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT role, department, COALESCE(soundvision_access_enabled, false)
+  INTO v_role, v_department, v_has_flag
+  FROM public.profiles
+  WHERE id = auth.uid();
+
+  IF v_role IS NULL THEN
+    RAISE EXCEPTION 'Profile not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_role IN ('admin', 'management') THEN
+    RETURN true;
+  END IF;
+
+  IF v_has_flag THEN
+    RETURN true;
+  END IF;
+
+  IF v_role = 'house_tech' AND lower(COALESCE(v_department, '')) = 'sound' THEN
+    RETURN true;
+  END IF;
+
+  RAISE EXCEPTION 'SoundVision access required' USING ERRCODE = '42501';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.assert_soundvision_access() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.assert_soundvision_access() TO authenticated;


### PR DESCRIPTION
## Summary
- add an `enabled` option to `useSoundVisionFiles`, enforce access via a dedicated RPC and reuse the guard in the SoundVision page
- delay the SoundVision files query until the authenticated user has explicit access to the feature
- add a migration that introduces the `assert_soundvision_access` RPC so Supabase can reject unauthorized callers server-side

## Testing
- `npm run lint` *(fails: missing @eslint/js dependency in the project environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691844662d1c832f8586b754e7b9f187)