### PR TITLE
Add festival subsystem architecture docs and expand Festival Management workflow docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,17 @@ Detailed documentation for each major subsystem — key files, database tables, 
 - **[Public Artist Form](workflows/public-artist-form.md)** — Tokenized public routes for artist rider submission
 - **[SoundVision Files](workflows/soundvision-files.md)** — File library with access request and review workflow
 
+
+## Festival architecture (section-specific)
+
+Detailed deep-dive docs for the full festival subsystem:
+
+- **[Festival System Architecture Index](architecture/festival-system/README.md)**
+- **[Artist Tables & Workflow](architecture/festival-system/artist-tables.md)**
+- **[Gear Setup & Comparison](architecture/festival-system/gear-setup-and-comparison.md)**
+- **[Scheduling Architecture](architecture/festival-system/scheduling.md)**
+- **[Flex Integration Architecture](architecture/festival-system/flex-integration.md)**
+
 ## Product / workflows
 - **SoundVision access workflow**
   - `SOUNDVISION_ACCESS_CHANGES.md`

--- a/docs/architecture/festival-system/README.md
+++ b/docs/architecture/festival-system/README.md
@@ -1,0 +1,64 @@
+# Festival System Architecture
+
+This section documents the full Festival subsystem in **Area Técnica**, split by architecture domain so each team (ops, product, engineering) can work with a focused reference.
+
+## Scope
+
+The festival system includes:
+
+- Artist lifecycle (roster, rider requests, public forms, submissions, rider files).
+- Gear setup and validation (global setup, per-stage setup, mismatch detection).
+- Staffing schedule (shifts, assignments, stage/day-level planning).
+- Flex integration (pullsheet push, folder/document integration, navigation/opening, and extras quote creation for mismatch remediation).
+
+## Reading order (recommended)
+
+1. [Artist data model & workflows](./artist-tables.md)
+2. [Gear setup & comparison architecture](./gear-setup-and-comparison.md)
+3. [Festival scheduling architecture](./scheduling.md)
+4. [Flex integration architecture](./flex-integration.md)
+
+## Core UI and orchestration entry points
+
+- Route pages: `src/pages/FestivalManagement.tsx`, `src/pages/FestivalArtistManagement.tsx`, `src/pages/FestivalGearManagement.tsx`, `src/pages/Festivals.tsx`.
+- Festival VM/orchestration: `src/pages/festival-management/useFestivalManagementVm.ts`.
+- Domain UI modules: `src/components/festival/` (`form`, `gear-setup`, `mobile`, `pdf`, `scheduling`).
+
+## Core database entities
+
+Festival behavior primarily reads/writes these entities:
+
+- `festival_artists`
+- `festival_artist_forms`
+- `festival_artist_form_submissions`
+- `festival_artist_files`
+- `festival_gear_setups`
+- `festival_stage_gear_setups`
+- `festival_shifts`
+- `festival_shift_assignments`
+- `festival_settings`
+- `festival_stages`
+
+(See typed schema details in `src/integrations/supabase/types.ts`.)
+
+## Workflow map
+
+```text
+Festival Job Created
+  ├─ Artist roster loaded
+  │   ├─ Form links generated
+  │   ├─ Public form submitted
+  │   └─ Rider files uploaded/reviewed
+  ├─ Gear setup configured
+  │   ├─ Global setup
+  │   ├─ Stage overrides
+  │   └─ Comparison/mismatch analysis
+  ├─ Scheduling configured
+  │   ├─ Shifts created
+  │   ├─ Technicians assigned
+  │   └─ Assignment copied/rebalanced
+  └─ Flex integration
+      ├─ Open related folders/elements
+      ├─ Push pullsheet items
+      └─ Track sync status/logs
+```

