### PR TITLE
fix: position FAB button above mobile navbar in Project Management

### DIFF
--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -421,7 +421,7 @@ const ProjectManagement = () => {
           department: selectedDepartment,
           date: currentDate
         })}
-        className="fixed bottom-6 right-6 md:bottom-8 md:right-8
+        className="fixed bottom-20 right-6 md:bottom-8 md:right-8
                    w-12 h-12 md:w-14 md:h-14
                    bg-blue-600 hover:bg-blue-500
                    text-white rounded-full shadow-lg


### PR DESCRIPTION
Changed mobile bottom spacing from bottom-6 (24px) to bottom-20 (80px) to ensure the create job FAB button renders above the mobile navigation bar instead of overlapping it.

Desktop positioning (md:bottom-8) remains unchanged.

https://claude.ai/code/session_015TQQwfz4vW26Mqx2zeqMmj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the floating action button positioning to display higher on the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->