### PR TITLE
fix: allow management/logistics/admin roles in replace_hoja_de_ruta_all RPC

### DIFF
--- a/supabase/migrations/20260218193000_fix_hoja_de_ruta_replace_rpcs_authorization.sql
+++ b/supabase/migrations/20260218193000_fix_hoja_de_ruta_replace_rpcs_authorization.sql
@@ -1,0 +1,38 @@
+-- Allow management/logistics/admin roles to atomically replace hoja de ruta child data.
+-- Previous check only allowed creator/approver, which blocked valid editors under RLS.
+
+create or replace function public.replace_hoja_de_ruta_all(
+  p_hoja_de_ruta_id uuid,
+  p_transport_rows jsonb,
+  p_contact_rows jsonb,
+  p_staff_rows jsonb
+)
+returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_role text;
+begin
+  if auth.role() <> 'service_role' then
+    v_role := public.get_current_user_role();
+
+    if coalesce(v_role, '') not in ('admin', 'management', 'logistics') then
+      if not exists (
+        select 1
+        from public.hoja_de_ruta h
+        where h.id = p_hoja_de_ruta_id
+          and (h.created_by = auth.uid() or h.approved_by = auth.uid())
+      ) then
+        raise exception 'Not authorized to replace this hoja de ruta''s child data'
+          using errcode = '42501';
+      end if;
+    end if;
+  end if;
+
+  perform public.replace_hoja_de_ruta_transport(p_hoja_de_ruta_id, p_transport_rows);
+  perform public.replace_hoja_de_ruta_contacts(p_hoja_de_ruta_id, p_contact_rows);
+  perform public.replace_hoja_de_ruta_staff(p_hoja_de_ruta_id, p_staff_rows);
+end;
+$$;


### PR DESCRIPTION
### Motivation
- The atomic replacement RPC `replace_hoja_de_ruta_all` raised `42501` (`Not authorized to replace this hoja de ruta's child data`) for valid operational users because the guard only allowed `service_role` or the row `created_by`/`approved_by` users.

### Description
- Added migration `supabase/migrations/20260218193000_fix_hoja_de_ruta_replace_rpcs_authorization.sql` that updates `public.replace_hoja_de_ruta_all(...)` to consult `public.get_current_user_role()` and allow roles `admin`, `management`, and `logistics` to proceed.
- The function keeps the `service_role` bypass and retains the fallback owner/approver check for other authenticated users, and still raises `ERRCODE '42501'` when unauthorized.
- The RPC continues to call the existing helper functions `replace_hoja_de_ruta_transport`, `replace_hoja_de_ruta_contacts`, and `replace_hoja_de_ruta_staff` to perform the atomic replacement.

### Testing
- Verified occurrences with `rg -n "Not authorized to replace this hoja de ruta's child data|42501" -S` which returned the RPC and migration locations (success).
- Reviewed the new migration with `sed`/`nl` to confirm the updated authorization logic (success).
- Added and committed the migration with `git add`/`git commit` and created the follow-up PR via the repository tooling, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f0f758d0832fadd16a2031eb868d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization controls for route management with stricter role-based access validation. Only users with appropriate roles can now modify route data.
  * Improved data consistency through atomic operations. Route information updates are now processed as a single, reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->