### PR TITLE
Sync wallboard config between public and authenticated modes

### DIFF
--- a/src/lib/wallboard-api.ts
+++ b/src/lib/wallboard-api.ts
@@ -51,6 +51,17 @@ export interface AnnouncementsFeed {
   announcements: Array<{ id: string; message: string; level: string; created_at: string; active: boolean }>;
 }
 
+export interface PresetConfigFeed {
+  config: {
+    panel_order: string[] | null;
+    panel_durations: Record<string, number> | null;
+    rotation_fallback_seconds: number | null;
+    highlight_ttl_seconds: number | null;
+    ticker_poll_interval_seconds: number | null;
+  };
+  slug: string;
+}
+
 export class WallboardApiError extends Error {
   status?: number;
   constructor(message: string, status?: number) {
@@ -105,6 +116,9 @@ export class WallboardApi {
   }
   announcements(): Promise<AnnouncementsFeed> {
     return this.request('/announcements');
+  }
+  presetConfig(): Promise<PresetConfigFeed> {
+    return this.request('/preset-config');
   }
 }
 

--- a/supabase/functions/wallboard-feed/index.ts
+++ b/supabase/functions/wallboard-feed/index.ts
@@ -382,6 +382,40 @@ serve(async (req) => {
       });
     }
 
+    if (path.endsWith("/preset-config")) {
+      // Return preset configuration for the given slug
+      if (!presetSlug) {
+        return new Response(JSON.stringify({ error: "No preset slug provided" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json", ...corsHeaders() },
+        });
+      }
+
+      const { data, error } = await sb
+        .from("wallboard_presets")
+        .select("panel_order, panel_durations, rotation_fallback_seconds, highlight_ttl_seconds, ticker_poll_interval_seconds")
+        .eq("slug", presetSlug)
+        .maybeSingle();
+
+      if (error) {
+        return new Response(JSON.stringify({ error: error.message }), {
+          status: 500,
+          headers: { "Content-Type": "application/json", ...corsHeaders() },
+        });
+      }
+
+      if (!data) {
+        return new Response(JSON.stringify({ error: "Preset not found", slug: presetSlug }), {
+          status: 404,
+          headers: { "Content-Type": "application/json", ...corsHeaders() },
+        });
+      }
+
+      return new Response(JSON.stringify({ config: data, slug: presetSlug }), {
+        headers: { "Content-Type": "application/json", ...corsHeaders() },
+      });
+    }
+
     return new Response(JSON.stringify({ error: "Not Found" }), {
       status: 404,
       headers: { "Content-Type": "application/json", ...corsHeaders() },


### PR DESCRIPTION
Public wallboards now use the same configuration (panels selected,
rotation time) as their authenticated counterparts. Previously, public
wallboards would always use default settings regardless of the preset
slug in the URL.

Changes:
- Added /preset-config endpoint to wallboard-feed edge function
- Added presetConfig() method to WallboardApi class
- Modified Wallboard.tsx to fetch and apply preset config for public wallboards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API-driven preset configuration loading with automatic fallback to defaults when unavailable.
  * Introduced new endpoint for retrieving preset configurations by identifier.

* **Bug Fixes**
  * Improved error handling and validation for preset configuration retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->