### PR TITLE
fix: scope error boundaries so transient crashes do not kill the whole app

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -198,8 +198,8 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
               : 'Encontramos un problema inesperado. Puedes intentar continuar, recargar la página o borrar los datos locales si el error persiste.'}
           </p>
           {this.state.error?.message && !isChunkError && (
-            <p className="text-xs text-muted-foreground truncate" title={this.state.error.message}>
-              {this.state.error.message}
+            <p className="text-xs text-muted-foreground truncate" title={import.meta.env.DEV ? this.state.error.message : undefined}>
+              {import.meta.env.DEV ? this.state.error.message : 'Ha ocurrido un error. Por favor, inténtelo más tarde.'}
             </p>
           )}
           <div className="flex flex-col sm:flex-row items-center justify-center gap-3">

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,17 +1,42 @@
 import React from 'react';
-import { RefreshCw, Trash2 } from 'lucide-react';
+import { RefreshCw, RotateCcw, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { isChunkLoadError } from '@/utils/errorUtils';
 import { CHUNK_ERROR_RELOAD_KEY, MAX_CHUNK_ERROR_RELOADS } from '@/utils/chunkErrorConstants';
+import { recordBoundaryError } from '@/utils/errorTelemetry';
+
+export type ErrorBoundaryFallbackRender = (args: {
+  error: Error;
+  reset: () => void;
+  reload: () => void;
+}) => React.ReactNode;
 
 type ErrorBoundaryProps = {
   children: React.ReactNode;
+  /** When any of these values change, the boundary resets and re-renders children. */
+  resetKeys?: ReadonlyArray<unknown>;
+  /** If true, the boundary renders nothing when it catches an error (non-critical UI). */
+  silent?: boolean;
+  /** Optional label used when logging / reporting the error. */
+  boundaryName?: string;
+  /** Custom render for the fallback UI. Receives error and reset/reload callbacks. */
+  fallback?: ErrorBoundaryFallbackRender;
+  /** Optional side-effect when an error is caught (e.g. for tests / custom telemetry). */
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
 };
 
 type ErrorBoundaryState = {
   hasError: boolean;
   error?: Error;
 };
+
+function areResetKeysEqual(a: ReadonlyArray<unknown> = [], b: ReadonlyArray<unknown> = []): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (!Object.is(a[i], b[i])) return false;
+  }
+  return true;
+}
 
 export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { hasError: false };
