### PR TITLE
JobCard: celebration animation for Andrea wedding job

### DIFF
--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -241,6 +241,7 @@ export function JobCardNewView({
   const [celebrateSeed, setCelebrateSeed] = React.useState(0);
   const lastCelebrateAtRef = React.useRef(0);
 
+  /** Trigger a celebratory confetti burst on actionable interactions (wedding job only). */
   const handleCelebrateCapture = React.useCallback((e: React.MouseEvent) => {
     if (!isAndreaWeddingJob) return;
     if (reducedMotion) return;

--- a/src/components/ui/celebration/ConfettiBurst.tsx
+++ b/src/components/ui/celebration/ConfettiBurst.tsx
@@ -21,6 +21,10 @@ type Piece = {
   emoji?: string;
 };
 
+/**
+ * Small, fast seeded PRNG so confetti patterns are deterministic per burst.
+ * (Not crypto-safe.)
+ */
 function mulberry32(a: number) {
   let t = a >>> 0;
   return () => {
@@ -34,6 +38,11 @@ function mulberry32(a: number) {
 const COLORS = ['#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7', '#ec4899'];
 const BALLOONS = ['🎈', '🎉'];
 
+/**
+ * Full-screen, short-lived confetti/balloon burst overlay.
+ *
+ * Intended to be rendered via a portal (document.body) so it appears above dialogs.
+ */
 export function ConfettiBurst({ seed, ttlMs = 1600 }: ConfettiBurstProps) {
   const reducedMotion = useReducedMotion();
   const [alive, setAlive] = React.useState(true);


### PR DESCRIPTION
Adds a small confetti/balloon burst animation on user interactions within the JobCard for Andrea's wedding job.

- Scoped ONLY to job id: `eeb00e4d-7d38-4687-9d04-31471b89adfc`
- Triggered via `onClickCapture` on actionable elements (buttons/links/checkbox/radio/select)
- Throttled to avoid spam (700ms)
- Respects `prefers-reduced-motion` via `useReducedMotion`

Implementation:
- `ConfettiBurst` component (framer-motion) with auto-unmount TTL
- Wired into `JobCardNewView`.

NOTE: This is intentionally an "easter egg"-style UX request; if we want it configurable (DB flag) later, we can follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a celebratory confetti animation that triggers on user interactions with job cards. The effect respects accessibility preferences, including reduced motion settings for users who prefer minimal animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->