### PR TITLE
Add navigable TOC entries in festival documentation PDFs

### DIFF
--- a/src/utils/pdf/festivalPdfGenerator.ts
+++ b/src/utils/pdf/festivalPdfGenerator.ts
@@ -1,3 +1,4 @@
+import { PDFArray, PDFDocument, PDFName } from 'pdf-lib';
 import { supabase } from '@/lib/supabase';
 import { exportArtistPDF, ArtistPdfData } from '../artistPdfExport';
 import { exportArtistTablePDF, ArtistTablePdfData } from '../artistTablePdfExport';
@@ -8,7 +9,7 @@ import { exportMissingRiderReportPDF, MissingRiderReportData } from '../missingR
 import { generateStageGearPDF } from '../gearSetupPdfExport';
 import { fetchJobLogo, fetchLogoUrl } from './logoUtils';
 import { generateCoverPage } from './coverPageGenerator';
-import { generateTableOfContents } from './tocGenerator';
+import { generateTableOfContents, TocLinkRegion, TocSection } from './tocGenerator';
 import { mergePDFs } from './pdfMerge';
 import { PrintOptions } from "@/components/festival/pdf/PrintOptionsDialog";
 import { exportWiredMicrophoneMatrixPDF, WiredMicrophoneMatrixData, organizeArtistsByDateAndStage } from '../wiredMicrophoneNeedsPdfExport';
@@ -22,6 +23,60 @@ import {
   buildRfIemArtists,
   sortArtistsChronologically,
 } from './festivalPdfSectionBuilders';
