### PR TITLE
[codex] Allow assignable managers tech self-service

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -185,6 +185,38 @@ describe("App route guards and global overlays", () => {
     expect(await screen.findByText("Technician Dashboard Route")).toBeInTheDocument();
   });
 
+  it("allows assignable management users into /tech-app", async () => {
+    mockOptimizedAuthRole("management", { assignableAsTech: true });
+
+    renderAppAt("/tech-app");
+
+    expect(await screen.findByText("Tech App Route")).toBeInTheDocument();
+  });
+
+  it("allows assignable management users into /technician-dashboard", async () => {
+    mockOptimizedAuthRole("management", { assignableAsTech: true });
+
+    renderAppAt("/technician-dashboard");
+
+    expect(await screen.findByText("Technician Dashboard Route")).toBeInTheDocument();
+  });
+
+  it("redirects non-assignable management users away from technician self-service routes", async () => {
+    mockOptimizedAuthRole("management", { assignableAsTech: false });
+
+    renderAppAt("/technician-dashboard");
+
+    expect(await screen.findByText("Dashboard Route")).toBeInTheDocument();
+  });
+
+  it("redirects non-assignable management users away from /tech-app", async () => {
+    mockOptimizedAuthRole("management", { assignableAsTech: false });
+
+    renderAppAt("/tech-app");
+
+    expect(await screen.findByText("Dashboard Route")).toBeInTheDocument();
+  });
+
   it("allows management users into /settings", async () => {
     mockOptimizedAuthRole("management");
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -266,7 +266,7 @@ export default function App() {
                             <Route
                               path="/tech-app"
                               element={
-                                <ProtectedRoute allowedRoles={['technician']}>
+                                <ProtectedRoute allowedRoles={['technician']} allowAssignableTech>
                                   <TechnicianSuperApp />
                                 </ProtectedRoute>
                               }
@@ -281,7 +281,7 @@ export default function App() {
                               <Route path="/personal" element={<ProtectedRoute allowedRoles={['admin', 'management', 'logistics', 'house_tech']}><Personal /></ProtectedRoute>} />
                               <Route path="/dashboard" element={<ProtectedRoute allowedRoles={['admin', 'management', 'logistics', 'oscar']}><Dashboard /></ProtectedRoute>} />
                               {/* House tech dashboard routes (regular technicians use /tech-app) */}
-                              <Route path="/technician-dashboard" element={<ProtectedRoute allowedRoles={['house_tech']}><TechnicianDashboard /></ProtectedRoute>} />
+                              <Route path="/technician-dashboard" element={<ProtectedRoute allowedRoles={['house_tech']} allowAssignableTech><TechnicianDashboard /></ProtectedRoute>} />
                               <Route path="/dashboard/unavailability" element={<ProtectedRoute allowedRoles={['house_tech','admin','management']}><TechnicianUnavailabilityAccessGuard /></ProtectedRoute>} />
                               <Route path="/morning-summary" element={<MorningSummary />} />
                               <Route path="/lights" element={<ProtectedRoute allowedRoles={['admin', 'management', 'house_tech']}><Lights /></ProtectedRoute>} />

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -33,6 +33,22 @@ const renderProtectedRoute = () =>
     { route: "/secure" },
   );
 
+const renderAssignableTechRoute = () =>
+  renderWithProviders(
+    <Routes>
+      <Route
+        path="/tech-self-service"
+        element={
+          <ProtectedRoute allowedRoles={["house_tech"]} allowAssignableTech>
+            <div>Tech Self Service</div>
+          </ProtectedRoute>
+        }
+      />
+      <Route path="/dashboard" element={<div>Dashboard</div>} />
+    </Routes>,
+    { route: "/tech-self-service" },
+  );
+
 beforeEach(() => {
   vi.clearAllMocks();
   useOptimizedAuthMock.mockReturnValue(createAuthState());
@@ -93,5 +109,25 @@ describe("ProtectedRoute", () => {
     );
 
     expect(screen.getByText("House Tech Content")).toBeInTheDocument();
+  });
+
+  it("allows assignable management users into technician self-service routes", () => {
+    useOptimizedAuthMock.mockReturnValue(
+      createAuthState({ userRole: "management", assignableAsTech: true }),
+    );
+
+    renderAssignableTechRoute();
+
+    expect(screen.getByText("Tech Self Service")).toBeInTheDocument();
+  });
+
+  it("blocks management users from technician self-service routes without assignable flag", async () => {
+    useOptimizedAuthMock.mockReturnValue(
+      createAuthState({ userRole: "management", assignableAsTech: false }),
+    );
+
+    renderAssignableTechRoute();
+
+    expect(await screen.findByText("Dashboard")).toBeInTheDocument();
   });
 });

--- a/src/components/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute.test.tsx
@@ -44,6 +44,7 @@ const renderAssignableTechRoute = () =>
           </ProtectedRoute>
         }
       />
+      <Route path="/tech-app" element={<div>Tech App</div>} />
       <Route path="/dashboard" element={<div>Dashboard</div>} />
     </Routes>,
     { route: "/tech-self-service" },
@@ -129,5 +130,13 @@ describe("ProtectedRoute", () => {
     renderAssignableTechRoute();
 
     expect(await screen.findByText("Dashboard")).toBeInTheDocument();
+  });
+
+  it("does not let allowAssignableTech bypass explicit role mismatches for technician roles", async () => {
+    useOptimizedAuthMock.mockReturnValue(createAuthState({ userRole: "technician" }));
+
+    renderAssignableTechRoute();
+
+    expect(await screen.findByText("Tech App")).toBeInTheDocument();
   });
 });

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { getDashboardPath } from '@/utils/roleBasedRouting';
-import { hasTechnicianSelfServiceAccess } from '@/utils/permissions';
 import { UserRole } from '@/types/user';
 
 interface ProtectedRouteProps {
@@ -32,7 +31,9 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 
   const isAllowedByRole = Boolean(userRole && allowedRoles.includes(userRole as UserRole));
   const isAllowedAsAssignableTech =
-    allowAssignableTech && hasTechnicianSelfServiceAccess(userRole, assignableAsTech);
+    allowAssignableTech &&
+    assignableAsTech === true &&
+    (userRole === 'admin' || userRole === 'management');
 
   if (!isAllowedByRole && !isAllowedAsAssignableTech) {
     const dashboardPath = getDashboardPath(userRole as UserRole | null);

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -2,18 +2,21 @@ import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { getDashboardPath } from '@/utils/roleBasedRouting';
+import { hasTechnicianSelfServiceAccess } from '@/utils/permissions';
 import { UserRole } from '@/types/user';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
   allowedRoles: UserRole[];
+  allowAssignableTech?: boolean;
 }
 
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   children,
-  allowedRoles
+  allowedRoles,
+  allowAssignableTech = false,
 }) => {
-  const { userRole, isLoading, isProfileLoading } = useOptimizedAuth();
+  const { userRole, assignableAsTech, isLoading, isProfileLoading } = useOptimizedAuth();
 
   // Wait for both session and profile to finish loading before making
   // routing decisions. Without this, userRole can be null while the
@@ -27,7 +30,11 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     );
   }
 
