### PR TITLE
Fix artist Flex quote time formatting

### DIFF
--- a/src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts
+++ b/src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatArtistDateTimeForFlex } from "../useCreateExtrasPresupuesto";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {},
+}));
+
+vi.mock("@/utils/flex-folders/api", () => ({
+  createFlexFolder: vi.fn(),
+}));
+
+describe("formatArtistDateTimeForFlex", () => {
+  it("formats artist local time in the Flex timestamp shape", () => {
+    expect(formatArtistDateTimeForFlex("2026-07-18", "20:30")).toBe(
+      "2026-07-18T20:30:00.000Z"
+    );
+  });
+
+  it("preserves explicit seconds when present", () => {
+    expect(formatArtistDateTimeForFlex("2026-07-18", "20:30:45")).toBe(
+      "2026-07-18T20:30:45.000Z"
+    );
+  });
+
+  it("rejects invalid artist times", () => {
+    expect(() => formatArtistDateTimeForFlex("2026-07-18", "24:00")).toThrow(
+      "Hora de artista invalida"
+    );
+  });
+});

--- a/src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts
+++ b/src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { formatArtistDateTimeForFlex } from "../useCreateExtrasPresupuesto";
+import {
+  formatArtistDateTimeForFlex,
+  formatArtistExtrasFolderDocumentNumber,
+} from "../useCreateExtrasPresupuesto";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -32,6 +35,14 @@ describe("formatArtistDateTimeForFlex", () => {
   it("rejects invalid artist times", () => {
     expect(() => formatArtistDateTimeForFlex("2026-07-18", "24:00")).toThrow(
       "Hora de artista invalida"
+    );
+  });
+});
+
+describe("formatArtistExtrasFolderDocumentNumber", () => {
+  it("uses the extras sound quote document number for the shared extras folder", () => {
+    expect(formatArtistExtrasFolderDocumentNumber(new Date("2026-05-07T12:00:00.000Z"))).toBe(
+      "070526ESQT"
     );
   });
 });

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -24,6 +24,10 @@ export function formatArtistDateTimeForFlex(date: string, time: string): string 
   return `${date}T${hours}:${minutes}:${seconds}.000Z`;
 }
 
+export function formatArtistExtrasFolderDocumentNumber(date: Date): string {
+  return `${format(date, "ddMMyy")}ESQT`;
+}
+
 async function insertWithRetry(insertFn: () => Promise<{ error: unknown }>): Promise<void> {
   let lastError: unknown = null;
   for (let i = 0; i <= RETRY_DELAYS.length; i++) {
@@ -99,6 +103,7 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
 
       const ordinal = (count ?? 0) + 1;
       const docDate = format(parsedDate, "ddMMyy");
+      const extrasFolderDocumentNumber = formatArtistExtrasFolderDocumentNumber(parsedDate);
       const documentNumber = `${docDate}.${ordinal}SQT`;
 
       // 4. Find the comercial department folder for this job
@@ -145,6 +150,7 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
           plannedEndDate,
           locationId: FLEX_FOLDER_IDS.location,
           departmentId: DEPARTMENT_IDS.sound,
+          documentNumber: extrasFolderDocumentNumber,
           personResponsibleId: RESPONSIBLE_PERSON_IDS.sound,
         });
 

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { format, parseISO, addDays } from "date-fns";
-import { fromZonedTime } from "date-fns-tz";
 import { supabase } from "@/integrations/supabase/client";
 import { createFlexFolder } from "@/utils/flex-folders/api";
 import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS } from "@/utils/flex-folders/constants";
@@ -12,9 +11,21 @@ import { FLEX_FOLDER_IDS, DEPARTMENT_IDS, RESPONSIBLE_PERSON_IDS } from "@/utils
 const jobCreationQueues = new Map<string, Promise<void>>();
 
 const RETRY_DELAYS = [500, 1000, 2000];
+const FLEX_TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/;
 
-async function insertWithRetry(insertFn: () => Promise<{ error: any }>): Promise<void> {
-  let lastError: any = null;
+export function formatArtistDateTimeForFlex(date: string, time: string): string {
+  const match = time.match(FLEX_TIME_PATTERN);
+  if (!match) {
+    throw new Error(`Hora de artista invalida para Flex: ${time || "(vacia)"}`);
+  }
+
+  const [, hours, minutes, seconds = "00"] = match;
+
+  return `${date}T${hours}:${minutes}:${seconds}.000Z`;
+}
+
+async function insertWithRetry(insertFn: () => Promise<{ error: unknown }>): Promise<void> {
+  let lastError: unknown = null;
   for (let i = 0; i <= RETRY_DELAYS.length; i++) {
     const { error } = await insertFn();
     if (!error) return;
@@ -71,16 +82,12 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
 
       const jobTitle = job.title?.trim() || "Sin título";
 
-      // 2. Build ISO date strings from the artist's show day/time
-      // Convert local Madrid datetime to UTC
+      // 2. Build Flex date strings from the artist's local show day/time
       const parsedDate = parseISO(artistDate);
       const endDateBase = isAfterMidnight ? addDays(parsedDate, 1) : parsedDate;
 
-      const localStartDatetime = `${artistDate}T${showStart}:00`;
-      const localEndDatetime = `${format(endDateBase, "yyyy-MM-dd")}T${showEnd}:00`;
-
-      const plannedStartDate = fromZonedTime(localStartDatetime, "Europe/Madrid").toISOString();
-      const plannedEndDate = fromZonedTime(localEndDatetime, "Europe/Madrid").toISOString();
+      const plannedStartDate = formatArtistDateTimeForFlex(artistDate, showStart);
+      const plannedEndDate = formatArtistDateTimeForFlex(format(endDateBase, "yyyy-MM-dd"), showEnd);
 
       // 3. Compute document number: DDMMAA.xSQT
       //    Count runs inside the queue so the ordinal is always fresh.


### PR DESCRIPTION
## Summary
- Format artist extras quote planned dates in Flex's expected timestamp shape (`yyyy-MM-ddTHH:mm:ss.000Z`)
- Preserve after-midnight end-date handling without converting Madrid wall time to UTC
- Set the shared artist Extras subfolder document number with the `ESQT` suffix (for example `070526ESQT`) so it no longer appears as `UNASSIGNED`
- Add focused tests for the Flex artist time and extras-folder document-number formatters

## Validation
- `vitest run src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts`
- `eslint src/hooks/festival/useCreateExtrasPresupuesto.ts src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts`