### PR TITLE
fix: hide duplicate interface on mobile in Lights and Video pages

### DIFF
--- a/src/pages/Lights.tsx
+++ b/src/pages/Lights.tsx
@@ -17,9 +17,11 @@ import { CalendarSection } from "@/components/dashboard/CalendarSection";
 import { TodaySchedule } from "@/components/dashboard/TodaySchedule";
 import { deleteJobOptimistically } from "@/services/optimisticJobDeletionService";
 import { DepartmentMobileHub } from "@/components/department/DepartmentMobileHub";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 const Lights = () => {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const [isJobDialogOpen, setIsJobDialogOpen] = useState(false);
   const [presetJobType, setPresetJobType] = useState<JobType | undefined>(undefined);
   
@@ -168,48 +170,52 @@ const Lights = () => {
           icon={Lightbulb}
           tools={mobileTools}
         />
-        <LightsHeader
-          onCreateJob={(preset) => { setPresetJobType(preset); setIsJobDialogOpen(true); }}
-          department="Luces"
-          canCreate={userRole ? ["admin","management"].includes(userRole) : true}
-        />
+        {!isMobile && (
+          <>
+            <LightsHeader
+              onCreateJob={(preset) => { setPresetJobType(preset); setIsJobDialogOpen(true); }}
+              department="Luces"
+              canCreate={userRole ? ["admin","management"].includes(userRole) : true}
+            />
 
-        <div className="bg-card border border-border rounded-xl p-3 sm:p-4 shadow-sm">
-          <div className="flex flex-wrap gap-3 sm:gap-4 items-center justify-end">
-            <Button
-              variant="outline"
-              onClick={() => navigate('/lights-disponibilidad')}
-              className="flex items-center gap-2"
-            >
-              <Calendar className="h-4 w-4" />
-              Disponibilidad
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => navigate('/lights-pesos-tool')}
-              className="flex items-center gap-2"
-            >
-              <Scale className="h-4 w-4" />
-              Calculadora de Peso
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => navigate('/lights-consumos-tool')}
-              className="flex items-center gap-2"
-            >
-              <Zap className="h-4 w-4" />
-              Calculadora de Potencia
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => navigate('/lights-memoria-tecnica')}
-              className="flex items-center gap-2"
-            >
-              <FileText className="h-4 w-4" />
-              Memoria Técnica
-            </Button>
-          </div>
-        </div>
+            <div className="bg-card border border-border rounded-xl p-3 sm:p-4 shadow-sm">
+              <div className="flex flex-wrap gap-3 sm:gap-4 items-center justify-end">
+                <Button
+                  variant="outline"
+                  onClick={() => navigate('/lights-disponibilidad')}
+                  className="flex items-center gap-2"
+                >
+                  <Calendar className="h-4 w-4" />
+                  Disponibilidad
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => navigate('/lights-pesos-tool')}
+                  className="flex items-center gap-2"
+                >
+                  <Scale className="h-4 w-4" />
+                  Calculadora de Peso
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => navigate('/lights-consumos-tool')}
+                  className="flex items-center gap-2"
+                >
+                  <Zap className="h-4 w-4" />
+                  Calculadora de Potencia
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => navigate('/lights-memoria-tecnica')}
+                  className="flex items-center gap-2"
+                >
+                  <FileText className="h-4 w-4" />
+                  Memoria Técnica
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
 
         <div className="grid grid-cols-1 xl:grid-cols-12 gap-6">
           <div className="xl:col-span-8 2xl:col-span-9">

--- a/src/pages/Video.tsx
+++ b/src/pages/Video.tsx
@@ -18,8 +18,10 @@ import type { JobType } from "@/types/job";
 import { CalendarSection } from "@/components/dashboard/CalendarSection";
 import { TodaySchedule } from "@/components/dashboard/TodaySchedule";
 import { DepartmentMobileHub } from "@/components/department/DepartmentMobileHub";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 const Video = () => {
+  const isMobile = useIsMobile();
   const [isJobDialogOpen, setIsJobDialogOpen] = useState(false);
   const [presetJobType, setPresetJobType] = useState<JobType | undefined>(undefined);
   
@@ -166,34 +168,38 @@ const Video = () => {
           icon={VideoIcon}
           tools={mobileTools}
         />
-        <LightsHeader
-          onCreateJob={(preset) => { setPresetJobType(preset); setIsJobDialogOpen(true); }}
-          department="Video"
-          canCreate={userRole ? ["admin","management"].includes(userRole) : true}
-        />
+        {!isMobile && (
+          <>
+            <LightsHeader
+              onCreateJob={(preset) => { setPresetJobType(preset); setIsJobDialogOpen(true); }}
+              department="Video"
+              canCreate={userRole ? ["admin","management"].includes(userRole) : true}
+            />
 
-        <div className="bg-card border border-border rounded-xl p-3 sm:p-4 shadow-sm">
-          <div className="flex flex-wrap gap-3 sm:gap-4 items-center justify-end">
-            <Link to="/video-pesos-tool">
-              <Button variant="outline" className="gap-2">
-                <Scale className="h-4 w-4" />
-                Weight Calculator
-              </Button>
-            </Link>
-            <Link to="/video-consumos-tool">
-              <Button variant="outline" className="gap-2">
-                <Zap className="h-4 w-4" />
-                Power Calculator
-              </Button>
-            </Link>
-            <Link to="/video-memoria-tecnica">
-              <Button variant="outline" className="gap-2">
-                <File className="h-4 w-4" />
-                Memoria Técnica
-              </Button>
-            </Link>
-          </div>
-        </div>
+            <div className="bg-card border border-border rounded-xl p-3 sm:p-4 shadow-sm">
+              <div className="flex flex-wrap gap-3 sm:gap-4 items-center justify-end">
+                <Link to="/video-pesos-tool">
+                  <Button variant="outline" className="gap-2">
+                    <Scale className="h-4 w-4" />
+                    Weight Calculator
+                  </Button>
+                </Link>
+                <Link to="/video-consumos-tool">
+                  <Button variant="outline" className="gap-2">
+                    <Zap className="h-4 w-4" />
+                    Power Calculator
+                  </Button>
+                </Link>
+                <Link to="/video-memoria-tecnica">
+                  <Button variant="outline" className="gap-2">
+                    <File className="h-4 w-4" />
+                    Memoria Técnica
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </>
+        )}
 
         <div className="grid grid-cols-1 xl:grid-cols-12 gap-6">
           <div className="xl:col-span-8 2xl:col-span-9">


### PR DESCRIPTION
The mobile views were showing both the new DepartmentMobileHub and the old
interface (LightsHeader + buttons card) simultaneously. Now the old interface
is conditionally hidden on mobile devices using the useIsMobile hook, ensuring
only the new mobile hub appears on mobile screens.

Changes:
- Added useIsMobile hook to both Lights.tsx and Video.tsx
- Wrapped LightsHeader and buttons card in {!isMobile && ...} condition
- Desktop users continue to see the original interface
- Mobile users now see only the DepartmentMobileHub interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Lights and Video pages now feature optimized layouts for mobile devices, with adjusted header visibility and button placement to enhance usability on smaller screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->