### PR TITLE
Align project management tabs with user department

### DIFF
--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -20,13 +20,15 @@ import { useToast } from "@/hooks/use-toast";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 
 const ProjectManagement = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const isMobile = useIsMobile();
+  const { userDepartment, isLoading: authLoading } = useOptimizedAuth();
   const [loading, setLoading] = useState(true);
-  const [selectedDepartment, setSelectedDepartment] = useState<Department>("sound");
+  const [selectedDepartment, setSelectedDepartment] = useState<Department>((userDepartment as Department) ?? "sound");
   const [currentDate, setCurrentDate] = useState(new Date());
   const [userRole, setUserRole] = useState<string | null>(null);
   const [selectedJobTypes, setSelectedJobTypes] = useState<string[]>([]);
@@ -42,6 +44,12 @@ const ProjectManagement = () => {
 
   const startDate = startOfMonth(currentDate);
   const endDate = endOfMonth(currentDate);
+
+  useEffect(() => {
+    if (!authLoading) {
+      setSelectedDepartment((userDepartment as Department) ?? "sound");
+    }
+  }, [authLoading, userDepartment]);
 
   // Use custom hook to keep the "jobs" tab active/visible.
   useTabVisibility(["jobs"]);

--- a/src/pages/__tests__/ProjectManagement.test.tsx
+++ b/src/pages/__tests__/ProjectManagement.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import ProjectManagement from "../ProjectManagement";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockUseOptimizedAuth = vi.fn();
+vi.mock("@/hooks/useOptimizedAuth", () => ({
+  useOptimizedAuth: () => mockUseOptimizedAuth(),
+}));
+
+const mockUseOptimizedJobs = vi.fn();
+vi.mock("@/hooks/useOptimizedJobs", () => ({
+  useOptimizedJobs: (...args: any[]) => mockUseOptimizedJobs(...args),
+}));
+
+vi.mock("@/hooks/useTabVisibility", () => ({
+  useTabVisibility: () => {},
+}));
+
+const mockForceSubscribe = vi.fn();
+vi.mock("@/providers/SubscriptionProvider", () => ({
+  useSubscriptionContext: () => ({
+    forceSubscribe: mockForceSubscribe,
+  }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@/components/project-management/MonthNavigation", () => ({
+  MonthNavigation: () => <div data-testid="month-navigation" />,
+}));
+
+vi.mock("@/components/project-management/JobTypeFilter", () => ({
+  JobTypeFilter: () => <div data-testid="job-type-filter" />,
+}));
+
+vi.mock("@/components/project-management/StatusFilter", () => ({
+  StatusFilter: () => <div data-testid="status-filter" />,
+}));
+
+vi.mock("@/components/jobs/cards/JobCardNew", () => ({
+  JobCardNew: ({ job }: { job: { title: string } }) => (
+    <div data-testid={`job-card-${job?.title ?? "unknown"}`}>{job?.title ?? "Unknown"}</div>
+  ),
+}));
+
+const mockAutoCompleteJobs = vi.fn().mockResolvedValue({ updatedJobs: [], updatedCount: 0 });
+vi.mock("@/utils/jobStatusUtils", () => ({
+  autoCompleteJobs: (...args: any[]) => mockAutoCompleteJobs(...args),
+}));
+
+const mockGetSession = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: (...args: any[]) => mockGetSession(...args),
+    },
+    from: (...args: any[]) => mockFrom(...args),
+  },
+}));
+
+describe("ProjectManagement department tabs", () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockForceSubscribe.mockReset();
+    mockUseOptimizedAuth.mockReset();
+    mockUseOptimizedJobs.mockReset();
+    mockAutoCompleteJobs.mockClear();
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: { id: "user-1" } } },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: (columns: string) => ({
+            eq: () => ({
+              single: () => {
+                if (columns.includes("selected_job_statuses")) {
+                  return Promise.resolve({
+                    data: { selected_job_statuses: ["Confirmado", "Tentativa"] },
+                    error: null,
+                  });
+                }
+                return Promise.resolve({
+                  data: { role: "management" },
+                  error: null,
+                });
+              },
+            }),
+          }),
+          update: () => ({
+            eq: () => Promise.resolve({ error: null }),
+          }),
+        };
+      }
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: null, error: null }),
+          }),
+        }),
+      };
+    });
+
+    mockUseOptimizedJobs.mockReturnValue({ data: [], isLoading: false, error: null });
+  });
+
+  it("activates the user's department tab on first render", async () => {
+    mockUseOptimizedAuth.mockReturnValue({
+      userDepartment: "lights",
+      isLoading: false,
+    });
+
+    render(<ProjectManagement />);
+
+    const lightsTab = await screen.findByRole("tab", { name: /lights/i });
+    const soundTab = screen.getByRole("tab", { name: /sound/i });
+
+    await waitFor(() => expect(lightsTab).toHaveAttribute("data-state", "active"));
+    expect(soundTab).toHaveAttribute("data-state", "inactive");
+  });
+
+  it("switches to the user's department once auth loading finishes", async () => {
+    let authState = { userDepartment: null as string | null, isLoading: true };
+    mockUseOptimizedAuth.mockImplementation(() => authState);
+
+    const { rerender } = render(<ProjectManagement />);
+
+    authState = { userDepartment: "video", isLoading: false };
+    rerender(<ProjectManagement />);
+
+    const videoTab = await screen.findByRole("tab", { name: /video/i });
+    await waitFor(() => expect(videoTab).toHaveAttribute("data-state", "active"));
+  });
+});


### PR DESCRIPTION
## Summary
- use the optimized auth context to seed the selected department and keep it in sync once the profile finishes loading
- ensure the project management tabs follow the authenticated user’s department so the right view is visible immediately
- add a focused jsdom test that exercises the initial render and auth-load transition scenarios

## Testing
- pnpm test --run src/pages/__tests__/ProjectManagement.test.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919133493d8832fb29257d26ce3b9ff)