### PR TITLE
fix: include dry-hire jobs in department calendar queries by default

### DIFF
--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -14,7 +14,7 @@ export const useOptimizedJobs = (
   department?: Department,
   startDate?: Date,
   endDate?: Date,
-  includeDryhire: boolean = false
+  includeDryhire: boolean = true
 ) => {
   // Subscribe only to tables that affect this hook's query results
   useMultiTableSubscription([


### PR DESCRIPTION
The useOptimizedJobs hook excluded dry-hire jobs from Supabase queries
by defaulting includeDryhire to false. This caused dry-hire jobs to be
invisible on all department pages (Lights, Video, Operaciones, etc.)
since none of them passed true for this parameter. Only ProjectManagement
explicitly opted in.

Change the default to true so dry-hire jobs are fetched and rendered in
department calendars like any other job type.

https://claude.ai/code/session_018URDDWq6kwtXxqPfarFkjP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dryhire jobs are now included in results by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->