### PR TITLE
fix: morning summary matches Personal agenda (timesheets source of truth)

### DIFF
--- a/src/pages/MorningSummary.tsx
+++ b/src/pages/MorningSummary.tsx
@@ -74,9 +74,7 @@ export default function MorningSummary() {
       setLoading(true);
       setError(null);
 
-      const nextDate = new Date(date);
-      nextDate.setDate(nextDate.getDate() + 1);
-      const tomorrowDate = nextDate.toISOString().split('T')[0];
+      // timesheets are per-day; no need to compute tomorrowDate or filter by jobs.start_time
 
       const summaries: MorningSummaryData[] = [];
 
@@ -94,9 +92,7 @@ export default function MorningSummary() {
           .eq('date', date)
           .eq('is_active', true)
           .eq('profiles.department', dept)
-          .eq('profiles.role', 'house_tech')
-          .gte('jobs.start_time', date)
-          .lt('jobs.start_time', tomorrowDate) as { data: TimesheetWithRelations[] | null };
+          .eq('profiles.role', 'house_tech') as { data: TimesheetWithRelations[] | null };
 
         // Get unavailable
       const { data: unavailable } = await supabase


### PR DESCRIPTION
Fixes mismatch where the daily **Morning Summary** push did not match the **Personal agenda** for a given day.

Changes:
- Scheduled push morning summary now queries `timesheets` per-day (`is_active` + `date`) instead of `job_assignments`.
- Removed filtering by `jobs.start_time` for morning summary (multi-day jobs still appear if there's a timesheet for that day).
- MorningSummary page query aligned: also removed `jobs.start_time` date filtering (timesheets already provide the exact work date).

Notes:
- No deployments/migrations included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified timesheet data retrieval to process daily entries without multi-day filtering constraints.
  * Updated query parameters to filter by date, active status, department, and role only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->