### PR TITLE
feat: setup parallel workflow infrastructure for Claude Code

### DIFF
--- a/.claude/commands/ci-fix.md
+++ b/.claude/commands/ci-fix.md
@@ -1,0 +1,15 @@
+---
+description: Fix failing CI/build. Run the build, read the errors, fix them all.
+disable-model-invocation: true
+---
+
+The CI/build is failing. Fix it.
+
+1. Run `npm run build` and capture ALL errors
+2. Categorize the errors (type errors, import errors, missing modules, etc.)
+3. Fix each error systematically — start with the ones that cascade (missing exports, broken imports)
+4. After fixing, run `npm run build` again to verify
+5. If there are still errors, repeat until the build is clean
+6. Run `npm run lint` to check for remaining lint issues
+
+Do NOT skip errors or add `@ts-ignore`. Fix the root cause.

--- a/.claude/commands/fix.md
+++ b/.claude/commands/fix.md
@@ -1,0 +1,18 @@
+---
+description: Diagnose and fix a bug from an error message, log output, or bug description. Paste the error and let Claude handle the rest.
+---
+
+Diagnose and fix the following issue:
+
+$ARGUMENTS
+
+Follow this process:
+
+1. **Reproduce**: Understand the error — read the stack trace, identify the file and line
+2. **Root cause**: Trace back to the actual cause, not just the symptom
+3. **Search for related issues**: Check if this pattern exists elsewhere in the codebase
+4. **Fix**: Make the minimal change needed to fix the root cause
+5. **Verify**: Ensure the fix doesn't break related functionality
+6. **Test**: Run `npm run build` to verify no type errors were introduced
+
+Do NOT refactor surrounding code. Do NOT add features. Just fix the bug.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,18 @@
+---
+description: Enter plan mode to analyze a complex task before implementation. Use for multi-file changes, architecture decisions, or when something went sideways.
+---
+
+Switch to plan mode. Analyze the codebase thoroughly before proposing any changes.
+
+**Task to plan**: $ARGUMENTS
+
+Follow this process:
+
+1. **Understand the scope**: Read all relevant files and understand the current implementation
+2. **Identify dependencies**: Map which files, hooks, components, and database tables are involved
+3. **Consider edge cases**: Think about error states, mobile vs desktop, timezone handling (Europe/Madrid), and existing patterns
+4. **Draft the plan**: Write a numbered step-by-step implementation plan with specific file paths and changes
+5. **Identify risks**: Note any breaking changes, migration needs, or Supabase RLS policy impacts
+6. **Estimate complexity**: How many files change? Are there database migrations needed?
+
+Do NOT make any code changes. Only produce the plan. Ask clarifying questions if the task is ambiguous.

--- a/.claude/commands/review-plan.md
+++ b/.claude/commands/review-plan.md
@@ -1,0 +1,20 @@
+---
+description: Review an implementation plan as a staff engineer would. Challenge assumptions and find gaps.
+---
+
+You are a senior staff engineer reviewing a proposed implementation plan. Be thorough and critical.
+
+Review the plan for:
+
+1. **Completeness**: Are any steps missing? Are all affected files identified?
+2. **Correctness**: Will the proposed changes actually work? Are there logical errors?
+3. **Edge cases**: What about error handling, empty states, race conditions, concurrent users?
+4. **Performance**: Will this cause N+1 queries, unnecessary re-renders, or bundle size bloat?
+5. **Security**: Any RLS policy gaps, XSS vectors, or exposed secrets?
+6. **Existing patterns**: Does the plan follow the codebase's established patterns (React Query, Zustand, shadcn/ui)?
+7. **Database impact**: Are migrations needed? Will they affect existing data?
+8. **Mobile/PWA**: Does this work on mobile viewports? Does it handle offline gracefully?
+
+Grade the plan: APPROVE, APPROVE WITH CHANGES, or REQUEST REVISION.
+
+If requesting revision, be specific about what needs to change and why.

