### PR TITLE
JobCard wedding confetti: stronger, burst at click

### DIFF
--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -239,6 +239,7 @@ export function JobCardNewView({
   const reducedMotion = useReducedMotion();
   const isAndreaWeddingJob = job?.id === "eeb00e4d-7d38-4687-9d04-31471b89adfc";
   const [celebrateSeed, setCelebrateSeed] = React.useState(0);
+  const [celebrateOrigin, setCelebrateOrigin] = React.useState<{ xPct: number; yPct: number } | null>(null);
   const lastCelebrateAtRef = React.useRef(0);
 
   /** Trigger a celebratory confetti burst on actionable interactions (wedding job only). */
@@ -258,6 +259,11 @@ export function JobCardNewView({
     const now = Date.now();
     if (now - lastCelebrateAtRef.current < 700) return; // throttle
     lastCelebrateAtRef.current = now;
+
+    // Origin near the click so the effect is obvious (and not always from the top).
+    const xPct = (e.clientX / Math.max(1, window.innerWidth)) * 100;
+    const yPct = (e.clientY / Math.max(1, window.innerHeight)) * 100;
+    setCelebrateOrigin({ xPct, yPct });
 
     setCelebrateSeed((s) => (s + 1) % 1_000_000);
   }, [isAndreaWeddingJob, reducedMotion]);
@@ -281,7 +287,15 @@ export function JobCardNewView({
         }}
       >
         {isAndreaWeddingJob && celebrateSeed > 0 && typeof document !== 'undefined' && (
-          createPortal(<ConfettiBurst key={celebrateSeed} seed={celebrateSeed} />, document.body)
+          createPortal(
+            <ConfettiBurst
+              key={celebrateSeed}
+              seed={celebrateSeed}
+              origin={celebrateOrigin ?? undefined}
+              ttlMs={2400}
+            />,
+            document.body
+          )
         )}
 
         {isJobBeingDeleted && (


### PR DESCRIPTION
Follow-up to #500: make the wedding JobCard celebration effect more obvious.

Changes
- Confetti burst now originates near the click position (so it’s visible even when a modal opens).
- Increased particle count and sizes, longer TTL.
- Still scoped to job id `eeb00e4d-7d38-4687-9d04-31471b89adfc` and respects `prefers-reduced-motion`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Enhanced confetti celebration effects: confetti now originates from click locations with improved animations, increased particle density, and extended animation duration for more impactful celebrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->