--- a/docs/architecture/festival-system/artist-tables.md
+++ b/docs/architecture/festival-system/artist-tables.md
@@ -1,0 +1,86 @@
+# Festival Artist Tables & Workflow Architecture
+
+This document covers the **artist-side architecture**: roster data, form tokens, submissions, and file uploads.
+
+## 1) Data model (artist domain)
+
+### `festival_artists` (primary roster record)
+
+Main row per artist/date/stage with technical request fields.
+
+Representative field groups:
+
+- Identity/scheduling: `name`, `job_id`, `date`, `stage`, `show_start`, `show_end`, `soundcheck_*`.
+- Console and monitoring: `foh_console`, `mon_console`, `monitors_enabled`, `monitors_quantity`.
+- RF/IEM/mics: `wireless_systems`, `iem_systems`, `wired_mics`, `mic_kit`.
+- Infrastructure: `infra_cat6_*`, `infra_hma_*`, `infra_coax_*`, `infra_opticalcon_duo_*`, `infra_analog`.
+- Extra requirements: `extras_sf`, `extras_df`, `extras_djbooth`, `extras_wired`.
+- Submission/language context: `form_language`, `notes`, rider metadata.
+
+### `festival_artist_forms` (token records)
+
+Stores the public-form token lifecycle for an artist form request.
+
+Typical responsibilities:
+
+- Token creation + expiry.
+- Pending/submitted/expired lifecycle tracking.
+- Traceability per artist.
+
+### `festival_artist_form_submissions` (submitted payload)
+
+Stores canonical submissions and associated metadata after the public form is sent.
+
+### `festival_artist_files` (rider uploads)
+
+Stores rider and supplemental file metadata (name/path/type/size/upload provenance).
+
+## 2) Main UI modules
+
+- Internal management table/list/edit:
+  - `src/components/festival/ArtistTable.tsx`
+  - `src/components/festival/ArtistManagementDialog.tsx`
+  - `src/components/festival/ArtistManagementForm.tsx`
+  - `src/components/festival/CopyArtistsDialog.tsx`
+- Public/private form flow:
+  - `src/components/festival/ArtistForm.tsx`
+  - `src/components/festival/ArtistRequirementsForm.tsx`
+  - `src/components/festival/ArtistFormLinkDialog.tsx`
+  - `src/components/festival/ArtistFormLinksDialog.tsx`
+  - `src/components/festival/ArtistFormSubmissionDialog.tsx`
+- Rider file UX:
+  - `src/components/festival/ArtistFileDialog.tsx`
+  - `src/components/festival/ViewFileDialog.tsx`
+
+## 3) Public form workflow (end-to-end)
+
+```text
+Manager creates/refreshes token
+  → Artist receives tokenized URL
+    → Artist opens public form (no login)
+      → Artist completes requirements + uploads rider files
+        → Submission is persisted and linked to artist/form
+          → Management reviews from internal festival UI
+```
+
+## 4) Public form backend integration points
+
+- `supabase/functions/submit-public-artist-form/index.ts`
+- `supabase/functions/upload-public-artist-rider/index.ts`
+- `supabase/functions/delete-public-artist-rider/index.ts`
+
+These functions enforce token validity, submission lifecycle guarantees, and file operation rules.
+
+## 5) Operational patterns
+
+- Keep the `festival_artists` row as the human-readable planning source.
+- Keep full form payload in submission tables for auditability and evolution.
+- Never assume one artist = one immutable token; treat token rows as lifecycle records.
+- Rider files are artifacts attached to artist context, not substitutes for structured fields.
+
+## 6) Consumer systems fed by artist data
+
+- Gear analysis/mismatch system.
+- Festival PDF and table exports.
+- Shift planning context (stage/date load).
+- Activity/event feed and management notifications.

