### PR TITLE
Restrict wallboard and announcement access to admins

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,13 +119,13 @@ export default function App() {
                         <Route path="/project-management" element={<ProtectedRoute allowedRoles={['admin', 'management', 'logistics']}><ProjectManagement /></ProtectedRoute>} />
                         <Route path="/equipment-management" element={<EquipmentManagement />} />
                         <Route path="/job-assignment-matrix" element={<ProtectedRoute allowedRoles={['admin', 'management']}><JobAssignmentMatrix /></ProtectedRoute>} />
-                        <Route path="/activity" element={<ProtectedRoute allowedRoles={['admin', 'management']}><ActivityCenter /></ProtectedRoute>} />
+                        <Route path="/activity" element={<ProtectedRoute allowedRoles={['admin']}><ActivityCenter /></ProtectedRoute>} />
                         <Route path="/timesheets" element={<Timesheets />} />
                         <Route path="/tours" element={<ProtectedRoute allowedRoles={['admin', 'management', 'house_tech']}><Tours /></ProtectedRoute>} />
                         <Route path="/festivals" element={<ProtectedRoute allowedRoles={['admin', 'management', 'house_tech']}><Festivals /></ProtectedRoute>} />
                         <Route path="/incident-reports" element={<ProtectedRoute allowedRoles={['admin', 'management']}><IncidentReports /></ProtectedRoute>} />
-                        <Route path="/announcements" element={<ProtectedRoute allowedRoles={['admin', 'management']}><Announcements /></ProtectedRoute>} />
-                        <Route path="/management/wallboard-presets" element={<ProtectedRoute allowedRoles={['admin', 'management']}><WallboardPresets /></ProtectedRoute>} />
+                        <Route path="/announcements" element={<ProtectedRoute allowedRoles={['admin']}><Announcements /></ProtectedRoute>} />
+                        <Route path="/management/wallboard-presets" element={<ProtectedRoute allowedRoles={['admin']}><WallboardPresets /></ProtectedRoute>} />
                         <Route path="/management/rates" element={<ProtectedRoute allowedRoles={['admin', 'management']}><RatesCenterPage /></ProtectedRoute>} />
                         <Route path="/manual" element={<UserManual />} />
 

--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -276,7 +276,7 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     mobilePriority: 12,
     mobileSlot: "secondary",
     getPath: () => "/management/wallboard-presets",
-    isVisible: ({ userRole }) => userRole === "admin" || userRole === "management",
+    isVisible: ({ userRole }) => userRole === "admin",
   },
   {
     id: "announcements",
@@ -286,8 +286,7 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     mobilePriority: 12,
     mobileSlot: "secondary",
     getPath: () => "/announcements",
-    isVisible: ({ userRole }) =>
-      userRole === "admin" || userRole === "management",
+    isVisible: ({ userRole }) => userRole === "admin",
   },
   {
     id: "incident-reports",
@@ -308,8 +307,7 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     mobilePriority: 14,
     mobileSlot: "secondary",
     getPath: () => "/activity",
-    isVisible: ({ userRole }) =>
-      userRole === "admin" || userRole === "management",
+    isVisible: ({ userRole }) => userRole === "admin",
   },
   {
     id: "settings",


### PR DESCRIPTION
## Summary
- limit the SidebarNavigation visibility of the wallboard presets, announcements, and activity entries to admin users only
- align the corresponding protected routes so that only admins can reach those pages while management users are excluded

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919089396f0832fab1b6b29a0f1e842)