### PR TITLE
fix: use standard Supabase auth pattern in send-job-payout-email edge function

### DIFF
--- a/supabase/functions/send-job-payout-email/index.ts
+++ b/supabase/functions/send-job-payout-email/index.ts
@@ -2,8 +2,14 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { getInvoicingCompanyDetails } from "../_shared/invoicing-company-data.ts";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  throw new Error(
+    "Missing required environment variables: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY"
+  );
+}
 
 const corsHeaders: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
The auth check added during recent refactors used SERVICE_ROLE_KEY as the
apikey for auth.getUser(token), which is non-standard and causes 403 errors.

Changes:
- Use SUPABASE_ANON_KEY for auth verification (standard edge function pattern)
- Call getUser() without explicit token (relies on Authorization header)
- Reuse single supabaseAdmin client for all DB queries instead of creating
  multiple clients
- Add diagnostic logging for auth/profile lookup failures

https://claude.ai/code/session_01QWCMq9Wrv3KFhHqAwyJUhN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and error logging for job payout email operations, reducing failed sends and easing troubleshooting.

* **Chores**
  * Streamlined backend access for payout data, improving consistency of payout information used in emails and tightening overall security handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->