### PR TITLE
fix: harden critical Supabase ops (no silent failures)

### DIFF
--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -561,7 +561,9 @@ function JobCardNewFull({
         queryClient.invalidateQueries({ queryKey: ['transport-request', job.id, departmentForReq] });
         queryClient.invalidateQueries({ queryKey: ['transport-requests-all', job.id] });
       }
-    } catch { }
+    } catch (err) {
+      console.error('checkAndFulfillRequest failed', err);
+    }
   };
 
   // Manual Flex sync handler

--- a/src/components/logistics/TransportRequestDialog.tsx
+++ b/src/components/logistics/TransportRequestDialog.tsx
@@ -84,8 +84,14 @@ export function TransportRequestDialog({
           .update(payload)
           .eq('id', requestId);
         if (error) throw error;
-        // Replace items
-        await supabase.from('transport_request_items').delete().eq('request_id', requestId);
+
+        // Replace items (do not ignore delete failures)
+        const { error: deleteItemsError } = await supabase
+          .from('transport_request_items')
+          .delete()
+          .eq('request_id', requestId);
+        if (deleteItemsError) throw deleteItemsError;
+
         const toInsert = items
           .filter((it) => !!it.transport_type)
           .map((it) => ({

--- a/src/components/tours/tour-date-management/createFoldersForDate.ts
+++ b/src/components/tours/tour-date-management/createFoldersForDate.ts
@@ -101,13 +101,19 @@ export async function createFoldersForDate(
       const mainFolderResponse = await createFlexFolder(mainFolderPayload);
       const mainFolderElementId = mainFolderResponse.elementId;
 
-      await supabase.from("flex_folders").insert({
-        tour_date_id: dateObj.id,
-        parent_id: parentRow.id,
-        element_id: mainFolderElementId,
-        department: dept,
-        folder_type: "tourdate",
-      });
+      {
+        const { error: insertMainErr } = await supabase.from("flex_folders").insert({
+          tour_date_id: dateObj.id,
+          parent_id: parentRow.id,
+          element_id: mainFolderElementId,
+          department: dept,
+          folder_type: "tourdate",
+        });
+        if (insertMainErr) {
+          console.error('Error inserting main flex_folders row:', insertMainErr);
+          throw insertMainErr;
+        }
+      }
 
       if (dept !== "personnel") {
         const subfolders = [
@@ -144,13 +150,19 @@ export async function createFoldersForDate(
           console.log(`Creating subfolder ${sf.name} for ${dept}:`, subPayload);
           const subResponse = await createFlexFolder(subPayload);
           const subFolderElementId = subResponse.elementId;
-          await supabase.from("flex_folders").insert({
-            tour_date_id: dateObj.id,
-            parent_id: parentRow.id,
-            element_id: subFolderElementId,
-            department: dept,
-            folder_type: "tourdate_subfolder",
-          });
+          {
+            const { error: insertSubErr } = await supabase.from("flex_folders").insert({
+              tour_date_id: dateObj.id,
+              parent_id: parentRow.id,
+              element_id: subFolderElementId,
+              department: dept,
+              folder_type: "tourdate_subfolder",
+            });
+            if (insertSubErr) {
+              console.error('Error inserting flex_folders subfolder row:', insertSubErr);
+              throw insertSubErr;
+            }
+          }
         }
       }
 
@@ -210,13 +222,19 @@ export async function createFoldersForDate(
           console.log(`Creating sound extra subfolder ${sf.name}:`, subPayload);
           const subResponse = await createFlexFolder(subPayload);
           const subFolderElementId = subResponse.elementId;
-          await supabase.from("flex_folders").insert({
-            tour_date_id: dateObj.id,
-            parent_id: parentRow.id,
-            element_id: subFolderElementId,
-            department: dept,
-            folder_type: "tourdate_subfolder",
-          });
+          {
+            const { error: insertSoundSubErr } = await supabase.from("flex_folders").insert({
+              tour_date_id: dateObj.id,
+              parent_id: parentRow.id,
+              element_id: subFolderElementId,
+              department: dept,
+              folder_type: "tourdate_subfolder",
+            });
+            if (insertSoundSubErr) {
+              console.error('Error inserting flex_folders sound subfolder row:', insertSoundSubErr);
+              throw insertSoundSubErr;
+            }
+          }
         }
       }
 
@@ -240,13 +258,19 @@ export async function createFoldersForDate(
           console.log(`Creating personnel subfolder ${sf.name}:`, subPayload);
           const subResponse = await createFlexFolder(subPayload);
           const subFolderElementId = subResponse.elementId;
-          await supabase.from("flex_folders").insert({
-            tour_date_id: dateObj.id,
-            parent_id: parentRow.id,
-            element_id: subFolderElementId,
-            department: dept,
-            folder_type: "tourdate_subfolder",
-          });
+          {
+            const { error: insertPersonnelErr } = await supabase.from("flex_folders").insert({
+              tour_date_id: dateObj.id,
+              parent_id: parentRow.id,
+              element_id: subFolderElementId,
+              department: dept,
+              folder_type: "tourdate_subfolder",
+            });
+            if (insertPersonnelErr) {
+              console.error('Error inserting flex_folders personnel subfolder row:', insertPersonnelErr);
+              throw insertPersonnelErr;
+            }
+          }
         }
         const personnelCrewCall = [
           { name: `Crew Call Sonido - ${tourData.name}`, suffix: "CCS" },
@@ -269,13 +293,19 @@ export async function createFoldersForDate(
           console.log(`Creating personnel crew call subfolder ${sf.name}:`, subPayload);
           const subResponse = await createFlexFolder(subPayload);
           const subFolderElementId = subResponse.elementId;
-          await supabase.from("flex_folders").insert({
-            tour_date_id: dateObj.id,
-            parent_id: parentRow.id,
-            element_id: subFolderElementId,
-            department: dept,
-            folder_type: "tourdate_subfolder",
-          });
+          {
+            const { error: insertCrewCallErr } = await supabase.from("flex_folders").insert({
+              tour_date_id: dateObj.id,
+              parent_id: parentRow.id,
+              element_id: subFolderElementId,
+              department: dept,
+              folder_type: "tourdate_subfolder",
+            });
+            if (insertCrewCallErr) {
+              console.error('Error inserting flex_folders crew call subfolder row:', insertCrewCallErr);
+              throw insertCrewCallErr;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Tech debt audit C1: stop ignoring Supabase errors in critical delete/insert flows.

Changes:
- StockCreationManager: check errors for dependent deletes before deleting equipment.
- TransportRequestDialog: check delete error when replacing items.
- createFoldersForDate: check and throw on flex_folders insert errors (avoids corrupted folder hierarchy).
- JobCardNew: remove empty catch; log error.

Notes:
- Intended as low-risk hardening; no behavioral change on success path.