--- a/docs/architecture/festival-system/flex-integration.md
+++ b/docs/architecture/festival-system/flex-integration.md
@@ -1,0 +1,65 @@
+# Festival Flex Integration Architecture
+
+This document explains how Festival management connects to Flex for folders, element navigation, pullsheet sync, and mismatch-driven commercial quote creation.
+
+## 1) Integration surfaces in festival UX
+
+- Festival orchestration uses Flex folder context through:
+  - `src/pages/festival-management/useFestivalManagementVm.ts`
+- Flex push operation for gear:
+  - `src/components/festival/PushToFlexPullsheetDialog.tsx`
+- Flex folder helpers and navigation:
+  - `src/utils/flex-folders/*`
+  - `src/hooks/useFlexUuid.ts`
+  - `src/utils/flexMainFolderId.ts`
+
+## 2) Pullsheet push flow
+
+Primary service path:
+
+- UI gathers selected gear sections and target pullsheet (`PushToFlexPullsheetDialog`).
+- Pullsheet targets are discovered with `getJobPullsheetsWithFlexApi`.
+- URL mode or selector mode resolves element ID (`extractFlexElementId`).
+- Equipment rows are mapped and sent via `pushEquipmentToPullsheet`.
+
+## 3) Folder/element workflow integration
+
+Festival jobs share platform-level job folder behavior:
+
+- Resolve/create Flex folder structure for the job.
+- Store local mirror rows in `flex_folders`.
+- Allow opening selected element(s) in Flex via helper utilities.
+
+## 4) Reliability and guardrails
+
+- Async load states prevent stale updates while dialog context changes.
+- Input mode fallback (`select` or `url`) keeps operation possible even when selector data is unavailable.
+- Push result tracks success and failures per equipment item for post-action troubleshooting.
+
+## 5) Recommended operating workflow
+
+```text
+Verify festival gear setup
+  → Open Push to Flex dialog
+    → Choose pullsheet (selector or URL)
+      → Select gear sections to export
+        → Execute push and review result summary
+          → Retry failed items or adjust local mappings
+```
+
+## 6) Create Extras Quote integration
+
+Mismatch-driven quote creation is implemented through:
+
+- UI trigger in artist actions (desktop/mobile) when mismatch severity includes `error`.
+- Hook: `src/hooks/festival/useCreateExtrasPresupuesto.ts`.
+- Folder strategy: reuse/create `comercial_extras` and then create a `comercial_presupuesto` element.
+- Persistence: write every created element to `flex_folders` (`folder_type`: `comercial_extras` / `comercial_presupuesto`).
+- Concurrency hardening: module-level per-job queue avoids duplicated quote ordinals.
+
+This is effectively the commercial escalation path from technical conflicts to actionable Flex quote artifacts.
+
+## 7) Related references
+
+- `docs/flex-folder-workflows.md` (cross-system folder architecture)
+- `docs/FLEX_SELECTOR_INTEGRATION.md` (selector behavior details)

