### PR TITLE
Update management department navigation

### DIFF
--- a/src/components/layout/Layout.test.ts
+++ b/src/components/layout/Layout.test.ts
@@ -48,7 +48,7 @@ describe("selectPrimaryNavigationItems", () => {
     })
 
     expect(primary.map((item) => item.id)).toEqual([
-      "department-sound",
+      "management-department",
       "project-management",
       "tours",
       "festivals",
@@ -67,7 +67,7 @@ describe("selectPrimaryNavigationItems", () => {
 
     expect(primary.map((item) => item.id)).toEqual([
       "project-management",
-      "department-lights",
+      "management-department",
       "disponibilidad",
       "logistics",
     ])
@@ -89,6 +89,26 @@ describe("selectPrimaryNavigationItems", () => {
       "logistics",
       "job-assignment-matrix",
     ])
+  })
+})
+
+describe("buildNavigationItems - management department navigation", () => {
+  it("omits the department link when userDepartment is missing", () => {
+    const context = buildContext({ userRole: "management", userDepartment: null })
+    const items = buildNavigationItems(context)
+
+    const managementDept = items.find((item) => item.id === "management-department")
+    expect(managementDept).toBeUndefined()
+  })
+
+  it("creates a department link that matches the assigned department", () => {
+    const context = buildContext({ userRole: "management", userDepartment: "lights" })
+    const items = buildNavigationItems(context)
+
+    const managementDept = items.find((item) => item.id === "management-department")
+    expect(managementDept).toBeDefined()
+    expect(managementDept?.label).toBe("Luces")
+    expect(managementDept?.to).toBe("/lights")
   })
 })
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -45,14 +45,14 @@ import { UserInfo } from "./UserInfo"
 
 const PRIMARY_NAVIGATION_PROFILE_MAP: Record<string, readonly string[]> = {
   sound: [
-    "department-sound",
+    "management-department",
     "project-management",
     "tours",
     "festivals",
   ],
   lights: [
     "project-management",
-    "department-lights",
+    "management-department",
     "disponibilidad",
     "logistics",
   ],

--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -72,6 +72,12 @@ const departmentLabelMap: Record<string, string> = {
   video: "Vídeo",
 }
 
+const departmentIconMap: Record<string, LucideIcon> = {
+  sound: Music2,
+  lights: Lightbulb,
+  video: Video,
+}
+
 const baseNavigationConfig: NavigationItemConfig[] = [
   {
     id: "management-dashboard",
@@ -146,34 +152,32 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     isVisible: ({ userRole }) => userRole === "management",
   },
   {
-    id: "department-sound",
-    label: "Sonido",
-    mobileLabel: "Sonido",
-    icon: Music2,
+    id: "management-department",
+    label: ({ userDepartment }) => {
+      const normalized = userDepartment?.toLowerCase() ?? ""
+      return departmentLabelMap[normalized] || userDepartment || null
+    },
+    mobileLabel: ({ userDepartment }) => {
+      const normalized = userDepartment?.toLowerCase() ?? ""
+      return departmentLabelMap[normalized] || "Departamento"
+    },
+    icon: (({ userDepartment }) => {
+      const normalized = userDepartment?.toLowerCase() ?? ""
+      return departmentIconMap[normalized] ?? null
+    }) as (context: NavigationContext) => LucideIcon | null,
     mobilePriority: 6,
     mobileSlot: "secondary",
-    getPath: () => "/sound",
-    isVisible: ({ userRole }) => userRole === "management",
-  },
-  {
-    id: "department-lights",
-    label: "Luces",
-    mobileLabel: "Luces",
-    icon: Lightbulb,
-    mobilePriority: 7,
-    mobileSlot: "secondary",
-    getPath: () => "/lights",
-    isVisible: ({ userRole }) => userRole === "management",
-  },
-  {
-    id: "department-video",
-    label: "Vídeo",
-    mobileLabel: "Vídeo",
-    icon: Video,
-    mobilePriority: 8,
-    mobileSlot: "secondary",
-    getPath: () => "/video",
-    isVisible: ({ userRole }) => userRole === "management",
+    getPath: ({ userDepartment }) => {
+      const normalized = userDepartment?.toLowerCase() ?? ""
+      return departmentIconMap[normalized] ? `/${normalized}` : null
+    },
+    isVisible: ({ userRole, userDepartment }) => {
+      if (userRole !== "management" || !userDepartment) {
+        return false
+      }
+      const normalized = userDepartment.toLowerCase()
+      return Boolean(departmentIconMap[normalized])
+    },
   },
   {
     id: "house-department",


### PR DESCRIPTION
## Summary
- replace the three static management department navigation entries with a single dynamic item that derives its label, icon, and path from the signed-in manager’s department
- update the primary navigation profile map and tests to use the consolidated department identifier and cover management department visibility rules

## Testing
- `npm run test -- src/components/layout/Layout.test.ts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69190f8ada0c832fa9abd4d51703a6d2)