### PR TITLE
Fix partial tourdate quote day counting

### DIFF
--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
@@ -81,6 +81,7 @@ describe("JobPayoutTotalsPanel autonomo badge", () => {
       buildFinDocUrl: () => null,
       techDaysMap: new Map([["tech-1", 1]]),
       techTotalDaysMap: new Map([["tech-1", 1]]),
+      technicianTimesheetDatesMap: new Map(),
       payoutOverrides: [],
       overrideActorMap: new Map(),
       getTechOverride: () => undefined,

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
@@ -87,6 +87,7 @@ describe("JobPayoutTotalsPanel autonomo badge", () => {
       calculatedGrandTotal: 100,
       isManager: true,
       isAdmin: false,
+      canViewTechnicianRateModePanel: false,
       isAdminOrAdministrative: false,
       userDepartment: null,
       rehearsalDateSet: new Set(),

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -193,4 +193,21 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
 
     expect(screen.getByText(/heredar \(ensayo\)/i)).toBeInTheDocument();
   });
+
+  it("does not crash when legacy payout data omits technician/date rate-mode handlers", () => {
+    useJobPayoutDataMock.mockReturnValue({
+      ...buildPayoutData(),
+      isAdmin: true,
+      isManager: true,
+      jobTimesheetDates: ["2026-04-10"],
+      rehearsalDateSet: new Set(["2026-04-10"]),
+      getTechRateModeDateSelection: undefined,
+      setTechnicianRateModeMutation: undefined,
+    });
+
+    renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
+
+    expect(screen.queryByText(/tarifa por técnico y fecha/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Ana Lopez")).toBeInTheDocument();
+  });
 });

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -92,6 +92,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     buildFinDocUrl: () => null,
     techDaysMap: new Map(),
     techTotalDaysMap: new Map(),
+    technicianTimesheetDatesMap: new Map<string, string[]>(),
     payoutOverrides: [],
     overrideActorMap: new Map(),
     getTechOverride: () => undefined,
@@ -164,7 +165,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
       isAdmin: false,
       canViewTechnicianRateModePanel: false,
       isManager: true,
-      jobTimesheetDates: ["2026-04-10"],
+      technicianTimesheetDatesMap: new Map([["tech-1", ["2026-04-10"]]]),
       rehearsalDateSet: new Set(["2026-04-10"]),
     });
 
@@ -181,7 +182,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
       isAdmin: true,
       canViewTechnicianRateModePanel: true,
       isManager: true,
-      jobTimesheetDates: ["2026-04-10"],
+      technicianTimesheetDatesMap: new Map([["tech-1", ["2026-04-10"]]]),
       rehearsalDateSet: new Set(["2026-04-10"]),
       getTechRateModeDateSelection: () => "inherit",
       setTechnicianRateModeMutation: { mutate: vi.fn(), isPending: false },
@@ -203,7 +204,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
       isAdmin: true,
       canViewTechnicianRateModePanel: true,
       isManager: true,
-      jobTimesheetDates: ["2026-04-10"],
+      technicianTimesheetDatesMap: new Map([["tech-1", ["2026-04-10"]]]),
       rehearsalDateSet: new Set(["2026-04-10"]),
       getTechRateModeDateSelection: undefined,
       setTechnicianRateModeMutation: undefined,
@@ -213,5 +214,29 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
 
     expect(screen.getByText(/tarifa por técnico y fecha/i)).toBeInTheDocument();
     expect(screen.getByText("Ana Lopez")).toBeInTheDocument();
+  });
+
+  it("renders only the technician active dates inside the admin exception panel", async () => {
+    const user = userEvent.setup();
+
+    useJobPayoutDataMock.mockReturnValue({
+      ...buildPayoutData(),
+      isAdmin: true,
+      canViewTechnicianRateModePanel: true,
+      isManager: true,
+      jobTimesheetDates: ["2026-04-08", "2026-04-09", "2026-04-10"],
+      technicianTimesheetDatesMap: new Map([["tech-1", ["2026-04-08", "2026-04-10"]]]),
+      rehearsalDateSet: new Set(["2026-04-08", "2026-04-09", "2026-04-10"]),
+      getTechRateModeDateSelection: () => "inherit",
+      setTechnicianRateModeMutation: { mutate: vi.fn(), isPending: false },
+    });
+
+    renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
+
+    await user.click(screen.getByRole("button", { name: /tarifa por técnico y fecha/i }));
+
+    expect(screen.getByText(/mié 8 abr/i)).toBeInTheDocument();
+    expect(screen.getByText(/vie 10 abr/i)).toBeInTheDocument();
+    expect(screen.queryByText(/jue 9 abr/i)).not.toBeInTheDocument();
   });
 });

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -98,6 +98,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     calculatedGrandTotal: 175,
     isManager: true,
     isAdmin: false,
+    canViewTechnicianRateModePanel: false,
     isAdminOrAdministrative: false,
     userDepartment: null,
     rehearsalDateSet: new Set<string>(),
