### PR TITLE
Fix hoja de ruta PDF sections visibility

### DIFF
--- a/src/utils/hoja-de-ruta/pdf/sections/content-sections.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/content-sections.ts
@@ -153,11 +153,15 @@ export class ContentSections {
     if (!accommodations || accommodations.length === 0) return false;
 
     return accommodations.some(acc => {
+      if (!acc) return false;
+
       const hasHotelInfo = DataValidators.hasData(acc.hotel_name) ||
         DataValidators.hasData(acc.hotel_address) ||
         DataValidators.hasData(acc.address);
       const hasDates = DataValidators.hasData(acc.check_in) || DataValidators.hasData(acc.check_out);
-      const hasRooms = Array.isArray(acc.rooms) && acc.rooms.some(DataValidators.hasMeaningfulRoomData);
+      const hasRooms = Array.isArray(acc.rooms) && (
+        acc.rooms.some(room => DataValidators.hasMeaningfulRoomData(room)) || acc.rooms.length > 0
+      );
 
       return hasHotelInfo || hasDates || hasRooms;
     });
@@ -173,7 +177,7 @@ export class ContentSections {
     if (!eventData.logistics) return false;
 
     const { transport = [], loadingDetails, unloadingDetails, equipmentLogistics } = eventData.logistics;
-    const hasTransportEntries = Array.isArray(transport) && transport.some(DataValidators.hasData);
+    const hasTransportEntries = Array.isArray(transport) && transport.some(item => DataValidators.hasData(item));
     const hasDetails = DataValidators.hasData(loadingDetails) ||
       DataValidators.hasData(unloadingDetails) ||
       DataValidators.hasData(equipmentLogistics);


### PR DESCRIPTION
## Summary
- ensure accommodation sections render when hotels contain address, dates, or room assignments
- allow logistics section to print when any transport or logistics details are present

## Testing
- npm run lint (fails: interrupted due to long execution)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3ef6213c832fb3797a5148f2f1fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened accommodation validation to require meaningful hotel info, accurate dates, and non-empty room details.
  * Expanded logistics validation to detect transport entries and loading/unloading/equipment details more reliably.
  * Added guarded handling for missing or incomplete data to reduce false positives and improve overall data accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->