### PR TITLE
fix: restructure personnel tab card layout for mobile

### DIFF
--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo } from "react";
-import { format } from "date-fns";
 import { es } from "date-fns/locale";
+import { formatInTimeZone } from "date-fns-tz";
 import { Users } from "lucide-react";
+
+const TZ = "Europe/Madrid";
 
 import { TabsContent } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -130,12 +132,12 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
                         if (dates && dates.size > 0) {
                           const sortedDates = Array.from(dates).sort();
                           if (sortedDates.length === 1) {
-                            return `Solo día: ${format(new Date(sortedDates[0]), "PPP", { locale: es })}`;
+                            return `Solo día: ${formatInTimeZone(sortedDates[0], TZ, "PPP", { locale: es })}`;
                           }
-                          return `Días: ${sortedDates.map((d) => format(new Date(d), "dd/MM")).join(", ")}`;
+                          return `Días: ${sortedDates.map((d) => formatInTimeZone(d, TZ, "dd/MM", { locale: es })).join(", ")}`;
                         }
                         return assignment.assignment_date
-                          ? `Solo día: ${format(new Date(assignment.assignment_date), "PPP", { locale: es })}`
+                          ? `Solo día: ${formatInTimeZone(assignment.assignment_date, TZ, "PPP", { locale: es })}`
                           : "Sin fecha definida";
                       })()}
                     </p>


### PR DESCRIPTION
The crew card layout used a side-by-side flex-row that caused names to
wrap character-by-character and dates to overflow on narrow screens.

Restructured to a vertical layout: avatar on the left with name,
department, role badges, and dates stacking in the remaining space.
This gives the text content full available width instead of competing
with non-shrinkable badge elements.

https://claude.ai/code/session_014kchq5FyPhZLEGpX5QbWtf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Reorganized personnel assignment layout in job details for improved visual clarity and information hierarchy
  * Consolidated avatar display with personnel metadata
  * Enhanced day/date indicators with dynamic labels ("Día único" or "Varios días")
  * Streamlined interface by removing separate date badges
  * Simplified responsive alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->