--- a/docs/architecture/festival-system/gear-setup-and-comparison.md
+++ b/docs/architecture/festival-system/gear-setup-and-comparison.md
@@ -1,0 +1,77 @@
+# Festival Gear Setup & Comparison Architecture
+
+This document explains how the festival system models equipment capacity and compares artist requirements against configured inventory.
+
+## 1) Data model
+
+### `festival_gear_setups` (global setup)
+
+Per-job global equipment capability:
+
+- Console inventories: `foh_consoles`, `mon_consoles`.
+- RF/IEM/mics inventories: `wireless_systems`, `iem_systems`, `wired_mics`.
+- Stage-wide capacities: monitors, infrastructure runs (`cat6`, `hma`, `coax`, `opticalcon_duo`, `analog`).
+- Extras: side fills, drum fills, DJ booths.
+- Planning metadata: `max_stages`, notes/outboard fields.
+
+### `festival_stage_gear_setups` (stage override setup)
+
+Per-stage override configuration linked by `gear_setup_id` and `stage_number`.
+
+This allows stage-specific capacity where global setup is not enough.
+
+## 2) Main UI modules
+
+- Festival setup UI:
+  - `src/components/festival/FestivalGearSetupForm.tsx`
+  - `src/components/festival/gear-setup/ConsoleConfig.tsx`
+  - `src/components/festival/gear-setup/WirelessConfig.tsx`
+  - `src/components/festival/gear-setup/WiredMicConfig.tsx`
+  - `src/components/festival/gear-setup/InfrastructureConfig.tsx`
+  - `src/components/festival/gear-setup/StageEquipmentConfig.tsx`
+- Analysis UI:
+  - `src/components/festival/GearMismatchIndicator.tsx`
+  - `src/components/festival/gear-setup/MicrophoneNeedsCalculator.tsx`
+  - `src/components/festival/gear-setup/MicrophoneAnalysisPreview.tsx`
+
+## 3) Comparison engine
+
+Core service: `src/utils/gearComparisonService.ts`.
+
+### What the comparison engine returns
+
+- Per-artist mismatch list (`error`, `warning`, `info`).
+- Category-level mismatch typing (console, wireless, iem, microphones, infrastructure, extras, monitors).
+- Aggregated additional equipment needs by model and subsystem.
+
+### Stage resolution behavior
+
+- Stage 1 may use global setup when stage override is absent.
+- Other stages rely on explicit stage setup; missing stage setup is treated as empty inventory.
+
+This design keeps capacity assumptions explicit and conservative for multi-stage festivals.
+
+## 4) Workflow
+
+```text
+Set global setup
+  → (Optional) define per-stage overrides
+    → Compare every artist requirement against effective stage setup
+      → Surface mismatches and shortages
+        → Update setup or rider assumptions
+          → Export validated tables/PDFs
+```
+
+## 5) Design considerations
+
+- Keep global inventory simple and reusable.
+- Use stage overrides only for actual divergence.
+- Treat comparison warnings as planning signals (not always blockers).
+- Track provider mode (`festival`/`band`/`mixed`) to avoid false conflict reporting.
+
+## 6) Output consumers
+
+- Artist table status indicators.
+- Gear planning dashboards.
+- Pullsheet push-to-Flex flow.
+- Printable technical documentation.

--- a/docs/architecture/festival-system/scheduling.md
+++ b/docs/architecture/festival-system/scheduling.md
@@ -27,14 +27,14 @@ Represents staffing allocations per shift:
 - Scheduling container:
   - `src/components/festival/scheduling/FestivalScheduling.tsx`
 - Shift CRUD:
-  - `CreateShiftDialog.tsx`
-  - `EditShiftDialog.tsx`
-  - `ShiftsTable.tsx`
-  - `ShiftsList.tsx`
+  - `src/components/festival/scheduling/CreateShiftDialog.tsx`
+  - `src/components/festival/scheduling/EditShiftDialog.tsx`
+  - `src/components/festival/scheduling/ShiftsTable.tsx`
+  - `src/components/festival/scheduling/ShiftsList.tsx`
 - Assignment operations:
-  - `ManageAssignmentsDialog.tsx`
-  - `CopyShiftsDialog.tsx`
-  - `ShiftTimeCalculator.tsx`
+  - `src/components/festival/scheduling/ManageAssignmentsDialog.tsx`
+  - `src/components/festival/scheduling/CopyShiftsDialog.tsx`
+  - `src/components/festival/scheduling/ShiftTimeCalculator.tsx`
 
 ## 3) Scheduling workflow
 

