### PR TITLE
Fix payout email totals when override is present

### DIFF
--- a/src/components/jobs/PayoutEmailPreview.tsx
+++ b/src/components/jobs/PayoutEmailPreview.tsx
@@ -6,6 +6,7 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { es } from 'date-fns/locale';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { JobPayoutEmailContextResult } from '@/lib/job-payout-email';
+import { effectiveTotal } from '@/lib/job-payout-email';
 import { getInvoicingCompanyDetails } from '@/utils/invoicing-company-data';
 import { HOUSE_TECH_LABEL } from '@/utils/autonomo';
 
@@ -114,13 +115,9 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
     const parts = formatCurrency(selectedAttachment.payout.timesheets_total_eur);
     const extras = formatCurrency(selectedAttachment.payout.extras_total_eur);
 
-    const payoutAny = selectedAttachment.payout as any;
-    const totalBeforeDeduction =
-      payoutAny?.has_override && payoutAny?.override_amount_eur != null
-        ? Number(payoutAny.override_amount_eur)
-        : Number(selectedAttachment.payout.total_eur ?? 0);
-
-    const grand = formatCurrency(totalBeforeDeduction - (selectedAttachment.deduction_eur || 0));
+    const grand = formatCurrency(
+      effectiveTotal(selectedAttachment.payout, selectedAttachment.deduction_eur || 0)
+    );
     const deductionAmount = selectedAttachment.deduction_eur ?? 0;
     const deductionFormatted = formatCurrency(deductionAmount);
     const hasDeduction = deductionAmount > 0;

--- a/src/types/jobExtras.ts
+++ b/src/types/jobExtras.ts
@@ -47,6 +47,14 @@ export interface JobPayoutTotals {
   vehicle_disclaimer: boolean;
   vehicle_disclaimer_text?: string;
   payout_approved?: boolean;
+
+  // Manual payout override metadata (enriched client-side / for exports)
+  has_override?: boolean;
+  override_amount_eur?: number;
+  calculated_total_eur?: number;
+  override_set_at?: string;
+  override_actor_name?: string;
+  override_actor_email?: string;
 }
 
 export const EXTRA_TYPE_LABELS: Record<JobExtraType, string> = {


### PR DESCRIPTION
## Problema
1) El **PDF** ya refleja el override correctamente, pero el cuerpo del email (Totales registrados → Total general) seguía mostrando el total **sin override**.
2) En la **Vista Previa - Correo de Pago**, el formateo de fechas era inconsistente (Intl/toLocale) y en el tab **Datos** aún se usaba `toLocaleDateString`.

## Fix
- Si `has_override && override_amount_eur != null`, el email usa `override_amount_eur` como total (menos deducción si aplica).
- La Vista Previa usa `date-fns-tz` con TZ fija `Europe/Madrid` + locale `es`.
- Tab **Datos** también formatea fechas con `formatInTimeZone`.
- Fallback defensivo si `job.start_time` viene vacío/invalid → "en fecha desconocida".

## Notas
- Build local OK.
- Consolidado: esto reemplaza a la PR #487.

@coderabbit review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for payout amount overrides in email previews and calculations.
  * Improved locale-aware date formatting with fallback text for invalid or missing dates.

* **Bug Fixes**
  * Enhanced date parsing and total payout calculation to gracefully handle edge cases and missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->