### PR TITLE
Scope dry hire Flex date sync to job elements

### DIFF
--- a/src/utils/flex-folders/__tests__/syncDateChange.dryhire.test.ts
+++ b/src/utils/flex-folders/__tests__/syncDateChange.dryhire.test.ts
@@ -7,7 +7,7 @@ const { getElementTreeMock, updateFlexElementHeaderMock, testState } = vi.hoiste
     job: {
       title: "Dry Hire - Alquiler AVL",
       job_type: "dryhire",
-      timezone: "Europe/Madrid",
+      timezone: "America/Los_Angeles",
       location: { name: "Madrid" },
     },
     folders: [] as Array<{
@@ -80,7 +80,7 @@ vi.mock("@/integrations/supabase/client", () => {
   };
 });
 
-import { syncFlexElementsForJobDateChange } from "../syncDateChange";
+import { syncFlexElementsForJobDateChange } from "@/utils/flex-folders/syncDateChange";
 
 describe("syncFlexElementsForJobDateChange dryhire scoping", () => {
   beforeEach(() => {
@@ -100,7 +100,7 @@ describe("syncFlexElementsForJobDateChange dryhire scoping", () => {
     testState.job = {
       title: "Dry Hire - Alquiler AVL",
       job_type: "dryhire",
-      timezone: "Europe/Madrid",
+      timezone: "America/Los_Angeles",
       location: { name: "Madrid" },
     };
     testState.folders = [
@@ -130,22 +130,22 @@ describe("syncFlexElementsForJobDateChange dryhire scoping", () => {
     expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
       "job-dryhire-folder",
       "documentNumber",
-      "260415S"
+      "260414S"
     );
     expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
       "job-dryhire-presupuesto",
       "documentNumber",
-      "260415SDH"
+      "260414SDH"
     );
     expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
       "job-dryhire-folder",
       "plannedStartDate",
-      "2026-04-15T00:30:00.000Z"
+      "2026-04-14T15:30:00.000Z"
     );
     expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
       "job-dryhire-presupuesto",
       "plannedEndDate",
-      "2026-04-15T03:00:00.000Z"
+      "2026-04-14T18:00:00.000Z"
     );
     expect(updateFlexElementHeaderMock).not.toHaveBeenCalledWith(
       "other-dryhire-folder",

--- a/src/utils/flex-folders/__tests__/syncDateChange.dryhire.test.ts
+++ b/src/utils/flex-folders/__tests__/syncDateChange.dryhire.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getElementTreeMock, updateFlexElementHeaderMock, testState } = vi.hoisted(() => ({
+  getElementTreeMock: vi.fn(),
+  updateFlexElementHeaderMock: vi.fn(),
+  testState: {
+    job: {
+      title: "Dry Hire - Alquiler AVL",
+      job_type: "dryhire",
+      timezone: "Europe/Madrid",
+      location: { name: "Madrid" },
+    },
+    folders: [] as Array<{
+      element_id: string;
+      department: string | null;
+      folder_type: string | null;
+    }>,
+  },
+}));
+
+vi.mock("@/utils/flex-folders/api", () => ({
+  updateFlexElementHeader: updateFlexElementHeaderMock,
+}));
+
+vi.mock("@/utils/flex-folders/getElementTree", () => ({
+  getElementTree: getElementTreeMock,
+}));
+
+vi.mock("@/integrations/supabase/client", () => {
+  type SupabaseResponse<T> = { data: T; error: null };
+  type SupabaseResult<T> = Promise<SupabaseResponse<T>>;
+
+  class MockQueryBuilder {
+    private table: string;
+    private singleResult = false;
+
+    constructor(table: string) {
+      this.table = table;
+    }
+
+    select(_columns?: string) {
+      return this;
+    }
+
+    eq(_column: string, _value: unknown) {
+      return this;
+    }
+
+    single() {
+      this.singleResult = true;
+      return this;
+    }
+
+    private async execute(): SupabaseResult<unknown> {
+      if (this.table === "jobs" && this.singleResult) {
+        return { data: testState.job, error: null };
+      }
+
+      if (this.table === "flex_folders") {
+        return { data: testState.folders, error: null };
+      }
+
+      throw new Error(`Unexpected table in dryhire sync test: ${this.table}`);
+    }
+
+    then<TResult1 = SupabaseResponse<unknown>, TResult2 = never>(
+      onfulfilled?:
+        | ((value: SupabaseResponse<unknown>) => TResult1 | PromiseLike<TResult1>)
+        | null,
+      onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ) {
+      return this.execute().then(onfulfilled, onrejected);
+    }
+  }
+
+  return {
+    supabase: {
+      from: (table: string) => new MockQueryBuilder(table),
+    },
+  };
+});
+
+import { syncFlexElementsForJobDateChange } from "../syncDateChange";
+
+describe("syncFlexElementsForJobDateChange dryhire scoping", () => {
+  beforeEach(() => {
+    updateFlexElementHeaderMock.mockReset();
+    getElementTreeMock.mockReset();
+    getElementTreeMock.mockResolvedValue([
+      {
+        elementId: "shared-month-parent",
+        documentNumber: "666.26.04",
+        children: [
+          { elementId: "other-dryhire-folder", documentNumber: "260401S" },
+          { elementId: "another-dryhire-folder", documentNumber: "260402S" },
+        ],
+      },
+    ]);
+    updateFlexElementHeaderMock.mockResolvedValue(undefined);
+    testState.job = {
+      title: "Dry Hire - Alquiler AVL",
+      job_type: "dryhire",
+      timezone: "Europe/Madrid",
+      location: { name: "Madrid" },
+    };
+    testState.folders = [
+      {
+        element_id: "job-dryhire-folder",
+        department: "sound",
+        folder_type: "dryhire",
+      },
+      {
+        element_id: "job-dryhire-presupuesto",
+        department: "sound",
+        folder_type: "dryhire_presupuesto",
+      },
+    ];
+  });
+
+  it("updates only recorded dryhire elements and does not traverse shared Flex trees", async () => {
+    const result = await syncFlexElementsForJobDateChange(
+      "job-1",
+      "2026-04-14T22:30:00.000Z",
+      "2026-04-15T01:00:00.000Z"
+    );
+
+    expect(result).toEqual({ success: 2, failed: 0, errors: [] });
+    expect(getElementTreeMock).not.toHaveBeenCalled();
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledTimes(6);
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "job-dryhire-folder",
+      "documentNumber",
+      "260415S"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "job-dryhire-presupuesto",
+      "documentNumber",
+      "260415SDH"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "job-dryhire-folder",
+      "plannedStartDate",
+      "2026-04-15T00:30:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "job-dryhire-presupuesto",
+      "plannedEndDate",
+      "2026-04-15T03:00:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).not.toHaveBeenCalledWith(
+      "other-dryhire-folder",
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  it("updates dryhire names when the job title changes without touching siblings", async () => {
+    const result = await syncFlexElementsForJobDateChange(
+      "job-1",
+      "2026-04-15T10:00:00.000Z",
+      "2026-04-15T18:00:00.000Z",
+      "Updated Dryhire"
+    );
+
+    expect(result).toEqual({ success: 2, failed: 0, errors: [] });
+    expect(getElementTreeMock).not.toHaveBeenCalled();
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "job-dryhire-folder",
+      "name",
+      "Dry Hire - Updated Dryhire"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "job-dryhire-presupuesto",
+      "name",
+      "Dry Hire - Updated Dryhire"
+    );
+  });
+});

--- a/src/utils/flex-folders/syncDateChange.ts
+++ b/src/utils/flex-folders/syncDateChange.ts
@@ -29,8 +29,8 @@ function getErrorMessage(error: unknown): string {
  * Format a date string for Flex API (ISO-like format with milliseconds)
  * Uses Europe/Madrid timezone for consistency with the app
  */
-function formatDateForFlex(date: Date): string {
-  const zonedDate = toZonedTime(date, DEFAULT_TIMEZONE);
+function formatDateForFlex(date: Date, timezone = DEFAULT_TIMEZONE): string {
+  const zonedDate = toZonedTime(date, timezone);
   // Format as ISO-like string in Madrid timezone
   const formatted = format(zonedDate, "yyyy-MM-dd'T'HH:mm:ss");
   return formatted + ".000Z";
@@ -40,8 +40,8 @@ function formatDateForFlex(date: Date): string {
  * Generate a YYMMDD document number from a date
  * Uses Europe/Madrid timezone for consistency with the app
  */
-function generateBaseDocumentNumber(date: Date): string {
-  const zonedDate = toZonedTime(date, DEFAULT_TIMEZONE);
+function generateBaseDocumentNumber(date: Date, timezone = DEFAULT_TIMEZONE): string {
+  const zonedDate = toZonedTime(date, timezone);
   return format(zonedDate, "yyMMdd");
 }
 
@@ -133,6 +133,108 @@ function generateFolderName(
   }
 }
 
+interface FlexFolderSyncRow {
+  element_id: string;
+  department: string | null;
+  folder_type: string | null;
+}
+
+function getDryhireDocumentSuffix(folder: FlexFolderSyncRow): string | null {
+  const department = folder.department;
+
+  if (department !== "sound" && department !== "lights") {
+    return null;
+  }
+
+  if (folder.folder_type === "dryhire") {
+    return department === "sound" ? "S" : "L";
+  }
+
+  if (folder.folder_type === "dryhire_presupuesto") {
+    return department === "sound" ? "SDH" : "LDH";
+  }
+
+  return null;
+}
+
+async function updateDryhireElement(
+  folder: FlexFolderSyncRow,
+  newBaseDocNumber: string,
+  formattedStartDate: string,
+  formattedEndDate: string,
+  newTitle?: string
+) {
+  const suffix = getDryhireDocumentSuffix(folder);
+
+  if (!suffix) {
+    throw new Error(
+      `Unsupported dryhire folder row: type=${folder.folder_type || "(none)"}, department=${folder.department || "(none)"}`
+    );
+  }
+
+  const newDocNumber = `${newBaseDocNumber}${suffix}`;
+
+  await updateFlexElementHeader(folder.element_id, "documentNumber", newDocNumber);
+  await updateFlexElementHeader(folder.element_id, "plannedStartDate", formattedStartDate);
+  await updateFlexElementHeader(folder.element_id, "plannedEndDate", formattedEndDate);
+
+  if (newTitle) {
+    await updateFlexElementHeader(folder.element_id, "name", `Dry Hire - ${newTitle}`);
+  }
+
+  return newDocNumber;
+}
+
+async function syncDryhireFlexElementsForJobDateChange(
+  folders: FlexFolderSyncRow[],
+  newBaseDocNumber: string,
+  formattedStartDate: string,
+  formattedEndDate: string,
+  newTitle?: string
+): Promise<SyncResult> {
+  const results: SyncResult = { success: 0, failed: 0, errors: [] };
+  const dryhireFolders = folders.filter(folder =>
+    folder.folder_type === "dryhire" || folder.folder_type === "dryhire_presupuesto"
+  );
+
+  if (dryhireFolders.length === 0) {
+    console.log("[syncFlexElements] No dryhire Flex folder rows found for job");
+    return results;
+  }
+
+  console.log(
+    `[syncFlexElements] Dryhire job detected. Syncing ${dryhireFolders.length} recorded dryhire element(s) without tree traversal.`
+  );
+
+  for (const folder of dryhireFolders) {
+    try {
+      const newDocNumber = await updateDryhireElement(
+        folder,
+        newBaseDocNumber,
+        formattedStartDate,
+        formattedEndDate,
+        newTitle
+      );
+
+      results.success++;
+      console.log(
+        `[syncFlexElements] Updated dryhire element ${folder.element_id} (${folder.folder_type || "unknown"}): ${newDocNumber}`
+      );
+    } catch (error: unknown) {
+      results.failed++;
+      const errorMsg = `Dryhire element ${folder.element_id}: ${getErrorMessage(error)}`;
+      results.errors.push(errorMsg);
+      console.error(`[syncFlexElements] ${errorMsg}`);
+    }
+  }
+
+  console.log(
+    `[syncFlexElements] Dryhire sync complete: ${results.success} succeeded, ${results.failed} failed`
+  );
+
+  return results;
+}
+
 /**
  * Sync all Flex elements for a job when its dates or title changes
  * Updates document numbers, planned dates, and folder names for all nested elements
@@ -170,6 +272,7 @@ export async function syncFlexElementsForJobDateChange(
     .select(`
       title,
       job_type,
+      timezone,
       location:locations(name)
     `)
     .eq("id", jobId)
@@ -198,6 +301,20 @@ export async function syncFlexElementsForJobDateChange(
   if (!folders || folders.length === 0) {
     console.log("[syncFlexElements] No flex folders found for job");
     return results;
+  }
+
+  if (jobData?.job_type === "dryhire") {
+    const timezone =
+      typeof jobData?.timezone === "string" && jobData.timezone.trim()
+        ? jobData.timezone.trim()
+        : DEFAULT_TIMEZONE;
+    return syncDryhireFlexElementsForJobDateChange(
+      folders,
+      generateBaseDocumentNumber(startDate, timezone),
+      formatDateForFlex(startDate, timezone),
+      formatDateForFlex(endDate, timezone),
+      newTitle
+    );
   }
 
   console.log(`[syncFlexElements] Found ${folders.length} root folders to sync`);

--- a/src/utils/flex-folders/syncDateChange.ts
+++ b/src/utils/flex-folders/syncDateChange.ts
@@ -27,18 +27,18 @@ function getErrorMessage(error: unknown): string {
 
 /**
  * Format a date string for Flex API (ISO-like format with milliseconds)
- * Uses Europe/Madrid timezone for consistency with the app
+ * Uses the job timezone for consistency with the app
  */
 function formatDateForFlex(date: Date, timezone = DEFAULT_TIMEZONE): string {
   const zonedDate = toZonedTime(date, timezone);
-  // Format as ISO-like string in Madrid timezone
+  // Format as ISO-like wall-clock time for Flex.
   const formatted = format(zonedDate, "yyyy-MM-dd'T'HH:mm:ss");
   return formatted + ".000Z";
 }
 
 /**
  * Generate a YYMMDD document number from a date
- * Uses Europe/Madrid timezone for consistency with the app
+ * Uses the job timezone for consistency with the app
  */
 function generateBaseDocumentNumber(date: Date, timezone = DEFAULT_TIMEZONE): string {
   const zonedDate = toZonedTime(date, timezone);
@@ -47,11 +47,17 @@ function generateBaseDocumentNumber(date: Date, timezone = DEFAULT_TIMEZONE): st
 
 /**
  * Format date for display in folder names (e.g., "Jan 15, 2026")
- * Uses Europe/Madrid timezone for consistency with the app
+ * Uses the job timezone for consistency with the app
  */
-function formatDateForDisplay(date: Date): string {
-  const zonedDate = toZonedTime(date, DEFAULT_TIMEZONE);
+function formatDateForDisplay(date: Date, timezone = DEFAULT_TIMEZONE): string {
+  const zonedDate = toZonedTime(date, timezone);
   return format(zonedDate, "MMM d, yyyy");
+}
+
+function getEffectiveTimezone(timezone: unknown): string {
+  return typeof timezone === "string" && timezone.trim()
+    ? timezone.trim()
+    : DEFAULT_TIMEZONE;
 }
 
 /**
@@ -256,15 +262,10 @@ export async function syncFlexElementsForJobDateChange(
   // Generate new date values
   const startDate = new Date(newStartTime);
   const endDate = new Date(newEndTime);
-  const newBaseDocNumber = generateBaseDocumentNumber(startDate);
-  const formattedStartDate = formatDateForFlex(startDate);
-  const formattedEndDate = formatDateForFlex(endDate);
-  const displayDate = formatDateForDisplay(startDate);
 
   console.log(
     `[syncFlexElements] Syncing job ${jobId} to new dates: ${newStartTime} - ${newEndTime}${newTitle ? `, new title: ${newTitle}` : ""}`
   );
-  console.log(`[syncFlexElements] New base document number: ${newBaseDocNumber}`);
 
   // Fetch job with location to get the location name and title for folder renaming
   const { data: jobData, error: jobError } = await supabase
@@ -286,6 +287,13 @@ export async function syncFlexElementsForJobDateChange(
   const locationName = jobData?.location?.name || "No Location";
   const jobTitle = newTitle || jobData?.title || "Untitled";
   const isTourDateJob = jobData?.job_type === "tourdate";
+  const effectiveTimezone = getEffectiveTimezone(jobData?.timezone);
+  const newBaseDocNumber = generateBaseDocumentNumber(startDate, effectiveTimezone);
+  const formattedStartDate = formatDateForFlex(startDate, effectiveTimezone);
+  const formattedEndDate = formatDateForFlex(endDate, effectiveTimezone);
+  const displayDate = formatDateForDisplay(startDate, effectiveTimezone);
+
+  console.log(`[syncFlexElements] New base document number: ${newBaseDocNumber}`);
 
   // Fetch all flex_folders for this job
   const { data: folders, error: foldersError } = await supabase
@@ -304,15 +312,11 @@ export async function syncFlexElementsForJobDateChange(
   }
 
   if (jobData?.job_type === "dryhire") {
-    const timezone =
-      typeof jobData?.timezone === "string" && jobData.timezone.trim()
-        ? jobData.timezone.trim()
-        : DEFAULT_TIMEZONE;
     return syncDryhireFlexElementsForJobDateChange(
       folders,
-      generateBaseDocumentNumber(startDate, timezone),
-      formatDateForFlex(startDate, timezone),
-      formatDateForFlex(endDate, timezone),
+      newBaseDocNumber,
+      formattedStartDate,
+      formattedEndDate,
       newTitle
     );
   }


### PR DESCRIPTION
## Summary
- scope dry-hire date/title sync to the job's recorded dryhire and dryhire_presupuesto Flex rows
- avoid Flex tree traversal for dry-hire jobs so shared monthly siblings are not touched
- preserve sound/lights document suffixes and use the job timezone for document numbers and planned dates
- add a regression test covering the shared-tree sibling case and title updates

## Tests
- npx vitest run src/utils/flex-folders/__tests__/syncDateChange.dryhire.test.ts
- npx vitest run src/utils/flex-folders/__tests__/syncDateChange.dryhire.test.ts src/utils/flex-folders/__tests__/folders.dryhire-document-number.test.ts src/utils/flex-folders/__tests__/folders.selection.test.ts src/utils/flex-folders/__tests__/folders.tourdate-location.test.ts
- npx eslint src/utils/flex-folders/syncDateChange.ts src/utils/flex-folders/__tests__/syncDateChange.dryhire.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced job date synchronization with timezone-aware scheduling support
  * Added specialized sync handling for dryhire job types with proper metadata updates

* **Tests**
  * Added test coverage for dryhire job date and title synchronization workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->