### PR TITLE
Allow admins to bypass sidebar visibility

### DIFF
--- a/src/components/layout/Layout.test.ts
+++ b/src/components/layout/Layout.test.ts
@@ -1,5 +1,5 @@
 import { Activity } from "lucide-react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import type {
   NavigationItemConfig,
   SidebarNavigationProps,
@@ -184,5 +184,24 @@ describe("buildNavigationItems - admin visibility", () => {
 
     expect(adminItems.map((item) => item.id)).toContain("future-route")
     expect(managerItems.map((item) => item.id)).not.toContain("future-route")
+  })
+
+  it("bypasses per-route visibility logic for admins", () => {
+    const context = buildContext({ userRole: "admin" })
+    const isVisible = vi.fn(() => false)
+    const guardedRoute: NavigationItemConfig = {
+      id: "guarded-route",
+      label: "Guarded route",
+      icon: Activity,
+      getPath: () => "/guarded",
+      isVisible,
+    }
+
+    const adminItems = buildNavigationItems(context, [guardedRoute])
+    const managerItems = buildNavigationItems(buildContext(), [guardedRoute])
+
+    expect(isVisible).toHaveBeenCalledTimes(1)
+    expect(adminItems.map((item) => item.id)).toContain("guarded-route")
+    expect(managerItems.map((item) => item.id)).not.toContain("guarded-route")
   })
 })

--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -364,42 +364,53 @@ export const buildNavigationItems = (
 
   const isAdmin = context.userRole === "admin"
 
+  const createNavigationItem = (
+    config: NavigationItemConfig,
+  ): NavigationItem | null => {
+    const to = config.getPath(context)
+    if (!to) {
+      return null
+    }
+
+    const label = resolveLabel(config.label, context)
+    const icon = resolveIcon(config.icon, context)
+
+    if (!label || !icon) {
+      return null
+    }
+
+    const mobileLabel =
+      resolveLabel(config.mobileLabel ?? config.label, context) ?? label
+    const mobileSlot = config.mobileSlot ?? "secondary"
+
+    const isActive = config.match
+      ? (pathname: string) => config.match?.(pathname, context, to) ?? false
+      : (pathname: string) => pathname === to
+
+    return {
+      id: config.id,
+      label,
+      mobileLabel,
+      to,
+      icon,
+      mobilePriority: config.mobilePriority,
+      mobileSlot,
+      isActive,
+    }
+  }
+
+  if (isAdmin) {
+    return navigationConfig
+      .map((config) => createNavigationItem(config))
+      .filter(Boolean) as NavigationItem[]
+  }
+
   return navigationConfig
     .map((config) => {
-      if (!isAdmin && !config.isVisible(context)) {
+      if (!config.isVisible(context)) {
         return null
       }
-
-      const to = config.getPath(context)
-      if (!to) {
-        return null
-      }
-
-      const label = resolveLabel(config.label, context)
-      const icon = resolveIcon(config.icon, context)
-
-      if (!label || !icon) {
-        return null
-      }
-
-      const mobileLabel =
-        resolveLabel(config.mobileLabel ?? config.label, context) ?? label
-      const mobileSlot = config.mobileSlot ?? "secondary"
-
-      const isActive = config.match
-        ? (pathname: string) => config.match?.(pathname, context, to) ?? false
-        : (pathname: string) => pathname === to
-
-      return {
-        id: config.id,
-        label,
-        mobileLabel,
-        to,
-        icon,
-        mobilePriority: config.mobilePriority,
-        mobileSlot,
-        isActive,
-      } satisfies NavigationItem
+      return createNavigationItem(config)
     })
     .filter(Boolean) as NavigationItem[]
 }


### PR DESCRIPTION
## Summary
- add an admin-only guard in `buildNavigationItems` so admins always receive the full navigation set while the regular visibility rules continue to gate non-admin roles
- centralize navigation item creation to keep behavior consistent regardless of role
- extend the admin visibility tests to assert that per-route visibility logic is skipped for admins while still respected for other users

## Testing
- `pnpm exec vitest run src/components/layout/Layout.test.ts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919836b61fc832f971e10d46d83269a)