-  if (!userRole || !allowedRoles.includes(userRole as UserRole)) {
+  const isAllowedByRole = Boolean(userRole && allowedRoles.includes(userRole as UserRole));
+  const isAllowedAsAssignableTech =
+    allowAssignableTech && hasTechnicianSelfServiceAccess(userRole, assignableAsTech);
+
+  if (!isAllowedByRole && !isAllowedAsAssignableTech) {
     const dashboardPath = getDashboardPath(userRole as UserRole | null);
     return <Navigate to={dashboardPath} replace />;
   }

--- a/src/components/layout/Layout.test.ts
+++ b/src/components/layout/Layout.test.ts
@@ -122,6 +122,31 @@ describe("buildNavigationItems - technician navigation", () => {
     const items = buildNavigationItems(context)
 
     expect(items.map((item) => item.id)).toEqual(["technician-dashboard", "profile"])
+    expect(items.find((item) => item.id === "technician-dashboard")?.to).toBe("/tech-app")
+  })
+
+  it("shows technician self-service entries for assignable management users", () => {
+    const context = buildContext({
+      userRole: "management",
+      userDepartment: "sound",
+      assignableAsTech: true,
+    })
+    const items = buildNavigationItems(context)
+
+    expect(items.find((item) => item.id === "technician-dashboard")?.to).toBe("/technician-dashboard")
+    expect(items.find((item) => item.id === "technician-jobs")?.to).toBe("/technician-dashboard?tab=jobs")
+  })
+
+  it("hides technician self-service entries for non-assignable management users", () => {
+    const context = buildContext({
+      userRole: "management",
+      userDepartment: "sound",
+      assignableAsTech: false,
+    })
+    const items = buildNavigationItems(context)
+
+    expect(items.find((item) => item.id === "technician-dashboard")).toBeUndefined()
+    expect(items.find((item) => item.id === "technician-jobs")).toBeUndefined()
   })
 
   it("shows the house-tech department routes for house technicians", () => {

--- a/src/components/layout/SidebarNavigation.tsx
+++ b/src/components/layout/SidebarNavigation.tsx
@@ -29,7 +29,7 @@ import {
 
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
-import { canManagePayouts } from "@/utils/permissions"
+import { canManagePayouts, hasTechnicianSelfServiceAccess } from "@/utils/permissions"
 
 import { SidebarNavigationSkeleton } from "./SidebarNavigationSkeleton"
 
@@ -101,22 +101,20 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     icon: LayoutDashboard,
     mobilePriority: 1,
     mobileSlot: "primary",
-    getPath: () => "/technician-dashboard",
+    getPath: ({ userRole }) => userRole === "technician" ? "/tech-app" : "/technician-dashboard",
     isVisible: ({ userRole, assignableAsTech }) =>
-      userRole === "technician" ||
-      userRole === "house_tech" ||
-      (userRole === "admin" && assignableAsTech === true) ||
-      (userRole === "management" && assignableAsTech === true),
+      hasTechnicianSelfServiceAccess(userRole, assignableAsTech),
   },
   {
     id: "technician-jobs",
-    label: "Trabajos",
+    label: "Mis trabajos",
     mobileLabel: "Trabajos",
     icon: ClipboardList,
     mobilePriority: 2,
     mobileSlot: "primary",
     getPath: () => "/technician-dashboard?tab=jobs",
-    isVisible: ({ userRole }) => userRole === "house_tech",
+    isVisible: ({ userRole, assignableAsTech }) =>
+      userRole !== "technician" && hasTechnicianSelfServiceAccess(userRole, assignableAsTech),
     match: (pathname, _, to) => pathname === "/technician-dashboard" && to.includes("tab=jobs") && window.location.search.includes("tab=jobs"),
   },
   {
@@ -127,7 +125,8 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     mobilePriority: 3,
     mobileSlot: "primary",
     getPath: () => "/technician-dashboard?tab=availability",
-    isVisible: ({ userRole }) => userRole === "house_tech",
+    isVisible: ({ userRole, assignableAsTech }) =>
+      userRole !== "technician" && hasTechnicianSelfServiceAccess(userRole, assignableAsTech),
     match: (pathname, _, to) => pathname === "/technician-dashboard" && to.includes("tab=availability") && window.location.search.includes("tab=availability"),
   },
   {
@@ -151,7 +150,8 @@ const baseNavigationConfig: NavigationItemConfig[] = [
     mobilePriority: 5,
     mobileSlot: "primary",
     getPath: () => "/technician-dashboard?tab=profile",
-    isVisible: ({ userRole }) => userRole === "house_tech",
+    isVisible: ({ userRole, assignableAsTech }) =>
+      userRole !== "technician" && hasTechnicianSelfServiceAccess(userRole, assignableAsTech),
     match: (pathname, _, to) => pathname === "/technician-dashboard" && to.includes("tab=profile") && window.location.search.includes("tab=profile"),
   },
   {
@@ -521,8 +521,14 @@ export const buildNavigationItems = (
   if (isAdmin) {
     return navigationConfig
       .map((config) => {
-        // Allow technician-dashboard for admins with assignableAsTech flag
-        if (config.id === "technician-dashboard" && context.assignableAsTech) {
+        // Allow technician self-service entries for admins with assignableAsTech flag.
+        if (
+          (config.id === "technician-dashboard" ||
+            config.id === "technician-jobs" ||
+            config.id === "technician-availability" ||
+            config.id === "technician-profile") &&
+          context.assignableAsTech
+        ) {
           return createNavigationItem(config)
         }
         if (adminExcludedIds.has(config.id)) {
@@ -547,6 +553,7 @@ export const SidebarNavigation = ({
   userRole,
   userDepartment,
   hasSoundVisionAccess,
+  assignableAsTech,
   onNavigate,
 }: SidebarNavigationProps) => {
   const location = useLocation()
@@ -556,8 +563,9 @@ export const SidebarNavigation = ({
         userRole,
         userDepartment,
         hasSoundVisionAccess,
+        assignableAsTech,
       }),
-    [userRole, userDepartment, hasSoundVisionAccess],
+    [userRole, userDepartment, hasSoundVisionAccess, assignableAsTech],
   )
 
   if (!userRole) {

--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -45,7 +45,10 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
   const jobId = assignment.jobs?.id || assignment.festival_jobs?.id;
   const { data: expensePermissions = [] } = useExpensePermissions(jobId);
   const hasActiveExpensePermissions = expensePermissions.some(p => isPermissionActive(p));
-  const { data: expenses = [] } = useJobExpenses(hasActiveExpensePermissions ? jobId : undefined);
+  const { data: expenses = [] } = useJobExpenses(
+    hasActiveExpensePermissions ? jobId : undefined,
+    { selfServiceOnly: true },
+  );
   const [expenseDialogOpen, setExpenseDialogOpen] = useState(false);
   const [showExpenseForm, setShowExpenseForm] = useState(false);
 

--- a/src/components/technician/TechJobCard.tsx
+++ b/src/components/technician/TechJobCard.tsx
@@ -20,7 +20,10 @@ export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techNam
     // Expense permissions check
     const { data: expensePermissions = [] } = useExpensePermissions(jobData?.id);
     const hasActiveExpensePermissions = expensePermissions.some(p => isPermissionActive(p));
-    const { data: expenses = [] } = useJobExpenses(hasActiveExpensePermissions ? jobData?.id : undefined);
+    const { data: expenses = [] } = useJobExpenses(
+        hasActiveExpensePermissions ? jobData?.id : undefined,
+        { selfServiceOnly: true },
+    );
     const jobTimezone = jobData?.timezone || 'Europe/Madrid';
 
     // Format time

--- a/src/hooks/__tests__/useJobExpenses.test.tsx
+++ b/src/hooks/__tests__/useJobExpenses.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAuthState } from "@/test/fixtures";
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+const { useOptimizedAuthMock } = vi.hoisted(() => ({
+  useOptimizedAuthMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/useOptimizedAuth", () => ({
+  useOptimizedAuth: (...args: any[]) => useOptimizedAuthMock(...args),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabase,
+}));
+
+import { useJobExpenses } from "../useJobExpenses";
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useJobExpenses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    useOptimizedAuthMock.mockReturnValue(
+      createAuthState({
+        user: { id: "manager-1", email: "manager@example.com" },
+        userRole: "management",
+      }),
+    );
+  });
+
+  it("filters to the current user when self-service mode is enabled", async () => {
+    const builder = createMockQueryBuilder({ data: [], error: null });
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(
+      () => useJobExpenses("job-1", { selfServiceOnly: true }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(builder.eq).toHaveBeenCalledWith("job_id", "job-1");
+    expect(builder.eq).toHaveBeenCalledWith("technician_id", "manager-1");
+  });
+
+  it("keeps manager review mode unfiltered by technician by default", async () => {
+    const builder = createMockQueryBuilder({ data: [], error: null });
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(
+      () => useJobExpenses("job-1"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(builder.eq).toHaveBeenCalledWith("job_id", "job-1");
+    expect(builder.eq).not.toHaveBeenCalledWith("technician_id", "manager-1");
+  });
+});

--- a/src/hooks/useJobExpenses.ts
+++ b/src/hooks/useJobExpenses.ts
@@ -51,14 +51,23 @@ export interface UpdateExpenseData {
   receipt_path?: string;
 }
 
+export interface UseJobExpensesOptions {
+  selfServiceOnly?: boolean;
+}
+
 /**
- * Hook to fetch job expenses for a specific job (filtered by technician for non-managers).
+ * Hook to fetch job expenses for a specific job.
+ * Managers see all expenses by default; selfServiceOnly forces the current user's technician scope.
  */
-export const useJobExpenses = (jobId: string | null | undefined) => {
+export const useJobExpenses = (
+  jobId: string | null | undefined,
+  options: UseJobExpensesOptions = {},
+) => {
   const { user, userRole } = useOptimizedAuth();
+  const selfServiceOnly = options.selfServiceOnly === true;
 
   return useQuery({
-    queryKey: ['job-expenses', jobId, user?.id],
+    queryKey: ['job-expenses', jobId, user?.id, { selfServiceOnly }],
     queryFn: async () => {
       if (!jobId || !user?.id) {
         return [];
@@ -92,8 +101,9 @@ export const useJobExpenses = (jobId: string | null | undefined) => {
         .order('expense_date', { ascending: false })
         .order('created_at', { ascending: false });
 
-      // Technicians and house_tech only see their own expenses
-      if (userRole === 'technician' || userRole === 'house_tech') {
+      // Technicians and house_tech only see their own expenses.
+      // Assignable managers/admins use selfServiceOnly from technician surfaces.
+      if (selfServiceOnly || userRole === 'technician' || userRole === 'house_tech') {
         query = query.eq('technician_id', user.id);
       }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,8 +1,19 @@
 import "@testing-library/jest-dom/vitest";
+import { createRequire } from "node:module";
 import { cleanup } from "@testing-library/react";
 import { afterEach, beforeEach, vi } from "vitest";
 
 import { resetMockSupabase } from "./mockSupabase";
+
+const require = createRequire(import.meta.url);
+
+if (typeof globalThis.WebSocket === "undefined") {
+  Object.defineProperty(globalThis, "WebSocket", {
+    configurable: true,
+    writable: true,
+    value: require("ws"),
+  });
+}
 
 const toast = Object.assign(vi.fn(), {
   error: vi.fn(),

--- a/src/utils/permissions.test.ts
+++ b/src/utils/permissions.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { canManagePayouts, isAdministrativeDepartment, normalizeDepartmentKey } from './permissions';
+import {
+  canManagePayouts,
+  hasTechnicianSelfServiceAccess,
+  isAdministrativeDepartment,
+  normalizeDepartmentKey,
+} from './permissions';
 
 describe('payout permissions', () => {
   it('allows admins regardless of department', () => {
@@ -26,5 +31,20 @@ describe('department normalization', () => {
   it('normalizes accented department names', () => {
     expect(normalizeDepartmentKey('Administración')).toBe('administracion');
     expect(isAdministrativeDepartment('Administración')).toBe(true);
+  });
+});
+
+describe('technician self-service access', () => {
+  it('allows technician roles and assignable admin/management users', () => {
+    expect(hasTechnicianSelfServiceAccess('technician')).toBe(true);
+    expect(hasTechnicianSelfServiceAccess('house_tech')).toBe(true);
+    expect(hasTechnicianSelfServiceAccess('management', true)).toBe(true);
+    expect(hasTechnicianSelfServiceAccess('admin', true)).toBe(true);
+  });
+
+  it('denies non-assignable privileged users and unrelated roles', () => {
+    expect(hasTechnicianSelfServiceAccess('management', false)).toBe(false);
+    expect(hasTechnicianSelfServiceAccess('admin', false)).toBe(false);
+    expect(hasTechnicianSelfServiceAccess('logistics', true)).toBe(false);
   });
 });

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -19,6 +19,14 @@ export const canManagePayouts = (role: UserRole, department?: UserDepartment): b
 
 export const isTechnicianRole = (role: UserRole) => role === 'technician' || role === 'house_tech';
 
+export const hasTechnicianSelfServiceAccess = (
+  role: UserRole,
+  assignableAsTech?: boolean | null,
+): boolean =>
+  role === 'technician' ||
+  role === 'house_tech' ||
+  ((role === 'admin' || role === 'management') && assignableAsTech === true);
+
 export const canViewDetails = (_role: UserRole) => true;
 
 export const canEditJobs = (role: UserRole) => ['admin', 'management', 'logistics'].includes(role || '');


### PR DESCRIPTION
## Summary
- Allow `admin`/`management` users with `assignable_as_tech = true` to access technician self-service routes.
- Show technician navigation entries, including `Mis trabajos`, for assignable managers/admins.
- Keep technician expense dialogs scoped to the current user's own expenses while preserving manager-wide `/gastos` review behavior.

## Root Cause
Managers marked assignable as techs could be assigned to jobs and have expense permissions, but route guards and navigation only treated literal technician/house-tech roles as technician self-service users. Expense dialogs also used manager-wide visibility by default.

## Validation
- `npm run test:run -- src/components/ProtectedRoute.test.tsx src/routes/__tests__/AuthenticatedShell.test.tsx src/components/layout/Layout.test.ts src/pages/__tests__/TechnicianSuperApp.test.tsx src/App.test.tsx src/hooks/__tests__/useJobExpenses.test.tsx src/utils/permissions.test.ts`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Management users with technician self-service permissions can now access technician-specific routes, including the technician dashboard and job management features.
  * Navigation dynamically displays technician-related menu items based on user permissions.
  * Expense data is now properly scoped for self-service access scenarios.

* **Tests**
  * Added comprehensive test coverage for permission-based route access and navigation visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->