### PR TITLE
feat: Allow technicians to use custom base rates

### DIFF
--- a/src/features/rates/components/HouseTechOverridesPanel.tsx
+++ b/src/features/rates/components/HouseTechOverridesPanel.tsx
@@ -26,9 +26,9 @@ export function HouseTechOverridesPanel() {
     <Card>
       <CardHeader>
         <CardTitle className="flex flex-col gap-2 text-base sm:flex-row sm:items-end sm:justify-between">
-          <span>Tarifas internas</span>
+          <span>Tarifas personalizadas</span>
           <Input
-            placeholder="Buscar técnicos en plantilla"
+            placeholder="Buscar técnicos..."
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             className="sm:w-64"
@@ -38,7 +38,7 @@ export function HouseTechOverridesPanel() {
       <CardContent>
         {isLoading && <Skeleton className="h-32 w-full" />}
         {!isLoading && filtered.length === 0 && (
-          <p className="text-sm text-muted-foreground">No se encontraron técnicos en plantilla con ese nombre.</p>
+          <p className="text-sm text-muted-foreground">No se encontraron técnicos con ese nombre.</p>
         )}
         {!isLoading && filtered.length > 0 && (
           <Accordion type="single" collapsible className="space-y-2">
@@ -54,7 +54,7 @@ export function HouseTechOverridesPanel() {
                     </div>
                     <div className="flex items-center gap-2">
                       {tech.overrideBaseDay ? (
-                        <Badge variant="secondary">Tarifa interna: {formatCurrency(tech.overrideBaseDay)}</Badge>
+                        <Badge variant="secondary">Tarifa personalizada: {formatCurrency(tech.overrideBaseDay)}</Badge>
                       ) : (
                         <Badge variant="outline">Usando valor por defecto</Badge>
                       )}

--- a/src/services/ratesService.ts
+++ b/src/services/ratesService.ts
@@ -122,7 +122,7 @@ export async function fetchHouseTechOverrides(): Promise<HouseTechOverrideListIt
   const { data: technicians, error: techniciansError } = await supabase
     .from('profiles')
     .select('id, first_name, last_name, default_timesheet_category, role')
-    .eq('role', 'house_tech')
+    .in('role', ['house_tech', 'technician'])
     .order('first_name', { ascending: true });
 
   if (techniciansError) throw techniciansError;


### PR DESCRIPTION
Previously only house_tech role could have custom rates configured.
Now technician role users can also have personalized rates set up,
making the custom rates feature available to all technician types.

- Update fetchHouseTechOverrides to include 'technician' role
- Update UI labels from "Tarifas internas" to "Tarifas personalizadas"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded the pool of technicians available for custom rate assignments.
  * Updated terminology and interface messaging across the custom rates panel for improved clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->