### PR TITLE
Fix document name overflow in job details modal

### DIFF
--- a/src/components/technician/DetailsModal.tsx
+++ b/src/components/technician/DetailsModal.tsx
@@ -450,7 +450,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
                                             >
                                                 <div className="flex-1 min-w-0 overflow-hidden">
                                                     <div
-                                                        className={`text-sm font-bold ${theme.textMain} leading-snug break-words line-clamp-2 sm:line-clamp-1 sm:truncate mb-1`}
+                                                        className={`text-sm font-bold ${theme.textMain} leading-snug break-words line-clamp-2 sm:truncate mb-1`}
                                                         title={doc.file_name}
                                                     >
                                                         {doc.file_name}


### PR DESCRIPTION
## Summary
- clamp long job document names to prevent overflow in the details modal
- adjust responsive layout so view/download actions stay accessible on small screens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936b61b72a4832fb368aa3546c29c7c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for the Documents tab so document entries reflow cleanly on small and larger screens.
  * File names now support multi-line wrapping, tighter line-height and controlled truncation for better readability across devices.
  * Action buttons (“View” and “Download”) have adjusted sizing and spacing to be more usable and consistent on mobile, tablet, and desktop.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->