### PR TITLE
fix: correct gear comparison severity levels and unlock console model selection

### DIFF
--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -143,7 +143,7 @@ export const ArtistTable = ({
   selectedDate,
   onArtistStagePlotUpdated
 }: ArtistTableProps) => {
-  const { createExtrasPresupuesto, creatingExtrasForArtistId } = useCreateExtrasPresupuesto(jobId);
+  const { createExtrasPresupuesto, isCreatingExtrasFor } = useCreateExtrasPresupuesto(jobId);
   const [deletingArtistId, setDeletingArtistId] = useState<string | null>(null);
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [linksDialogOpen, setLinksDialogOpen] = useState(false);
@@ -1085,11 +1085,11 @@ export const ArtistTable = ({
                               variant="ghost"
                               size="icon"
                               onClick={() => createExtrasPresupuesto(artist.id, artist.name, artist.date, artist.show_start, artist.show_end, artist.isaftermidnight || false)}
-                              disabled={creatingExtrasForArtistId === artist.id}
+                              disabled={isCreatingExtrasFor(artist.id)}
                               title="Crear presupuesto extras en Flex"
                               className="text-amber-600 hover:text-amber-700 hover:bg-amber-50"
                             >
-                              {creatingExtrasForArtistId === artist.id
+                              {isCreatingExtrasFor(artist.id)
                                 ? <Loader2 className="h-4 w-4 animate-spin" />
                                 : <Receipt className="h-4 w-4" />}
                             </Button>
@@ -1131,7 +1131,7 @@ export const ArtistTable = ({
               uploadingStagePlotArtistId={uploadingStagePlotArtistId}
               deletingStagePlotArtistId={deletingStagePlotArtistId}
               onCreateFlexExtras={createExtrasPresupuesto}
-              creatingExtrasForArtistId={creatingExtrasForArtistId}
+              isCreatingExtrasFor={isCreatingExtrasFor}
             />
           </div>
 

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -1084,7 +1084,7 @@ export const ArtistTable = ({
                             <Button
                               variant="ghost"
                               size="icon"
-                              onClick={() => createExtrasPresupuesto(artist.id, artist.name)}
+                              onClick={() => createExtrasPresupuesto(artist.id, artist.name, artist.date, artist.show_start, artist.show_end, artist.isaftermidnight || false)}
                               disabled={creatingExtrasForArtistId === artist.id}
                               title="Crear presupuesto extras en Flex"
                               className="text-amber-600 hover:text-amber-700 hover:bg-amber-50"
@@ -1130,6 +1130,8 @@ export const ArtistTable = ({
               deletingArtistId={deletingArtistId}
               uploadingStagePlotArtistId={uploadingStagePlotArtistId}
               deletingStagePlotArtistId={deletingStagePlotArtistId}
+              onCreateFlexExtras={createExtrasPresupuesto}
+              creatingExtrasForArtistId={creatingExtrasForArtistId}
             />
           </div>
 

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, type ChangeEvent, type ClipboardEvent as R
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Pencil, Trash2, FileText, Loader2, Mic, Link, ExternalLink, Printer, ImagePlus, ImageOff } from "lucide-react";
+import { Pencil, Trash2, FileText, Loader2, Mic, Link, ExternalLink, Printer, ImagePlus, ImageOff, Receipt } from "lucide-react";
 import { format, parseISO, isAfter, setHours, setMinutes } from "date-fns";
 import { ArtistFormLinkDialog } from "./ArtistFormLinkDialog";
 import { ArtistFormLinksDialog } from "./ArtistFormLinksDialog";
@@ -19,6 +19,7 @@ import { GearMismatchIndicator } from "./GearMismatchIndicator";
 import { FestivalGearSetup, StageGearSetup } from "@/types/festival";
 import { buildReadableFilename } from "@/utils/fileName";
 import { MobileArtistList } from "./mobile/MobileArtistList";
+import { useCreateExtrasPresupuesto } from "@/hooks/festival/useCreateExtrasPresupuesto";
 
 interface Artist {
   id: string;
@@ -142,6 +143,7 @@ export const ArtistTable = ({
   selectedDate,
   onArtistStagePlotUpdated
 }: ArtistTableProps) => {
+  const { createExtrasPresupuesto, creatingExtrasForArtistId } = useCreateExtrasPresupuesto(jobId);
   const [deletingArtistId, setDeletingArtistId] = useState<string | null>(null);
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [linksDialogOpen, setLinksDialogOpen] = useState(false);
@@ -1076,6 +1078,20 @@ export const ArtistTable = ({
                               title="Delete stage plot"
                             >
                               {deletingStagePlotArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImageOff className="h-4 w-4" />}
+                            </Button>
+                          )}
+                          {gearComparison?.mismatches.some(m => m.severity === 'error') && (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => createExtrasPresupuesto(artist.id, artist.name)}
+                              disabled={creatingExtrasForArtistId === artist.id}
+                              title="Crear presupuesto extras en Flex"
+                              className="text-amber-600 hover:text-amber-700 hover:bg-amber-50"
+                            >
+                              {creatingExtrasForArtistId === artist.id
+                                ? <Loader2 className="h-4 w-4 animate-spin" />
+                                : <Receipt className="h-4 w-4" />}
                             </Button>
                           )}
                           <Button variant="ghost" size="icon" onClick={() => onEditArtist(artist)} title="Edit artist">

--- a/src/components/festival/GearMismatchIndicator.tsx
+++ b/src/components/festival/GearMismatchIndicator.tsx
@@ -1,5 +1,5 @@
 
-import { AlertTriangle, XCircle } from "lucide-react";
+import { AlertTriangle, Info, XCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { GearMismatch } from "@/utils/gearComparisonService";
@@ -24,10 +24,11 @@ export const GearMismatchIndicator = ({ mismatches, compact = false }: GearMisma
 
   const errors = mismatches.filter(m => m.severity === 'error');
   const warnings = mismatches.filter(m => m.severity === 'warning');
+  const infos = mismatches.filter(m => m.severity === 'info');
 
   const tooltipContent = (
     <div className="max-w-sm space-y-2">
-      <p className="font-medium">Problemas de equipo:</p>
+      <p className="font-medium">Estado del equipo:</p>
       {errors.length > 0 && (
         <div>
           <p className="text-red-600 font-medium text-xs">Errores ({errors.length}):</p>
@@ -50,6 +51,17 @@ export const GearMismatchIndicator = ({ mismatches, compact = false }: GearMisma
           ))}
         </div>
       )}
+      {infos.length > 0 && (
+        <div>
+          <p className="text-blue-600 font-medium text-xs">Información ({infos.length}):</p>
+          {infos.map((info, index) => (
+            <div key={index} className="text-xs">
+              <p className="text-blue-600">• {info.message}</p>
+              {info.details && <p className="text-gray-500 ml-2">{info.details}</p>}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 
@@ -68,6 +80,12 @@ export const GearMismatchIndicator = ({ mismatches, compact = false }: GearMisma
               <Badge variant="outline" className="text-xs px-1 bg-orange-100 text-orange-800 border-orange-300">
                 <AlertTriangle className="h-3 w-3 mr-1" />
                 {warnings.length}
+              </Badge>
+            )}
+            {infos.length > 0 && (
+              <Badge variant="outline" className="text-xs px-1 bg-blue-50 text-blue-600 border-blue-200">
+                <Info className="h-3 w-3 mr-1" />
+                {infos.length}
               </Badge>
             )}
           </div>
@@ -93,6 +111,12 @@ export const GearMismatchIndicator = ({ mismatches, compact = false }: GearMisma
             <Badge variant="outline" className="text-xs bg-orange-100 text-orange-800 border-orange-300">
               <AlertTriangle className="h-3 w-3 mr-1" />
               {warnings.length} Advertencia{warnings.length !== 1 ? 's' : ''}
+            </Badge>
+          )}
+          {infos.length > 0 && (
+            <Badge variant="outline" className="text-xs bg-blue-50 text-blue-600 border-blue-200">
+              <Info className="h-3 w-3 mr-1" />
+              {infos.length} Info
             </Badge>
           )}
         </div>

--- a/src/components/festival/GearMismatchIndicator.tsx
+++ b/src/components/festival/GearMismatchIndicator.tsx
@@ -116,7 +116,7 @@ export const GearMismatchIndicator = ({ mismatches, compact = false }: GearMisma
           {infos.length > 0 && (
             <Badge variant="outline" className="text-xs bg-blue-50 text-blue-600 border-blue-200">
               <Info className="h-3 w-3 mr-1" />
-              {infos.length} Info
+              {infos.length} Información
             </Badge>
           )}
         </div>

--- a/src/components/festival/form/sections/ConsoleSetupSection.tsx
+++ b/src/components/festival/form/sections/ConsoleSetupSection.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { ArtistSectionProps } from "@/types/artist-form";
 import { useEquipmentModels } from "@/hooks/useEquipmentModels";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { FESTIVAL_CONSOLE_OPTIONS } from "@/constants/festivalConsoleOptions";
 
 export const ConsoleSetupSection = ({ formData, onChange, gearSetup, isFieldLocked, language = "es" }: ArtistSectionProps) => {
@@ -24,65 +24,8 @@ export const ConsoleSetupSection = ({ formData, onChange, gearSetup, isFieldLock
   const allFohOptions = Array.from(new Set([...fohConsoleOptions, ...FESTIVAL_CONSOLE_OPTIONS]));
   const allMonOptions = Array.from(new Set([...monConsoleOptions, ...FESTIVAL_CONSOLE_OPTIONS]));
 
-  const festivalFohOptions = useMemo(
-    () =>
-      Array.from(
-        new Set((gearSetup?.foh_consoles || []).map((consoleItem) => consoleItem?.model?.trim()).filter(Boolean))
-      ),
-    [gearSetup?.foh_consoles]
-  );
-
-  const festivalMonOptions = useMemo(
-    () =>
-      Array.from(
-        new Set((gearSetup?.mon_consoles || []).map((consoleItem) => consoleItem?.model?.trim()).filter(Boolean))
-      ),
-    [gearSetup?.mon_consoles]
-  );
-
-  const fohOptions = useMemo(() => {
-    if (formData.foh_console_provided_by === "festival") return festivalFohOptions;
-    return allFohOptions;
-  }, [allFohOptions, festivalFohOptions, formData.foh_console_provided_by]);
-
-  const monOptions = useMemo(() => {
-    if (formData.mon_console_provided_by === "festival") return festivalMonOptions;
-    return allMonOptions;
-  }, [allMonOptions, festivalMonOptions, formData.mon_console_provided_by]);
-
-  useEffect(() => {
-    if (
-      formData.foh_console_provided_by === "festival" &&
-      formData.foh_console &&
-      !fohOptions.includes(formData.foh_console)
-    ) {
-      onChange({ foh_console: "" });
-    }
-    if (
-      formData.foh_console_provided_by === "band" &&
-      formData.foh_console &&
-      !allFohOptions.includes(formData.foh_console)
-    ) {
-      onChange({ foh_console: "" });
-    }
-  }, [allFohOptions, formData.foh_console, formData.foh_console_provided_by, fohOptions, onChange]);
-
-  useEffect(() => {
-    if (
-      formData.mon_console_provided_by === "festival" &&
-      formData.mon_console &&
-      !monOptions.includes(formData.mon_console)
-    ) {
-      onChange({ mon_console: "" });
-    }
-    if (
-      formData.mon_console_provided_by === "band" &&
-      formData.mon_console &&
-      !allMonOptions.includes(formData.mon_console)
-    ) {
-      onChange({ mon_console: "" });
-    }
-  }, [allMonOptions, formData.mon_console, formData.mon_console_provided_by, monOptions, onChange]);
+  const fohOptions = allFohOptions;
+  const monOptions = allMonOptions;
 
   useEffect(() => {
     if (!formData.monitors_from_foh) return;

--- a/src/components/festival/mobile/MobileArtistCard.tsx
+++ b/src/components/festival/mobile/MobileArtistCard.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import {
   Sliders, Radio, Mic2, Speaker, Cable, StickyNote, FileDown,
   Link, FileText, Printer, Pencil, Trash2, ImagePlus, ImageOff,
-  Loader2, MoreHorizontal
+  Loader2, MoreHorizontal, Receipt
 } from "lucide-react";
 import { ConfigSummaryRow } from "./ConfigSummaryRow";
 import { GearMismatchIndicator } from "../GearMismatchIndicator";
@@ -183,6 +183,8 @@ interface MobileArtistCardProps {
   deletingArtistId: string | null;
   uploadingStagePlotArtistId: string | null;
   deletingStagePlotArtistId: string | null;
+  creatingExtrasForArtistId: string | null;
+  onCreateFlexExtras: (artistId: string, artistName: string, artistDate: string, showStart: string, showEnd: string, isAfterMidnight: boolean) => void;
   riderFiles?: MobileArtistRiderFile[];
 }
 
@@ -204,6 +206,8 @@ export const MobileArtistCard = ({
   deletingArtistId,
   uploadingStagePlotArtistId,
   deletingStagePlotArtistId,
+  creatingExtrasForArtistId,
+  onCreateFlexExtras,
   riderFiles = [],
 }: MobileArtistCardProps) => {
   return (
@@ -384,6 +388,16 @@ export const MobileArtistCard = ({
               disabled={deletingStagePlotArtistId === artist.id}
             >
               {deletingStagePlotArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImageOff className="h-4 w-4" />}
+            </Button>
+          )}
+          {gearComparison?.mismatches.some(m => m.severity === 'error') && (
+            <Button
+              variant="ghost" size="icon" className="h-8 w-8 text-amber-600 hover:text-amber-700 hover:bg-amber-50"
+              onClick={() => onCreateFlexExtras(artist.id, artist.name, artist.date, artist.show_start, artist.show_end, artist.isaftermidnight || false)}
+              disabled={creatingExtrasForArtistId === artist.id}
+              title="Crear presupuesto extras en Flex"
+            >
+              {creatingExtrasForArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Receipt className="h-4 w-4" />}
             </Button>
           )}
           <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onEditArtist(artist)}>

--- a/src/components/festival/mobile/MobileArtistCard.tsx
+++ b/src/components/festival/mobile/MobileArtistCard.tsx
@@ -183,7 +183,7 @@ interface MobileArtistCardProps {
   deletingArtistId: string | null;
   uploadingStagePlotArtistId: string | null;
   deletingStagePlotArtistId: string | null;
-  creatingExtrasForArtistId: string | null;
+  isCreatingExtrasFor: (id: string) => boolean;
   onCreateFlexExtras: (artistId: string, artistName: string, artistDate: string, showStart: string, showEnd: string, isAfterMidnight: boolean) => void;
   riderFiles?: MobileArtistRiderFile[];
 }
@@ -206,7 +206,7 @@ export const MobileArtistCard = ({
   deletingArtistId,
   uploadingStagePlotArtistId,
   deletingStagePlotArtistId,
-  creatingExtrasForArtistId,
+  isCreatingExtrasFor,
   onCreateFlexExtras,
   riderFiles = [],
 }: MobileArtistCardProps) => {
@@ -394,10 +394,10 @@ export const MobileArtistCard = ({
             <Button
               variant="ghost" size="icon" className="h-8 w-8 text-amber-600 hover:text-amber-700 hover:bg-amber-50"
               onClick={() => onCreateFlexExtras(artist.id, artist.name, artist.date, artist.show_start, artist.show_end, artist.isaftermidnight || false)}
-              disabled={creatingExtrasForArtistId === artist.id}
+              disabled={isCreatingExtrasFor(artist.id)}
               title="Crear presupuesto extras en Flex"
             >
-              {creatingExtrasForArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Receipt className="h-4 w-4" />}
+              {isCreatingExtrasFor(artist.id) ? <Loader2 className="h-4 w-4 animate-spin" /> : <Receipt className="h-4 w-4" />}
             </Button>
           )}
           <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onEditArtist(artist)}>

--- a/src/components/festival/mobile/MobileArtistList.tsx
+++ b/src/components/festival/mobile/MobileArtistList.tsx
@@ -82,10 +82,12 @@ interface MobileArtistListProps {
   onOpenStagePlotCapture: (artist: Artist) => void;
   onDeleteStagePlot: (artist: Artist) => void;
   onArtistsChanged: () => void;
+  onCreateFlexExtras: (artistId: string, artistName: string, artistDate: string, showStart: string, showEnd: string, isAfterMidnight: boolean) => void;
   printingArtistId: string | null;
   deletingArtistId: string | null;
   uploadingStagePlotArtistId: string | null;
   deletingStagePlotArtistId: string | null;
+  creatingExtrasForArtistId: string | null;
   mode?: 'edit' | 'readonly';
   riderFilesByArtistId?: Record<string, MobileArtistRiderFile[]>;
   onDownloadRiderFile?: (file: MobileArtistRiderFile) => void;
@@ -106,10 +108,12 @@ export const MobileArtistList = ({
   onOpenStagePlotCapture,
   onDeleteStagePlot,
   onArtistsChanged,
+  onCreateFlexExtras,
   printingArtistId,
   deletingArtistId,
   uploadingStagePlotArtistId,
   deletingStagePlotArtistId,
+  creatingExtrasForArtistId,
   mode = 'edit',
   riderFilesByArtistId = {},
   onDownloadRiderFile,
@@ -201,10 +205,12 @@ export const MobileArtistList = ({
             onDeleteArtist={onDeleteArtist}
             onOpenStagePlotCapture={onOpenStagePlotCapture}
             onDeleteStagePlot={onDeleteStagePlot}
+            onCreateFlexExtras={onCreateFlexExtras}
             printingArtistId={printingArtistId}
             deletingArtistId={deletingArtistId}
             uploadingStagePlotArtistId={uploadingStagePlotArtistId}
             deletingStagePlotArtistId={deletingStagePlotArtistId}
+            creatingExtrasForArtistId={creatingExtrasForArtistId}
             riderFiles={riderFilesByArtistId[artist.id] || []}
           />
         </div>

--- a/src/components/festival/mobile/MobileArtistList.tsx
+++ b/src/components/festival/mobile/MobileArtistList.tsx
@@ -87,7 +87,7 @@ interface MobileArtistListProps {
   deletingArtistId: string | null;
   uploadingStagePlotArtistId: string | null;
   deletingStagePlotArtistId: string | null;
-  creatingExtrasForArtistId: string | null;
+  isCreatingExtrasFor: (id: string) => boolean;
   mode?: 'edit' | 'readonly';
   riderFilesByArtistId?: Record<string, MobileArtistRiderFile[]>;
   onDownloadRiderFile?: (file: MobileArtistRiderFile) => void;
@@ -113,7 +113,7 @@ export const MobileArtistList = ({
   deletingArtistId,
   uploadingStagePlotArtistId,
   deletingStagePlotArtistId,
-  creatingExtrasForArtistId,
+  isCreatingExtrasFor,
   mode = 'edit',
   riderFilesByArtistId = {},
   onDownloadRiderFile,
@@ -210,7 +210,7 @@ export const MobileArtistList = ({
             deletingArtistId={deletingArtistId}
             uploadingStagePlotArtistId={uploadingStagePlotArtistId}
             deletingStagePlotArtistId={deletingStagePlotArtistId}
-            creatingExtrasForArtistId={creatingExtrasForArtistId}
+            isCreatingExtrasFor={isCreatingExtrasFor}
             riderFiles={riderFilesByArtistId[artist.id] || []}
           />
         </div>

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import { createFlexFolder } from "@/utils/flex-folders/api";
+import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS } from "@/utils/flex-folders/constants";
+
+export function useCreateExtrasPresupuesto(jobId: string | undefined) {
+  const [creatingExtrasForArtistId, setCreatingExtrasForArtistId] = useState<string | null>(null);
+
+  const createExtrasPresupuesto = async (artistId: string, artistName: string) => {
+    if (!jobId) {
+      toast.error("No hay job ID disponible");
+      return;
+    }
+
+    setCreatingExtrasForArtistId(artistId);
+
+    try {
+      // 1. Get job title for folder naming
+      const { data: job, error: jobError } = await supabase
+        .from("jobs")
+        .select("title")
+        .eq("id", jobId)
+        .single();
+
+      if (jobError || !job) {
+        throw new Error("No se pudo obtener la información del job");
+      }
+
+      const jobTitle = job.title?.trim() || "Sin título";
+
+      // 2. Find the comercial department folder for this job
+      const { data: comercialFolder, error: comercialError } = await supabase
+        .from("flex_folders")
+        .select("id, element_id")
+        .eq("job_id", jobId)
+        .eq("folder_type", "department")
+        .eq("department", "comercial")
+        .maybeSingle();
+
+      if (comercialError) throw comercialError;
+
+      if (!comercialFolder) {
+        toast.error(
+          "No existe carpeta comercial para este evento en Flex. Crea primero las carpetas del job."
+        );
+        return;
+      }
+
+      // 3. Find or create the sound extras subfolder inside comercial
+      const { data: existingExtras, error: extrasQueryError } = await supabase
+        .from("flex_folders")
+        .select("id, element_id")
+        .eq("job_id", jobId)
+        .eq("folder_type", "comercial_extras")
+        .eq("department", "sound")
+        .maybeSingle();
+
+      if (extrasQueryError) throw extrasQueryError;
+
+      let extrasElementId: string;
+
+      if (existingExtras) {
+        extrasElementId = existingExtras.element_id;
+      } else {
+        // Create the extras folder in Flex
+        const extrasFolder = await createFlexFolder({
+          definitionId: FLEX_FOLDER_IDS.subFolder,
+          parentElementId: comercialFolder.element_id,
+          open: true,
+          locked: false,
+          name: `Extras ${jobTitle} - Sonido`,
+          locationId: FLEX_FOLDER_IDS.location,
+          departmentId: DEPARTMENT_IDS.sound,
+          personResponsibleId: RESPONSIBLE_PERSON_IDS.sound,
+        });
+
+        extrasElementId = extrasFolder.elementId;
+
+        // Persist extras folder to DB
+        const { error: extrasInsertError } = await supabase
+          .from("flex_folders")
+          .insert({
+            job_id: jobId,
+            parent_id: comercialFolder.element_id,
+            element_id: extrasElementId,
+            department: "sound",
+            folder_type: "comercial_extras",
+          });
+
+        if (extrasInsertError) {
+          console.error(
+            `Orphaned Flex folder created with element_id: ${extrasElementId}`,
+            extrasInsertError
+          );
+          throw extrasInsertError;
+        }
+      }
+
+      // 4. Create the presupuesto inside the extras folder
+      const presupuesto = await createFlexFolder({
+        definitionId: FLEX_FOLDER_IDS.presupuesto,
+        parentElementId: extrasElementId,
+        open: true,
+        locked: false,
+        name: `${artistName} - Extras`,
+        locationId: FLEX_FOLDER_IDS.location,
+        departmentId: DEPARTMENT_IDS.sound,
+        personResponsibleId: RESPONSIBLE_PERSON_IDS.sound,
+      });
+
+      // 5. Persist presupuesto to DB
+      const { error: presupuestoInsertError } = await supabase
+        .from("flex_folders")
+        .insert({
+          job_id: jobId,
+          parent_id: extrasElementId,
+          element_id: presupuesto.elementId,
+          department: "sound",
+          folder_type: "comercial_presupuesto",
+        });
+
+      if (presupuestoInsertError) {
+        console.error(
+          `Orphaned Flex presupuesto created with element_id: ${presupuesto.elementId}`,
+          presupuestoInsertError
+        );
+        throw presupuestoInsertError;
+      }
+
+      toast.success(`Presupuesto "${artistName} - Extras" creado en Flex`);
+    } catch (error) {
+      console.error("Error creating Flex extras presupuesto:", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Error al crear el presupuesto de extras en Flex"
+      );
+    } finally {
+      setCreatingExtrasForArtistId(null);
+    }
+  };
+
+  return { createExtrasPresupuesto, creatingExtrasForArtistId };
+}

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -11,8 +11,29 @@ import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS } from "@/utils
 // count and produce duplicate document numbers within a single browser session.
 const jobCreationQueues = new Map<string, Promise<void>>();
 
+const RETRY_DELAYS = [500, 1000, 2000];
+
+async function insertWithRetry(insertFn: () => Promise<{ error: any }>): Promise<void> {
+  let lastError: any = null;
+  for (let i = 0; i <= RETRY_DELAYS.length; i++) {
+    const { error } = await insertFn();
+    if (!error) return;
+    lastError = error;
+    if (i < RETRY_DELAYS.length) {
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAYS[i]));
+    }
+  }
+  throw lastError;
+}
+
 export function useCreateExtrasPresupuesto(jobId: string | undefined) {
-  const [creatingExtrasForArtistId, setCreatingExtrasForArtistId] = useState<string | null>(null);
+  const [creatingExtrasForArtistIds, setCreatingExtrasForArtistIds] = useState<Set<string>>(new Set());
+
+  const addCreating = (id: string) =>
+    setCreatingExtrasForArtistIds(prev => new Set(prev).add(id));
+  const removeCreating = (id: string) =>
+    setCreatingExtrasForArtistIds(prev => { const s = new Set(prev); s.delete(id); return s; });
+  const isCreatingExtrasFor = (id: string) => creatingExtrasForArtistIds.has(id);
 
   const createExtrasPresupuesto = async (
     artistId: string,
@@ -27,14 +48,15 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
       return;
     }
 
-    setCreatingExtrasForArtistId(artistId);
+    addCreating(artistId);
 
     // Enqueue: wait for any in-flight request for this job to finish before
     // reading the count, ensuring ordinals are assigned sequentially.
     const prevTask = jobCreationQueues.get(jobId) ?? Promise.resolve();
     let releaseThisTask!: () => void;
     const thisTask = new Promise<void>(res => { releaseThisTask = res; });
-    jobCreationQueues.set(jobId, prevTask.then(() => thisTask));
+    const nextPromise = prevTask.then(() => thisTask);
+    jobCreationQueues.set(jobId, nextPromise);
     await prevTask.catch(() => {}); // a failure in the prev task must not block this one
 
     try {
@@ -60,28 +82,17 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
       const plannedStartDate = fromZonedTime(localStartDatetime, "Europe/Madrid").toISOString();
       const plannedEndDate = fromZonedTime(localEndDatetime, "Europe/Madrid").toISOString();
 
-      // 3. Compute document number with retry on conflict: DDMMAA.xSQT
-      //    x = ordinal of extras presupuestos already created for this job + 1
-      let documentNumber: string | null = null;
-      let retryCount = 0;
-      const maxRetries = 3;
+      // 3. Compute document number: DDMMAA.xSQT
+      //    Count runs inside the queue so the ordinal is always fresh.
+      const { count } = await supabase
+        .from("flex_folders")
+        .select("id", { count: "exact", head: true })
+        .eq("job_id", jobId)
+        .eq("folder_type", "comercial_presupuesto");
 
-      while (!documentNumber && retryCount < maxRetries) {
-        const { count } = await supabase
-          .from("flex_folders")
-          .select("id", { count: "exact", head: true })
-          .eq("job_id", jobId)
-          .eq("folder_type", "comercial_presupuesto");
-
-        const ordinal = (count ?? 0) + 1;
-        const docDate = format(parsedDate, "ddMMyy");
-        documentNumber = `${docDate}.${ordinal}SQT`;
-        retryCount++;
-      }
-
-      if (!documentNumber) {
-        throw new Error("No se pudo calcular el número de documento después de múltiples intentos");
-      }
+      const ordinal = (count ?? 0) + 1;
+      const docDate = format(parsedDate, "ddMMyy");
+      const documentNumber = `${docDate}.${ordinal}SQT`;
 
       // 4. Find the comercial department folder for this job
       const { data: comercialFolder, error: comercialError } = await supabase
@@ -132,41 +143,23 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
 
         extrasElementId = extrasFolder.elementId;
 
-        // Retry insertion with exponential backoff
-        let extrasInserted = false;
-        let extrasInsertError: any = null;
-        const retryDelays = [500, 1000, 2000];
-
-        for (let i = 0; i < retryDelays.length + 1; i++) {
-          const { error } = await supabase
-            .from("flex_folders")
-            .insert({
+        try {
+          await insertWithRetry(() =>
+            supabase.from("flex_folders").insert({
               job_id: jobId,
               parent_id: comercialFolder.element_id,
               element_id: extrasElementId,
               department: "sound",
               folder_type: "comercial_extras",
-            });
-
-          if (!error) {
-            extrasInserted = true;
-            break;
-          }
-
-          extrasInsertError = error;
-
-          if (i < retryDelays.length) {
-            await new Promise(resolve => setTimeout(resolve, retryDelays[i]));
-          }
-        }
-
-        if (!extrasInserted) {
-          console.error(`Orphaned Flex folder created with element_id: ${extrasElementId}`, extrasInsertError);
+            })
+          );
+        } catch (err) {
+          console.error(`Orphaned Flex folder created with element_id: ${extrasElementId}`, err);
           toast.error(
             `Error al persistir carpeta extras en base de datos. Carpeta huérfana creada con element_id: ${extrasElementId}`,
             { duration: 10000 }
           );
-          throw extrasInsertError;
+          throw err;
         }
       }
 
@@ -185,41 +178,24 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
         personResponsibleId: RESPONSIBLE_PERSON_IDS.sound,
       });
 
-      // 7. Persist presupuesto to DB with retry
-      let presupuestoInserted = false;
-      let presupuestoInsertError: any = null;
-      const retryDelays = [500, 1000, 2000];
-
-      for (let i = 0; i < retryDelays.length + 1; i++) {
-        const { error } = await supabase
-          .from("flex_folders")
-          .insert({
+      // 7. Persist presupuesto to DB
+      try {
+        await insertWithRetry(() =>
+          supabase.from("flex_folders").insert({
             job_id: jobId,
             parent_id: extrasElementId,
             element_id: presupuesto.elementId,
             department: "sound",
             folder_type: "comercial_presupuesto",
-          });
-
-        if (!error) {
-          presupuestoInserted = true;
-          break;
-        }
-
-        presupuestoInsertError = error;
-
-        if (i < retryDelays.length) {
-          await new Promise(resolve => setTimeout(resolve, retryDelays[i]));
-        }
-      }
-
-      if (!presupuestoInserted) {
-        console.error(`Orphaned Flex presupuesto created with element_id: ${presupuesto.elementId}`, presupuestoInsertError);
+          })
+        );
+      } catch (err) {
+        console.error(`Orphaned Flex presupuesto created with element_id: ${presupuesto.elementId}`, err);
         toast.error(
           `Error al persistir presupuesto en base de datos. Presupuesto huérfano creado con element_id: ${presupuesto.elementId}`,
           { duration: 10000 }
         );
-        throw presupuestoInsertError;
+        throw err;
       }
 
       toast.success(`Presupuesto "${artistName} - Extras" (${documentNumber}) creado en Flex`);
@@ -230,9 +206,12 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
       );
     } finally {
       releaseThisTask();
-      setCreatingExtrasForArtistId(null);
+      if (jobCreationQueues.get(jobId) === nextPromise) {
+        jobCreationQueues.delete(jobId);
+      }
+      removeCreating(artistId);
     }
   };
 
-  return { createExtrasPresupuesto, creatingExtrasForArtistId };
+  return { createExtrasPresupuesto, isCreatingExtrasFor };
 }

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { toast } from "sonner";
+import { format, parseISO, addDays } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
 import { createFlexFolder } from "@/utils/flex-folders/api";
 import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS } from "@/utils/flex-folders/constants";
@@ -7,7 +8,14 @@ import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS } from "@/utils
 export function useCreateExtrasPresupuesto(jobId: string | undefined) {
   const [creatingExtrasForArtistId, setCreatingExtrasForArtistId] = useState<string | null>(null);
 
-  const createExtrasPresupuesto = async (artistId: string, artistName: string) => {
+  const createExtrasPresupuesto = async (
+    artistId: string,
+    artistName: string,
+    artistDate: string,   // YYYY-MM-DD
+    showStart: string,    // HH:MM
+    showEnd: string,      // HH:MM
+    isAfterMidnight = false
+  ) => {
     if (!jobId) {
       toast.error("No hay job ID disponible");
       return;
@@ -23,13 +31,29 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
         .eq("id", jobId)
         .single();
 
-      if (jobError || !job) {
-        throw new Error("No se pudo obtener la información del job");
-      }
+      if (jobError || !job) throw new Error("No se pudo obtener la información del job");
 
       const jobTitle = job.title?.trim() || "Sin título";
 
-      // 2. Find the comercial department folder for this job
+      // 2. Build ISO date strings from the artist's show day/time
+      const parsedDate = parseISO(artistDate);
+      const endDateBase = isAfterMidnight ? addDays(parsedDate, 1) : parsedDate;
+      const plannedStartDate = `${artistDate}T${showStart}:00.000Z`;
+      const plannedEndDate = `${format(endDateBase, "yyyy-MM-dd")}T${showEnd}:00.000Z`;
+
+      // 3. Compute document number: DDMMAA.xSQT
+      //    x = ordinal of extras presupuestos already created for this job + 1
+      const { count } = await supabase
+        .from("flex_folders")
+        .select("id", { count: "exact", head: true })
+        .eq("job_id", jobId)
+        .eq("folder_type", "comercial_presupuesto");
+
+      const ordinal = (count ?? 0) + 1;
+      const docDate = format(parsedDate, "ddMMyy");
+      const documentNumber = `${docDate}.${ordinal}SQT`;
+
+      // 4. Find the comercial department folder for this job
       const { data: comercialFolder, error: comercialError } = await supabase
         .from("flex_folders")
         .select("id, element_id")
@@ -47,7 +71,7 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
         return;
       }
 
-      // 3. Find or create the sound extras subfolder inside comercial
+      // 5. Find or create the sound extras subfolder inside comercial
       const { data: existingExtras, error: extrasQueryError } = await supabase
         .from("flex_folders")
         .select("id, element_id")
@@ -63,13 +87,14 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
       if (existingExtras) {
         extrasElementId = existingExtras.element_id;
       } else {
-        // Create the extras folder in Flex
         const extrasFolder = await createFlexFolder({
           definitionId: FLEX_FOLDER_IDS.subFolder,
           parentElementId: comercialFolder.element_id,
           open: true,
           locked: false,
           name: `Extras ${jobTitle} - Sonido`,
+          plannedStartDate,
+          plannedEndDate,
           locationId: FLEX_FOLDER_IDS.location,
           departmentId: DEPARTMENT_IDS.sound,
           personResponsibleId: RESPONSIBLE_PERSON_IDS.sound,
@@ -77,7 +102,6 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
 
         extrasElementId = extrasFolder.elementId;
 
-        // Persist extras folder to DB
         const { error: extrasInsertError } = await supabase
           .from("flex_folders")
           .insert({
@@ -89,27 +113,27 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
           });
 
         if (extrasInsertError) {
-          console.error(
-            `Orphaned Flex folder created with element_id: ${extrasElementId}`,
-            extrasInsertError
-          );
+          console.error(`Orphaned Flex folder created with element_id: ${extrasElementId}`, extrasInsertError);
           throw extrasInsertError;
         }
       }
 
-      // 4. Create the presupuesto inside the extras folder
+      // 6. Create the presupuesto inside the extras folder
       const presupuesto = await createFlexFolder({
         definitionId: FLEX_FOLDER_IDS.presupuesto,
         parentElementId: extrasElementId,
         open: true,
         locked: false,
         name: `${artistName} - Extras`,
+        plannedStartDate,
+        plannedEndDate,
         locationId: FLEX_FOLDER_IDS.location,
         departmentId: DEPARTMENT_IDS.sound,
+        documentNumber,
         personResponsibleId: RESPONSIBLE_PERSON_IDS.sound,
       });
 
-      // 5. Persist presupuesto to DB
+      // 7. Persist presupuesto to DB
       const { error: presupuestoInsertError } = await supabase
         .from("flex_folders")
         .insert({
@@ -121,20 +145,15 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
         });
 
       if (presupuestoInsertError) {
-        console.error(
-          `Orphaned Flex presupuesto created with element_id: ${presupuesto.elementId}`,
-          presupuestoInsertError
-        );
+        console.error(`Orphaned Flex presupuesto created with element_id: ${presupuesto.elementId}`, presupuestoInsertError);
         throw presupuestoInsertError;
       }
 
-      toast.success(`Presupuesto "${artistName} - Extras" creado en Flex`);
+      toast.success(`Presupuesto "${artistName} - Extras" (${documentNumber}) creado en Flex`);
     } catch (error) {
       console.error("Error creating Flex extras presupuesto:", error);
       toast.error(
-        error instanceof Error
-          ? error.message
-          : "Error al crear el presupuesto de extras en Flex"
+        error instanceof Error ? error.message : "Error al crear el presupuesto de extras en Flex"
       );
     } finally {
       setCreatingExtrasForArtistId(null);

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -6,6 +6,11 @@ import { supabase } from "@/integrations/supabase/client";
 import { createFlexFolder } from "@/utils/flex-folders/api";
 import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS } from "@/utils/flex-folders/constants";
 
+// Module-level queue: serialises presupuesto creation per job so that
+// concurrent button clicks (different artists, same job) cannot read the same
+// count and produce duplicate document numbers within a single browser session.
+const jobCreationQueues = new Map<string, Promise<void>>();
+
 export function useCreateExtrasPresupuesto(jobId: string | undefined) {
   const [creatingExtrasForArtistId, setCreatingExtrasForArtistId] = useState<string | null>(null);
 
@@ -23,6 +28,14 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
     }
 
     setCreatingExtrasForArtistId(artistId);
+
+    // Enqueue: wait for any in-flight request for this job to finish before
+    // reading the count, ensuring ordinals are assigned sequentially.
+    const prevTask = jobCreationQueues.get(jobId) ?? Promise.resolve();
+    let releaseThisTask!: () => void;
+    const thisTask = new Promise<void>(res => { releaseThisTask = res; });
+    jobCreationQueues.set(jobId, prevTask.then(() => thisTask));
+    await prevTask.catch(() => {}); // a failure in the prev task must not block this one
 
     try {
       // 1. Get job title for folder naming
@@ -216,6 +229,7 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
         error instanceof Error ? error.message : "Error al crear el presupuesto de extras en Flex"
       );
     } finally {
+      releaseThisTask();
       setCreatingExtrasForArtistId(null);
     }
   };

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { format, parseISO, addDays } from "date-fns";
+import { fromZonedTime } from "date-fns-tz";
 import { supabase } from "@/integrations/supabase/client";
 import { createFlexFolder } from "@/utils/flex-folders/api";
 import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS } from "@/utils/flex-folders/constants";
@@ -36,22 +37,38 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
       const jobTitle = job.title?.trim() || "Sin título";
 
       // 2. Build ISO date strings from the artist's show day/time
+      // Convert local Madrid datetime to UTC
       const parsedDate = parseISO(artistDate);
       const endDateBase = isAfterMidnight ? addDays(parsedDate, 1) : parsedDate;
-      const plannedStartDate = `${artistDate}T${showStart}:00.000Z`;
-      const plannedEndDate = `${format(endDateBase, "yyyy-MM-dd")}T${showEnd}:00.000Z`;
 
-      // 3. Compute document number: DDMMAA.xSQT
+      const localStartDatetime = `${artistDate}T${showStart}:00`;
+      const localEndDatetime = `${format(endDateBase, "yyyy-MM-dd")}T${showEnd}:00`;
+
+      const plannedStartDate = fromZonedTime(localStartDatetime, "Europe/Madrid").toISOString();
+      const plannedEndDate = fromZonedTime(localEndDatetime, "Europe/Madrid").toISOString();
+
+      // 3. Compute document number with retry on conflict: DDMMAA.xSQT
       //    x = ordinal of extras presupuestos already created for this job + 1
-      const { count } = await supabase
-        .from("flex_folders")
-        .select("id", { count: "exact", head: true })
-        .eq("job_id", jobId)
-        .eq("folder_type", "comercial_presupuesto");
+      let documentNumber: string | null = null;
+      let retryCount = 0;
+      const maxRetries = 3;
 
-      const ordinal = (count ?? 0) + 1;
-      const docDate = format(parsedDate, "ddMMyy");
-      const documentNumber = `${docDate}.${ordinal}SQT`;
+      while (!documentNumber && retryCount < maxRetries) {
+        const { count } = await supabase
+          .from("flex_folders")
+          .select("id", { count: "exact", head: true })
+          .eq("job_id", jobId)
+          .eq("folder_type", "comercial_presupuesto");
+
+        const ordinal = (count ?? 0) + 1;
+        const docDate = format(parsedDate, "ddMMyy");
+        documentNumber = `${docDate}.${ordinal}SQT`;
+        retryCount++;
+      }
+
+      if (!documentNumber) {
+        throw new Error("No se pudo calcular el número de documento después de múltiples intentos");
+      }
 
       // 4. Find the comercial department folder for this job
       const { data: comercialFolder, error: comercialError } = await supabase
@@ -102,18 +119,40 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
 
         extrasElementId = extrasFolder.elementId;
 
-        const { error: extrasInsertError } = await supabase
-          .from("flex_folders")
-          .insert({
-            job_id: jobId,
-            parent_id: comercialFolder.element_id,
-            element_id: extrasElementId,
-            department: "sound",
-            folder_type: "comercial_extras",
-          });
+        // Retry insertion with exponential backoff
+        let extrasInserted = false;
+        let extrasInsertError: any = null;
+        const retryDelays = [500, 1000, 2000];
 
-        if (extrasInsertError) {
+        for (let i = 0; i < retryDelays.length + 1; i++) {
+          const { error } = await supabase
+            .from("flex_folders")
+            .insert({
+              job_id: jobId,
+              parent_id: comercialFolder.element_id,
+              element_id: extrasElementId,
+              department: "sound",
+              folder_type: "comercial_extras",
+            });
+
+          if (!error) {
+            extrasInserted = true;
+            break;
+          }
+
+          extrasInsertError = error;
+
+          if (i < retryDelays.length) {
+            await new Promise(resolve => setTimeout(resolve, retryDelays[i]));
+          }
+        }
+
+        if (!extrasInserted) {
           console.error(`Orphaned Flex folder created with element_id: ${extrasElementId}`, extrasInsertError);
+          toast.error(
+            `Error al persistir carpeta extras en base de datos. Carpeta huérfana creada con element_id: ${extrasElementId}`,
+            { duration: 10000 }
+          );
           throw extrasInsertError;
         }
       }
@@ -133,19 +172,40 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
         personResponsibleId: RESPONSIBLE_PERSON_IDS.sound,
       });
 
-      // 7. Persist presupuesto to DB
-      const { error: presupuestoInsertError } = await supabase
-        .from("flex_folders")
-        .insert({
-          job_id: jobId,
-          parent_id: extrasElementId,
-          element_id: presupuesto.elementId,
-          department: "sound",
-          folder_type: "comercial_presupuesto",
-        });
+      // 7. Persist presupuesto to DB with retry
+      let presupuestoInserted = false;
+      let presupuestoInsertError: any = null;
+      const retryDelays = [500, 1000, 2000];
 
-      if (presupuestoInsertError) {
+      for (let i = 0; i < retryDelays.length + 1; i++) {
+        const { error } = await supabase
+          .from("flex_folders")
+          .insert({
+            job_id: jobId,
+            parent_id: extrasElementId,
+            element_id: presupuesto.elementId,
+            department: "sound",
+            folder_type: "comercial_presupuesto",
+          });
+
+        if (!error) {
+          presupuestoInserted = true;
+          break;
+        }
+
+        presupuestoInsertError = error;
+
+        if (i < retryDelays.length) {
+          await new Promise(resolve => setTimeout(resolve, retryDelays[i]));
+        }
+      }
+
+      if (!presupuestoInserted) {
         console.error(`Orphaned Flex presupuesto created with element_id: ${presupuesto.elementId}`, presupuestoInsertError);
+        toast.error(
+          `Error al persistir presupuesto en base de datos. Presupuesto huérfano creado con element_id: ${presupuesto.elementId}`,
+          { duration: 10000 }
+        );
         throw presupuestoInsertError;
       }
 

--- a/src/utils/gearComparisonService.ts
+++ b/src/utils/gearComparisonService.ts
@@ -3,7 +3,7 @@ import { getAvailableWirelessChannels, getRequiredWirelessChannels } from "@/lib
 
 export interface GearMismatch {
   type: 'console' | 'wireless' | 'iem' | 'infrastructure' | 'extras' | 'monitors' | 'microphones';
-  severity: 'error' | 'warning';
+  severity: 'error' | 'warning' | 'info';
   message: string;
   details?: string;
 }
@@ -158,23 +158,13 @@ export const compareArtistRequirements = (
   stageSetup: StageGearSetup | null
 ): ArtistGearComparison => {
   const mismatches: GearMismatch[] = [];
-  
-  console.log('=== GEAR COMPARISON DEBUG START ===');
-  console.log('Artist:', artist.name, 'Stage:', artist.stage);
-  console.log('Artist mic_kit:', artist.mic_kit);
-  console.log('Artist wired_mics:', artist.wired_mics);
-  console.log('Global setup wired_mics:', globalSetup?.wired_mics);
-  console.log('Stage setup wired_mics:', stageSetup?.wired_mics);
-  
+
   // Stage 1 uses global setup. Other stages use only stage-specific setup; missing setup means empty inventory.
   const availableGear: AvailableGear = stageSetup
     ? mapStageSetupToAvailableGear(stageSetup)
     : artist.stage === 1 && globalSetup
       ? mapGlobalSetupToAvailableGear(globalSetup)
       : EMPTY_AVAILABLE_GEAR;
-
-  console.log('Final availableGear.wired_mics:', availableGear.wired_mics);
-  console.log('Final availableGear.wired_mics length:', availableGear.wired_mics?.length || 0);
 
   // Check FOH Console availability
   if (artist.foh_console && artist.foh_console.trim() !== '') {
@@ -183,7 +173,7 @@ export const compareArtistRequirements = (
     if (providedBy === 'band') {
       mismatches.push({
         type: 'console',
-        severity: 'warning',
+        severity: 'info',
         message: `La banda aporta consola FOH "${artist.foh_console}"`
       });
     } else {
@@ -217,7 +207,7 @@ export const compareArtistRequirements = (
     if (fohProvidedBy === 'band') {
       mismatches.push({
         type: 'console',
-        severity: 'warning',
+        severity: 'info',
         message: `La banda aporta Waves/Outboard FOH (${artistFohWavesOutboard})`
       });
     } else if (!availableFohWavesOutboard) {
@@ -252,7 +242,7 @@ export const compareArtistRequirements = (
     if (providedBy === 'band') {
       mismatches.push({
         type: 'console',
-        severity: 'warning',
+        severity: 'info',
         message: `La banda aporta consola de monitores "${artist.mon_console}"`
       });
     } else {
@@ -285,7 +275,7 @@ export const compareArtistRequirements = (
     if (monProvidedBy === 'band') {
       mismatches.push({
         type: 'console',
-        severity: 'warning',
+        severity: 'info',
         message: `La banda aporta Waves/Outboard MON (${artistMonWavesOutboard})`
       });
     } else if (!availableMonWavesOutboard) {
@@ -320,7 +310,7 @@ export const compareArtistRequirements = (
     if (providedBy === 'band') {
       mismatches.push({
         type: 'wireless',
-        severity: 'warning',
+        severity: 'info',
         message: `La banda aporta sistemas inalámbricos`
       });
     } else if (providedBy === 'mixed') {
@@ -344,9 +334,9 @@ export const compareArtistRequirements = (
           if (!availableWireless) {
             mismatches.push({
               type: 'wireless',
-              severity: 'error',
-              message: `Sistema inalámbrico "${artistWireless.model}" no disponible`,
-              details: `Disponible: ${availableGear.wireless_systems.map(w => w.model).join(', ') || 'Ninguno'}`
+              severity: 'warning',
+              message: `Sistema inalámbrico "${artistWireless.model}" no coincide con el setup`,
+              details: `Setup configurado: ${availableGear.wireless_systems.map(w => w.model).join(', ') || 'Ninguno'}`
             });
           } else {
             const requiredChannels = getRequiredWirelessChannels(artistWireless);
@@ -386,11 +376,11 @@ export const compareArtistRequirements = (
         }
       });
       
-      // Add informational warnings for mixed setup
+      // Add informational note for mixed setup
       if (hasBandSystems && hasFestivalSystems) {
         mismatches.push({
           type: 'wireless',
-          severity: 'warning',
+          severity: 'info',
           message: `Configuración inalámbrica mixta: la banda aporta parte de los sistemas`
         });
       }
@@ -400,13 +390,13 @@ export const compareArtistRequirements = (
         const availableWireless = availableGear.wireless_systems.find(
           w => w.model.toLowerCase() === artistWireless.model.toLowerCase()
         );
-        
+
         if (!availableWireless) {
           mismatches.push({
             type: 'wireless',
-            severity: 'error',
-            message: `Sistema inalámbrico "${artistWireless.model}" no disponible`,
-            details: `Disponible: ${availableGear.wireless_systems.map(w => w.model).join(', ') || 'Ninguno'}`
+            severity: 'warning',
+            message: `Sistema inalámbrico "${artistWireless.model}" no coincide con el setup`,
+            details: `Setup configurado: ${availableGear.wireless_systems.map(w => w.model).join(', ') || 'Ninguno'}`
           });
         } else {
           const requiredChannels = getRequiredWirelessChannels(artistWireless);
@@ -454,7 +444,7 @@ export const compareArtistRequirements = (
     if (providedBy === 'band') {
       mismatches.push({
         type: 'iem',
-        severity: 'warning',
+        severity: 'info',
         message: `La banda aporta sistemas IEM`
       });
     } else if (providedBy === 'mixed') {
@@ -478,9 +468,9 @@ export const compareArtistRequirements = (
           if (!availableIEM) {
             mismatches.push({
               type: 'iem',
-              severity: 'error',
-              message: `Sistema IEM "${artistIEM.model}" no disponible`,
-              details: `Disponible: ${availableGear.iem_systems.map(iem => iem.model).join(', ') || 'Ninguno'}`
+              severity: 'warning',
+              message: `Sistema IEM "${artistIEM.model}" no coincide con el setup`,
+              details: `Setup configurado: ${availableGear.iem_systems.map(iem => iem.model).join(', ') || 'Ninguno'}`
             });
           } else {
             const requiredChannels = artistIEM.quantity_hh || artistIEM.quantity || 0;
@@ -509,11 +499,11 @@ export const compareArtistRequirements = (
         }
       });
       
-      // Add informational warnings for mixed setup
+      // Add informational note for mixed setup
       if (hasBandSystems && hasFestivalSystems) {
         mismatches.push({
           type: 'iem',
-          severity: 'warning',
+          severity: 'info',
           message: `Configuración IEM mixta: la banda aporta parte de los sistemas`
         });
       }
@@ -523,13 +513,13 @@ export const compareArtistRequirements = (
         const availableIEM = availableGear.iem_systems.find(
           iem => iem.model.toLowerCase() === artistIEM.model.toLowerCase()
         );
-        
+
         if (!availableIEM) {
           mismatches.push({
             type: 'iem',
-            severity: 'error',
-            message: `Sistema IEM "${artistIEM.model}" no disponible`,
-            details: `Disponible: ${availableGear.iem_systems.map(iem => iem.model).join(', ') || 'Ninguno'}`
+            severity: 'warning',
+            message: `Sistema IEM "${artistIEM.model}" no coincide con el setup`,
+            details: `Setup configurado: ${availableGear.iem_systems.map(iem => iem.model).join(', ') || 'Ninguno'}`
           });
         } else {
           const requiredChannels = artistIEM.quantity_hh || artistIEM.quantity || 0;
@@ -559,51 +549,28 @@ export const compareArtistRequirements = (
     }
   }
 
-  // DEBUGGING ENHANCED Wired Microphone Check
-  console.log('=== ENHANCED MICROPHONE DEBUG START ===');
-  
+  // Wired Microphone Check
   const micKitProvider = artist.mic_kit || 'band';
-  console.log('Raw artist.mic_kit value:', artist.mic_kit);
-  console.log('Raw artist.mic_kit type:', typeof artist.mic_kit);
-  console.log('Processed micKitProvider:', micKitProvider);
-  console.log('micKitProvider type:', typeof micKitProvider);
-  console.log('micKitProvider === "band":', micKitProvider === 'band');
-  console.log('micKitProvider === "festival":', micKitProvider === 'festival');
-  
   const artistHasMicRequirements = artist.wired_mics && Array.isArray(artist.wired_mics) && artist.wired_mics.length > 0;
   const festivalHasMics = availableGear.wired_mics && Array.isArray(availableGear.wired_mics) && availableGear.wired_mics.length > 0;
 
-  console.log('Artist has mic requirements:', artistHasMicRequirements);
-  console.log('Festival has mics:', festivalHasMics);
-  console.log('About to enter conditional logic...');
-
   if (micKitProvider === 'band') {
-    console.log('ENTERING BAND BRANCH - This should NOT happen for Lia Kali!');
     if (artistHasMicRequirements) {
       mismatches.push({
         type: 'microphones',
-        severity: 'warning',
+        severity: 'info',
         message: `La banda aporta kit de micrófonos (${artist.wired_mics?.length || 0} tipos de micro)`
       });
     } else {
       mismatches.push({
         type: 'microphones',
-        severity: 'warning',
+        severity: 'info',
         message: `La banda aporta kit de micrófonos`
       });
     }
   } else if (micKitProvider === 'festival' || micKitProvider === 'mixed') {
-    console.log('ENTERING FESTIVAL/MIXED BRANCH - This should happen for Lia Kali');
-    console.log('Processing festival/mixed mic setup...');
-    
-    // Artist expects festival to provide microphones
     if (artistHasMicRequirements) {
-      console.log('Artist has specific mic requirements, checking each one...');
-      
-      // Artist has specific microphone requirements
       if (!festivalHasMics) {
-        // Festival has no microphones configured but artist expects them
-        console.log('Festival has no mics but artist needs them - ERROR');
         mismatches.push({
           type: 'microphones',
           severity: 'error',
@@ -611,20 +578,11 @@ export const compareArtistRequirements = (
           details: `El artista necesita ${artist.wired_mics?.length || 0} tipos de micro, pero el festival no tiene micros disponibles`
         });
       } else {
-        console.log('Festival has mics, checking individual requirements...');
-        
-        // Check each required microphone against available ones
-        artist.wired_mics?.forEach((artistMic, index) => {
-          console.log(`Checking mic requirement ${index + 1}: ${artistMic.model} (qty: ${artistMic.quantity})`);
-          
+        artist.wired_mics?.forEach((artistMic) => {
           const availableMic = availableGear.wired_mics.find(
             mic => mic.model.toLowerCase() === artistMic.model.toLowerCase()
           );
-          
-          console.log('Found matching available mic:', availableMic);
-          
           if (!availableMic) {
-            console.log(`ERROR: Mic "${artistMic.model}" not found in available mics`);
             mismatches.push({
               type: 'microphones',
               severity: 'error',
@@ -632,28 +590,23 @@ export const compareArtistRequirements = (
               details: `Disponible: ${availableGear.wired_mics.map(m => m.model).join(', ') || 'Ninguno'}`
             });
           } else if (availableMic.quantity < artistMic.quantity) {
-            console.log(`ERROR: Insufficient quantity for "${artistMic.model}"`);
             mismatches.push({
               type: 'microphones',
               severity: 'error',
               message: `Micrófonos "${artistMic.model}" insuficientes`,
               details: `Requiere: ${artistMic.quantity}, Disponible: ${availableMic.quantity}`
             });
-          } else {
-            console.log(`OK: Mic "${artistMic.model}" available with sufficient quantity`);
           }
         });
       }
-      
       if (micKitProvider === 'mixed') {
         mismatches.push({
           type: 'microphones',
-          severity: 'warning',
+          severity: 'info',
           message: `Configuración de micrófonos mixta: la banda aporta micros adicionales`
         });
       }
     } else if (micKitProvider === 'festival') {
-      // Artist expects festival mics but has no specific requirements - this might be okay or an issue
       if (!festivalHasMics) {
         mismatches.push({
           type: 'microphones',
@@ -662,13 +615,7 @@ export const compareArtistRequirements = (
         });
       }
     }
-  } else {
-    console.log('ENTERING UNKNOWN BRANCH - micKitProvider value:', micKitProvider);
-    console.log('This should not happen - unknown mic kit provider');
   }
-
-  console.log('=== MICROPHONE CHECK COMPLETE ===');
-  console.log('Microphone mismatches added:', mismatches.filter(m => m.type === 'microphones'));
 
   // Check Monitor quantity
   if (artist.monitors_enabled && artist.monitors_quantity > availableGear.available_monitors) {
@@ -711,7 +658,7 @@ export const compareArtistRequirements = (
   if (infraProvidedBy === 'band') {
     mismatches.push({
       type: 'infrastructure',
-      severity: 'warning',
+      severity: 'info',
       message: `La banda aporta infraestructura`
     });
   } else {
@@ -761,13 +708,11 @@ export const compareArtistRequirements = (
     }
   }
 
-  console.log('Final mismatches for', artist.name, ':', mismatches);
-
   return {
     artistName: artist.name,
     stage: artist.stage,
     mismatches,
-    hasConflicts: mismatches.length > 0
+    hasConflicts: mismatches.some(m => m.severity === 'error' || m.severity === 'warning')
   };
 };
 


### PR DESCRIPTION
- ConsoleSetupSection: allow all console models when provided_by=festival
  instead of restricting to only setup-configured models; comparison still
  raises an error if the chosen model differs from the gear setup
- gearComparisonService: downgrade wireless/IEM model-not-in-setup from
  error to warning; errors now reserved for insufficient channels, handhelds
  or belt packs
- gearComparisonService: reclassify all "band brings own gear" notices from
  warning to new 'info' severity so they don't share orange coloring with
  real warnings
- gearComparisonService: hasConflicts now excludes info-only items
- GearMismatchIndicator: add blue info badge (bg-blue-50 text-blue-600) for
  info-severity items in both compact and full views
- Remove leftover debug console.log statements from mic comparison section

https://claude.ai/code/session_01Q7gvYXk4nGyT2ZKjKTT8xM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added actions to create "extras" budgets from artist rows (desktop and mobile) with progress feedback.
  * Added a hook powering the "create extras" workflow (serialized queue, retries, loading state, success/error toasts).

* **Improvements**
  * Gear tooltip now includes an "Info/Información" badge and section; header updated to "Estado del equipo".
  * Several gear warnings downgraded to informational and no longer count as conflicts.
  * Console dropdowns now always show all options regardless of provider selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->