### PR TITLE
Allow admin/management access to My Unavailability when assignable_as_tech

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,6 +150,27 @@ const DisponibilidadAccessGuard = () => {
   return <Disponibilidad />;
 };
 
+const TechnicianUnavailabilityAccessGuard = () => {
+  const { userRole, assignableAsTech, isLoading } = useOptimizedAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
+  // House techs always manage their own availability here.
+  if (userRole === 'house_tech') {
+    return <TechnicianUnavailability />;
+  }
+
+  // Admin/management can only access if they are assignable as technician.
+  const isPrivileged = userRole === 'admin' || userRole === 'management';
+  if (isPrivileged && assignableAsTech) {
+    return <TechnicianUnavailability />;
+  }
+
+  return <Navigate to="/dashboard" replace />;
+};
+
 export default function App() {
   // Initialize multi-tab coordinator
   React.useEffect(() => {
@@ -212,7 +233,7 @@ export default function App() {
                               <Route path="/dashboard" element={<ProtectedRoute allowedRoles={['admin', 'management', 'logistics', 'oscar']}><Dashboard /></ProtectedRoute>} />
                               {/* House tech dashboard routes (regular technicians use /tech-app) */}
                               <Route path="/technician-dashboard" element={<ProtectedRoute allowedRoles={['house_tech']}><TechnicianDashboard /></ProtectedRoute>} />
-                              <Route path="/dashboard/unavailability" element={<ProtectedRoute allowedRoles={['house_tech']}><TechnicianUnavailability /></ProtectedRoute>} />
+                              <Route path="/dashboard/unavailability" element={<ProtectedRoute allowedRoles={['house_tech','admin','management']}><TechnicianUnavailabilityAccessGuard /></ProtectedRoute>} />
                               <Route path="/morning-summary" element={<MorningSummary />} />
                               <Route path="/lights" element={<ProtectedRoute allowedRoles={['admin', 'management', 'house_tech']}><Lights /></ProtectedRoute>} />
                               <Route path="/video" element={<ProtectedRoute allowedRoles={['admin', 'management', 'house_tech']}><Video /></ProtectedRoute>} />


### PR DESCRIPTION
## Qué
Extiende el acceso a **Mi disponibilidad** (`/dashboard/unavailability`) a usuarios **management/admin** siempre que tengan `assignable_as_tech = true`.

## Reglas
- `house_tech` → acceso siempre (comportamiento actual)
- `admin|management` → acceso **solo** si `assignableAsTech` (flag de perfil)
- Nadie puede editar disponibilidad de terceros: la página sigue siendo "la suya".

## Implementación
- Añade `TechnicianUnavailabilityAccessGuard` (App.tsx) que aplica el gating por rol + flag.
- Actualiza la route `allowedRoles` para incluir `admin|management` y dejar el resto al guard.

@coderabbit review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced access control for the technician unavailability feature by implementing role-based permission verification that restricts access based on user permissions and redirects unauthorized users to the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->