--- a/.claude/commands/techdebt.md
+++ b/.claude/commands/techdebt.md
@@ -1,0 +1,20 @@
+---
+description: Scan the codebase for technical debt, duplicated code, and cleanup opportunities. Run at the end of every session.
+disable-model-invocation: true
+---
+
+Scan the codebase for technical debt. Focus on recently changed files and the areas around them.
+
+Look for:
+
+1. **Duplicated code**: Functions or components that do nearly the same thing. Suggest consolidation.
+2. **Dead code**: Unused imports, unreachable branches, commented-out blocks, exported functions with zero consumers.
+3. **Inconsistent patterns**: Places where older code doesn't follow current conventions (e.g., direct Supabase calls instead of React Query hooks, inline styles instead of Tailwind).
+4. **Type safety gaps**: Any `as any` casts, missing return types on exported functions, or untyped API responses.
+5. **TODO/FIXME/HACK comments**: List them with file paths and line numbers.
+6. **Large files**: Components over 300 lines that should be split.
+7. **Missing error handling**: API calls without proper error handling or user feedback.
+
+Output a prioritized list with file paths and specific line numbers. Group by severity: Critical, High, Medium, Low.
+
+Do NOT fix anything. Just report.

--- a/.claude/commands/update-notes.md
+++ b/.claude/commands/update-notes.md
@@ -1,0 +1,19 @@
+---
+description: Update the session notes after completing a task or PR. Captures decisions, patterns discovered, and lessons learned.
+disable-model-invocation: true
+---
+
+Update the project notes in `.claude/notes/` to capture what was learned in this session.
+
+Create or update a note file named after today's date and task: `.claude/notes/YYYY-MM-DD-<short-description>.md`
+
+Include:
+
+1. **Task summary**: What was done in 1-2 sentences
+2. **Files changed**: List the key files modified
+3. **Decisions made**: Why specific approaches were chosen over alternatives
+4. **Patterns discovered**: Any codebase patterns or conventions that were clarified
+5. **Gotchas**: Anything surprising or tricky that future sessions should know about
+6. **Follow-up items**: Things that were noticed but not addressed
+
+Also check if any of these discoveries should be added to CLAUDE.md. If so, update CLAUDE.md with the new guidance.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,16 @@
+---
+description: Verify that recent changes work correctly. Diff against main, run the build, and prove correctness.
+disable-model-invocation: true
+---
+
+Verify the current changes are correct and complete.
+
+1. **Diff review**: Run `git diff main...HEAD` and review every change
+2. **Build check**: Run `npm run build` — it must pass with zero errors
+3. **Behavioral check**: For each changed file, verify the logic is correct by reading the surrounding code
+4. **Integration check**: Are all the pieces connected? Do imports resolve? Are React Query keys consistent?
+5. **Regression check**: Could any change break existing functionality? Check callers of modified functions.
+
+Report: PASS or FAIL with specific issues found.
+
+Do NOT make changes. Only verify and report.

--- a/.claude/notes/README.md
+++ b/.claude/notes/README.md
@@ -1,0 +1,22 @@
+# Session Notes
+
+This directory stores notes from Claude Code sessions. Each file captures decisions, patterns, and lessons learned during a task.
+
+## Naming Convention
+
+Files follow the pattern: `YYYY-MM-DD-<short-description>.md`
+
+Examples:
+- `2025-06-15-auth-refactor.md`
+- `2025-06-16-festival-pdf-export.md`
+
+## Purpose
+
+- Maintain institutional memory across Claude sessions
+- Track decisions and their rationale
+- Capture gotchas and codebase-specific knowledge
+- Feed back into CLAUDE.md when patterns are confirmed
+
+## Usage
+
+Run `/update-notes` at the end of any session that produced meaningful changes or discoveries.

