### PR TITLE
fix: restructure document card layout in DetailsModal Docs tab

### DIFF
--- a/src/components/technician/DetailsModal.tsx
+++ b/src/components/technician/DetailsModal.tsx
@@ -603,35 +603,35 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
                                                             </div>
                                                         )}
                                                     </div>
-                                                    <div className="flex gap-1 shrink-0">
+                                                    <div className="flex gap-3 shrink-0">
                                                         <Button
                                                             variant="outline"
-                                                            size="sm"
+                                                            size="icon"
                                                             onClick={() => handleViewDocument(doc)}
                                                             disabled={documentLoading.has(doc.id)}
-                                                            className="h-8 w-8 p-0"
+                                                            className="h-10 w-10 p-0"
                                                             title={`Ver ${doc.file_name}`}
                                                             aria-label={`Ver ${doc.file_name}`}
                                                         >
                                                             {documentLoading.has(doc.id) ? (
                                                                 <Loader2 className="h-4 w-4 animate-spin" />
                                                             ) : (
-                                                                <Eye size={16} />
+                                                                <Eye size={18} />
                                                             )}
                                                         </Button>
                                                         <Button
                                                             variant="outline"
-                                                            size="sm"
+                                                            size="icon"
                                                             onClick={() => handleDownload(doc)}
                                                             disabled={documentLoading.has(doc.id)}
-                                                            className="h-8 w-8 p-0"
+                                                            className="h-10 w-10 p-0"
                                                             title={`Descargar ${doc.file_name}`}
                                                             aria-label={`Descargar ${doc.file_name}`}
                                                         >
                                                             {documentLoading.has(doc.id) ? (
                                                                 <Loader2 className="h-4 w-4 animate-spin" />
                                                             ) : (
-                                                                <Download size={16} />
+                                                                <Download size={18} />
                                                             )}
                                                         </Button>
                                                     </div>


### PR DESCRIPTION
The document cards used flex-col sm:flex-row layout, but since the
modal is max-w-md (448px), the sm: breakpoint (640px) never activated.
Combined with overflow-hidden on the text section and Radix ScrollArea
viewport wrapping, the Ver/Descargar buttons rendered outside the
clickable area.

Changed to always-horizontal layout with compact icon buttons on the
right side, matching the working pattern in AssignmentCard.

https://claude.ai/code/session_01W41QaWp2wNSm9KYNXMtD7W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Streamlined document card layout in the technician details view with tighter padding and left-aligned content for a more compact presentation.
  * Reworked action controls into small square icon buttons (view/download) with adjusted icon and loader sizing.
  * Consolidated title, date, badges and metadata into a single content block and improved accessibility attributes for action controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->