### PR TITLE
fix(jobs): harden EditJobDialog job_departments updates

### DIFF
--- a/src/components/jobs/EditJobDialog.tsx
+++ b/src/components/jobs/EditJobDialog.tsx
@@ -205,29 +205,35 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
       if (jobError) throw jobError;
 
       // Update departments
-      const { data: currentDepts } = await supabase
+      const { data: currentDepts, error: currentDeptsError } = await supabase
         .from("job_departments")
         .select("department")
         .eq("job_id", job.id);
 
-      const currentDepartments = currentDepts?.map(d => d.department) || [];
+      if (currentDeptsError) throw currentDeptsError;
+
+      const currentDepartments = currentDepts?.map((d) => d.department) || [];
 
       // Remove deselected departments
-      const toRemove = currentDepartments.filter(dept => !selectedDepartments.includes(dept as Department));
+      const toRemove = currentDepartments.filter(
+        (dept) => !selectedDepartments.includes(dept as Department)
+      );
       if (toRemove.length > 0) {
-        await supabase
+        const { error: deleteDeptError } = await supabase
           .from("job_departments")
           .delete()
           .eq("job_id", job.id)
           .in("department", toRemove);
+        if (deleteDeptError) throw deleteDeptError;
       }
 
       // Add new departments
-      const toAdd = selectedDepartments.filter(dept => !currentDepartments.includes(dept));
+      const toAdd = selectedDepartments.filter((dept) => !currentDepartments.includes(dept));
       if (toAdd.length > 0) {
-        await supabase
+        const { error: insertDeptError } = await supabase
           .from("job_departments")
-          .insert(toAdd.map(department => ({ job_id: job.id, department })));
+          .insert(toAdd.map((department) => ({ job_id: job.id, department })));
+        if (insertDeptError) throw insertDeptError;
       }
 
       // Broadcast push notification about update (summarized changes)


### PR DESCRIPTION
Tech debt audit C1/H7: stop ignoring Supabase errors when updating job_departments.

- Check error for current department fetch.
- Check error for delete of removed departments.
- Check error for insert of added departments.

Build passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when editing jobs with department changes to prevent partial updates and ensure users receive clear feedback if operations encounter errors during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->