### PR TITLE
Ensure Sound schedule visible on mobile

### DIFF
--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -173,7 +173,7 @@ const Sound = () => {
             onDateTypeChange={() => {}}
           />
         </div>
-        <div className="w-full hidden md:block">
+        <div className="w-full px-4 sm:px-6 lg:px-8">
           <TodaySchedule
             jobs={getSelectedDateJobs()}
             onEditClick={handleEditClick}


### PR DESCRIPTION
## Summary
- remove the breakpoint wrapper that hid the TodaySchedule component on smaller viewports
- add responsive padding so the schedule retains comfortable spacing on phones while remaining full width on desktop

## Testing
- npm run test -- Sound *(fails: no test files were found for this filter)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691afd3bad4c832f88485ad7eb63cfe7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * TodaySchedule component is now visible on mobile devices
  * Added responsive horizontal padding for improved layout spacing across all screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->