### PR TITLE
[codex] Fix festival WhatsApp stage groups

### DIFF
--- a/src/pages/festival-management/FestivalManagementDialogs.tsx
+++ b/src/pages/festival-management/FestivalManagementDialogs.tsx
@@ -115,7 +115,7 @@ export const FestivalManagementDialogs = ({ vm }: { vm: any }) => {
           number: idx + 1,
           name: `Stage ${idx + 1}`,
         }));
-  const requiresStageScopedWhatsapp = maxStages > 1 && waDepartment !== "lights";
+  const requiresStageScopedWhatsapp = maxStages > 1 && waDepartment === "sound";
 
   return (
     <>
@@ -379,7 +379,7 @@ export const FestivalManagementDialogs = ({ vm }: { vm: any }) => {
             </div>
             {requiresStageScopedWhatsapp && (
               <div>
-                <label className="block text-sm font-medium mb-2">Stage</label>
+                <label className="block text-sm font-medium mb-2">Stage de sonido</label>
                 <select
                   className="w-full h-9 rounded-md border bg-background px-3 text-sm"
                   value={waStageNumber > 0 ? String(waStageNumber) : ""}
@@ -397,7 +397,7 @@ export const FestivalManagementDialogs = ({ vm }: { vm: any }) => {
             {waGroup && (
               <div className="rounded-md bg-green-50 border border-green-200 p-3">
                 <p className="text-sm text-green-800 font-medium">
-                  ✓ Grupo ya creado para este departamento{requiresStageScopedWhatsapp && waStageNumber > 0 ? ` (Stage ${waStageNumber})` : ""}
+                  ✓ Grupo ya creado para {requiresStageScopedWhatsapp && waStageNumber > 0 ? `sonido stage ${waStageNumber}` : "este departamento"}
                 </p>
               </div>
             )}

--- a/src/pages/festival-management/__tests__/FestivalManagementDialogs.test.tsx
+++ b/src/pages/festival-management/__tests__/FestivalManagementDialogs.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders } from "@/test/renderWithProviders";
+
+vi.mock("@/components/festival/scheduling/FestivalScheduling", () => ({
+  FestivalScheduling: () => <div data-testid="festival-scheduling" />,
+}));
+
+vi.mock("@/components/festival/pdf/PrintOptionsDialog", () => ({
+  PrintOptionsDialog: () => <div data-testid="print-options-dialog" />,
+}));
+
+vi.mock("@/components/flex/FlexFolderPicker", () => ({
+  FlexFolderPicker: () => <div data-testid="flex-folder-picker" />,
+}));
+
+vi.mock("@/components/hoja-de-ruta/ModernHojaDeRuta", () => ({
+  ModernHojaDeRuta: () => <div data-testid="modern-hoja-de-ruta" />,
+}));
+
+vi.mock("@/components/jobs/JobAssignmentDialog", () => ({
+  JobAssignmentDialog: () => <div data-testid="job-assignment-dialog" />,
+}));
+
+vi.mock("@/components/jobs/JobDetailsDialog", () => ({
+  JobDetailsDialog: () => <div data-testid="job-details-dialog" />,
+}));
+
+vi.mock("@/components/jobs/FlexSyncLogDialog", () => ({
+  FlexSyncLogDialog: () => <div data-testid="flex-sync-log-dialog" />,
+}));
+
+vi.mock("@/components/jobs/JobPresetManagerDialog", () => ({
+  JobPresetManagerDialog: () => <div data-testid="job-preset-manager-dialog" />,
+}));
+
+import { FestivalManagementDialogs } from "../FestivalManagementDialogs";
+
+const baseVm = {
+  job: { id: "festival-1", title: "Stage Test Festival" },
+  jobId: "festival-1",
+  navigate: vi.fn(),
+  isSchedulingRoute: false,
+  jobDates: [],
+  isViewOnly: false,
+  isAssignmentDialogOpen: false,
+  setIsAssignmentDialogOpen: vi.fn(),
+  handleAssignmentChange: vi.fn(),
+  assignmentDepartment: "sound",
+  isJobDetailsOpen: false,
+  setIsJobDetailsOpen: vi.fn(),
+  isFlexLogOpen: false,
+  setIsFlexLogOpen: vi.fn(),
+  isFlexPickerOpen: false,
+  setIsFlexPickerOpen: vi.fn(),
+  handleFlexPickerConfirm: vi.fn(),
+  flexPickerOptions: undefined,
+  isRouteSheetOpen: false,
+  setIsRouteSheetOpen: vi.fn(),
+  isPrintDialogOpen: false,
+  setIsPrintDialogOpen: vi.fn(),
+  handlePrintAllDocumentation: vi.fn(),
+  maxStages: 3,
+  isJobPresetsOpen: false,
+  setIsJobPresetsOpen: vi.fn(),
+  isArchiveDialogOpen: false,
+  setIsArchiveDialogOpen: vi.fn(),
+  archiveMode: "by-prefix",
+  setArchiveMode: vi.fn(),
+  archiveIncludeTemplates: false,
+  setArchiveIncludeTemplates: vi.fn(),
+  archiveDryRun: false,
+  setArchiveDryRun: vi.fn(),
+  isArchiving: false,
+  archiveResult: null,
+  archiveError: null,
+  handleArchiveToFlex: vi.fn(),
+  isBackfillDialogOpen: false,
+  setIsBackfillDialogOpen: vi.fn(),
+  bfSound: true,
+  setBfSound: vi.fn(),
+  bfLights: true,
+  setBfLights: vi.fn(),
+  bfVideo: true,
+  setBfVideo: vi.fn(),
+  bfProduction: true,
+  setBfProduction: vi.fn(),
+  uuidSound: "",
+  setUuidSound: vi.fn(),
+  uuidLights: "",
+  setUuidLights: vi.fn(),
+  uuidVideo: "",
+  setUuidVideo: vi.fn(),
+  uuidProduction: "",
+  setUuidProduction: vi.fn(),
+  isWhatsappDialogOpen: true,
+  setIsWhatsappDialogOpen: vi.fn(),
+  festivalStageOptions: [
+    { number: 1, name: "Main Stage" },
+    { number: 2, name: "Second Stage" },
+    { number: 3, name: "Third Stage" },
+  ],
+  waGroup: null,
+  waRequest: null,
+  isSendingWa: false,
+  handleRetryWhatsappGroup: vi.fn(),
+  isAlmacenDialogOpen: false,
+  setIsAlmacenDialogOpen: vi.fn(),
+  waMessage: "",
+  setWaMessage: vi.fn(),
+  handleSendToAlmacen: vi.fn(),
+  isDeleteDialogOpen: false,
+  setIsDeleteDialogOpen: vi.fn(),
+  isDeleting: false,
+  handleDeleteJob: vi.fn(),
+};
+
+function FestivalWhatsappHarness({ onCreate }: { onCreate: (payload: { department: string; stage_number: number }) => void }) {
+  const [waDepartment, setWaDepartment] = React.useState<"sound" | "lights" | "video">("sound");
+  const [waStageNumber, setWaStageNumber] = React.useState(1);
+
+  return (
+    <FestivalManagementDialogs
+      vm={{
+        ...baseVm,
+        waDepartment,
+        setWaDepartment,
+        waStageNumber,
+        setWaStageNumber,
+        handleCreateWhatsappGroup: () => {
+          onCreate({
+            department: waDepartment,
+            stage_number: waDepartment === "sound" ? waStageNumber : 0,
+          });
+        },
+      }}
+    />
+  );
+}
+
+describe("FestivalManagementDialogs WhatsApp stage scope", () => {
+  it("uses the selected sound stage for multi-stage festival WhatsApp groups", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+
+    renderWithProviders(<FestivalWhatsappHarness onCreate={onCreate} />);
+
+    expect(screen.getByText("Stage de sonido")).toBeInTheDocument();
+    await user.selectOptions(screen.getByRole("combobox"), "2");
+    await user.click(screen.getByRole("button", { name: "Crear Grupo" }));
+
+    expect(onCreate).toHaveBeenCalledWith({ department: "sound", stage_number: 2 });
+  });
+
+  it("keeps lights and video WhatsApp groups at global stage zero", async () => {
+    const user = userEvent.setup();
+    const onCreate = vi.fn();
+
+    renderWithProviders(<FestivalWhatsappHarness onCreate={onCreate} />);
+
+    await user.click(screen.getByRole("radio", { name: "Vídeo" }));
+    expect(screen.queryByText("Stage de sonido")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Crear Grupo" }));
+    expect(onCreate).toHaveBeenLastCalledWith({ department: "video", stage_number: 0 });
+
+    await user.click(screen.getByRole("radio", { name: "Luces" }));
+    expect(screen.queryByText("Stage de sonido")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Crear Grupo" }));
+    expect(onCreate).toHaveBeenLastCalledWith({ department: "lights", stage_number: 0 });
+  });
+});

--- a/src/pages/festival-management/useFestivalManagementVm.ts
+++ b/src/pages/festival-management/useFestivalManagementVm.ts
@@ -22,6 +22,28 @@ type FestivalStageOption = {
   name: string;
 };
 
+const getFunctionErrorMessage = async (error: unknown, fallback: string) => {
+  const candidate = error as {
+    message?: string;
+    details?: string;
+    context?: {
+      json?: () => Promise<{ error?: string; message?: string; reason?: string; details?: string }>;
+    };
+  };
+
+  if (candidate?.context?.json) {
+    try {
+      const payload = await candidate.context.json();
+      const messageFromBody = payload?.error || payload?.message || payload?.reason || payload?.details;
+      if (messageFromBody) return messageFromBody;
+    } catch {
+      // Fall back to the top-level error message when the function body cannot be parsed.
+    }
+  }
+
+  return candidate?.details || candidate?.message || fallback;
+};
+
 export type FestivalManagementVmResult =
   | { status: "missing_job_id" }
   | { status: "loading" }
@@ -90,6 +112,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
   const [isWhatsappDialogOpen, setIsWhatsappDialogOpen] = useState(false);
   const [waDepartment, setWaDepartment] = useState<'sound' | 'lights' | 'video'>('sound');
   const [waStageNumber, setWaStageNumber] = useState<number>(0);
+  const waEffectiveStageNumber = waDepartment === "sound" ? waStageNumber : 0;
   const [isAlmacenDialogOpen, setIsAlmacenDialogOpen] = useState(false);
   const [waMessage, setWaMessage] = useState<string>("");
   const [isSendingWa, setIsSendingWa] = useState(false);
@@ -98,7 +121,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
 
   // Check if WhatsApp group already exists for this job/department
   const { data: waGroup, refetch: refetchWaGroup } = useQuery({
-    queryKey: ['job-whatsapp-group', jobId, waDepartment, waStageNumber],
+    queryKey: ['job-whatsapp-group', jobId, waDepartment, waEffectiveStageNumber],
     enabled: !!jobId && !!waDepartment && (userRole === 'management' || userRole === 'admin'),
     queryFn: async () => {
       if (!jobId) return null;
@@ -107,7 +130,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
         .select('id, wa_group_id')
         .eq('job_id', jobId)
         .eq('department', waDepartment)
-        .eq('stage_number', waStageNumber)
+        .eq('stage_number', waEffectiveStageNumber)
         .maybeSingle();
       if (error) return null;
       return data;
@@ -115,7 +138,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
   });
 
   const { data: waRequest, refetch: refetchWaRequest } = useQuery({
-    queryKey: ['job-whatsapp-group-request', jobId, waDepartment, waStageNumber],
+    queryKey: ['job-whatsapp-group-request', jobId, waDepartment, waEffectiveStageNumber],
     enabled: !!jobId && !!waDepartment && (userRole === 'management' || userRole === 'admin'),
     queryFn: async () => {
       if (!jobId) return null;
@@ -124,7 +147,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
         .select('id, created_at')
         .eq('job_id', jobId)
         .eq('department', waDepartment)
-        .eq('stage_number', waStageNumber)
+        .eq('stage_number', waEffectiveStageNumber)
         .maybeSingle();
       if (error) return null;
       return data;
@@ -133,7 +156,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
 
   useEffect(() => {
     const total = Math.max(maxStages, 1);
-    const usesStageScopedWhatsapp = waDepartment !== "lights";
+    const usesStageScopedWhatsapp = waDepartment === "sound";
 
     if (!usesStageScopedWhatsapp) {
       setWaStageNumber(0);
@@ -1039,7 +1062,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
       try {
         setIsSendingWa(true);
         const { error } = await supabase.functions.invoke("create-whatsapp-group", {
-          body: { job_id: jobId, department: waDepartment, stage_number: waStageNumber },
+          body: { job_id: jobId, department: waDepartment, stage_number: waEffectiveStageNumber },
         });
         if (error) throw error;
         toast({
@@ -1050,9 +1073,10 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
         await Promise.all([refetchWaGroup(), refetchWaRequest()]);
       } catch (error: any) {
         console.error("Error creating WhatsApp group:", error);
+        const description = await getFunctionErrorMessage(error, "Error al crear grupo de WhatsApp");
         toast({
           title: "Error",
-          description: error.message || "Error al crear grupo de WhatsApp",
+          description,
           variant: "destructive",
         });
         await Promise.all([refetchWaGroup(), refetchWaRequest()]);
@@ -1060,7 +1084,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
         setIsSendingWa(false);
       }
     },
-    [jobId, waDepartment, waStageNumber, refetchWaGroup, refetchWaRequest, toast],
+    [jobId, waDepartment, waEffectiveStageNumber, refetchWaGroup, refetchWaRequest, toast],
   );
 
   const handleRetryWhatsappGroup = useCallback(
@@ -1075,7 +1099,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
         // Clear the failed request using RPC function
         const { data: clearResult, error: clearError } = await supabase.rpc(
           'clear_whatsapp_group_request',
-          { p_job_id: jobId, p_department: waDepartment, p_stage_number: waStageNumber }
+          { p_job_id: jobId, p_department: waDepartment, p_stage_number: waEffectiveStageNumber }
         );
 
         if (clearError) {
@@ -1122,7 +1146,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
         setIsSendingWa(false);
       }
     },
-    [jobId, waDepartment, waStageNumber, refetchWaGroup, refetchWaRequest, handleCreateWhatsappGroup, toast],
+    [jobId, waDepartment, waEffectiveStageNumber, refetchWaGroup, refetchWaRequest, handleCreateWhatsappGroup, toast],
   );
 
   const handleSendToAlmacen = useCallback(

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -308,10 +308,16 @@ serve(async (req: Request) => {
       }
     }
 
-    // De-duplicate
-    const uniqueParticipants = Array.from(new Set(participants));
+    const actorPhoneNormalized = actor?.phone ? normalizePhone(actor.phone, defaultCC) : null;
+    const actorPhone = actorPhoneNormalized?.ok ? actorPhoneNormalized.value : null;
+
+    // De-duplicate. Do not send the WAHA sender as an explicit participant:
+    // WhatsApp includes the group creator automatically, and WAHA can reject
+    // create-group requests that try to add the creator as a participant.
+    const uniqueParticipants = Array.from(new Set(participants))
+      .filter((phone) => phone !== actorPhone);
     if (uniqueParticipants.length === 0) {
-      return new Response(JSON.stringify({ error: 'No valid phone numbers found', warnings: { missing, invalid } }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      return new Response(JSON.stringify({ error: 'No valid phone numbers found besides the WhatsApp sender', warnings: { missing, invalid } }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
     // WAHA config - use actor's endpoint
@@ -337,12 +343,22 @@ serve(async (req: Request) => {
       return { id: jid };
     });
     const actorJidCandidate = (() => {
-      if (actor?.phone && actor.department === department) {
-        const norm = normalizePhone(actor.phone, defaultCC);
-        if (norm.ok) return norm.value.replace(/^\+/, '') + '@c.us';
-      }
       return null;
     })();
+
+    const clearRequestLock = async () => {
+      try {
+        const { error: clearErr } = await supabaseAdmin
+          .from('job_whatsapp_group_requests')
+          .delete()
+          .eq('job_id', job_id)
+          .eq('department', department)
+          .eq('stage_number', effectiveStageNumber);
+        if (clearErr) console.warn('Failed to clear WhatsApp request lock after WAHA failure', clearErr);
+      } catch (clearException) {
+        console.warn('Error clearing WhatsApp request lock after WAHA failure', clearException);
+      }
+    };
 
     let usedFallback = false;
     let wa_group_id = '';
@@ -358,6 +374,7 @@ serve(async (req: Request) => {
           body: JSON.stringify({ name: subject, participants: participantObjects })
         });
       } catch (fe) {
+        await clearRequestLock();
         return new Response(JSON.stringify({ error: 'WAHA request failed', step: 'create-group', url: groupUrl, message: (fe as Error)?.message || String(fe) }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
       }
       if (!groupRes.ok) {
@@ -373,14 +390,17 @@ serve(async (req: Request) => {
             });
             if (!fallbackRes.ok) {
               const fbTxt = await fallbackRes.text().catch(() => '');
+              await clearRequestLock();
               return new Response(JSON.stringify({ error: 'WAHA group creation failed', status: fallbackRes.status, url: groupUrl, response: fbTxt, firstAttempt: { status: groupRes.status, body: txt } }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
             }
             usedFallback = true;
             groupRes = fallbackRes;
           } catch (fe2) {
+            await clearRequestLock();
             return new Response(JSON.stringify({ error: 'WAHA request failed', step: 'create-group-fallback', url: groupUrl, message: (fe2 as Error)?.message || String(fe2), firstAttempt: { status: groupRes.status, body: txt } }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
           }
         } else {
+          await clearRequestLock();
           return new Response(JSON.stringify({ error: 'WAHA group creation failed', status: groupRes.status, url: groupUrl, response: txt }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
         }
       }


### PR DESCRIPTION
## Emergency status

`create-whatsapp-group` was restored to the pre-today `main` behavior, then patched narrowly for the WAHA failure observed in production.

## Live Edge Function

Deployed to Supabase project `syldobdcdsgfgjtbuwxm` from commit `22f9a8a3`.

Live backend changes:

- Filters the WAHA sender/creator out of the participants sent to `POST /api/{session}/groups`.
- Fallback group creation no longer chooses the WAHA sender as the one participant.
- WAHA create failures clear the request lock so retries do not silently get stuck.

Reason: WAHA returned `info query returned status 400: bad-request`, followed by `429: rate-overlimit`. Sending the creator as a participant is a plausible trigger because WhatsApp already includes the creator when creating a group.

## Remaining PR changes

- Festival management UI still sends sound stage selection and lights/video `stage_number: 0`.
- Focused UI tests for festival WhatsApp stage behavior remain in this branch.
- Backend festival stage-scoping needs to be redesigned before this PR is mergeable.

## Validation

- `npm run lint:functions -- --quiet`
- `git diff --check`