### PR TITLE
fix: change worked hours rounding from nearest 0.5 to round UP

### DIFF
--- a/supabase/migrations/20251217235807_harden_security_definer_rpcs.sql
+++ b/supabase/migrations/20251217235807_harden_security_definer_rpcs.sql
@@ -125,6 +125,9 @@ GRANT EXECUTE ON FUNCTION public.get_timesheet_amounts_visible() TO authenticate
 -- 3) Profiles-with-skills RPC (fix broken auth check; limit PII)
 -- -----------------------------------------------------------------------------
 
+-- Drop existing function first since return type changed
+DROP FUNCTION IF EXISTS public.get_profiles_with_skills();
+
 CREATE OR REPLACE FUNCTION public.get_profiles_with_skills()
 RETURNS TABLE(
   id uuid,


### PR DESCRIPTION
BREAKING CHANGE: Worked hours are now rounded UP to the nearest whole hour instead of to the nearest 0.5 hour.

Before: 12.7h -> 12.5h (nearest 0.5)
After: 12.7h -> 13h (CEILING)

This affects the "Horas Redondeadas" field in timesheets and ensures technicians are always paid for the full hour when working partial hours.

The overtime hours were already fixed to round UP on Dec 2, 2025 (commit c613b7d). This change completes the rounding fix by also applying CEILING to worked hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timesheet calculations now round worked hours to the nearest whole hour, changing how amounts are computed.

* **Enhancements**
  * Profile data now consistently includes skill information and related profile fields in responses, improving visibility of user skills.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->