### PR TITLE
Docs: README overhaul + documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,84 @@
-# Area Tecnica
+# Área Técnica (Sector Pro)
 
-**Production URL:** https://sector-pro.work
+**Production:** https://sector-pro.work
 
-Area Tecnica is Sector Pro’s technical operations platform for live events, festivals, tours, logistics, and crew workflows. It ships as a PWA and a Capacitor-wrapped iOS/Android app.
+Área Técnica is Sector Pro’s technical operations platform for live events, festivals and tours. It consolidates workflows that normally live in spreadsheets, emails, WhatsApp and external tools into a single **mobile‑first PWA** (also shipped as **iOS/Android apps via Capacitor**).
 
-## Release Notes
-- Latest changes are tracked in `CHANGELOG.md` (append-only).
-- For deployment notes, tag the PR with the release date and include the preview URL.
+---
 
-## Stack
+## Who is it for? (roles)
+- **Admin / Management:** planning, staffing, approvals, documentation, communications
+- **Logistics:** logistics workflows and expenses
+- **House Techs:** technician dashboard + availability/unavailability
+- **Technicians:** mobile Tech App for assignments, documents, timesheets and messaging
+- **Wallboard users:** digital signage / operational dashboards
+
+Roles in the system: `admin`, `management`, `logistics`, `technician`, `house_tech`, `wallboard`, `oscar`.
+
+---
+
+## Key capabilities (high level)
+- **Jobs / Projects:** job lifecycle, departments, documents, status and ops tooling
+- **Tours:** dates, crew assignments, presets, logistics, scheduling, docs, rate tooling
+- **Festivals:** festival management, artist intake (public tokenized forms), riders/docs, scheduling, gear planning
+- **Staffing matrix:** crew assignment matrix + conflict tooling
+- **Hoja de Ruta (Roadmap / Day Sheet):** structured event sheet with **PDF/XLS exports**, plus weather & restaurant utilities
+- **Global Tasks:** cross‑department task system with assignees, due dates, attachments, linking to jobs/tours
+- **Timesheets & Rates Center:** rates/extras, overrides, approvals, payout summaries
+- **Technician App (`/tech-app`):** mobile UI for assignments, docs, messages, availability and timesheets
+- **Wallboard (`/wallboard`):** configurable signage presets + **public tokenized access**
+- **SoundVision library:** Mapbox-based venue map, uploads, ratings/reviews, access workflow
+- **Communications:** web/native push notifications, WhatsApp group/message automation, corporate email automation
+- **Integrations:** Flex Rental Solutions (folders, crew sync, work orders), technician **ICS calendars**
+
+---
+
+## Screenshots
+A curated gallery lives in `docs/screenshots/`.
+
+- Dashboard
+  - ![Dashboard](docs/screenshots/dashboard.png)
+- Festival Management
+  - ![Festival Management](docs/screenshots/festival-management.png)
+- Tour Management
+  - ![Tour Management](docs/screenshots/tour-management.png)
+- Hoja de Ruta / Day Sheet
+  - ![Day Sheet](docs/screenshots/day-sheet.png)
+- Technician experience
+  - ![Freelancer Portal](docs/screenshots/freelancer-portal.png)
+- Crew Assignment Matrix
+  - ![Crew Assignment Matrix](docs/screenshots/crew-assignment-matrix.png)
+- Technical tools
+  - ![Technical Tools](docs/screenshots/technical-tools.png)
+- Digital signage
+  - ![Digital Signage](docs/screenshots/digital-signage.png)
+
+---
+
+## Tech stack
 - React 18 + TypeScript
 - Vite 6
 - Tailwind + shadcn/ui
-- React Query
+- TanStack React Query
 - Supabase (Auth, DB, Storage, Edge Functions)
 - Capacitor (iOS/Android wrapper)
 
-## Project Structure
-```
-src/
-├── components/     # UI components (inventory, wireless configs)
-├── integrations/   # Supabase client
-├── types/          # TypeScript definitions
-└── pages/          # Routes
-```
+---
 
-## Local Development
+## Local development
 ```bash
 npm install --legacy-peer-deps
 npm run dev
+# http://localhost:8080
 ```
-- Dev server: http://localhost:8080
-- Env vars (Cloudflare):
-  - `VITE_SUPABASE_URL`
-  - `VITE_SUPABASE_ANON_KEY`
-  - `VITE_VAPID_PUBLIC_KEY` (web push)
+
+Environment variables (Cloudflare):
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+- `VITE_SUPABASE_FUNCTIONS_URL` (if applicable)
+- `VITE_VAPID_PUBLIC_KEY` (web push)
+
+---
 
 ## Mobile (Capacitor)
 ```bash
@@ -42,60 +86,14 @@ npm run cap:ios
 npm run cap:android
 ```
 