@@ -48,7 +73,34 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error('Unhandled error captured by ErrorBoundary', error, errorInfo);
+    const { boundaryName, onError, silent } = this.props;
+    const label = boundaryName ?? 'ErrorBoundary';
+
+    console.error(`[${label}] Unhandled error captured`, error, errorInfo);
+
+    try {
+      recordBoundaryError({
+        boundary: label,
+        message: error.message,
+        name: error.name,
+        stack: error.stack,
+        componentStack: errorInfo.componentStack ?? undefined,
+        url: typeof window !== 'undefined' ? window.location.href : undefined,
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
+        silent: Boolean(silent),
+        timestamp: new Date().toISOString(),
+      });
+    } catch (telemetryError) {
+      console.warn('[ErrorBoundary] Failed to record telemetry', telemetryError);
+    }
+
+    if (onError) {
+      try {
+        onError(error, errorInfo);
+      } catch (hookError) {
+        console.warn('[ErrorBoundary] onError callback threw', hookError);
+      }
+    }
 
     // Cancel the reload count clear timeout if error occurs
     if (this.clearTimeoutId) {
@@ -61,7 +113,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
       const reloadCount = this.getReloadCount();
 
       if (reloadCount < MAX_CHUNK_ERROR_RELOADS) {
-        console.log(`[ErrorBoundary] Chunk load error detected. Auto-reloading (${reloadCount + 1}/${MAX_CHUNK_ERROR_RELOADS})...`);
+        console.log(`[${label}] Chunk load error detected. Auto-reloading (${reloadCount + 1}/${MAX_CHUNK_ERROR_RELOADS})...`);
         this.incrementReloadCount();
 
         // Brief delay before reload to prevent too-fast reload loops
@@ -69,13 +121,17 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
           window.location.reload();
         }, 500);
       } else {
-        console.error('[ErrorBoundary] Max auto-reload attempts reached. Showing error UI.');
+        console.error(`[${label}] Max auto-reload attempts reached. Showing error UI.`);
       }
     }
   }
 
   private handleReload = () => {
     window.location.reload();
+  };
+
+  private handleReset = () => {
+    this.setState({ hasError: false, error: undefined });
   };
 
   private handleClearStorage = () => {
@@ -96,6 +152,13 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     }, 1000); // 1 second delay after mount
   }
 
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (!this.state.hasError) return;
+    if (!areResetKeysEqual(prevProps.resetKeys, this.props.resetKeys)) {
+      this.setState({ hasError: false, error: undefined });
+    }
+  }
+
   componentWillUnmount() {
     // Clean up timeout if component unmounts before it fires
     if (this.clearTimeoutId) {
@@ -105,43 +168,61 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
   }
 
   render() {
-    if (this.state.hasError) {
-      const isChunkError = this.state.error && isChunkLoadError(this.state.error);
-
-      return (
-        <div className="min-h-screen w-full flex items-center justify-center bg-background text-foreground p-6">
-          <div className="max-w-lg w-full space-y-4 text-center">
-            <h1 className="text-2xl font-semibold">
-              {isChunkError ? 'Nueva versión disponible' : 'Algo salió mal'}
-            </h1>
-            <p className="text-muted-foreground text-sm">
-              {isChunkError
-                ? 'La aplicación se ha actualizado. Por favor, recarga la página para obtener la última versión.'
-                : 'Encontramos un problema al cargar la aplicación. Intenta recargar la página o borra los datos locales si el error persiste.'}
-            </p>
-            {this.state.error?.message && !isChunkError && (
-              <p className="text-xs text-muted-foreground truncate" title={this.state.error.message}>
-                {this.state.error.message}
-              </p>
-            )}
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Button onClick={this.handleReload} className="w-full sm:w-auto">
-                <RefreshCw className="h-4 w-4 mr-2" />
-                Recargar
-              </Button>
-              {!isChunkError && (
-                <Button variant="outline" onClick={this.handleClearStorage} className="w-full sm:w-auto">
-                  <Trash2 className="h-4 w-4 mr-2" />
-                  Borrar datos locales
-                </Button>
-              )}
-            </div>
-          </div>
-        </div>
-      );
+    if (!this.state.hasError || !this.state.error) {
+      return this.props.children;
     }
 
-    return this.props.children;
+    if (this.props.silent) {
+      return null;
+    }
+
+    if (this.props.fallback) {
+      return this.props.fallback({
+        error: this.state.error,
+        reset: this.handleReset,
+        reload: this.handleReload,
+      });
+    }
+
+    const isChunkError = isChunkLoadError(this.state.error);
+
+    return (
+      <div className="min-h-screen w-full flex items-center justify-center bg-background text-foreground p-6">
+        <div className="max-w-lg w-full space-y-4 text-center">
+          <h1 className="text-2xl font-semibold">
+            {isChunkError ? 'Nueva versión disponible' : 'Algo salió mal'}
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            {isChunkError
+              ? 'La aplicación se ha actualizado. Por favor, recarga la página para obtener la última versión.'
+              : 'Encontramos un problema inesperado. Puedes intentar continuar, recargar la página o borrar los datos locales si el error persiste.'}
+          </p>
+          {this.state.error?.message && !isChunkError && (
+            <p className="text-xs text-muted-foreground truncate" title={this.state.error.message}>
+              {this.state.error.message}
+            </p>
+          )}
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            {!isChunkError && (
+              <Button onClick={this.handleReset} variant="secondary" className="w-full sm:w-auto">
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Intentar de nuevo
+              </Button>
+            )}
+            <Button onClick={this.handleReload} className="w-full sm:w-auto">
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Recargar
+            </Button>
+            {!isChunkError && (
+              <Button variant="outline" onClick={this.handleClearStorage} className="w-full sm:w-auto">
+                <Trash2 className="h-4 w-4 mr-2" />
+                Borrar datos locales
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
   }
 }
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -85,7 +85,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
         name: error.name,
         stack: error.stack,
         componentStack: errorInfo.componentStack ?? undefined,
-        url: typeof window !== 'undefined' ? window.location.href : undefined,
+        url: typeof window !== 'undefined' ? window.location.pathname : undefined,
         userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
         silent: Boolean(silent),
         timestamp: new Date().toISOString(),

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { RefreshCw, RotateCcw, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { isChunkLoadError } from '@/utils/errorUtils';
-import { CHUNK_ERROR_RELOAD_KEY, MAX_CHUNK_ERROR_RELOADS } from '@/utils/chunkErrorConstants';
+import {
+  CHUNK_ERROR_RELOAD_KEY,
+  CHUNK_ERROR_RELOAD_OWNER_KEY,
+  CHUNK_ERROR_RELOAD_OWNER_TTL_MS,
+  MAX_CHUNK_ERROR_RELOADS,
+} from '@/utils/chunkErrorConstants';
 import { recordBoundaryError } from '@/utils/errorTelemetry';
 
 export type ErrorBoundaryFallbackRender = (args: {
@@ -38,9 +43,23 @@ function areResetKeysEqual(a: ReadonlyArray<unknown> = [], b: ReadonlyArray<unkn
   return true;
 }
 
+function generateOwnerId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // fall through to fallback
+  }
+  return `eb-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
 export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { hasError: false };
   private clearTimeoutId?: ReturnType<typeof setTimeout>;
+  // Unique per-instance id used to scope the chunk-reload counter so sibling
+  // boundaries cannot clear a counter another instance just incremented.
+  private readonly ownerId: string = generateOwnerId();
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { hasError: true, error };
@@ -59,14 +78,55 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
     try {
       const count = this.getReloadCount();
       sessionStorage.setItem(CHUNK_ERROR_RELOAD_KEY, (count + 1).toString());
+      sessionStorage.setItem(
+        CHUNK_ERROR_RELOAD_OWNER_KEY,
+        JSON.stringify({ ownerId: this.ownerId, ts: Date.now() }),
+      );
     } catch {
       // Ignore sessionStorage errors
     }
   }
 
-  private clearReloadCount(): void {
+  /**
+   * Clears the reload counter only if this instance "owns" it (i.e. incremented
+   * it last) or if the owner entry is stale. Sibling boundaries whose mount
+   * timer fires while another boundary has an in-flight reload must not wipe
+   * the counter, or MAX_CHUNK_ERROR_RELOADS can be bypassed on every reload.
+   */
+  private maybeClearReloadCount(): void {
     try {
-      sessionStorage.removeItem(CHUNK_ERROR_RELOAD_KEY);
+      const countRaw = sessionStorage.getItem(CHUNK_ERROR_RELOAD_KEY);
+      if (!countRaw) {
+        // Counter already cleared (usually by main.tsx on successful load).
+        // Remove any orphan ownership entry so it can't haunt a later cycle.
+        sessionStorage.removeItem(CHUNK_ERROR_RELOAD_OWNER_KEY);
+        return;
+      }
+
+      const ownerRaw = sessionStorage.getItem(CHUNK_ERROR_RELOAD_OWNER_KEY);
+      if (!ownerRaw) {
+        // Counter exists but no owner metadata — legacy or external write.
+        // Treat as unowned and clear it (matches the prior behaviour).
+        sessionStorage.removeItem(CHUNK_ERROR_RELOAD_KEY);
+        return;
+      }
+
+      let parsed: { ownerId?: string; ts?: number } | null = null;
+      try {
+        parsed = JSON.parse(ownerRaw);
+      } catch {
+        parsed = null;
+      }
+
+      const isOwner = parsed?.ownerId === this.ownerId;
+      const age = Date.now() - (Number(parsed?.ts) || 0);
+      const isStale = age > CHUNK_ERROR_RELOAD_OWNER_TTL_MS;
+
+      if (isOwner || isStale) {
+        sessionStorage.removeItem(CHUNK_ERROR_RELOAD_KEY);
+        sessionStorage.removeItem(CHUNK_ERROR_RELOAD_OWNER_KEY);
+      }
+      // Otherwise another boundary owns the in-flight counter — leave alone.
     } catch {
       // Ignore sessionStorage errors
     }
@@ -145,9 +205,10 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
   componentDidMount() {
     // Clear reload count after a short delay to ensure child components have rendered
-    // This prevents clearing the count before initial render errors might occur
+    // This prevents clearing the count before initial render errors might occur.
+    // Only this instance's counter (or a stale one) is cleared — see maybeClearReloadCount.
     this.clearTimeoutId = setTimeout(() => {
-      this.clearReloadCount();
+      this.maybeClearReloadCount();
       this.clearTimeoutId = undefined;
     }, 1000); // 1 second delay after mount
   }
@@ -198,8 +259,13 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
               : 'Encontramos un problema inesperado. Puedes intentar continuar, recargar la página o borrar los datos locales si el error persiste.'}
           </p>
           {this.state.error?.message && !isChunkError && (
-            <p className="text-xs text-muted-foreground truncate" title={import.meta.env.DEV ? this.state.error.message : undefined}>
-              {import.meta.env.DEV ? this.state.error.message : 'Ha ocurrido un error. Por favor, inténtelo más tarde.'}
+            <p
+              className="text-xs text-muted-foreground truncate"
+              title={import.meta.env.DEV ? this.state.error.message : undefined}
+            >
+              {import.meta.env.DEV
+                ? this.state.error.message
+                : 'Ha ocurrido un error. Por favor, inténtelo más tarde.'}
             </p>
           )}
           <div className="flex flex-col sm:flex-row items-center justify-center gap-3">

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -5,6 +5,10 @@ import userEvent from '@testing-library/user-event';
 
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { clearBoundaryErrors, getBoundaryErrors } from '@/utils/errorTelemetry';
+import {
+  CHUNK_ERROR_RELOAD_KEY,
+  CHUNK_ERROR_RELOAD_OWNER_KEY,
+} from '@/utils/chunkErrorConstants';
 
 const TOGGLE: { throwOnRender: boolean } = { throwOnRender: true };
 
@@ -128,5 +132,60 @@ describe('ErrorBoundary', () => {
     TOGGLE.throwOnRender = false;
     await user.click(screen.getByText('retry'));
     expect(screen.getByText('child ok')).toBeInTheDocument();
+  });
+
+  it('does not expose raw error messages in the default fallback', () => {
+    render(
+      <ErrorBoundary>
+        <Thrower message="secret internal stacktrace string" />
+      </ErrorBoundary>,
+    );
+    // Production build: raw message is hidden. In the Vitest/JSDOM environment
+    // import.meta.env.DEV is true by default — so we just make sure the public
+    // UI copy is always present regardless of env.
+    expect(screen.getByText('Algo salió mal')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Encontramos un problema inesperado/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not let a sibling boundary's mount timer wipe another's in-flight chunk counter", () => {
+    vi.useFakeTimers();
+    try {
+      sessionStorage.clear();
+
+      // Sibling that has no error and will mount a clear timer.
+      const Ok = (): React.ReactElement => <div>ok</div>;
+      render(
+        <>
+          <ErrorBoundary boundaryName="sibling-a">
+            <Ok />
+          </ErrorBoundary>
+          <ErrorBoundary boundaryName="sibling-b">
+            <Ok />
+          </ErrorBoundary>
+        </>,
+      );
+
+      // Simulate another boundary (elsewhere in the tree) having just
+      // incremented the chunk-reload counter during an in-flight reload.
+      sessionStorage.setItem(CHUNK_ERROR_RELOAD_KEY, '1');
+      sessionStorage.setItem(
+        CHUNK_ERROR_RELOAD_OWNER_KEY,
+        JSON.stringify({ ownerId: 'some-other-boundary', ts: Date.now() }),
+      );
+
+      // Fire the mount clear timers of the two sibling boundaries.
+      act(() => {
+        vi.advanceTimersByTime(1500);
+      });
+
+      // The counter must survive — otherwise MAX_CHUNK_ERROR_RELOADS is bypassed.
+      expect(sessionStorage.getItem(CHUNK_ERROR_RELOAD_KEY)).toBe('1');
+      expect(sessionStorage.getItem(CHUNK_ERROR_RELOAD_OWNER_KEY)).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+      sessionStorage.clear();
+    }
   });
 });

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { clearBoundaryErrors, getBoundaryErrors } from '@/utils/errorTelemetry';
+
+const TOGGLE: { throwOnRender: boolean } = { throwOnRender: true };
+
+function Thrower({ message = 'boom' }: { message?: string }): React.ReactElement {
+  if (TOGGLE.throwOnRender) {
+    throw new Error(message);
+  }
+  return <div>child ok</div>;
+}
+
+describe('ErrorBoundary', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    TOGGLE.throwOnRender = true;
+    clearBoundaryErrors();
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('renders children when no error is thrown', () => {
+    TOGGLE.throwOnRender = false;
+    render(
+      <ErrorBoundary>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('child ok')).toBeInTheDocument();
+  });
+
+  it('renders the default fallback when children throw', () => {
+    render(
+      <ErrorBoundary>
+        <Thrower message="kaboom" />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Algo salió mal')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /intentar de nuevo/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /recargar/i })).toBeInTheDocument();
+  });
+
+  it('resets without a full reload when the user clicks "Intentar de nuevo"', async () => {
+    const user = userEvent.setup();
+    render(
+      <ErrorBoundary>
+        <Thrower message="transient" />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Algo salió mal')).toBeInTheDocument();
+
+    // Next render will succeed
+    TOGGLE.throwOnRender = false;
+    await user.click(screen.getByRole('button', { name: /intentar de nuevo/i }));
+
+    expect(screen.getByText('child ok')).toBeInTheDocument();
+  });
+
+  it('renders null when silent and an error occurs', () => {
+    const { container } = render(
+      <ErrorBoundary silent>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('auto-resets when resetKeys change', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['a']}>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Algo salió mal')).toBeInTheDocument();
+
+    TOGGLE.throwOnRender = false;
+    act(() => {
+      rerender(
+        <ErrorBoundary resetKeys={['b']}>
+          <Thrower />
+        </ErrorBoundary>,
+      );
+    });
+
+    expect(screen.getByText('child ok')).toBeInTheDocument();
+  });
+
+  it('records caught errors in telemetry with boundary name', () => {
+    render(
+      <ErrorBoundary boundaryName="test-zone">
+        <Thrower message="telemetry-check" />
+      </ErrorBoundary>,
+    );
+
+    const records = getBoundaryErrors();
+    expect(records).toHaveLength(1);
+    expect(records[0].boundary).toBe('test-zone');
+    expect(records[0].message).toBe('telemetry-check');
+  });
+
+  it('invokes fallback render with error and reset callback', async () => {
+    const user = userEvent.setup();
+    const fallback = vi.fn(({ error, reset }) => (
+      <div>
+        <span data-testid="err">{error.message}</span>
+        <button onClick={reset}>retry</button>
+      </div>
+    ));
+
+    render(
+      <ErrorBoundary fallback={fallback}>
+        <Thrower message="custom" />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByTestId('err')).toHaveTextContent('custom');
+
+    TOGGLE.throwOnRender = false;
+    await user.click(screen.getByText('retry'));
+    expect(screen.getByText('child ok')).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -558,7 +558,11 @@ const Layout = () => {
           userEmail={session.user?.email ?? undefined}
         />
       )}
-      <ErrorBoundary boundaryName="pending-tasks-modal" silent>
+      <ErrorBoundary
+        boundaryName="pending-tasks-modal"
+        silent
+        resetKeys={[showPendingTasksModal, userId, userRole, userDepartment]}
+      >
         <PendingTasksModal
           open={showPendingTasksModal}
           onOpenChange={setShowPendingTasksModal}
@@ -567,7 +571,11 @@ const Layout = () => {
           userDepartment={userDepartment}
         />
       </ErrorBoundary>
-      <ErrorBoundary boundaryName="single-task-popup" silent>
+      <ErrorBoundary
+        boundaryName="single-task-popup"
+        silent
+        resetKeys={[showSingleTaskPopup, currentTaskIndex, unacknowledgedTasks.length]}
+      >
         {unacknowledgedTasks.length > 0 && unacknowledgedTasks[currentTaskIndex] && (
           <SingleTaskPopup
             open={showSingleTaskPopup}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -30,6 +30,7 @@ import { PendingTasksModal } from "@/components/tasks/PendingTasksModal"
 import { SingleTaskPopup } from "@/components/tasks/SingleTaskPopup"
 import { PendingTasksBadge } from "@/components/tasks/PendingTasksBadge"
 
+import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { AboutCard } from "./AboutCard"
 import { HelpButton } from "./HelpButton"
 import { MobileNavBar } from "./MobileNavBar"
@@ -515,7 +516,34 @@ const Layout = () => {
                   : "pb-10",
             )}
           >
-            <Outlet />
+            <ErrorBoundary
+              boundaryName="route"
+              resetKeys={[location.pathname, location.search]}
+              fallback={({ error, reset, reload }) => (
+                <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+                  <h2 className="text-xl font-semibold">No pudimos cargar esta página</h2>
+                  <p className="max-w-md text-sm text-muted-foreground">
+                    Se produjo un error al mostrar el contenido. Puedes intentar recargar esta sección
+                    o volver a abrirla más tarde. El resto de la aplicación sigue funcionando.
+                  </p>
+                  {error?.message && (
+                    <p className="max-w-md truncate text-xs text-muted-foreground" title={error.message}>
+                      {error.message}
+                    </p>
+                  )}
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Button onClick={reset} variant="secondary">
+                      Intentar de nuevo
+                    </Button>
+                    <Button onClick={reload}>
+                      Recargar página
+                    </Button>
+                  </div>
+                </div>
+              )}
+            >
+              <Outlet />
+            </ErrorBoundary>
           </main>
         </div>
       </div>
@@ -530,27 +558,31 @@ const Layout = () => {
           userEmail={session.user?.email ?? undefined}
         />
       )}
-      <PendingTasksModal
-        open={showPendingTasksModal}
-        onOpenChange={setShowPendingTasksModal}
-        userId={userId}
-        userRole={userRole}
-        userDepartment={userDepartment}
-      />
-      {unacknowledgedTasks && unacknowledgedTasks.length > 0 && (
-        <SingleTaskPopup
-          open={showSingleTaskPopup}
-          onOpenChange={setShowSingleTaskPopup}
-          task={unacknowledgedTasks[currentTaskIndex] || null}
-          jobOrTourName={unacknowledgedTasks[currentTaskIndex]?.jobOrTourName || ''}
-          jobOrTourType={unacknowledgedTasks[currentTaskIndex]?.jobOrTourType || 'job'}
-          client={unacknowledgedTasks[currentTaskIndex]?.client}
-          onDismiss={handleSingleTaskDismiss}
-          onViewAll={handleViewAllTasks}
-          totalPendingCount={unacknowledgedTasks.length}
-          currentIndex={currentTaskIndex}
+      <ErrorBoundary boundaryName="pending-tasks-modal" silent>
+        <PendingTasksModal
+          open={showPendingTasksModal}
+          onOpenChange={setShowPendingTasksModal}
+          userId={userId}
+          userRole={userRole}
+          userDepartment={userDepartment}
         />
-      )}
+      </ErrorBoundary>
+      <ErrorBoundary boundaryName="single-task-popup" silent>
+        {unacknowledgedTasks.length > 0 && unacknowledgedTasks[currentTaskIndex] && (
+          <SingleTaskPopup
+            open={showSingleTaskPopup}
+            onOpenChange={setShowSingleTaskPopup}
+            task={unacknowledgedTasks[currentTaskIndex]}
+            jobOrTourName={unacknowledgedTasks[currentTaskIndex]?.jobOrTourName || ''}
+            jobOrTourType={unacknowledgedTasks[currentTaskIndex]?.jobOrTourType || 'job'}
+            client={unacknowledgedTasks[currentTaskIndex]?.client}
+            onDismiss={handleSingleTaskDismiss}
+            onViewAll={handleViewAllTasks}
+            totalPendingCount={unacknowledgedTasks.length}
+            currentIndex={currentTaskIndex}
+          />
+        )}
+      </ErrorBoundary>
     </SidebarProvider>
   )
 }

--- a/src/routes/AuthenticatedShell.tsx
+++ b/src/routes/AuthenticatedShell.tsx
@@ -67,18 +67,23 @@ function OscarRouteGuard() {
 }
 
 export default function AuthenticatedShell() {
+  const location = useLocation();
+  const { user } = useOptimizedAuth();
+  const userId = user?.id ?? null;
+  const recoveryKeys = [location.pathname, userId];
+
   return (
     <RequireAuth>
       <SubscriptionProvider>
-        <ErrorBoundary boundaryName="app-init" silent>
+        <ErrorBoundary boundaryName="app-init" silent resetKeys={recoveryKeys}>
           <AppInit />
         </ErrorBoundary>
-        <ErrorBoundary boundaryName="activity-push-fallback" silent>
+        <ErrorBoundary boundaryName="activity-push-fallback" silent resetKeys={recoveryKeys}>
           <ActivityPushFallbackInit />
         </ErrorBoundary>
         <TechnicianRouteGuard />
         <OscarRouteGuard />
-        <ErrorBoundary boundaryName="achievement-banner" silent>
+        <ErrorBoundary boundaryName="achievement-banner" silent resetKeys={recoveryKeys}>
           <AchievementBanner />
         </ErrorBoundary>
         <Outlet />

--- a/src/routes/AuthenticatedShell.tsx
+++ b/src/routes/AuthenticatedShell.tsx
@@ -6,6 +6,7 @@ import { AppInit } from "@/components/AppInit";
 import { useActivityPushFallback } from "@/hooks/useActivityPushFallback";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { AchievementBanner } from "@/components/achievements/AchievementBanner";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 function ActivityPushFallbackInit() {
   useActivityPushFallback();
@@ -69,11 +70,17 @@ export default function AuthenticatedShell() {
   return (
     <RequireAuth>
       <SubscriptionProvider>
-        <AppInit />
-        <ActivityPushFallbackInit />
+        <ErrorBoundary boundaryName="app-init" silent>
+          <AppInit />
+        </ErrorBoundary>
+        <ErrorBoundary boundaryName="activity-push-fallback" silent>
+          <ActivityPushFallbackInit />
+        </ErrorBoundary>
         <TechnicianRouteGuard />
         <OscarRouteGuard />
-        <AchievementBanner />
+        <ErrorBoundary boundaryName="achievement-banner" silent>
+          <AchievementBanner />
+        </ErrorBoundary>
         <Outlet />
       </SubscriptionProvider>
     </RequireAuth>

--- a/src/utils/chunkErrorConstants.ts
+++ b/src/utils/chunkErrorConstants.ts
@@ -4,4 +4,14 @@
  */
 
 export const CHUNK_ERROR_RELOAD_KEY = 'chunk-error-reload-count';
+/**
+ * Companion key that records which ErrorBoundary instance last incremented the
+ * counter so sibling boundaries do not wipe it via their mount-time clear timer.
+ */
+export const CHUNK_ERROR_RELOAD_OWNER_KEY = 'chunk-error-reload-owner';
+/**
+ * If the owner entry is older than this, any boundary may clear the counter —
+ * this prevents a crashed instance from permanently pinning the counter.
+ */
+export const CHUNK_ERROR_RELOAD_OWNER_TTL_MS = 60_000;
 export const MAX_CHUNK_ERROR_RELOADS = 2;

--- a/src/utils/errorTelemetry.ts
+++ b/src/utils/errorTelemetry.ts
@@ -1,0 +1,78 @@
+/**
+ * Lightweight, browser-only telemetry for errors caught by ErrorBoundary.
+ *
+ * Persists the last N errors to sessionStorage so support can inspect them
+ * via `window.__sectorProErrors` without requiring a backend round-trip.
+ */
+
+export interface BoundaryErrorRecord {
+  boundary: string;
+  message: string;
+  name: string;
+  stack?: string;
+  componentStack?: string;
+  url?: string;
+  userAgent?: string;
+  silent: boolean;
+  timestamp: string;
+}
+
+const STORAGE_KEY = 'sector-pro:boundary-errors';
+const MAX_RECORDS = 10;
+
+declare global {
+  interface Window {
+    __sectorProErrors?: BoundaryErrorRecord[];
+  }
+}
+
+function loadRecords(): BoundaryErrorRecord[] {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is BoundaryErrorRecord =>
+        !!entry &&
+        typeof entry === 'object' &&
+        typeof (entry as BoundaryErrorRecord).message === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function saveRecords(records: BoundaryErrorRecord[]): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+  } catch {
+    // sessionStorage may be full or unavailable — ignore
+  }
+}
+
+export function recordBoundaryError(record: BoundaryErrorRecord): void {
+  const records = loadRecords();
+  records.push(record);
+  while (records.length > MAX_RECORDS) records.shift();
+  saveRecords(records);
+
+  if (typeof window !== 'undefined') {
+    window.__sectorProErrors = records;
+  }
+}
+
+export function getBoundaryErrors(): BoundaryErrorRecord[] {
+  return loadRecords();
+}
+
+export function clearBoundaryErrors(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+  if (typeof window !== 'undefined') {
+    window.__sectorProErrors = [];
+  }
+}


### PR DESCRIPTION
Users across roles occasionally saw the global error screen prompting them to
reload. Root cause: a single top-level ErrorBoundary wraps the entire tree, so
any uncaught render error anywhere (realtime payload, task popup, route code)
dismounts the whole UI and forces a reload that loses state. The boundary also
had no telemetry, so these crashes were invisible.

- Enhance ErrorBoundary with resetKeys, silent mode, custom fallback render,
  onError hook, and a "try again" button that recovers without a full reload.
- Record caught errors (message, stack, component stack, route, UA) to
  sessionStorage and window.__sectorProErrors for support triage.
- Wrap the authenticated <Outlet /> in a route-scoped boundary that resets on
  navigation and keeps the shell/sidebar usable when a route crashes.
- Wrap SingleTaskPopup, PendingTasksModal, AchievementBanner, AppInit, and the
  activity push fallback in silent boundaries so non-critical side effects can
  fail without taking down the app.
- Guard the SingleTaskPopup mount on the current task actually existing in the
  (possibly mutated) unacknowledged list.
- Add tests covering reset, resetKeys, silent, fallback render and telemetry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced error boundaries with configurable fallback rendering, silent mode, named boundaries, and automatic recovery when configured keys change.
  * Spanish fallback UI updated to show the error when available plus “Intentar de nuevo” and “Recargar página” actions.
  * Scoped boundaries added around routes, modals, banners and init flows.
  * Client-side capture and persisted telemetry of recent boundary errors for diagnostics.

* **Tests**
  * Added comprehensive tests for fallback UI, retry/reset behavior, silent mode, resetKeys auto-reset, telemetry recording, and custom fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->