### PR TITLE
fix: add error handling to CLEAR_CACHES SW message handler

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,3 @@
-/staffing/confirm/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/confirm/:splat 200
-/staffing/decline/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/decline/:splat 200
+/staffing/confirm/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/confirm/:splat 302
+/staffing/decline/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/decline/:splat 302
 /* /index.html 200

--- a/public/sw.js
+++ b/public/sw.js
@@ -384,6 +384,10 @@ self.addEventListener('message', (event) => {
         .then(() => {
           event.source?.postMessage({ source: 'sw', type: 'caches-cleared', ts: Date.now() })
         })
+        .catch((e) => {
+          console.error('[sw] Failed to clear caches:', e)
+          event.source?.postMessage({ source: 'sw', type: 'caches-clear-error', error: String(e), ts: Date.now() })
+        })
     )
   }
 })

--- a/public/sw.js
+++ b/public/sw.js
@@ -107,43 +107,35 @@ self.addEventListener('fetch', (event) => {
     return
   }
 
-  // Stale-while-revalidate strategy for HTML/navigation requests, with timeout.
-  // This avoids hangs on poor networks while still keeping HTML fresh.
+  // Network-first strategy for HTML/navigation requests.
+  // Serving stale HTML can cause chunk hash mismatches after a new deploy, so we
+  // always attempt the network first and only fall back to cache when offline.
   if (request.mode === 'navigate' || request.destination === 'document' || url.pathname.endsWith('.html')) {
     event.respondWith(
       (async () => {
         const cache = await caches.open(RUNTIME_CACHE)
-        const cached = await cache.match(request)
 
-        const networkFetch = self.fetchWithTimeout(request, HTML_TIMEOUT_MS)
-          .then((response) => {
-            if (response && response.ok) {
-              cache.put(request, response.clone()).catch((e) => {
-                console.warn('[sw] Failed to cache HTML response:', e)
-              })
-            }
-            return response
+        try {
+          const response = await self.fetchWithTimeout(request, HTML_TIMEOUT_MS)
+          if (response && response.ok) {
+            cache.put(request, response.clone()).catch((e) => {
+              console.warn('[sw] Failed to cache HTML response:', e)
+            })
+          }
+          return response
+        } catch {
+          // Network timed out or failed — serve cached shell to stay usable offline
+          const cached = await cache.match(request)
+          if (cached) return cached
+
+          return caches.match('/').then((shell) => {
+            return shell || new Response('Offline', {
+              status: 503,
+              statusText: 'Service Unavailable',
+              headers: { 'Content-Type': 'text/plain' }
+            })
           })
-          .catch(() => null)
-
-        if (cached) {
-          event.waitUntil(networkFetch)
-          return cached
         }
-
-        const networkResponse = await networkFetch
-        if (networkResponse) {
-          return networkResponse
-        }
-
-        // Offline fallback: serve cached app shell if available
-        return caches.match('/').then((shell) => {
-          return shell || new Response('Offline', {
-            status: 503,
-            statusText: 'Service Unavailable',
-            headers: { 'Content-Type': 'text/plain' }
-          })
-        })
       })()
     )
     return
@@ -163,6 +155,19 @@ self.addEventListener('fetch', (event) => {
           // Only cache successful responses
           if (!response || response.status !== 200 || response.type !== 'basic') {
             return response
+          }
+
+          // Detect stale SPA fallback: Cloudflare returned HTML for a JS/CSS/font asset.
+          // This happens when a chunk hash no longer exists on the CDN after a deploy.
+          // Return a 404 so the browser rejects the module load and triggers auto-reload.
+          const contentType = response.headers.get('content-type') || ''
+          const isAssetPath =
+            url.pathname.startsWith('/assets/') ||
+            url.pathname.endsWith('.js') ||
+            url.pathname.endsWith('.css')
+          if (isAssetPath && contentType.includes('text/html')) {
+            console.warn('[sw] HTML response intercepted for asset:', url.pathname, '— stale SPA fallback detected')
+            return new Response(null, { status: 404, statusText: 'Stale Asset' })
           }
 
           // Clone the response to cache it
@@ -370,5 +375,15 @@ self.addEventListener('message', (event) => {
     )
   } else if (type === 'sw:ping') {
     event.source?.postMessage({ source: 'sw', type: 'sw:pong', ts: Date.now() })
+  } else if (type === 'CLEAR_CACHES') {
+    // Called by the app when a chunk load error is detected so the next reload
+    // fetches all assets fresh from the network.
+    event.waitUntil(
+      caches.keys()
+        .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
+        .then(() => {
+          event.source?.postMessage({ source: 'sw', type: 'caches-cleared', ts: Date.now() })
+        })
+    )
   }
 })

--- a/public/sw.js
+++ b/public/sw.js
@@ -124,7 +124,20 @@ self.addEventListener('fetch', (event) => {
           }
           return response
         } catch {
-          // Network timed out or failed — serve cached shell to stay usable offline
+          // Network timed out — attempt one untimed fetch to get fresh HTML
+          // Only fall back to cache if that also fails
+          try {
+            const untimedResponse = await fetch(request)
+            if (untimedResponse && untimedResponse.ok) {
+              cache.put(request, untimedResponse.clone()).catch((e) => {
+                console.warn('[sw] Failed to cache HTML response from untimed fetch:', e)
+              })
+              return untimedResponse
+            }
+          } catch {
+            // Untimed fetch also failed — serve cached shell to stay usable offline
+          }
+
           const cached = await cache.match(request)
           if (cached) return cached
 
@@ -382,11 +395,11 @@ self.addEventListener('message', (event) => {
       caches.keys()
         .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
         .then(() => {
-          event.source?.postMessage({ source: 'sw', type: 'caches-cleared', ts: Date.now() })
+          event.source?.postMessage({ source: 'sw', type: 'CLEAR_CACHES_DONE', ts: Date.now() })
         })
         .catch((e) => {
           console.error('[sw] Failed to clear caches:', e)
-          event.source?.postMessage({ source: 'sw', type: 'caches-clear-error', error: String(e), ts: Date.now() })
+          event.source?.postMessage({ source: 'sw', type: 'CLEAR_CACHES_ERROR', error: String(e), ts: Date.now() })
         })
     )
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,13 +12,46 @@ declare global {
   }
 }
 
-const handleChunkLoadError = () => {
+const handleChunkLoadError = async () => {
   // Ask the service worker to wipe all caches before we reload so the browser
   // fetches every asset fresh and won't re-encounter the stale-shell mismatch.
-  try {
-    if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-      navigator.serviceWorker.controller.postMessage({ type: 'CLEAR_CACHES' })
+  const waitForCacheClear = async (): Promise<void> => {
+    if (!('serviceWorker' in navigator) || !navigator.serviceWorker.controller) {
+      return;
     }
+
+    return new Promise<void>((resolve) => {
+      const timeoutId = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, 2000); // 2 second timeout
+
+      const messageHandler = (event: MessageEvent) => {
+        if (event.data?.source === 'sw' &&
+            (event.data?.type === 'CLEAR_CACHES_DONE' || event.data?.type === 'CLEAR_CACHES_ERROR')) {
+          cleanup();
+          resolve();
+        }
+      };
+
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        navigator.serviceWorker.removeEventListener('message', messageHandler);
+      };
+
+      navigator.serviceWorker.addEventListener('message', messageHandler);
+
+      try {
+        navigator.serviceWorker.controller.postMessage({ type: 'CLEAR_CACHES' });
+      } catch (error) {
+        cleanup();
+        resolve();
+      }
+    });
+  };
+
+  try {
+    await waitForCacheClear();
   } catch {
     // ignore — reload will still happen
   }
@@ -58,7 +91,7 @@ try {
 window.addEventListener('unhandledrejection', (event) => {
   if (isChunkLoadPromiseRejection(event)) {
     event.preventDefault();
-    handleChunkLoadError();
+    void handleChunkLoadError();
   }
 });
 
@@ -66,7 +99,7 @@ window.addEventListener('unhandledrejection', (event) => {
 window.addEventListener('error', (event) => {
   if (isChunkLoadErrorEvent(event)) {
     event.preventDefault();
-    handleChunkLoadError();
+    void handleChunkLoadError();
   }
 });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,16 @@ declare global {
 }
 
 const handleChunkLoadError = () => {
+  // Ask the service worker to wipe all caches before we reload so the browser
+  // fetches every asset fresh and won't re-encounter the stale-shell mismatch.
+  try {
+    if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage({ type: 'CLEAR_CACHES' })
+    }
+  } catch {
+    // ignore — reload will still happen
+  }
+
   try {
     const count = parseInt(sessionStorage.getItem(CHUNK_ERROR_RELOAD_KEY) || '0', 10);
 

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -11,6 +11,7 @@ export const CHUNK_FAILURE_PATTERNS = [
   /Failed to fetch dynamically imported module/i,
   /Importing a module script failed/i,
   /error loading dynamically imported module/i,
+  /Failed to load module script/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- [ ] I described what changed and why.

## Risk Assessment
- [ ] I assessed functional, data, and deployment risk.
- Risk level: <!-- low | medium | high -->
- Main risks:

## Test Evidence
- [ ] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint`
  - `npm run test:critical`
  - `npm run test:run`
  - `npm run build`
- Results:

## Rollback Plan
- [ ] I documented how to safely revert this change.
- Rollback steps:

## Migration Impact
- [ ] I confirmed whether this PR changes schema/functions.
- Migration required: <!-- yes | no -->
- If yes, describe migration, impact, and backout plan:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better recovery when updated assets fail to load, reducing broken pages and reload loops
  * Improved offline behavior and asset handling to avoid serving HTML in place of JS/CSS/fonts
  * Fixed redirect status codes for staffing confirmation and decline links

* **Chores**
  * Added a cache-clear capability to help recover from corrupted or stale caches automatically
<!-- end of auto-generated comment: release notes by coderabbit.ai -->