### PR TITLE
fix: correct personnel assignment date filtering to use timesheet dates

### DIFF
--- a/src/components/personal/MobilePersonalCalendar.tsx
+++ b/src/components/personal/MobilePersonalCalendar.tsx
@@ -78,16 +78,21 @@ export const MobilePersonalCalendar: React.FC<MobilePersonalCalendarProps> = ({
 
   const getAssignmentsForDate = useCallback((targetDate: Date) => {
     return assignments.filter(assignment => {
-      // Check if this is a single-day assignment
+      // Check if this is a single-day assignment (legacy/fallback)
       if (assignment.single_day && assignment.assignment_date) {
         const assignmentDate = new Date(assignment.assignment_date);
         return isSameDay(targetDate, assignmentDate);
       }
 
-      // Otherwise, use the job's full date range
-      const startDate = new Date(assignment.job.start_time);
-      const endDate = new Date(assignment.job.end_time);
-      return isSameDay(targetDate, startDate) || isWithinInterval(targetDate, { start: startDate, end: endDate });
+      // Check specific dates from timesheets if available
+      if (assignment.dates && assignment.dates.length > 0) {
+        const dayString = format(targetDate, 'yyyy-MM-dd');
+        return assignment.dates.includes(dayString);
+      }
+
+      // No fallback - if there are no specific timesheet dates, don't show the assignment
+      // This prevents showing techs assigned to the whole job span when they only worked specific days
+      return false;
     });
   }, [assignments]);
 

--- a/src/components/personal/PersonalCalendar.tsx
+++ b/src/components/personal/PersonalCalendar.tsx
@@ -113,10 +113,9 @@ export const PersonalCalendar: React.FC<PersonalCalendarProps> = ({
         return assignment.dates.includes(dayString);
       }
 
-      // Fallback to job's full date range if no specific dates (shouldn't happen with new logic)
-      const startDate = new Date(assignment.job.start_time);
-      const endDate = new Date(assignment.job.end_time);
-      return isSameDay(day, startDate) || isWithinInterval(day, { start: startDate, end: endDate });
+      // No fallback - if there are no specific timesheet dates, don't show the assignment
+      // This prevents showing techs assigned to the whole job span when they only worked specific days
+      return false;
     });
   };
 


### PR DESCRIPTION
Fixed the getAssignmentsForDate function in both PersonalCalendar and
MobilePersonalCalendar components to properly filter assignments based
on confirmed timesheet dates instead of showing assignments for the
entire job span.

Changes:
- MobilePersonalCalendar: Added logic to check the dates array from
  timesheets, previously was only checking single_day assignments
- PersonalCalendar: Removed fallback that showed full job span
- Both components now return false if no specific timesheet dates exist,
  preventing techs from appearing assigned to jobs they only worked
  partial days on

This fixes the issue where a house tech assigned to only 2 days of a
job was showing as assigned for the entire job duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Calendar assignments now display only on their explicitly scheduled dates instead of appearing across entire job date ranges.
* This prevents assignments from incorrectly appearing on unrelated calendar dates and improves overall schedule accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->