### PR TITLE
fix: add missing AlertDialogTrigger import to TimesheetView

### DIFF
--- a/src/components/timesheet/TimesheetView.tsx
+++ b/src/components/timesheet/TimesheetView.tsx
@@ -26,7 +26,8 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
-  AlertDialogTitle
+  AlertDialogTitle,
+  AlertDialogTrigger
 } from "@/components/ui/alert-dialog";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ExpenseForm, ExpenseList, ExpenseSummaryCard } from "@/components/expenses";


### PR DESCRIPTION
The TimesheetView component was using AlertDialogTrigger on line 776 but it wasn't imported, causing the error "Can't find variable: AlertDialogTrigger" and preventing timesheets from loading. Added AlertDialogTrigger to the imports from @/components/ui/alert-dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated component imports to enable dialog trigger functionality in the timesheet view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->