### PR TITLE
Secure wallboard public auth via edge function

### DIFF
--- a/src/pages/WallboardPublic.tsx
+++ b/src/pages/WallboardPublic.tsx
@@ -48,65 +48,50 @@ export default function WallboardPublic() {
         return;
       }
 
-      // Step 1: Validate the token against environment variable
-      const expectedToken = import.meta.env.VITE_WALLBOARD_TOKEN || 'demo-wallboard-token';
-
-      // Debug logging (remove in production)
-      console.log('🔐 Token validation:', {
-        urlToken: token,
-        expectedToken: expectedToken,
-        envVarSet: !!import.meta.env.VITE_WALLBOARD_TOKEN,
-        match: token === expectedToken
-      });
-
-      if (token !== expectedToken) {
-        setError('Invalid access token');
-        setIsValidating(false);
-        setAuthComplete(true);
-        return;
-      }
-
-      // Step 2: Authenticate with Supabase using wallboard service account
+      // Step 1: Ask edge function to validate the shared token and mint a Supabase session
       try {
-        // Check if there are wallboard credentials configured
-        const wallboardEmail = import.meta.env.VITE_WALLBOARD_USER_EMAIL;
-        const wallboardPassword = import.meta.env.VITE_WALLBOARD_USER_PASSWORD;
+        const response = await fetch('/functions/v1/wallboard-auth', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ token }),
+        });
 
-        if (wallboardEmail && wallboardPassword) {
-          // Sign in with dedicated wallboard account
-          const { error: signInError } = await supabase.auth.signInWithPassword({
-            email: wallboardEmail,
-            password: wallboardPassword,
-          });
-
-          if (signInError) {
-            console.error('Wallboard auth error:', signInError);
-            setError('Failed to authenticate wallboard session. Please check configuration.');
-            setIsValidating(false);
-            setAuthComplete(true);
-            return;
-          }
-
-          // Successfully authenticated
-          setIsValid(true);
+        if (!response.ok) {
+          setError('Invalid or expired access token.');
           setIsValidating(false);
           setAuthComplete(true);
-        } else {
-          // No credentials configured - check if there's already a valid session
-          const { data: { session } } = await supabase.auth.getSession();
-
-          if (session) {
-            // User is already logged in, use their session
-            setIsValid(true);
-            setIsValidating(false);
-            setAuthComplete(true);
-          } else {
-            // No credentials and no session - provide setup instructions
-            setError('Wallboard service account not configured. See documentation for setup instructions.');
-            setIsValidating(false);
-            setAuthComplete(true);
-          }
+          return;
         }
+
+        const payload: { token?: string; refreshToken?: string } = await response.json();
+        const accessToken = payload.token;
+        const refreshToken = payload.refreshToken;
+
+        if (!accessToken || !refreshToken) {
+          setError('Authentication service returned an invalid response.');
+          setIsValidating(false);
+          setAuthComplete(true);
+          return;
+        }
+
+        const { error: sessionError } = await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        });
+
+        if (sessionError) {
+          console.error('Wallboard session error:', sessionError);
+          setError('Failed to establish wallboard session.');
+          setIsValidating(false);
+          setAuthComplete(true);
+          return;
+        }
+
+        setIsValid(true);
+        setIsValidating(false);
+        setAuthComplete(true);
       } catch (err) {
         console.error('Authentication exception:', err);
         setError('Failed to authenticate. Please try again.');

--- a/supabase/functions/wallboard-auth/index.ts
+++ b/supabase/functions/wallboard-auth/index.ts
@@ -1,8 +1,11 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { create, getNumericDate, Header, Payload } from "https://deno.land/x/djwt@v3.0.2/mod.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 const WALLBOARD_SHARED_TOKEN = Deno.env.get("WALLBOARD_SHARED_TOKEN") ?? "";
-const WALLBOARD_JWT_SECRET = Deno.env.get("WALLBOARD_JWT_SECRET") ?? "";
+const WALLBOARD_SERVICE_EMAIL = Deno.env.get("WALLBOARD_SERVICE_EMAIL") ?? "";
+const WALLBOARD_SERVICE_PASSWORD = Deno.env.get("WALLBOARD_SERVICE_PASSWORD") ?? "";
 const DEFAULT_TTL_SECONDS = parseInt(Deno.env.get("WALLBOARD_JWT_TTL") ?? "900", 10); // 15 minutes
 
 function cors() {
@@ -12,35 +15,77 @@ function cors() {
   } as Record<string, string>;
 }
 
-async function sign(payload: Payload) {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(WALLBOARD_JWT_SECRET),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  const header: Header = { alg: "HS256", typ: "JWT" };
-  return await create(header, payload, key);
+const supabase = SUPABASE_URL && SERVICE_ROLE_KEY
+  ? createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    })
+  : null;
+
+async function createWallboardSession() {
+  if (!supabase) {
+    throw new Error("Supabase configuration is missing");
+  }
+  if (!WALLBOARD_SERVICE_EMAIL || !WALLBOARD_SERVICE_PASSWORD) {
+    throw new Error("Wallboard service credentials are not configured");
+  }
+
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: WALLBOARD_SERVICE_EMAIL,
+    password: WALLBOARD_SERVICE_PASSWORD,
+  });
+
+  if (error || !data.session) {
+    throw new Error(error?.message ?? "Unable to authenticate wallboard session");
+  }
+
+  const { session } = data;
+  const expiresIn = session.expires_in ?? DEFAULT_TTL_SECONDS;
+
+  return {
+    accessToken: session.access_token,
+    refreshToken: session.refresh_token,
+    expiresIn,
+  };
 }
 
 serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: cors() });
   try {
     const url = new URL(req.url);
-    const token = url.searchParams.get("wallboardToken") || (await req.text()).trim();
+    let token = url.searchParams.get("wallboardToken");
+    if (!token) {
+      const rawBody = (await req.text()).trim();
+      if (rawBody) {
+        try {
+          const parsed = JSON.parse(rawBody);
+          const candidate =
+            typeof parsed === "string"
+              ? parsed
+              : typeof parsed === "object" && parsed
+                ? (parsed as Record<string, unknown>).token ??
+                  (parsed as Record<string, unknown>).accessToken ??
+                  (parsed as Record<string, unknown>).wallboardToken ??
+                  (parsed as Record<string, unknown>).sharedToken ??
+                  null
+                : null;
+          if (typeof candidate === "string") {
+            token = candidate;
+          }
+        } catch (_) {
+          token = rawBody;
+        }
+      }
+    }
     if (!token || token !== WALLBOARD_SHARED_TOKEN) {
       return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: cors() });
     }
-    const now = Math.floor(Date.now() / 1000);
-    const ttl = Math.max(60, DEFAULT_TTL_SECONDS);
-    const jwt = await sign({
-      iss: "wallboard-auth",
-      iat: now,
-      exp: getNumericDate(ttl),
-      scope: "wallboard",
-    });
-    return new Response(JSON.stringify({ token: jwt, expiresIn: ttl }), {
+
+    const { accessToken, refreshToken, expiresIn } = await createWallboardSession();
+
+    return new Response(JSON.stringify({ token: accessToken, refreshToken, expiresIn }), {
       headers: { "Content-Type": "application/json", ...cors() },
     });
   } catch (e: any) {


### PR DESCRIPTION
## Summary
- replace the client-side token comparison with a server-side validation round trip to the `wallboard-auth` edge function and only continue once a Supabase session is established
- update the `wallboard-auth` function to accept POST bodies, validate the shared token, and mint short-lived Supabase access and refresh tokens for the wallboard service account

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185f247e34832f90631b3c1d7cc79d)