### PR TITLE
Show tour multiplier breakdown in payout UI

### DIFF
--- a/src/components/department/EnhancedJobDetailsModal.tsx
+++ b/src/components/department/EnhancedJobDetailsModal.tsx
@@ -22,6 +22,7 @@ import { useJobApprovalStatus } from '@/hooks/useJobApprovalStatus';
 import { JobPayoutTotalsPanel } from '@/components/jobs/JobPayoutTotalsPanel';
 import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 import { canManagePayouts } from '@/utils/permissions';
+import { getVisibleFinancialTechnicianIds } from '@/components/jobs/financialViewerScope';
 
 interface EnhancedJobDetailsModalProps {
     theme: {
@@ -52,6 +53,7 @@ interface StaffAssignment {
         first_name: string;
         last_name: string;
         email?: string;
+        department?: string | null;
     } | null;
 }
 
@@ -107,7 +109,7 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
           sound_role,
           lights_role,
           video_role,
-          technician:profiles(id, first_name, last_name, email)
+          technician:profiles(id, first_name, last_name, email, department)
         `)
                 .eq('job_id', job.id)
                 .eq('status', 'confirmed');
@@ -175,6 +177,17 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
             setActiveTab('Info');
         }
     }, [resolvedJobId]);
+
+    const visibleFinancialTechnicianIds = React.useMemo(() => {
+        const technicians = (staffAssignments as StaffAssignment[])
+            .map((assignment) => ({
+                id: assignment.technician?.id ?? '',
+                department: assignment.technician?.department ?? null,
+            }))
+            .filter((assignment) => Boolean(assignment.id));
+
+        return getVisibleFinancialTechnicianIds(technicians, userRole, userDepartment);
+    }, [staffAssignments, userDepartment, userRole]);
 
     const invalidateJobQueries = () => {
         if (!resolvedJobId) return;
@@ -895,7 +908,11 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
                             </div>
 
                             <div className={`${isDark ? 'bg-[#0f1219] border-[#1f232e]' : 'bg-slate-50 border-slate-200'} border rounded-lg p-4 w-full min-w-0 overflow-hidden`}>
-                                <JobExtrasManagement jobId={resolvedJobId} />
+                                <JobExtrasManagement
+                                    jobId={resolvedJobId}
+                                    isManager={isManager}
+                                    visibleTechnicianIds={visibleFinancialTechnicianIds ?? undefined}
+                                />
                             </div>
                         </div>
                     )}

--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -22,6 +22,7 @@ import { JobDetailsWeatherTab } from "./job-details-dialog/tabs/JobDetailsWeathe
 import { StaffingOrchestratorPanel } from "@/components/matrix/StaffingOrchestratorPanel";
 import { useJobExpenses } from "@/hooks/useJobExpenses";
 import { canManagePayouts } from "@/utils/permissions";
+import { getVisibleFinancialTechnicianIds } from "@/components/jobs/financialViewerScope";
 
 export { enrichTimesheetsWithProfiles } from "./job-details-dialog/enrichTimesheetsWithProfiles";
 
@@ -118,6 +119,23 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
     });
     return Array.from(map.entries()).map(([id, name]) => ({ id, name: name || id }));
   }, [jobDetails?.job_assignments, jobDetails?.timesheets]);
+
+  const visibleFinancialTechnicianIds = useMemo(() => {
+    const assignmentTechnicians = (jobDetails?.job_assignments ?? [])
+      .map((assignment: any) => ({
+        id: assignment.technician_id as string,
+        department: assignment.profiles?.department as string | null | undefined,
+      }))
+      .filter((assignment: { id?: string }) => Boolean(assignment.id));
+
+    return getVisibleFinancialTechnicianIds(assignmentTechnicians, userRole, userDepartment);
+  }, [jobDetails?.job_assignments, userDepartment, userRole]);
+
+  const visibleExpenseTechnicianOptions = useMemo(() => {
+    if (!visibleFinancialTechnicianIds) return expenseTechnicianOptions;
+    const visibleTechnicianIdSet = new Set(visibleFinancialTechnicianIds);
+    return expenseTechnicianOptions.filter((technician) => visibleTechnicianIdSet.has(technician.id));
+  }, [expenseTechnicianOptions, visibleFinancialTechnicianIds]);
 
   useEffect(() => {
     if (!showTourRatesTab && selectedTab === "tour-rates") {
@@ -314,7 +332,12 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
 
               {!isDryhire && showExtrasTab && (
                 <TabsContent value="extras" className="space-y-4 min-w-0 overflow-x-hidden">
-                  <JobExtrasManagement jobId={resolvedJobId} isManager={isManager} technicianId={isManager ? undefined : user?.id || undefined} />
+                  <JobExtrasManagement
+                    jobId={resolvedJobId}
+                    isManager={isManager}
+                    technicianId={isManager ? undefined : user?.id || undefined}
+                    visibleTechnicianIds={visibleFinancialTechnicianIds ?? undefined}
+                  />
                 </TabsContent>
               )}
 
@@ -323,8 +346,9 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
                   <JobExpensesPanel
                     jobId={resolvedJobId || job.id}
                     jobTitle={jobDetails?.title || job?.title}
-                    technicians={expenseTechnicianOptions}
+                    technicians={visibleExpenseTechnicianOptions}
                     canManage={canManageExpenses}
+                    visibleTechnicianIds={visibleFinancialTechnicianIds ?? undefined}
                   />
                 </TabsContent>
               )}

--- a/src/components/jobs/JobExpensesPanel.tsx
+++ b/src/components/jobs/JobExpensesPanel.tsx
@@ -54,6 +54,7 @@ interface JobExpensesPanelProps {
   jobTitle?: string;
   technicians: TechnicianOption[];
   canManage: boolean;
+  visibleTechnicianIds?: string[];
 }
 
 interface ExpenseRow {
@@ -161,9 +162,14 @@ export const JobExpensesPanel: React.FC<JobExpensesPanelProps> = ({
   jobTitle,
   technicians,
   canManage,
+  visibleTechnicianIds,
 }) => {
   const queryClient = useQueryClient();
   const technicianMap = React.useMemo(() => new Map(technicians.map((tech) => [tech.id, tech.name])), [technicians]);
+  const visibleTechnicianIdSet = React.useMemo(
+    () => new Set(visibleTechnicianIds ?? technicians.map((tech) => tech.id)),
+    [technicians, visibleTechnicianIds]
+  );
 
   const {
     data: expenseCategories = [],
@@ -288,6 +294,16 @@ export const JobExpensesPanel: React.FC<JobExpensesPanelProps> = ({
     [technicianMap]
   );
 
+  const visibleExpenses = React.useMemo(
+    () => expenses.filter((expense) => visibleTechnicianIdSet.has(expense.technician_id)),
+    [expenses, visibleTechnicianIdSet]
+  );
+
+  const visiblePermissions = React.useMemo(
+    () => permissions.filter((permission) => visibleTechnicianIdSet.has(permission.technician_id)),
+    [permissions, visibleTechnicianIdSet]
+  );
+
   const groupedByStatus = React.useMemo(() => {
     const initial = STATUS_ORDER.reduce<Record<ExpenseStatus, Map<string, ExpenseRow[]>>>(
       (acc, status) => {
@@ -302,7 +318,7 @@ export const JobExpensesPanel: React.FC<JobExpensesPanelProps> = ({
       }
     );
 
-    expenses.forEach((expense) => {
+    visibleExpenses.forEach((expense) => {
       const status = expense.status ?? 'draft';
       const group = initial[status];
       const list = group.get(expense.technician_id) ?? [];
@@ -311,10 +327,10 @@ export const JobExpensesPanel: React.FC<JobExpensesPanelProps> = ({
     });
 
     return initial;
-  }, [expenses]);
+  }, [visibleExpenses]);
 
   const aggregatedTotals = React.useMemo(() => {
-    return expenses.reduce(
+    return visibleExpenses.reduce(
       (acc, expense) => {
         acc.count += 1;
         acc.amount += expense.amount_eur;
@@ -329,7 +345,7 @@ export const JobExpensesPanel: React.FC<JobExpensesPanelProps> = ({
       },
       { count: 0, amount: 0, pendingCount: 0, pendingAmount: 0, approvedAmount: 0 }
     );
-  }, [expenses]);
+  }, [visibleExpenses]);
 
   const resetPermissionForm = React.useCallback(() => {
     setPermissionForm({
@@ -635,11 +651,11 @@ export const JobExpensesPanel: React.FC<JobExpensesPanelProps> = ({
 
             <div className="space-y-3">
               <h4 className="font-semibold text-sm">Permisos actuales</h4>
-              {permissions.length === 0 ? (
+              {visiblePermissions.length === 0 ? (
                 <p className="text-xs text-muted-foreground">Todavía no hay permisos configurados para este trabajo.</p>
               ) : (
                 <div className="space-y-2">
-                  {permissions.map((permission) => (
+                  {visiblePermissions.map((permission) => (
                     <div
                       key={permission.id}
                       className="flex flex-col md:flex-row md:items-center md:justify-between gap-2 p-3 rounded-lg border border-border bg-muted/30"

--- a/src/components/jobs/JobExtrasManagement.tsx
+++ b/src/components/jobs/JobExtrasManagement.tsx
@@ -13,6 +13,7 @@ interface JobExtrasManagementProps {
   jobId: string;
   isManager?: boolean;
   technicianId?: string; // when provided (non-manager), restrict view to this tech
+  visibleTechnicianIds?: string[];
 }
 
 interface JobAssignment {
@@ -36,9 +37,19 @@ const surface = "bg-muted/30 border-border";
 const subtle = "text-muted-foreground";
 const pill = "bg-primary/5 border-primary/10 text-primary dark:text-primary-foreground";
 
-export const JobExtrasManagement = ({ jobId, isManager = false, technicianId }: JobExtrasManagementProps) => {
+export const JobExtrasManagement = ({
+  jobId,
+  isManager = false,
+  technicianId,
+  visibleTechnicianIds,
+}: JobExtrasManagementProps) => {
+  const visibleTechnicianIdSet = useMemo(
+    () => new Set(visibleTechnicianIds ?? []),
+    [visibleTechnicianIds]
+  );
+
   const { data: assignments, isLoading: assignmentsLoading } = useQuery({
-    queryKey: ['job-assignments', jobId],
+    queryKey: ['job-assignments', jobId, technicianId, visibleTechnicianIds?.join(',') ?? 'all'],
     queryFn: async () => {
       let query = supabase
         .from('job_assignments')
@@ -54,6 +65,8 @@ export const JobExtrasManagement = ({ jobId, isManager = false, technicianId }: 
         .eq('job_id', jobId);
       if (technicianId && !isManager) {
         query = query.eq('technician_id', technicianId);
+      } else if (isManager && visibleTechnicianIds && visibleTechnicianIds.length > 0) {
+        query = query.in('technician_id', visibleTechnicianIds);
       }
       const { data, error } = await query;
 
@@ -64,9 +77,18 @@ export const JobExtrasManagement = ({ jobId, isManager = false, technicianId }: 
   });
 
   // Fetch custom travel rates for all assigned technicians
+  const visibleAssignments = useMemo(
+    () => (assignments ?? []).filter((assignment) => {
+      if (technicianId) return assignment.technician_id === technicianId;
+      if (!visibleTechnicianIds) return true;
+      return visibleTechnicianIdSet.has(assignment.technician_id);
+    }),
+    [assignments, technicianId, visibleTechnicianIds, visibleTechnicianIdSet]
+  );
+
   const techIds = useMemo(
-    () => (assignments?.map(a => a.technician_id) ?? []).sort(),
-    [assignments]
+    () => visibleAssignments.map((assignment) => assignment.technician_id).sort(),
+    [visibleAssignments]
   );
   const techIdsKey = techIds.join(',');
   const { data: customTravelRates, isLoading: customTravelRatesLoading } = useQuery({
@@ -104,9 +126,6 @@ export const JobExtrasManagement = ({ jobId, isManager = false, technicianId }: 
     );
   }
 
-  // When not manager and technicianId provided, filter assignments to that technician only
-  const visibleAssignments = assignments?.filter(a => !technicianId || a.technician_id === technicianId) || [];
-
   if (assignmentsLoading || payoutLoading) {
     // covered above, but keep logic order consistent
   }
@@ -129,7 +148,12 @@ export const JobExtrasManagement = ({ jobId, isManager = false, technicianId }: 
     );
   }
 
-  const totalExtrasAmount = (isManager ? (payoutTotals?.reduce((sum, payout) => sum + (payout.extras_total_eur || 0), 0) || 0) : (payoutTotals?.[0]?.extras_total_eur || 0));
+  const visiblePayoutTotals = (payoutTotals ?? []).filter((payout) =>
+    visibleAssignments.some((assignment) => assignment.technician_id === payout.technician_id)
+  );
+  const totalExtrasAmount = isManager
+    ? visiblePayoutTotals.reduce((sum, payout) => sum + (payout.extras_total_eur || 0), 0)
+    : (visiblePayoutTotals[0]?.extras_total_eur || 0);
 
   return (
     <Card className={cardBase}>
@@ -192,7 +216,7 @@ export const JobExtrasManagement = ({ jobId, isManager = false, technicianId }: 
                 showVehicleDisclaimer={technicianPayout?.vehicle_disclaimer || false}
               />
 
-              {index < assignments.length - 1 && <Separator className="mt-4 sm:mt-6" />}
+              {index < visibleAssignments.length - 1 && <Separator className="mt-4 sm:mt-6" />}
             </div>
           );
         })}

--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -239,4 +239,58 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
     expect(screen.getByText(/vie 10 abr/i)).toBeInTheDocument();
     expect(screen.queryByText(/jue 9 abr/i)).not.toBeInTheDocument();
   });
+
+  it("shows the multiplier breakdown from the tour quote when a standard-rate bonus applies", () => {
+    useJobPayoutDataMock.mockReturnValue({
+      ...buildPayoutData(),
+      payoutTotals: [
+        {
+          technician_id: "tech-1",
+          job_id: "job-tour-1",
+          timesheets_total_eur: 1200,
+          extras_total_eur: 0,
+          total_eur: 1200,
+          payout_approved: true,
+          extras_breakdown: { items: [], total_eur: 0 },
+          vehicle_disclaimer: false,
+          vehicle_disclaimer_text: null,
+          expenses_total_eur: 0,
+          expenses_breakdown: [],
+        },
+      ],
+      visibleTourQuotes: [
+        {
+          job_id: "job-tour-1",
+          technician_id: "tech-1",
+          start_time: "2026-04-08T08:00:00Z",
+          end_time: "2026-04-15T23:59:00Z",
+          job_type: "tourdate",
+          tour_id: "tour-1",
+          title: "Tour Date",
+          is_house_tech: false,
+          is_tour_team_member: true,
+          category: "responsable",
+          base_day_eur: 1200,
+          week_count: 1,
+          multiplier: 1.5,
+          per_job_multiplier: 1.5,
+          iso_year: 2026,
+          iso_week: 15,
+          total_eur: 1200,
+          breakdown: {
+            standard_days: 2,
+            standard_day_rate_eur: 480,
+            multiplied_standard_days: 1,
+            standard_multiplier_bonus_eur: 240,
+          },
+        },
+      ],
+    });
+
+    renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
+
+    expect(screen.getByText(/estándar: 2 x/i)).toBeInTheDocument();
+    expect(screen.getByText(/multiplicador gira: 1 día con factor 1,5x/i)).toBeInTheDocument();
+    expect(screen.getByText(/\+240/)).toBeInTheDocument();
+  });
 });

--- a/src/components/jobs/__tests__/financialViewerScope.test.ts
+++ b/src/components/jobs/__tests__/financialViewerScope.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { getVisibleFinancialTechnicianIds } from '@/components/jobs/financialViewerScope';
+
+const technicians = [
+  { id: 'sound-1', department: 'sound' },
+  { id: 'lights-1', department: 'lights' },
+  { id: 'admin-1', department: 'administrative' },
+];
+
+describe('getVisibleFinancialTechnicianIds', () => {
+  it('scopes department managers to their own department technicians', () => {
+    expect(getVisibleFinancialTechnicianIds(technicians, 'management', 'sound')).toEqual(['sound-1']);
+    expect(getVisibleFinancialTechnicianIds(technicians, 'management', 'lights')).toEqual(['lights-1']);
+  });
+
+  it('lets administrative managers and admins see all technicians', () => {
+    expect(getVisibleFinancialTechnicianIds(technicians, 'management', 'administrative')).toBeNull();
+    expect(getVisibleFinancialTechnicianIds(technicians, 'admin', 'sound')).toBeNull();
+  });
+
+  it('lets logistics users see all technicians in the expenses flow', () => {
+    expect(getVisibleFinancialTechnicianIds(technicians, 'logistics', 'sound')).toBeNull();
+  });
+
+  it('returns an empty list when a scoped manager has no matching department', () => {
+    expect(getVisibleFinancialTechnicianIds(technicians, 'management', 'video')).toEqual([]);
+    expect(getVisibleFinancialTechnicianIds(technicians, 'management', null)).toEqual([]);
+  });
+});

--- a/src/components/jobs/financialViewerScope.ts
+++ b/src/components/jobs/financialViewerScope.ts
@@ -1,0 +1,35 @@
+import { isAdministrativeDepartment, normalizeDepartmentKey } from '@/utils/permissions';
+
+interface TechnicianDepartmentRow {
+  id: string;
+  department?: string | null;
+}
+
+export const getVisibleFinancialTechnicianIds = (
+  technicians: TechnicianDepartmentRow[],
+  userRole?: string | null,
+  userDepartment?: string | null,
+): string[] | null => {
+  if (!technicians.length) return [];
+
+  if (
+    userRole === 'admin'
+    || userRole === 'logistics'
+    || isAdministrativeDepartment(userDepartment)
+  ) {
+    return null;
+  }
+
+  if (userRole !== 'management') {
+    return null;
+  }
+
+  const normalizedViewerDepartment = normalizeDepartmentKey(userDepartment);
+  if (!normalizedViewerDepartment) {
+    return [];
+  }
+
+  return technicians
+    .filter((technician) => normalizeDepartmentKey(technician.department) === normalizedViewerDepartment)
+    .map((technician) => technician.id);
+};

--- a/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
+++ b/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
@@ -14,6 +14,7 @@ import { TechnicianPayoutCard } from './TechnicianPayoutCard';
 import { PayoutGrandTotal } from './PayoutGrandTotal';
 import { cardBase, subtleText, NON_AUTONOMO_DEDUCTION_EUR } from './types';
 import type { JobPayoutTotalsPanelProps } from './types';
+import type { TourJobRateQuote } from '@/types/tourRates';
 
 export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPanelProps) {
   const data = useJobPayoutData(jobId, technicianId);
@@ -72,6 +73,11 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
   const filteredPayoutOverrides = React.useMemo(
     () => data.payoutOverrides.filter(o => displayedTechIds.has(o.technician_id)),
     [data.payoutOverrides, displayedTechIds]
+  );
+
+  const visibleTourQuoteMap = React.useMemo(
+    () => new Map(data.visibleTourQuotes.map((quote) => [quote.technician_id, quote] as const)),
+    [data.visibleTourQuotes]
   );
 
   /* ── Grand total for filtered view ── */
@@ -230,6 +236,7 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
           <TechnicianPayoutCard
             key={payout.technician_id}
             payout={payout}
+            tourQuote={visibleTourQuoteMap.get(payout.technician_id) as TourJobRateQuote | undefined}
             jobId={jobId}
             isTourDate={data.isTourDate}
             isCicloJob={isCicloJob}

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -175,7 +175,10 @@ export function TechnicianPayoutCard({
   const multipliedStandardDays = Number(quoteBreakdown?.multiplied_standard_days ?? 0);
   const standardMultiplierBonus = Number(quoteBreakdown?.standard_multiplier_bonus_eur ?? 0);
   const multiplierFactor = Number(
-    quoteBreakdown?.per_job_multiplier ?? tourQuote?.per_job_multiplier ?? 1,
+    quoteBreakdown?.per_job_multiplier
+      ?? tourQuote?.per_job_multiplier
+      ?? tourQuote?.multiplier
+      ?? 1,
   );
   const showTourRateBreakdown =
     isTourDate && !!tourQuote && (rehearsalDays > 0 || standardDays > 0 || standardMultiplierBonus > 0);

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -14,6 +14,7 @@ import { getAutonomoBadgeLabel } from '@/utils/autonomo';
 import { JobPayoutOverrideSection, type JobPayoutOverride } from '@/components/jobs/JobPayoutOverrideSection';
 import type { TechnicianDateRateMode } from '@/hooks/useTechnicianRateModeDates';
 import type { JobPayoutTotals } from '@/types/jobExtras';
+import type { TourJobRateQuote } from '@/types/tourRates';
 import type { TechnicianProfileWithEmail } from '@/lib/job-payout-email';
 import { surface, controlButton, NON_AUTONOMO_DEDUCTION_EUR } from './types';
 
@@ -27,6 +28,7 @@ const categoryLabels: Record<string, string> = {
 
 interface TechnicianPayoutCardProps {
   payout: JobPayoutTotals;
+  tourQuote?: TourJobRateQuote;
   jobId: string;
   isTourDate: boolean;
   isCicloJob?: boolean;
@@ -70,6 +72,7 @@ interface TechnicianPayoutCardProps {
 
 export function TechnicianPayoutCard({
   payout,
+  tourQuote,
   jobId,
   isTourDate,
   isCicloJob = false,
@@ -163,6 +166,25 @@ export function TechnicianPayoutCard({
     : activeRateModeOverrideCount === 1
       ? '1 excepción'
       : `${activeRateModeOverrideCount} excepciones`;
+
+  const quoteBreakdown = tourQuote?.breakdown ?? null;
+  const rehearsalDays = Number(quoteBreakdown?.rehearsal_days ?? 0);
+  const standardDays = Number(quoteBreakdown?.standard_days ?? 0);
+  const rehearsalDayRate = Number(quoteBreakdown?.rehearsal_rate_eur ?? 0);
+  const standardDayRate = Number(quoteBreakdown?.standard_day_rate_eur ?? 0);
+  const multipliedStandardDays = Number(quoteBreakdown?.multiplied_standard_days ?? 0);
+  const standardMultiplierBonus = Number(quoteBreakdown?.standard_multiplier_bonus_eur ?? 0);
+  const multiplierFactor = Number(
+    quoteBreakdown?.per_job_multiplier ?? tourQuote?.per_job_multiplier ?? 1,
+  );
+  const showTourRateBreakdown =
+    isTourDate && !!tourQuote && (rehearsalDays > 0 || standardDays > 0 || standardMultiplierBonus > 0);
+  const multiplierFactorLabel = multiplierFactor.toLocaleString('es-ES', {
+    minimumFractionDigits: Number.isInteger(multiplierFactor) ? 0 : 1,
+    maximumFractionDigits: 3,
+  });
+  const multiplierDaysLabel =
+    multipliedStandardDays === 1 ? '1 día' : `${multipliedStandardDays} días`;
 
   return (
     <div
@@ -300,6 +322,33 @@ export function TechnicianPayoutCard({
             <span>
               Solo {approvedDays} de {totalDays} partes aprobados — el total puede no reflejar todos los días asignados
             </span>
+          </div>
+        )}
+
+        {showTourRateBreakdown && (
+          <div className="ml-6 space-y-1 rounded-md border border-border/60 bg-muted/20 px-3 py-2">
+            {rehearsalDays > 0 && (
+              <div className="flex justify-between gap-3 text-xs text-muted-foreground">
+                <span>Ensayo: {rehearsalDays} x {formatCurrency(rehearsalDayRate)}</span>
+                <span>{formatCurrency(rehearsalDays * rehearsalDayRate)}</span>
+              </div>
+            )}
+
+            {standardDays > 0 && (
+              <div className="flex justify-between gap-3 text-xs text-muted-foreground">
+                <span>Estándar: {standardDays} x {formatCurrency(standardDayRate)}</span>
+                <span>{formatCurrency(standardDays * standardDayRate)}</span>
+              </div>
+            )}
+
+            {standardMultiplierBonus > 0 && (
+              <div className="flex justify-between gap-3 text-xs text-muted-foreground">
+                <span>
+                  Multiplicador gira: {multiplierDaysLabel} con factor {multiplierFactorLabel}x
+                </span>
+                <span>+{formatCurrency(standardMultiplierBonus)}</span>
+              </div>
+            )}
           </div>
         )}
 

--- a/src/types/tourRates.ts
+++ b/src/types/tourRates.ts
@@ -33,6 +33,8 @@ export interface TourJobRateQuote {
     standard_days?: number;
     rehearsal_rate_eur?: number;
     standard_day_rate_eur?: number;
+    multiplied_standard_days?: number;
+    standard_multiplier_bonus_eur?: number;
     forced_rehearsal_rate?: boolean;
     [key: string]: any;
   };


### PR DESCRIPTION
## Summary
- [ ] I described what changed and why.

## Risk Assessment
- [ ] I assessed functional, data, and deployment risk.
- Risk level: <!-- low | medium | high -->
- Main risks:

## Test Evidence
- [ ] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint`
  - `npm run test:critical`
  - `npm run test:run`
  - `npm run build`
- Results:

## Rollback Plan
- [ ] I documented how to safely revert this change.
- Rollback steps:

## Migration Impact
- [ ] I confirmed whether this PR changes schema/functions.
- Migration required: <!-- yes | no -->
- If yes, describe migration, impact, and backout plan:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tour job technician payouts now display detailed rate breakdowns, including standard-day counts, multiplier factors, and calculated bonus amounts for enhanced financial transparency.

* **Tests**
  * Added test coverage validating the display of tour job rate breakdown components and bonus calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->