### PR TITLE
Show 'Mi disponibilidad' in nav for assignable admins

### DIFF
--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -137,10 +137,9 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     mobilePriority: 4,
     mobileSlot: "primary",
     getPath: () => "/dashboard/unavailability",
-    isVisible: ({ userRole, assignableAsTech }) =>
-      userRole === "house_tech" ||
-      (userRole === "admin" && assignableAsTech === true) ||
-      (userRole === "management" && assignableAsTech === true),
+    // For admin/management this can be confused with the department-level "Disponibilidad" page.
+    // Keep it in the main nav only for house_tech; privileged users (assignable) get access via Profile.
+    isVisible: ({ userRole }) => userRole === "house_tech",
     match: (pathname) => pathname === "/dashboard/unavailability",
   },
   {
@@ -511,12 +510,8 @@ export const buildNavigationItems = (
   if (isAdmin) {
     return navigationConfig
       .map((config) => {
-        // Allow limited technician navigation for admins with assignableAsTech flag
-        if (
-          (config.id === "technician-dashboard" ||
-            config.id === "technician-unavailability") &&
-          context.assignableAsTech
-        ) {
+        // Allow technician-dashboard for admins with assignableAsTech flag
+        if (config.id === "technician-dashboard" && context.assignableAsTech) {
           return createNavigationItem(config)
         }
         if (adminExcludedIds.has(config.id)) {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -10,7 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Department, ALL_DEPARTMENTS, DEPARTMENT_LABELS, getDepartmentLabel } from "@/types/department";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Loader2, Save, UserCircle, AlertTriangle, Calendar as CalendarIcon, RefreshCcw, Shield, ExternalLink, Trophy } from "lucide-react";
+import { Loader2, Save, UserCircle, AlertTriangle, Calendar as CalendarIcon, CalendarCheck, RefreshCcw, Shield, ExternalLink, Trophy } from "lucide-react";
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/api-config";
 import { FolderStructureEditor, type FolderStructure } from "@/components/profile/FolderStructureEditor";
 import { ProfilePictureUpload } from "@/components/profile/ProfilePictureUpload";
@@ -55,6 +55,9 @@ export const Profile = () => {
   const isBlocked = permission === 'denied';
   const showPushControls = ['technician', 'house_tech', 'oscar'].includes(profile?.role);
   const showIcsCard = ['technician', 'house_tech', 'management', 'admin'].includes(profile?.role);
+  const showTechnicianSelfTools =
+    (profile?.role === 'admin' || profile?.role === 'management') &&
+    profile?.assignable_as_tech === true;
 
   // Fetch user profile on component mount
   useEffect(() => {
@@ -520,6 +523,32 @@ export const Profile = () => {
                     Ver mis logros
                   </Button>
                 </Link>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Technician self tools (assignable admin/management) */}
+          {showTechnicianSelfTools && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <CalendarCheck className="h-5 w-5" />
+                  Herramientas de técnico
+                </CardTitle>
+                <CardDescription>
+                  Accesos personales (no confundir con la Disponibilidad del departamento).
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <Link to="/dashboard/unavailability">
+                  <Button className="w-full" variant="outline">
+                    <CalendarCheck className="mr-2 h-4 w-4" />
+                    Mi disponibilidad
+                  </Button>
+                </Link>
+                <p className="text-xs text-muted-foreground">
+                  Solo afecta a tu usuario.
+                </p>
               </CardContent>
             </Card>
           )}


### PR DESCRIPTION
## Problema
Admins/management con `assignable_as_tech=true` ya pueden acceder a `/dashboard/unavailability`, pero **no aparece en la navegación** porque los items técnicos están excluidos para admin y el menú no tenía un item específico.

## Fix
- Añade item de navegación **"Mi disponibilidad"** → `/dashboard/unavailability`.
- Visible para:
  - `house_tech`
  - `admin|management` cuando `assignableAsTech === true`
- En modo admin, se permite este item junto a `technician-dashboard` cuando `assignableAsTech`.

@coderabbit review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "My Availability" navigation option in the sidebar that enables technicians to manage their scheduling preferences, update availability status, and coordinate their work schedules directly from the dashboard interface.
  * Enhanced navigation menu structure to provide streamlined access to availability management features for authorized technician and administrative users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->