### PR TITLE
fix: honor multi-day assignments in mobile personal calendar

### DIFF
--- a/src/components/personal/MobilePersonalCalendar.tsx
+++ b/src/components/personal/MobilePersonalCalendar.tsx
@@ -73,16 +73,16 @@ export const MobilePersonalCalendar: React.FC<MobilePersonalCalendarProps> = ({
 
   const getAssignmentsForDate = useCallback((targetDate: Date) => {
     return assignments.filter(assignment => {
-      // Check if this is a single-day assignment (legacy/fallback)
-      if (assignment.single_day && assignment.assignment_date) {
-        const assignmentDate = new Date(assignment.assignment_date);
-        return isSameDay(targetDate, assignmentDate);
-      }
-
-      // Check specific dates from timesheets if available
+      // Check specific dates from timesheets FIRST (source of truth)
       if (assignment.dates && assignment.dates.length > 0) {
         const dayString = format(targetDate, 'yyyy-MM-dd');
         return assignment.dates.includes(dayString);
+      }
+
+      // Fallback to single-day assignment check (legacy) only if no timesheet dates exist
+      if (assignment.single_day && assignment.assignment_date) {
+        const assignmentDate = new Date(assignment.assignment_date);
+        return isSameDay(targetDate, assignmentDate);
       }
 
       // No fallback - if there are no specific timesheet dates, don't show the assignment


### PR DESCRIPTION
### Motivation
- The mobile personal calendar was prioritizing legacy single-day `job_assignments` fields over timesheet-derived multi-day dates, causing house techs assigned across multiple dates to only show the "on job" badge for the first date instead of every assigned day.

### Description
- Update `getAssignmentsForDate` in `src/components/personal/MobilePersonalCalendar.tsx` to check `assignment.dates` (timesheet-derived multi-day dates) first and use the `single_day`/`assignment_date` check only as a fallback so multi-day assignments are honored per date.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69898c83bed4832f8cf8a4219fe3ea4c)