### PR TITLE
feat: add photo upload to incident reports with improved PDF layout

### DIFF
--- a/src/utils/incident-report/photo-utils.ts
+++ b/src/utils/incident-report/photo-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Photo optimization utilities for incident reports
+ */
+
+export const MAX_PHOTOS = 6;
+export const MAX_PHOTO_SIZE_MB = 10;
+export const OPTIMIZED_MAX_DIMENSION = 1600;
+export const OPTIMIZED_QUALITY = 0.85;
+
+/**
+ * Optimizes a photo file for PDF inclusion by resizing and compressing to JPEG
+ * @param file - The photo file to optimize
+ * @param maxDimension - Maximum width or height in pixels
+ * @param quality - JPEG quality (0-1)
+ * @returns Promise resolving to a base64 data URL
+ */
+export function optimizePhotoForPDF(file: File, maxDimension: number, quality: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onload = () => {
+        let { width, height } = img;
+        if (width > maxDimension || height > maxDimension) {
+          if (width > height) {
+            height = Math.round(height * (maxDimension / width));
+            width = maxDimension;
+          } else {
+            width = Math.round(width * (maxDimension / height));
+            height = maxDimension;
+          }
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) { reject(new Error('No canvas context')); return; }
+        ctx.imageSmoothingEnabled = true;
+        ctx.imageSmoothingQuality = 'high';
+        ctx.drawImage(img, 0, 0, width, height);
+        resolve(canvas.toDataURL('image/jpeg', quality));
+      };
+      img.onerror = () => reject(new Error('Failed to load image'));
+      img.src = e.target?.result as string;
+    };
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}


### PR DESCRIPTION
- Add photo upload capability (up to 4 photos) to both the technician
  incident report dialog and the sound department incident report form
- Photos are optimized client-side (resized to 1200px max, JPEG 80%)
  before embedding in the PDF
- PDF generator now includes a "EVIDENCIA FOTOGRÁFICA" section that
  renders uploaded photos in a 2-column grid with labels
- Improved PDF styling: section headers with red accent bars, content
  boxes with subtle backgrounds, metadata bar below header, page
  numbers on every page footer
- Mobile-friendly: camera capture attribute on file input for direct
  photo taking on devices

https://claude.ai/code/session_014zC5UarTSK4Qiiu7ypoKC6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Photo upload for incident reports with client-side optimization, photo limits, and inclusion in exported PDFs
  * Enhanced PDF export: evidence photo grid, redesigned header/sections, localized dates, persistent footer/logo and timestamped filename
* **UI Enhancements**
  * Photo thumbnail grid with remove controls, add-photos flow, and camera icon
  * Processing/loading indicators during photo handling and PDF generation; responsive modal/layout refinements
* **Validation**
  * Form validation updated to require signature and account for photos
<!-- end of auto-generated comment: release notes by coderabbit.ai -->