### PR TITLE
Secure wallboard feed access

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -32,3 +32,6 @@ verify_jwt = true
 
 [functions.cleanup-corporate-email-images]
 verify_jwt = false
+
+[functions.wallboard-feed]
+verify_jwt = true


### PR DESCRIPTION
## Summary
- require either a signed wallboard JWT or shared secret before creating the service-role client in the wallboard-feed function and surface preset metadata in responses
- add reusable error handling plus richer CORS headers so unauthorized requests are rejected with the correct status codes
- configure the wallboard-feed deployment to reject unauthenticated traffic at the Supabase gateway level

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185ba34240832fabbf6d7c3438e154)