### PR TITLE
fix: wait for profile loading before making routing decisions

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -9,13 +9,17 @@ interface ProtectedRouteProps {
   allowedRoles: UserRole[];
 }
 
-export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ 
-  children, 
-  allowedRoles 
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  children,
+  allowedRoles
 }) => {
-  const { userRole, isLoading } = useOptimizedAuth();
+  const { userRole, isLoading, isProfileLoading } = useOptimizedAuth();
 
-  if (isLoading) {
+  // Wait for both session and profile to finish loading before making
+  // routing decisions. Without this, userRole can be null while the
+  // profile is still being fetched from the network (cache miss),
+  // causing a premature redirect to /profile.
+  if (isLoading || isProfileLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 dark:border-white" />

--- a/src/routes/AuthenticatedShell.tsx
+++ b/src/routes/AuthenticatedShell.tsx
@@ -15,12 +15,12 @@ function ActivityPushFallbackInit() {
 // Redirect 'technician' role to /tech-app (house_tech can access Layout routes).
 // Allow-list a small set of technician-accessible routes outside /tech-app (e.g. tools like SysCalc).
 function TechnicianRouteGuard() {
-  const { userRole, isLoading } = useOptimizedAuth();
+  const { userRole, isLoading, isProfileLoading } = useOptimizedAuth();
   const location = useLocation();
   const navigate = useNavigate();
 
   React.useEffect(() => {
-    if (isLoading) return;
+    if (isLoading || isProfileLoading) return;
     if (userRole !== "technician") return;
     const isAllowedTechnicianRoute =
       location.pathname === "/tech-app" ||
@@ -34,18 +34,18 @@ function TechnicianRouteGuard() {
     }
 
     navigate("/tech-app", { replace: true });
-  }, [userRole, isLoading, location.pathname, navigate]);
+  }, [userRole, isLoading, isProfileLoading, location.pathname, navigate]);
 
   return null;
 }
 
 function OscarRouteGuard() {
-  const { userRole, isLoading } = useOptimizedAuth();
+  const { userRole, isLoading, isProfileLoading } = useOptimizedAuth();
   const location = useLocation();
   const navigate = useNavigate();
 
   React.useEffect(() => {
-    if (isLoading) return;
+    if (isLoading || isProfileLoading) return;
     if (userRole !== "oscar") return;
 
     const isAllowedOscarRoute =
@@ -60,7 +60,7 @@ function OscarRouteGuard() {
     }
 
     navigate("/dashboard", { replace: true });
-  }, [userRole, isLoading, location.pathname, navigate]);
+  }, [userRole, isLoading, isProfileLoading, location.pathname, navigate]);
 
   return null;
 }


### PR DESCRIPTION
ProtectedRoute and route guards (TechnicianRouteGuard, OscarRouteGuard)
were only checking isLoading (session) but not isProfileLoading. When
the 30-minute profile cache expired, fetchUserProfile() ran as a
background network request. During this window, userRole was null,
causing ProtectedRoute to redirect technicians to /profile instead of
allowing /tech-app — making the account appear "empty".

Now all three components check isProfileLoading alongside isLoading,
showing a spinner until the profile (and role) has been resolved.

https://claude.ai/code/session_018dnfutgGZ1YBnuRFWqg5hZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication flow to wait for profile data to fully load before processing route redirects, ensuring more reliable user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->