### PR TITLE
Fix erratic tab loading in JobDetailsDialog

### DIFF
--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -414,7 +414,8 @@ export const JobDetailsDialog: React.FC<JobDetailsDialogProps> = ({
         coordinates
       );
     },
-    enabled: open && !!jobDetails?.locations && (!!jobDetails?.locations?.formatted_address || !!jobDetails?.locations?.name || (!!jobDetails?.locations?.latitude && !!jobDetails?.locations?.longitude))
+    // Wait for jobDetails to load before running this query
+    enabled: open && !isJobLoading && !!jobDetails?.locations && (!!jobDetails?.locations?.formatted_address || !!jobDetails?.locations?.name || (!!jobDetails?.locations?.latitude && !!jobDetails?.locations?.longitude))
   });
 
   // Weather data for job dates


### PR DESCRIPTION
Resolves race condition where tabs would fail to render when:
1. Switching between jobs while dialog remains open
2. Job data is still loading but cached data shows isJobLoading=false
3. Secondary queries (restaurants, riders, etc.) haven't loaded yet

Changes:
- Reset tab to 'info' when job.id changes, not just when dialog opens
- Added job.id tracking to detect job changes while dialog is open
- Invalidate all job-related queries when job changes to ensure fresh data
- Added loading indicators to location, personnel, documents tabs
- Improved loading states for restaurants and weather tabs to check both job and tab-specific loading

This ensures users always see loading spinners instead of empty states
when switching between jobs or when data is still being fetched.