### PR TITLE
feat: add presupuesto creation from festival stage gear and presets

### DIFF
--- a/src/components/festival/CreatePresupuestoDialog.tsx
+++ b/src/components/festival/CreatePresupuestoDialog.tsx
@@ -1,0 +1,405 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { toast } from '@/hooks/use-toast';
+import { Loader2, CheckCircle2, XCircle, AlertTriangle, FileText } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { supabase } from '@/lib/supabase';
+import { createPresupuestoFromStage, getStagePresupuestoItems } from '@/services/flexPresupuesto';
+import { FLEX_API_BASE_URL } from '@/lib/api-config';
+
+interface CreatePresupuestoDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  jobId: string;
+}
+
+interface Stage {
+  id: string;
+  number: number;
+  name: string;
+}
+
+interface ItemPreview {
+  category: string;
+  count: number;
+  totalQuantity: number;
+}
+
+export function CreatePresupuestoDialog({
+  open,
+  onOpenChange,
+  jobId,
+}: CreatePresupuestoDialogProps) {
+  const [stages, setStages] = useState<Stage[]>([]);
+  const [selectedStage, setSelectedStage] = useState<number | null>(null);
+  const [department, setDepartment] = useState<'sound' | 'lights'>('sound');
+  const [useExtrasFolder, setUseExtrasFolder] = useState(false);
+  const [customName, setCustomName] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [isLoadingStages, setIsLoadingStages] = useState(false);
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
+  const [itemsPreview, setItemsPreview] = useState<ItemPreview[]>([]);
+  const [totalItems, setTotalItems] = useState(0);
+  const [createdPresupuestoId, setCreatedPresupuestoId] = useState<string | null>(null);
+  const [pushResult, setPushResult] = useState<{ succeeded: number; failed: Array<{ name: string; error: string }> } | null>(null);
+
+  // Load stages when dialog opens
+  useEffect(() => {
+    if (!open || !jobId) {
+      setStages([]);
+      setSelectedStage(null);
+      return;
+    }
+
+    const loadStages = async () => {
+      setIsLoadingStages(true);
+      try {
+        const { data, error } = await supabase
+          .from('festival_stages')
+          .select('id, number, name')
+          .eq('job_id', jobId)
+          .order('number');
+
+        if (error) throw error;
+
+        const stagesData = (data || []) as Stage[];
+        setStages(stagesData);
+
+        // Auto-select first stage
+        if (stagesData.length > 0) {
+          setSelectedStage(stagesData[0].number);
+        }
+      } catch (error) {
+        console.error('Failed to load stages:', error);
+        toast({
+          title: 'Error',
+          description: 'Failed to load stages for this festival',
+          variant: 'destructive',
+        });
+      } finally {
+        setIsLoadingStages(false);
+      }
+    };
+
+    loadStages();
+  }, [open, jobId]);
+
+  // Load preview when stage or department changes
+  useEffect(() => {
+    if (!open || selectedStage === null || !jobId) {
+      setItemsPreview([]);
+      setTotalItems(0);
+      return;
+    }
+
+    const loadPreview = async () => {
+      setIsLoadingPreview(true);
+      try {
+        const items = await getStagePresupuestoItems(jobId, selectedStage, department);
+
+        // Group by category for preview
+        const categoryMap = new Map<string, { count: number; totalQuantity: number }>();
+
+        for (const item of items) {
+          const category = item.category || 'uncategorized';
+          const existing = categoryMap.get(category);
+
+          if (existing) {
+            existing.count++;
+            existing.totalQuantity += item.quantity;
+          } else {
+            categoryMap.set(category, { count: 1, totalQuantity: item.quantity });
+          }
+        }
+
+        const preview: ItemPreview[] = Array.from(categoryMap.entries()).map(([category, data]) => ({
+          category,
+          count: data.count,
+          totalQuantity: data.totalQuantity,
+        }));
+
+        setItemsPreview(preview);
+        setTotalItems(items.length);
+      } catch (error) {
+        console.error('Failed to load preview:', error);
+        setItemsPreview([]);
+        setTotalItems(0);
+      } finally {
+        setIsLoadingPreview(false);
+      }
+    };
+
+    loadPreview();
+  }, [open, selectedStage, department, jobId]);
+
+  const handleCreate = async () => {
+    if (selectedStage === null) {
+      toast({
+        title: 'Error',
+        description: 'Please select a stage',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (totalItems === 0) {
+      toast({
+        title: 'Error',
+        description: 'No equipment items found for this stage and department. Cannot create empty presupuesto.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsCreating(true);
+    setCreatedPresupuestoId(null);
+    setPushResult(null);
+
+    try {
+      const result = await createPresupuestoFromStage({
+        jobId,
+        stageNumber: selectedStage,
+        department,
+        useExtrasFolder,
+        customName: customName.trim() || undefined,
+      });
+
+      setCreatedPresupuestoId(result.presupuestoId);
+      setPushResult(result.pushResult);
+
+      toast({
+        title: 'Success',
+        description: `Presupuesto created successfully with ${result.pushResult.succeeded} items`,
+      });
+    } catch (error) {
+      console.error('Failed to create presupuesto:', error);
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to create presupuesto',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleClose = () => {
+    setSelectedStage(null);
+    setDepartment('sound');
+    setUseExtrasFolder(false);
+    setCustomName('');
+    setCreatedPresupuestoId(null);
+    setPushResult(null);
+    setItemsPreview([]);
+    setTotalItems(0);
+    onOpenChange(false);
+  };
+
+  const presupuestoUrl = createdPresupuestoId
+    ? `${FLEX_API_BASE_URL.replace('/v2', '')}/element/${createdPresupuestoId}`
+    : null;
+
+  const selectedStageName = stages.find(s => s.number === selectedStage)?.name || `Stage ${selectedStage}`;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Create Presupuesto from Stage Gear
+          </DialogTitle>
+          <DialogDescription>
+            Create a presupuesto in the comercial folder with equipment from the selected stage
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Stage Selection */}
+          <div className="space-y-2">
+            <Label>Stage</Label>
+            {isLoadingStages ? (
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading stages...
+              </div>
+            ) : stages.length === 0 ? (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  No stages found. Please create stages in the gear management page first.
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <Select
+                value={selectedStage?.toString()}
+                onValueChange={(value) => setSelectedStage(parseInt(value))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a stage" />
+                </SelectTrigger>
+                <SelectContent>
+                  {stages.map((stage) => (
+                    <SelectItem key={stage.id} value={stage.number.toString()}>
+                      Stage {stage.number} - {stage.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          {/* Department Selection */}
+          <div className="space-y-2">
+            <Label>Department</Label>
+            <Select value={department} onValueChange={(value) => setDepartment(value as 'sound' | 'lights')}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="sound">Sonido</SelectItem>
+                <SelectItem value="lights">Luces</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Options */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="extras-folder" className="cursor-pointer">
+                Create Extras Folder
+              </Label>
+              <Switch
+                id="extras-folder"
+                checked={useExtrasFolder}
+                onCheckedChange={setUseExtrasFolder}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {useExtrasFolder
+                ? 'Presupuesto will be created inside an "Extras" subfolder'
+                : 'Presupuesto will be created directly in the Comercial folder'}
+            </p>
+          </div>
+
+          {/* Custom Name */}
+          <div className="space-y-2">
+            <Label htmlFor="custom-name">Custom Name (optional)</Label>
+            <Input
+              id="custom-name"
+              value={customName}
+              onChange={(e) => setCustomName(e.target.value)}
+              placeholder="Leave empty for default naming"
+            />
+          </div>
+
+          {/* Preview */}
+          {selectedStage !== null && (
+            <div className="space-y-2 rounded-lg border p-4 bg-muted/50">
+              <div className="flex items-center justify-between">
+                <Label className="text-base">Equipment Preview</Label>
+                {isLoadingPreview && <Loader2 className="h-4 w-4 animate-spin" />}
+              </div>
+
+              {totalItems === 0 ? (
+                <Alert variant="destructive">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertDescription>
+                    No equipment items found for {selectedStageName} in {department === 'sound' ? 'Sonido' : 'Luces'}.
+                    Cannot create empty presupuesto.
+                  </AlertDescription>
+                </Alert>
+              ) : (
+                <>
+                  <p className="text-sm text-muted-foreground">
+                    {totalItems} item{totalItems !== 1 ? 's' : ''} from gear setup and presets
+                  </p>
+
+                  {itemsPreview.length > 0 && (
+                    <div className="space-y-1 mt-2">
+                      {itemsPreview.map((preview) => (
+                        <div key={preview.category} className="flex justify-between text-xs">
+                          <span className="font-medium">{preview.category}</span>
+                          <span className="text-muted-foreground">
+                            {preview.count} type{preview.count !== 1 ? 's' : ''}, {preview.totalQuantity} units
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Result */}
+          {createdPresupuestoId && pushResult && (
+            <Alert className={pushResult.failed.length > 0 ? 'border-yellow-500' : 'border-green-500'}>
+              {pushResult.failed.length === 0 ? (
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+              ) : (
+                <AlertTriangle className="h-4 w-4 text-yellow-500" />
+              )}
+              <AlertDescription>
+                <div className="space-y-2">
+                  <p className="font-semibold">
+                    Presupuesto created: {pushResult.succeeded} items added successfully
+                  </p>
+                  {pushResult.failed.length > 0 && (
+                    <div className="text-xs">
+                      <p className="font-medium text-destructive">{pushResult.failed.length} items failed:</p>
+                      <ul className="list-disc list-inside">
+                        {pushResult.failed.slice(0, 5).map((item, i) => (
+                          <li key={i}>{item.name}: {item.error}</li>
+                        ))}
+                        {pushResult.failed.length > 5 && (
+                          <li>...and {pushResult.failed.length - 5} more</li>
+                        )}
+                      </ul>
+                    </div>
+                  )}
+                  {presupuestoUrl && (
+                    <a
+                      href={presupuestoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 hover:underline text-sm"
+                    >
+                      Open presupuesto in Flex →
+                    </a>
+                  )}
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={isCreating}>
+            {createdPresupuestoId ? 'Close' : 'Cancel'}
+          </Button>
+          {!createdPresupuestoId && (
+            <Button
+              onClick={handleCreate}
+              disabled={isCreating || selectedStage === null || totalItems === 0 || isLoadingPreview}
+            >
+              {isCreating ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                'Create Presupuesto'
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/FestivalManagement.tsx
+++ b/src/pages/FestivalManagement.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, useMemo } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Users, Music2, Layout, Calendar, Printer, Loader2, FileText, Download, Eye, Clock, FolderPlus, RefreshCw, MapPin, Link as LinkIcon, Box, Upload, Trash2, Archive, RotateCw, MessageCircle, Scale, Zap, AlertCircle } from "lucide-react";
+import { Users, Music2, Layout, Calendar, Printer, Loader2, FileText, Download, Eye, Clock, FolderPlus, RefreshCw, MapPin, Link as LinkIcon, Box, Upload, Trash2, Archive, RotateCw, MessageCircle, Scale, Zap, AlertCircle, DollarSign } from "lucide-react";
 import createFolderIcon from "@/assets/icons/icon.png";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/hooks/use-toast";
@@ -32,6 +32,7 @@ import { resolveJobDocLocation } from "@/utils/jobDocuments";
 import { TechnicianIncidentReportDialog } from "@/components/incident-reports/TechnicianIncidentReportDialog";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { CreatePresupuestoDialog } from "@/components/festival/CreatePresupuestoDialog";
 
 interface FestivalJob {
   id: string;
@@ -148,6 +149,7 @@ const FestivalManagement = () => {
   const [isSendingWa, setIsSendingWa] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isPresupuestoDialogOpen, setIsPresupuestoDialogOpen] = useState(false);
 
   const resolveJobDocumentLocation = useCallback((path: string) => resolveJobDocLocation(path), []);
 
@@ -1468,6 +1470,27 @@ const FestivalManagement = () => {
                   </Button>
                 </div>
 
+                {/* Create Presupuesto */}
+                {canEdit && (
+                  <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-green-500/5">
+                    <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
+                      <DollarSign className="h-4 w-4 flex-shrink-0 text-green-500" />
+                      Crear Presupuesto
+                    </div>
+                    <p className="text-xs md:text-sm text-muted-foreground">
+                      Crea un presupuesto con el equipo del escenario seleccionado.
+                    </p>
+                    <Button
+                      onClick={() => setIsPresupuestoDialogOpen(true)}
+                      disabled={!job || !folderExists}
+                      size="sm"
+                      className="w-full"
+                    >
+                      Crear Presupuesto
+                    </Button>
+                  </div>
+                )}
+
                 {/* Upload Documents */}
                 {canEdit && (
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-blue-500/5">
@@ -1861,6 +1884,14 @@ const FestivalManagement = () => {
           onOpenChange={setIsJobDetailsOpen}
           job={job}
           department={assignmentDepartment}
+        />
+      )}
+
+      {jobId && (
+        <CreatePresupuestoDialog
+          open={isPresupuestoDialogOpen}
+          onOpenChange={setIsPresupuestoDialogOpen}
+          jobId={jobId}
         />
       )}
 

--- a/src/services/flexPresupuesto.ts
+++ b/src/services/flexPresupuesto.ts
@@ -1,0 +1,463 @@
+import { supabase } from '@/integrations/supabase/client';
+import { FLEX_API_BASE_URL } from '@/lib/api-config';
+import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS, DEPARTMENT_SUFFIXES } from '@/utils/flex-folders/constants';
+import { createFlexFolder } from '@/utils/flex-folders/api';
+import { FlexFolderPayload } from '@/utils/flex-folders/types';
+import type { EquipmentItem, PushResult } from './flexPullsheets';
+import { pushEquipmentToPullsheet } from './flexPullsheets';
+import type { PresetSubsystem } from '@/types/equipment';
+
+let cachedFlexToken: string | null = null;
+
+/**
+ * Gets the Flex authentication token from Supabase secrets
+ */
+async function getFlexAuthToken(): Promise<string> {
+  if (cachedFlexToken) return cachedFlexToken;
+
+  const { data, error } = await supabase.functions.invoke('get-secret', {
+    body: { secretName: 'X_AUTH_TOKEN' },
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Failed to resolve Flex auth token');
+  }
+
+  const token = (data as { X_AUTH_TOKEN?: string } | null)?.X_AUTH_TOKEN;
+  if (!token) {
+    throw new Error('Flex auth token response missing X_AUTH_TOKEN');
+  }
+
+  cachedFlexToken = token;
+  return token;
+}
+
+/**
+ * Format date string for Flex API (ISO format with milliseconds)
+ */
+function formatDateForFlex(dateStr: string | undefined): string | undefined {
+  if (!dateStr) return undefined;
+  try {
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return undefined;
+    return date.toISOString().split('.')[0] + '.000Z';
+  } catch {
+    return undefined;
+  }
+}
+
+const SUBSYSTEM_TO_FLEX_CATEGORY: Record<PresetSubsystem, string> = {
+  mains: 'pa_mains',
+  outs: 'pa_outfill',
+  subs: 'pa_subs',
+  fronts: 'pa_frontfill',
+  delays: 'pa_delays',
+  other: 'pa_mains',
+  amplification: 'pa_amp',
+};
+
+/**
+ * Extract equipment items from festival gear setup JSON fields
+ */
+function extractGearItems(
+  gearSetup: any,
+  department: 'sound' | 'lights'
+): EquipmentItem[] {
+  if (!gearSetup) return [];
+
+  const items: EquipmentItem[] = [];
+
+  // Fields to extract based on department
+  const soundFields = ['foh_consoles', 'mon_consoles', 'wireless_systems', 'iem_systems', 'wired_mics'];
+  const lightsFields = ['lighting_consoles', 'dimmers', 'fixtures'];
+  const fields = department === 'sound' ? soundFields : lightsFields;
+
+  for (const field of fields) {
+    const fieldData = gearSetup[field];
+    if (!fieldData) continue;
+
+    try {
+      const parsed = typeof fieldData === 'string' ? JSON.parse(fieldData) : fieldData;
+      if (Array.isArray(parsed)) {
+        for (const item of parsed) {
+          if (item.resource_id && item.quantity) {
+            items.push({
+              resourceId: item.resource_id,
+              quantity: item.quantity,
+              name: item.name || item.model || 'Unknown',
+              category: mapGearFieldToCategory(field),
+            });
+          }
+        }
+      }
+    } catch (e) {
+      console.warn(`Failed to parse gear field ${field}:`, e);
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Map gear setup field names to flex categories
+ */
+function mapGearFieldToCategory(fieldName: string): string {
+  const mapping: Record<string, string> = {
+    foh_consoles: 'foh_console',
+    mon_consoles: 'mon_console',
+    wireless_systems: 'wireless',
+    iem_systems: 'iem',
+    wired_mics: 'wired_mics',
+    lighting_consoles: 'lights_console',
+    dimmers: 'lights_dimmer',
+    fixtures: 'lights_fixture',
+  };
+  return mapping[fieldName] || 'uncategorized';
+}
+
+/**
+ * Extract equipment items from presets
+ */
+async function extractPresetItems(
+  jobId: string,
+  department: 'sound' | 'lights',
+  dateFilter?: string
+): Promise<EquipmentItem[]> {
+  let query = supabase
+    .from('day_preset_assignments')
+    .select(`
+      *,
+      preset:presets!inner (
+        *,
+        items:preset_items (
+          *,
+          equipment:equipment (
+            resource_id,
+            name,
+            category
+          )
+        )
+      )
+    `)
+    .eq('source', 'job')
+    .eq('source_id', jobId)
+    .eq('preset.department', department);
+
+  if (dateFilter) {
+    query = query.eq('date', dateFilter);
+  }
+
+  const { data: presetAssignments, error } = await query;
+
+  if (error) {
+    console.error('Failed to fetch preset assignments:', error);
+    return [];
+  }
+
+  if (!presetAssignments) return [];
+
+  const items: EquipmentItem[] = [];
+
+  for (const assignment of presetAssignments) {
+    const preset = assignment.preset as any;
+    if (!preset?.items) continue;
+
+    for (const presetItem of preset.items) {
+      const equipment = presetItem.equipment;
+      if (!equipment?.resource_id) continue;
+
+      // Resolve category from subsystem or equipment category
+      let category = 'uncategorized';
+      if (presetItem.subsystem) {
+        category = SUBSYSTEM_TO_FLEX_CATEGORY[presetItem.subsystem as PresetSubsystem];
+      } else if (equipment.category) {
+        category = equipment.category;
+      }
+
+      items.push({
+        resourceId: equipment.resource_id,
+        quantity: presetItem.quantity || 1,
+        name: equipment.name || 'Unknown',
+        category,
+        subsystem: presetItem.subsystem,
+      });
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Merge and deduplicate equipment items by resourceId
+ */
+function mergeEquipmentItems(items: EquipmentItem[]): EquipmentItem[] {
+  const merged = new Map<string, EquipmentItem>();
+
+  for (const item of items) {
+    const key = `${item.resourceId}:${item.category || 'uncategorized'}`;
+    const existing = merged.get(key);
+
+    if (existing) {
+      existing.quantity += item.quantity;
+    } else {
+      merged.set(key, { ...item });
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+/**
+ * Get all equipment items for a festival stage
+ */
+export async function getStagePresupuestoItems(
+  jobId: string,
+  stageNumber: number,
+  department: 'sound' | 'lights',
+  dateFilter?: string
+): Promise<EquipmentItem[]> {
+  // 1. Get stage gear setup
+  const { data: globalGear, error: globalError } = await supabase
+    .from('festival_gear_setups')
+    .select('*')
+    .eq('job_id', jobId)
+    .maybeSingle();
+
+  if (globalError) {
+    console.error('Failed to fetch global gear setup:', globalError);
+    throw new Error('Failed to fetch gear setup');
+  }
+
+  let gearSetup = globalGear;
+
+  // Check for stage-specific overrides
+  if (globalGear?.id) {
+    const { data: stageGear } = await supabase
+      .from('festival_stage_gear_setups')
+      .select('*')
+      .eq('gear_setup_id', globalGear.id)
+      .eq('stage_number', stageNumber)
+      .maybeSingle();
+
+    if (stageGear) {
+      gearSetup = stageGear;
+    }
+  }
+
+  // 2. Extract gear items
+  const gearItems = gearSetup ? extractGearItems(gearSetup, department) : [];
+
+  // 3. Extract preset items
+  const presetItems = await extractPresetItems(jobId, department, dateFilter);
+
+  // 4. Merge and deduplicate
+  const allItems = mergeEquipmentItems([...gearItems, ...presetItems]);
+
+  console.log(`[FlexPresupuesto] Found ${gearItems.length} gear items + ${presetItems.length} preset items = ${allItems.length} total items`);
+
+  return allItems;
+}
+
+/**
+ * Get or create the comercial folder for a job
+ */
+async function ensureComercialFolder(jobId: string): Promise<{ element_id: string }> {
+  // Check if comercial folder already exists
+  const { data: existing } = await supabase
+    .from('flex_folders')
+    .select('element_id')
+    .eq('job_id', jobId)
+    .eq('folder_type', 'comercial')
+    .maybeSingle();
+
+  if (existing?.element_id) {
+    return { element_id: existing.element_id };
+  }
+
+  // If not, we need to create it - but this should typically be done via flex folder creation
+  throw new Error('Comercial folder not found. Please create Flex folders first.');
+}
+
+/**
+ * Create a presupuesto document in the comercial folder
+ */
+async function createPresupuestoDocument(options: {
+  jobId: string;
+  comercialFolderId: string;
+  department: 'sound' | 'lights';
+  useExtrasFolder: boolean;
+  customName?: string;
+  stageNumber?: number;
+}): Promise<string> {
+  const { jobId, comercialFolderId, department, useExtrasFolder, customName, stageNumber } = options;
+
+  // Get job details for naming
+  const { data: job, error: jobError } = await supabase
+    .from('jobs')
+    .select('title, start_time, end_time')
+    .eq('id', jobId)
+    .single();
+
+  if (jobError || !job) {
+    throw new Error('Failed to fetch job details');
+  }
+
+  // Get comercial folder document number
+  const { data: comercialFolder } = await supabase
+    .from('flex_folders')
+    .select('element_id')
+    .eq('job_id', jobId)
+    .eq('folder_type', 'comercial')
+    .single();
+
+  if (!comercialFolder) {
+    throw new Error('Comercial folder not found');
+  }
+
+  // Fetch document number from Flex API
+  const token = await getFlexAuthToken();
+  const response = await fetch(`${FLEX_API_BASE_URL}/element/${comercialFolder.element_id}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Auth-Token': token,
+      'apikey': token,
+    },
+  });
+
+  let documentNumber = '';
+  if (response.ok) {
+    const data = await response.json();
+    documentNumber = data.documentNumber || '';
+  }
+
+  const deptLabel = department === 'sound' ? 'Sonido' : 'Luces';
+  const deptSuffix = department === 'sound' ? 'SQT' : 'LQT';
+  const jobTitle = job.title?.trim() || 'Unknown Job';
+  const stageSuffix = stageNumber ? ` S${stageNumber}` : '';
+
+  const formattedStartDate = formatDateForFlex(job.start_time);
+  const formattedEndDate = formatDateForFlex(job.end_time);
+
+  let presupuestoParentId = comercialFolderId;
+  let presupuestoDocNumber = `${documentNumber}${deptSuffix}${stageSuffix}`;
+
+  // Create extras folder if requested
+  if (useExtrasFolder) {
+    const extrasName = `Extras ${jobTitle}${stageNumber ? ` - Stage ${stageNumber}` : ''} - ${deptLabel}`;
+    const extrasPayload: FlexFolderPayload = {
+      definitionId: FLEX_FOLDER_IDS.subFolder,
+      parentElementId: comercialFolderId,
+      name: extrasName,
+      open: true,
+      locked: false,
+      plannedStartDate: formattedStartDate,
+      plannedEndDate: formattedEndDate,
+      locationId: FLEX_FOLDER_IDS.location,
+      departmentId: DEPARTMENT_IDS[department],
+      documentNumber: presupuestoDocNumber,
+      personResponsibleId: RESPONSIBLE_PERSON_IDS[department],
+    };
+
+    const extrasFolder = await createFlexFolder(extrasPayload);
+    if (!extrasFolder.elementId) {
+      throw new Error('Failed to create extras folder');
+    }
+
+    // Save extras folder to database
+    await supabase.from('flex_folders').insert({
+      job_id: jobId,
+      parent_id: comercialFolderId,
+      element_id: extrasFolder.elementId,
+      department,
+      folder_type: 'comercial_extras',
+      stage_number: stageNumber,
+    });
+
+    presupuestoParentId = extrasFolder.elementId;
+  }
+
+  // Create presupuesto document
+  const presupuestoName = customName
+    ? customName
+    : `${jobTitle}${stageNumber ? ` - Stage ${stageNumber}` : ''} - ${deptLabel} - Presupuesto`;
+
+  const presupuestoPayload: FlexFolderPayload = {
+    definitionId: FLEX_FOLDER_IDS.presupuesto,
+    parentElementId: presupuestoParentId,
+    name: presupuestoName,
+    open: true,
+    locked: false,
+    plannedStartDate: formattedStartDate,
+    plannedEndDate: formattedEndDate,
+    locationId: FLEX_FOLDER_IDS.location,
+    departmentId: DEPARTMENT_IDS[department],
+    documentNumber: `${presupuestoDocNumber}PR01`,
+    personResponsibleId: RESPONSIBLE_PERSON_IDS[department],
+  };
+
+  const presupuestoResponse = await createFlexFolder(presupuestoPayload);
+  if (!presupuestoResponse.elementId) {
+    throw new Error('Failed to create presupuesto document');
+  }
+
+  // Save presupuesto to database
+  await supabase.from('flex_folders').insert({
+    job_id: jobId,
+    parent_id: presupuestoParentId,
+    element_id: presupuestoResponse.elementId,
+    department,
+    folder_type: 'comercial_presupuesto',
+    stage_number: stageNumber,
+  });
+
+  console.log(`[FlexPresupuesto] Created presupuesto: ${presupuestoResponse.elementId}`);
+  return presupuestoResponse.elementId;
+}
+
+/**
+ * Create a presupuesto from festival stage gear and presets
+ */
+export async function createPresupuestoFromStage(options: {
+  jobId: string;
+  stageNumber: number;
+  department: 'sound' | 'lights';
+  useExtrasFolder?: boolean;
+  customName?: string;
+  dateFilter?: string;
+}): Promise<{ presupuestoId: string; pushResult: PushResult }> {
+  const {
+    jobId,
+    stageNumber,
+    department,
+    useExtrasFolder = false,
+    customName,
+    dateFilter,
+  } = options;
+
+  // 1. Get all items for this stage
+  const items = await getStagePresupuestoItems(jobId, stageNumber, department, dateFilter);
+
+  // Validation: Don't allow empty presupuesto
+  if (items.length === 0) {
+    throw new Error('No equipment items found for this stage and department. Cannot create empty presupuesto.');
+  }
+
+  // 2. Get comercial folder
+  const comercialFolder = await ensureComercialFolder(jobId);
+
+  // 3. Create presupuesto document
+  const presupuestoId = await createPresupuestoDocument({
+    jobId,
+    comercialFolderId: comercialFolder.element_id,
+    department,
+    useExtrasFolder,
+    customName,
+    stageNumber,
+  });
+
+  // 4. Add line items to presupuesto (reuse pushEquipmentToPullsheet logic)
+  const pushResult = await pushEquipmentToPullsheet(presupuestoId, items);
+
+  return { presupuestoId, pushResult };
+}


### PR DESCRIPTION
Add feature to create presupuestos in the comercial folder populated with equipment from festival stage gear setups and assigned presets.

New files:
- src/services/flexPresupuesto.ts: Service layer for presupuesto creation
  - getStagePresupuestoItems(): Gathers gear + preset items for a stage
  - createPresupuestoFromStage(): Creates presupuesto and adds line items
  - Reuses existing pushEquipmentToPullsheet logic for categorization

- src/components/festival/CreatePresupuestoDialog.tsx: UI dialog
  - Stage selection
  - Department selection (Sound/Lights)
  - Optional extras folder creation
  - Equipment preview with category breakdown
  - Validation to prevent empty presupuestos

Modified:
- src/pages/FestivalManagement.tsx:
  - Added "Crear Presupuesto" button in Quick Actions section
  - Integrated CreatePresupuestoDialog component

Features:
- Per-stage presupuesto creation
- Combines both gear setup items AND preset items (PA/speakers/amps)
- Optional extras folder structure
- Custom naming support
- Category-based line item organization
- Proper document numbering following existing conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added budget creation tool in festival management. Users can now create budgets for specific festival stages by selecting a department (sound/lights), preview equipment allocation, optionally create extras folders, and assign custom names. Budgets automatically populate with stage-specific equipment and are accessible in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->