@@ -161,6 +162,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     useJobPayoutDataMock.mockReturnValue({
       ...buildPayoutData(),
       isAdmin: false,
+      canViewTechnicianRateModePanel: false,
       isManager: true,
       jobTimesheetDates: ["2026-04-10"],
       rehearsalDateSet: new Set(["2026-04-10"]),
@@ -177,6 +179,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     useJobPayoutDataMock.mockReturnValue({
       ...buildPayoutData(),
       isAdmin: true,
+      canViewTechnicianRateModePanel: true,
       isManager: true,
       jobTimesheetDates: ["2026-04-10"],
       rehearsalDateSet: new Set(["2026-04-10"]),
@@ -198,6 +201,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     useJobPayoutDataMock.mockReturnValue({
       ...buildPayoutData(),
       isAdmin: true,
+      canViewTechnicianRateModePanel: true,
       isManager: true,
       jobTimesheetDates: ["2026-04-10"],
       rehearsalDateSet: new Set(["2026-04-10"]),

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -194,7 +194,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     expect(screen.getByText(/heredar \(ensayo\)/i)).toBeInTheDocument();
   });
 
-  it("does not crash when legacy payout data omits technician/date rate-mode handlers", () => {
+  it("keeps the admin panel visible when legacy payout data omits technician/date rate-mode handlers", () => {
     useJobPayoutDataMock.mockReturnValue({
       ...buildPayoutData(),
       isAdmin: true,
@@ -207,7 +207,7 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
 
     renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
 
-    expect(screen.queryByText(/tarifa por técnico y fecha/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/tarifa por técnico y fecha/i)).toBeInTheDocument();
     expect(screen.getByText("Ana Lopez")).toBeInTheDocument();
   });
 });

--- a/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
+++ b/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
@@ -243,7 +243,7 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
             buildFinDocUrl={data.buildFinDocUrl}
             techDaysMap={data.techDaysMap}
             techTotalDaysMap={data.techTotalDaysMap}
-            jobTimesheetDates={data.jobTimesheetDates}
+            technicianTimesheetDates={data.technicianTimesheetDatesMap.get(payout.technician_id) ?? []}
             rehearsalDateSet={data.rehearsalDateSet}
             missingEmailTechIds={actions.missingEmailTechIds}
             sendingByTech={actions.sendingByTech}

--- a/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
+++ b/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
@@ -234,7 +234,7 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
             isTourDate={data.isTourDate}
             isCicloJob={isCicloJob}
             isManager={data.isManager}
-            isAdmin={data.isAdmin}
+            canViewTechnicianRateModePanel={data.canViewTechnicianRateModePanel}
             profileMap={data.profileMap}
             autonomoMap={data.autonomoMap}
             getTechName={data.getTechName}

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -47,8 +47,8 @@ interface TechnicianPayoutCardProps {
   isClosureLocked: boolean;
   /* Override */
   getTechOverride: (techId: string) => JobPayoutOverride | undefined;
-  getTechRateModeDateSelection: (techId: string, date: string) => TechnicianDateRateMode;
-  setTechnicianRateModeMutation: {
+  getTechRateModeDateSelection?: (techId: string, date: string) => TechnicianDateRateMode;
+  setTechnicianRateModeMutation?: {
     mutate: (args: { jobId: string; technicianId: string; date: string; mode: TechnicianDateRateMode }) => void;
     isPending: boolean;
   };
@@ -136,12 +136,20 @@ export function TechnicianPayoutCard({
   const totalDays = techTotalDaysMap.get(techId) || 0;
   const approvedDays = techDaysMap.get(techId) || 0;
   const showDaysWarning = !isTourDate && totalDays > 1 && approvedDays < totalDays;
-  const showAdminRateModeSection = isTourDate && isAdmin && jobTimesheetDates.length > 0;
+  const canManageTechRateModes =
+    typeof getTechRateModeDateSelection === 'function' && !!setTechnicianRateModeMutation;
+  const safeGetTechRateModeDateSelection = React.useCallback((date: string) => {
+    if (typeof getTechRateModeDateSelection === 'function') {
+      return getTechRateModeDateSelection(techId, date);
+    }
+    return 'inherit' as TechnicianDateRateMode;
+  }, [getTechRateModeDateSelection, techId]);
+  const showAdminRateModeSection = isTourDate && isAdmin && canManageTechRateModes && jobTimesheetDates.length > 0;
   const activeRateModeOverrideCount = React.useMemo(() => {
     return jobTimesheetDates.reduce((count, dateStr) => {
-      return count + (getTechRateModeDateSelection(techId, dateStr) === 'inherit' ? 0 : 1);
+      return count + (safeGetTechRateModeDateSelection(dateStr) === 'inherit' ? 0 : 1);
     }, 0);
-  }, [getTechRateModeDateSelection, jobTimesheetDates, techId]);
+  }, [jobTimesheetDates, safeGetTechRateModeDateSelection]);
   const [isAdminRateModeOpen, setIsAdminRateModeOpen] = React.useState(activeRateModeOverrideCount > 0);
 
   React.useEffect(() => {
@@ -405,7 +413,7 @@ export function TechnicianPayoutCard({
 
             <CollapsibleContent className="space-y-2">
               {jobTimesheetDates.map((dateStr) => {
-                const selectedMode = getTechRateModeDateSelection(techId, dateStr);
+                const selectedMode = safeGetTechRateModeDateSelection(dateStr);
                 const inheritsRehearsal = rehearsalDateSet.has(dateStr);
                 const inheritedLabel = inheritsRehearsal ? 'Ensayo' : 'Estándar';
                 const dateLabel = formatInTimeZone(parseISO(dateStr), 'Europe/Madrid', 'EEE d MMM', {
@@ -427,6 +435,7 @@ export function TechnicianPayoutCard({
                       onValueChange={(nextMode) => {
                         const mode = nextMode as TechnicianDateRateMode;
                         if (mode === selectedMode) return;
+                        if (!setTechnicianRateModeMutation) return;
                         setTechnicianRateModeMutation.mutate({
                           jobId,
                           technicianId: techId,
@@ -434,7 +443,7 @@ export function TechnicianPayoutCard({
                           mode,
                         });
                       }}
-                      disabled={setTechnicianRateModeMutation.isPending}
+                      disabled={setTechnicianRateModeMutation?.isPending ?? false}
                     >
                       <SelectTrigger className="h-8 w-full text-xs sm:w-[220px]">
                         <SelectValue />
@@ -449,7 +458,7 @@ export function TechnicianPayoutCard({
                 );
               })}
             </CollapsibleContent>
-            {setTechnicianRateModeMutation.isPending && (
+            {setTechnicianRateModeMutation?.isPending && (
               <div className="text-xs text-muted-foreground animate-pulse">Actualizando tarifa calculada…</div>
             )}
           </Collapsible>

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -31,7 +31,7 @@ interface TechnicianPayoutCardProps {
   isTourDate: boolean;
   isCicloJob?: boolean;
   isManager: boolean;
-  isAdmin: boolean;
+  canViewTechnicianRateModePanel: boolean;
   profileMap: Map<string, TechnicianProfileWithEmail>;
   autonomoMap: Map<string, boolean | null>;
   getTechName: (id: string) => string;
@@ -74,7 +74,7 @@ export function TechnicianPayoutCard({
   isTourDate,
   isCicloJob = false,
   isManager,
-  isAdmin,
+  canViewTechnicianRateModePanel,
   profileMap,
   autonomoMap,
   getTechName,
@@ -144,7 +144,7 @@ export function TechnicianPayoutCard({
     }
     return 'inherit' as TechnicianDateRateMode;
   }, [getTechRateModeDateSelection, techId]);
-  const showAdminRateModeSection = isTourDate && isAdmin && jobTimesheetDates.length > 0;
+  const showAdminRateModeSection = isTourDate && canViewTechnicianRateModePanel && jobTimesheetDates.length > 0;
   const activeRateModeOverrideCount = React.useMemo(() => {
     return jobTimesheetDates.reduce((count, dateStr) => {
       return count + (safeGetTechRateModeDateSelection(dateStr) === 'inherit' ? 0 : 1);

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -136,7 +136,7 @@ export function TechnicianPayoutCard({
   const totalDays = techTotalDaysMap.get(techId) || 0;
   const approvedDays = techDaysMap.get(techId) || 0;
   const showDaysWarning = !isTourDate && totalDays > 1 && approvedDays < totalDays;
-  const canManageTechRateModes =
+  const hasRateModeHandlers =
     typeof getTechRateModeDateSelection === 'function' && !!setTechnicianRateModeMutation;
   const safeGetTechRateModeDateSelection = React.useCallback((date: string) => {
     if (typeof getTechRateModeDateSelection === 'function') {
@@ -144,7 +144,7 @@ export function TechnicianPayoutCard({
     }
     return 'inherit' as TechnicianDateRateMode;
   }, [getTechRateModeDateSelection, techId]);
-  const showAdminRateModeSection = isTourDate && isAdmin && canManageTechRateModes && jobTimesheetDates.length > 0;
+  const showAdminRateModeSection = isTourDate && isAdmin && jobTimesheetDates.length > 0;
   const activeRateModeOverrideCount = React.useMemo(() => {
     return jobTimesheetDates.reduce((count, dateStr) => {
       return count + (safeGetTechRateModeDateSelection(dateStr) === 'inherit' ? 0 : 1);
@@ -443,7 +443,7 @@ export function TechnicianPayoutCard({
                           mode,
                         });
                       }}
-                      disabled={setTechnicianRateModeMutation?.isPending ?? false}
+                      disabled={!hasRateModeHandlers || (setTechnicianRateModeMutation?.isPending ?? false)}
                     >
                       <SelectTrigger className="h-8 w-full text-xs sm:w-[220px]">
                         <SelectValue />
@@ -460,6 +460,11 @@ export function TechnicianPayoutCard({
             </CollapsibleContent>
             {setTechnicianRateModeMutation?.isPending && (
               <div className="text-xs text-muted-foreground animate-pulse">Actualizando tarifa calculada…</div>
+            )}
+            {!hasRateModeHandlers && (
+              <div className="text-xs text-muted-foreground">
+                La edición de excepciones no está disponible en esta carga. Recarga la vista para sincronizar los controles.
+              </div>
             )}
           </Collapsible>
         </>

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -40,7 +40,7 @@ interface TechnicianPayoutCardProps {
   buildFinDocUrl: (elementId: string | null | undefined) => string | null;
   techDaysMap: Map<string, number>;
   techTotalDaysMap: Map<string, number>;
-  jobTimesheetDates: string[];
+  technicianTimesheetDates: string[];
   rehearsalDateSet: Set<string>;
   missingEmailTechIds: string[];
   sendingByTech: Record<string, boolean>;
@@ -83,7 +83,7 @@ export function TechnicianPayoutCard({
   buildFinDocUrl,
   techDaysMap,
   techTotalDaysMap,
-  jobTimesheetDates,
+  technicianTimesheetDates,
   rehearsalDateSet,
   missingEmailTechIds,
   sendingByTech,
@@ -144,12 +144,12 @@ export function TechnicianPayoutCard({
     }
     return 'inherit' as TechnicianDateRateMode;
   }, [getTechRateModeDateSelection, techId]);
-  const showAdminRateModeSection = isTourDate && canViewTechnicianRateModePanel && jobTimesheetDates.length > 0;
+  const showAdminRateModeSection = isTourDate && canViewTechnicianRateModePanel && technicianTimesheetDates.length > 0;
   const activeRateModeOverrideCount = React.useMemo(() => {
-    return jobTimesheetDates.reduce((count, dateStr) => {
+    return technicianTimesheetDates.reduce((count, dateStr) => {
       return count + (safeGetTechRateModeDateSelection(dateStr) === 'inherit' ? 0 : 1);
     }, 0);
-  }, [jobTimesheetDates, safeGetTechRateModeDateSelection]);
+  }, [technicianTimesheetDates, safeGetTechRateModeDateSelection]);
   const [isAdminRateModeOpen, setIsAdminRateModeOpen] = React.useState(activeRateModeOverrideCount > 0);
 
   React.useEffect(() => {
@@ -412,7 +412,7 @@ export function TechnicianPayoutCard({
             </CollapsibleTrigger>
 
             <CollapsibleContent className="space-y-2">
-              {jobTimesheetDates.map((dateStr) => {
+              {technicianTimesheetDates.map((dateStr) => {
                 const selectedMode = safeGetTechRateModeDateSelection(dateStr);
                 const inheritsRehearsal = rehearsalDateSet.has(dateStr);
                 const inheritedLabel = inheritsRehearsal ? 'Ensayo' : 'Estándar';

--- a/src/components/jobs/payout-totals/types.ts
+++ b/src/components/jobs/payout-totals/types.ts
@@ -55,6 +55,7 @@ export interface JobPayoutData {
   calculatedGrandTotal: number;
   isManager: boolean;
   isAdmin: boolean;
+  canViewTechnicianRateModePanel: boolean;
   isAdminOrAdministrative: boolean;
   userDepartment: string | null | undefined;
   rehearsalDateSet: Set<string>;

--- a/src/components/jobs/payout-totals/types.ts
+++ b/src/components/jobs/payout-totals/types.ts
@@ -49,6 +49,7 @@ export interface JobPayoutData {
   buildFinDocUrl: (elementId: string | null | undefined) => string | null;
   techDaysMap: Map<string, number>;
   techTotalDaysMap: Map<string, number>;
+  technicianTimesheetDatesMap: Map<string, string[]>;
   payoutOverrides: JobPayoutOverride[];
   overrideActorMap: Map<string, { name: string; email: string | null }>;
   getTechOverride: (techId: string) => JobPayoutOverride | undefined;

--- a/src/components/jobs/payout-totals/useJobPayoutData.ts
+++ b/src/components/jobs/payout-totals/useJobPayoutData.ts
@@ -100,6 +100,34 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     staleTime: 30 * 1000,
   });
 
+  const { data: technicianTimesheetDatesMap = new Map<string, string[]>() } = useQuery({
+    queryKey: ['job-tech-timesheet-dates', jobId],
+    enabled: !!jobId && isTourDate && !jobMetaLoading,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('timesheets')
+        .select('technician_id, date')
+        .eq('job_id', jobId)
+        .eq('is_active', true);
+
+      if (error) throw error;
+
+      const byTech = new Map<string, Set<string>>();
+      (data || []).forEach((row) => {
+        if (!row.technician_id || !row.date) return;
+        if (!byTech.has(row.technician_id)) {
+          byTech.set(row.technician_id, new Set());
+        }
+        byTech.get(row.technician_id)!.add(row.date);
+      });
+
+      return new Map(
+        Array.from(byTech.entries()).map(([techId, dates]) => [techId, Array.from(dates).sort()]),
+      );
+    },
+    staleTime: 30_000,
+  });
+
   /* ── Standard tech days (approved + total) ── */
   const { data: techDaysMaps = { approved: new Map<string, number>(), total: new Map<string, number>() } } = useQuery({
     queryKey: ['job-tech-days', jobId],
@@ -413,6 +441,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     buildFinDocUrl,
     techDaysMap,
     techTotalDaysMap,
+    technicianTimesheetDatesMap,
     payoutOverrides,
     overrideActorMap,
     getTechOverride,

--- a/src/components/jobs/payout-totals/useJobPayoutData.ts
+++ b/src/components/jobs/payout-totals/useJobPayoutData.ts
@@ -347,10 +347,16 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
   );
 
   /* ── Admin-only technician/date rate-mode exceptions ── */
-  const { data: technicianRateModeDates = [] } = useJobTechnicianRateModeDates(jobId, {
-    enabled: isAdmin && isTourDate && !jobMetaLoading,
+  const shouldProbeTechnicianRateModes =
+    !!jobId && isTourDate && !jobMetaLoading && (isManager || isAdminOrAdministrative);
+  const {
+    data: technicianRateModeDates = [],
+    error: technicianRateModeError,
+  } = useJobTechnicianRateModeDates(jobId, {
+    enabled: shouldProbeTechnicianRateModes,
   });
   const setTechnicianRateModeMutation = useSetTechnicianDateRateMode();
+  const canViewTechnicianRateModePanel = shouldProbeTechnicianRateModes && !technicianRateModeError;
 
   const technicianRateModeMap = React.useMemo(() => {
     const map = new Map<string, Map<string, 'rehearsal' | 'standard'>>();
@@ -413,6 +419,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     calculatedGrandTotal,
     isManager,
     isAdmin,
+    canViewTechnicianRateModePanel,
     isAdminOrAdministrative,
     userDepartment,
     rehearsalDateSet,

--- a/src/lib/tour-payout-email.ts
+++ b/src/lib/tour-payout-email.ts
@@ -48,6 +48,14 @@ export interface TourJobEmailInput {
   profiles: (TechnicianProfile & { email?: string | null })[];
 }
 
+// Backward-compatible no-op for stale dev/HMR imports. Multi-day rehearsal math
+// is now computed server-side in compute_tour_job_rate_quote_2025.
+export function adjustRehearsalQuotesForMultiDay(
+  quotes: TourJobRateQuote[],
+): TourJobRateQuote[] {
+  return quotes;
+}
+
 async function blobToBase64(blob: Blob): Promise<string> {
   const arrayBuffer = await blob.arrayBuffer();
   const bytes = new Uint8Array(arrayBuffer);

--- a/src/utils/__tests__/tour-job-rate-multiplier-guard.test.ts
+++ b/src/utils/__tests__/tour-job-rate-multiplier-guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('tour job quote multiplier regression guard', () => {
+  const migrationsDir = join(__dirname, '..', '..', '..', 'supabase', 'migrations');
+  const computeTourQuoteDefinitionPattern =
+    /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:"?public"?\.)?"?compute_tour_job_rate_quote_2025"?\s*\(/i;
+  const migrationFiles = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  it('latest compute_tour_job_rate_quote_2025 migration applies the standard tour multiplier once per quote, not once per standard day', () => {
+    const functionMigrations = migrationFiles
+      .map((name) => ({
+        name,
+        content: readFileSync(join(migrationsDir, name), 'utf-8'),
+      }))
+      .filter((migration) => computeTourQuoteDefinitionPattern.test(migration.content));
+
+    expect(functionMigrations.length).toBeGreaterThan(0);
+
+    const latest = functionMigrations[functionMigrations.length - 1];
+    const codeOnly = latest.content
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('--'))
+      .join('\n');
+
+    expect(codeOnly).toMatch(/standard_multiplier_bonus numeric\(10,2\) := 0/i);
+    expect(codeOnly).toMatch(/multiplied_standard_days int := 0/i);
+    expect(codeOnly).toMatch(/standard_day_rate := ROUND\(standard_base,\s*2\)/i);
+    expect(codeOnly).toMatch(/standard_multiplier_bonus := ROUND\(standard_after_discount \* \(per_job_multiplier - 1\.0\),\s*2\)/i);
+    expect(codeOnly).toMatch(/standard_total := ROUND\(\(standard_day_rate \* standard_days\) \+ standard_multiplier_bonus,\s*2\)/i);
+    expect(codeOnly).toMatch(/'multiplied_standard_days', multiplied_standard_days/i);
+    expect(codeOnly).toMatch(/'standard_multiplier_bonus_eur', standard_multiplier_bonus/i);
+  });
+});

--- a/src/utils/__tests__/tour-job-rate-schedule-range-guard.test.ts
+++ b/src/utils/__tests__/tour-job-rate-schedule-range-guard.test.ts
@@ -10,7 +10,7 @@ describe('tour job quote schedule-range regression guard', () => {
     .filter((file) => file.endsWith('.sql'))
     .sort();
 
-  it('latest compute_tour_job_rate_quote_2025 migration derives multi-day span from job_date_types before stale tour_dates', () => {
+  it('latest compute_tour_job_rate_quote_2025 migration derives multi-day span from job_date_types and prices only assigned technician dates', () => {
     const functionMigrations = migrationFiles
       .map((name) => ({
         name,
@@ -30,6 +30,14 @@ describe('tour job quote schedule-range regression guard', () => {
     expect(codeOnly).toMatch(/FROM public\.job_date_types jdt/i);
     expect(codeOnly).toMatch(/schedule_start := COALESCE\(\s*job_date_type_start,\s*tour_date_start,\s*job_start_date,\s*tour_date_legacy_date/i);
     expect(codeOnly).toMatch(/schedule_end := COALESCE\(\s*job_date_type_end,\s*tour_date_end,\s*job_end_date,\s*tour_date_start,\s*tour_date_legacy_date,\s*job_start_date/i);
+    expect(codeOnly).toMatch(/WITH active_timesheet_dates AS \(/i);
+    expect(codeOnly).toMatch(/SELECT DISTINCT t\.date AS payable_date/i);
+    expect(codeOnly).toMatch(/FROM public\.timesheets t/i);
+    expect(codeOnly).toMatch(/AND COALESCE\(t\.is_active,\s*TRUE\)/i);
+    expect(codeOnly).toMatch(/fallback_assignment_dates AS \(/i);
+    expect(codeOnly).toMatch(/COALESCE\(ja\.single_day,\s*FALSE\)/i);
+    expect(codeOnly).toMatch(/fallback_schedule_dates AS \(/i);
+    expect(codeOnly).toMatch(/FROM payable_dates pd/i);
     expect(codeOnly).toMatch(/COUNT\(\*\)::int,\s*COUNT\(\*\) FILTER/i);
     expect(codeOnly).toMatch(/has_override := COALESCE\(has_override,\s*FALSE\)/i);
     expect(codeOnly).toMatch(/SELECT COALESCE\(\s*EXISTS\s*\(/i);

--- a/supabase/migrations/20260412153000_fix_tour_quote_partial_assignment_dates.sql
+++ b/supabase/migrations/20260412153000_fix_tour_quote_partial_assignment_dates.sql
@@ -193,7 +193,7 @@ BEGIN
   END IF;
 
   IF tour_group IS NOT NULL THEN
-    SELECT COALESCE(ja.use_tour_multipliers, FALSE)
+    SELECT COALESCE(bool_or(ja.use_tour_multipliers), FALSE)
     INTO has_override
     FROM public.job_assignments ja
     WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
@@ -277,7 +277,9 @@ BEGIN
       END
     INTO cat
     FROM public.job_assignments
-    WHERE job_id = _job_id AND technician_id = _tech_id;
+    WHERE job_id = _job_id AND technician_id = _tech_id
+    ORDER BY assigned_at DESC
+    LIMIT 1;
 
     IF cat IS NULL THEN
       SELECT default_timesheet_category INTO cat

--- a/supabase/migrations/20260412153000_fix_tour_quote_partial_assignment_dates.sql
+++ b/supabase/migrations/20260412153000_fix_tour_quote_partial_assignment_dates.sql
@@ -1,0 +1,450 @@
+-- Tour-date quotes must follow the technician's assigned dates, not the full
+-- job span. For tourdate jobs those dates are encoded in active timesheets,
+-- including schedule-only rows created for staffing coverage.
+
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  et timestamptz;
+  job_start_date date;
+  job_end_date date;
+  tour_group uuid;
+  tour_date_ref uuid;
+  schedule_start date;
+  schedule_end date;
+  scheduled_days int := 1;
+  rehearsal_days int := 0;
+  standard_days int := 0;
+  technician_override_days int := 0;
+  cat text;
+  house boolean := false;
+  is_autonomo boolean := true;
+  is_reduced_rehearsal boolean := false;
+  standard_discount_per_day numeric(10,2) := 0;
+  rehearsal_discount_per_day numeric(10,2) := 0;
+  total_autonomo_discount numeric(10,2) := 0;
+  standard_base_before_discount numeric(10,2) := 0;
+  standard_after_discount numeric(10,2) := 0;
+  rehearsal_base_before_discount numeric(10,2) := 0;
+  team_member boolean := false;
+  has_override boolean := false;
+  standard_base numeric(10,2);
+  standard_day_rate numeric(10,2) := 0;
+  rehearsal_day_rate numeric(10,2) := 0;
+  standard_total numeric(10,2) := 0;
+  rehearsal_total numeric(10,2) := 0;
+  total_base numeric(10,2) := 0;
+  base_calculation_total numeric(10,2) := 0;
+  after_discount_total numeric(10,2) := 0;
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  display_multiplier numeric(6,3) := 1.0;
+  display_per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  has_custom_standard_rate boolean := FALSE;
+  has_custom_rehearsal_rate boolean := FALSE;
+  has_custom_rate boolean := FALSE;
+  display_category text := 'rehearsal';
+  job_date_type_start date;
+  job_date_type_end date;
+  tour_date_start date;
+  tour_date_end date;
+  tour_date_legacy_date date;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT job_type, start_time, end_time, tour_id, tour_date_id
+  INTO jtype, st, et, tour_group, tour_date_ref
+  FROM public.jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  job_start_date := (st AT TIME ZONE 'Europe/Madrid')::date;
+  job_end_date := COALESCE((et AT TIME ZONE 'Europe/Madrid')::date, job_start_date);
+
+  -- job_date_types is the canonical scheduled span for payout logic because it
+  -- reflects the real per-day schedule even when an older tour_dates row still
+  -- points at a single legacy date.
+  SELECT MIN(jdt.date), MAX(jdt.date)
+  INTO job_date_type_start, job_date_type_end
+  FROM public.job_date_types jdt
+  WHERE jdt.job_id = _job_id;
+
+  SELECT td.start_date, td.end_date, td.date
+  INTO tour_date_start, tour_date_end, tour_date_legacy_date
+  FROM public.tour_dates td
+  WHERE td.id = tour_date_ref;
+
+  schedule_start := COALESCE(
+    job_date_type_start,
+    tour_date_start,
+    job_start_date,
+    tour_date_legacy_date
+  );
+  schedule_end := COALESCE(
+    job_date_type_end,
+    tour_date_end,
+    job_end_date,
+    tour_date_start,
+    tour_date_legacy_date,
+    job_start_date
+  );
+
+  schedule_start := COALESCE(schedule_start, job_start_date);
+  schedule_end := COALESCE(schedule_end, schedule_start, job_end_date, job_start_date);
+  IF schedule_end < schedule_start THEN
+    schedule_end := schedule_start;
+  END IF;
+
+  -- Pricing must follow the technician's active assignment dates first.
+  -- This covers partial staffing on multi-day tour dates, including the
+  -- schedule-only timesheets created for tour/tourdate coverage.
+  WITH active_timesheet_dates AS (
+    SELECT DISTINCT t.date AS payable_date
+    FROM public.timesheets t
+    WHERE t.job_id = _job_id
+      AND t.technician_id = _tech_id
+      AND COALESCE(t.is_active, TRUE)
+  ),
+  fallback_assignment_dates AS (
+    SELECT ja.assignment_date AS payable_date
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id
+      AND ja.technician_id = _tech_id
+      AND COALESCE(ja.single_day, FALSE)
+      AND ja.assignment_date IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM active_timesheet_dates
+      )
+  ),
+  fallback_schedule_dates AS (
+    SELECT generated_series.date_value::date AS payable_date
+    FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS generated_series(date_value)
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM active_timesheet_dates
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM fallback_assignment_dates
+      )
+  ),
+  payable_dates AS (
+    SELECT payable_date
+    FROM active_timesheet_dates
+    UNION
+    SELECT payable_date
+    FROM fallback_assignment_dates
+    UNION
+    SELECT payable_date
+    FROM fallback_schedule_dates
+  )
+  SELECT
+    COUNT(*)::int,
+    COUNT(*) FILTER (
+      WHERE COALESCE(trmd.use_rehearsal_rate, jrd.job_id IS NOT NULL)
+    )::int,
+    COUNT(*) FILTER (WHERE trmd.job_id IS NOT NULL)::int
+  INTO scheduled_days, rehearsal_days, technician_override_days
+  FROM payable_dates pd
+  LEFT JOIN public.job_technician_rate_mode_dates trmd
+    ON trmd.job_id = _job_id
+   AND trmd.technician_id = _tech_id
+   AND trmd.date = pd.payable_date
+  LEFT JOIN public.job_rehearsal_dates jrd
+    ON jrd.job_id = _job_id
+   AND jrd.date = pd.payable_date;
+
+  rehearsal_days := LEAST(rehearsal_days, scheduled_days);
+  standard_days := GREATEST(0, scheduled_days - rehearsal_days);
+
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END,
+    COALESCE(role IN ('house_tech', 'admin', 'management'), false)
+  INTO house, is_autonomo, is_reduced_rehearsal
+  FROM public.profiles
+  WHERE id = _tech_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','profile_not_found','technician_id',_tech_id);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(ja.use_tour_multipliers, FALSE)
+    INTO has_override
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+
+    has_override := COALESCE(has_override, FALSE);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(
+      EXISTS (
+        SELECT 1
+        FROM public.tour_assignments ta
+        WHERE ta.tour_id = tour_group
+          AND ta.technician_id = _tech_id
+      ) OR has_override,
+      FALSE
+    )
+    INTO team_member;
+
+    team_member := COALESCE(team_member, FALSE);
+  END IF;
+
+  SELECT iso_year, iso_week INTO y, w
+  FROM public.iso_year_week_madrid(st);
+
+  IF team_member THEN
+    DECLARE
+      total_tour_dates int;
+      tech_assigned_dates int;
+    BEGIN
+      SELECT count(DISTINCT j.id) INTO total_tour_dates
+      FROM public.jobs j
+      WHERE j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      SELECT count(DISTINCT j.id) INTO tech_assigned_dates
+      FROM public.jobs j
+      JOIN public.job_assignments a ON a.job_id = j.id
+      WHERE a.technician_id = _tech_id
+        AND j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      IF tech_assigned_dates = total_tour_dates THEN
+        cnt := total_tour_dates;
+
+        IF cnt <= 1 THEN
+          mult := 1.5;
+          per_job_multiplier := 1.5;
+        ELSIF cnt = 2 THEN
+          mult := 2.25;
+          per_job_multiplier := 1.125;
+        ELSE
+          mult := 1.0;
+          per_job_multiplier := 1.0;
+        END IF;
+      ELSE
+        cnt := tech_assigned_dates;
+        mult := 1.0;
+        per_job_multiplier := 1.0;
+      END IF;
+    END;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+  END IF;
+
+  IF standard_days > 0 THEN
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM public.job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM public.profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+
+    IF cat = 'responsable' THEN
+      SELECT COALESCE(
+        tour_base_responsable_eur,
+        base_day_responsable_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSIF cat = 'especialista' THEN
+      SELECT COALESCE(
+        tour_base_especialista_eur,
+        tour_base_other_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      SELECT COALESCE(
+        tour_base_other_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    END IF;
+
+    IF standard_base IS NOT NULL THEN
+      has_custom_standard_rate := TRUE;
+      has_custom_rate := TRUE;
+    ELSE
+      SELECT base_day_eur INTO standard_base
+      FROM public.rate_cards_tour_2025
+      WHERE category = cat;
+
+      IF standard_base IS NULL THEN
+        RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+      END IF;
+    END IF;
+
+    standard_base_before_discount := standard_base;
+
+    IF NOT house AND NOT is_autonomo THEN
+      standard_discount_per_day := 30.00;
+      standard_base := standard_base - standard_discount_per_day;
+    END IF;
+
+    standard_after_discount := standard_base;
+    standard_day_rate := ROUND(standard_base * per_job_multiplier, 2);
+    standard_total := ROUND(standard_day_rate * standard_days, 2);
+    display_category := cat;
+  END IF;
+
+  IF rehearsal_days > 0 THEN
+    SELECT rehearsal_day_eur INTO rehearsal_day_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF rehearsal_day_rate IS NOT NULL THEN
+      has_custom_rehearsal_rate := TRUE;
+      has_custom_rate := TRUE;
+      rehearsal_base_before_discount := rehearsal_day_rate;
+    ELSE
+      IF is_reduced_rehearsal THEN
+        rehearsal_day_rate := 60.00;
+        rehearsal_base_before_discount := 60.00;
+      ELSE
+        rehearsal_day_rate := 180.00;
+        rehearsal_base_before_discount := 180.00;
+      END IF;
+    END IF;
+
+    IF NOT is_autonomo AND NOT is_reduced_rehearsal THEN
+      rehearsal_discount_per_day := 30.00;
+      rehearsal_day_rate := rehearsal_day_rate - rehearsal_discount_per_day;
+    END IF;
+
+    rehearsal_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+
+    IF standard_days = 0 THEN
+      display_category := 'rehearsal';
+    END IF;
+  END IF;
+
+  total_base := ROUND(standard_total + rehearsal_total, 2);
+  total_autonomo_discount := ROUND(
+    (standard_discount_per_day * standard_days) + (rehearsal_discount_per_day * rehearsal_days),
+    2
+  );
+  base_calculation_total := ROUND(
+    (standard_base_before_discount * standard_days) + (rehearsal_base_before_discount * rehearsal_days),
+    2
+  );
+
+  IF rehearsal_days > 0 THEN
+    display_multiplier := 1.0;
+    display_per_job_multiplier := 1.0;
+    after_discount_total := total_base;
+  ELSE
+    display_multiplier := mult;
+    display_per_job_multiplier := per_job_multiplier;
+    after_discount_total := ROUND(standard_after_discount * standard_days, 2);
+  END IF;
+
+  extras := public.extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(total_base + extras_total, 2);
+
+  disclaimer := public.needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,
+    'category', display_category,
+    'base_day_eur', total_base,
+    'has_custom_rate', has_custom_rate,
+    'autonomo_discount_eur', total_autonomo_discount,
+    'base_day_before_discount_eur', base_calculation_total,
+    'week_count', cnt,
+    'multiplier', ROUND(display_multiplier, 3),
+    'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', total_base,
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', final_total,
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', base_calculation_total,
+      'autonomo_discount', total_autonomo_discount,
+      'after_discount', after_discount_total,
+      'multiplier', ROUND(display_multiplier, 3),
+      'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+      'final_base', total_base,
+      'has_custom_rate', has_custom_rate,
+      'has_custom_standard_rate', has_custom_standard_rate,
+      'has_custom_rehearsal_rate', has_custom_rehearsal_rate,
+      'scheduled_days', scheduled_days,
+      'rehearsal_days', rehearsal_days,
+      'standard_days', standard_days,
+      'technician_override_days', technician_override_days,
+      'rehearsal_rate_eur', CASE WHEN rehearsal_days > 0 THEN rehearsal_day_rate ELSE NULL END,
+      'standard_day_rate_eur', CASE WHEN standard_days > 0 THEN standard_day_rate ELSE NULL END,
+      'forced_rehearsal_rate', (rehearsal_days > 0)
+    )
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) IS
+  'Calculates tour job rate quotes for technicians. Rehearsal pricing precedence is technician/date overrides in job_technician_rate_mode_dates, then job_rehearsal_dates. The quote derives its multi-day span from job_date_types first, but counts payable days from the technician''s active timesheets before falling back to legacy assignment metadata or the job span.';

--- a/supabase/migrations/20260412183000_fix_tour_quote_multiplier_once_per_multiday_job.sql
+++ b/supabase/migrations/20260412183000_fix_tour_quote_multiplier_once_per_multiday_job.sql
@@ -1,0 +1,460 @@
+-- Multi-day tourdate quotes should apply the tour multiplier once per quote,
+-- not once per payable standard day. Without this, a technician who only works
+-- a subset of dates inside a single multi-day tourdate gets every standard day
+-- multiplied, which overstates the total.
+
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  et timestamptz;
+  job_start_date date;
+  job_end_date date;
+  tour_group uuid;
+  tour_date_ref uuid;
+  schedule_start date;
+  schedule_end date;
+  scheduled_days int := 1;
+  rehearsal_days int := 0;
+  standard_days int := 0;
+  technician_override_days int := 0;
+  cat text;
+  house boolean := false;
+  is_autonomo boolean := true;
+  is_reduced_rehearsal boolean := false;
+  standard_discount_per_day numeric(10,2) := 0;
+  rehearsal_discount_per_day numeric(10,2) := 0;
+  total_autonomo_discount numeric(10,2) := 0;
+  standard_base_before_discount numeric(10,2) := 0;
+  standard_after_discount numeric(10,2) := 0;
+  standard_multiplier_bonus numeric(10,2) := 0;
+  multiplied_standard_days int := 0;
+  rehearsal_base_before_discount numeric(10,2) := 0;
+  team_member boolean := false;
+  has_override boolean := false;
+  standard_base numeric(10,2);
+  standard_day_rate numeric(10,2) := 0;
+  rehearsal_day_rate numeric(10,2) := 0;
+  standard_total numeric(10,2) := 0;
+  rehearsal_total numeric(10,2) := 0;
+  total_base numeric(10,2) := 0;
+  base_calculation_total numeric(10,2) := 0;
+  after_discount_total numeric(10,2) := 0;
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  display_multiplier numeric(6,3) := 1.0;
+  display_per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  has_custom_standard_rate boolean := FALSE;
+  has_custom_rehearsal_rate boolean := FALSE;
+  has_custom_rate boolean := FALSE;
+  display_category text := 'rehearsal';
+  job_date_type_start date;
+  job_date_type_end date;
+  tour_date_start date;
+  tour_date_end date;
+  tour_date_legacy_date date;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT job_type, start_time, end_time, tour_id, tour_date_id
+  INTO jtype, st, et, tour_group, tour_date_ref
+  FROM public.jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  job_start_date := (st AT TIME ZONE 'Europe/Madrid')::date;
+  job_end_date := COALESCE((et AT TIME ZONE 'Europe/Madrid')::date, job_start_date);
+
+  SELECT MIN(jdt.date), MAX(jdt.date)
+  INTO job_date_type_start, job_date_type_end
+  FROM public.job_date_types jdt
+  WHERE jdt.job_id = _job_id;
+
+  SELECT td.start_date, td.end_date, td.date
+  INTO tour_date_start, tour_date_end, tour_date_legacy_date
+  FROM public.tour_dates td
+  WHERE td.id = tour_date_ref;
+
+  schedule_start := COALESCE(
+    job_date_type_start,
+    tour_date_start,
+    job_start_date,
+    tour_date_legacy_date
+  );
+  schedule_end := COALESCE(
+    job_date_type_end,
+    tour_date_end,
+    job_end_date,
+    tour_date_start,
+    tour_date_legacy_date,
+    job_start_date
+  );
+
+  schedule_start := COALESCE(schedule_start, job_start_date);
+  schedule_end := COALESCE(schedule_end, schedule_start, job_end_date, job_start_date);
+  IF schedule_end < schedule_start THEN
+    schedule_end := schedule_start;
+  END IF;
+
+  WITH active_timesheet_dates AS (
+    SELECT DISTINCT t.date AS payable_date
+    FROM public.timesheets t
+    WHERE t.job_id = _job_id
+      AND t.technician_id = _tech_id
+      AND COALESCE(t.is_active, TRUE)
+  ),
+  fallback_assignment_dates AS (
+    SELECT ja.assignment_date AS payable_date
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id
+      AND ja.technician_id = _tech_id
+      AND COALESCE(ja.single_day, FALSE)
+      AND ja.assignment_date IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM active_timesheet_dates
+      )
+  ),
+  fallback_schedule_dates AS (
+    SELECT generated_series.date_value::date AS payable_date
+    FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS generated_series(date_value)
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM active_timesheet_dates
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM fallback_assignment_dates
+      )
+  ),
+  payable_dates AS (
+    SELECT payable_date
+    FROM active_timesheet_dates
+    UNION
+    SELECT payable_date
+    FROM fallback_assignment_dates
+    UNION
+    SELECT payable_date
+    FROM fallback_schedule_dates
+  )
+  SELECT
+    COUNT(*)::int,
+    COUNT(*) FILTER (
+      WHERE COALESCE(trmd.use_rehearsal_rate, jrd.job_id IS NOT NULL)
+    )::int,
+    COUNT(*) FILTER (WHERE trmd.job_id IS NOT NULL)::int
+  INTO scheduled_days, rehearsal_days, technician_override_days
+  FROM payable_dates pd
+  LEFT JOIN public.job_technician_rate_mode_dates trmd
+    ON trmd.job_id = _job_id
+   AND trmd.technician_id = _tech_id
+   AND trmd.date = pd.payable_date
+  LEFT JOIN public.job_rehearsal_dates jrd
+    ON jrd.job_id = _job_id
+   AND jrd.date = pd.payable_date;
+
+  rehearsal_days := LEAST(rehearsal_days, scheduled_days);
+  standard_days := GREATEST(0, scheduled_days - rehearsal_days);
+
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END,
+    COALESCE(role IN ('house_tech', 'admin', 'management'), false)
+  INTO house, is_autonomo, is_reduced_rehearsal
+  FROM public.profiles
+  WHERE id = _tech_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','profile_not_found','technician_id',_tech_id);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(bool_or(ja.use_tour_multipliers), FALSE)
+    INTO has_override
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+
+    has_override := COALESCE(has_override, FALSE);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(
+      EXISTS (
+        SELECT 1
+        FROM public.tour_assignments ta
+        WHERE ta.tour_id = tour_group
+          AND ta.technician_id = _tech_id
+      ) OR has_override,
+      FALSE
+    )
+    INTO team_member;
+
+    team_member := COALESCE(team_member, FALSE);
+  END IF;
+
+  SELECT iso_year, iso_week INTO y, w
+  FROM public.iso_year_week_madrid(st);
+
+  IF team_member THEN
+    DECLARE
+      total_tour_dates int;
+      tech_assigned_dates int;
+    BEGIN
+      SELECT count(DISTINCT j.id) INTO total_tour_dates
+      FROM public.jobs j
+      WHERE j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      SELECT count(DISTINCT j.id) INTO tech_assigned_dates
+      FROM public.jobs j
+      JOIN public.job_assignments a ON a.job_id = j.id
+      WHERE a.technician_id = _tech_id
+        AND j.job_type = 'tourdate'
+        AND j.tour_id = tour_group
+        AND j.status != 'Cancelado'
+        AND (SELECT iso_year FROM public.iso_year_week_madrid(j.start_time)) = y
+        AND (SELECT iso_week FROM public.iso_year_week_madrid(j.start_time)) = w;
+
+      IF tech_assigned_dates = total_tour_dates THEN
+        cnt := total_tour_dates;
+
+        IF cnt <= 1 THEN
+          mult := 1.5;
+          per_job_multiplier := 1.5;
+        ELSIF cnt = 2 THEN
+          mult := 2.25;
+          per_job_multiplier := 1.125;
+        ELSE
+          mult := 1.0;
+          per_job_multiplier := 1.0;
+        END IF;
+      ELSE
+        cnt := tech_assigned_dates;
+        mult := 1.0;
+        per_job_multiplier := 1.0;
+      END IF;
+    END;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+  END IF;
+
+  IF standard_days > 0 THEN
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM public.job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id
+    ORDER BY assigned_at DESC
+    LIMIT 1;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM public.profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+
+    IF cat = 'responsable' THEN
+      SELECT COALESCE(
+        tour_base_responsable_eur,
+        base_day_responsable_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSIF cat = 'especialista' THEN
+      SELECT COALESCE(
+        tour_base_especialista_eur,
+        tour_base_other_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      SELECT COALESCE(
+        tour_base_other_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    END IF;
+
+    IF standard_base IS NOT NULL THEN
+      has_custom_standard_rate := TRUE;
+      has_custom_rate := TRUE;
+    ELSE
+      SELECT base_day_eur INTO standard_base
+      FROM public.rate_cards_tour_2025
+      WHERE category = cat;
+
+      IF standard_base IS NULL THEN
+        RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+      END IF;
+    END IF;
+
+    standard_base_before_discount := standard_base;
+
+    IF NOT house AND NOT is_autonomo THEN
+      standard_discount_per_day := 30.00;
+      standard_base := standard_base - standard_discount_per_day;
+    END IF;
+
+    standard_after_discount := standard_base;
+    standard_day_rate := ROUND(standard_base, 2);
+
+    IF per_job_multiplier > 1.0 THEN
+      standard_multiplier_bonus := ROUND(standard_after_discount * (per_job_multiplier - 1.0), 2);
+      multiplied_standard_days := 1;
+    ELSE
+      standard_multiplier_bonus := 0;
+      multiplied_standard_days := 0;
+    END IF;
+
+    standard_total := ROUND((standard_day_rate * standard_days) + standard_multiplier_bonus, 2);
+    display_category := cat;
+  END IF;
+
+  IF rehearsal_days > 0 THEN
+    SELECT rehearsal_day_eur INTO rehearsal_day_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF rehearsal_day_rate IS NOT NULL THEN
+      has_custom_rehearsal_rate := TRUE;
+      has_custom_rate := TRUE;
+      rehearsal_base_before_discount := rehearsal_day_rate;
+    ELSE
+      IF is_reduced_rehearsal THEN
+        rehearsal_day_rate := 60.00;
+        rehearsal_base_before_discount := 60.00;
+      ELSE
+        rehearsal_day_rate := 180.00;
+        rehearsal_base_before_discount := 180.00;
+      END IF;
+    END IF;
+
+    IF NOT is_autonomo AND NOT is_reduced_rehearsal THEN
+      rehearsal_discount_per_day := 30.00;
+      rehearsal_day_rate := rehearsal_day_rate - rehearsal_discount_per_day;
+    END IF;
+
+    rehearsal_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+
+    IF standard_days = 0 THEN
+      display_category := 'rehearsal';
+    END IF;
+  END IF;
+
+  total_base := ROUND(standard_total + rehearsal_total, 2);
+  total_autonomo_discount := ROUND(
+    (standard_discount_per_day * standard_days) + (rehearsal_discount_per_day * rehearsal_days),
+    2
+  );
+  base_calculation_total := ROUND(
+    (standard_base_before_discount * standard_days) + (rehearsal_base_before_discount * rehearsal_days),
+    2
+  );
+
+  IF rehearsal_days > 0 THEN
+    display_multiplier := 1.0;
+    display_per_job_multiplier := 1.0;
+    after_discount_total := total_base;
+  ELSE
+    display_multiplier := mult;
+    display_per_job_multiplier := per_job_multiplier;
+    after_discount_total := ROUND(standard_after_discount * standard_days, 2);
+  END IF;
+
+  extras := public.extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(total_base + extras_total, 2);
+
+  disclaimer := public.needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,
+    'category', display_category,
+    'base_day_eur', total_base,
+    'has_custom_rate', has_custom_rate,
+    'autonomo_discount_eur', total_autonomo_discount,
+    'base_day_before_discount_eur', base_calculation_total,
+    'week_count', cnt,
+    'multiplier', ROUND(display_multiplier, 3),
+    'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', total_base,
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', final_total,
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', base_calculation_total,
+      'autonomo_discount', total_autonomo_discount,
+      'after_discount', after_discount_total,
+      'multiplier', ROUND(display_multiplier, 3),
+      'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+      'final_base', total_base,
+      'has_custom_rate', has_custom_rate,
+      'has_custom_standard_rate', has_custom_standard_rate,
+      'has_custom_rehearsal_rate', has_custom_rehearsal_rate,
+      'scheduled_days', scheduled_days,
+      'rehearsal_days', rehearsal_days,
+      'standard_days', standard_days,
+      'technician_override_days', technician_override_days,
+      'multiplied_standard_days', multiplied_standard_days,
+      'standard_multiplier_bonus_eur', standard_multiplier_bonus,
+      'rehearsal_rate_eur', CASE WHEN rehearsal_days > 0 THEN rehearsal_day_rate ELSE NULL END,
+      'standard_day_rate_eur', CASE WHEN standard_days > 0 THEN standard_day_rate ELSE NULL END,
+      'forced_rehearsal_rate', (rehearsal_days > 0)
+    )
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) IS
+  'Calculates tour job rate quotes for technicians. Rehearsal pricing precedence is technician/date overrides in job_technician_rate_mode_dates, then job_rehearsal_dates. The quote derives its multi-day span from job_date_types first, counts payable days from the technician''s active timesheets before falling back to legacy assignment metadata or the job span, and applies any standard-rate tour multiplier once per quote rather than once per payable day.';


### PR DESCRIPTION
## Summary
- [ ] I described what changed and why.

## Risk Assessment
- [ ] I assessed functional, data, and deployment risk.
- Risk level: <!-- low | medium | high -->
- Main risks:

## Test Evidence
- [ ] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint`
  - `npm run test:critical`
  - `npm run test:run`
  - `npm run build`
- Results:

## Rollback Plan
- [ ] I documented how to safely revert this change.
- Rollback steps:

## Migration Impact
- [ ] I confirmed whether this PR changes schema/functions.
- Migration required: <!-- yes | no -->
- If yes, describe migration, impact, and backout plan:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side tour-date quote computation that more accurately derives multi-day payable spans and returns detailed technician quote breakdowns.
  * Added an exported helper to adjust rehearsal quotes (currently a backward-compatible no-op).

* **UI**
  * Technician payout card now tolerates missing backend handlers and shows a safe fallback UI instead of breaking admin controls.

* **Tests**
  * Added/updated tests validating schedule-range and quote computation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->