+
+
+const addTableOfContentsLinks = async (mergedBlob: Blob, links: TocLinkRegion[]): Promise<Blob> => {
+  if (links.length === 0) return mergedBlob;
+
+  const mergedBytes = await mergedBlob.arrayBuffer();
+  const mergedPdf = await PDFDocument.load(mergedBytes, {
+    ignoreEncryption: true,
+    throwOnInvalidObject: false,
+    updateMetadata: false,
+  });
+
+  for (const link of links) {
+    const tocPage = mergedPdf.getPage(1 + link.pageIndex);
+    const destinationPage = mergedPdf.getPage(link.targetPage - 1);
+
+    if (!tocPage || !destinationPage) continue;
+
+    const context = mergedPdf.context;
+    const destination = context.obj([
+      destinationPage.ref,
+      PDFName.of('XYZ'),
+      null,
+      null,
+      null,
+    ]);
+
+    const action = context.obj({
+      Type: 'Action',
+      S: 'GoTo',
+      D: destination,
+    });
+
+    const annotation = context.obj({
+      Type: 'Annot',
+      Subtype: 'Link',
+      Rect: [link.x, link.y, link.x + link.width, link.y + link.height],
+      Border: [0, 0, 0],
+      A: action,
+    });
+
+    const pageNode = tocPage.node as any;
+    const existingAnnots = pageNode.lookupMaybe(PDFName.of('Annots'), PDFArray);
+
+    if (existingAnnots) {
+      existingAnnots.push(annotation);
+    } else {
+      pageNode.set(PDFName.of('Annots'), context.obj([annotation]));
+    }
+  }
+
+  const linkedPdfBytes = await mergedPdf.save();
+  return new Blob([new Uint8Array(linkedPdfBytes)], { type: 'application/pdf' });
+};
 
 export const generateAndMergeFestivalPDFs = async (
   jobId: string,
@@ -58,6 +113,7 @@ export const generateAndMergeFestivalPDFs = async (
   const shiftPdfs: Blob[] = [];
   const artistTablePdfs: Blob[] = [];
   const individualArtistPdfs: Blob[] = [];
+  const individualArtistIndexEntries: { title: string; pageCount: number }[] = [];
   let rfIemTablePdf: Blob | null = null;
   let infrastructureTablePdf: Blob | null = null;
   let missingRiderReportPdf: Blob | null = null;
@@ -391,6 +447,10 @@ export const generateAndMergeFestivalPDFs = async (
           console.log(`Generated PDF for artist ${artist.name}, size: ${pdf.size} bytes`);
           if (pdf && pdf.size > 0) {
             individualArtistPdfs.push(pdf);
+            individualArtistIndexEntries.push({
+              title: artist.name || 'Unnamed Artist',
+              pageCount: 1,
+            });
           } else {
             console.warn(`Generated empty PDF for artist ${artist.name}, skipping`);
           }
@@ -606,7 +666,7 @@ export const generateAndMergeFestivalPDFs = async (
       }
     }
     
-    const tocSections = [];
+    const tocSections: TocSection[] = [];
     
     if (options.includeShiftSchedules && shiftPdfs.length > 0) {
       tocSections.push({ title: "Turnos de Personal", pageCount: shiftPdfs.length });
@@ -633,13 +693,17 @@ export const generateAndMergeFestivalPDFs = async (
       tocSections.push({ title: "Reporte de Riders Faltantes", pageCount: 1 });
     }
     if (options.includeArtistRequirements && individualArtistPdfs.length > 0) {
-      tocSections.push({ title: "Requerimientos Individuales por Artista", pageCount: individualArtistPdfs.length });
+      tocSections.push({
+        title: "Requerimientos Individuales por Artista",
+        pageCount: individualArtistPdfs.length,
+        children: individualArtistIndexEntries,
+      });
     }
     
     console.log(`Table of contents sections:`, tocSections);
     
     const coverPage = await generateCoverPage(jobId, jobTitle, logoUrl);
-    const tableOfContents = await generateTableOfContents(tocSections, logoUrl);
+    const { blob: tableOfContents, links: tocLinks } = await generateTableOfContents(tocSections, logoUrl);
     
     // Updated PDF order according to requirements
     const selectedPdfs = [
@@ -693,11 +757,12 @@ export const generateAndMergeFestivalPDFs = async (
     }
     
     const mergedBlob = await mergePDFs(selectedPdfs);
+    const mergedBlobWithTocLinks = await addTableOfContentsLinks(mergedBlob, tocLinks);
     
     // Generate filename if not provided
     const filename = customFilename || buildReadableFilename([jobTitle || "Festival", "Documentación completa"]);
     
-    return { blob: mergedBlob, filename };
+    return { blob: mergedBlobWithTocLinks, filename };
   } catch (error) {
     console.error('Error generating festival PDFs:', error);
     throw error;

--- a/src/utils/pdf/tocGenerator.ts
+++ b/src/utils/pdf/tocGenerator.ts
@@ -1,133 +1,215 @@
-
 import { PDFDocument, rgb } from 'pdf-lib';
 
+export type TocChildEntry = {
+  title: string;
+  pageCount: number;
+};
+
+export type TocSection = {
+  title: string;
+  pageCount: number;
+  children?: TocChildEntry[];
+};
+
+export type TocLinkRegion = {
+  pageIndex: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  targetPage: number;
+};
+
+export type TocGenerationResult = {
+  blob: Blob;
+  links: TocLinkRegion[];
+  pageCount: number;
+};
+
+type TocLine = {
+  title: string;
+  indent: number;
+  fontSize: number;
+  targetPage: number;
+};
+
 export const generateTableOfContents = async (
-  sections: { title: string; pageCount: number }[],
+  sections: TocSection[],
   logoUrl?: string
-): Promise<Blob> => {
+): Promise<TocGenerationResult> => {
   try {
-    console.log("Generating table of contents");
-    const pdfDoc = await PDFDocument.create();
-    const page = pdfDoc.addPage([595.28, 841.89]); // A4 size
-    
-    const { width, height } = page.getSize();
-    
-    page.drawRectangle({
-      x: 0,
-      y: height - 100,
-      width,
-      height: 100,
-      color: rgb(125/255, 1/255, 1/255), // Corporate red
-    });
-    
-    page.drawText("INDICE", {
-      x: 50,
-      y: height - 60,
-      size: 24,
-      color: rgb(1, 1, 1),
-    });
-    
-    if (logoUrl) {
-      try {
-        console.log("Attempting to load logo on TOC page:", logoUrl);
-        const logoResponse = await fetch(logoUrl);
-        const logoImageData = await logoResponse.arrayBuffer();
-        let logoImage;
-        
-        if (logoUrl.toLowerCase().endsWith('.png')) {
-          logoImage = await pdfDoc.embedPng(logoImageData);
-        } else {
-          logoImage = await pdfDoc.embedJpg(logoImageData);
+    console.log('Generating table of contents');
+
+    const pageHeight = 841.89;
+    const startY = pageHeight - 200;
+    const lineHeight = 30;
+    const minY = 70;
+    const rowsPerPage = Math.max(1, Math.floor((startY - minY) / lineHeight) + 1);
+
+    const topLevelCount = sections.length;
+    const childCount = sections.reduce((sum, section) => sum + (section.children?.length || 0), 0);
+    const totalLines = topLevelCount + childCount;
+    const tocPageCount = Math.max(1, Math.ceil(totalLines / rowsPerPage));
+
+    const lines: TocLine[] = [];
+    let currentTargetPage = 2 + tocPageCount;
+
+    for (const section of sections) {
+      const sectionStartPage = currentTargetPage;
+      lines.push({
+        title: section.title,
+        indent: 0,
+        fontSize: 12,
+        targetPage: sectionStartPage,
+      });
+
+      if (section.children && section.children.length > 0) {
+        let childPage = sectionStartPage;
+        for (const child of section.children) {
+          lines.push({
+            title: child.title,
+            indent: 1,
+            fontSize: 11,
+            targetPage: childPage,
+          });
+          childPage += child.pageCount;
         }
-        
-        if (logoImage) {
+      }
+
+      currentTargetPage += section.pageCount;
+    }
+
+    const pdfDoc = await PDFDocument.create();
+    const tocLinks: TocLinkRegion[] = [];
+
+    for (let tocPageIndex = 0; tocPageIndex < tocPageCount; tocPageIndex += 1) {
+      const page = pdfDoc.addPage([595.28, pageHeight]);
+      const { width, height } = page.getSize();
+
+      page.drawRectangle({
+        x: 0,
+        y: height - 100,
+        width,
+        height: 100,
+        color: rgb(125 / 255, 1 / 255, 1 / 255),
+      });
+
+      page.drawText('INDICE', {
+        x: 50,
+        y: height - 60,
+        size: 24,
+        color: rgb(1, 1, 1),
+      });
+
+      if (logoUrl) {
+        try {
+          const logoResponse = await fetch(logoUrl);
+          const logoImageData = await logoResponse.arrayBuffer();
+          const logoImage = logoUrl.toLowerCase().endsWith('.png')
+            ? await pdfDoc.embedPng(logoImageData)
+            : await pdfDoc.embedJpg(logoImageData);
+
           const imgWidth = 100;
           const imgHeight = (logoImage.height / logoImage.width) * imgWidth;
-          
+
           page.drawImage(logoImage, {
             x: width - imgWidth - 50,
-            y: height - 60 - (imgHeight / 2) + 10,
+            y: height - 60 - imgHeight / 2 + 10,
             width: imgWidth,
             height: imgHeight,
           });
-          console.log("Logo successfully added to TOC page");
+        } catch (logoError) {
+          console.error('Error adding logo to TOC:', logoError);
         }
-      } catch (logoError) {
-        console.error("Error adding logo to TOC:", logoError);
       }
-    } else {
-      console.log("No logo URL provided for TOC page");
-    }
-    
-    let currentY = height - 150;
-    let pageCounter = 3;
-    
-    page.drawText("Seccion", {
-      x: 50,
-      y: currentY,
-      size: 14,
-      color: rgb(0, 0, 0),
-    });
-    
-    page.drawText("Pagina", {
-      x: width - 100,
-      y: currentY,
-      size: 14,
-      color: rgb(0, 0, 0),
-    });
-    
-    currentY -= 20;
-    
-    page.drawLine({
-      start: { x: 50, y: currentY },
-      end: { x: width - 50, y: currentY },
-      thickness: 1,
-      color: rgb(0.8, 0.8, 0.8),
-    });
-    
-    currentY -= 30;
-    
-    for (const section of sections) {
-      page.drawText(section.title, {
+
+      let currentY = height - 150;
+
+      page.drawText('Seccion', {
         x: 50,
         y: currentY,
-        size: 12,
+        size: 14,
         color: rgb(0, 0, 0),
       });
-      
-      page.drawText(pageCounter.toString(), {
+
+      page.drawText('Pagina', {
         x: width - 100,
         y: currentY,
-        size: 12,
+        size: 14,
         color: rgb(0, 0, 0),
       });
-      
-      let dotX = 250;
-      while (dotX < width - 105) {
-        page.drawText(".", {
-          x: dotX,
-          y: currentY,
-          size: 12,
-          color: rgb(0.7, 0.7, 0.7),
-        });
-        dotX += 10;
-      }
-      
-      pageCounter += section.pageCount;
+
+      currentY -= 20;
+
+      page.drawLine({
+        start: { x: 50, y: currentY },
+        end: { x: width - 50, y: currentY },
+        thickness: 1,
+        color: rgb(0.8, 0.8, 0.8),
+      });
+
       currentY -= 30;
+
+      const pageStart = tocPageIndex * rowsPerPage;
+      const pageLines = lines.slice(pageStart, pageStart + rowsPerPage);
+
+      for (const line of pageLines) {
+        const textX = line.indent === 0 ? 50 : 70;
+        const dotStartX = line.indent === 0 ? 250 : 270;
+
+        page.drawText(line.title, {
+          x: textX,
+          y: currentY,
+          size: line.fontSize,
+          color: rgb(0, 0, 0.1),
+        });
+
+        page.drawText(line.targetPage.toString(), {
+          x: width - 100,
+          y: currentY,
+          size: line.fontSize,
+          color: rgb(0, 0, 0),
+        });
+
+        let dotX = dotStartX;
+        while (dotX < width - 105) {
+          page.drawText('.', {
+            x: dotX,
+            y: currentY,
+            size: line.fontSize,
+            color: rgb(0.7, 0.7, 0.7),
+          });
+          dotX += 10;
+        }
+
+        tocLinks.push({
+          pageIndex: tocPageIndex,
+          x: textX,
+          y: currentY - 2,
+          width: width - textX - 40,
+          height: 16,
+          targetPage: line.targetPage,
+        });
+
+        currentY -= lineHeight;
+      }
+
+      page.drawText(`Pagina ${2 + tocPageIndex}`, {
+        x: width / 2,
+        y: 30,
+        size: 10,
+        color: rgb(0.5, 0.5, 0.5),
+      });
     }
-    
-    page.drawText("Pagina 2", {
-      x: width / 2,
-      y: 30,
-      size: 10,
-      color: rgb(0.5, 0.5, 0.5),
-    });
-    
+
     const pdfBytes = await pdfDoc.save();
-    return new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' });
+    return {
+      blob: new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' }),
+      links: tocLinks,
+      pageCount: tocPageCount,
+    };
   } catch (error) {
-    console.error("Error generating table of contents:", error);
+    console.error('Error generating table of contents:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- made festival documentation table-of-contents entries clickable so section titles navigate to their target pages
- added artist-level index entries under "Requerimientos Individuales por Artista" so each artist page is directly accessible from the index
- extended TOC generation to support child entries and multi-page TOC layout when long lists are present

## Implementation details
- `src/utils/pdf/tocGenerator.ts`
  - introduced structured TOC types (`TocSection`, child entries, link-region metadata)
  - added pagination logic for long TOCs and nested child line rendering
  - returns both TOC PDF blob and link-region metadata for post-merge link annotation
- `src/utils/pdf/festivalPdfGenerator.ts`
  - collects artist names in generation order for the individual requirements section
  - injects artist entries as TOC children under the individual requirements section
  - post-processes merged PDF to add internal GoTo link annotations on TOC pages using `pdf-lib`

## Validation
- ran `git diff --check` to ensure no whitespace/conflict issues in the final patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a940e4b158832faffcfb5435c21581)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive table of contents with clickable links for PDF navigation
  * Multi-page table of contents with improved layout and formatting
  * Nested table of contents structure for hierarchical organization

* **Improvements**
  * Enhanced error handling for logo loading in generated PDFs
  * Better structured table of contents with page indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->