--- a/docs/architecture/festival-system/scheduling.md
+++ b/docs/architecture/festival-system/scheduling.md
@@ -1,0 +1,60 @@
+# Festival Scheduling Architecture
+
+This document covers festival shift planning and assignment architecture.
+
+## 1) Data model
+
+### `festival_shifts`
+
+Represents schedule blocks by festival day:
+
+- Identity: `id`, `job_id`, `name`.
+- Time: `date`, `start_time`, `end_time`.
+- Context: `department`, `stage`, `notes`.
+- Audit: `created_at`, `updated_at`.
+
+### `festival_shift_assignments`
+
+Represents staffing allocations per shift:
+
+- `shift_id` (FK to `festival_shifts`).
+- `technician_id` (internal user assignment).
+- `external_technician_name` (external staffing).
+- `role`.
+
+## 2) Main UI modules
+
+- Scheduling container:
+  - `src/components/festival/scheduling/FestivalScheduling.tsx`
+- Shift CRUD:
+  - `CreateShiftDialog.tsx`
+  - `EditShiftDialog.tsx`
+  - `ShiftsTable.tsx`
+  - `ShiftsList.tsx`
+- Assignment operations:
+  - `ManageAssignmentsDialog.tsx`
+  - `CopyShiftsDialog.tsx`
+  - `ShiftTimeCalculator.tsx`
+
+## 3) Scheduling workflow
+
+```text
+Create shifts per day/stage/department
+  → Assign technicians/internal-external roles
+    → Validate overlaps and day boundaries
+      → Copy/reuse shifts for similar dates
+        → Publish/use for execution and reporting
+```
+
+## 4) System integration points
+
+- Festival stage definitions (`festival_stages`) help constrain stage targeting.
+- Festival settings (`festival_settings.day_start_time`) support day-boundary behavior.
+- Assignment decisions feed downstream staffing and operational visibility.
+
+## 5) Practical architecture principles
+
+- Keep shift entity small and declarative; assignments are separate join records.
+- Support both internal and external staffing in the same assignment model.
+- Preserve day/stage segmentation to avoid cross-stage ambiguity.
+- Make copy operations explicit/auditable to reduce accidental propagation.

--- a/docs/workflows/festival-management.md
+++ b/docs/workflows/festival-management.md
@@ -1,83 +1,94 @@
-# Festival Management
+# Festival Management Workflow (System Reference)
 
-> Multi-day event management with artists, riders, gear setup, shift scheduling, and Flex integration.
+> Multi-day event management with artists, riders, gear setup, scheduling, gear comparison, and Flex integration.
 
 ## Overview
 
-Festival management handles multi-day events with complex artist rosters, technical rider requirements, gear allocation, and crew shift scheduling. Festivals are linked to jobs in the `tours` table with festival-specific workflows.
+Festival management is the event-operations subsystem used to:
 
-## Key Files
+- manage artists and rider requirements,
+- configure technical gear globally and by stage,
+- schedule and assign crews,
+- compare artist demand versus configured inventory,
+- and push validated setup information to Flex.
 
-| Category | Path |
-|----------|------|
-| **Pages** | `src/pages/FestivalManagement.tsx`, `FestivalArtistManagement.tsx`, `FestivalGearManagement.tsx`, `Festivals.tsx` |
-| **View model** | `src/pages/festival-management/useFestivalManagementVm.ts` |
-| **Components** | `src/components/festival/` (30+ components in subdirectories) |
-| **Hooks** | `src/hooks/useFestival.ts`, `useFestivalArtists.ts`, `useCombinedGearSetup.ts` |
-| **Shift hooks** | `src/hooks/festival/useFestivalShifts.ts` |
-| **PDF export** | `src/utils/artistPdfExport.ts`, `artistTablePdfExport.ts`, `gearSetupPdfExport.ts`, `shiftsTablePdfExport.ts` |
+Festival execution is attached to a parent job (`jobs.id`) and orchestrated primarily through the festival management pages and view model.
 
-## Database Tables
+## Entry points
 
