### PR TITLE
Fix dry hire Flex dates and document numbers

### DIFF
--- a/src/utils/flex-folders/__tests__/folders.dryhire-document-number.test.ts
+++ b/src/utils/flex-folders/__tests__/folders.dryhire-document-number.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createFlexFolderMock, getDryhireParentFolderIdMock } = vi.hoisted(() => ({
+const {
+  createFlexFolderMock,
+  updateFlexElementHeaderMock,
+  getDryhireParentFolderIdMock,
+  insertMock,
+} = vi.hoisted(() => ({
   createFlexFolderMock: vi.fn(),
+  updateFlexElementHeaderMock: vi.fn(),
   getDryhireParentFolderIdMock: vi.fn(),
+  insertMock: vi.fn(),
 }));
 
 vi.mock("../api", () => ({
   createFlexFolder: createFlexFolderMock,
+  updateFlexElementHeader: updateFlexElementHeaderMock,
 }));
 
 vi.mock("../dryhireFolderService", () => ({
@@ -42,6 +50,7 @@ vi.mock("@/lib/supabase", () => {
 
     insert(_payload: any) {
       this.action = "insert";
+      insertMock(this.table, _payload);
       return this;
     }
 
@@ -91,9 +100,12 @@ import { createAllFoldersForJob } from "../folders";
 describe("createAllFoldersForJob dryhire document numbers", () => {
   beforeEach(() => {
     createFlexFolderMock.mockReset();
+    updateFlexElementHeaderMock.mockReset();
     getDryhireParentFolderIdMock.mockReset();
+    insertMock.mockReset();
 
     getDryhireParentFolderIdMock.mockResolvedValue("dryhire-month-parent");
+    updateFlexElementHeaderMock.mockResolvedValue(undefined);
     createFlexFolderMock
       .mockResolvedValueOnce({ elementId: "dryhire-folder" })
       .mockResolvedValueOnce({ elementId: "dryhire-presupuesto" });
@@ -121,6 +133,30 @@ describe("createAllFoldersForJob dryhire document numbers", () => {
 
     expect(dryhirePayload.documentNumber).toBe("250101S");
     expect(presupuestoPayload.documentNumber).toBe("250101SDH");
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      1,
+      "dryhire-folder",
+      "documentNumber",
+      "250101S"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      2,
+      "dryhire-folder",
+      "plannedStartDate",
+      "2025-01-01T11:00:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      3,
+      "dryhire-folder",
+      "plannedEndDate",
+      "2025-01-01T19:00:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      4,
+      "dryhire-presupuesto",
+      "documentNumber",
+      "250101SDH"
+    );
   });
 
   it("assigns distinct dryhire and presupuesto numbers for lights jobs", async () => {
@@ -150,5 +186,107 @@ describe("createAllFoldersForJob dryhire document numbers", () => {
 
     expect(dryhirePayload.documentNumber).toBe("250101L");
     expect(presupuestoPayload.documentNumber).toBe("250101LDH");
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      1,
+      "dryhire-folder-lights",
+      "documentNumber",
+      "250101L"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      4,
+      "dryhire-presupuesto-lights",
+      "documentNumber",
+      "250101LDH"
+    );
+  });
+
+  it("uses the job timezone when local date differs from UTC date", async () => {
+    const job = {
+      id: "job-boundary-dryhire",
+      job_type: "dryhire",
+      title: "Boundary Dryhire Job",
+      start_time: "2026-03-31T22:30:00.000Z",
+      end_time: "2026-04-01T00:45:00.000Z",
+      timezone: "Europe/Madrid",
+      job_departments: [{ department: "sound" }],
+    };
+
+    await createAllFoldersForJob(
+      job,
+      "1999-01-01T00:00:00.000Z",
+      "1999-01-01T01:00:00.000Z",
+      "990101"
+    );
+
+    const [dryhirePayload] = createFlexFolderMock.mock.calls[0];
+    const [presupuestoPayload] = createFlexFolderMock.mock.calls[1];
+
+    expect(getDryhireParentFolderIdMock).toHaveBeenCalledWith(2026, "sound", "04");
+    expect(dryhirePayload.documentNumber).toBe("260401S");
+    expect(presupuestoPayload.documentNumber).toBe("260401SDH");
+    expect(dryhirePayload.plannedStartDate).toBe("2026-04-01T00:30:00.000Z");
+    expect(dryhirePayload.plannedEndDate).toBe("2026-04-01T02:45:00.000Z");
+    expect(presupuestoPayload.plannedStartDate).toBe(dryhirePayload.plannedStartDate);
+    expect(presupuestoPayload.plannedEndDate).toBe(dryhirePayload.plannedEndDate);
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      1,
+      "dryhire-folder",
+      "documentNumber",
+      "260401S"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      2,
+      "dryhire-folder",
+      "plannedStartDate",
+      "2026-04-01T00:30:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      3,
+      "dryhire-folder",
+      "plannedEndDate",
+      "2026-04-01T02:45:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      4,
+      "dryhire-presupuesto",
+      "documentNumber",
+      "260401SDH"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      5,
+      "dryhire-presupuesto",
+      "plannedStartDate",
+      "2026-04-01T00:30:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenNthCalledWith(
+      6,
+      "dryhire-presupuesto",
+      "plannedEndDate",
+      "2026-04-01T02:45:00.000Z"
+    );
+  });
+
+  it("does not persist local folder rows when header enforcement fails", async () => {
+    updateFlexElementHeaderMock.mockRejectedValueOnce(new Error("header update failed"));
+
+    const job = {
+      id: "job-header-failure-dryhire",
+      job_type: "dryhire",
+      title: "Header Failure Dryhire Job",
+      start_time: "2025-01-01T10:00:00.000Z",
+      end_time: "2025-01-01T18:00:00.000Z",
+      job_departments: [{ department: "sound" }],
+    };
+
+    await expect(
+      createAllFoldersForJob(
+        job,
+        "2025-01-01T10:00:00.000Z",
+        "2025-01-01T18:00:00.000Z",
+        "250101"
+      )
+    ).rejects.toThrow("header update failed");
+
+    expect(insertMock).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/flex-folders/__tests__/folders.dryhire-document-number.test.ts
+++ b/src/utils/flex-folders/__tests__/folders.dryhire-document-number.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   createFlexFolderMock,
+  deleteFlexFolderMock,
   updateFlexElementHeaderMock,
   getDryhireParentFolderIdMock,
   insertMock,
 } = vi.hoisted(() => ({
   createFlexFolderMock: vi.fn(),
+  deleteFlexFolderMock: vi.fn(),
   updateFlexElementHeaderMock: vi.fn(),
   getDryhireParentFolderIdMock: vi.fn(),
   insertMock: vi.fn(),
@@ -14,6 +16,7 @@ const {
 
 vi.mock("../api", () => ({
   createFlexFolder: createFlexFolderMock,
+  deleteFlexFolder: deleteFlexFolderMock,
   updateFlexElementHeader: updateFlexElementHeaderMock,
 }));
 
@@ -100,11 +103,13 @@ import { createAllFoldersForJob } from "../folders";
 describe("createAllFoldersForJob dryhire document numbers", () => {
   beforeEach(() => {
     createFlexFolderMock.mockReset();
+    deleteFlexFolderMock.mockReset();
     updateFlexElementHeaderMock.mockReset();
     getDryhireParentFolderIdMock.mockReset();
     insertMock.mockReset();
 
     getDryhireParentFolderIdMock.mockResolvedValue("dryhire-month-parent");
+    deleteFlexFolderMock.mockResolvedValue(undefined);
     updateFlexElementHeaderMock.mockResolvedValue(undefined);
     createFlexFolderMock
       .mockResolvedValueOnce({ elementId: "dryhire-folder" })
@@ -266,7 +271,7 @@ describe("createAllFoldersForJob dryhire document numbers", () => {
     );
   });
 
-  it("does not persist local folder rows when header enforcement fails", async () => {
+  it("cleans up created Flex elements and does not persist local rows when header enforcement fails", async () => {
     updateFlexElementHeaderMock.mockRejectedValueOnce(new Error("header update failed"));
 
     const job = {
@@ -287,6 +292,43 @@ describe("createAllFoldersForJob dryhire document numbers", () => {
       )
     ).rejects.toThrow("header update failed");
 
+    expect(deleteFlexFolderMock).toHaveBeenNthCalledWith(1, "dryhire-presupuesto");
+    expect(deleteFlexFolderMock).toHaveBeenNthCalledWith(2, "dryhire-folder");
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces cleanup failures with dryhire element context", async () => {
+    updateFlexElementHeaderMock
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("presupuesto header failed"));
+    deleteFlexFolderMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("dryhire delete failed"));
+
+    const job = {
+      id: "job-cleanup-failure-dryhire",
+      job_type: "dryhire",
+      title: "Cleanup Failure Dryhire Job",
+      start_time: "2025-01-01T10:00:00.000Z",
+      end_time: "2025-01-01T18:00:00.000Z",
+      job_departments: [{ department: "sound" }],
+    };
+
+    await expect(
+      createAllFoldersForJob(
+        job,
+        "2025-01-01T10:00:00.000Z",
+        "2025-01-01T18:00:00.000Z",
+        "250101"
+      )
+    ).rejects.toThrow(
+      "Cleanup also failed for: folder dryhire-folder (250101S): dryhire delete failed"
+    );
+
+    expect(deleteFlexFolderMock).toHaveBeenNthCalledWith(1, "dryhire-presupuesto");
+    expect(deleteFlexFolderMock).toHaveBeenNthCalledWith(2, "dryhire-folder");
     expect(insertMock).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/flex-folders/folders.ts
+++ b/src/utils/flex-folders/folders.ts
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import { toZonedTime } from "date-fns-tz";
 import { supabase } from "@/lib/supabase";
 import { Department } from "@/types/department";
 import {
@@ -9,7 +10,7 @@ import {
   getDepartmentExtrasPresupuestoMetadata,
   getSubfolderSelectionSummary,
 } from "./types";
-import { createFlexFolder } from "./api";
+import { createFlexFolder, updateFlexElementHeader } from "./api";
 import {
   FLEX_FOLDER_IDS,
   DEPARTMENT_IDS,
@@ -17,6 +18,8 @@ import {
   DEPARTMENT_SUFFIXES
 } from "./constants";
 import { getDryhireParentFolderId } from "./dryhireFolderService";
+
+const DEFAULT_FLEX_TIMEZONE = "Europe/Madrid";
 
 /**
  * Format date string for Flex API (ISO format with milliseconds)
@@ -32,6 +35,61 @@ function formatDateForFlex(dateStr: string | undefined): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function formatZonedDateForFlex(date: Date, timezone: string): string {
+  const zonedDate = toZonedTime(date, timezone);
+  return `${format(zonedDate, "yyyy-MM-dd'T'HH:mm:ss")}.000Z`;
+}
+
+function parseJobDate(value: unknown, fieldName: string): Date {
+  if (typeof value !== "string" && !(value instanceof Date)) {
+    throw new Error(`Invalid ${fieldName} for dryhire job`);
+  }
+
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    throw new Error(`Invalid ${fieldName} for dryhire job`);
+  }
+
+  return date;
+}
+
+function getJobTimezone(job: any): string {
+  const timezone = typeof job?.timezone === "string" ? job.timezone.trim() : "";
+  return timezone || DEFAULT_FLEX_TIMEZONE;
+}
+
+function getDryhireFlexSchedule(job: any) {
+  const timezone = getJobTimezone(job);
+  const startDate = parseJobDate(job?.start_time, "start_time");
+  const endDate = parseJobDate(job?.end_time, "end_time");
+  const zonedStartDate = toZonedTime(startDate, timezone);
+
+  return {
+    year: Number(format(zonedStartDate, "yyyy")),
+    monthKey: format(zonedStartDate, "MM"),
+    documentNumber: format(zonedStartDate, "yyMMdd"),
+    plannedStartDate: formatZonedDateForFlex(startDate, timezone),
+    plannedEndDate: formatZonedDateForFlex(endDate, timezone),
+  };
+}
+
+async function enforceDryhireHeaderFields(
+  elementId: string,
+  documentNumber: string,
+  plannedStartDate: string,
+  plannedEndDate: string
+) {
+  if (!elementId) {
+    throw new Error("Flex dryhire element creation returned no element ID");
+  }
+
+  await Promise.all([
+    updateFlexElementHeader(elementId, "documentNumber", documentNumber),
+    updateFlexElementHeader(elementId, "plannedStartDate", plannedStartDate),
+    updateFlexElementHeader(elementId, "plannedEndDate", plannedEndDate),
+  ]);
 }
 
 /**
@@ -473,24 +531,23 @@ export async function createAllFoldersForJob(
       throw new Error("Invalid department for dryhire job");
     }
 
-    const startDate = new Date(job.start_time);
-    const year = startDate.getFullYear();
-    const monthKey = startDate.toISOString().slice(5, 7);
+    const dryhireSchedule = getDryhireFlexSchedule(job);
+    const { year, monthKey } = dryhireSchedule;
     const parentFolderId = await getDryhireParentFolderId(year, department as "sound" | "lights", monthKey);
 
     if (!parentFolderId) {
       throw new Error(`No parent folder found for ${year}/${monthKey}. Please create dryhire folders for ${year} in Settings.`);
     }
 
-    const parentDocumentNumber = `${documentNumber}${DEPARTMENT_SUFFIXES[department as Department]}`;
+    const parentDocumentNumber = `${dryhireSchedule.documentNumber}${DEPARTMENT_SUFFIXES[department as Department]}`;
     const dryHireFolderPayload = {
       definitionId: FLEX_FOLDER_IDS.subFolder,
       parentElementId: parentFolderId,
       open: true,
       locked: false,
       name: `Dry Hire - ${job.title}`,
-      plannedStartDate: formattedStartDate,
-      plannedEndDate: formattedEndDate,
+      plannedStartDate: dryhireSchedule.plannedStartDate,
+      plannedEndDate: dryhireSchedule.plannedEndDate,
       locationId: FLEX_FOLDER_IDS.location,
       departmentId: DEPARTMENT_IDS[department as Department],
       documentNumber: parentDocumentNumber,
@@ -500,9 +557,13 @@ export async function createAllFoldersForJob(
     console.log("Creating dryhire folder with payload:", dryHireFolderPayload);
     const dryHireFolder = await createFlexFolder(dryHireFolderPayload);
 
+    if (!dryHireFolder.elementId) {
+      throw new Error("Flex dryhire folder creation returned no element ID");
+    }
+
     const dryHireDocumentSuffix = department === "sound" ? "SDH" : "LDH";
-    const dryHirePresupuestoDocumentNumber = `${documentNumber}${dryHireDocumentSuffix}`;
-    const presupuestoFolder = await createFlexFolder({
+    const dryHirePresupuestoDocumentNumber = `${dryhireSchedule.documentNumber}${dryHireDocumentSuffix}`;
+    const presupuestoFolderPayload = {
       definitionId: FLEX_FOLDER_IDS.presupuestoDryHire,
       parentElementId: dryHireFolder.elementId,
       open: true,
@@ -514,7 +575,23 @@ export async function createAllFoldersForJob(
       departmentId: dryHireFolderPayload.departmentId,
       documentNumber: dryHirePresupuestoDocumentNumber,
       personResponsibleId: dryHireFolderPayload.personResponsibleId,
-    });
+    };
+    const presupuestoFolder = await createFlexFolder(presupuestoFolderPayload);
+
+    await Promise.all([
+      enforceDryhireHeaderFields(
+        dryHireFolder.elementId,
+        dryHireFolderPayload.documentNumber,
+        dryHireFolderPayload.plannedStartDate,
+        dryHireFolderPayload.plannedEndDate
+      ),
+      enforceDryhireHeaderFields(
+        presupuestoFolder.elementId,
+        presupuestoFolderPayload.documentNumber,
+        presupuestoFolderPayload.plannedStartDate,
+        presupuestoFolderPayload.plannedEndDate
+      ),
+    ]);
 
     // Save both dryhire parent and presupuesto folders
     await supabase

--- a/src/utils/flex-folders/folders.ts
+++ b/src/utils/flex-folders/folders.ts
@@ -10,7 +10,7 @@ import {
   getDepartmentExtrasPresupuestoMetadata,
   getSubfolderSelectionSummary,
 } from "./types";
-import { createFlexFolder, updateFlexElementHeader } from "./api";
+import { createFlexFolder, deleteFlexFolder, updateFlexElementHeader } from "./api";
 import {
   FLEX_FOLDER_IDS,
   DEPARTMENT_IDS,
@@ -55,6 +55,16 @@ function parseJobDate(value: unknown, fieldName: string): Date {
   return date;
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}
+
 function getJobTimezone(job: any): string {
   const timezone = typeof job?.timezone === "string" ? job.timezone.trim() : "";
   return timezone || DEFAULT_FLEX_TIMEZONE;
@@ -75,21 +85,76 @@ function getDryhireFlexSchedule(job: any) {
   };
 }
 
-async function enforceDryhireHeaderFields(
-  elementId: string,
-  documentNumber: string,
-  plannedStartDate: string,
-  plannedEndDate: string
-) {
+interface DryhireCreatedElement {
+  label: string;
+  elementId: string;
+  documentNumber: string;
+}
+
+interface DryhireHeaderFields extends DryhireCreatedElement {
+  plannedStartDate: string;
+  plannedEndDate: string;
+}
+
+async function enforceDryhireHeaderFields({
+  label,
+  elementId,
+  documentNumber,
+  plannedStartDate,
+  plannedEndDate,
+}: DryhireHeaderFields) {
   if (!elementId) {
-    throw new Error("Flex dryhire element creation returned no element ID");
+    throw new Error(`Flex dryhire ${label} creation returned no element ID`);
   }
 
-  await Promise.all([
-    updateFlexElementHeader(elementId, "documentNumber", documentNumber),
-    updateFlexElementHeader(elementId, "plannedStartDate", plannedStartDate),
-    updateFlexElementHeader(elementId, "plannedEndDate", plannedEndDate),
-  ]);
+  const fields = [
+    { fieldType: "documentNumber", value: documentNumber },
+    { fieldType: "plannedStartDate", value: plannedStartDate },
+    { fieldType: "plannedEndDate", value: plannedEndDate },
+  ];
+
+  for (const field of fields) {
+    try {
+      await updateFlexElementHeader(elementId, field.fieldType, field.value);
+    } catch (error) {
+      console.error("Failed to enforce dryhire Flex header field:", {
+        label,
+        elementId,
+        documentNumber,
+        fieldType: field.fieldType,
+        value: field.value,
+        error,
+      });
+      throw new Error(
+        `Failed to enforce dryhire ${label} ${field.fieldType} for element ${elementId} (${documentNumber}): ${getErrorMessage(error)}`
+      );
+    }
+  }
+}
+
+async function cleanupCreatedDryhireElements(elements: DryhireCreatedElement[]) {
+  const cleanupFailures: string[] = [];
+
+  for (const element of elements) {
+    if (!element.elementId) {
+      continue;
+    }
+
+    try {
+      await deleteFlexFolder(element.elementId);
+      console.warn("Deleted dryhire Flex element after header enforcement failure:", element);
+    } catch (error) {
+      console.error("Failed to delete dryhire Flex element after header enforcement failure:", {
+        ...element,
+        error,
+      });
+      cleanupFailures.push(
+        `${element.label} ${element.elementId} (${element.documentNumber}): ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  return cleanupFailures;
 }
 
 /**
@@ -578,20 +643,47 @@ export async function createAllFoldersForJob(
     };
     const presupuestoFolder = await createFlexFolder(presupuestoFolderPayload);
 
-    await Promise.all([
-      enforceDryhireHeaderFields(
-        dryHireFolder.elementId,
-        dryHireFolderPayload.documentNumber,
-        dryHireFolderPayload.plannedStartDate,
-        dryHireFolderPayload.plannedEndDate
-      ),
-      enforceDryhireHeaderFields(
-        presupuestoFolder.elementId,
-        presupuestoFolderPayload.documentNumber,
-        presupuestoFolderPayload.plannedStartDate,
-        presupuestoFolderPayload.plannedEndDate
-      ),
-    ]);
+    const dryhireHeaderFields: DryhireHeaderFields = {
+      label: "folder",
+      elementId: dryHireFolder.elementId,
+      documentNumber: dryHireFolderPayload.documentNumber,
+      plannedStartDate: dryHireFolderPayload.plannedStartDate,
+      plannedEndDate: dryHireFolderPayload.plannedEndDate,
+    };
+    const presupuestoHeaderFields: DryhireHeaderFields = {
+      label: "presupuesto",
+      elementId: presupuestoFolder.elementId,
+      documentNumber: presupuestoFolderPayload.documentNumber,
+      plannedStartDate: presupuestoFolderPayload.plannedStartDate,
+      plannedEndDate: presupuestoFolderPayload.plannedEndDate,
+    };
+
+    try {
+      await enforceDryhireHeaderFields(dryhireHeaderFields);
+      await enforceDryhireHeaderFields(presupuestoHeaderFields);
+    } catch (error) {
+      console.error("Dryhire Flex header enforcement failed before local persistence. Attempting cleanup.", {
+        jobId: job.id,
+        dryhireElementId: dryhireHeaderFields.elementId,
+        dryhireDocumentNumber: dryhireHeaderFields.documentNumber,
+        presupuestoElementId: presupuestoHeaderFields.elementId,
+        presupuestoDocumentNumber: presupuestoHeaderFields.documentNumber,
+        error,
+      });
+
+      const cleanupFailures = await cleanupCreatedDryhireElements([
+        presupuestoHeaderFields,
+        dryhireHeaderFields,
+      ]);
+      const cleanupMessage =
+        cleanupFailures.length > 0
+          ? ` Cleanup also failed for: ${cleanupFailures.join("; ")}. Manual cleanup may be required.`
+          : " Created Flex elements were deleted; no local folder rows were persisted.";
+
+      throw new Error(
+        `Dryhire Flex header enforcement failed before local persistence: ${getErrorMessage(error)}.${cleanupMessage}`
+      );
+    }
 
     // Save both dryhire parent and presupuesto folders
     await supabase


### PR DESCRIPTION
## Summary
- derive dry-hire Flex parent month/year, document numbers, and planned dates from the job timezone instead of caller-provided UTC values
- enforce dry-hire folder and presupuesto header fields after Flex creation and before local flex_folders persistence
- add regression coverage for sound/lights numbers, Europe/Madrid UTC-boundary dates, and header-update failure behavior

## Tests
- ✅ npx vitest run src/utils/flex-folders/__tests__/folders.dryhire-document-number.test.ts src/utils/flex-folders/__tests__/folders.selection.test.ts src/utils/flex-folders/__tests__/folders.tourdate-location.test.ts
- ✅ git diff --check
- ⚠️ npx vitest run src/utils/flex-folders/__tests__ reports all 146 assertions passing but exits nonzero due existing unhandled Supabase auth storage errors in openFlexElement tests
- ⚠️ npx tsc -p tsconfig.app.json --noEmit fails on existing repo-wide type errors unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timezone-aware scheduling for dryhire jobs (Europe/Madrid default); document numbers and planned dates now follow the job's timezone.

* **Bug Fixes**
  * Stronger enforcement of required header fields on created folders; failures are logged, rolled back (created folders removed), and surfaced to callers to avoid incomplete persistence.

* **Tests**
  * Expanded test coverage for timezone handling, header-enforcement failures, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->