-## Push Notifications
-- **Web/PWA:** uses Service Worker + VAPID keys.
-- **iOS (Capacitor):** uses APNs with device tokens stored server-side.
-  - Required Supabase Edge Function secrets:
-    - `APNS_AUTH_KEY` (APNs .p8 contents)
-    - `APNS_KEY_ID`
-    - `APNS_TEAM_ID`
-    - `APNS_BUNDLE_ID`
-    - `APNS_ENV` (`sandbox` or `production`)
-  - Without APNs configured, iOS native push is skipped.
+---
 
-## Screenshots
-### Dashboard
-![Dashboard](docs/screenshots/dashboard.png)
+## Documentation
+Start here: **`docs/README.md`** (index of product/ops/engineering docs).
 
-### Festival Management
-![Festival Management](docs/screenshots/festival-management.png)
+---
 
-### Tour Management
-![Tour Management](docs/screenshots/tour-management.png)
-
-### Day Sheet
-![Day Sheet](docs/screenshots/day-sheet.png)
-
-### Freelancer Portal
-![Freelancer Portal](docs/screenshots/freelancer-portal.png)
-
-### Crew Assignment Matrix
-![Crew Assignment Matrix](docs/screenshots/crew-assignment-matrix.png)
-
-### Technical Tools
-![Technical Tools](docs/screenshots/technical-tools.png)
-
-### Digital Signage
-![Digital Signage](docs/screenshots/digital-signage.png)
-
-## Build & Deploy (Cloudflare Pages)
-```bash
-npm install --legacy-peer-deps && npm run build
-```
-- Output: `dist/`
-- `vite.config.ts` base must remain `/`
-- Do not add `package-lock.json` to the repo
-
-## Workflow
-```bash
-git checkout dev
-# make changes
-git commit -m "feat: description"
-git push origin dev
-# Create PR → merge to main when approved
-```
-
-## Notes
+## Notes / constraints
 - Maintain compatibility with the existing Supabase schema.
 - date-fns must remain at `^3.6.0`.
-- Vite is pinned to `^6.3.3`.
+- Vite is pinned (see `package.json`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,55 @@
+# Área Técnica — Documentation Index
+
+This folder currently contains a mix of:
+- product notes,
+- engineering audits,
+- ops runbooks,
+- and long-form plans.
+
+This index helps you find what you need without having to remember filenames.
+
+## Product / workflows
+- **SoundVision access workflow**
+  - `SOUNDVISION_ACCESS_CHANGES.md`
+  - `soundvision-access-workflow.md`
+  - `soundvision-access-test-cases.md`
+- **Wallboard (tokenized/public access)**
+  - `WALLBOARD_TOKENIZED_ACCESS.md`
+  - `WALLBOARD_STATUS.md`
+  - `WALLBOARD_PRESET_DEBUG.md`
+
+## Operations
+- **Push notifications**
+  - `PUSH_NOTIFICATIONS_SUMMARY.md`
+  - `PUSH_NOTIFICATIONS_IMPLEMENTATION_SUMMARY.md`
+  - `push-subscription-recovery.md`
+  - `pwa-push-credentials.md`
+  - `pwa-service-worker-cache-control.md`
+- **Timesheets reminders / deployment notes**
+  - `DEPLOY_TIMESHEET_REMINDER.md`
+
+## Engineering / audits / deep dives
+- **Job Assignment Matrix audit**
+  - `AUDIT_REPORT_JOB_ASSIGNMENT_MATRIX.md`
+  - `JOB_ASSIGNMENTS_SYSTEM_AUDIT.md`
+  - `FINAL_DEEP_AUDIT_REPORT.md`
+  - `ULTRA_DEEP_AUDIT_AND_WORKFLOWS.md`
+- **Performance**
+  - `PERFORMANCE_AUDIT.md`
+  - `PERFORMANCE_AUDIT_REPORT.md`
+
+## Plans / Roadmaps
+- `plans/` (grouped plans)
+- `migrations/` (migration notes)
+
+## Screenshots
+- `screenshots/` (README gallery images)
+
+---
+
+## Next documentation upgrades (planned)
+- Rewrite root README to reflect the full product surface.
+- Add a bilingual **in-app user manual** (ES/EN) with updated screenshots.
+- Create structured folders:
+  - `docs/product/`, `docs/operations/`, `docs/engineering/`, `docs/user-manual/`
+  while keeping the existing documents (we can migrate incrementally).


### PR DESCRIPTION
## Qué
Mejora la documentación base del repo:
- README más orientado a producto (roles + capacidades) para reflejar el alcance real de la plataforma.
- Añade `docs/README.md` como índice para navegar la documentación existente (sin mover nada todavía).

## Qué NO hace (todavía)
- No actualiza el manual in-app (/manual).
- No añade screenshots nuevos (solo organiza y referencia los existentes).

## Siguiente PR
- Manual bilingüe ES/EN en la app + screenshots actualizados.

@coderabbit review
