### PR TITLE
fix: remove staffing response redirect loop

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,3 @@
 /staffing/confirm/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/confirm/:splat 302
 /staffing/decline/* https://syldobdcdsgfgjtbuwxm.functions.supabase.co/staffing-click/decline/:splat 302
-/staffing-response /staffing-response.html 200
 /* /index.html 200


### PR DESCRIPTION
%23%23 Summary
- remove the explicit `/staffing-response` rewrite from `public/_redirects`
- keep the static `staffing-response.html` page in place without bouncing between the clean path and the html file

%23%23 Verification
- `npm run build`
- confirmed the current production issue is an infinite `308` redirect loop on `/staffing-response`
- local build still outputs `dist/staffing-response.html` and `dist/_redirects` correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed explicit redirect rule for `/staffing-response`, allowing the path to follow standard routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->