### PR TITLE
[codex] Deploy branded WhatsApp staffing links

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,3 @@
+/staffing/confirm/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/confirm/:splat 200
+/staffing/decline/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/decline/:splat 200
 /* /index.html 200

--- a/supabase/functions/send-staffing-email/__tests__/messageUtils.test.ts
+++ b/supabase/functions/send-staffing-email/__tests__/messageUtils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLegacyStaffingActionUrl,
+  buildPathStaffingActionUrl,
+  buildWhatsAppStaffingMessage,
+} from "../messageUtils.ts";
+
+describe("messageUtils", () => {
+  it("builds branded path links without query parameters", () => {
+    expect(
+      buildPathStaffingActionUrl(
+        "https://sector-pro.work/staffing/",
+        "confirm",
+        "request-1",
+        "tok_en-123",
+      ),
+    ).toBe("https://sector-pro.work/staffing/confirm/request-1/tok_en-123");
+  });
+
+  it("builds legacy query links for email compatibility", () => {
+    expect(
+      buildLegacyStaffingActionUrl({
+        base: "https://project.functions.supabase.co/staffing-click",
+        rid: "request-1",
+        action: "decline",
+        exp: "2026-04-12T08:58:46.807Z",
+        token: "token-1",
+        channel: "email",
+      }),
+    ).toContain("a=decline");
+  });
+
+  it("renders channel-specific WhatsApp copy without email wording", () => {
+    const text = buildWhatsAppStaffingMessage({
+      phase: "availability",
+      fullName: "Marco Arancibia Sanchez",
+      jobTitle: "Operación Triunfo Tour 2026",
+      roleLabel: "Montador — Técnico",
+      normalizedDates: ["jueves, 16 de abril de 2026", "sábado, 18 de abril de 2026"],
+      isSingleDayRequest: false,
+      targetDateLabel: null,
+      startDate: "jueves, 16 de abril de 2026",
+      endDate: "sábado, 18 de abril de 2026",
+      callTime: "08:00",
+      location: "Bilbao Exhibition Centre (BEC)",
+      note: null,
+      tourPdfSignedUrl: null,
+      confirmUrl: "https://sector-pro.work/staffing/confirm/request-1/token-1",
+      declineUrl: "https://sector-pro.work/staffing/decline/request-1/token-1",
+    });
+
+    expect(text).toContain("Consulta de disponibilidad para Operación Triunfo Tour 2026.");
+    expect(text).toContain("Confirmar disponibilidad: https://sector-pro.work/staffing/confirm/request-1/token-1");
+    expect(text).toContain("No disponible: https://sector-pro.work/staffing/decline/request-1/token-1");
+    expect(text).not.toContain("Este email");
+  });
+});

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -1,5 +1,11 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import {
+  buildLegacyStaffingActionUrl,
+  buildPathStaffingActionUrl,
+  buildWhatsAppStaffingMessage,
+  normalizeStaffingConfirmBase,
+} from "./messageUtils.ts";
 
 // Inlined from roles.ts for dashboard deployment compatibility
 const CODE_TO_LABEL: Record<string, string> = {
@@ -47,14 +53,17 @@ function labelForRoleCode(value?: string | null): string | null {
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const TOKEN_SECRET = Deno.env.get("STAFFING_TOKEN_SECRET")!;
-// Compute confirmation base URL using the functions domain so GET is allowed
-const __RAW_CONFIRM_BASE = Deno.env.get("PUBLIC_CONFIRM_BASE");
+// Compute confirmation base URL using the functions domain so GET is allowed.
+// WhatsApp uses a branded path when PUBLIC_STAFFING_CONFIRM_BASE is configured.
+const __RAW_CONFIRM_BASE = Deno.env.get("PUBLIC_STAFFING_CONFIRM_BASE");
 const __PROJECT_REF = (() => {
   try { return new URL(SUPABASE_URL).host.split('.')[0]; } catch { return ''; }
 })();
 const __FUNCTIONS_HOST = __PROJECT_REF ? `https://${__PROJECT_REF}.functions.supabase.co` : '';
 const __DEFAULT_CONFIRM_BASE = __FUNCTIONS_HOST ? `${__FUNCTIONS_HOST}/staffing-click` : `${SUPABASE_URL}/functions/v1/staffing-click`;
-const CONFIRM_BASE = (__RAW_CONFIRM_BASE && /staffing-click(\b|[/?#])/i.test(__RAW_CONFIRM_BASE)) ? __RAW_CONFIRM_BASE : __DEFAULT_CONFIRM_BASE;
+const STAFFING_CONFIRM_BASE = __RAW_CONFIRM_BASE
+  ? normalizeStaffingConfirmBase(__RAW_CONFIRM_BASE)
+  : __DEFAULT_CONFIRM_BASE;
 const BREVO_KEY = Deno.env.get("BREVO_API_KEY")!;
 const BREVO_FROM = Deno.env.get("BREVO_FROM")!;
 // Optional branding
@@ -203,15 +212,14 @@ serve(async (req) => {
     console.log('🔧 CHECKING ENV VARIABLES:', {
       DAILY_CAP: { value: DAILY_CAP, exists: !!DAILY_CAP },
       TOKEN_SECRET: { exists: !!TOKEN_SECRET, length: TOKEN_SECRET?.length },
-      CONFIRM_BASE: { exists: !!CONFIRM_BASE, value: CONFIRM_BASE },
+      STAFFING_CONFIRM_BASE: { configured: !!__RAW_CONFIRM_BASE, value: STAFFING_CONFIRM_BASE },
       BREVO_KEY: desiredChannel === 'email' ? { exists: !!BREVO_KEY, length: BREVO_KEY?.length } : { skipped: true },
       BREVO_FROM: desiredChannel === 'email' ? { exists: !!BREVO_FROM, value: BREVO_FROM } : { skipped: true }
     });
 
-    if (!TOKEN_SECRET || !CONFIRM_BASE || (desiredChannel === 'email' && (!BREVO_KEY || !BREVO_FROM))) {
+    if (!TOKEN_SECRET || (desiredChannel === 'email' && (!BREVO_KEY || !BREVO_FROM))) {
       const missingEnvs = [];
       if (!TOKEN_SECRET) missingEnvs.push('STAFFING_TOKEN_SECRET');
-      if (!CONFIRM_BASE) missingEnvs.push('PUBLIC_CONFIRM_BASE');
       if (desiredChannel === 'email') {
         if (!BREVO_KEY) missingEnvs.push('BREVO_API_KEY');
         if (!BREVO_FROM) missingEnvs.push('BREVO_FROM');
@@ -751,8 +759,34 @@ serve(async (req) => {
 
       // Step 5: Build content (email or whatsapp)
       console.log('📧 BUILDING EMAIL CONTENT...');
-      const confirmUrl = `${CONFIRM_BASE}?rid=${encodeURIComponent(insertedId)}&a=confirm&exp=${encodeURIComponent(exp)}&t=${token}&c=${encodeURIComponent(desiredChannel)}`;
-      const declineUrl = `${CONFIRM_BASE}?rid=${encodeURIComponent(insertedId)}&a=decline&exp=${encodeURIComponent(exp)}&t=${token}&c=${encodeURIComponent(desiredChannel)}`;
+      const emailConfirmUrl = buildLegacyStaffingActionUrl({
+        base: __DEFAULT_CONFIRM_BASE,
+        rid: insertedId,
+        action: 'confirm',
+        exp,
+        token,
+        channel: desiredChannel,
+      });
+      const emailDeclineUrl = buildLegacyStaffingActionUrl({
+        base: __DEFAULT_CONFIRM_BASE,
+        rid: insertedId,
+        action: 'decline',
+        exp,
+        token,
+        channel: desiredChannel,
+      });
+      const whatsappConfirmUrl = buildPathStaffingActionUrl(
+        STAFFING_CONFIRM_BASE,
+        'confirm',
+        insertedId,
+        token,
+      );
+      const whatsappDeclineUrl = buildPathStaffingActionUrl(
+        STAFFING_CONFIRM_BASE,
+        'decline',
+        insertedId,
+        token,
+      );
 
       const roleLabel = labelForRoleCode(role) || null;
       const subject = phase === "availability"
@@ -861,10 +895,10 @@ serve(async (req) => {
                     <table role="presentation" cellspacing="0" cellpadding="0" style="width:100%;">
                       <tr>
                         <td align="left" style="padding:8px 0;">
-                          <a href="${confirmUrl}" style="display:inline-block;background:#10b981;color:#ffffff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:600;">${primaryCta}</a>
+                          <a href="${emailConfirmUrl}" style="display:inline-block;background:#10b981;color:#ffffff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:600;">${primaryCta}</a>
                         </td>
                         <td align="right" style="padding:8px 0;">
-                          <a href="${declineUrl}" style="display:inline-block;background:#ef4444;color:#ffffff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:600;">${secondaryCta}</a>
+                          <a href="${emailDeclineUrl}" style="display:inline-block;background:#ef4444;color:#ffffff;padding:10px 16px;border-radius:8px;text-decoration:none;font-weight:600;">${secondaryCta}</a>
                         </td>
                       </tr>
                     </table>
@@ -889,45 +923,30 @@ serve(async (req) => {
       </html>`;
 
       // Step 6: Deliver via chosen channel
-      console.log('🔗 CONFIRM LINKS:', { confirmUrl, declineUrl });
+      console.log('🔗 CONFIRM LINKS:', {
+        emailConfirmUrl,
+        emailDeclineUrl,
+        whatsappConfirmUrl,
+        whatsappDeclineUrl,
+      });
       if (desiredChannel === 'whatsapp') {
-        // Build WhatsApp text (plain)
-        const lines: string[] = [];
-        lines.push(`Hola ${fullName || ''},`);
-        if (phase === 'availability') {
-          lines.push(`¿Tendrías disponibilidad para ${datePhrasing}?`);
-          lines.push('');
-          lines.push('ATENCIÓN: Este email SOLO confirma disponibilidad, no te cierra el evento.');
-          lines.push('Si confirmas, recibirás un segundo email con la oferta de trabajo detallada.');
-        } else {
-          lines.push(`Tienes una oferta para ${job.title}.`);
-          if (roleLabel) lines.push(`Puesto: ${roleLabel}`);
-        }
-        lines.push('');
-        lines.push('Detalles del trabajo:');
-        if (normalizedDates.length > 1) {
-          lines.push('- Fechas seleccionadas:');
-          normalizedDates.forEach(d => lines.push(`  • ${fmtDate(`${d}T00:00:00Z`)}`));
-        } else if (isSingleDayRequest && targetDateLabel) {
-          lines.push(`- Fecha: ${targetDateLabel}`);
-        } else {
-          lines.push(`- Fechas: ${startDate}${job.end_time ? ` — ${endDate}` : ''}`);
-        }
-        lines.push(`- Horario: ${callTime}`);
-        lines.push(`- Ubicación: ${loc}`);
-        if (roleLabel) lines.push(`- Rol: ${roleLabel}`);
-        if (phase === 'offer' && (message ?? '').trim()) {
-          lines.push('');
-          lines.push((message as string).trim());
-        }
-        lines.push('');
-        if (tourPdfSignedUrl) {
-          lines.push(`Calendario del tour (PDF): ${tourPdfSignedUrl}`);
-          lines.push('');
-        }
-        lines.push(`Confirmar: ${confirmUrl}`);
-        lines.push(`No estoy disponible: ${declineUrl}`);
-        const text = lines.join('\n');
+        const text = buildWhatsAppStaffingMessage({
+          phase,
+          fullName,
+          jobTitle: job.title,
+          roleLabel,
+          note: phase === 'offer' ? message : null,
+          normalizedDates: normalizedDates.map((d) => fmtDate(`${d}T00:00:00Z`)),
+          isSingleDayRequest,
+          targetDateLabel,
+          startDate,
+          endDate,
+          callTime,
+          location: loc,
+          tourPdfSignedUrl,
+          confirmUrl: whatsappConfirmUrl,
+          declineUrl: whatsappDeclineUrl,
+        });
 
         // WAHA config - use actor's endpoint
         const normalizeBase = (s: string) => {

--- a/supabase/functions/send-staffing-email/messageUtils.ts
+++ b/supabase/functions/send-staffing-email/messageUtils.ts
@@ -1,0 +1,111 @@
+export type StaffingPhase = "availability" | "offer";
+export type StaffingAction = "confirm" | "decline";
+
+export interface BuildWhatsAppStaffingMessageArgs {
+  phase: StaffingPhase;
+  fullName?: string | null;
+  jobTitle: string;
+  roleLabel?: string | null;
+  note?: string | null;
+  normalizedDates: string[];
+  isSingleDayRequest: boolean;
+  targetDateLabel?: string | null;
+  startDate: string;
+  endDate?: string | null;
+  callTime: string;
+  location: string;
+  tourPdfSignedUrl?: string | null;
+  confirmUrl: string;
+  declineUrl: string;
+}
+
+export function normalizeStaffingConfirmBase(input: string): string {
+  return input.trim().replace(/\/+$/, "");
+}
+
+export function buildPathStaffingActionUrl(
+  base: string,
+  action: StaffingAction,
+  rid: string,
+  token: string,
+): string {
+  const normalizedBase = normalizeStaffingConfirmBase(base);
+  return `${normalizedBase}/${action}/${encodeURIComponent(rid)}/${encodeURIComponent(token)}`;
+}
+
+export function buildLegacyStaffingActionUrl(args: {
+  base: string;
+  rid: string;
+  action: StaffingAction;
+  exp: string;
+  token: string;
+  channel: "email" | "whatsapp";
+}): string {
+  const normalizedBase = normalizeStaffingConfirmBase(args.base);
+  const params = new URLSearchParams({
+    rid: args.rid,
+    a: args.action,
+    exp: args.exp,
+    t: args.token,
+    c: args.channel,
+  });
+  return `${normalizedBase}?${params.toString()}`;
+}
+
+export function buildWhatsAppStaffingMessage(
+  args: BuildWhatsAppStaffingMessageArgs,
+): string {
+  const fullName = (args.fullName || "").trim();
+  const jobTitle = args.jobTitle.trim() || "el trabajo";
+  const note = (args.note || "").trim();
+  const roleLabel = (args.roleLabel || "").trim();
+  const lines: string[] = [fullName ? `Hola ${fullName},` : "Hola,"];
+
+  if (args.phase === "availability") {
+    lines.push(`Consulta de disponibilidad para ${jobTitle}.`);
+  } else {
+    lines.push(`Tienes una oferta para ${jobTitle}.`);
+  }
+
+  lines.push("");
+  lines.push("Resumen:");
+
+  if (roleLabel) {
+    lines.push(`- Rol: ${roleLabel}`);
+  }
+
+  if (args.normalizedDates.length > 1) {
+    lines.push("- Fechas:");
+    args.normalizedDates.forEach((dateLabel) => {
+      lines.push(`  • ${dateLabel}`);
+    });
+  } else if (args.isSingleDayRequest && args.targetDateLabel) {
+    lines.push(`- Fecha: ${args.targetDateLabel}`);
+  } else {
+    lines.push(`- Fechas: ${args.startDate}${args.endDate ? ` — ${args.endDate}` : ""}`);
+  }
+
+  lines.push(`- Horario: ${args.callTime}`);
+  lines.push(`- Ubicación: ${args.location}`);
+
+  if (note) {
+    lines.push("");
+    lines.push(note);
+  }
+
+  if (args.tourPdfSignedUrl) {
+    lines.push("");
+    lines.push(`Calendario del tour (PDF): ${args.tourPdfSignedUrl}`);
+  }
+
+  lines.push("");
+  if (args.phase === "availability") {
+    lines.push(`Confirmar disponibilidad: ${args.confirmUrl}`);
+    lines.push(`No disponible: ${args.declineUrl}`);
+  } else {
+    lines.push(`Aceptar oferta: ${args.confirmUrl}`);
+    lines.push(`Rechazar oferta: ${args.declineUrl}`);
+  }
+
+  return lines.join("\n");
+}

--- a/supabase/functions/staffing-click/__tests__/requestUtils.test.ts
+++ b/supabase/functions/staffing-click/__tests__/requestUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { parseStaffingClickRequest } from "../requestUtils.ts";
+
+describe("parseStaffingClickRequest", () => {
+  it("parses the legacy query-string link format", () => {
+    const parsed = parseStaffingClickRequest(
+      "https://project.functions.supabase.co/staffing-click?rid=request-1&a=confirm&exp=2026-04-12T08%3A58%3A46.807Z&t=token-1&c=whatsapp",
+    );
+
+    expect(parsed).toEqual({
+      action: "confirm",
+      rid: "request-1",
+      token: "token-1",
+      exp: "2026-04-12T08:58:46.807Z",
+      channelHint: "whatsapp",
+      urlStyle: "legacy",
+    });
+  });
+
+  it("parses the branded path-based link format", () => {
+    const parsed = parseStaffingClickRequest(
+      "https://project.functions.supabase.co/staffing-click/decline/request-2/token-2",
+    );
+
+    expect(parsed).toEqual({
+      action: "decline",
+      rid: "request-2",
+      token: "token-2",
+      exp: null,
+      channelHint: "",
+      urlStyle: "path",
+    });
+  });
+});

--- a/supabase/functions/staffing-click/index.ts
+++ b/supabase/functions/staffing-click/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { detectConflictForAssignment, type AssignmentCoverage, type JobTimeInfo } from "./conflictUtils.ts";
+import { parseStaffingClickRequest } from "./requestUtils.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -25,17 +26,22 @@ serve(async (req) => {
 
   try {
     const url = new URL(req.url);
+    const parsedRequest = parseStaffingClickRequest(url);
     console.log('🔗 PARSED URL:', {
       pathname: url.pathname,
-      searchParams: Object.fromEntries(url.searchParams.entries())
+      searchParams: Object.fromEntries(url.searchParams.entries()),
+      parsedRequest,
     });
-    const rid = url.searchParams.get("rid");
-    const action = url.searchParams.get("a"); // 'confirm' | 'decline'
-    const exp = url.searchParams.get("exp");
-    const t = url.searchParams.get("t");
-    const c = (url.searchParams.get('c') || '').toLowerCase(); // optional channel hint: 'email'|'wa'|'whatsapp'
+    const { rid, action, exp, token: t, channelHint: c, urlStyle } = parsedRequest;
     
-    console.log('✅ STEP 1: Parameters parsed', { rid, action, exp: exp?.substring(0, 20), t: t?.substring(0, 20), channel: c });
+    console.log('✅ STEP 1: Parameters parsed', {
+      rid,
+      action,
+      exp: exp?.substring(0, 20),
+      t: t?.substring(0, 20),
+      channel: c,
+      urlStyle,
+    });
     
     // For link preview HEAD requests, avoid rendering/html to reduce plaintext in previews
     if (req.method === 'HEAD') {
@@ -43,7 +49,7 @@ serve(async (req) => {
       return new Response(null, { status: 204 });
     }
 
-    if (!rid || !action || !exp || !t) {
+    if (!rid || !action || !t || (urlStyle === 'legacy' && !exp)) {
       console.log('❌ STEP 2 FAILED: Missing parameters');
       return await redirectResponse({
         title: 'Enlace inválido',
@@ -53,26 +59,13 @@ serve(async (req) => {
       });
     }
     console.log('✅ STEP 2: All required parameters present');
-    
-    const expTime = new Date(exp).getTime();
-    const nowTime = Date.now();
-    if (expTime < nowTime) {
-      console.log('❌ STEP 3 FAILED: Link expired', { expTime, nowTime, diff: nowTime - expTime });
-      return await redirectResponse({
-        title: 'Enlace caducado',
-        status: 'warning',
-        heading: 'Enlace caducado',
-        message: 'Este enlace ha caducado. Contacta con tu responsable para solicitar uno nuevo.'
-      });
-    }
-    console.log('✅ STEP 3: Link not expired', { expTime, nowTime });
 
-    console.log('🔍 STEP 4: Querying database for staffing request', { rid });
+    console.log('🔍 STEP 3: Querying database for staffing request', { rid, urlStyle });
     const supabase = createClient(SUPABASE_URL, SERVICE_ROLE);
     const { data: row, error: dbError } = await supabase.from("staffing_requests").select("*").eq("id", rid).maybeSingle();
     
     if (dbError) {
-      console.error('❌ STEP 4 FAILED: Database error', dbError);
+      console.error('❌ STEP 3 FAILED: Database error', dbError);
       return await redirectResponse({
         title: 'Error de base de datos',
         status: 'error',
@@ -82,7 +75,7 @@ serve(async (req) => {
     }
     
     if (!row) {
-      console.log('❌ STEP 4 FAILED: Request not found in database', { rid });
+      console.log('❌ STEP 3 FAILED: Request not found in database', { rid });
       return await redirectResponse({
         title: 'No encontrado',
         status: 'error',
@@ -90,15 +83,39 @@ serve(async (req) => {
         message: 'No hemos podido localizar esta solicitud.'
       });
     }
-    console.log('✅ STEP 4: Request found', { rid, phase: row.phase, status: row.status });
+    console.log('✅ STEP 3: Request found', { rid, phase: row.phase, status: row.status });
+
+    const effectiveExp = exp || row.token_expires_at || null;
+    if (!effectiveExp) {
+      console.log('❌ STEP 4 FAILED: Missing effective expiry', { rid, urlStyle, token_expires_at: row.token_expires_at });
+      return await redirectResponse({
+        title: 'Enlace inválido',
+        status: 'error',
+        heading: 'Enlace inválido',
+        message: 'No se pudo validar este enlace. Solicita uno nuevo.'
+      });
+    }
+
+    const expTime = new Date(effectiveExp).getTime();
+    const nowTime = Date.now();
+    if (Number.isNaN(expTime) || expTime < nowTime) {
+      console.log('❌ STEP 4 FAILED: Link expired', { expTime, nowTime, diff: nowTime - expTime, urlStyle });
+      return await redirectResponse({
+        title: 'Enlace caducado',
+        status: 'warning',
+        heading: 'Enlace caducado',
+        message: 'Este enlace ha caducado. Contacta con tu responsable para solicitar uno nuevo.'
+      });
+    }
+    console.log('✅ STEP 4: Link not expired', { expTime, nowTime, urlStyle });
 
     // Recompute expected token hash (HMAC over rid:phase:exp)
-    console.log('🔐 STEP 5: Starting token validation');
+    console.log('🔐 STEP 5: Starting token validation', { effectiveExp: effectiveExp.substring(0, 20), urlStyle });
     try {
       const key = await crypto.subtle.importKey("raw", new TextEncoder().encode(TOKEN_SECRET),
         { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
       const sig = new Uint8Array(await crypto.subtle.sign("HMAC", key,
-        new TextEncoder().encode(`${rid}:${row.phase}:${exp}`)));
+        new TextEncoder().encode(`${rid}:${row.phase}:${effectiveExp}`)));
       const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", sig));
       const token_hash_expected = Array.from(digest).map(x=>x.toString(16).padStart(2,'0')).join('');
 
@@ -118,7 +135,7 @@ serve(async (req) => {
         title: 'Token inválido',
         status: 'error',
         heading: 'Token inválido',
-        message: 'Este enlace no es válido. Utiliza el enlace original de tu correo.'
+        message: 'Este enlace no es válido. Utiliza el enlace original que recibiste.'
       });
       }
       console.log('✅ STEP 5: Token validated successfully');

--- a/supabase/functions/staffing-click/requestUtils.ts
+++ b/supabase/functions/staffing-click/requestUtils.ts
@@ -1,0 +1,58 @@
+export type StaffingClickAction = "confirm" | "decline";
+export type StaffingClickUrlStyle = "legacy" | "path" | "invalid";
+
+export interface ParsedStaffingClickRequest {
+  action: StaffingClickAction | null;
+  rid: string | null;
+  token: string | null;
+  exp: string | null;
+  channelHint: string;
+  urlStyle: StaffingClickUrlStyle;
+}
+
+function isStaffingClickAction(value: string | null | undefined): value is StaffingClickAction {
+  return value === "confirm" || value === "decline";
+}
+
+export function parseStaffingClickRequest(input: URL | string): ParsedStaffingClickRequest {
+  const url = typeof input === "string" ? new URL(input) : input;
+  const channelHint = (url.searchParams.get("c") || "").toLowerCase();
+  const queryRid = url.searchParams.get("rid");
+  const queryAction = url.searchParams.get("a");
+  const queryExp = url.searchParams.get("exp");
+  const queryToken = url.searchParams.get("t");
+
+  if (queryRid || queryAction || queryExp || queryToken) {
+    return {
+      action: isStaffingClickAction(queryAction) ? queryAction : null,
+      rid: queryRid,
+      token: queryToken,
+      exp: queryExp,
+      channelHint,
+      urlStyle: "legacy",
+    };
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const markerIndex = segments.lastIndexOf("staffing-click");
+  if (markerIndex === -1) {
+    return {
+      action: null,
+      rid: null,
+      token: null,
+      exp: null,
+      channelHint,
+      urlStyle: "invalid",
+    };
+  }
+
+  const [pathAction, rid, token] = segments.slice(markerIndex + 1, markerIndex + 4);
+  return {
+    action: isStaffingClickAction(pathAction) ? pathAction : null,
+    rid: rid || null,
+    token: token || null,
+    exp: null,
+    channelHint,
+    urlStyle: "path",
+  };
+}


### PR DESCRIPTION
## Summary
- switch staffing WhatsApp copy to a channel-specific short format
- generate branded path-based confirm/decline links for WhatsApp while keeping legacy email/query links working
- add branded Cloudflare redirect rules for `/staffing/confirm/*` and `/staffing/decline/*`

## Why
The previous WhatsApp message reused email-oriented copy and exposed long raw Supabase function URLs, which looked confusing and suspicious to end users.

## Validation
- `npx vitest run supabase/functions/send-staffing-email/__tests__/messageUtils.test.ts supabase/functions/staffing-click/__tests__/requestUtils.test.ts supabase/functions/staffing-click/__tests__/conflictUtils.test.ts`
- `npx eslint supabase/functions/send-staffing-email/index.ts supabase/functions/send-staffing-email/messageUtils.ts supabase/functions/staffing-click/index.ts supabase/functions/staffing-click/requestUtils.ts supabase/functions/send-staffing-email/__tests__/messageUtils.test.ts supabase/functions/staffing-click/__tests__/requestUtils.test.ts`
- `npm run build`

## Deployment
- deployed Supabase functions `send-staffing-email` and `staffing-click` to project `syldobdcdsgfgjtbuwxm`
- set Supabase secret `PUBLIC_STAFFING_CONFIRM_BASE=https://sector-pro.work/staffing`
- production static deploy is waiting on this PR because `main` is protected and Cloudflare Pages deploys production from `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved staffing request handling with flexible URL routing options for confirmation and decline actions
  * Enhanced WhatsApp messaging with better formatting, Spanish language support, complete availability details, and clearer action links
  * Simplified configuration requirements with reduced mandatory environment variables

* **Tests**
  * Added comprehensive test coverage for staffing request parsing and message generation functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->