--- a/.claude/skills/plan-review/SKILL.md
+++ b/.claude/skills/plan-review/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: plan-review
+description: Two-phase planning workflow. First creates a detailed implementation plan, then reviews it as a staff engineer before proceeding with implementation.
+disable-model-invocation: true
+context: fork
+agent: Plan
+---
+
+You are planning a complex implementation task. Do NOT write any code.
+
+**Task**: $ARGUMENTS
+
+## Phase 1: Create the Plan
+
+1. Explore the relevant codebase areas using Glob, Grep, and Read
+2. Understand the current architecture and patterns in use
+3. Create a detailed step-by-step implementation plan that includes:
+   - Specific file paths that need to change
+   - What each change involves
+   - Order of operations (what depends on what)
+   - Database migration needs (if any)
+   - Any new files that need to be created
+
+## Phase 2: Self-Review
+
+After creating the plan, review it critically:
+
+- Are any steps missing?
+- Could any change break existing functionality?
+- Does the plan follow the codebase's established patterns?
+- Are there simpler alternatives?
+- What are the risks?
+
+## Output
+
+Present the final plan with a confidence rating (High/Medium/Low) and any open questions that need human input before proceeding.

--- a/.claude/skills/techdebt/SKILL.md
+++ b/.claude/skills/techdebt/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: techdebt-scan
+description: Comprehensive technical debt scanner. Finds duplicated code, dead code, inconsistent patterns, and cleanup opportunities.
+disable-model-invocation: true
+context: fork
+agent: Explore
+---
+
+Scan the codebase for technical debt. Focus on the most impactful issues.
+
+## What to Look For
+
+1. **Duplicated logic**: Components or functions that do nearly the same thing
+2. **Dead code**: Unused exports, unreachable branches, orphaned files
+3. **Pattern inconsistencies**: Old code not following current conventions
+4. **Large files**: Components over 300 lines that should be split
+5. **TODO/FIXME/HACK**: Collect all with file:line references
+6. **Type safety**: `as any` casts, missing types on public APIs
+7. **Missing error handling**: Unhandled promise rejections, missing catch blocks
+
+## Output Format
+
+Prioritized list grouped by severity:
+- **Critical**: Bugs waiting to happen, security issues
+- **High**: Significant duplication, major pattern violations
+- **Medium**: Code quality issues, missing types
+- **Low**: Style inconsistencies, minor cleanup
+
+Include specific file paths and line numbers for each item.

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ android/app/build
 # Supabase CLI local state
 supabase/.branches/
 supabase/.temp/
