### PR TITLE
Restrict festivals access to sound department

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/toaster';
@@ -45,7 +45,7 @@ import { RequireAuth } from '@/components/RequireAuth';
 import { ProtectedRoute } from '@/components/ProtectedRoute';
 import FestivalGearManagement from '@/pages/FestivalGearManagement';
 import Festivals from '@/pages/Festivals';
-import { OptimizedAuthProvider } from "@/hooks/useOptimizedAuth";
+import { OptimizedAuthProvider, useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { SubscriptionProvider } from "@/providers/SubscriptionProvider";
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AppInit } from "@/components/AppInit";
@@ -68,6 +68,25 @@ function ActivityPushFallbackInit() {
   useActivityPushFallback();
   return null;
 }
+
+const SOUND_DEPARTMENT = "sound";
+
+const FestivalsAccessGuard = () => {
+  const { userRole, userDepartment, isLoading } = useOptimizedAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  const isAdmin = userRole === "admin";
+  const isSoundMember = userDepartment?.toLowerCase() === SOUND_DEPARTMENT;
+
+  if (!isAdmin && !isSoundMember) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <Festivals />;
+};
 
 export default function App() {
   // Initialize multi-tab coordinator
@@ -122,7 +141,7 @@ export default function App() {
                         <Route path="/activity" element={<ProtectedRoute allowedRoles={['admin']}><ActivityCenter /></ProtectedRoute>} />
                         <Route path="/timesheets" element={<Timesheets />} />
                         <Route path="/tours" element={<ProtectedRoute allowedRoles={['admin', 'management', 'house_tech']}><Tours /></ProtectedRoute>} />
-                        <Route path="/festivals" element={<ProtectedRoute allowedRoles={['admin', 'management', 'house_tech']}><Festivals /></ProtectedRoute>} />
+                        <Route path="/festivals" element={<ProtectedRoute allowedRoles={['admin', 'management', 'house_tech']}><FestivalsAccessGuard /></ProtectedRoute>} />
                         <Route path="/incident-reports" element={<ProtectedRoute allowedRoles={['admin', 'management']}><IncidentReports /></ProtectedRoute>} />
                         <Route path="/announcements" element={<ProtectedRoute allowedRoles={['admin']}><Announcements /></ProtectedRoute>} />
                         <Route path="/management/wallboard-presets" element={<ProtectedRoute allowedRoles={['admin']}><WallboardPresets /></ProtectedRoute>} />

--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -221,8 +221,8 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     mobilePriority: 6,
     mobileSlot: "secondary",
     getPath: () => "/festivals",
-    isVisible: ({ userRole }) =>
-      userRole === "management" || userRole === "house_tech",
+    isVisible: ({ userDepartment }) =>
+      userDepartment?.toLowerCase() === "sound",
   },
   {
     id: "disponibilidad",

--- a/src/pages/Festivals.tsx
+++ b/src/pages/Festivals.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { useJobsRealtime } from "@/hooks/useJobsRealtime";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { JobCard } from "@/components/jobs/JobCard";
@@ -24,12 +24,13 @@ const ITEMS_PER_PAGE = 9; // 3x3 grid
  */
 const Festivals = () => {
   const navigate = useNavigate();
-  const { 
-    jobs, 
-    isLoading, 
-    isError, 
-    error, 
-    isRefreshing, 
+  const { userRole, userDepartment, isLoading: authLoading } = useOptimizedAuth();
+  const {
+    jobs,
+    isLoading,
+    isError,
+    error,
+    isRefreshing,
     refetch,
     realtimeStatus
   } = useJobsRealtime();
@@ -42,7 +43,6 @@ const Festivals = () => {
   const [printDialogOpen, setPrintDialogOpen] = useState(false);
   const [selectedJobForPrint, setSelectedJobForPrint] = useState<{ id: string; title: string } | null>(null);
   const [showCompleted, setShowCompleted] = useState(false);
-  const { userRole } = useOptimizedAuth();
   const { status: connectionStatus, recoverConnection } = useConnectionStatus();
   const festivalRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
@@ -210,6 +210,13 @@ const Festivals = () => {
       toast.error("No se pudieron actualizar los datos. Por favor, inténtalo de nuevo.");
     }
   };
+
+  const isAdmin = userRole === 'admin';
+  const isSoundMember = userDepartment?.toLowerCase() === 'sound';
+
+  if (!authLoading && !isAdmin && !isSoundMember) {
+    return <Navigate to="/dashboard" replace />;
+  }
 
   const canPrintDocuments = ['admin', 'management', 'logistics'].includes(userRole || '');
   const emptyFunction = () => {};


### PR DESCRIPTION
## Summary
- restrict the festivals navigation item to sound department users (admins remain exempt)
- add a dedicated access guard for the /festivals route that only allows admins or sound department members
- ensure the Festivals page itself redirects away when a non-sound user reaches it directly

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919117b1b04832f88e6c4d55d021d2f)