### PR TITLE
fix: prevent text wrapping on personnel cards in JobDetailsDialog

### DIFF
--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
@@ -115,7 +115,7 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
                     )}
                   </div>
                 </div>
-                <div className="flex flex-wrap gap-1 md:justify-end">
+                <div className="flex flex-wrap gap-1 w-full md:w-auto md:justify-end">
                   {assignment.sound_role && (
                     <Badge variant="outline" className="text-xs">
                       Sonido: {labelForCode(assignment.sound_role)}


### PR DESCRIPTION
The crew card layout used sm: breakpoint (640px) for horizontal layout,
causing badges with shrink-0 to squeeze names into a tiny column on
phones/small tablets. Bumps row layout to md: breakpoint, removes
shrink-0 from badges, and adds min-width to the name section.

https://claude.ai/code/session_01B8yurQz1udetXwZH1YvUCZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for personnel display: reworked medium-and-up alignment and spacing for better visual hierarchy, tightened gaps, introduced a minimum width for avatar row to stabilize avatar/text grouping, and adjusted action area positioning for consistent layout on medium and larger viewports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->