-| Table | Purpose |
-|-------|---------|
-| `festival_artists` | Artist roster (name, stage, date, show times, soundcheck info) |
-| `festival_artist_forms` | Tokenized form templates for artist requirements |
-| `festival_artist_form_submissions` | Submitted artist requirement forms |
-| `festival_artist_files` | Uploaded rider PDFs and files |
-| `festival_gear_setups` | Global gear config (consoles, wireless, mics, infrastructure) |
-| `festival_stage_gear_setups` | Per-stage gear overrides |
-| `festival_shifts` | Shift time blocks (date, start/end, department, stage) |
-| `festival_shift_assignments` | Technician-to-shift assignments |
-| `festival_settings` | Festival-wide settings (day_start_time) |
-| `festival_stages` | Stage definitions (number, name) |
+| Type | Path |
+|---|---|
+| Main page | `src/pages/FestivalManagement.tsx` |
+| Artist-focused view | `src/pages/FestivalArtistManagement.tsx` |
+| Gear-focused view | `src/pages/FestivalGearManagement.tsx` |
+| Listing/launcher | `src/pages/Festivals.tsx` |
+| VM/orchestration | `src/pages/festival-management/useFestivalManagementVm.ts` |
 
-## Workflows
+## Architecture docs by section
 
-### Artist & Rider Workflow
+For full section-specific architecture, use:
 
-```text
-1. CREATE FESTIVAL → linked to a job
-2. ADD ARTISTS → name, stage, date, show times
-3. SEND FORM LINKS → tokenized URL (7-day expiry) via email/QR code
-4. ARTIST FILLS FORM → consoles, wireless, IEM, mics, infrastructure
-5. ARTIST UPLOADS RIDER → PDF/images stored in festival_artist_files
-6. MANAGEMENT REVIEWS → approval in ArtistManagementDialog
-7. SYSTEM CALCULATES → MicrophoneNeedsCalculator aggregates all artist needs
-8. GENERATE PDF → artist requirements, rider tables
-```
+- [Festival system architecture index](../architecture/festival-system/README.md)
+- [Artist tables & workflow architecture](../architecture/festival-system/artist-tables.md)
+- [Gear setup & comparison architecture](../architecture/festival-system/gear-setup-and-comparison.md)
+- [Scheduling architecture](../architecture/festival-system/scheduling.md)
+- [Flex integration architecture](../architecture/festival-system/flex-integration.md)
 
-### Gear Setup Workflow
+## Core database tables
+
+- Artist domain: `festival_artists`, `festival_artist_forms`, `festival_artist_form_submissions`, `festival_artist_files`
+- Gear domain: `festival_gear_setups`, `festival_stage_gear_setups`
+- Scheduling domain: `festival_shifts`, `festival_shift_assignments`
+- Festival configuration domain: `festival_settings`, `festival_stages`
+
+## End-to-end workflow
 
 ```text
-1. SET GLOBAL GEAR → festival_gear_setups: max stages, consoles, wireless, mics
-2. STAGE OVERRIDES → festival_stage_gear_setups for per-stage differences
-3. COMBINED VIEW → useCombinedGearSetup merges global + stage-specific
-4. MISMATCH DETECTION → GearMismatchIndicator flags conflicts
-5. PDF EXPORT → gear setup documentation
+1) Festival job context initialized
+2) Artists created/imported and form links distributed
+3) Artists submit requirements + rider files
+4) Management reviews submissions and finalizes artist table
+5) Gear setup configured globally and per stage
+6) Gear comparison system flags conflicts/capacity gaps
+7) Crew shifts are created and assignments filled
+8) When mismatches block delivery, create Extras quote in Flex (artist-level action)
+9) Setup data exported (PDF/tables) and/or pushed to Flex pullsheets
+10) Team executes show using validated schedule + technical data
 ```
 
-### Shift Scheduling Workflow
+## Gear comparison system (operational summary)
 
-```text
-1. CREATE SHIFTS → date, time range, department, stage
-2. ASSIGN TECHNICIANS → via ManageAssignmentsDialog
-3. REALTIME UPDATES → useFestivalShifts hook
-4. VIEW → ShiftsTable with color-coded assignments
-5. EXPORT → shifts PDF
-```
+- Compares artist requirements against effective setup (global + stage override rules).
+- Produces mismatch items with severity (`error`, `warning`, `info`).
+- Aggregates additional-needs suggestions by model/category.
+- Renders status via table indicators and detailed tooltip summaries.
 
