### PR TITLE
fix: run replace_hoja_de_ruta_all as SECURITY DEFINER to resolve 42501

### DIFF
--- a/supabase/migrations/20260218193000_fix_replace_hoja_de_ruta_all_execute_permissions.sql
+++ b/supabase/migrations/20260218193000_fix_replace_hoja_de_ruta_all_execute_permissions.sql
@@ -1,0 +1,10 @@
+-- Ensure authenticated callers can execute replace_hoja_de_ruta_all without needing
+-- direct EXECUTE permissions on internal helper functions.
+
+alter function public.replace_hoja_de_ruta_all(uuid, jsonb, jsonb, jsonb)
+  security definer
+  set search_path = public;
+
+revoke execute on function public.replace_hoja_de_ruta_all(uuid, jsonb, jsonb, jsonb) from public, anon;
+grant execute on function public.replace_hoja_de_ruta_all(uuid, jsonb, jsonb, jsonb) to authenticated;
+grant execute on function public.replace_hoja_de_ruta_all(uuid, jsonb, jsonb, jsonb) to service_role;


### PR DESCRIPTION
### Motivation
- Fix the `42501 permission denied for function replace_hoja_de_ruta_transport` error that occurs when calling the top-level RPC which orchestrates helper functions whose direct `EXECUTE` was revoked. 

### Description
- Altered `public.replace_hoja_de_ruta_all(uuid, jsonb, jsonb, jsonb)` to run as `SECURITY DEFINER` and set `search_path = public` so the orchestration RPC can call internal helper functions without callers needing direct `EXECUTE` on them. 
- Kept execution scope tight by revoking `EXECUTE` from `public`/`anon` and granting `EXECUTE` only to `authenticated` and `service_role`. 
- Added a new migration file `supabase/migrations/20260218193000_fix_replace_hoja_de_ruta_all_execute_permissions.sql` containing the changes and committed it to the branch. 

### Testing
- Inspected the original RPC definitions with `sed -n '1,260p' supabase/migrations/20260218180000_atomic_hoja_de_ruta_replace_rpcs.sql` to confirm helper functions and permission revokes, and the command completed successfully. 
- Verified the new migration contents with `sed -n '1,200p' supabase/migrations/20260218193000_fix_replace_hoja_de_ruta_all_execute_permissions.sql`, and the output matched the intended changes. 
- Created and committed the migration (`git add` + `git commit`) which succeeded, producing a new migration file in the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f0f758d0832fadd16a2031eb868d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security settings and access permissions for backend operations to restrict execution to authenticated users and service processes only, while removing public and anonymous access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->