+
+# Claude Code local settings (shared settings go in .claude/settings.json)
+.claude/settings.local.json

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# worktree.sh — Manage git worktrees for parallel Claude Code sessions
+#
+# Usage:
+#   ./scripts/worktree.sh create <name> [base-branch]   Create a new worktree
+#   ./scripts/worktree.sh list                           List all worktrees
+#   ./scripts/worktree.sh remove <name>                  Remove a worktree
+#   ./scripts/worktree.sh status                         Show status of all worktrees
+#   ./scripts/worktree.sh clean                          Remove all worktrees except main
+#
+# Examples:
+#   ./scripts/worktree.sh create feature-auth            # branch from current HEAD
+#   ./scripts/worktree.sh create bugfix-123 main         # branch from main
+#   ./scripts/worktree.sh remove feature-auth
+#
+# Worktrees are created as siblings: ../area-tecnica-<name>/
+# Each worktree gets its own node_modules via npm install --legacy-peer-deps
+
+set -euo pipefail
+
+REPO_NAME="area-tecnica"
+PARENT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$PARENT_DIR"
+
+create_worktree() {
+    local name="$1"
+    local base="${2:-HEAD}"
+    local worktree_dir="$(dirname "$REPO_ROOT")/${REPO_NAME}-${name}"
+    local branch_name="wt/${name}"
+
+    if [ -d "$worktree_dir" ]; then
+        echo "Error: Worktree directory already exists: $worktree_dir"
+        exit 1
+    fi
+
+    echo "Creating worktree: $worktree_dir (branch: $branch_name from $base)"
+    git -C "$REPO_ROOT" worktree add -b "$branch_name" "$worktree_dir" "$base"
+
+    echo "Installing dependencies..."
+    (cd "$worktree_dir" && npm install --legacy-peer-deps)
+
+    echo ""
+    echo "Worktree ready. To start working:"
+    echo "  cd $worktree_dir"
+    echo "  claude"
+    echo ""
+    echo "Shell alias (add to ~/.bashrc or ~/.zshrc):"
+    echo "  alias z${name:0:1}='cd $worktree_dir && claude'"
+}
+
+list_worktrees() {
+    echo "Active worktrees:"
+    echo ""
+    git -C "$REPO_ROOT" worktree list
+}
+
+remove_worktree() {
+    local name="$1"
+    local worktree_dir="$(dirname "$REPO_ROOT")/${REPO_NAME}-${name}"
+    local branch_name="wt/${name}"
+
+    if [ ! -d "$worktree_dir" ]; then
+        echo "Error: Worktree not found: $worktree_dir"
+        exit 1
+    fi
+
+    echo "Removing worktree: $worktree_dir"
+    git -C "$REPO_ROOT" worktree remove "$worktree_dir" --force
+
+    # Optionally delete the branch
+    read -p "Delete branch $branch_name? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        git -C "$REPO_ROOT" branch -D "$branch_name" 2>/dev/null || true
+    fi
+
+    echo "Worktree removed."
+}
+
+status_worktrees() {
+    echo "Worktree status:"
+    echo ""
+    git -C "$REPO_ROOT" worktree list --porcelain | while IFS= read -r line; do
+        if [[ "$line" == worktree* ]]; then
+            dir="${line#worktree }"
+            echo "--- $dir ---"
+            if [ -d "$dir" ]; then
+                (cd "$dir" && git status --short 2>/dev/null || echo "  (unable to read)")
+            fi
+            echo ""
+        fi
+    done
+}
+
+clean_worktrees() {
+    echo "This will remove ALL worktrees except the main one."
+    read -p "Are you sure? [y/N] " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Cancelled."
+        exit 0
+    fi
+
+    git -C "$REPO_ROOT" worktree list --porcelain | while IFS= read -r line; do
+        if [[ "$line" == worktree* ]]; then
+            dir="${line#worktree }"
+            if [ "$dir" != "$REPO_ROOT" ]; then
+                echo "Removing: $dir"
+                git -C "$REPO_ROOT" worktree remove "$dir" --force 2>/dev/null || true
+            fi
+        fi
+    done
+
+    git -C "$REPO_ROOT" worktree prune
+    echo "All worktrees cleaned."
+}
+
+# --- Main ---
+case "${1:-help}" in
+    create)
+        [ -z "${2:-}" ] && { echo "Usage: $0 create <name> [base-branch]"; exit 1; }
+        create_worktree "$2" "${3:-HEAD}"
+        ;;
+    list)
+        list_worktrees
+        ;;
+    remove)
+        [ -z "${2:-}" ] && { echo "Usage: $0 remove <name>"; exit 1; }
+        remove_worktree "$2"
+        ;;
+    status)
+        status_worktrees
+        ;;
+    clean)
+        clean_worktrees
+        ;;
+    help|*)
+        echo "Usage: $0 <command> [args]"
+        echo ""
+        echo "Commands:"
+        echo "  create <name> [base]   Create worktree (default base: HEAD)"
+        echo "  list                   List all worktrees"
+        echo "  remove <name>          Remove a worktree"
+        echo "  status                 Show status of all worktrees"
+        echo "  clean                  Remove all worktrees except main"
+        echo ""
+        echo "Worktrees are created at: ../area-tecnica-<name>/"
+        echo "Branches are named: wt/<name>"
+        ;;
+esac


### PR DESCRIPTION
Add git worktree management, slash commands, skills, session notes, and
CLAUDE.md workflow guide to enable parallel Claude Code sessions.

- scripts/worktree.sh: create/list/remove/clean git worktrees
- .claude/commands/: /plan, /review-plan, /fix, /techdebt, /ci-fix, /verify, /update-notes
- .claude/skills/: plan-review (subagent), techdebt-scan (Explore agent)
- .claude/notes/: session knowledge capture directory
- CLAUDE.md: parallel worktrees, plan mode, subagents, prompting patterns, learned rules
- .gitignore: exclude .claude/settings.local.json

https://claude.ai/code/session_01PFf2TN95w4surXXwDBpqUc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Claude Code workflow guides covering planning, implementation, code review, technical debt scanning, and verification procedures.
  * Added session notes documentation and README for tracking decisions and learnings.

* **Chores**
  * Added script for managing parallel development sessions via Git worktrees.
  * Updated .gitignore to exclude local configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->