### PR TITLE
unify rehearsal rate source of truth

### DIFF
--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
@@ -87,11 +87,16 @@ describe("JobPayoutTotalsPanel autonomo badge", () => {
       getTechOverride: () => undefined,
       calculatedGrandTotal: 100,
       isManager: true,
+      isAdmin: false,
+      isAdminOrAdministrative: false,
+      userDepartment: null,
       rehearsalDateSet: new Set(),
       jobTimesheetDates: [],
       allDatesMarked: false,
       toggleDateRehearsalMutation: { mutate: vi.fn(), isPending: false },
       toggleAllDatesRehearsalMutation: { mutate: vi.fn(), isPending: false },
+      getTechRateModeDateSelection: () => "inherit",
+      setTechnicianRateModeMutation: { mutate: vi.fn(), isPending: false },
       standardPayoutTotals: [],
     });
 

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
@@ -53,7 +53,6 @@ describe("JobPayoutTotalsPanel autonomo badge", () => {
         },
       ],
       visibleTourQuotes: [],
-      tourTimesheetDays: new Map(),
       profilesWithEmail: [
         {
           id: "tech-1",

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -21,51 +21,61 @@ vi.mock("@/components/jobs/payout-totals/usePayoutActions", () => ({
 import { JobPayoutTotalsPanel } from "../JobPayoutTotalsPanel";
 
 describe("JobPayoutTotalsPanel tourdate payouts", () => {
-  beforeEach(() => {
-    useJobPayoutDataMock.mockReturnValue({
-      jobMeta: {
-        id: "job-tour-1",
-        title: "Tour Date",
-        start_time: "2024-01-01T00:00:00Z",
-        end_time: "2024-01-01T06:00:00Z",
-        timezone: "Europe/Madrid",
-        tour_id: "tour-1",
-        rates_approved: true,
-        job_type: "tourdate",
-        invoicing_company: null,
-      },
-      isTourDate: true,
-      isLoading: false,
-      error: null,
-      isClosureLocked: false,
-      payoutTotals: [
-        {
-          technician_id: "tech-1",
-          job_id: "job-tour-1",
-          timesheets_total_eur: 150,
-          extras_total_eur: 25,
-          total_eur: 175,
-          payout_approved: true,
-          extras_breakdown: {
-            items: [
-              {
-                extra_type: "travel_half",
-                quantity: 1,
-                unit_eur: 25,
-                amount_eur: 25,
-              },
-            ],
-            total_eur: 25,
-          },
-          vehicle_disclaimer: true,
-          vehicle_disclaimer_text: "Vehículo asignado por la gira.",
-          expenses_total_eur: 0,
-          expenses_breakdown: [],
+  const buildPayoutData = () => ({
+    jobMeta: {
+      id: "job-tour-1",
+      title: "Tour Date",
+      start_time: "2024-01-01T00:00:00Z",
+      end_time: "2024-01-01T06:00:00Z",
+      timezone: "Europe/Madrid",
+      tour_id: "tour-1",
+      rates_approved: true,
+      job_type: "tourdate",
+      invoicing_company: null,
+    },
+    isTourDate: true,
+    isLoading: false,
+    error: null,
+    isClosureLocked: false,
+    payoutTotals: [
+      {
+        technician_id: "tech-1",
+        job_id: "job-tour-1",
+        timesheets_total_eur: 150,
+        extras_total_eur: 25,
+        total_eur: 175,
+        payout_approved: true,
+        extras_breakdown: {
+          items: [
+            {
+              extra_type: "travel_half",
+              quantity: 1,
+              unit_eur: 25,
+              amount_eur: 25,
+            },
+          ],
+          total_eur: 25,
         },
-      ],
-      visibleTourQuotes: [],
-      tourTimesheetDays: new Map([["tech-1", 1]]),
-      profilesWithEmail: [
+        vehicle_disclaimer: true,
+        vehicle_disclaimer_text: "Vehículo asignado por la gira.",
+        expenses_total_eur: 0,
+        expenses_breakdown: [],
+      },
+    ],
+    visibleTourQuotes: [],
+    tourTimesheetDays: new Map([["tech-1", 1]]),
+    profilesWithEmail: [
+      {
+        id: "tech-1",
+        first_name: "Ana",
+        last_name: "Lopez",
+        email: "ana@example.com",
+        autonomo: false,
+      },
+    ],
+    profileMap: new Map([
+      [
+        "tech-1",
         {
           id: "tech-1",
           first_name: "Ana",
@@ -74,37 +84,34 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
           autonomo: false,
         },
       ],
-      profileMap: new Map([
-        [
-          "tech-1",
-          {
-            id: "tech-1",
-            first_name: "Ana",
-            last_name: "Lopez",
-            email: "ana@example.com",
-            autonomo: false,
-          },
-        ],
-      ]),
-      autonomoMap: new Map([["tech-1", false]]),
-      getTechName: () => "Ana Lopez",
-      lpoMap: new Map(),
-      flexElementMap: new Map(),
-      buildFinDocUrl: () => null,
-      techDaysMap: new Map(),
-      techTotalDaysMap: new Map(),
-      payoutOverrides: [],
-      overrideActorMap: new Map(),
-      getTechOverride: () => undefined,
-      calculatedGrandTotal: 175,
-      isManager: true,
-      rehearsalDateSet: new Set(),
-      jobTimesheetDates: [],
-      allDatesMarked: false,
-      toggleDateRehearsalMutation: { mutate: vi.fn(), isPending: false },
-      toggleAllDatesRehearsalMutation: { mutate: vi.fn(), isPending: false },
-      standardPayoutTotals: [],
-    });
+    ]),
+    autonomoMap: new Map([["tech-1", false]]),
+    getTechName: () => "Ana Lopez",
+    lpoMap: new Map(),
+    flexElementMap: new Map(),
+    buildFinDocUrl: () => null,
+    techDaysMap: new Map(),
+    techTotalDaysMap: new Map(),
+    payoutOverrides: [],
+    overrideActorMap: new Map(),
+    getTechOverride: () => undefined,
+    calculatedGrandTotal: 175,
+    isManager: true,
+    isAdmin: false,
+    isAdminOrAdministrative: false,
+    userDepartment: null,
+    rehearsalDateSet: new Set<string>(),
+    jobTimesheetDates: [] as string[],
+    allDatesMarked: false,
+    toggleDateRehearsalMutation: { mutate: vi.fn(), isPending: false },
+    toggleAllDatesRehearsalMutation: { mutate: vi.fn(), isPending: false },
+    getTechRateModeDateSelection: () => "inherit",
+    setTechnicianRateModeMutation: { mutate: vi.fn(), isPending: false },
+    standardPayoutTotals: [],
+  });
+
+  beforeEach(() => {
+    useJobPayoutDataMock.mockReturnValue(buildPayoutData());
 
     usePayoutActionsMock.mockReturnValue({
       isExporting: false,
@@ -148,5 +155,36 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     expect(screen.getByText(/travel half/i)).toBeInTheDocument();
     expect(screen.getByText(/vehículo asignado por la gira/i)).toBeInTheDocument();
     expect(screen.queryByText(/no hay información de pagos para este trabajo/i)).not.toBeInTheDocument();
+  });
+
+  it("hides the technician/date rate-mode section from non-admin payout managers", () => {
+    useJobPayoutDataMock.mockReturnValue({
+      ...buildPayoutData(),
+      isAdmin: false,
+      isManager: true,
+      jobTimesheetDates: ["2026-04-10"],
+      rehearsalDateSet: new Set(["2026-04-10"]),
+    });
+
+    renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
+
+    expect(screen.queryByText(/tarifa por técnico y fecha/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the technician/date rate-mode section to admins only", () => {
+    useJobPayoutDataMock.mockReturnValue({
+      ...buildPayoutData(),
+      isAdmin: true,
+      isManager: true,
+      jobTimesheetDates: ["2026-04-10"],
+      rehearsalDateSet: new Set(["2026-04-10"]),
+      getTechRateModeDateSelection: () => "inherit",
+      setTechnicianRateModeMutation: { mutate: vi.fn(), isPending: false },
+    });
+
+    renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
+
+    expect(screen.getByText(/tarifa por técnico y fecha/i)).toBeInTheDocument();
+    expect(screen.getByText(/heredar \(ensayo\)/i)).toBeInTheDocument();
   });
 });

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -64,7 +64,6 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
       },
     ],
     visibleTourQuotes: [],
-    tourTimesheetDays: new Map([["tech-1", 1]]),
     profilesWithEmail: [
       {
         id: "tech-1",

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { formatCurrency } from "@/lib/utils";
@@ -171,7 +172,9 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     expect(screen.queryByText(/tarifa por técnico y fecha/i)).not.toBeInTheDocument();
   });
 
-  it("shows the technician/date rate-mode section to admins only", () => {
+  it("shows the technician/date rate-mode section to admins only", async () => {
+    const user = userEvent.setup();
+
     useJobPayoutDataMock.mockReturnValue({
       ...buildPayoutData(),
       isAdmin: true,
@@ -185,6 +188,10 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
 
     expect(screen.getByText(/tarifa por técnico y fecha/i)).toBeInTheDocument();
+    expect(screen.queryByText(/heredar \(ensayo\)/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /tarifa por técnico y fecha/i }));
+
     expect(screen.getByText(/heredar \(ensayo\)/i)).toBeInTheDocument();
   });
 });

--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsInfoTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsInfoTab.tsx
@@ -20,7 +20,6 @@ import { generateTimesheetPDF } from "@/utils/timesheet-pdf";
 import { generateJobPayoutPDF, generateRateQuotePDF } from "@/utils/rates-pdf-export";
 import { sendJobPayoutEmails } from "@/lib/job-payout-email";
 import { prepareJobPayoutData } from "@/lib/job-payout-data";
-import { adjustRehearsalQuotesForMultiDay } from "@/lib/tour-payout-email";
 import { isJobPastClosureWindow } from "@/utils/jobClosureUtils";
 import { JobPayoutTotalsPanel } from "@/components/jobs/JobPayoutTotalsPanel";
 import { useJobApprovalStatus } from "@/hooks/useJobApprovalStatus";
@@ -605,18 +604,9 @@ export const JobDetailsInfoTab: React.FC<JobDetailsInfoTabProps> = ({
                       }
 
                       const payoutProfiles = Array.from(profileMap.values());
-                      const techDates = new Map<string, Set<string>>();
-                      (timesheets || []).forEach((row: any) => {
-                        if (!row?.technician_id || !row?.date) return;
-                        if (!techDates.has(row.technician_id)) techDates.set(row.technician_id, new Set());
-                        techDates.get(row.technician_id)!.add(row.date);
-                      });
-                      const daysCounts = new Map<string, number>();
-                      techDates.forEach((dates, techId) => daysCounts.set(techId, dates.size));
-                      const adjustedQuotes = adjustRehearsalQuotesForMultiDay(quotes as any, daysCounts);
                       const quotesWithOverrides = await attachPayoutOverridesToTourQuotes(
                         resolvedJobId,
-                        adjustedQuotes as any
+                        quotes as any
                       );
                       const quoteBlob = (await generateRateQuotePDF(
                         quotesWithOverrides as any,

--- a/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
+++ b/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
@@ -96,7 +96,6 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
     jobMeta: data.jobMeta,
     standardPayoutTotals: filteredStandardPayoutTotals,
     visibleTourQuotes: filteredVisibleTourQuotes,
-    tourTimesheetDays: data.tourTimesheetDays,
     payoutTotals: displayedPayouts,
     profilesWithEmail: filteredProfilesWithEmail,
     profileMap: data.profileMap,

--- a/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
+++ b/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
@@ -234,6 +234,7 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
             isTourDate={data.isTourDate}
             isCicloJob={isCicloJob}
             isManager={data.isManager}
+            isAdmin={data.isAdmin}
             profileMap={data.profileMap}
             autonomoMap={data.autonomoMap}
             getTechName={data.getTechName}
@@ -242,10 +243,14 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
             buildFinDocUrl={data.buildFinDocUrl}
             techDaysMap={data.techDaysMap}
             techTotalDaysMap={data.techTotalDaysMap}
+            jobTimesheetDates={data.jobTimesheetDates}
+            rehearsalDateSet={data.rehearsalDateSet}
             missingEmailTechIds={actions.missingEmailTechIds}
             sendingByTech={actions.sendingByTech}
             isClosureLocked={data.isClosureLocked}
             getTechOverride={data.getTechOverride}
+            getTechRateModeDateSelection={data.getTechRateModeDateSelection}
+            setTechnicianRateModeMutation={data.setTechnicianRateModeMutation}
             overrideActorMap={data.overrideActorMap}
             editingTechId={actions.editingTechId}
             editingAmount={actions.editingAmount}

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
+import { parseISO } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
+import { es } from 'date-fns/locale';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertCircle, Clock, CheckCircle, ExternalLink, Send, Receipt } from 'lucide-react';
 import { cn, formatCurrency } from '@/lib/utils';
 import { getAutonomoBadgeLabel } from '@/utils/autonomo';
 import { JobPayoutOverrideSection, type JobPayoutOverride } from '@/components/jobs/JobPayoutOverrideSection';
+import type { TechnicianDateRateMode } from '@/hooks/useTechnicianRateModeDates';
 import type { JobPayoutTotals } from '@/types/jobExtras';
 import type { TechnicianProfileWithEmail } from '@/lib/job-payout-email';
 import { surface, controlButton, NON_AUTONOMO_DEDUCTION_EUR } from './types';
@@ -25,6 +30,7 @@ interface TechnicianPayoutCardProps {
   isTourDate: boolean;
   isCicloJob?: boolean;
   isManager: boolean;
+  isAdmin: boolean;
   profileMap: Map<string, TechnicianProfileWithEmail>;
   autonomoMap: Map<string, boolean | null>;
   getTechName: (id: string) => string;
@@ -33,11 +39,18 @@ interface TechnicianPayoutCardProps {
   buildFinDocUrl: (elementId: string | null | undefined) => string | null;
   techDaysMap: Map<string, number>;
   techTotalDaysMap: Map<string, number>;
+  jobTimesheetDates: string[];
+  rehearsalDateSet: Set<string>;
   missingEmailTechIds: string[];
   sendingByTech: Record<string, boolean>;
   isClosureLocked: boolean;
   /* Override */
   getTechOverride: (techId: string) => JobPayoutOverride | undefined;
+  getTechRateModeDateSelection: (techId: string, date: string) => TechnicianDateRateMode;
+  setTechnicianRateModeMutation: {
+    mutate: (args: { jobId: string; technicianId: string; date: string; mode: TechnicianDateRateMode }) => void;
+    isPending: boolean;
+  };
   overrideActorMap: Map<string, { name: string; email: string | null }>;
   editingTechId: string | null;
   editingAmount: string;
@@ -60,6 +73,7 @@ export function TechnicianPayoutCard({
   isTourDate,
   isCicloJob = false,
   isManager,
+  isAdmin,
   profileMap,
   autonomoMap,
   getTechName,
@@ -68,10 +82,14 @@ export function TechnicianPayoutCard({
   buildFinDocUrl,
   techDaysMap,
   techTotalDaysMap,
+  jobTimesheetDates,
+  rehearsalDateSet,
   missingEmailTechIds,
   sendingByTech,
   isClosureLocked,
   getTechOverride,
+  getTechRateModeDateSelection,
+  setTechnicianRateModeMutation,
   overrideActorMap,
   editingTechId,
   editingAmount,
@@ -117,6 +135,7 @@ export function TechnicianPayoutCard({
   const totalDays = techTotalDaysMap.get(techId) || 0;
   const approvedDays = techDaysMap.get(techId) || 0;
   const showDaysWarning = !isTourDate && totalDays > 1 && approvedDays < totalDays;
+  const showAdminRateModeSection = isTourDate && isAdmin && jobTimesheetDates.length > 0;
 
   return (
     <div
@@ -328,6 +347,69 @@ export function TechnicianPayoutCard({
                 ? 'Puede aplicarse compensación de combustible/conducción al usar vehículo propio. Coordina con RR. HH. por cada trabajo.'
                 : payout.vehicle_disclaimer_text}
             </span>
+          </div>
+        </>
+      )}
+
+      {showAdminRateModeSection && (
+        <>
+          <Separator className="border-border" />
+          <div className="space-y-2">
+            <div>
+              <div className="text-sm font-medium">Tarifa por técnico y fecha</div>
+              <div className="text-xs text-muted-foreground">
+                Hereda la tarifa global de ensayo salvo cuando fijes una excepción para este técnico.
+              </div>
+            </div>
+            <div className="space-y-2">
+              {jobTimesheetDates.map((dateStr) => {
+                const selectedMode = getTechRateModeDateSelection(techId, dateStr);
+                const inheritsRehearsal = rehearsalDateSet.has(dateStr);
+                const inheritedLabel = inheritsRehearsal ? 'Ensayo' : 'Estándar';
+                const dateLabel = formatInTimeZone(parseISO(dateStr), 'Europe/Madrid', 'EEE d MMM', {
+                  locale: es,
+                });
+
+                return (
+                  <div
+                    key={`${techId}-${dateStr}`}
+                    className="flex flex-col gap-2 rounded-md border border-border/60 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium capitalize">{dateLabel}</div>
+                      <div className="text-xs text-muted-foreground">Tarifa global: {inheritedLabel}</div>
+                    </div>
+
+                    <Select
+                      value={selectedMode}
+                      onValueChange={(nextMode) => {
+                        const mode = nextMode as TechnicianDateRateMode;
+                        if (mode === selectedMode) return;
+                        setTechnicianRateModeMutation.mutate({
+                          jobId,
+                          technicianId: techId,
+                          date: dateStr,
+                          mode,
+                        });
+                      }}
+                      disabled={setTechnicianRateModeMutation.isPending}
+                    >
+                      <SelectTrigger className="h-8 w-full text-xs sm:w-[220px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="inherit">Heredar ({inheritedLabel})</SelectItem>
+                        <SelectItem value="rehearsal">Forzar ensayo</SelectItem>
+                        <SelectItem value="standard">Forzar estándar</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                );
+              })}
+            </div>
+            {setTechnicianRateModeMutation.isPending && (
+              <div className="text-xs text-muted-foreground animate-pulse">Actualizando tarifa calculada…</div>
+            )}
           </div>
         </>
       )}

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -6,8 +6,9 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { AlertCircle, Clock, CheckCircle, ExternalLink, Send, Receipt } from 'lucide-react';
+import { AlertCircle, ChevronDown, Clock, CheckCircle, ExternalLink, Send, Receipt } from 'lucide-react';
 import { cn, formatCurrency } from '@/lib/utils';
 import { getAutonomoBadgeLabel } from '@/utils/autonomo';
 import { JobPayoutOverrideSection, type JobPayoutOverride } from '@/components/jobs/JobPayoutOverrideSection';
@@ -136,6 +137,24 @@ export function TechnicianPayoutCard({
   const approvedDays = techDaysMap.get(techId) || 0;
   const showDaysWarning = !isTourDate && totalDays > 1 && approvedDays < totalDays;
   const showAdminRateModeSection = isTourDate && isAdmin && jobTimesheetDates.length > 0;
+  const activeRateModeOverrideCount = React.useMemo(() => {
+    return jobTimesheetDates.reduce((count, dateStr) => {
+      return count + (getTechRateModeDateSelection(techId, dateStr) === 'inherit' ? 0 : 1);
+    }, 0);
+  }, [getTechRateModeDateSelection, jobTimesheetDates, techId]);
+  const [isAdminRateModeOpen, setIsAdminRateModeOpen] = React.useState(activeRateModeOverrideCount > 0);
+
+  React.useEffect(() => {
+    if (activeRateModeOverrideCount > 0) {
+      setIsAdminRateModeOpen(true);
+    }
+  }, [activeRateModeOverrideCount]);
+
+  const rateModeSummaryLabel = activeRateModeOverrideCount === 0
+    ? 'Sin excepciones'
+    : activeRateModeOverrideCount === 1
+      ? '1 excepción'
+      : `${activeRateModeOverrideCount} excepciones`;
 
   return (
     <div
@@ -354,14 +373,37 @@ export function TechnicianPayoutCard({
       {showAdminRateModeSection && (
         <>
           <Separator className="border-border" />
-          <div className="space-y-2">
-            <div>
-              <div className="text-sm font-medium">Tarifa por técnico y fecha</div>
-              <div className="text-xs text-muted-foreground">
-                Hereda la tarifa global de ensayo salvo cuando fijes una excepción para este técnico.
-              </div>
-            </div>
-            <div className="space-y-2">
+          <Collapsible
+            open={isAdminRateModeOpen}
+            onOpenChange={setIsAdminRateModeOpen}
+            className="space-y-2"
+          >
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="flex w-full items-start justify-between gap-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-left transition-colors hover:bg-muted/40"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-medium">Tarifa por técnico y fecha</div>
+                  <div className="text-xs text-muted-foreground">
+                    Hereda la tarifa global de ensayo salvo cuando fijes una excepción para este técnico.
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Badge variant={activeRateModeOverrideCount > 0 ? 'default' : 'secondary'} className="text-[10px]">
+                    {rateModeSummaryLabel}
+                  </Badge>
+                  <ChevronDown
+                    className={cn(
+                      'h-4 w-4 text-muted-foreground transition-transform',
+                      isAdminRateModeOpen && 'rotate-180',
+                    )}
+                  />
+                </div>
+              </button>
+            </CollapsibleTrigger>
+
+            <CollapsibleContent className="space-y-2">
               {jobTimesheetDates.map((dateStr) => {
                 const selectedMode = getTechRateModeDateSelection(techId, dateStr);
                 const inheritsRehearsal = rehearsalDateSet.has(dateStr);
@@ -406,11 +448,11 @@ export function TechnicianPayoutCard({
                   </div>
                 );
               })}
-            </div>
+            </CollapsibleContent>
             {setTechnicianRateModeMutation.isPending && (
               <div className="text-xs text-muted-foreground animate-pulse">Actualizando tarifa calculada…</div>
             )}
-          </div>
+          </Collapsible>
         </>
       )}
 

--- a/src/components/jobs/payout-totals/types.ts
+++ b/src/components/jobs/payout-totals/types.ts
@@ -39,7 +39,6 @@ export interface JobPayoutData {
   isClosureLocked: boolean;
   payoutTotals: JobPayoutTotals[];
   visibleTourQuotes: TourJobRateQuote[];
-  tourTimesheetDays: Map<string, number>;
   profilesWithEmail: TechnicianProfileWithEmail[];
   profileMap: Map<string, TechnicianProfileWithEmail>;
   autonomoMap: Map<string, boolean | null>;

--- a/src/components/jobs/payout-totals/types.ts
+++ b/src/components/jobs/payout-totals/types.ts
@@ -2,6 +2,7 @@ import type { JobPayoutTotals } from '@/types/jobExtras';
 import type { TourJobRateQuote } from '@/types/tourRates';
 import type { TechnicianProfileWithEmail, JobPayoutEmailContextResult } from '@/lib/job-payout-email';
 import type { JobPayoutOverride } from '@/components/jobs/JobPayoutOverrideSection';
+import type { TechnicianDateRateMode } from '@/hooks/useTechnicianRateModeDates';
 
 export { NON_AUTONOMO_DEDUCTION_EUR } from '@/types/jobExtras';
 
@@ -53,6 +54,7 @@ export interface JobPayoutData {
   getTechOverride: (techId: string) => JobPayoutOverride | undefined;
   calculatedGrandTotal: number;
   isManager: boolean;
+  isAdmin: boolean;
   isAdminOrAdministrative: boolean;
   userDepartment: string | null | undefined;
   rehearsalDateSet: Set<string>;
@@ -60,6 +62,11 @@ export interface JobPayoutData {
   allDatesMarked: boolean;
   toggleDateRehearsalMutation: { mutate: (args: { jobId: string; date: string; enabled: boolean }) => void; isPending: boolean };
   toggleAllDatesRehearsalMutation: { mutate: (args: { jobId: string; dates: string[]; enabled: boolean }) => void; isPending: boolean };
+  getTechRateModeDateSelection: (techId: string, date: string) => TechnicianDateRateMode;
+  setTechnicianRateModeMutation: {
+    mutate: (args: { jobId: string; technicianId: string; date: string; mode: TechnicianDateRateMode }) => void;
+    isPending: boolean;
+  };
   standardPayoutTotals: JobPayoutTotals[];
 }
 

--- a/src/components/jobs/payout-totals/useJobPayoutData.ts
+++ b/src/components/jobs/payout-totals/useJobPayoutData.ts
@@ -6,6 +6,7 @@ import { useManagerJobQuotes } from '@/hooks/useManagerJobQuotes';
 import { useJobTechnicianPayoutOverrides } from '@/hooks/useJobPayoutOverride';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { useJobRehearsalDates, useToggleDateRehearsalRate, useToggleAllDatesRehearsalRate } from '@/hooks/useToggleJobRehearsalRate';
+import { useJobTechnicianRateModeDates, useSetTechnicianDateRateMode } from '@/hooks/useTechnicianRateModeDates';
 import type { TechnicianProfileWithEmail } from '@/lib/job-payout-email';
 import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 import { canManagePayouts, isAdministrativeDepartment } from '@/utils/permissions';
@@ -20,6 +21,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
   /* ── Auth ── */
   const { userRole, userDepartment } = useOptimizedAuth();
   const isManager = canManagePayouts(userRole, userDepartment);
+  const isAdmin = userRole === 'admin';
   const isAdminOrAdministrative = userRole === 'admin' || isAdministrativeDepartment(userDepartment);
 
   /* ── Job metadata ── */
@@ -322,21 +324,18 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
 
       if (scheduledError) throw scheduledError;
 
-      const scheduledDates = Array.from(
-        new Set((scheduledRows || []).map((row) => row.date).filter(Boolean))
-      ) as string[];
-
-      if (scheduledDates.length > 0) {
-        return scheduledDates.sort();
-      }
-
-      const { data, error } = await supabase
+      const { data: timesheetRows, error } = await supabase
         .from('timesheets')
         .select('date')
         .eq('job_id', jobId)
         .eq('is_active', true);
       if (error) throw error;
-      const uniqueDates = Array.from(new Set((data || []).map(t => t.date).filter(Boolean))) as string[];
+
+      const uniqueDates = Array.from(new Set([
+        ...(scheduledRows || []).map((row) => row.date).filter(Boolean),
+        ...(timesheetRows || []).map((row) => row.date).filter(Boolean),
+      ])) as string[];
+
       return uniqueDates.sort();
     },
     staleTime: 60_000,
@@ -346,6 +345,33 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     () => jobTimesheetDates.length > 0 && jobTimesheetDates.every(date => rehearsalDateSet.has(date)),
     [jobTimesheetDates, rehearsalDateSet]
   );
+
+  /* ── Admin-only technician/date rate-mode exceptions ── */
+  const { data: technicianRateModeDates = [] } = useJobTechnicianRateModeDates(jobId, {
+    enabled: isAdmin && isTourDate && !jobMetaLoading,
+  });
+  const setTechnicianRateModeMutation = useSetTechnicianDateRateMode();
+
+  const technicianRateModeMap = React.useMemo(() => {
+    const map = new Map<string, Map<string, 'rehearsal' | 'standard'>>();
+
+    technicianRateModeDates.forEach((row) => {
+      if (!map.has(row.technician_id)) {
+        map.set(row.technician_id, new Map());
+      }
+
+      map.get(row.technician_id)!.set(
+        row.date,
+        row.use_rehearsal_rate ? 'rehearsal' : 'standard',
+      );
+    });
+
+    return map;
+  }, [technicianRateModeDates]);
+
+  const getTechRateModeDateSelection = React.useCallback((techId: string, date: string) => {
+    return technicianRateModeMap.get(techId)?.get(date) ?? 'inherit';
+  }, [technicianRateModeMap]);
 
   /* ── Grand total ── */
   const calculatedGrandTotal = React.useMemo(() => {
@@ -386,6 +412,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     getTechOverride,
     calculatedGrandTotal,
     isManager,
+    isAdmin,
     isAdminOrAdministrative,
     userDepartment,
     rehearsalDateSet,
@@ -393,6 +420,8 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     allDatesMarked,
     toggleDateRehearsalMutation,
     toggleAllDatesRehearsalMutation,
+    getTechRateModeDateSelection,
+    setTechnicianRateModeMutation,
     standardPayoutTotals,
   };
 }

--- a/src/components/jobs/payout-totals/useJobPayoutData.ts
+++ b/src/components/jobs/payout-totals/useJobPayoutData.ts
@@ -66,8 +66,8 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     jobMeta?.tour_id ?? undefined
   );
 
-  /* ── Tour timesheet data (approvals + day counts) ── */
-  const { data: tourTimesheetData = { approvals: new Map<string, boolean>(), daysCounts: new Map<string, number>() } } = useQuery({
+  /* ── Tour timesheet approvals ── */
+  const { data: tourApprovals = new Map<string, boolean>() } = useQuery({
     queryKey: ['job-tech-payout', jobId, 'tour-timesheet-data'],
     enabled: !!jobId && isTourDate,
     queryFn: async () => {
@@ -80,16 +80,11 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
       if (error) throw error;
 
       const techApprovals = new Map<string, boolean[]>();
-      const techDates = new Map<string, Set<string>>();
       (data || []).forEach(t => {
         if (!t.technician_id) return;
         const current = techApprovals.get(t.technician_id) || [];
         current.push(t.approved_by_manager || false);
         techApprovals.set(t.technician_id, current);
-        if (t.date) {
-          if (!techDates.has(t.technician_id)) techDates.set(t.technician_id, new Set());
-          techDates.get(t.technician_id)!.add(t.date);
-        }
       });
 
       const approvalMap = new Map<string, boolean>();
@@ -98,15 +93,10 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
         approvalMap.set(techId, allApproved);
       });
 
-      const daysCountMap = new Map<string, number>();
-      techDates.forEach((dates, techId) => { daysCountMap.set(techId, dates.size); });
-
-      return { approvals: approvalMap, daysCounts: daysCountMap };
+      return approvalMap;
     },
     staleTime: 30 * 1000,
   });
-  const tourApprovals = tourTimesheetData.approvals;
-  const tourTimesheetDays = tourTimesheetData.daysCounts;
 
   /* ── Standard tech days (approved + total) ── */
   const { data: techDaysMaps = { approved: new Map<string, number>(), total: new Map<string, number>() } } = useQuery({
@@ -188,13 +178,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
 
   const tourPayoutTotals = React.useMemo<JobPayoutTotals[]>(() => {
     return visibleTourQuotes.map((quote) => {
-      const isRehearsalFlat = quote.category === 'rehearsal';
-      const scheduledDays = isRehearsalFlat
-        ? (tourTimesheetDays.get(quote.technician_id) || 1)
-        : 1;
-
-      const perDayRate = Number(quote.total_eur ?? 0);
-      const baseTotal = perDayRate * scheduledDays;
+      const baseTotal = Number(quote.total_eur ?? 0);
       const extrasTotal = Number(
         quote.extras_total_eur ?? (quote.extras?.total_eur != null ? quote.extras.total_eur : 0)
       );
@@ -224,7 +208,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
         expenses_breakdown: techExpenses?.breakdown ?? [],
       } satisfies JobPayoutTotals;
     });
-  }, [visibleTourQuotes, tourApprovals, tourTimesheetDays, tourExpenseData]);
+  }, [visibleTourQuotes, tourApprovals, tourExpenseData]);
 
   const payoutTotals = isTourDate ? tourPayoutTotals : standardPayoutTotals;
   const isLoading = jobMetaLoading || (isTourDate ? tourQuotesLoading : standardLoading);
@@ -331,6 +315,21 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     queryKey: ['job-timesheet-dates', jobId],
     enabled: !!jobId && !jobMetaLoading && isManager,
     queryFn: async () => {
+      const { data: scheduledRows, error: scheduledError } = await supabase
+        .from('job_date_types')
+        .select('date')
+        .eq('job_id', jobId);
+
+      if (scheduledError) throw scheduledError;
+
+      const scheduledDates = Array.from(
+        new Set((scheduledRows || []).map((row) => row.date).filter(Boolean))
+      ) as string[];
+
+      if (scheduledDates.length > 0) {
+        return scheduledDates.sort();
+      }
+
       const { data, error } = await supabase
         .from('timesheets')
         .select('date')
@@ -373,7 +372,6 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     isClosureLocked,
     payoutTotals,
     visibleTourQuotes,
-    tourTimesheetDays,
     profilesWithEmail,
     profileMap,
     autonomoMap,

--- a/src/components/jobs/payout-totals/usePayoutActions.ts
+++ b/src/components/jobs/payout-totals/usePayoutActions.ts
@@ -12,7 +12,7 @@ import {
   type JobPayoutEmailContextResult,
   type TechnicianProfileWithEmail,
 } from '@/lib/job-payout-email';
-import { sendTourJobEmails, prepareTourJobEmailContext, adjustRehearsalQuotesForMultiDay } from '@/lib/tour-payout-email';
+import { sendTourJobEmails, prepareTourJobEmailContext } from '@/lib/tour-payout-email';
 import { generateJobPayoutPDF, generateRateQuotePDF, type TechnicianProfile } from '@/utils/rates-pdf-export';
 import type { JobPayoutTotals } from '@/types/jobExtras';
 import type { TourJobRateQuote } from '@/types/tourRates';
@@ -25,7 +25,6 @@ interface UsePayoutActionsArgs {
   jobMeta: JobMetadata | null | undefined;
   standardPayoutTotals: JobPayoutTotals[];
   visibleTourQuotes: TourJobRateQuote[];
-  tourTimesheetDays: Map<string, number>;
   payoutTotals: JobPayoutTotals[];
   profilesWithEmail: TechnicianProfileWithEmail[];
   profileMap: Map<string, TechnicianProfileWithEmail>;
@@ -41,7 +40,6 @@ export function usePayoutActions({
   jobMeta,
   standardPayoutTotals,
   visibleTourQuotes,
-  tourTimesheetDays,
   payoutTotals,
   profilesWithEmail,
   profileMap,
@@ -136,9 +134,8 @@ export function usePayoutActions({
       if (visibleTourQuotes.length === 0 || !jobMeta) return;
       setIsExporting(true);
       try {
-        const adjustedQuotes = adjustRehearsalQuotesForMultiDay(visibleTourQuotes, tourTimesheetDays);
         await generateRateQuotePDF(
-          adjustedQuotes,
+          visibleTourQuotes,
           {
             id: jobMeta.id,
             title: jobMeta.title,
@@ -186,7 +183,6 @@ export function usePayoutActions({
     lpoMap,
     standardPayoutTotals,
     prepareStandardContext,
-    tourTimesheetDays,
   ]);
 
   /* ── Bulk email send ── */

--- a/src/components/tours/TourDateFormFields.tsx
+++ b/src/components/tours/TourDateFormFields.tsx
@@ -40,10 +40,10 @@ export const TourDateFormFields: React.FC<TourDateFormFieldsProps> = ({
   return (
     <div className="space-y-4">
       <div>
-        <Label htmlFor="tourDateType">Type</Label>
+        <Label htmlFor="tourDateType">Tipo</Label>
         <Select value={tourDateType} onValueChange={setTourDateType}>
           <SelectTrigger>
-            <SelectValue placeholder="Select date type" />
+            <SelectValue placeholder="Seleccione tipo de fecha" />
           </SelectTrigger>
           <SelectContent>
             {TOUR_DATE_TYPE_OPTIONS.map((option) => {

--- a/src/components/tours/TourDateListItem.tsx
+++ b/src/components/tours/TourDateListItem.tsx
@@ -98,7 +98,7 @@ export const TourDateListItem: React.FC<TourDateListItemProps> = ({
           />
           <Select value={editingTourDateType} onValueChange={setEditingTourDateType}>
             <SelectTrigger>
-              <SelectValue placeholder="Select date type" />
+              <SelectValue placeholder="Seleccione tipo de fecha" />
             </SelectTrigger>
             <SelectContent>
               {TOUR_DATE_TYPE_OPTIONS.map((option) => (

--- a/src/components/tours/TourDateManagementDialog.tsx
+++ b/src/components/tours/TourDateManagementDialog.tsx
@@ -21,7 +21,6 @@ import {
   Edit,
   Package,
   Clock,
-  Music,
 } from "lucide-react";
 import { TourDateFormFields } from "./TourDateFormFields";
 import { TourDateListItem } from "./TourDateListItem";
@@ -30,10 +29,20 @@ import { useTourDateRealtime } from "@/hooks/useTourDateRealtime";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { deleteJobDateTypes } from "@/services/deleteJobDateTypes";
+import {
+  buildInclusiveDateRange,
+  syncJobRehearsalDates,
+  syncJobRehearsalDatesForJobs,
+} from "@/services/jobRehearsalDates";
 import { PlaceAutocomplete } from "@/components/maps/PlaceAutocomplete";
 import { TECHNICAL_DEPARTMENTS } from "@/types/department";
 import { syncFlexElementsForTourDateChange } from "@/utils/flex-folders/syncDateChange";
-import { DateType, getDateTypeMeta, isSingleDayDateType } from "@/constants/dateTypes";
+import {
+  DateType,
+  getDateTypeMeta,
+  isSingleDayDateType,
+  TOUR_DATE_TYPE_OPTIONS,
+} from "@/constants/dateTypes";
 
 interface TourDateObject {
   id: string;
@@ -239,17 +248,12 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         throw deptError;
       }
 
-      // Create job date types for each day in the date range
-      const jobDateTypes = [];
-      const start = new Date(startDate);
-      const end = new Date(finalEndDate);
-      for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-        jobDateTypes.push({
-          job_id: newJob.id,
-          date: d.toISOString().split('T')[0],
-          type: tourDateType
-        });
-      }
+      const scheduledDates = buildInclusiveDateRange(startDate, finalEndDate);
+      const jobDateTypes = scheduledDates.map((date) => ({
+        job_id: newJob.id,
+        date,
+        type: tourDateType,
+      }));
 
       const { error: dateTypeError } = await supabase
         .from("job_date_types")
@@ -257,6 +261,10 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
       if (dateTypeError) {
         console.error("Error creating job date types:", dateTypeError);
         throw dateTypeError;
+      }
+
+      if (tourDateType === "rehearsal") {
+        await syncJobRehearsalDates(newJob.id, scheduledDates, { seedMissing: true });
       }
 
       // Force refresh all related queries after successful creation
@@ -384,6 +392,8 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         throw jobsError;
       }
 
+      const scheduledDates = buildInclusiveDateRange(startDate, finalEndDate);
+
       // Update job date types for all jobs of this tour date
       if (jobs && jobs.length > 0) {
         for (const job of jobs) {
@@ -394,16 +404,11 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
             .eq("job_id", job.id);
 
           // Create new job date types for the updated date range
-          const jobDateTypes = [];
-          const start = new Date(startDate);
-          const end = new Date(finalEndDate);
-          for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-            jobDateTypes.push({
-              job_id: job.id,
-              date: d.toISOString().split('T')[0],
-              type: tourDateType
-            });
-          }
+          const jobDateTypes = scheduledDates.map((date) => ({
+            job_id: job.id,
+            date,
+            type: tourDateType,
+          }));
 
           if (jobDateTypes.length > 0) {
             const { error: dateTypeError } = await supabase
@@ -414,6 +419,12 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
             }
           }
         }
+
+        await syncJobRehearsalDatesForJobs(
+          jobs.map((job) => job.id),
+          scheduledDates,
+          { seedMissing: tourDateType === "rehearsal" }
+        );
       }
 
       // Sync Flex elements if date changed and flex folders exist
@@ -767,6 +778,37 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
                     <div key={dateObj.id} className="p-3 md:p-4 border rounded-lg">
                       {editingTourDate && editingTourDate.id === dateObj.id && !readOnly ? (
                         <div className="flex flex-col gap-3">
+                          <div className="space-y-2">
+                            <Label htmlFor={`edit-tour-date-type-${dateObj.id}`}>Type</Label>
+                            <Select
+                              value={editTourDateType}
+                              onValueChange={(value) => {
+                                const nextType = value as DateType;
+                                setEditTourDateType(nextType);
+                                if (isSingleDayDateType(nextType)) {
+                                  setEditEndDate(editStartDate);
+                                }
+                              }}
+                            >
+                              <SelectTrigger id={`edit-tour-date-type-${dateObj.id}`}>
+                                <SelectValue placeholder="Select date type" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {TOUR_DATE_TYPE_OPTIONS.map((option) => {
+                                  const Icon = option.icon;
+
+                                  return (
+                                    <SelectItem key={option.value} value={option.value}>
+                                      <div className="flex items-center gap-2">
+                                        <Icon className={`h-4 w-4 ${option.iconClassName}`} />
+                                        {option.label}
+                                      </div>
+                                    </SelectItem>
+                                  );
+                                })}
+                              </SelectContent>
+                            </Select>
+                          </div>
                           <div className="flex items-center gap-2">
                             <Calendar className="h-4 w-4 flex-shrink-0" />
                             <Input

--- a/src/components/tours/TourDateManagementDialog.tsx
+++ b/src/components/tours/TourDateManagementDialog.tsx
@@ -779,7 +779,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
                       {editingTourDate && editingTourDate.id === dateObj.id && !readOnly ? (
                         <div className="flex flex-col gap-3">
                           <div className="space-y-2">
-                            <Label htmlFor={`edit-tour-date-type-${dateObj.id}`}>Type</Label>
+                            <Label htmlFor={`edit-tour-date-type-${dateObj.id}`}>Tipo</Label>
                             <Select
                               value={editTourDateType}
                               onValueChange={(value) => {
@@ -791,7 +791,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
                               }}
                             >
                               <SelectTrigger id={`edit-tour-date-type-${dateObj.id}`}>
-                                <SelectValue placeholder="Select date type" />
+                                <SelectValue placeholder="Seleccione tipo de fecha" />
                               </SelectTrigger>
                               <SelectContent>
                                 {TOUR_DATE_TYPE_OPTIONS.map((option) => {

--- a/src/components/tours/TourRatesManagerDialog.tsx
+++ b/src/components/tours/TourRatesManagerDialog.tsx
@@ -26,7 +26,7 @@ import { invalidateRatesContext } from '@/services/ratesService';
 import { syncFlexWorkOrdersForJob, FlexWorkOrderSyncResult } from '@/services/flexWorkOrders';
 import { toast } from 'sonner';
 import { generateRateQuotePDF, generateTourRatesSummaryPDF } from '@/utils/rates-pdf-export';
-import { adjustRehearsalQuotesForMultiDay, sendTourJobEmails } from '@/lib/tour-payout-email';
+import { sendTourJobEmails } from '@/lib/tour-payout-email';
 import { buildTourRatesExportPayload } from '@/services/tourRatesExport';
 import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 
@@ -417,27 +417,8 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                       const lpoMap = new Map(
                         (lpoRows || []).map(r => [r.technician_id, r.lpo_number])
                       );
-                      
-                      const { data: ts, error: tsError } = await supabase
-                        .from('timesheets')
-                        .select('technician_id, date')
-                        .eq('job_id', selectedJobId)
-                        .eq('is_active', true);
-                      if (tsError) {
-                        console.error('[TourRatesManagerDialog] Failed loading timesheets for PDF', tsError);
-                      }
 
-                      const techDates = new Map<string, Set<string>>();
-                      (ts || []).forEach((row: any) => {
-                        if (!row?.technician_id || !row?.date) return;
-                        if (!techDates.has(row.technician_id)) techDates.set(row.technician_id, new Set());
-                        techDates.get(row.technician_id)!.add(row.date);
-                      });
-                      const daysCounts = new Map<string, number>();
-                      techDates.forEach((dates, techId) => daysCounts.set(techId, dates.size));
-                      const adjustedQuotes = adjustRehearsalQuotesForMultiDay(quotes, daysCounts);
-
-                      await generateRateQuotePDF(adjustedQuotes, job, profiles as any, lpoMap);
+                      await generateRateQuotePDF(quotes, job, profiles as any, lpoMap);
                       toast.success('PDF generado');
                     }}
                   >

--- a/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
+++ b/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+import { renderWithProviders } from "@/test/renderWithProviders";
+
+const {
+  toastMock,
+  getOrCreateLocationMock,
+  getOrCreateLocationWithDetailsMock,
+  syncJobRehearsalDatesMock,
+  syncJobRehearsalDatesForJobsMock,
+  syncFlexElementsForTourDateChangeMock,
+} = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  getOrCreateLocationMock: vi.fn(),
+  getOrCreateLocationWithDetailsMock: vi.fn(),
+  syncJobRehearsalDatesMock: vi.fn(),
+  syncJobRehearsalDatesForJobsMock: vi.fn(),
+  syncFlexElementsForTourDateChangeMock: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/hooks/useLocationManagement", () => ({
+  useLocationManagement: () => ({
+    getOrCreateLocation: getOrCreateLocationMock,
+    getOrCreateLocationWithDetails: getOrCreateLocationWithDetailsMock,
+  }),
+}));
+
+vi.mock("@/hooks/useTourDateRealtime", () => ({
+  useTourDateRealtime: vi.fn(),
+}));
+
+vi.mock("@/services/jobRehearsalDates", async () => {
+  const actual = await vi.importActual<typeof import("@/services/jobRehearsalDates")>("@/services/jobRehearsalDates");
+
+  return {
+    ...actual,
+    syncJobRehearsalDates: syncJobRehearsalDatesMock,
+    syncJobRehearsalDatesForJobs: syncJobRehearsalDatesForJobsMock,
+  };
+});
+
+vi.mock("@/utils/flex-folders/syncDateChange", () => ({
+  syncFlexElementsForTourDateChange: syncFlexElementsForTourDateChangeMock,
+}));
+
+vi.mock("@/components/maps/PlaceAutocomplete", () => ({
+  PlaceAutocomplete: ({
+    value,
+    label = "Location",
+    placeholder,
+    onInputChange,
+  }: {
+    value: string;
+    label?: string;
+    placeholder?: string;
+    onInputChange?: (value: string) => void;
+  }) => (
+    <div>
+      <label htmlFor={`mock-place-${label}`}>{label}</label>
+      <input
+        id={`mock-place-${label}`}
+        aria-label={label}
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onInputChange?.(event.target.value)}
+      />
+    </div>
+  ),
+}));
+
+import { TourDateManagementDialog } from "../TourDateManagementDialog";
+
+function queueTableBuilders(buildersByTable: Record<string, ReturnType<typeof createMockQueryBuilder>[]>) {
+  const queue = new Map(Object.entries(buildersByTable));
+
+  mockSupabase.from.mockImplementation((table: string) => {
+    const builders = queue.get(table);
+    if (!builders || builders.length === 0) {
+      return createMockQueryBuilder();
+    }
+    return builders.shift() ?? createMockQueryBuilder();
+  });
+}
+
+describe("TourDateManagementDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    getOrCreateLocationMock.mockResolvedValue("location-1");
+    getOrCreateLocationWithDetailsMock.mockResolvedValue("location-1");
+    syncJobRehearsalDatesMock.mockResolvedValue(undefined);
+    syncJobRehearsalDatesForJobsMock.mockResolvedValue(undefined);
+    syncFlexElementsForTourDateChangeMock.mockResolvedValue({ success: 0, failed: 0, errors: [] });
+  });
+
+  it("seeds rehearsal toggle rows for every scheduled day when creating a rehearsal date", async () => {
+    const user = userEvent.setup();
+    const tourDateBuilder = createMockQueryBuilder({
+      data: {
+        id: "tour-date-1",
+        date: "2026-04-10",
+        start_date: "2026-04-10",
+        end_date: "2026-04-12",
+        tour_date_type: "rehearsal",
+        rehearsal_days: 3,
+        is_tour_pack_only: false,
+        location: { id: "location-1", name: "Madrid Arena" },
+      },
+      error: null,
+    });
+    const tourBuilder = createMockQueryBuilder({
+      data: {
+        name: "World Tour",
+        color: "#123456",
+        tour_dates: [{ jobs: [{ job_departments: [{ department: "sound" }] }] }],
+      },
+      error: null,
+    });
+    const jobsBuilder = createMockQueryBuilder({
+      data: { id: "job-1" },
+      error: null,
+    });
+    const jobDepartmentsBuilder = createMockQueryBuilder({ data: null, error: null });
+    const jobDateTypesBuilder = createMockQueryBuilder({ data: null, error: null });
+
+    queueTableBuilders({
+      tour_dates: [tourDateBuilder],
+      tours: [tourBuilder],
+      jobs: [jobsBuilder],
+      job_departments: [jobDepartmentsBuilder],
+      job_date_types: [jobDateTypesBuilder],
+    });
+
+    renderWithProviders(
+      <TourDateManagementDialog
+        open
+        onOpenChange={vi.fn()}
+        tourId="tour-1"
+        tourDates={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: /rehearsal/i }));
+    await user.type(screen.getByLabelText(/^location$/i), "Madrid Arena");
+    await user.type(screen.getByLabelText(/start date/i), "2026-04-10");
+    await user.type(screen.getByLabelText(/end date/i), "2026-04-12");
+
+    await user.click(screen.getByRole("button", { name: /añadir/i }));
+
+    await waitFor(() => {
+      expect(syncJobRehearsalDatesMock).toHaveBeenCalledWith(
+        "job-1",
+        ["2026-04-10", "2026-04-11", "2026-04-12"],
+        { seedMissing: true },
+      );
+    });
+
+    expect(jobDateTypesBuilder.insert).toHaveBeenCalledWith([
+      { job_id: "job-1", date: "2026-04-10", type: "rehearsal" },
+      { job_id: "job-1", date: "2026-04-11", type: "rehearsal" },
+      { job_id: "job-1", date: "2026-04-12", type: "rehearsal" },
+    ]);
+  });
+
+  it("keeps rehearsal toggles as the pricing source of truth when editing a rehearsal date back to show", async () => {
+    const user = userEvent.setup();
+    const flexFoldersBuilder = createMockQueryBuilder({
+      data: [],
+      error: null,
+    });
+    const toursBuilder = createMockQueryBuilder({
+      data: { name: "World Tour" },
+      error: null,
+    });
+    const updatedTourDateBuilder = createMockQueryBuilder({
+      data: {
+        id: "tour-date-1",
+        date: "2026-04-01",
+        is_tour_pack_only: false,
+        location: { id: "location-1", name: "Madrid Arena" },
+        tours: { name: "World Tour" },
+      },
+      error: null,
+    });
+    const jobsBuilder = createMockQueryBuilder({
+      data: [{ id: "job-1" }],
+      error: null,
+    });
+    const deleteJobDateTypesBuilder = createMockQueryBuilder({ data: null, error: null });
+    const insertJobDateTypesBuilder = createMockQueryBuilder({ data: null, error: null });
+
+    queueTableBuilders({
+      flex_folders: [flexFoldersBuilder],
+      tours: [toursBuilder],
+      tour_dates: [updatedTourDateBuilder],
+      jobs: [jobsBuilder],
+      job_date_types: [deleteJobDateTypesBuilder, insertJobDateTypesBuilder],
+    });
+
+    renderWithProviders(
+      <TourDateManagementDialog
+        open
+        onOpenChange={vi.fn()}
+        tourId="tour-1"
+        tourDates={[
+          {
+            id: "tour-date-1",
+            date: "2026-04-01",
+            start_date: "2026-04-01",
+            end_date: "2026-04-03",
+            tour_id: "tour-1",
+            location_id: "location-1",
+            location: { id: "location-1", name: "Madrid Arena" },
+            tour_date_type: "rehearsal",
+            is_tour_pack_only: false,
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByTitle("Edit Date"));
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(screen.getByRole("option", { name: /^show$/i }));
+
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(syncJobRehearsalDatesForJobsMock).toHaveBeenCalledWith(
+        ["job-1"],
+        ["2026-04-01"],
+        { seedMissing: false },
+      );
+    });
+
+    expect(insertJobDateTypesBuilder.insert).toHaveBeenCalledWith([
+      { job_id: "job-1", date: "2026-04-01", type: "show" },
+    ]);
+  });
+});

--- a/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
+++ b/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
@@ -154,7 +154,7 @@ describe("TourDateManagementDialog", () => {
     );
 
     await user.click(screen.getByRole("combobox"));
-    await user.click(screen.getByRole("option", { name: /rehearsal/i }));
+    await user.click(screen.getByRole("option", { name: /ensayo/i }));
     await user.type(screen.getByLabelText(/^location$/i), "Madrid Arena");
     await user.type(screen.getByLabelText(/start date/i), "2026-04-10");
     await user.type(screen.getByLabelText(/end date/i), "2026-04-12");
@@ -235,7 +235,7 @@ describe("TourDateManagementDialog", () => {
     await user.click(screen.getByTitle("Edit Date"));
 
     await user.click(screen.getAllByRole("combobox")[0]);
-    await user.click(screen.getByRole("option", { name: /^show$/i }));
+    await user.click(screen.getByRole("option", { name: /^concierto$/i }));
 
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 

--- a/src/constants/dateTypes.ts
+++ b/src/constants/dateTypes.ts
@@ -158,4 +158,7 @@ export function isKeyFestivalDateType(value?: string | null): boolean {
 }
 
 export const DATE_TYPE_OPTIONS = DATE_TYPE_ORDER.map((type) => DATE_TYPE_META[type]);
-export const TOUR_DATE_TYPE_OPTIONS = TOUR_DATE_TYPE_ORDER.map((type) => DATE_TYPE_META[type]);
+export const TOUR_DATE_TYPE_OPTIONS = TOUR_DATE_TYPE_ORDER.map((type) => ({
+  ...DATE_TYPE_META[type],
+  label: DATE_TYPE_META[type].labelEs,
+}));

--- a/src/hooks/useTechnicianRateModeDates.ts
+++ b/src/hooks/useTechnicianRateModeDates.ts
@@ -62,10 +62,6 @@ export function useSetTechnicianDateRateMode() {
 
         if (error) throw error;
       } else {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-
         const { error } = await supabase
           .from('job_technician_rate_mode_dates')
           .upsert(
@@ -74,8 +70,6 @@ export function useSetTechnicianDateRateMode() {
               technician_id: technicianId,
               date,
               use_rehearsal_rate: mode === 'rehearsal',
-              updated_at: new Date().toISOString(),
-              updated_by: user?.id ?? null,
             },
             { onConflict: 'job_id,technician_id,date' },
           );

--- a/src/hooks/useTechnicianRateModeDates.ts
+++ b/src/hooks/useTechnicianRateModeDates.ts
@@ -1,0 +1,111 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { Tables } from '@/integrations/supabase/types';
+import { createEntityQueryOptions } from '@/lib/react-query';
+import { toast } from 'sonner';
+import { invalidateRehearsalRateQueries, recalculateTimesheets } from '@/hooks/useToggleJobRehearsalRate';
+
+export type TechnicianDateRateMode = 'inherit' | 'rehearsal' | 'standard';
+
+type TechnicianRateModeRow = Tables<'job_technician_rate_mode_dates'>;
+
+interface UseJobTechnicianRateModeDatesOptions {
+  enabled?: boolean;
+}
+
+export function useJobTechnicianRateModeDates(
+  jobId: string,
+  options: UseJobTechnicianRateModeDatesOptions = {},
+) {
+  const { enabled = true } = options;
+
+  return useQuery(
+    createEntityQueryOptions<TechnicianRateModeRow[]>(
+      'job-technician-rate-mode-dates',
+      jobId,
+      {
+        enabled: !!jobId && enabled,
+        queryFn: async (): Promise<TechnicianRateModeRow[]> => {
+          const { data, error } = await supabase
+            .from('job_technician_rate_mode_dates')
+            .select('job_id, technician_id, date, use_rehearsal_rate, created_at, created_by, updated_at, updated_by')
+            .eq('job_id', jobId);
+
+          if (error) throw error;
+          return (data || []) as TechnicianRateModeRow[];
+        },
+        staleTime: 30_000,
+      },
+    ),
+  );
+}
+
+interface SetTechnicianDateRateModeParams {
+  jobId: string;
+  technicianId: string;
+  date: string;
+  mode: TechnicianDateRateMode;
+}
+
+export function useSetTechnicianDateRateMode() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ jobId, technicianId, date, mode }: SetTechnicianDateRateModeParams) => {
+      if (mode === 'inherit') {
+        const { error } = await supabase
+          .from('job_technician_rate_mode_dates')
+          .delete()
+          .eq('job_id', jobId)
+          .eq('technician_id', technicianId)
+          .eq('date', date);
+
+        if (error) throw error;
+      } else {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        const { error } = await supabase
+          .from('job_technician_rate_mode_dates')
+          .upsert(
+            {
+              job_id: jobId,
+              technician_id: technicianId,
+              date,
+              use_rehearsal_rate: mode === 'rehearsal',
+              updated_at: new Date().toISOString(),
+              updated_by: user?.id ?? null,
+            },
+            { onConflict: 'job_id,technician_id,date' },
+          );
+
+        if (error) throw error;
+      }
+
+      const { data: timesheets, error: timesheetError } = await supabase
+        .from('timesheets')
+        .select('id')
+        .eq('job_id', jobId)
+        .eq('technician_id', technicianId)
+        .eq('date', date)
+        .eq('is_active', true);
+
+      if (timesheetError) throw timesheetError;
+
+      const recalculated = await recalculateTimesheets(
+        timesheets?.map((timesheet) => timesheet.id) ?? [],
+      );
+
+      return { jobId, technicianId, date, mode, recalculated };
+    },
+    onSuccess: (result) => {
+      invalidateRehearsalRateQueries(queryClient, result.jobId);
+      queryClient.invalidateQueries({ queryKey: ['job-technician-rate-mode-dates', result.jobId] });
+    },
+    onError: (error) => {
+      console.error('[useSetTechnicianDateRateMode] Error:', error);
+      toast.error('No se pudo actualizar la tarifa por técnico para esta fecha');
+    },
+  });
+}

--- a/src/hooks/useToggleJobRehearsalRate.ts
+++ b/src/hooks/useToggleJobRehearsalRate.ts
@@ -47,7 +47,10 @@ const invalidateRehearsalRateQueries = (queryClient: QueryClient, jobId: string)
     ['job-rehearsal-dates', jobId],
     ['job-tech-payout', jobId],
     ['job-tech-days', jobId],
-    ['manager-job-quotes', jobId],
+    ['manager-job-quotes'],
+    ['tour-job-rate-quotes'],
+    ['tour-job-rate-quotes-manager'],
+    ['technician-tour-rate-quotes'],
     ['timesheets'],
     ['job-tech-payout', jobId, 'tour-timesheet-data'],
   ]);

--- a/src/hooks/useToggleJobRehearsalRate.ts
+++ b/src/hooks/useToggleJobRehearsalRate.ts
@@ -42,7 +42,7 @@ interface ToggleDateRehearsalParams {
   enabled: boolean;
 }
 
-const invalidateRehearsalRateQueries = (queryClient: QueryClient, jobId: string) => {
+export const invalidateRehearsalRateQueries = (queryClient: QueryClient, jobId: string) => {
   optimizedInvalidation.invalidateQueryKeys(queryClient, [
     ['job-rehearsal-dates', jobId],
     ['job-tech-payout', jobId],
@@ -62,7 +62,7 @@ const invalidateRehearsalRateQueries = (queryClient: QueryClient, jobId: string)
  * @returns The number of successfully recalculated timesheets
  * @throws Error if any recalculations fail
  */
-async function recalculateTimesheets(timesheetIds: string[]): Promise<number> {
+export async function recalculateTimesheets(timesheetIds: string[]): Promise<number> {
   if (timesheetIds.length === 0) return 0;
 
   const results = await Promise.allSettled(

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3803,6 +3803,103 @@ export type Database = {
           },
         ]
       }
+      job_technician_rate_mode_dates: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          date: string
+          job_id: string
+          technician_id: string
+          updated_at: string
+          updated_by: string | null
+          use_rehearsal_rate: boolean
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          date: string
+          job_id: string
+          technician_id: string
+          updated_at?: string
+          updated_by?: string | null
+          use_rehearsal_rate: boolean
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          date?: string
+          job_id?: string
+          technician_id?: string
+          updated_at?: string
+          updated_by?: string | null
+          use_rehearsal_rate?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "v_job_staffing_summary"
+            referencedColumns: ["job_id"]
+          },
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "v_job_tech_payout_2025"
+            referencedColumns: ["job_id"]
+          },
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_technician_id_fkey"
+            columns: ["technician_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_technician_id_fkey"
+            columns: ["technician_id"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_technician_rate_mode_dates_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       job_required_roles: {
         Row: {
           created_at: string

--- a/src/lib/tour-payout-email.ts
+++ b/src/lib/tour-payout-email.ts
@@ -48,48 +48,6 @@ export interface TourJobEmailInput {
   profiles: (TechnicianProfile & { email?: string | null })[];
 }
 
-/**
- * For rehearsal-category quotes the RPC returns a per-day flat rate.
- * This helper multiplies the relevant totals by the number of scheduled
- * timesheet days so that PDFs and emails show the correct multi-day amount.
- */
-export function adjustRehearsalQuotesForMultiDay(
-  quotes: TourJobRateQuote[],
-  daysCounts: Map<string, number>
-): TourJobRateQuote[] {
-  return quotes.map(quote => {
-    if (quote.category !== 'rehearsal') return quote;
-
-    const days = daysCounts.get(quote.technician_id) || 1;
-    if (days <= 1) return quote;
-
-    const adjustedBaseDayEur = Number(quote.base_day_eur ?? 0) * days;
-    const adjustedTotalEur = Number(quote.total_eur ?? 0) * days;
-    const extrasTotal = Number(
-      quote.extras_total_eur ?? (quote.extras?.total_eur != null ? quote.extras.total_eur : 0)
-    );
-
-    return {
-      ...quote,
-      base_day_eur: adjustedBaseDayEur,
-      total_eur: adjustedTotalEur,
-      total_with_extras_eur: adjustedTotalEur + extrasTotal,
-      calculated_total_eur:
-        quote.calculated_total_eur != null ? Number(quote.calculated_total_eur) * days : quote.calculated_total_eur,
-      breakdown: {
-        ...quote.breakdown,
-        ...(quote.breakdown?.after_discount != null
-          ? { after_discount: Number(quote.breakdown.after_discount) * days }
-          : {}),
-        ...(quote.breakdown?.base_calculation != null
-          ? { base_calculation: Number(quote.breakdown.base_calculation) * days }
-          : {}),
-        rehearsal_days: days,
-      },
-    };
-  });
-}
-
 async function blobToBase64(blob: Blob): Promise<string> {
   const arrayBuffer = await blob.arrayBuffer();
   const bytes = new Uint8Array(arrayBuffer);
@@ -171,18 +129,13 @@ export async function prepareTourJobEmailContext(
       timesheetDateMap.get(row.technician_id)!.add(row.date);
   });
 
-  // Adjust rehearsal quotes for multi-day (RPC returns per-day flat rate)
-  const daysCounts = new Map<string, number>();
-  timesheetDateMap.forEach((dates, techId) => daysCounts.set(techId, dates.size));
-  const adjustedQuotes = adjustRehearsalQuotesForMultiDay(quotes, daysCounts);
-
   const profileMap = new Map(profiles.map((p) => [p.id, p]));
   const attachments: TourJobEmailAttachment[] = [];
 
   // Generate one PDF per technician (filtered quote array per tech)
-  const techIds = Array.from(new Set(adjustedQuotes.map(q => q.technician_id)));
+  const techIds = Array.from(new Set(quotes.map(q => q.technician_id)));
   for (const techId of techIds) {
-    const techQuotes = adjustedQuotes.filter(q => q.technician_id === techId);
+    const techQuotes = quotes.filter(q => q.technician_id === techId);
     if (!techQuotes.length) continue;
 
     const profile = profileMap.get(techId);
@@ -243,7 +196,7 @@ export async function prepareTourJobEmailContext(
 
   return {
     job,
-    quotes: adjustedQuotes,
+    quotes,
     profiles,
     lpoMap,
     timesheetDateMap,

--- a/src/services/jobRehearsalDates.test.ts
+++ b/src/services/jobRehearsalDates.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildInclusiveDateRange,
+  planJobRehearsalDateSync,
+} from './jobRehearsalDates';
+
+describe('buildInclusiveDateRange', () => {
+  it('builds an inclusive date range for a multi-day span', () => {
+    expect(buildInclusiveDateRange('2026-04-08', '2026-04-10')).toEqual([
+      '2026-04-08',
+      '2026-04-09',
+      '2026-04-10',
+    ]);
+  });
+
+  it('returns a single date when the end date is omitted', () => {
+    expect(buildInclusiveDateRange('2026-04-08')).toEqual(['2026-04-08']);
+  });
+
+  it('returns an empty array for an invalid range', () => {
+    expect(buildInclusiveDateRange('2026-04-10', '2026-04-08')).toEqual([]);
+  });
+});
+
+describe('planJobRehearsalDateSync', () => {
+  it('seeds missing scheduled dates and deletes out-of-range dates', () => {
+    const plan = planJobRehearsalDateSync(
+      ['2026-04-08', '2026-04-12'],
+      ['2026-04-08', '2026-04-09', '2026-04-10'],
+      true
+    );
+
+    expect(plan).toEqual({
+      toInsert: ['2026-04-09', '2026-04-10'],
+      toDelete: ['2026-04-12'],
+      retained: ['2026-04-08'],
+    });
+  });
+
+  it('keeps in-range rows when seedMissing is disabled', () => {
+    const plan = planJobRehearsalDateSync(
+      ['2026-04-08', '2026-04-09', '2026-04-11'],
+      ['2026-04-08', '2026-04-09', '2026-04-10'],
+      false
+    );
+
+    expect(plan).toEqual({
+      toInsert: [],
+      toDelete: ['2026-04-11'],
+      retained: ['2026-04-08', '2026-04-09'],
+    });
+  });
+});

--- a/src/services/jobRehearsalDates.ts
+++ b/src/services/jobRehearsalDates.ts
@@ -1,0 +1,104 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export interface JobRehearsalDateSyncPlan {
+  toInsert: string[];
+  toDelete: string[];
+  retained: string[];
+}
+
+export const buildInclusiveDateRange = (startDate: string, endDate?: string): string[] => {
+  if (!startDate) return [];
+
+  const normalizedEndDate = endDate || startDate;
+  const start = new Date(`${startDate}T00:00:00Z`);
+  const end = new Date(`${normalizedEndDate}T00:00:00Z`);
+
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || start > end) {
+    return [];
+  }
+
+  const dates: string[] = [];
+  for (const current = new Date(start); current <= end; current.setUTCDate(current.getUTCDate() + 1)) {
+    dates.push(current.toISOString().split('T')[0]);
+  }
+
+  return dates;
+};
+
+export const planJobRehearsalDateSync = (
+  existingDates: string[],
+  scheduledDates: string[],
+  seedMissing: boolean
+): JobRehearsalDateSyncPlan => {
+  const scheduledSet = new Set(scheduledDates);
+  const existingSet = new Set(existingDates);
+
+  const retained = existingDates.filter((date) => scheduledSet.has(date));
+  const toDelete = existingDates.filter((date) => !scheduledSet.has(date));
+  const toInsert = seedMissing
+    ? scheduledDates.filter((date) => !existingSet.has(date))
+    : [];
+
+  return { toInsert, toDelete, retained };
+};
+
+export async function syncJobRehearsalDates(
+  jobId: string,
+  scheduledDates: string[],
+  options: { seedMissing?: boolean } = {}
+) {
+  const { seedMissing = false } = options;
+
+  const { data: existingRows, error: existingError } = await supabase
+    .from('job_rehearsal_dates')
+    .select('date')
+    .eq('job_id', jobId);
+
+  if (existingError) {
+    throw existingError;
+  }
+
+  const existingDates = (existingRows || [])
+    .map((row) => row.date)
+    .filter((date): date is string => typeof date === 'string' && date.length > 0);
+
+  const plan = planJobRehearsalDateSync(existingDates, scheduledDates, seedMissing);
+
+  if (plan.toDelete.length > 0) {
+    const { error: deleteError } = await supabase
+      .from('job_rehearsal_dates')
+      .delete()
+      .eq('job_id', jobId)
+      .in('date', plan.toDelete);
+
+    if (deleteError) {
+      throw deleteError;
+    }
+  }
+
+  if (plan.toInsert.length > 0) {
+    const { error: insertError } = await supabase
+      .from('job_rehearsal_dates')
+      .upsert(
+        plan.toInsert.map((date) => ({
+          job_id: jobId,
+          date,
+        })),
+        { onConflict: 'job_id,date', ignoreDuplicates: true }
+      );
+
+    if (insertError) {
+      throw insertError;
+    }
+  }
+
+  return plan;
+}
+
+export async function syncJobRehearsalDatesForJobs(
+  jobIds: string[],
+  scheduledDates: string[],
+  options: { seedMissing?: boolean } = {}
+) {
+  return Promise.all(jobIds.map((jobId) => syncJobRehearsalDates(jobId, scheduledDates, options)));
+}

--- a/src/services/tourPayoutOverrides.ts
+++ b/src/services/tourPayoutOverrides.ts
@@ -7,9 +7,8 @@ import type { TourJobRateQuote } from '@/types/tourRates';
  *
  * This helper merges overrides into TourJobRateQuote objects so PDFs/emails/UI can reflect the exception.
  *
- * Note: we DO NOT overwrite `total_eur` / `total_with_extras_eur` here because tour-date quotes can be
- * treated as per-day rates in some flows (multi-day rehearsals). Consumers should use
- * `override_amount_eur` when `has_override` is true.
+ * Note: we DO NOT overwrite `total_eur` / `total_with_extras_eur` here.
+ * Consumers should use `override_amount_eur` when `has_override` is true.
  */
 export async function attachPayoutOverridesToTourQuotes(
   jobId: string,

--- a/src/services/tourRatesExport.ts
+++ b/src/services/tourRatesExport.ts
@@ -1,7 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
 import { syncFlexWorkOrdersForJob } from '@/services/flexWorkOrders';
 import type { TourJobRateQuote } from '@/types/tourRates';
-import { adjustRehearsalQuotesForMultiDay } from '@/lib/tour-payout-email';
 import { attachPayoutOverridesToTourQuotes } from '@/services/tourPayoutOverrides';
 
 export interface TourRatesExportJob {
@@ -194,46 +193,6 @@ export async function buildTourRatesExportPayload(
         })
       );
       filteredQuotes = (quotes.filter(Boolean) as TourJobRateQuote[]).filter(q => q.technician_id);
-
-      // Adjust rehearsal-category quotes for multi-day rehearsal jobs.
-      // Tourdate timesheets are fixed-rate and don't require approvals, so count all active timesheets.
-      const techDates = new Map<string, Set<string>>();
-      const { data: tsDays, error: tsDaysError } = await supabase
-        .from('timesheets')
-        .select('technician_id, date')
-        .eq('job_id', job.id)
-        .eq('is_active', true)
-        .in('technician_id', techIds);
-
-      if (!tsDaysError && Array.isArray(tsDays) && tsDays.length) {
-        (tsDays as any[]).forEach((row: any) => {
-          if (!row?.technician_id || !row?.date) return;
-          if (!techDates.has(row.technician_id)) techDates.set(row.technician_id, new Set());
-          techDates.get(row.technician_id)!.add(row.date);
-        });
-      }
-
-      if ((tsDaysError || !tsDays || tsDays.length === 0) && techDates.size === 0) {
-        const { data: tsVisible } = await supabase.rpc('get_timesheet_amounts_visible');
-        if (Array.isArray(tsVisible) && tsVisible.length) {
-          (tsVisible as any[])
-            .filter(
-              (row) =>
-                row.job_id === job.id &&
-                techIds.includes(row.technician_id) &&
-                (row.is_active == null || row.is_active === true)
-            )
-            .forEach((row: any) => {
-              if (!row?.technician_id || !row?.date) return;
-              if (!techDates.has(row.technician_id)) techDates.set(row.technician_id, new Set());
-              techDates.get(row.technician_id)!.add(row.date);
-            });
-        }
-      }
-
-      const daysCounts = new Map<string, number>();
-      techDates.forEach((dates, techId) => daysCounts.set(techId, dates.size));
-      filteredQuotes = adjustRehearsalQuotesForMultiDay(filteredQuotes, daysCounts);
 
       // Attach manual payout overrides (so PDFs reflect exceptions)
       filteredQuotes = await attachPayoutOverridesToTourQuotes(job.id, filteredQuotes);

--- a/src/types/tourRates.ts
+++ b/src/types/tourRates.ts
@@ -28,6 +28,12 @@ export interface TourJobRateQuote {
   breakdown: {
     error?: string;
     autonomo_discount_eur?: number;
+    scheduled_days?: number;
+    rehearsal_days?: number;
+    standard_days?: number;
+    rehearsal_rate_eur?: number;
+    standard_day_rate_eur?: number;
+    forced_rehearsal_rate?: boolean;
     [key: string]: any;
   };
   // Payout override fields (when manual override is set)

--- a/src/utils/__tests__/rehearsal-rate-source-of-truth-guard.test.ts
+++ b/src/utils/__tests__/rehearsal-rate-source-of-truth-guard.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("rehearsal-rate source-of-truth migration guard", () => {
+  const migrationPath = join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "supabase",
+    "migrations",
+    "20260411130000_unify_rehearsal_rate_source_of_truth.sql",
+  );
+  const migration = readFileSync(migrationPath, "utf-8");
+
+  it("backfills rehearsal toggle rows from scheduled dates and persisted timesheet dates", () => {
+    expect(migration).toMatch(/INSERT INTO public\.job_rehearsal_dates \(job_id, date\)/i);
+    expect(migration).toMatch(/generate_series\(/i);
+    expect(migration).toMatch(/UNION/i);
+    expect(migration).toMatch(/FROM public\.timesheets t/i);
+    expect(migration).toMatch(/SELECT\s+t\.job_id,\s+t\.date/i);
+    expect(migration).toMatch(/t\.date IS NOT NULL/i);
+    expect(migration).toMatch(/ON CONFLICT \(job_id, date\) DO NOTHING/i);
+  });
+});

--- a/src/utils/__tests__/technician-rate-mode-guard.test.ts
+++ b/src/utils/__tests__/technician-rate-mode-guard.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("technician/date rate-mode migration guard", () => {
+  const migrationPath = join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "supabase",
+    "migrations",
+    "20260411223000_add_admin_only_technician_rate_modes.sql",
+  );
+  const migration = readFileSync(migrationPath, "utf-8");
+
+  it("creates an admin-only technician/date override table", () => {
+    expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS public\.job_technician_rate_mode_dates/i);
+    expect(migration).toMatch(/ALTER TABLE public\.job_technician_rate_mode_dates ENABLE ROW LEVEL SECURITY/i);
+    expect(migration).toMatch(/FOR SELECT[\s\S]*USING \(public\.is_admin\(\)\)/i);
+    expect(migration).toMatch(/FOR INSERT[\s\S]*WITH CHECK \(public\.is_admin\(\)\)/i);
+    expect(migration).toMatch(/FOR UPDATE[\s\S]*USING \(public\.is_admin\(\)\)[\s\S]*WITH CHECK \(public\.is_admin\(\)\)/i);
+    expect(migration).toMatch(/FOR DELETE[\s\S]*USING \(public\.is_admin\(\)\)/i);
+  });
+
+  it("gives technician/date overrides precedence over job-wide rehearsal dates in both pricing functions", () => {
+    expect(migration).toMatch(/FROM public\.job_technician_rate_mode_dates trmd[\s\S]*technician_id = v_timesheet\.technician_id/i);
+    expect(migration).toMatch(/v_rate_mode_source := 'technician_override'/i);
+    expect(migration).toMatch(/COALESCE\(trmd\.use_rehearsal_rate,\s*jrd\.job_id IS NOT NULL\)/i);
+    expect(migration).toMatch(/technician_override_days/i);
+  });
+});

--- a/src/utils/__tests__/technician-rate-mode-guard.test.ts
+++ b/src/utils/__tests__/technician-rate-mode-guard.test.ts
@@ -16,11 +16,23 @@ describe("technician/date rate-mode migration guard", () => {
 
   it("creates an admin-only technician/date override table", () => {
     expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS public\.job_technician_rate_mode_dates/i);
+    expect(migration).toMatch(/created_at timestamptz NOT NULL DEFAULT now\(\)/i);
+    expect(migration).toMatch(/created_by uuid NULL DEFAULT auth\.uid\(\)/i);
+    expect(migration).toMatch(/updated_at timestamptz NOT NULL DEFAULT now\(\)/i);
+    expect(migration).toMatch(/updated_by uuid NULL DEFAULT auth\.uid\(\)/i);
     expect(migration).toMatch(/ALTER TABLE public\.job_technician_rate_mode_dates ENABLE ROW LEVEL SECURITY/i);
     expect(migration).toMatch(/FOR SELECT[\s\S]*USING \(public\.is_admin\(\)\)/i);
     expect(migration).toMatch(/FOR INSERT[\s\S]*WITH CHECK \(public\.is_admin\(\)\)/i);
     expect(migration).toMatch(/FOR UPDATE[\s\S]*USING \(public\.is_admin\(\)\)[\s\S]*WITH CHECK \(public\.is_admin\(\)\)/i);
     expect(migration).toMatch(/FOR DELETE[\s\S]*USING \(public\.is_admin\(\)\)/i);
+  });
+
+  it("touches updated_at and updated_by on database-side updates", () => {
+    expect(migration).toMatch(/CREATE OR REPLACE FUNCTION public\.tg_job_technician_rate_mode_dates_touch\(\)/i);
+    expect(migration).toMatch(/NEW\.updated_at := now\(\)/i);
+    expect(migration).toMatch(/NEW\.updated_by := COALESCE\(auth\.uid\(\), NEW\.updated_by, OLD\.updated_by\)/i);
+    expect(migration).toMatch(/CREATE TRIGGER trg_job_technician_rate_mode_dates_touch/i);
+    expect(migration).toMatch(/BEFORE UPDATE ON public\.job_technician_rate_mode_dates/i);
   });
 
   it("gives technician/date overrides precedence over job-wide rehearsal dates in both pricing functions", () => {

--- a/src/utils/__tests__/timesheet-ot-category-guard.test.ts
+++ b/src/utils/__tests__/timesheet-ot-category-guard.test.ts
@@ -5,6 +5,8 @@ import { join } from 'path';
 describe('timesheet OT category regression guard', () => {
   const migrationsDir = join(__dirname, '..', '..', '..', 'supabase', 'migrations');
   const targetMigrationName = '20260303130950_house_tech_overtime_by_category.sql';
+  const computeTimesheetAmountDefinitionPattern =
+    /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:"?public"?\.)?"?compute_timesheet_amount_2025"?\s*\(/i;
   const migrationFiles = readdirSync(migrationsDir)
     .filter((f) => f.endsWith('.sql'))
     .sort();
@@ -29,7 +31,7 @@ describe('timesheet OT category regression guard', () => {
         name,
         content: readFileSync(join(migrationsDir, name), 'utf-8'),
       }))
-      .filter((m) => m.content.includes('compute_timesheet_amount_2025'));
+      .filter((m) => computeTimesheetAmountDefinitionPattern.test(m.content));
 
     expect(functionMigrations.length).toBeGreaterThan(0);
 

--- a/src/utils/__tests__/timesheet-ot-category-guard.test.ts
+++ b/src/utils/__tests__/timesheet-ot-category-guard.test.ts
@@ -23,7 +23,7 @@ describe('timesheet OT category regression guard', () => {
     expect(content).toMatch(/CASE[\s\S]*overtime_hour_eur\s*=\s*15(?:\.00)?[\s\S]*THEN\s*20(?:\.00)?/i);
   });
 
-  it('latest compute_timesheet_amount_2025 migration has category-aware OT + targeted backfill', () => {
+  it('latest compute_timesheet_amount_2025 migration preserves category-aware OT logic', () => {
     const functionMigrations = migrationFiles
       .map((name) => ({
         name,
@@ -34,7 +34,6 @@ describe('timesheet OT category regression guard', () => {
     expect(functionMigrations.length).toBeGreaterThan(0);
 
     const latest = functionMigrations[functionMigrations.length - 1];
-    expect(latest.name).toBe(targetMigrationName);
 
     const codeOnly = latest.content
       .split('\n')
@@ -42,11 +41,17 @@ describe('timesheet OT category regression guard', () => {
       .join('\n');
 
     expect(codeOnly).toMatch(/v_is_house_tech\s+AND\s+v_category\s*=\s*'especialista'/i);
+    expect(codeOnly).toMatch(/v_is_house_tech\s+AND\s+v_category\s*=\s*'responsable'/i);
     expect(codeOnly).toMatch(/overtime_hour_especialista_eur/i);
     expect(codeOnly).toMatch(/overtime_hour_responsable_eur/i);
     expect(codeOnly).toMatch(/CASE\s+WHEN\s+ctr\.overtime_hour_eur\s*=\s*15(?:\.00)?\s+THEN\s+20(?:\.00)?/i);
     expect(codeOnly).toMatch(/p\.role\s*=\s*'house_tech'/i);
-    expect(codeOnly).toMatch(/t\.category\s*=\s*'responsable'/i);
-    expect(codeOnly).toMatch(/amount_breakdown->>'overtime_hours'/i);
+  });
+
+  it('the OT-category migration keeps the targeted persisted-timesheet backfill', () => {
+    const content = readFileSync(join(migrationsDir, targetMigrationName), 'utf-8');
+
+    expect(content).toMatch(/amount_breakdown->>'overtime_hours'/i);
+    expect(content).toMatch(/PERFORM public\.compute_timesheet_amount_2025\(rec\.id,\s*true\)/i);
   });
 });

--- a/src/utils/__tests__/tour-job-rate-schedule-range-guard.test.ts
+++ b/src/utils/__tests__/tour-job-rate-schedule-range-guard.test.ts
@@ -31,5 +31,8 @@ describe('tour job quote schedule-range regression guard', () => {
     expect(codeOnly).toMatch(/schedule_start := COALESCE\(\s*job_date_type_start,\s*tour_date_start,\s*job_start_date,\s*tour_date_legacy_date/i);
     expect(codeOnly).toMatch(/schedule_end := COALESCE\(\s*job_date_type_end,\s*tour_date_end,\s*job_end_date,\s*tour_date_start,\s*tour_date_legacy_date,\s*job_start_date/i);
     expect(codeOnly).toMatch(/COUNT\(\*\)::int,\s*COUNT\(\*\) FILTER/i);
+    expect(codeOnly).toMatch(/has_override := COALESCE\(has_override,\s*FALSE\)/i);
+    expect(codeOnly).toMatch(/SELECT COALESCE\(\s*EXISTS\s*\(/i);
+    expect(codeOnly).toMatch(/team_member := COALESCE\(team_member,\s*FALSE\)/i);
   });
 });

--- a/src/utils/__tests__/tour-job-rate-schedule-range-guard.test.ts
+++ b/src/utils/__tests__/tour-job-rate-schedule-range-guard.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('tour job quote schedule-range regression guard', () => {
+  const migrationsDir = join(__dirname, '..', '..', '..', 'supabase', 'migrations');
+  const computeTourQuoteDefinitionPattern =
+    /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:"?public"?\.)?"?compute_tour_job_rate_quote_2025"?\s*\(/i;
+  const migrationFiles = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  it('latest compute_tour_job_rate_quote_2025 migration derives multi-day span from job_date_types before stale tour_dates', () => {
+    const functionMigrations = migrationFiles
+      .map((name) => ({
+        name,
+        content: readFileSync(join(migrationsDir, name), 'utf-8'),
+      }))
+      .filter((migration) => computeTourQuoteDefinitionPattern.test(migration.content));
+
+    expect(functionMigrations.length).toBeGreaterThan(0);
+
+    const latest = functionMigrations[functionMigrations.length - 1];
+    const codeOnly = latest.content
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('--'))
+      .join('\n');
+
+    expect(codeOnly).toMatch(/SELECT MIN\(jdt\.date\), MAX\(jdt\.date\)/i);
+    expect(codeOnly).toMatch(/FROM public\.job_date_types jdt/i);
+    expect(codeOnly).toMatch(/schedule_start := COALESCE\(\s*job_date_type_start,\s*tour_date_start,\s*job_start_date,\s*tour_date_legacy_date/i);
+    expect(codeOnly).toMatch(/schedule_end := COALESCE\(\s*job_date_type_end,\s*tour_date_end,\s*job_end_date,\s*tour_date_start,\s*tour_date_legacy_date,\s*job_start_date/i);
+    expect(codeOnly).toMatch(/COUNT\(\*\)::int,\s*COUNT\(\*\) FILTER/i);
+  });
+});

--- a/supabase/migrations/20260411130000_unify_rehearsal_rate_source_of_truth.sql
+++ b/supabase/migrations/20260411130000_unify_rehearsal_rate_source_of_truth.sql
@@ -1,0 +1,682 @@
+-- Make job_rehearsal_dates the sole source of truth for rehearsal pricing.
+-- Preserve current live behavior by backfilling existing rehearsal tour dates
+-- before removing tour_date_type as a pricing trigger.
+
+INSERT INTO public.job_rehearsal_dates (job_id, date)
+SELECT
+  j.id,
+  scheduled_date::date
+FROM public.jobs j
+JOIN public.tour_dates td
+  ON td.id = j.tour_date_id
+CROSS JOIN LATERAL generate_series(
+  COALESCE(td.start_date, td.date),
+  COALESCE(td.end_date, td.start_date, td.date),
+  INTERVAL '1 day'
+) AS scheduled_date
+WHERE j.job_type = 'tourdate'
+  AND td.tour_date_type = 'rehearsal'
+ON CONFLICT (job_id, date) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public.compute_timesheet_amount_2025(
+  _timesheet_id uuid,
+  _persist boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_timesheet RECORD;
+  v_job_type TEXT;
+  v_category TEXT;
+  v_rate_card RECORD;
+  v_worked_hours NUMERIC;
+  v_raw_worked_hours NUMERIC;
+  v_billable_hours NUMERIC;
+  v_base_day_amount NUMERIC := 0;
+  v_plus_10_12_hours NUMERIC := 0;
+  v_plus_10_12_amount NUMERIC := 0;
+  v_overtime_hours NUMERIC := 0;
+  v_overtime_amount NUMERIC := 0;
+  v_total_amount NUMERIC := 0;
+  v_breakdown JSONB;
+  v_result JSONB;
+  v_is_rehearsal BOOLEAN := FALSE;
+  v_is_extended_shift BOOLEAN := FALSE;
+  v_rehearsal_flat_rate NUMERIC := NULL;
+  v_is_autonomo BOOLEAN := TRUE;
+  v_is_house_tech BOOLEAN := FALSE;
+  v_is_reduced_rehearsal BOOLEAN := FALSE;
+  v_autonomo_discount NUMERIC := 0;
+  v_forced_rehearsal BOOLEAN := FALSE;
+BEGIN
+  -- Fetch timesheet with job info, category, autonomo status, and role-based flags
+  SELECT
+    t.*,
+    j.job_type,
+    CASE WHEN p.role = 'technician' THEN COALESCE(p.autonomo, true) ELSE true END as is_autonomo,
+    COALESCE(p.role = 'house_tech', false) as is_house_tech,
+    COALESCE(p.role IN ('house_tech', 'admin', 'management'), false) as is_reduced_rehearsal,
+    COALESCE(
+      t.category,
+      CASE
+        WHEN a.sound_role LIKE '%-R' OR a.lights_role LIKE '%-R' OR a.video_role LIKE '%-R' THEN 'responsable'
+        WHEN a.sound_role LIKE '%-E' OR a.lights_role LIKE '%-E' OR a.video_role LIKE '%-E' THEN 'especialista'
+        WHEN a.sound_role LIKE '%-T' OR a.lights_role LIKE '%-T' OR a.video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END,
+      'tecnico'
+    ) as category
+  INTO v_timesheet
+  FROM public.timesheets t
+  LEFT JOIN public.jobs j ON t.job_id = j.id
+  LEFT JOIN public.job_assignments a ON t.job_id = a.job_id AND t.technician_id = a.technician_id
+  LEFT JOIN public.profiles p ON t.technician_id = p.id
+  WHERE t.id = _timesheet_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Timesheet not found: %', _timesheet_id;
+  END IF;
+
+  IF NOT (
+    auth.role() = 'service_role'
+    OR public.is_admin_or_management()
+    OR auth.uid() = v_timesheet.technician_id
+  ) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  v_job_type := v_timesheet.job_type;
+  v_category := v_timesheet.category;
+
+  -- Rehearsal pricing now depends only on the per-date toggle table.
+  IF v_timesheet.date IS NOT NULL AND v_timesheet.job_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.job_rehearsal_dates
+      WHERE job_id = v_timesheet.job_id AND date = v_timesheet.date
+    ) INTO v_forced_rehearsal;
+  END IF;
+
+  v_is_rehearsal := v_forced_rehearsal;
+
+  -- Get autonomo / house_tech / reduced rehearsal status from the main query
+  v_is_autonomo := v_timesheet.is_autonomo;
+  v_is_house_tech := v_timesheet.is_house_tech;
+  v_is_reduced_rehearsal := v_timesheet.is_reduced_rehearsal;
+
+  -- Calculate worked hours once for both rehearsal and standard paths
+  IF v_timesheet.end_time < v_timesheet.start_time OR COALESCE(v_timesheet.ends_next_day, false) THEN
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      v_timesheet.end_time - v_timesheet.start_time + INTERVAL '24 hours'
+    )) / 3600.0 - (COALESCE(v_timesheet.break_minutes, 0) / 60.0);
+  ELSE
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      v_timesheet.end_time - v_timesheet.start_time
+    )) / 3600.0 - (COALESCE(v_timesheet.break_minutes, 0) / 60.0);
+  END IF;
+  -- Preserve raw fractional hours for audit trail, then round to nearest whole hour
+  -- IMPORTANT: Do NOT change this to half-hour rounding (ROUND(x*2)/2). See PR #467.
+  v_raw_worked_hours := v_worked_hours;
+  v_worked_hours := ROUND(v_worked_hours);
+
+  -- Handle rehearsal flat rate
+  IF v_is_rehearsal THEN
+    -- Check for custom rehearsal rate first
+    SELECT rehearsal_day_eur INTO v_rehearsal_flat_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = v_timesheet.technician_id;
+
+    -- If no custom rate, use role-based defaults:
+    -- house_tech / admin / management -> EUR 60, regular technicians -> EUR 180
+    IF v_rehearsal_flat_rate IS NULL THEN
+      IF v_is_reduced_rehearsal THEN
+        v_rehearsal_flat_rate := 60.00;
+      ELSE
+        v_rehearsal_flat_rate := 180.00;
+      END IF;
+    END IF;
+
+    -- Apply discount for non-autonomo regular technicians only.
+    -- House techs, admin, and management are exempt from the autonomo discount.
+    IF NOT v_is_autonomo AND NOT v_is_reduced_rehearsal THEN
+      v_autonomo_discount := 30.00;
+      v_rehearsal_flat_rate := v_rehearsal_flat_rate - v_autonomo_discount;
+    END IF;
+
+    v_total_amount := v_rehearsal_flat_rate;
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rehearsal_flat_rate;
+
+    v_breakdown := jsonb_build_object(
+      'worked_hours', v_raw_worked_hours,
+      'worked_hours_rounded', v_worked_hours,
+      'hours_rounded', v_worked_hours,
+      'billable_hours', v_billable_hours,
+      'is_rehearsal', true,
+      'is_rehearsal_flat_rate', true,
+      'rehearsal_rate_eur', v_rehearsal_flat_rate,
+      'autonomo_discount_eur', v_autonomo_discount,
+      'base_day_before_discount_eur', CASE WHEN v_autonomo_discount > 0 THEN v_rehearsal_flat_rate + v_autonomo_discount ELSE v_rehearsal_flat_rate END,
+      'base_amount_eur', v_rehearsal_flat_rate,
+      'base_day_eur', v_rehearsal_flat_rate,
+      'plus_10_12_hours', 0,
+      'plus_10_12_eur', 0,
+      'plus_10_12_amount_eur', 0,
+      'overtime_hours', 0,
+      'overtime_hour_eur', 0,
+      'overtime_amount_eur', 0,
+      'total_eur', v_total_amount,
+      'category', 'rehearsal',
+      'forced_rehearsal_rate', v_forced_rehearsal
+    );
+
+    v_result := jsonb_build_object(
+      'timesheet_id', _timesheet_id,
+      'amount_eur', v_total_amount,
+      'amount_breakdown', v_breakdown
+    );
+
+    IF _persist THEN
+      UPDATE public.timesheets
+      SET
+        amount_eur = v_total_amount,
+        amount_breakdown = v_breakdown,
+        category = v_category,
+        updated_at = NOW()
+      WHERE id = _timesheet_id;
+    END IF;
+
+    RETURN v_result;
+  END IF;
+
+  -- Standard rate card lookup (non-rehearsal).
+  -- House-tech OT is category-aware; non-house roles preserve legacy behavior.
+  SELECT
+    COALESCE(
+      CASE
+        WHEN v_category = 'responsable' THEN COALESCE(ctr.base_day_responsable_eur, ctr.base_day_especialista_eur, ctr.base_day_eur)
+        WHEN v_category = 'especialista' THEN COALESCE(ctr.base_day_especialista_eur, ctr.base_day_eur)
+        ELSE ctr.base_day_eur
+      END,
+      (SELECT rc.base_day_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)
+    ) AS base_day_eur,
+    COALESCE(ctr.plus_10_12_eur, (SELECT rc.plus_10_12_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)) as plus_10_12_eur,
+    COALESCE(
+      CASE
+        WHEN v_is_house_tech AND v_category = 'tecnico' THEN ctr.overtime_hour_eur
+        WHEN v_is_house_tech AND v_category = 'especialista' THEN COALESCE(ctr.overtime_hour_especialista_eur, ctr.overtime_hour_eur)
+        WHEN v_is_house_tech AND v_category = 'responsable' THEN COALESCE(
+          ctr.overtime_hour_responsable_eur,
+          CASE WHEN ctr.overtime_hour_eur = 15.00 THEN 20.00 END,
+          ctr.overtime_hour_eur
+        )
+        ELSE ctr.overtime_hour_eur
+      END,
+      (SELECT rc.overtime_hour_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)
+    ) as overtime_hour_eur
+  INTO v_rate_card
+  FROM public.custom_tech_rates ctr
+  WHERE ctr.profile_id = v_timesheet.technician_id;
+
+  IF NOT FOUND THEN
+    SELECT * INTO v_rate_card
+    FROM public.rate_cards_2025
+    WHERE category = v_category;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Rate card not found for category: %', v_category;
+    END IF;
+  END IF;
+
+  -- Handle evento jobs (fixed 12-hour rate)
+  IF v_job_type = 'evento' THEN
+    v_billable_hours := 12.0;
+    v_base_day_amount := v_rate_card.base_day_eur;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+    v_overtime_hours := 0;
+    v_overtime_amount := 0;
+    v_total_amount := v_base_day_amount + v_plus_10_12_amount;
+  -- Handle extended shifts (21+ hours / over 20.5 hrs): double base rate only
+  ELSIF v_worked_hours > 20.5 THEN
+    v_is_extended_shift := TRUE;
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rate_card.base_day_eur * 2;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := 0;
+    v_overtime_hours := 0;
+    v_overtime_amount := 0;
+    v_total_amount := v_base_day_amount;
+  ELSE
+    -- Standard rate calculation tiers
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rate_card.base_day_eur;
+
+    IF v_worked_hours <= 10.5 THEN
+      v_total_amount := v_base_day_amount;
+    ELSIF v_worked_hours <= 12.5 THEN
+      v_plus_10_12_hours := 0;
+      v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+      v_total_amount := v_base_day_amount + v_plus_10_12_amount;
+    ELSE
+      v_plus_10_12_hours := 0;
+      v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+
+      v_overtime_hours := v_worked_hours - 12;
+
+      v_overtime_amount := v_rate_card.overtime_hour_eur * v_overtime_hours;
+      v_total_amount := v_base_day_amount + v_plus_10_12_amount + v_overtime_amount;
+    END IF;
+  END IF;
+
+  v_breakdown := jsonb_build_object(
+    'worked_hours', v_raw_worked_hours,
+    'worked_hours_rounded', v_worked_hours,
+    'hours_rounded', v_worked_hours,
+    'billable_hours', v_billable_hours,
+    'is_evento', (v_job_type = 'evento'),
+    'is_extended_shift', v_is_extended_shift,
+    'is_double_base_rate', v_is_extended_shift,
+    'base_amount_eur', COALESCE(v_base_day_amount, 0),
+    'base_day_eur', COALESCE(v_base_day_amount, 0),
+    'single_base_day_eur', CASE WHEN v_is_extended_shift THEN v_rate_card.base_day_eur ELSE v_base_day_amount END,
+    'plus_10_12_hours', COALESCE(v_plus_10_12_hours, 0),
+    'plus_10_12_eur', v_rate_card.plus_10_12_eur,
+    'plus_10_12_amount_eur', COALESCE(v_plus_10_12_amount, 0),
+    'overtime_hours', COALESCE(v_overtime_hours, 0),
+    'overtime_hour_eur', v_rate_card.overtime_hour_eur,
+    'overtime_amount_eur', COALESCE(v_overtime_amount, 0),
+    'total_eur', v_total_amount,
+    'category', v_category
+  );
+
+  v_result := jsonb_build_object(
+    'timesheet_id', _timesheet_id,
+    'amount_eur', v_total_amount,
+    'amount_breakdown', v_breakdown
+  );
+
+  IF _persist THEN
+    UPDATE public.timesheets
+    SET
+      amount_eur = v_total_amount,
+      amount_breakdown = v_breakdown,
+      category = v_category,
+      updated_at = NOW()
+    WHERE id = _timesheet_id;
+  END IF;
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.compute_timesheet_amount_2025(uuid,boolean) IS
+  'Calculates timesheet amounts based on rate cards. Hours rounded to nearest whole number (not half hour). Rehearsal flat rate: EUR 60 for house_tech/admin/management roles, EUR 180 for regular technicians. Rehearsal pricing is triggered only by matching rows in job_rehearsal_dates. House-tech overtime is category-aware: tecnico uses overtime_hour_eur, especialista uses overtime_hour_especialista_eur fallback to overtime_hour_eur, responsable uses overtime_hour_responsable_eur fallback (including 15->20 rule) then overtime_hour_eur.';
+
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  et timestamptz;
+  job_start_date date;
+  job_end_date date;
+  tour_group uuid;
+  tour_date_ref uuid;
+  schedule_start date;
+  schedule_end date;
+  scheduled_days int := 1;
+  rehearsal_days int := 0;
+  standard_days int := 0;
+  cat text;
+  house boolean := false;
+  is_autonomo boolean := true;
+  is_reduced_rehearsal boolean := false;
+  standard_discount_per_day numeric(10,2) := 0;
+  rehearsal_discount_per_day numeric(10,2) := 0;
+  total_autonomo_discount numeric(10,2) := 0;
+  standard_base_before_discount numeric(10,2) := 0;
+  standard_after_discount numeric(10,2) := 0;
+  rehearsal_base_before_discount numeric(10,2) := 0;
+  team_member boolean := false;
+  has_override boolean := false;
+  standard_base numeric(10,2);
+  standard_day_rate numeric(10,2) := 0;
+  rehearsal_day_rate numeric(10,2) := 0;
+  standard_total numeric(10,2) := 0;
+  rehearsal_total numeric(10,2) := 0;
+  total_base numeric(10,2) := 0;
+  base_calculation_total numeric(10,2) := 0;
+  after_discount_total numeric(10,2) := 0;
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  display_multiplier numeric(6,3) := 1.0;
+  display_per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  has_custom_standard_rate boolean := FALSE;
+  has_custom_rehearsal_rate boolean := FALSE;
+  has_custom_rate boolean := FALSE;
+  display_category text := 'rehearsal';
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  -- Fetch job info
+  SELECT job_type, start_time, end_time, tour_id, tour_date_id
+  INTO jtype, st, et, tour_group, tour_date_ref
+  FROM public.jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  job_start_date := (st AT TIME ZONE 'Europe/Madrid')::date;
+  job_end_date := COALESCE((et AT TIME ZONE 'Europe/Madrid')::date, job_start_date);
+
+  SELECT
+    COALESCE(td.start_date, td.date, job_start_date),
+    COALESCE(td.end_date, td.start_date, td.date, job_end_date, job_start_date)
+  INTO schedule_start, schedule_end
+  FROM public.tour_dates td
+  WHERE td.id = tour_date_ref;
+
+  schedule_start := COALESCE(schedule_start, job_start_date);
+  schedule_end := COALESCE(schedule_end, schedule_start, job_end_date, job_start_date);
+  IF schedule_end < schedule_start THEN
+    schedule_end := schedule_start;
+  END IF;
+
+  scheduled_days := GREATEST(1, (schedule_end - schedule_start) + 1);
+
+  SELECT count(*)
+  INTO rehearsal_days
+  FROM public.job_rehearsal_dates
+  WHERE job_id = _job_id
+    AND date BETWEEN schedule_start AND schedule_end;
+
+  rehearsal_days := LEAST(rehearsal_days, scheduled_days);
+  standard_days := scheduled_days - rehearsal_days;
+
+  -- Check house tech, autonomo status, and reduced-rehearsal role
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END,
+    COALESCE(role IN ('house_tech', 'admin', 'management'), false)
+  INTO house, is_autonomo, is_reduced_rehearsal
+  FROM public.profiles
+  WHERE id = _tech_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','profile_not_found','technician_id',_tech_id);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(ja.use_tour_multipliers, FALSE)
+    INTO has_override
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.tour_assignments ta
+      WHERE ta.tour_id = tour_group
+        AND ta.technician_id = _tech_id
+    ) OR has_override
+    INTO team_member;
+  END IF;
+
+  SELECT iso_year, iso_week INTO y, w
+  FROM public.iso_year_week_madrid(st);
+
+  IF team_member THEN
+    DECLARE
+      total_tour_dates int;
+      tech_assigned_dates int;
+    BEGIN
+      SELECT count(DISTINCT j.id) INTO total_tour_dates
+      FROM public.jobs j
+      WHERE j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      SELECT count(DISTINCT j.id) INTO tech_assigned_dates
+      FROM public.jobs j
+      JOIN public.job_assignments a ON a.job_id = j.id
+      WHERE a.technician_id = _tech_id
+        AND j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      IF tech_assigned_dates = total_tour_dates THEN
+        cnt := total_tour_dates;
+
+        -- Full-week tour team multiplier tiers: 1 date=1.5x, 2 dates=2.25x total,
+        -- 3+ dates use baseline 1.0x to avoid over-scaling longer runs.
+        IF cnt <= 1 THEN
+          mult := 1.5;
+          per_job_multiplier := 1.5;
+        ELSIF cnt = 2 THEN
+          mult := 2.25;
+          per_job_multiplier := 1.125;
+        ELSE
+          mult := 1.0;
+          per_job_multiplier := 1.0;
+        END IF;
+      ELSE
+        cnt := tech_assigned_dates;
+        mult := 1.0;
+        per_job_multiplier := 1.0;
+      END IF;
+    END;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+  END IF;
+
+  IF standard_days > 0 THEN
+    -- Resolve category for everyone when any standard day remains.
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM public.job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM public.profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+
+    -- Base rate lookup - custom_tech_rates for all technicians (category-aware)
+    IF cat = 'responsable' THEN
+      SELECT COALESCE(
+        tour_base_responsable_eur,
+        base_day_responsable_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSIF cat = 'especialista' THEN
+      SELECT COALESCE(
+        tour_base_especialista_eur,
+        tour_base_other_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      SELECT COALESCE(
+        tour_base_other_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    END IF;
+
+    IF standard_base IS NOT NULL THEN
+      has_custom_standard_rate := TRUE;
+      has_custom_rate := TRUE;
+    ELSE
+      SELECT base_day_eur INTO standard_base
+      FROM public.rate_cards_tour_2025
+      WHERE category = cat;
+
+      IF standard_base IS NULL THEN
+        RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+      END IF;
+    END IF;
+
+    standard_base_before_discount := standard_base;
+
+    IF NOT house AND NOT is_autonomo THEN
+      standard_discount_per_day := 30.00;
+      standard_base := standard_base - standard_discount_per_day;
+    END IF;
+
+    standard_after_discount := standard_base;
+    standard_day_rate := ROUND(standard_base * per_job_multiplier, 2);
+    standard_total := ROUND(standard_day_rate * standard_days, 2);
+    display_category := cat;
+  END IF;
+
+  IF rehearsal_days > 0 THEN
+    SELECT rehearsal_day_eur INTO rehearsal_day_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF rehearsal_day_rate IS NOT NULL THEN
+      has_custom_rehearsal_rate := TRUE;
+      has_custom_rate := TRUE;
+      rehearsal_base_before_discount := rehearsal_day_rate;
+    ELSE
+      IF is_reduced_rehearsal THEN
+        rehearsal_day_rate := 60.00;
+        rehearsal_base_before_discount := 60.00;
+      ELSE
+        rehearsal_day_rate := 180.00;
+        rehearsal_base_before_discount := 180.00;
+      END IF;
+    END IF;
+
+    IF NOT is_autonomo AND NOT is_reduced_rehearsal THEN
+      rehearsal_discount_per_day := 30.00;
+      rehearsal_day_rate := rehearsal_day_rate - rehearsal_discount_per_day;
+    END IF;
+
+    rehearsal_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+
+    IF standard_days = 0 THEN
+      display_category := 'rehearsal';
+    END IF;
+  END IF;
+
+  total_base := ROUND(standard_total + rehearsal_total, 2);
+  total_autonomo_discount := ROUND(
+    (standard_discount_per_day * standard_days) + (rehearsal_discount_per_day * rehearsal_days),
+    2
+  );
+  base_calculation_total := ROUND(
+    (standard_base_before_discount * standard_days) + (rehearsal_base_before_discount * rehearsal_days),
+    2
+  );
+
+  IF rehearsal_days > 0 THEN
+    -- Mixed and full-rehearsal jobs already return an aggregated base total from SQL.
+    display_multiplier := 1.0;
+    display_per_job_multiplier := 1.0;
+    after_discount_total := total_base;
+  ELSE
+    display_multiplier := mult;
+    display_per_job_multiplier := per_job_multiplier;
+    after_discount_total := ROUND(standard_after_discount * standard_days, 2);
+  END IF;
+
+  extras := public.extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(total_base + extras_total, 2);
+
+  disclaimer := public.needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,
+    'category', display_category,
+    'base_day_eur', total_base,
+    'has_custom_rate', has_custom_rate,
+    'autonomo_discount_eur', total_autonomo_discount,
+    'base_day_before_discount_eur', base_calculation_total,
+    'week_count', cnt,
+    'multiplier', ROUND(display_multiplier, 3),
+    'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', total_base,
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', final_total,
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', base_calculation_total,
+      'autonomo_discount', total_autonomo_discount,
+      'after_discount', after_discount_total,
+      'multiplier', ROUND(display_multiplier, 3),
+      'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+      'final_base', total_base,
+      'has_custom_rate', has_custom_rate,
+      'has_custom_standard_rate', has_custom_standard_rate,
+      'has_custom_rehearsal_rate', has_custom_rehearsal_rate,
+      'scheduled_days', scheduled_days,
+      'rehearsal_days', rehearsal_days,
+      'standard_days', standard_days,
+      'rehearsal_rate_eur', CASE WHEN rehearsal_days > 0 THEN rehearsal_day_rate ELSE NULL END,
+      'standard_day_rate_eur', CASE WHEN standard_days > 0 THEN standard_day_rate ELSE NULL END,
+      'forced_rehearsal_rate', (rehearsal_days > 0)
+    )
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) IS
+  'Calculates tour job rate quotes for technicians. job_rehearsal_dates is the only rehearsal-rate trigger. The quote aggregates rehearsal and standard days across the full scheduled tour-date range, preserving manual payout overrides in downstream consumers.';

--- a/supabase/migrations/20260411130000_unify_rehearsal_rate_source_of_truth.sql
+++ b/supabase/migrations/20260411130000_unify_rehearsal_rate_source_of_truth.sql
@@ -4,18 +4,40 @@
 
 INSERT INTO public.job_rehearsal_dates (job_id, date)
 SELECT
-  j.id,
-  scheduled_date::date
-FROM public.jobs j
-JOIN public.tour_dates td
-  ON td.id = j.tour_date_id
-CROSS JOIN LATERAL generate_series(
-  COALESCE(td.start_date, td.date),
-  COALESCE(td.end_date, td.start_date, td.date),
-  INTERVAL '1 day'
-) AS scheduled_date
-WHERE j.job_type = 'tourdate'
-  AND td.tour_date_type = 'rehearsal'
+  seeded.job_id,
+  seeded.date
+FROM (
+  SELECT
+    j.id AS job_id,
+    scheduled_date::date AS date
+  FROM public.jobs j
+  JOIN public.tour_dates td
+    ON td.id = j.tour_date_id
+  CROSS JOIN LATERAL generate_series(
+    COALESCE(td.start_date, td.date),
+    COALESCE(td.end_date, td.start_date, td.date),
+    INTERVAL '1 day'
+  ) AS scheduled_date
+  WHERE j.job_type = 'tourdate'
+    AND td.tour_date_type = 'rehearsal'
+
+  UNION
+
+  -- Historical rehearsal pricing was also driven by tour_date_type, even when
+  -- persisted timesheet dates drifted outside the scheduled tour-date range.
+  -- Seed those dates too so existing payouts do not silently change on deploy.
+  SELECT
+    t.job_id,
+    t.date
+  FROM public.timesheets t
+  JOIN public.jobs j
+    ON j.id = t.job_id
+  JOIN public.tour_dates td
+    ON td.id = j.tour_date_id
+  WHERE j.job_type = 'tourdate'
+    AND td.tour_date_type = 'rehearsal'
+    AND t.date IS NOT NULL
+) AS seeded
 ON CONFLICT (job_id, date) DO NOTHING;
 
 CREATE OR REPLACE FUNCTION public.compute_timesheet_amount_2025(

--- a/supabase/migrations/20260411223000_add_admin_only_technician_rate_modes.sql
+++ b/supabase/migrations/20260411223000_add_admin_only_technician_rate_modes.sql
@@ -57,6 +57,25 @@ GRANT ALL ON TABLE public.job_technician_rate_mode_dates TO service_role;
 COMMENT ON TABLE public.job_technician_rate_mode_dates IS
   'Admin-only per-technician per-date pricing exceptions for tour jobs. Rows override job_rehearsal_dates for the specific technician/date; missing rows inherit the job-wide setting.';
 
+CREATE OR REPLACE FUNCTION public.tg_job_technician_rate_mode_dates_touch()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $function$
+BEGIN
+  NEW.updated_at := now();
+  NEW.updated_by := COALESCE(auth.uid(), NEW.updated_by, OLD.updated_by);
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_job_technician_rate_mode_dates_touch ON public.job_technician_rate_mode_dates;
+
+CREATE TRIGGER trg_job_technician_rate_mode_dates_touch
+  BEFORE UPDATE ON public.job_technician_rate_mode_dates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.tg_job_technician_rate_mode_dates_touch();
+
 CREATE OR REPLACE FUNCTION public.compute_timesheet_amount_2025(
   _timesheet_id uuid,
   _persist boolean DEFAULT false

--- a/supabase/migrations/20260411223000_add_admin_only_technician_rate_modes.sql
+++ b/supabase/migrations/20260411223000_add_admin_only_technician_rate_modes.sql
@@ -1,0 +1,760 @@
+-- Admin-only per-technician per-date pricing exceptions for rare mixed-rate
+-- tour dates. Absence of a row means "inherit the job-wide rehearsal toggle".
+
+CREATE TABLE IF NOT EXISTS public.job_technician_rate_mode_dates (
+  job_id uuid NOT NULL REFERENCES public.jobs(id) ON DELETE CASCADE,
+  technician_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  date date NOT NULL,
+  use_rehearsal_rate boolean NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid NULL DEFAULT auth.uid() REFERENCES public.profiles(id),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by uuid NULL DEFAULT auth.uid() REFERENCES public.profiles(id),
+  CONSTRAINT job_technician_rate_mode_dates_pkey PRIMARY KEY (job_id, technician_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_technician_rate_mode_dates_job
+  ON public.job_technician_rate_mode_dates(job_id);
+
+CREATE INDEX IF NOT EXISTS idx_job_technician_rate_mode_dates_job_tech
+  ON public.job_technician_rate_mode_dates(job_id, technician_id);
+
+ALTER TABLE public.job_technician_rate_mode_dates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "job_technician_rate_mode_dates_select_admin" ON public.job_technician_rate_mode_dates;
+DROP POLICY IF EXISTS "job_technician_rate_mode_dates_insert_admin" ON public.job_technician_rate_mode_dates;
+DROP POLICY IF EXISTS "job_technician_rate_mode_dates_update_admin" ON public.job_technician_rate_mode_dates;
+DROP POLICY IF EXISTS "job_technician_rate_mode_dates_delete_admin" ON public.job_technician_rate_mode_dates;
+
+CREATE POLICY "job_technician_rate_mode_dates_select_admin"
+  ON public.job_technician_rate_mode_dates
+  FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+CREATE POLICY "job_technician_rate_mode_dates_insert_admin"
+  ON public.job_technician_rate_mode_dates
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "job_technician_rate_mode_dates_update_admin"
+  ON public.job_technician_rate_mode_dates
+  FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+CREATE POLICY "job_technician_rate_mode_dates_delete_admin"
+  ON public.job_technician_rate_mode_dates
+  FOR DELETE
+  TO authenticated
+  USING (public.is_admin());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.job_technician_rate_mode_dates TO authenticated;
+GRANT ALL ON TABLE public.job_technician_rate_mode_dates TO service_role;
+
+COMMENT ON TABLE public.job_technician_rate_mode_dates IS
+  'Admin-only per-technician per-date pricing exceptions for tour jobs. Rows override job_rehearsal_dates for the specific technician/date; missing rows inherit the job-wide setting.';
+
+CREATE OR REPLACE FUNCTION public.compute_timesheet_amount_2025(
+  _timesheet_id uuid,
+  _persist boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_timesheet RECORD;
+  v_job_type TEXT;
+  v_category TEXT;
+  v_rate_card RECORD;
+  v_worked_hours NUMERIC;
+  v_raw_worked_hours NUMERIC;
+  v_billable_hours NUMERIC;
+  v_base_day_amount NUMERIC := 0;
+  v_plus_10_12_hours NUMERIC := 0;
+  v_plus_10_12_amount NUMERIC := 0;
+  v_overtime_hours NUMERIC := 0;
+  v_overtime_amount NUMERIC := 0;
+  v_total_amount NUMERIC := 0;
+  v_breakdown JSONB;
+  v_result JSONB;
+  v_is_rehearsal BOOLEAN := FALSE;
+  v_is_extended_shift BOOLEAN := FALSE;
+  v_rehearsal_flat_rate NUMERIC := NULL;
+  v_is_autonomo BOOLEAN := TRUE;
+  v_is_house_tech BOOLEAN := FALSE;
+  v_is_reduced_rehearsal BOOLEAN := FALSE;
+  v_autonomo_discount NUMERIC := 0;
+  v_forced_rehearsal BOOLEAN := FALSE;
+  v_technician_rate_mode_override BOOLEAN := NULL;
+  v_has_technician_rate_mode_override BOOLEAN := FALSE;
+  v_rate_mode_source TEXT := 'standard';
+BEGIN
+  -- Fetch timesheet with job info, category, autonomo status, and role-based flags
+  SELECT
+    t.*,
+    j.job_type,
+    CASE WHEN p.role = 'technician' THEN COALESCE(p.autonomo, true) ELSE true END as is_autonomo,
+    COALESCE(p.role = 'house_tech', false) as is_house_tech,
+    COALESCE(p.role IN ('house_tech', 'admin', 'management'), false) as is_reduced_rehearsal,
+    COALESCE(
+      t.category,
+      CASE
+        WHEN a.sound_role LIKE '%-R' OR a.lights_role LIKE '%-R' OR a.video_role LIKE '%-R' THEN 'responsable'
+        WHEN a.sound_role LIKE '%-E' OR a.lights_role LIKE '%-E' OR a.video_role LIKE '%-E' THEN 'especialista'
+        WHEN a.sound_role LIKE '%-T' OR a.lights_role LIKE '%-T' OR a.video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END,
+      'tecnico'
+    ) as category
+  INTO v_timesheet
+  FROM public.timesheets t
+  LEFT JOIN public.jobs j ON t.job_id = j.id
+  LEFT JOIN public.job_assignments a ON t.job_id = a.job_id AND t.technician_id = a.technician_id
+  LEFT JOIN public.profiles p ON t.technician_id = p.id
+  WHERE t.id = _timesheet_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Timesheet not found: %', _timesheet_id;
+  END IF;
+
+  IF NOT (
+    auth.role() = 'service_role'
+    OR public.is_admin_or_management()
+    OR auth.uid() = v_timesheet.technician_id
+  ) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  v_job_type := v_timesheet.job_type;
+  v_category := v_timesheet.category;
+
+  -- Rehearsal pricing uses technician/date overrides first, then the job-wide
+  -- rehearsal toggle table.
+  IF v_timesheet.date IS NOT NULL AND v_timesheet.job_id IS NOT NULL THEN
+    SELECT trmd.use_rehearsal_rate
+    INTO v_technician_rate_mode_override
+    FROM public.job_technician_rate_mode_dates trmd
+    WHERE trmd.job_id = v_timesheet.job_id
+      AND trmd.technician_id = v_timesheet.technician_id
+      AND trmd.date = v_timesheet.date;
+
+    IF FOUND THEN
+      v_has_technician_rate_mode_override := TRUE;
+      v_forced_rehearsal := COALESCE(v_technician_rate_mode_override, FALSE);
+      v_rate_mode_source := 'technician_override';
+    ELSE
+      SELECT EXISTS (
+        SELECT 1 FROM public.job_rehearsal_dates
+        WHERE job_id = v_timesheet.job_id AND date = v_timesheet.date
+      ) INTO v_forced_rehearsal;
+
+      v_rate_mode_source := CASE
+        WHEN v_forced_rehearsal THEN 'job_rehearsal_date'
+        ELSE 'standard'
+      END;
+    END IF;
+  END IF;
+
+  v_is_rehearsal := v_forced_rehearsal;
+
+  -- Get autonomo / house_tech / reduced rehearsal status from the main query
+  v_is_autonomo := v_timesheet.is_autonomo;
+  v_is_house_tech := v_timesheet.is_house_tech;
+  v_is_reduced_rehearsal := v_timesheet.is_reduced_rehearsal;
+
+  -- Calculate worked hours once for both rehearsal and standard paths
+  IF v_timesheet.end_time < v_timesheet.start_time OR COALESCE(v_timesheet.ends_next_day, false) THEN
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      v_timesheet.end_time - v_timesheet.start_time + INTERVAL '24 hours'
+    )) / 3600.0 - (COALESCE(v_timesheet.break_minutes, 0) / 60.0);
+  ELSE
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      v_timesheet.end_time - v_timesheet.start_time
+    )) / 3600.0 - (COALESCE(v_timesheet.break_minutes, 0) / 60.0);
+  END IF;
+  -- Preserve raw fractional hours for audit trail, then round to nearest whole hour
+  -- IMPORTANT: Do NOT change this to half-hour rounding (ROUND(x*2)/2). See PR #467.
+  v_raw_worked_hours := v_worked_hours;
+  v_worked_hours := ROUND(v_worked_hours);
+
+  -- Handle rehearsal flat rate
+  IF v_is_rehearsal THEN
+    -- Check for custom rehearsal rate first
+    SELECT rehearsal_day_eur INTO v_rehearsal_flat_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = v_timesheet.technician_id;
+
+    -- If no custom rate, use role-based defaults:
+    -- house_tech / admin / management -> EUR 60, regular technicians -> EUR 180
+    IF v_rehearsal_flat_rate IS NULL THEN
+      IF v_is_reduced_rehearsal THEN
+        v_rehearsal_flat_rate := 60.00;
+      ELSE
+        v_rehearsal_flat_rate := 180.00;
+      END IF;
+    END IF;
+
+    -- Apply discount for non-autonomo regular technicians only.
+    -- House techs, admin, and management are exempt from the autonomo discount.
+    IF NOT v_is_autonomo AND NOT v_is_reduced_rehearsal THEN
+      v_autonomo_discount := 30.00;
+      v_rehearsal_flat_rate := v_rehearsal_flat_rate - v_autonomo_discount;
+    END IF;
+
+    v_total_amount := v_rehearsal_flat_rate;
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rehearsal_flat_rate;
+
+    v_breakdown := jsonb_build_object(
+      'worked_hours', v_raw_worked_hours,
+      'worked_hours_rounded', v_worked_hours,
+      'hours_rounded', v_worked_hours,
+      'billable_hours', v_billable_hours,
+      'is_rehearsal', true,
+      'is_rehearsal_flat_rate', true,
+      'rehearsal_rate_eur', v_rehearsal_flat_rate,
+      'autonomo_discount_eur', v_autonomo_discount,
+      'base_day_before_discount_eur', CASE WHEN v_autonomo_discount > 0 THEN v_rehearsal_flat_rate + v_autonomo_discount ELSE v_rehearsal_flat_rate END,
+      'base_amount_eur', v_rehearsal_flat_rate,
+      'base_day_eur', v_rehearsal_flat_rate,
+      'plus_10_12_hours', 0,
+      'plus_10_12_eur', 0,
+      'plus_10_12_amount_eur', 0,
+      'overtime_hours', 0,
+      'overtime_hour_eur', 0,
+      'overtime_amount_eur', 0,
+      'total_eur', v_total_amount,
+      'category', 'rehearsal',
+      'forced_rehearsal_rate', v_forced_rehearsal,
+      'rate_mode_source', v_rate_mode_source,
+      'has_technician_rate_mode_override', v_has_technician_rate_mode_override,
+      'technician_rate_mode_override_rehearsal', v_technician_rate_mode_override
+    );
+
+    v_result := jsonb_build_object(
+      'timesheet_id', _timesheet_id,
+      'amount_eur', v_total_amount,
+      'amount_breakdown', v_breakdown
+    );
+
+    IF _persist THEN
+      UPDATE public.timesheets
+      SET
+        amount_eur = v_total_amount,
+        amount_breakdown = v_breakdown,
+        category = v_category,
+        updated_at = NOW()
+      WHERE id = _timesheet_id;
+    END IF;
+
+    RETURN v_result;
+  END IF;
+
+  -- Standard rate card lookup (non-rehearsal).
+  -- House-tech OT is category-aware; non-house roles preserve legacy behavior.
+  SELECT
+    COALESCE(
+      CASE
+        WHEN v_category = 'responsable' THEN COALESCE(ctr.base_day_responsable_eur, ctr.base_day_especialista_eur, ctr.base_day_eur)
+        WHEN v_category = 'especialista' THEN COALESCE(ctr.base_day_especialista_eur, ctr.base_day_eur)
+        ELSE ctr.base_day_eur
+      END,
+      (SELECT rc.base_day_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)
+    ) AS base_day_eur,
+    COALESCE(ctr.plus_10_12_eur, (SELECT rc.plus_10_12_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)) as plus_10_12_eur,
+    COALESCE(
+      CASE
+        WHEN v_is_house_tech AND v_category = 'tecnico' THEN ctr.overtime_hour_eur
+        WHEN v_is_house_tech AND v_category = 'especialista' THEN COALESCE(ctr.overtime_hour_especialista_eur, ctr.overtime_hour_eur)
+        WHEN v_is_house_tech AND v_category = 'responsable' THEN COALESCE(
+          ctr.overtime_hour_responsable_eur,
+          CASE WHEN ctr.overtime_hour_eur = 15.00 THEN 20.00 END,
+          ctr.overtime_hour_eur
+        )
+        ELSE ctr.overtime_hour_eur
+      END,
+      (SELECT rc.overtime_hour_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)
+    ) as overtime_hour_eur
+  INTO v_rate_card
+  FROM public.custom_tech_rates ctr
+  WHERE ctr.profile_id = v_timesheet.technician_id;
+
+  IF NOT FOUND THEN
+    SELECT * INTO v_rate_card
+    FROM public.rate_cards_2025
+    WHERE category = v_category;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Rate card not found for category: %', v_category;
+    END IF;
+  END IF;
+
+  -- Handle evento jobs (fixed 12-hour rate)
+  IF v_job_type = 'evento' THEN
+    v_billable_hours := 12.0;
+    v_base_day_amount := v_rate_card.base_day_eur;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+    v_overtime_hours := 0;
+    v_overtime_amount := 0;
+    v_total_amount := v_base_day_amount + v_plus_10_12_amount;
+  -- Handle extended shifts (21+ hours / over 20.5 hrs): double base rate only
+  ELSIF v_worked_hours > 20.5 THEN
+    v_is_extended_shift := TRUE;
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rate_card.base_day_eur * 2;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := 0;
+    v_overtime_hours := 0;
+    v_overtime_amount := 0;
+    v_total_amount := v_base_day_amount;
+  ELSE
+    -- Standard rate calculation tiers
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rate_card.base_day_eur;
+
+    IF v_worked_hours <= 10.5 THEN
+      v_total_amount := v_base_day_amount;
+    ELSIF v_worked_hours <= 12.5 THEN
+      v_plus_10_12_hours := 0;
+      v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+      v_total_amount := v_base_day_amount + v_plus_10_12_amount;
+    ELSE
+      v_plus_10_12_hours := 0;
+      v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+
+      v_overtime_hours := v_worked_hours - 12;
+
+      v_overtime_amount := v_rate_card.overtime_hour_eur * v_overtime_hours;
+      v_total_amount := v_base_day_amount + v_plus_10_12_amount + v_overtime_amount;
+    END IF;
+  END IF;
+
+  v_breakdown := jsonb_build_object(
+    'worked_hours', v_raw_worked_hours,
+    'worked_hours_rounded', v_worked_hours,
+    'hours_rounded', v_worked_hours,
+    'billable_hours', v_billable_hours,
+    'is_evento', (v_job_type = 'evento'),
+    'is_extended_shift', v_is_extended_shift,
+    'is_double_base_rate', v_is_extended_shift,
+    'base_amount_eur', COALESCE(v_base_day_amount, 0),
+    'base_day_eur', COALESCE(v_base_day_amount, 0),
+    'single_base_day_eur', CASE WHEN v_is_extended_shift THEN v_rate_card.base_day_eur ELSE v_base_day_amount END,
+    'plus_10_12_hours', COALESCE(v_plus_10_12_hours, 0),
+    'plus_10_12_eur', v_rate_card.plus_10_12_eur,
+    'plus_10_12_amount_eur', COALESCE(v_plus_10_12_amount, 0),
+    'overtime_hours', COALESCE(v_overtime_hours, 0),
+    'overtime_hour_eur', v_rate_card.overtime_hour_eur,
+    'overtime_amount_eur', COALESCE(v_overtime_amount, 0),
+    'total_eur', v_total_amount,
+    'category', v_category,
+    'forced_rehearsal_rate', false,
+    'rate_mode_source', v_rate_mode_source,
+    'has_technician_rate_mode_override', v_has_technician_rate_mode_override,
+    'technician_rate_mode_override_rehearsal', v_technician_rate_mode_override
+  );
+
+  v_result := jsonb_build_object(
+    'timesheet_id', _timesheet_id,
+    'amount_eur', v_total_amount,
+    'amount_breakdown', v_breakdown
+  );
+
+  IF _persist THEN
+    UPDATE public.timesheets
+    SET
+      amount_eur = v_total_amount,
+      amount_breakdown = v_breakdown,
+      category = v_category,
+      updated_at = NOW()
+    WHERE id = _timesheet_id;
+  END IF;
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.compute_timesheet_amount_2025(uuid,boolean) IS
+  'Calculates timesheet amounts based on rate cards. Hours rounded to nearest whole number (not half hour). Rehearsal flat rate: EUR 60 for house_tech/admin/management roles, EUR 180 for regular technicians. Rehearsal pricing precedence is technician/date overrides in job_technician_rate_mode_dates, then matching rows in job_rehearsal_dates. House-tech overtime is category-aware: tecnico uses overtime_hour_eur, especialista uses overtime_hour_especialista_eur fallback to overtime_hour_eur, responsable uses overtime_hour_responsable_eur fallback (including 15->20 rule) then overtime_hour_eur.';
+
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  et timestamptz;
+  job_start_date date;
+  job_end_date date;
+  tour_group uuid;
+  tour_date_ref uuid;
+  schedule_start date;
+  schedule_end date;
+  scheduled_days int := 1;
+  rehearsal_days int := 0;
+  standard_days int := 0;
+  technician_override_days int := 0;
+  cat text;
+  house boolean := false;
+  is_autonomo boolean := true;
+  is_reduced_rehearsal boolean := false;
+  standard_discount_per_day numeric(10,2) := 0;
+  rehearsal_discount_per_day numeric(10,2) := 0;
+  total_autonomo_discount numeric(10,2) := 0;
+  standard_base_before_discount numeric(10,2) := 0;
+  standard_after_discount numeric(10,2) := 0;
+  rehearsal_base_before_discount numeric(10,2) := 0;
+  team_member boolean := false;
+  has_override boolean := false;
+  standard_base numeric(10,2);
+  standard_day_rate numeric(10,2) := 0;
+  rehearsal_day_rate numeric(10,2) := 0;
+  standard_total numeric(10,2) := 0;
+  rehearsal_total numeric(10,2) := 0;
+  total_base numeric(10,2) := 0;
+  base_calculation_total numeric(10,2) := 0;
+  after_discount_total numeric(10,2) := 0;
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  display_multiplier numeric(6,3) := 1.0;
+  display_per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  has_custom_standard_rate boolean := FALSE;
+  has_custom_rehearsal_rate boolean := FALSE;
+  has_custom_rate boolean := FALSE;
+  display_category text := 'rehearsal';
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  -- Fetch job info
+  SELECT job_type, start_time, end_time, tour_id, tour_date_id
+  INTO jtype, st, et, tour_group, tour_date_ref
+  FROM public.jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  job_start_date := (st AT TIME ZONE 'Europe/Madrid')::date;
+  job_end_date := COALESCE((et AT TIME ZONE 'Europe/Madrid')::date, job_start_date);
+
+  SELECT
+    COALESCE(td.start_date, td.date, job_start_date),
+    COALESCE(td.end_date, td.start_date, td.date, job_end_date, job_start_date)
+  INTO schedule_start, schedule_end
+  FROM public.tour_dates td
+  WHERE td.id = tour_date_ref;
+
+  schedule_start := COALESCE(schedule_start, job_start_date);
+  schedule_end := COALESCE(schedule_end, schedule_start, job_end_date, job_start_date);
+  IF schedule_end < schedule_start THEN
+    schedule_end := schedule_start;
+  END IF;
+
+  SELECT
+    COUNT(*)::int,
+    COUNT(*) FILTER (
+      WHERE COALESCE(trmd.use_rehearsal_rate, jrd.job_id IS NOT NULL)
+    )::int,
+    COUNT(*) FILTER (WHERE trmd.job_id IS NOT NULL)::int
+  INTO scheduled_days, rehearsal_days, technician_override_days
+  FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS scheduled_date(date_value)
+  LEFT JOIN public.job_technician_rate_mode_dates trmd
+    ON trmd.job_id = _job_id
+   AND trmd.technician_id = _tech_id
+   AND trmd.date = scheduled_date.date_value::date
+  LEFT JOIN public.job_rehearsal_dates jrd
+    ON jrd.job_id = _job_id
+   AND jrd.date = scheduled_date.date_value::date;
+
+  rehearsal_days := LEAST(rehearsal_days, scheduled_days);
+  standard_days := GREATEST(0, scheduled_days - rehearsal_days);
+
+  -- Check house tech, autonomo status, and reduced-rehearsal role
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END,
+    COALESCE(role IN ('house_tech', 'admin', 'management'), false)
+  INTO house, is_autonomo, is_reduced_rehearsal
+  FROM public.profiles
+  WHERE id = _tech_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','profile_not_found','technician_id',_tech_id);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(ja.use_tour_multipliers, FALSE)
+    INTO has_override
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.tour_assignments ta
+      WHERE ta.tour_id = tour_group
+        AND ta.technician_id = _tech_id
+    ) OR has_override
+    INTO team_member;
+  END IF;
+
+  SELECT iso_year, iso_week INTO y, w
+  FROM public.iso_year_week_madrid(st);
+
+  IF team_member THEN
+    DECLARE
+      total_tour_dates int;
+      tech_assigned_dates int;
+    BEGIN
+      SELECT count(DISTINCT j.id) INTO total_tour_dates
+      FROM public.jobs j
+      WHERE j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      SELECT count(DISTINCT j.id) INTO tech_assigned_dates
+      FROM public.jobs j
+      JOIN public.job_assignments a ON a.job_id = j.id
+      WHERE a.technician_id = _tech_id
+        AND j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      IF tech_assigned_dates = total_tour_dates THEN
+        cnt := total_tour_dates;
+
+        -- Full-week tour team multiplier tiers: 1 date=1.5x, 2 dates=2.25x total,
+        -- 3+ dates use baseline 1.0x to avoid over-scaling longer runs.
+        IF cnt <= 1 THEN
+          mult := 1.5;
+          per_job_multiplier := 1.5;
+        ELSIF cnt = 2 THEN
+          mult := 2.25;
+          per_job_multiplier := 1.125;
+        ELSE
+          mult := 1.0;
+          per_job_multiplier := 1.0;
+        END IF;
+      ELSE
+        cnt := tech_assigned_dates;
+        mult := 1.0;
+        per_job_multiplier := 1.0;
+      END IF;
+    END;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+  END IF;
+
+  IF standard_days > 0 THEN
+    -- Resolve category for everyone when any standard day remains.
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM public.job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM public.profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+
+    -- Base rate lookup - custom_tech_rates for all technicians (category-aware)
+    IF cat = 'responsable' THEN
+      SELECT COALESCE(
+        tour_base_responsable_eur,
+        base_day_responsable_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSIF cat = 'especialista' THEN
+      SELECT COALESCE(
+        tour_base_especialista_eur,
+        tour_base_other_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      SELECT COALESCE(
+        tour_base_other_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    END IF;
+
+    IF standard_base IS NOT NULL THEN
+      has_custom_standard_rate := TRUE;
+      has_custom_rate := TRUE;
+    ELSE
+      SELECT base_day_eur INTO standard_base
+      FROM public.rate_cards_tour_2025
+      WHERE category = cat;
+
+      IF standard_base IS NULL THEN
+        RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+      END IF;
+    END IF;
+
+    standard_base_before_discount := standard_base;
+
+    IF NOT house AND NOT is_autonomo THEN
+      standard_discount_per_day := 30.00;
+      standard_base := standard_base - standard_discount_per_day;
+    END IF;
+
+    standard_after_discount := standard_base;
+    standard_day_rate := ROUND(standard_base * per_job_multiplier, 2);
+    standard_total := ROUND(standard_day_rate * standard_days, 2);
+    display_category := cat;
+  END IF;
+
+  IF rehearsal_days > 0 THEN
+    SELECT rehearsal_day_eur INTO rehearsal_day_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF rehearsal_day_rate IS NOT NULL THEN
+      has_custom_rehearsal_rate := TRUE;
+      has_custom_rate := TRUE;
+      rehearsal_base_before_discount := rehearsal_day_rate;
+    ELSE
+      IF is_reduced_rehearsal THEN
+        rehearsal_day_rate := 60.00;
+        rehearsal_base_before_discount := 60.00;
+      ELSE
+        rehearsal_day_rate := 180.00;
+        rehearsal_base_before_discount := 180.00;
+      END IF;
+    END IF;
+
+    IF NOT is_autonomo AND NOT is_reduced_rehearsal THEN
+      rehearsal_discount_per_day := 30.00;
+      rehearsal_day_rate := rehearsal_day_rate - rehearsal_discount_per_day;
+    END IF;
+
+    rehearsal_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+
+    IF standard_days = 0 THEN
+      display_category := 'rehearsal';
+    END IF;
+  END IF;
+
+  total_base := ROUND(standard_total + rehearsal_total, 2);
+  total_autonomo_discount := ROUND(
+    (standard_discount_per_day * standard_days) + (rehearsal_discount_per_day * rehearsal_days),
+    2
+  );
+  base_calculation_total := ROUND(
+    (standard_base_before_discount * standard_days) + (rehearsal_base_before_discount * rehearsal_days),
+    2
+  );
+
+  IF rehearsal_days > 0 THEN
+    -- Mixed and full-rehearsal jobs already return an aggregated base total from SQL.
+    display_multiplier := 1.0;
+    display_per_job_multiplier := 1.0;
+    after_discount_total := total_base;
+  ELSE
+    display_multiplier := mult;
+    display_per_job_multiplier := per_job_multiplier;
+    after_discount_total := ROUND(standard_after_discount * standard_days, 2);
+  END IF;
+
+  extras := public.extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(total_base + extras_total, 2);
+
+  disclaimer := public.needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,
+    'category', display_category,
+    'base_day_eur', total_base,
+    'has_custom_rate', has_custom_rate,
+    'autonomo_discount_eur', total_autonomo_discount,
+    'base_day_before_discount_eur', base_calculation_total,
+    'week_count', cnt,
+    'multiplier', ROUND(display_multiplier, 3),
+    'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', total_base,
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', final_total,
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', base_calculation_total,
+      'autonomo_discount', total_autonomo_discount,
+      'after_discount', after_discount_total,
+      'multiplier', ROUND(display_multiplier, 3),
+      'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+      'final_base', total_base,
+      'has_custom_rate', has_custom_rate,
+      'has_custom_standard_rate', has_custom_standard_rate,
+      'has_custom_rehearsal_rate', has_custom_rehearsal_rate,
+      'scheduled_days', scheduled_days,
+      'rehearsal_days', rehearsal_days,
+      'standard_days', standard_days,
+      'technician_override_days', technician_override_days,
+      'rehearsal_rate_eur', CASE WHEN rehearsal_days > 0 THEN rehearsal_day_rate ELSE NULL END,
+      'standard_day_rate_eur', CASE WHEN standard_days > 0 THEN standard_day_rate ELSE NULL END,
+      'forced_rehearsal_rate', (rehearsal_days > 0)
+    )
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) IS
+  'Calculates tour job rate quotes for technicians. Rehearsal pricing precedence is technician/date overrides in job_technician_rate_mode_dates, then job_rehearsal_dates. The quote aggregates rehearsal and standard days across the full scheduled tour-date range, preserving manual payout overrides in downstream consumers.';

--- a/supabase/migrations/20260411234000_fix_tour_quote_multi_day_schedule_range.sql
+++ b/supabase/migrations/20260411234000_fix_tour_quote_multi_day_schedule_range.sql
@@ -1,0 +1,398 @@
+-- Ensure tour quote math uses the full scheduled span even when older tour_dates
+-- rows lag behind the job's real multi-day range.
+
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  et timestamptz;
+  job_start_date date;
+  job_end_date date;
+  tour_group uuid;
+  tour_date_ref uuid;
+  schedule_start date;
+  schedule_end date;
+  scheduled_days int := 1;
+  rehearsal_days int := 0;
+  standard_days int := 0;
+  technician_override_days int := 0;
+  cat text;
+  house boolean := false;
+  is_autonomo boolean := true;
+  is_reduced_rehearsal boolean := false;
+  standard_discount_per_day numeric(10,2) := 0;
+  rehearsal_discount_per_day numeric(10,2) := 0;
+  total_autonomo_discount numeric(10,2) := 0;
+  standard_base_before_discount numeric(10,2) := 0;
+  standard_after_discount numeric(10,2) := 0;
+  rehearsal_base_before_discount numeric(10,2) := 0;
+  team_member boolean := false;
+  has_override boolean := false;
+  standard_base numeric(10,2);
+  standard_day_rate numeric(10,2) := 0;
+  rehearsal_day_rate numeric(10,2) := 0;
+  standard_total numeric(10,2) := 0;
+  rehearsal_total numeric(10,2) := 0;
+  total_base numeric(10,2) := 0;
+  base_calculation_total numeric(10,2) := 0;
+  after_discount_total numeric(10,2) := 0;
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  display_multiplier numeric(6,3) := 1.0;
+  display_per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  has_custom_standard_rate boolean := FALSE;
+  has_custom_rehearsal_rate boolean := FALSE;
+  has_custom_rate boolean := FALSE;
+  display_category text := 'rehearsal';
+  job_date_type_start date;
+  job_date_type_end date;
+  tour_date_start date;
+  tour_date_end date;
+  tour_date_legacy_date date;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT job_type, start_time, end_time, tour_id, tour_date_id
+  INTO jtype, st, et, tour_group, tour_date_ref
+  FROM public.jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  job_start_date := (st AT TIME ZONE 'Europe/Madrid')::date;
+  job_end_date := COALESCE((et AT TIME ZONE 'Europe/Madrid')::date, job_start_date);
+
+  -- job_date_types is the canonical scheduled span for payout logic because it
+  -- reflects the real per-day schedule even when an older tour_dates row still
+  -- points at a single legacy date.
+  SELECT MIN(jdt.date), MAX(jdt.date)
+  INTO job_date_type_start, job_date_type_end
+  FROM public.job_date_types jdt
+  WHERE jdt.job_id = _job_id;
+
+  SELECT td.start_date, td.end_date, td.date
+  INTO tour_date_start, tour_date_end, tour_date_legacy_date
+  FROM public.tour_dates td
+  WHERE td.id = tour_date_ref;
+
+  schedule_start := COALESCE(
+    job_date_type_start,
+    tour_date_start,
+    job_start_date,
+    tour_date_legacy_date
+  );
+  schedule_end := COALESCE(
+    job_date_type_end,
+    tour_date_end,
+    job_end_date,
+    tour_date_start,
+    tour_date_legacy_date,
+    job_start_date
+  );
+
+  schedule_start := COALESCE(schedule_start, job_start_date);
+  schedule_end := COALESCE(schedule_end, schedule_start, job_end_date, job_start_date);
+  IF schedule_end < schedule_start THEN
+    schedule_end := schedule_start;
+  END IF;
+
+  SELECT
+    COUNT(*)::int,
+    COUNT(*) FILTER (
+      WHERE COALESCE(trmd.use_rehearsal_rate, jrd.job_id IS NOT NULL)
+    )::int,
+    COUNT(*) FILTER (WHERE trmd.job_id IS NOT NULL)::int
+  INTO scheduled_days, rehearsal_days, technician_override_days
+  FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS scheduled_date(date_value)
+  LEFT JOIN public.job_technician_rate_mode_dates trmd
+    ON trmd.job_id = _job_id
+   AND trmd.technician_id = _tech_id
+   AND trmd.date = scheduled_date.date_value::date
+  LEFT JOIN public.job_rehearsal_dates jrd
+    ON jrd.job_id = _job_id
+   AND jrd.date = scheduled_date.date_value::date;
+
+  rehearsal_days := LEAST(rehearsal_days, scheduled_days);
+  standard_days := GREATEST(0, scheduled_days - rehearsal_days);
+
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END,
+    COALESCE(role IN ('house_tech', 'admin', 'management'), false)
+  INTO house, is_autonomo, is_reduced_rehearsal
+  FROM public.profiles
+  WHERE id = _tech_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','profile_not_found','technician_id',_tech_id);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(ja.use_tour_multipliers, FALSE)
+    INTO has_override
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM public.tour_assignments ta
+      WHERE ta.tour_id = tour_group
+        AND ta.technician_id = _tech_id
+    ) OR has_override
+    INTO team_member;
+  END IF;
+
+  SELECT iso_year, iso_week INTO y, w
+  FROM public.iso_year_week_madrid(st);
+
+  IF team_member THEN
+    DECLARE
+      total_tour_dates int;
+      tech_assigned_dates int;
+    BEGIN
+      SELECT count(DISTINCT j.id) INTO total_tour_dates
+      FROM public.jobs j
+      WHERE j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      SELECT count(DISTINCT j.id) INTO tech_assigned_dates
+      FROM public.jobs j
+      JOIN public.job_assignments a ON a.job_id = j.id
+      WHERE a.technician_id = _tech_id
+        AND j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      IF tech_assigned_dates = total_tour_dates THEN
+        cnt := total_tour_dates;
+
+        IF cnt <= 1 THEN
+          mult := 1.5;
+          per_job_multiplier := 1.5;
+        ELSIF cnt = 2 THEN
+          mult := 2.25;
+          per_job_multiplier := 1.125;
+        ELSE
+          mult := 1.0;
+          per_job_multiplier := 1.0;
+        END IF;
+      ELSE
+        cnt := tech_assigned_dates;
+        mult := 1.0;
+        per_job_multiplier := 1.0;
+      END IF;
+    END;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+  END IF;
+
+  IF standard_days > 0 THEN
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM public.job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM public.profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+
+    IF cat = 'responsable' THEN
+      SELECT COALESCE(
+        tour_base_responsable_eur,
+        base_day_responsable_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSIF cat = 'especialista' THEN
+      SELECT COALESCE(
+        tour_base_especialista_eur,
+        tour_base_other_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      SELECT COALESCE(
+        tour_base_other_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    END IF;
+
+    IF standard_base IS NOT NULL THEN
+      has_custom_standard_rate := TRUE;
+      has_custom_rate := TRUE;
+    ELSE
+      SELECT base_day_eur INTO standard_base
+      FROM public.rate_cards_tour_2025
+      WHERE category = cat;
+
+      IF standard_base IS NULL THEN
+        RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+      END IF;
+    END IF;
+
+    standard_base_before_discount := standard_base;
+
+    IF NOT house AND NOT is_autonomo THEN
+      standard_discount_per_day := 30.00;
+      standard_base := standard_base - standard_discount_per_day;
+    END IF;
+
+    standard_after_discount := standard_base;
+    standard_day_rate := ROUND(standard_base * per_job_multiplier, 2);
+    standard_total := ROUND(standard_day_rate * standard_days, 2);
+    display_category := cat;
+  END IF;
+
+  IF rehearsal_days > 0 THEN
+    SELECT rehearsal_day_eur INTO rehearsal_day_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF rehearsal_day_rate IS NOT NULL THEN
+      has_custom_rehearsal_rate := TRUE;
+      has_custom_rate := TRUE;
+      rehearsal_base_before_discount := rehearsal_day_rate;
+    ELSE
+      IF is_reduced_rehearsal THEN
+        rehearsal_day_rate := 60.00;
+        rehearsal_base_before_discount := 60.00;
+      ELSE
+        rehearsal_day_rate := 180.00;
+        rehearsal_base_before_discount := 180.00;
+      END IF;
+    END IF;
+
+    IF NOT is_autonomo AND NOT is_reduced_rehearsal THEN
+      rehearsal_discount_per_day := 30.00;
+      rehearsal_day_rate := rehearsal_day_rate - rehearsal_discount_per_day;
+    END IF;
+
+    rehearsal_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+
+    IF standard_days = 0 THEN
+      display_category := 'rehearsal';
+    END IF;
+  END IF;
+
+  total_base := ROUND(standard_total + rehearsal_total, 2);
+  total_autonomo_discount := ROUND(
+    (standard_discount_per_day * standard_days) + (rehearsal_discount_per_day * rehearsal_days),
+    2
+  );
+  base_calculation_total := ROUND(
+    (standard_base_before_discount * standard_days) + (rehearsal_base_before_discount * rehearsal_days),
+    2
+  );
+
+  IF rehearsal_days > 0 THEN
+    display_multiplier := 1.0;
+    display_per_job_multiplier := 1.0;
+    after_discount_total := total_base;
+  ELSE
+    display_multiplier := mult;
+    display_per_job_multiplier := per_job_multiplier;
+    after_discount_total := ROUND(standard_after_discount * standard_days, 2);
+  END IF;
+
+  extras := public.extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(total_base + extras_total, 2);
+
+  disclaimer := public.needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,
+    'category', display_category,
+    'base_day_eur', total_base,
+    'has_custom_rate', has_custom_rate,
+    'autonomo_discount_eur', total_autonomo_discount,
+    'base_day_before_discount_eur', base_calculation_total,
+    'week_count', cnt,
+    'multiplier', ROUND(display_multiplier, 3),
+    'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', total_base,
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', final_total,
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', base_calculation_total,
+      'autonomo_discount', total_autonomo_discount,
+      'after_discount', after_discount_total,
+      'multiplier', ROUND(display_multiplier, 3),
+      'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+      'final_base', total_base,
+      'has_custom_rate', has_custom_rate,
+      'has_custom_standard_rate', has_custom_standard_rate,
+      'has_custom_rehearsal_rate', has_custom_rehearsal_rate,
+      'scheduled_days', scheduled_days,
+      'rehearsal_days', rehearsal_days,
+      'standard_days', standard_days,
+      'technician_override_days', technician_override_days,
+      'rehearsal_rate_eur', CASE WHEN rehearsal_days > 0 THEN rehearsal_day_rate ELSE NULL END,
+      'standard_day_rate_eur', CASE WHEN standard_days > 0 THEN standard_day_rate ELSE NULL END,
+      'forced_rehearsal_rate', (rehearsal_days > 0)
+    )
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) IS
+  'Calculates tour job rate quotes for technicians. Rehearsal pricing precedence is technician/date overrides in job_technician_rate_mode_dates, then job_rehearsal_dates. The quote derives its multi-day span from job_date_types first, then job timestamps, and finally the linked tour_dates row to avoid collapsing older multi-day jobs into a single-date quote.';

--- a/supabase/migrations/20260411234000_fix_tour_quote_multi_day_schedule_range.sql
+++ b/supabase/migrations/20260411234000_fix_tour_quote_multi_day_schedule_range.sql
@@ -152,16 +152,23 @@ BEGIN
     INTO has_override
     FROM public.job_assignments ja
     WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+
+    has_override := COALESCE(has_override, FALSE);
   END IF;
 
   IF tour_group IS NOT NULL THEN
-    SELECT EXISTS (
-      SELECT 1
-      FROM public.tour_assignments ta
-      WHERE ta.tour_id = tour_group
-        AND ta.technician_id = _tech_id
-    ) OR has_override
+    SELECT COALESCE(
+      EXISTS (
+        SELECT 1
+        FROM public.tour_assignments ta
+        WHERE ta.tour_id = tour_group
+          AND ta.technician_id = _tech_id
+      ) OR has_override,
+      FALSE
+    )
     INTO team_member;
+
+    team_member := COALESCE(team_member, FALSE);
   END IF;
 
   SELECT iso_year, iso_week INTO y, w


### PR DESCRIPTION
## Summary
- [ ] I described what changed and why.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: <!-- low | medium | high -->
- Main risks:

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint`
  - `npm run test:critical`
  - `npm run test:run`
  - `npm run build`
- Results:

## Rollback Plan
- [x] I documented how to safely revert this change.
- Rollback steps:

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: <!-- yes | no -->
- If yes, describe migration, impact, and backout plan:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editable tour date "Tipo" with multi-day range creation and automatic rehearsal-date synchronization across jobs.
  * Admin-only per-technician/per-date rate-mode controls in payout UI (inherit/rehearsal/standard), with per-date selectors and update status.

* **Bug Fixes**
  * Export and payout flows now use current quotes directly, eliminating prior multi-day adjustment for more consistent rates.
  * Rehearsal-rate logic unified and backfilled server-side for consistent quote and timesheet calculations.

* **Tests**
  * Added comprehensive tests for date management, rehearsal-date sync planning, rate-mode guards, and migration guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->