### PR TITLE
fix: ensure CreateJobDialog scrolls on all screen sizes

### DIFF
--- a/src/components/jobs/CreateJobDialog.tsx
+++ b/src/components/jobs/CreateJobDialog.tsx
@@ -304,7 +304,7 @@ export const CreateJobDialog = ({ open, onOpenChange, currentDepartment, initial
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] md:max-h-none md:h-auto overflow-y-auto md:overflow-visible">
+      <DialogContent className="max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Create New Job</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
Remove md: breakpoint overrides (md:max-h-none, md:overflow-visible) that disabled the scroll constraints on desktop. The dialog now maintains max-h-[90vh] with overflow-y-auto across all breakpoints, preventing the submit button from becoming inaccessible when many departments/roles are added.

Fixes #455

https://claude.ai/code/session_013qfBpVprTvRzHXQ3NiWYzT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the job creation dialog to have consistent scrolling behavior across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->