### PR TITLE
feat: add haptic feedback across mobile interface using web-haptics

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
+    "web-haptics": "^0.0.6",
     "ws": "^8.18.3",
     "zod": "^3.23.8",
     "zustand": "^5.0.5"

--- a/src/components/dashboard/MobileDayCalendar.tsx
+++ b/src/components/dashboard/MobileDayCalendar.tsx
@@ -51,6 +51,7 @@ import {
 import { formatInJobTimezone, isJobOnDate } from "@/utils/timezoneUtils";
 import { useMobileDayCalendarSubscriptions } from "@/hooks/useMobileRealtimeSubscriptions";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useHaptics } from "@/hooks/useHaptics";
 
 interface MobileDayCalendarProps {
   date: Date | undefined;
@@ -100,6 +101,7 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
 }) => {
   const [currentDate, setCurrentDate] = useState(date);
   const queryClient = useQueryClient();
+  const { trigger: haptic } = useHaptics();
   
   // Set up realtime subscriptions for all mobile calendar data
   useMobileDayCalendarSubscriptions();
@@ -194,18 +196,21 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
   };
 
   const navigateToPrevious = () => {
+    haptic("light");
     const previousDay = subDays(currentDate, 1);
     setCurrentDate(previousDay);
     onDateSelect(previousDay);
   };
 
   const navigateToNext = () => {
+    haptic("light");
     const nextDay = addDays(currentDate, 1);
     setCurrentDate(nextDay);
     onDateSelect(nextDay);
   };
 
   const navigateToToday = () => {
+    haptic("medium");
     const today = new Date();
     setCurrentDate(today);
     onDateSelect(today);

--- a/src/components/dashboard/MobileJobCard.tsx
+++ b/src/components/dashboard/MobileJobCard.tsx
@@ -42,6 +42,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { openFlexElement } from "@/utils/flex-folders";
 import { isFestivalLikeJobType } from "@/utils/jobType";
 import { DateType, DATE_TYPE_OPTIONS, getDateTypeMeta } from "@/constants/dateTypes";
+import { useHaptics } from "@/hooks/useHaptics";
 
 interface MobileJobCardProps {
   job: any;
@@ -68,6 +69,7 @@ export function MobileJobCard({
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { userRole } = useOptimizedAuth();
+  const { trigger: haptic } = useHaptics();
   const [dateTypeDialogOpen, setDateTypeDialogOpen] = useState(false);
   const [selectedDateType, setSelectedDateType] = useState<DateType>('show');
   const [jobDetailsDialogOpen, setJobDetailsDialogOpen] = useState(false);
@@ -141,8 +143,9 @@ export function MobileJobCard({
     if (isHouseTech || isJobBeingDeleted) {
       return;
     }
-    
+
     if (userRole !== "logistics" && onJobClick) {
+      haptic("light");
       onJobClick(job.id);
     }
   };
@@ -175,6 +178,7 @@ export function MobileJobCard({
 
       if (error) throw error;
 
+      haptic("success");
       toast({
         title: "Date type updated",
         description: `Set to ${DATE_TYPE_OPTIONS.find(opt => opt.value === newType)?.label}`
@@ -191,6 +195,7 @@ export function MobileJobCard({
       }
     } catch (error: any) {
       console.error('Error updating date type:', error);
+      haptic("error");
       toast({
         title: "Error",
         description: "Failed to update date type",

--- a/src/components/disponibilidad/MobileAvailabilityView.tsx
+++ b/src/components/disponibilidad/MobileAvailabilityView.tsx
@@ -12,6 +12,7 @@ import { SubRentalDialog } from '@/components/equipment/SubRentalDialog';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { useTechnicianTheme } from '@/hooks/useTechnicianTheme';
+import { useHaptics } from '@/hooks/useHaptics';
 
 type DisponibilidadDepartment = 'sound' | 'lights';
 
@@ -43,6 +44,7 @@ export function MobileAvailabilityView({
 }: MobileAvailabilityViewProps) {
     const scrollRef = useRef<HTMLDivElement>(null);
     const { theme, isDark } = useTechnicianTheme();
+    const { trigger: haptic } = useHaptics();
     const [showActionsMenu, setShowActionsMenu] = useState(false);
     const [showPresetDialog, setShowPresetDialog] = useState(false);
     const [showWeeklySummary, setShowWeeklySummary] = useState(false);
@@ -54,10 +56,12 @@ export function MobileAvailabilityView({
     });
 
     const handlePrevDay = () => {
+        haptic("light");
         onDateSelect(subDays(selectedDate, 1));
     };
 
     const handleNextDay = () => {
+        haptic("light");
         onDateSelect(addDays(selectedDate, 1));
     };
 
@@ -99,6 +103,7 @@ export function MobileAvailabilityView({
                                                     variant={department === value ? 'default' : 'outline'}
                                                     size="sm"
                                                     onClick={() => {
+                                                        haptic("selection");
                                                         onDepartmentChange(value as DisponibilidadDepartment);
                                                         setShowActionsMenu(false);
                                                     }}
@@ -163,7 +168,7 @@ export function MobileAvailabilityView({
                         return (
                             <button
                                 key={date.toISOString()}
-                                onClick={() => onDateSelect(date)}
+                                onClick={() => { haptic("selection"); onDateSelect(date); }}
                                 className={cn(
                                     "flex flex-col items-center justify-center min-w-[50px] h-[70px] rounded-xl transition-all snap-center border",
                                     isSelected

--- a/src/components/layout/MobileActionTray.tsx
+++ b/src/components/layout/MobileActionTray.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 import { NavigationItem } from "./SidebarNavigation"
 import { ThemeToggle } from "./ThemeToggle"
@@ -38,12 +39,15 @@ export const MobileActionTray = ({
 }: MobileActionTrayProps) => {
   const [open, setOpen] = useState(false)
   const { pathname } = useLocation()
+  const { trigger } = useHaptics()
 
   const handleNavigate = () => {
+    trigger("light")
     setOpen(false)
   }
 
   const handleSignOut = async () => {
+    trigger("heavy")
     await onSignOut()
     setOpen(false)
   }

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "react-router-dom"
 import { MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 import { NavigationItem } from "./SidebarNavigation"
 import { MobileActionTray } from "./MobileActionTray"
@@ -30,6 +31,7 @@ export const MobileNavBar = ({
   userEmail,
 }: MobileNavBarProps) => {
   const { pathname } = useLocation()
+  const { trigger } = useHaptics()
   const hasNavigation = primaryItems.length > 0 || trayItems.length > 0
   // Always render the tray trigger so persistent actions like Sign Out and About
   // remain accessible for all roles, even when there are no additional tray items.
@@ -58,6 +60,7 @@ export const MobileNavBar = ({
               to={item.to}
               aria-label={item.label}
               aria-current={isActive ? "page" : undefined}
+              onClick={() => trigger("light")}
               className={cn(
                 "flex min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-2 text-[11px] font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 isActive

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useUserPreferences } from "@/hooks/useUserPreferences"
+import { useHaptics } from "@/hooks/useHaptics"
 
 interface ThemeToggleProps {
   display?: "sidebar" | "icon"
@@ -19,6 +20,7 @@ export const ThemeToggle = ({
 }: ThemeToggleProps = {}) => {
   const { resolvedTheme, setTheme } = useTheme()
   const { preferences, updatePreferences } = useUserPreferences()
+  const { trigger } = useHaptics()
   const [mounted, setMounted] = useState(false)
   const hasManuallyToggled = useRef(false)
 
@@ -39,6 +41,7 @@ export const ThemeToggle = ({
 
   const toggleDarkMode = useCallback(() => {
     hasManuallyToggled.current = true
+    trigger("medium")
     const newTheme = isDarkMode ? 'light' : 'dark'
     setTheme(newTheme)
 

--- a/src/components/logistics/MobileLogisticsCalendar.tsx
+++ b/src/components/logistics/MobileLogisticsCalendar.tsx
@@ -10,6 +10,7 @@ import { LogisticsEventDialog } from "./LogisticsEventDialog";
 import { LogisticsEventCard } from "./LogisticsEventCard";
 import { LogisticsCalendarPrintDialog } from "./LogisticsCalendarPrintDialog";
 import { generateLogisticsCalendarXLS, generateLogisticsCalendarPDF } from "@/utils/logisticsCalendarExport";
+import { useHaptics } from "@/hooks/useHaptics";
 
 interface MobileLogisticsCalendarProps {
   date: Date;
@@ -28,6 +29,7 @@ export const MobileLogisticsCalendar: React.FC<MobileLogisticsCalendarProps> = (
   const [showPrintDialog, setShowPrintDialog] = useState(false);
   const [visibleEventsCount, setVisibleEventsCount] = useState(DEFAULT_VISIBLE_EVENTS);
   const { toast } = useToast();
+  const { trigger: haptic } = useHaptics();
 
   useEffect(() => {
     setCurrentDate(date);
@@ -100,18 +102,21 @@ export const MobileLogisticsCalendar: React.FC<MobileLogisticsCalendarProps> = (
   };
 
   const navigateToPrevious = () => {
+    haptic("light");
     const newDate = subDays(currentDate, 1);
     setCurrentDate(newDate);
     onDateSelect(newDate);
   };
 
   const navigateToNext = () => {
+    haptic("light");
     const newDate = addDays(currentDate, 1);
     setCurrentDate(newDate);
     onDateSelect(newDate);
   };
 
   const navigateToToday = () => {
+    haptic("medium");
     const today = new Date();
     setCurrentDate(today);
     onDateSelect(today);

--- a/src/components/personal/MobilePersonalCalendar.tsx
+++ b/src/components/personal/MobilePersonalCalendar.tsx
@@ -28,6 +28,7 @@ import { Theme } from "@/components/technician/types";
 import { PersonalCalendarPrintDialog } from "./PersonalCalendarPrintDialog";
 import { generatePersonalCalendarPDF, generatePersonalCalendarXLS } from "@/utils/personalCalendarPdfExport";
 import { useMadridHolidays } from "@/hooks/useMadridHolidays";
+import { useHaptics } from "@/hooks/useHaptics";
 
 interface MobilePersonalCalendarProps {
   date: Date;
@@ -45,6 +46,7 @@ export const MobilePersonalCalendar: React.FC<MobilePersonalCalendarProps> = ({
   isDark
 }) => {
   const [currentDate, setCurrentDate] = useState(date);
+  const { trigger: haptic } = useHaptics();
   const [selectedDepartment, setSelectedDepartment] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<'all' | 'warehouse' | 'job' | 'off'>('all');
   const [showPrintDialog, setShowPrintDialog] = useState(false);
@@ -99,18 +101,21 @@ export const MobilePersonalCalendar: React.FC<MobilePersonalCalendarProps> = ({
   ).sort();
 
   const navigateToPrevious = () => {
+    haptic("light");
     const newDate = subDays(currentDate, 1);
     setCurrentDate(newDate);
     onDateSelect(newDate);
   };
 
   const navigateToNext = () => {
+    haptic("light");
     const newDate = addDays(currentDate, 1);
     setCurrentDate(newDate);
     onDateSelect(newDate);
   };
 
   const navigateToToday = () => {
+    haptic("medium");
     const today = new Date();
     setCurrentDate(today);
     onDateSelect(today);

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -3,6 +3,7 @@ import * as AccordionPrimitive from "@radix-ui/react-accordion"
 import { ChevronDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 const Accordion = AccordionPrimitive.Root
 
@@ -21,21 +22,28 @@ AccordionItem.displayName = "AccordionItem"
 const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Header className="flex">
-    <AccordionPrimitive.Trigger
-      ref={ref}
-      className={cn(
-        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
-    </AccordionPrimitive.Trigger>
-  </AccordionPrimitive.Header>
-))
+>(({ className, children, onClick, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        ref={ref}
+        className={cn(
+          "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        onClick={(e) => {
+          trigger("light")
+          onClick?.(e)
+        }}
+        {...props}
+      >
+        {children}
+        <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+})
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
 
 const AccordionContent = React.forwardRef<

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -3,8 +3,26 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
+import { useHaptics } from "@/hooks/useHaptics"
 
-const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialogHaptic = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Root>
+>(({ onOpenChange, ...props }, _ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <AlertDialogPrimitive.Root
+      onOpenChange={(open) => {
+        if (open) trigger("warning")
+        onOpenChange?.(open)
+      }}
+      {...props}
+    />
+  )
+})
+AlertDialogHaptic.displayName = "AlertDialog"
+
+const AlertDialog = AlertDialogHaptic as typeof AlertDialogPrimitive.Root
 
 const AlertDialogTrigger = AlertDialogPrimitive.Trigger
 
@@ -99,13 +117,20 @@ AlertDialogDescription.displayName =
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action
-    ref={ref}
-    className={cn(buttonVariants(), className)}
-    {...props}
-  />
-))
+>(({ className, onClick, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <AlertDialogPrimitive.Action
+      ref={ref}
+      className={cn(buttonVariants(), className)}
+      onClick={(e) => {
+        trigger("heavy")
+        onClick?.(e)
+      }}
+      {...props}
+    />
+  )
+})
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
 
 const AlertDialogCancel = React.forwardRef<

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -3,26 +3,34 @@ import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { Check } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <CheckboxPrimitive.Root
-    ref={ref}
-    className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
-      className
-    )}
-    {...props}
-  >
-    <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
+>(({ className, onCheckedChange, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      className={cn(
+        "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        className
+      )}
+      onCheckedChange={(checked) => {
+        trigger("selection")
+        onCheckedChange?.(checked)
+      }}
+      {...props}
     >
-      <Check className="h-4 w-4" />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
-))
+      <CheckboxPrimitive.Indicator
+        className={cn("flex items-center justify-center text-current")}
+      >
+        <Check className="h-4 w-4" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+})
 Checkbox.displayName = CheckboxPrimitive.Root.displayName
 
 export { Checkbox }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,8 +3,26 @@ import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
-const Dialog = DialogPrimitive.Root
+const DialogHaptic = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root>
+>(({ onOpenChange, ...props }, _ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <DialogPrimitive.Root
+      onOpenChange={(open) => {
+        trigger(open ? "medium" : "light")
+        onOpenChange?.(open)
+      }}
+      {...props}
+    />
+  )
+})
+DialogHaptic.displayName = "Dialog"
+
+const Dialog = DialogHaptic as typeof DialogPrimitive.Root
 
 const DialogTrigger = DialogPrimitive.Trigger
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -81,40 +82,54 @@ const DropdownMenuItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean
   }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 touch-manipulation",
-      inset && "pl-8",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, inset, onSelect, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <DropdownMenuPrimitive.Item
+      ref={ref}
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 touch-manipulation",
+        inset && "pl-8",
+        className
+      )}
+      onSelect={(e) => {
+        trigger("light")
+        onSelect?.(e)
+      }}
+      {...props}
+    />
+  )
+})
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.CheckboxItem>
-))
+>(({ className, children, checked, onCheckedChange, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      ref={ref}
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      checked={checked}
+      onCheckedChange={(v) => {
+        trigger("selection")
+        onCheckedChange?.(v)
+      }}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+})
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -3,8 +3,26 @@ import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
-const Select = SelectPrimitive.Root
+const SelectHaptic = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root>
+>(({ onValueChange, ...props }, _ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <SelectPrimitive.Root
+      onValueChange={(value) => {
+        trigger("selection")
+        onValueChange?.(value)
+      }}
+      {...props}
+    />
+  )
+})
+SelectHaptic.displayName = "Select"
+
+const Select = SelectHaptic as typeof SelectPrimitive.Root
 
 const SelectGroup = SelectPrimitive.Group
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -4,8 +4,26 @@ import { X } from "lucide-react"
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
-const Sheet = SheetPrimitive.Root
+const SheetHaptic = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Root>
+>(({ onOpenChange, ...props }, _ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <SheetPrimitive.Root
+      onOpenChange={(open) => {
+        trigger(open ? "medium" : "light")
+        onOpenChange?.(open)
+      }}
+      {...props}
+    />
+  )
+})
+SheetHaptic.displayName = "Sheet"
+
+const Sheet = SheetHaptic as typeof SheetPrimitive.Root
 
 const SheetTrigger = SheetPrimitive.Trigger
 

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -2,25 +2,33 @@ import * as React from "react"
 import * as SliderPrimitive from "@radix-ui/react-slider"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
-      className
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-))
+>(({ className, onValueCommit, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className
+      )}
+      onValueCommit={(value) => {
+        trigger("light")
+        onValueCommit?.(value)
+      }}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    </SliderPrimitive.Root>
+  )
+})
 Slider.displayName = SliderPrimitive.Root.displayName
 
 export { Slider }

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -2,26 +2,34 @@ import * as React from "react"
 import * as SwitchPrimitives from "@radix-ui/react-switch"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
-      className
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
+>(({ className, onCheckedChange, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <SwitchPrimitives.Root
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className
       )}
-    />
-  </SwitchPrimitives.Root>
-))
+      onCheckedChange={(checked) => {
+        trigger("selection")
+        onCheckedChange?.(checked)
+      }}
+      {...props}
+      ref={ref}
+    >
+      <SwitchPrimitives.Thumb
+        className={cn(
+          "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitives.Root>
+  )
+})
 Switch.displayName = SwitchPrimitives.Root.displayName
 
 export { Switch }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 const Tabs = TabsPrimitive.Root
 
@@ -23,16 +24,23 @@ TabsList.displayName = TabsPrimitive.List.displayName
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, onClick, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        className
+      )}
+      onClick={(e) => {
+        trigger("selection")
+        onClick?.(e)
+      }}
+      {...props}
+    />
+  )
+})
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
 const TabsContent = React.forwardRef<

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -4,6 +4,7 @@ import { type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 import { toggleVariants } from "@/components/ui/toggle"
+import { useHaptics } from "@/hooks/useHaptics"
 
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants>
@@ -34,8 +35,9 @@ const ToggleGroupItem = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
     VariantProps<typeof toggleVariants>
->(({ className, children, variant, size, ...props }, ref) => {
+>(({ className, children, variant, size, onClick, ...props }, ref) => {
   const context = React.useContext(ToggleGroupContext)
+  const { trigger } = useHaptics()
 
   return (
     <ToggleGroupPrimitive.Item
@@ -47,6 +49,10 @@ const ToggleGroupItem = React.forwardRef<
         }),
         className
       )}
+      onClick={(e) => {
+        trigger("selection")
+        onClick?.(e)
+      }}
       {...props}
     >
       {children}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -3,6 +3,7 @@ import * as TogglePrimitive from "@radix-ui/react-toggle"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
+import { useHaptics } from "@/hooks/useHaptics"
 
 const toggleVariants = cva(
   "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
@@ -30,13 +31,20 @@ const Toggle = React.forwardRef<
   React.ElementRef<typeof TogglePrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
     VariantProps<typeof toggleVariants>
->(({ className, variant, size, ...props }, ref) => (
-  <TogglePrimitive.Root
-    ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
-    {...props}
-  />
-))
+>(({ className, variant, size, onPressedChange, ...props }, ref) => {
+  const { trigger } = useHaptics()
+  return (
+    <TogglePrimitive.Root
+      ref={ref}
+      className={cn(toggleVariants({ variant, size, className }))}
+      onPressedChange={(pressed) => {
+        trigger("selection")
+        onPressedChange?.(pressed)
+      }}
+      {...props}
+    />
+  )
+})
 
 Toggle.displayName = TogglePrimitive.Root.displayName
 

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -1,6 +1,14 @@
 
 import { toast as toastPrimitive } from "sonner";
 import * as React from "react";
+import { triggerHaptic } from "@/hooks/useHaptics";
+
+// Fire-and-forget haptic for toast notifications (outside React lifecycle)
+function toastHaptic(pattern: string) {
+  try {
+    triggerHaptic(pattern);
+  } catch { /* non-critical */ }
+}
 
 type ToasterToast = any;
 
@@ -160,24 +168,28 @@ function toast(options: string | React.ReactNode | Omit<ToastData, "id"> | {
   if (variant) {
     switch (variant) {
       case "destructive":
+        toastHaptic("error");
         return toastPrimitive.error(rest.title, {
           description: rest.description,
           id,
           ...rest
         });
       case "success":
+        toastHaptic("success");
         return toastPrimitive.success(rest.title, {
           description: rest.description,
           id,
           ...rest
         });
       case "warning":
+        toastHaptic("warning");
         return toastPrimitive.warning(rest.title, {
           description: rest.description,
           id,
           ...rest
         });
       case "info":
+        toastHaptic("nudge");
         return toastPrimitive.info(rest.title, {
           description: rest.description,
           id,
@@ -203,21 +215,25 @@ function toast(options: string | React.ReactNode | Omit<ToastData, "id"> | {
 
 // Add API-compatible methods for backward compatibility
 toast.success = (title: string, options?: any) => {
+  toastHaptic("success");
   const { description, ...rest } = options || {};
   return toastPrimitive.success(title, { description, ...rest });
 };
 
 toast.error = (title: string, options?: any) => {
+  toastHaptic("error");
   const { description, ...rest } = options || {};
   return toastPrimitive.error(title, { description, ...rest });
 };
 
 toast.warning = (title: string, options?: any) => {
+  toastHaptic("warning");
   const { description, ...rest } = options || {};
   return toastPrimitive.warning(title, { description, ...rest });
 };
 
 toast.info = (title: string, options?: any) => {
+  toastHaptic("nudge");
   const { description, ...rest } = options || {};
   return toastPrimitive.info(title, { description, ...rest });
 };

--- a/src/hooks/useHaptics.ts
+++ b/src/hooks/useHaptics.ts
@@ -1,0 +1,57 @@
+import { useRef, useEffect, useCallback } from "react"
+import { WebHaptics, type HapticInput, type TriggerOptions } from "web-haptics"
+
+let sharedInstance: WebHaptics | null = null
+let refCount = 0
+
+function getSharedInstance(): WebHaptics | null {
+  if (!WebHaptics.isSupported) return null
+  if (!sharedInstance) {
+    sharedInstance = new WebHaptics()
+  }
+  return sharedInstance
+}
+
+/**
+ * Lightweight haptic feedback hook using web-haptics.
+ * Shares a single WebHaptics instance across the entire app.
+ *
+ * Built-in patterns: success, warning, error, light, medium, heavy,
+ * soft, rigid, selection, nudge, buzz
+ */
+export function useHaptics() {
+  const instanceRef = useRef<WebHaptics | null>(null)
+
+  useEffect(() => {
+    instanceRef.current = getSharedInstance()
+    refCount++
+    return () => {
+      refCount--
+      if (refCount === 0 && sharedInstance) {
+        sharedInstance.destroy()
+        sharedInstance = null
+      }
+    }
+  }, [])
+
+  const trigger = useCallback(
+    (input?: HapticInput, options?: TriggerOptions) => {
+      instanceRef.current?.trigger(input, options)
+    },
+    [],
+  )
+
+  const cancel = useCallback(() => {
+    instanceRef.current?.cancel()
+  }, [])
+
+  return { trigger, cancel, isSupported: WebHaptics.isSupported }
+}
+
+/**
+ * Standalone haptic trigger for use outside React components (e.g. toast functions).
+ * Uses the same shared WebHaptics singleton.
+ */
+export function triggerHaptic(input?: HapticInput, options?: TriggerOptions) {
+  getSharedInstance()?.trigger(input, options)
+}


### PR DESCRIPTION
Integrate the web-haptics library to provide tactile feedback on mobile devices throughout the app. Haptics are wired into shadcn/ui base components (Switch, Tabs, Toggle, Dialog, Sheet, AlertDialog, Checkbox, Select, Accordion, Slider, DropdownMenu, ToggleGroup) so every consumer gets feedback automatically, plus explicit integration in mobile-specific components (MobileNavBar, MobileActionTray, MobileJobCard, MobileDayCalendar, MobileAvailabilityView, MobilePersonalCalendar, MobileLogisticsCalendar, ThemeToggle) and the toast notification system.

Pattern mapping:
- selection: checkbox, switch, toggle, tabs, select, toggle group
- light: nav links, accordion, dropdown items, date navigation
- medium: dialog/sheet open, today button, theme toggle
- heavy: destructive actions (sign out, alert dialog confirm)
- success/error/warning/nudge: toast notifications by variant

https://claude.ai/code/session_01EjbTuGDvihXEoiyf5CSefW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added haptic feedback throughout the app for enhanced tactile user interactions, including navigation, button clicks, dialog actions, form controls, and theme toggling
  * Haptic patterns vary by interaction type (light, medium, heavy) to provide intuitive tactile responses

* **Chores**
  * Added web-haptics dependency to support haptic feedback functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->