### PR TITLE
Fix timesheets button not opening modal in tech-app

### DIFF
--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -240,9 +240,9 @@ export default function TechnicianSuperApp() {
 
   const t = getThemeStyles(isDark);
 
-  const handleOpenAction = (action: string, assignment?: TechnicianAssignment) => {
-    // Pass the nested job data, not the full assignment
-    setSelectedJob(assignment?.jobs || null);
+  const handleOpenAction = (action: string, jobData?: TechnicianJobData) => {
+    // TechJobCard already extracts job data before calling onAction
+    setSelectedJob(jobData || null);
     setActiveModal(action);
   };
 


### PR DESCRIPTION
The handleOpenAction function was expecting an assignment object with a
nested .jobs property, but TechJobCard extracts and passes the job data
directly. This caused selectedJob to be null, preventing the modal from
opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal data handling in the technician application to improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->