### PR TITLE
fix: handle branded staffing click runtime paths

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,4 @@
 /staffing/confirm/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/confirm/:splat 302
 /staffing/decline/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/decline/:splat 302
+/staffing-response /staffing-response.html 200
 /* /index.html 200

--- a/public/staffing-response.html
+++ b/public/staffing-response.html
@@ -180,7 +180,9 @@
     const heading = urlParams.get('heading') || 'Respuesta registrada';
     const message = urlParams.get('message') || 'Tu respuesta ha sido procesada.';
     const submessage = urlParams.get('submessage') || 'Puedes cerrar esta pestaña.';
-    const status = urlParams.get('status') || 'neutral';
+    const allowedStatuses = ['neutral', 'success', 'warning', 'error'];
+    const requestedStatus = urlParams.get('status') || 'neutral';
+    const normalizedStatus = allowedStatuses.includes(requestedStatus) ? requestedStatus : 'neutral';
 
     document.getElementById('page-title').textContent = `${title} | ${baseTitle}`;
     document.title = `${title} | ${baseTitle}`;
@@ -189,9 +191,9 @@
     document.getElementById('submessage').textContent = submessage;
 
     const iconElement = document.getElementById('status-icon');
-    iconElement.className = `icon ${status}`;
+    iconElement.className = `icon ${normalizedStatus}`;
 
-    switch (status) {
+    switch (normalizedStatus) {
       case 'success':
         iconElement.textContent = '✓';
         break;

--- a/public/staffing-response.html
+++ b/public/staffing-response.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
+  <title id="page-title">Respuesta de staffing | Sector Pro</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #eef2f7, #f9fafc);
+      color: #333;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+
+    .shell {
+      width: 100%;
+      max-width: 480px;
+    }
+
+    .logo-container {
+      text-align: center;
+      margin-bottom: 25px;
+    }
+
+    .logo {
+      width: 140px;
+      max-width: 40%;
+      height: auto;
+    }
+
+    .container {
+      background: #fff;
+      border-radius: 16px;
+      padding: 40px 30px;
+      text-align: center;
+      box-shadow: 0 12px 35px rgba(0,0,0,0.08);
+      animation: fadeIn 0.8s ease-out;
+      border-top: 5px solid #667eea;
+    }
+
+    .icon {
+      width: 90px;
+      height: 90px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 25px;
+      font-size: 42px;
+      font-weight: bold;
+      color: #fff;
+      animation: popIn 0.6s ease;
+    }
+
+    .icon.error {
+      background: linear-gradient(135deg, #e53935, #c62828);
+      box-shadow: 0 6px 15px rgba(229,57,53,0.3);
+    }
+
+    .icon.success {
+      background: linear-gradient(135deg, #43a047, #2e7d32);
+      box-shadow: 0 6px 15px rgba(67,160,71,0.3);
+    }
+
+    .icon.warning {
+      background: linear-gradient(135deg, #fb8c00, #ef6c00);
+      box-shadow: 0 6px 15px rgba(251,140,0,0.3);
+    }
+
+    .icon.neutral {
+      background: linear-gradient(135deg, #1e88e5, #1565c0);
+      box-shadow: 0 6px 15px rgba(30,136,229,0.3);
+    }
+
+    h1 {
+      font-size: 26px;
+      font-weight: 700;
+      margin-bottom: 12px;
+      color: #222;
+    }
+
+    .message {
+      font-size: 18px;
+      margin-bottom: 10px;
+      color: #555;
+    }
+
+    .submessage {
+      font-size: 15px;
+      color: #777;
+      font-style: italic;
+      margin-bottom: 30px;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 12px 24px;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+      color: #fff;
+      font-weight: 600;
+      border-radius: 8px;
+      text-decoration: none;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    }
+
+    .btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 8px 20px rgba(0,0,0,0.25);
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(20px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes popIn {
+      0% { transform: scale(0.5); opacity: 0; }
+      100% { transform: scale(1); opacity: 1; }
+    }
+
+    @media (max-width: 480px) {
+      .container {
+        padding: 30px 20px;
+      }
+
+      .logo {
+        width: 100px;
+      }
+
+      .icon {
+        width: 70px;
+        height: 70px;
+        font-size: 32px;
+      }
+
+      h1 {
+        font-size: 22px;
+      }
+
+      .message {
+        font-size: 16px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="logo-container">
+      <img
+        src="https://syldobdcdsgfgjtbuwxm.supabase.co/storage/v1/object/public/public%20logos/sectorpro.png"
+        alt="Sector Pro"
+        class="logo"
+      >
+    </div>
+    <div class="container">
+      <div class="icon neutral" id="status-icon">ℹ</div>
+      <h1 id="heading">Respuesta registrada</h1>
+      <div class="message" id="message">Tu respuesta ha sido procesada.</div>
+      <div class="submessage" id="submessage">Puedes cerrar esta pestaña.</div>
+      <a href="https://sector-pro.work" class="btn">Volver a Sector Pro</a>
+    </div>
+  </div>
+
+  <script>
+    const urlParams = new URLSearchParams(window.location.search);
+    const baseTitle = 'Sector Pro';
+    const title = urlParams.get('title') || urlParams.get('heading') || 'Respuesta de staffing';
+    const heading = urlParams.get('heading') || 'Respuesta registrada';
+    const message = urlParams.get('message') || 'Tu respuesta ha sido procesada.';
+    const submessage = urlParams.get('submessage') || 'Puedes cerrar esta pestaña.';
+    const status = urlParams.get('status') || 'neutral';
+
+    document.getElementById('page-title').textContent = `${title} | ${baseTitle}`;
+    document.title = `${title} | ${baseTitle}`;
+    document.getElementById('heading').textContent = heading;
+    document.getElementById('message').textContent = message;
+    document.getElementById('submessage').textContent = submessage;
+
+    const iconElement = document.getElementById('status-icon');
+    iconElement.className = `icon ${status}`;
+
+    switch (status) {
+      case 'success':
+        iconElement.textContent = '✓';
+        break;
+      case 'warning':
+        iconElement.textContent = '⚠';
+        break;
+      case 'error':
+        iconElement.textContent = '✗';
+        break;
+      case 'neutral':
+      default:
+        iconElement.textContent = 'ℹ';
+    }
+  </script>
+</body>
+</html>

--- a/supabase/functions/staffing-click/__tests__/requestUtils.test.ts
+++ b/supabase/functions/staffing-click/__tests__/requestUtils.test.ts
@@ -32,4 +32,19 @@ describe("parseStaffingClickRequest", () => {
       urlStyle: "path",
     });
   });
+
+  it("parses the stripped runtime path format used by the edge handler", () => {
+    const parsed = parseStaffingClickRequest(
+      "https://project.functions.supabase.co/confirm/request-3/token-3",
+    );
+
+    expect(parsed).toEqual({
+      action: "confirm",
+      rid: "request-3",
+      token: "token-3",
+      exp: null,
+      channelHint: "",
+      urlStyle: "path",
+    });
+  });
 });

--- a/supabase/functions/staffing-click/index.ts
+++ b/supabase/functions/staffing-click/index.ts
@@ -639,10 +639,11 @@ serve(async (req) => {
 async function redirectResponse(opts: { title: string, status: 'success'|'warning'|'error'|'neutral', heading: string, message: string, submessage?: string }) {
   // Prefer redirect if an explicit result page URL is configured and reachable.
   const configuredBase = Deno.env.get('PUBLIC_CONFIRM_RESULT_URL') || Deno.env.get('PUBLIC_RESULT_PAGE_URL') || '';
-  const defaultBase = 'https://sector-pro.work/temp_error.html';
+  const defaultBase = 'https://sector-pro.work/staffing-response';
   const baseUrl = configuredBase || defaultBase;
 
   const params = new URLSearchParams({
+    title: opts.title,
     status: opts.status,
     heading: opts.heading,
     message: opts.message,

--- a/supabase/functions/staffing-click/index.ts
+++ b/supabase/functions/staffing-click/index.ts
@@ -152,9 +152,20 @@ serve(async (req) => {
     // Check if already responded
     console.log('🔍 STEP 6: Checking current status', { currentStatus: row.status });
     if (row.status !== 'pending') {
-      const statusText = row.status === 'confirmed' ? 'confirmado' : 'rechazado';
       const phase = row.phase === 'offer' ? 'la oferta' : 'la disponibilidad';
       console.log('⚠️ STEP 6: Already responded', { status: row.status, phase: row.phase });
+
+      if (row.status === 'expired') {
+        return await redirectResponse({
+          title: 'Enlace caducado',
+          status: 'warning',
+          heading: 'Solicitud caducada',
+          message: `Esta solicitud para ${phase} ya no está activa.`,
+          submessage: 'Contacta con tu responsable si necesitas un enlace nuevo.'
+        });
+      }
+
+      const statusText = row.status === 'confirmed' ? 'confirmado' : 'rechazado';
       return await redirectResponse({
         title: 'Respuesta registrada',
         status: 'warning',

--- a/supabase/functions/staffing-click/requestUtils.ts
+++ b/supabase/functions/staffing-click/requestUtils.ts
@@ -35,7 +35,13 @@ export function parseStaffingClickRequest(input: URL | string): ParsedStaffingCl
 
   const segments = url.pathname.split("/").filter(Boolean);
   const markerIndex = segments.lastIndexOf("staffing-click");
-  if (markerIndex === -1) {
+  const pathSegments =
+    markerIndex === -1
+      ? segments.slice(0, 3)
+      : segments.slice(markerIndex + 1, markerIndex + 4);
+  const [pathAction, rid, token] = pathSegments;
+
+  if (!isStaffingClickAction(pathAction) || !rid || !token) {
     return {
       action: null,
       rid: null,
@@ -46,11 +52,10 @@ export function parseStaffingClickRequest(input: URL | string): ParsedStaffingCl
     };
   }
 
-  const [pathAction, rid, token] = segments.slice(markerIndex + 1, markerIndex + 4);
   return {
-    action: isStaffingClickAction(pathAction) ? pathAction : null,
-    rid: rid || null,
-    token: token || null,
+    action: pathAction,
+    rid,
+    token,
     exp: null,
     channelHint,
     urlStyle: "path",


### PR DESCRIPTION
## Summary
- accept branded staffing click paths both with and without the `staffing-click` path segment
- add a regression test for the stripped runtime path used by the edge handler
- show an expired-link message instead of treating expired requests as declined

## Verification
- `npx vitest run supabase/functions/staffing-click/__tests__/requestUtils.test.ts supabase/functions/staffing-click/__tests__/conflictUtils.test.ts`
- redeployed `staffing-click` to project `syldobdcdsgfgjtbuwxm`
- verified the branded test link no longer hits the invalid-parameters branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Spanish staffing response page that displays status, title, heading, message and a return link; it reads query parameters to populate content.
  * Added a user-facing route for staffing responses.

* **Bug Fixes**
  * Improved handling and messaging for expired staffing requests with an expiration-specific warning.

* **Tests**
  * Added a test validating parsing of path-style staffing click links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->