-## Component Structure
+## Flex integration summary
 
-- `form/sections/` — Form input sections (BasicInfoSection, ConsoleSetupSection, WirelessSetupSection, etc.)
-- `gear-setup/` — Gear configuration (ConsoleConfig, MicrophoneNeedsCalculator, WiredMicConfig, etc.)
-- `scheduling/` — Shift scheduling (CreateShiftDialog, EditShiftDialog, ShiftsTable, etc.)
-- `pdf/` — PDF generation dialogs
-- `mobile/` — Mobile-specific UI
+- Festival UI resolves available Flex context for the current job.
+- Pullsheet push supports selection mode or direct URL mode.
+- Export can be narrowed by gear sections to reduce bad writes.
+- Result summary reports succeeded/failed rows for troubleshooting.
 
-## Integration Points
+## Create Extras Quote integration (Flex)
 
-- **Public Artist Form**: Tokenized public routes (`/festival/artist-form/{token}`) for artists to submit requirements without authentication
-- **Flex Integration**: Push gear data to Flex via `PushToFlexPullsheetDialog`
-- **Activity Logging**: Artist form submissions trigger `festival.public_form.submitted` events
-- **Job System**: Each festival is linked to a parent job record
+Festival artist rows include a **"Crear presupuesto extras en Flex"** action when the gear comparison detects at least one `error` mismatch.
+
+Operational behavior:
+
+- Triggered from desktop and mobile artist actions (`ArtistTable`, `MobileArtistCard`).
+- Uses `useCreateExtrasPresupuesto` to create/resolve: 
+  1. `comercial` department folder,
+  2. `comercial_extras` sound subfolder,
+  3. a new `comercial_presupuesto` document in Flex.
+- Persists created elements in `flex_folders` for traceability.
+- Uses per-job queueing to avoid duplicate document numbers under concurrent clicks.
+
+This integration closes the loop between **gear mismatch detection** and **commercial remediation workflow**.
+
+
+## Related docs
+
+- [Public artist form workflow](./public-artist-form.md)
+- [Flex folder workflows audit](../flex-folder-workflows.md)
+- [Flex selector integration](../FLEX_SELECTOR_INTEGRATION.md)


### PR DESCRIPTION
### Motivation

- Provide a focused, sectioned architecture reference for the Festival subsystem to centralize design, data model, and integration details.  
- Improve discoverability from the main documentation index by linking the new architecture docs from `docs/README.md`.  
- Clarify workflows and surface integration points (gear comparison, Flex/pullsheet, public artist forms, scheduling) for ops, product, and engineering.  

### Description

- Added a new architecture section under `docs/architecture/festival-system/` including `README.md`, `artist-tables.md`, `gear-setup-and-comparison.md`, `scheduling.md`, and `flex-integration.md` that document data models, UI entry points, workflows, and integration surfaces.  
- Updated `docs/README.md` to include a new "Festival architecture (section-specific)" index linking the new architecture pages.  
- Reworked `docs/workflows/festival-management.md` to expand the overview, clarify entry points and core tables, reorganize workflows, and add operational summaries for gear comparison, Flex integration, and the "Crear presupuesto extras en Flex" flow.  
- Documented concrete source file locations and key services/hooks/components used by the festival subsystem (e.g. `src/pages/FestivalManagement.tsx`, `src/pages/festival-management/useFestivalManagementVm.ts`, `src/utils/gearComparisonService.ts`, and `useCreateExtrasPresupuesto`).  

### Testing

- No automated tests were required or run since this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e8169df08320b9982f9602e45e95)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed Festival subsystem architecture documentation covering artist roster management, gear setup validation, shift scheduling, and Flex integration
  * Reorganized and updated Festival management workflow reference for improved navigation and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->