### PR TITLE
fix: move status filtering to client-side so filter boxes work correctly

### DIFF
--- a/src/pages/GlobalTasks.tsx
+++ b/src/pages/GlobalTasks.tsx
@@ -146,9 +146,8 @@ export default function GlobalTasks() {
   const [linkTask, setLinkTask] = React.useState<GlobalTask | null>(null);
 
   const filters: GlobalTaskFilters = {};
-  if (statusFilter && statusFilter !== 'all' && statusFilter !== 'active') {
-    filters.status = statusFilter as GlobalTaskFilters['status'];
-  }
+  // Status filtering is handled entirely client-side so that the `tasks`
+  // array always contains every task and the stats cards stay accurate.
   if (assigneeFilter && assigneeFilter !== 'all') {
     if (assigneeFilter === 'me') {
       filters.assignedTo = userId;
@@ -170,6 +169,8 @@ export default function GlobalTasks() {
     let result = tasks;
     if (statusFilter === 'active') {
       result = result.filter((t) => t.status !== 'completed');
+    } else if (statusFilter && statusFilter !== 'all') {
+      result = result.filter((t) => t.status === statusFilter);
     }
     if (assigneeFilter === 'unassigned') {
       result = result.filter((t) => !t.assigned_to);


### PR DESCRIPTION
Clicking a status filter box (Sin empezar, En progreso, Completadas)
was passing the status to the server-side Supabase query, which narrowed
the `tasks` array to only that status. This broke the stats cards
(they showed counts from the filtered subset instead of all tasks) and
made the page appear empty for statuses with zero matching tasks.

Now status filtering is handled entirely client-side while the hook
always fetches all tasks, keeping stats accurate and filter boxes
functional.

https://claude.ai/code/session_016Wc5F2r3QjPU31GfJFd7su

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized status filtering logic by moving processing to the client-side, reducing server load while maintaining the same filtering behavior for task lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->