### PR TITLE
Fix availability section: add scrolling and filter by month

### DIFF
--- a/src/components/technician/AvailabilityView.tsx
+++ b/src/components/technician/AvailabilityView.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { supabase } from '@/lib/supabase';
 import { toast } from 'sonner';
-import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, addMonths, isWithinInterval, parseISO } from 'date-fns';
+import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, addMonths, parseISO } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { ChevronLeft, ChevronRight, Plus, Trash2, Loader2, Palmtree } from 'lucide-react';
 import { Input } from '@/components/ui/input';
@@ -135,12 +135,15 @@ export const AvailabilityView = ({ theme, isDark }: AvailabilityViewProps) => {
     const filteredBlocks = useMemo(() => {
         if (!blocks.length) return [];
 
+        // Use string-based comparisons to avoid timezone shifts
         const monthStartDate = startOfMonth(currentMonth);
         const monthEndDate = endOfMonth(currentMonth);
+        const monthStartStr = format(monthStartDate, 'yyyy-MM-dd');
+        const monthEndStr = format(monthEndDate, 'yyyy-MM-dd');
 
         return blocks.filter(block => {
-            const blockDate = new Date(block.date);
-            return isWithinInterval(blockDate, { start: monthStartDate, end: monthEndDate });
+            // Lexicographic comparison of YYYY-MM-DD strings
+            return block.date >= monthStartStr && block.date <= monthEndStr;
         });
     }, [blocks, currentMonth]);
 


### PR DESCRIPTION
- Add ScrollArea component to make the unavailability list scrollable (h-400px)
- Filter displayed blocks to show only dates from the current month in calendar
- Add empty state message when no unavailable dates exist for the month
- Remove the limit of 5 items, now shows all dates for the selected month
- Import useMemo and isWithinInterval from date-fns for efficient filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Month-based filtering: unavailability blocks now show only for the current month
  * Empty-state messaging: Spanish message shown when no blocks exist for the current month
  * Enhanced UI: scrollable area for viewing blocks
  * Inline delete actions: per-item delete button with loading indicator during deletion

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->