### PR TITLE
Fix wallboard feed authentication to support x-wallboard-jwt header

### DIFF
--- a/supabase/functions/wallboard-feed/index.ts
+++ b/supabase/functions/wallboard-feed/index.ts
@@ -17,8 +17,8 @@ type Dept = "sound" | "lights" | "video";
 function corsHeaders() {
   return {
     "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-wallboard-jwt",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
   } as Record<string, string>;
 }
 


### PR DESCRIPTION
The recent changes to wallboard-api.ts switched from using the
Authorization: Bearer header to x-wallboard-jwt header for passing
the JWT token. This update adds support for the new header format
in the wallboard-feed edge function's authenticate() function while
maintaining backward compatibility with the old Authorization header.

This fixes the issue where the wallboard was returning an empty feed
with no job cards or data in any panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JWT-based client authentication with optional preset selection.
  * Added shared-token authentication as an alternative method.
  * Requests may now accept a path from either the URL or POST body.
  * CORS updated to support the new auth flow and POST invocations.

* **Bug Fixes**
  * Improved handling of missing/invalid credentials with proper 401/403 responses.
  * Preserves legacy bearer auth behavior for compatibility while enforcing stricter validation.
  * Added request/query logging, extra debug info in responses, and more robust job-overview handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->