### PR TITLE
Fix tourdate Flex date sync scoping

### DIFF
--- a/src/utils/flex-folders/__tests__/syncDateChange.tourdate.test.ts
+++ b/src/utils/flex-folders/__tests__/syncDateChange.tourdate.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getElementTreeMock, updateFlexElementHeaderMock, testState } = vi.hoisted(() => ({
+  getElementTreeMock: vi.fn(),
+  updateFlexElementHeaderMock: vi.fn(),
+  testState: {
+    job: {
+      title: "Loquillo - Mallorca",
+      job_type: "tourdate",
+      timezone: "Europe/Madrid",
+      location: { name: "Mallorca" },
+    },
+    tourDate: {
+      location: { name: "Mallorca" },
+    },
+    folders: [] as Array<{
+      element_id: string;
+      department: string | null;
+      folder_type: string | null;
+    }>,
+  },
+}));
+
+vi.mock("@/utils/flex-folders/api", () => ({
+  updateFlexElementHeader: updateFlexElementHeaderMock,
+}));
+
+vi.mock("@/utils/flex-folders/getElementTree", () => ({
+  getElementTree: getElementTreeMock,
+}));
+
+vi.mock("@/integrations/supabase/client", () => {
+  type SupabaseResponse<T> = { data: T; error: null };
+  type SupabaseResult<T> = Promise<SupabaseResponse<T>>;
+
+  class MockQueryBuilder {
+    private table: string;
+    private singleResult = false;
+
+    constructor(table: string) {
+      this.table = table;
+    }
+
+    select(_columns?: string) {
+      return this;
+    }
+
+    eq(_column: string, _value: unknown) {
+      return this;
+    }
+
+    single() {
+      this.singleResult = true;
+      return this;
+    }
+
+    private async execute(): SupabaseResult<unknown> {
+      if (this.table === "jobs" && this.singleResult) {
+        return { data: testState.job, error: null };
+      }
+
+      if (this.table === "tour_dates" && this.singleResult) {
+        return { data: testState.tourDate, error: null };
+      }
+
+      if (this.table === "flex_folders") {
+        return { data: testState.folders, error: null };
+      }
+
+      throw new Error(`Unexpected table in tourdate sync test: ${this.table}`);
+    }
+
+    then<TResult1 = SupabaseResponse<unknown>, TResult2 = never>(
+      onfulfilled?:
+        | ((value: SupabaseResponse<unknown>) => TResult1 | PromiseLike<TResult1>)
+        | null,
+      onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ) {
+      return this.execute().then(onfulfilled, onrejected);
+    }
+  }
+
+  return {
+    supabase: {
+      from: (table: string) => new MockQueryBuilder(table),
+    },
+  };
+});
+
+import {
+  syncFlexElementsForJobDateChange,
+  syncFlexElementsForTourDateChange,
+} from "@/utils/flex-folders/syncDateChange";
+
+describe("syncFlexElementsForTourDateChange scoping", () => {
+  beforeEach(() => {
+    updateFlexElementHeaderMock.mockReset();
+    getElementTreeMock.mockReset();
+    updateFlexElementHeaderMock.mockResolvedValue(undefined);
+    testState.job = {
+      title: "Loquillo - Mallorca",
+      job_type: "tourdate",
+      timezone: "Europe/Madrid",
+      location: { name: "Mallorca" },
+    };
+    testState.tourDate = {
+      location: { name: "Mallorca" },
+    };
+    testState.folders = [
+      {
+        element_id: "tourdate-sound-folder",
+        department: "sound",
+        folder_type: "tourdate",
+      },
+      {
+        element_id: "tourdate-sound-quote",
+        department: "sound",
+        folder_type: "presupuestos_recibidos",
+      },
+    ];
+
+    getElementTreeMock.mockImplementation((elementId: string) => {
+      if (elementId === "tourdate-sound-folder") {
+        return Promise.resolve([
+          {
+            elementId: "tourdate-sound-folder",
+            displayName: "Mallorca - Old Date - Sound",
+            documentNumber: "260502S",
+            children: [
+              {
+                elementId: "unrelated-tour-child",
+                displayName: "Unrelated Tour Child",
+                documentNumber: "260502BAD",
+              },
+            ],
+          },
+        ]);
+      }
+
+      if (elementId === "tourdate-sound-quote") {
+        return Promise.resolve([
+          {
+            elementId: "tourdate-sound-quote",
+            displayName: "Old Quote",
+            documentNumber: "260502SPR",
+            children: [
+              {
+                elementId: "unrelated-nested-quote-child",
+                displayName: "Unrelated Nested Quote Child",
+                documentNumber: "260502BAD",
+              },
+            ],
+          },
+        ]);
+      }
+
+      return Promise.reject(new Error(`Unexpected tree lookup: ${elementId}`));
+    });
+  });
+
+  it("updates only recorded tour date elements and leaves nested tree elements untouched", async () => {
+    const result = await syncFlexElementsForTourDateChange(
+      "tour-date-1",
+      "2026-06-03T00:00:00.000Z"
+    );
+
+    expect(result).toEqual({ success: 2, failed: 0, errors: [] });
+    expect(getElementTreeMock).toHaveBeenCalledTimes(2);
+    expect(getElementTreeMock).toHaveBeenCalledWith("tourdate-sound-folder");
+    expect(getElementTreeMock).toHaveBeenCalledWith("tourdate-sound-quote");
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledTimes(7);
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-folder",
+      "documentNumber",
+      "260603S"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-quote",
+      "documentNumber",
+      "260603SPR"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-folder",
+      "plannedStartDate",
+      "2026-06-03T02:00:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-quote",
+      "plannedEndDate",
+      "2026-06-03T02:00:00.000Z"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-folder",
+      "name",
+      "Mallorca - Jun 3, 2026 - Sound"
+    );
+    expect(updateFlexElementHeaderMock).not.toHaveBeenCalledWith(
+      "unrelated-tour-child",
+      expect.any(String),
+      expect.any(String)
+    );
+    expect(updateFlexElementHeaderMock).not.toHaveBeenCalledWith(
+      "unrelated-nested-quote-child",
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  it("keeps tour date job date sync scoped to recorded rows too", async () => {
+    const result = await syncFlexElementsForJobDateChange(
+      "job-1",
+      "2026-06-03T00:00:00.000Z",
+      "2026-06-03T21:59:00.000Z"
+    );
+
+    expect(result).toEqual({ success: 2, failed: 0, errors: [] });
+    expect(getElementTreeMock).toHaveBeenCalledTimes(2);
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledTimes(8);
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-folder",
+      "documentNumber",
+      "260603S"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-quote",
+      "documentNumber",
+      "260603SPR"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-folder",
+      "name",
+      "Mallorca - Jun 3, 2026 - Sound"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-quote",
+      "name",
+      "Loquillo - Mallorca - Presupuestos Recibidos - Sound"
+    );
+    expect(updateFlexElementHeaderMock).not.toHaveBeenCalledWith(
+      "unrelated-tour-child",
+      expect.any(String),
+      expect.any(String)
+    );
+    expect(updateFlexElementHeaderMock).not.toHaveBeenCalledWith(
+      "unrelated-nested-quote-child",
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+});

--- a/src/utils/flex-folders/__tests__/syncDateChange.tourdate.test.ts
+++ b/src/utils/flex-folders/__tests__/syncDateChange.tourdate.test.ts
@@ -206,6 +206,46 @@ describe("syncFlexElementsForTourDateChange scoping", () => {
     );
   });
 
+  it("handles Flex trees that omit the queried root element", async () => {
+    testState.folders = [
+      {
+        element_id: "tourdate-sound-folder",
+        department: "sound",
+        folder_type: "tourdate",
+      },
+    ];
+    getElementTreeMock.mockResolvedValue([
+      {
+        elementId: "child-only-response",
+        displayName: "Child Only",
+        documentNumber: "260502BAD",
+      },
+    ]);
+
+    const result = await syncFlexElementsForTourDateChange(
+      "tour-date-1",
+      "2026-06-03T00:00:00.000Z"
+    );
+
+    expect(result).toEqual({ success: 1, failed: 0, errors: [] });
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledTimes(4);
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-folder",
+      "documentNumber",
+      "260603"
+    );
+    expect(updateFlexElementHeaderMock).toHaveBeenCalledWith(
+      "tourdate-sound-folder",
+      "name",
+      "Mallorca - Jun 3, 2026 - Sound"
+    );
+    expect(updateFlexElementHeaderMock).not.toHaveBeenCalledWith(
+      "child-only-response",
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
   it("keeps tour date job date sync scoped to recorded rows too", async () => {
     const result = await syncFlexElementsForJobDateChange(
       "job-1",

--- a/src/utils/flex-folders/syncDateChange.ts
+++ b/src/utils/flex-folders/syncDateChange.ts
@@ -126,6 +126,25 @@ function findElementInTree(
   return null;
 }
 
+function getRecordedElementFromTree(
+  tree: FlexElementNode[],
+  elementId: string
+): { elementId: string; documentNumber?: string; displayName?: string } {
+  const element = findElementInTree(tree, elementId);
+  if (element) return element;
+
+  const treeWithSyntheticRoot: FlexElementNode[] = [
+    {
+      elementId,
+      displayName: "",
+      documentNumber: undefined,
+    },
+    ...tree,
+  ];
+
+  return findElementInTree(treeWithSyntheticRoot, elementId)!;
+}
+
 /**
  * Generate folder name based on folder type and job data
  */
@@ -280,14 +299,7 @@ async function syncRecordedFlexFolderRowsForDateChange(
   for (const folder of folders) {
     try {
       const tree = await getElementTree(folder.element_id);
-      const element = findElementInTree(tree, folder.element_id);
-
-      if (!element) {
-        throw new Error(
-          `Element ${folder.element_id} not found in tree. Cannot determine document number suffix for resync.`
-        );
-      }
-
+      const element = getRecordedElementFromTree(tree, folder.element_id);
       const suffix = element.documentNumber
         ? extractDocumentNumberSuffix(element.documentNumber)
         : "";

--- a/src/utils/flex-folders/syncDateChange.ts
+++ b/src/utils/flex-folders/syncDateChange.ts
@@ -280,12 +280,14 @@ async function syncRecordedFlexFolderRowsForDateChange(
   for (const folder of folders) {
     try {
       const tree = await getElementTree(folder.element_id);
-      const element =
-        findElementInTree(tree, folder.element_id) || {
-          elementId: folder.element_id,
-          documentNumber: undefined,
-          displayName: undefined,
-        };
+      const element = findElementInTree(tree, folder.element_id);
+
+      if (!element) {
+        throw new Error(
+          `Element ${folder.element_id} not found in tree. Cannot determine document number suffix for resync.`
+        );
+      }
+
       const suffix = element.documentNumber
         ? extractDocumentNumberSuffix(element.documentNumber)
         : "";

--- a/src/utils/flex-folders/syncDateChange.ts
+++ b/src/utils/flex-folders/syncDateChange.ts
@@ -104,6 +104,28 @@ function collectAllElements(
   return result;
 }
 
+function findElementInTree(
+  nodes: FlexElementNode[],
+  elementId: string
+): { elementId: string; documentNumber?: string; displayName?: string } | null {
+  for (const node of nodes) {
+    if (node.elementId === elementId) {
+      return {
+        elementId: node.elementId,
+        documentNumber: node.documentNumber,
+        displayName: node.displayName,
+      };
+    }
+
+    if (node.children && node.children.length > 0) {
+      const match = findElementInTree(node.children, elementId);
+      if (match) return match;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Generate folder name based on folder type and job data
  */
@@ -241,6 +263,71 @@ async function syncDryhireFlexElementsForJobDateChange(
   return results;
 }
 
+async function syncRecordedFlexFolderRowsForDateChange(
+  folders: FlexFolderSyncRow[],
+  newBaseDocNumber: string,
+  formattedStartDate: string,
+  formattedEndDate: string,
+  getFolderName: (folder: FlexFolderSyncRow) => string | null,
+  scopeLabel: string
+): Promise<SyncResult> {
+  const results: SyncResult = { success: 0, failed: 0, errors: [] };
+
+  console.log(
+    `[syncFlexElements] Syncing ${folders.length} recorded ${scopeLabel} element(s) without tree traversal updates.`
+  );
+
+  for (const folder of folders) {
+    try {
+      const tree = await getElementTree(folder.element_id);
+      const element =
+        findElementInTree(tree, folder.element_id) || {
+          elementId: folder.element_id,
+          documentNumber: undefined,
+          displayName: undefined,
+        };
+      const suffix = element.documentNumber
+        ? extractDocumentNumberSuffix(element.documentNumber)
+        : "";
+      const newDocNumber = `${newBaseDocNumber}${suffix}`;
+      const updates: Promise<void>[] = [
+        updateFlexElementHeader(folder.element_id, "documentNumber", newDocNumber),
+        updateFlexElementHeader(folder.element_id, "plannedStartDate", formattedStartDate),
+        updateFlexElementHeader(folder.element_id, "plannedEndDate", formattedEndDate),
+      ];
+
+      const newName = getFolderName(folder);
+      if (newName) {
+        updates.push(updateFlexElementHeader(folder.element_id, "name", newName));
+      }
+
+      await Promise.all(updates);
+
+      if (newName) {
+        console.log(
+          `[syncFlexElements] Updated folder name: ${element.displayName || "(unknown)"} -> ${newName}`
+        );
+      }
+
+      results.success++;
+      console.log(
+        `[syncFlexElements] Updated recorded ${scopeLabel} element ${folder.element_id}: ${element.documentNumber || "(no doc#)"} -> ${newDocNumber}`
+      );
+    } catch (error: unknown) {
+      results.failed++;
+      const errorMsg = `Recorded ${scopeLabel} element ${folder.element_id}: ${getErrorMessage(error)}`;
+      results.errors.push(errorMsg);
+      console.error(`[syncFlexElements] ${errorMsg}`);
+    }
+  }
+
+  console.log(
+    `[syncFlexElements] ${scopeLabel} sync complete: ${results.success} succeeded, ${results.failed} failed`
+  );
+
+  return results;
+}
+
 /**
  * Sync all Flex elements for a job when its dates or title changes
  * Updates document numbers, planned dates, and folder names for all nested elements
@@ -318,6 +405,29 @@ export async function syncFlexElementsForJobDateChange(
       formattedStartDate,
       formattedEndDate,
       newTitle
+    );
+  }
+
+  if (isTourDateJob) {
+    return syncRecordedFlexFolderRowsForDateChange(
+      folders,
+      newBaseDocNumber,
+      formattedStartDate,
+      formattedEndDate,
+      (folder) => {
+        if (!folder.department || !folder.folder_type) {
+          return null;
+        }
+
+        return generateFolderName(
+          folder.folder_type,
+          folder.department,
+          jobTitle,
+          locationName,
+          displayDate
+        );
+      },
+      "tour date job"
     );
   }
 
@@ -415,8 +525,8 @@ export async function syncFlexElementsForJobDateChange(
 }
 
 /**
- * Sync all Flex elements for a tour date when its date changes
- * Updates document numbers, planned dates, and folder names for all nested elements
+ * Sync recorded Flex elements for a tour date when its date changes
+ * Updates only elements linked to the tour date in flex_folders.
  *
  * @param tourDateId The tour_date ID whose date changed
  * @param newDate The new date (ISO string)
@@ -471,87 +581,19 @@ export async function syncFlexElementsForTourDateChange(
     return results;
   }
 
-  console.log(`[syncFlexElements] Found ${folders.length} root folders to sync`);
-
-  // Process each root folder and its tree
-  for (const folder of folders) {
-    try {
-      // Fetch the element tree starting from this folder
-      const tree = await getElementTree(folder.element_id);
-
-      // Collect all elements (including the root and all nested children)
-      const allElements = collectAllElements(tree);
-
-      // Also add the root folder itself if not in tree response
-      const hasRoot = allElements.some((e) => e.elementId === folder.element_id);
-      if (!hasRoot) {
-        allElements.unshift({ elementId: folder.element_id, documentNumber: undefined });
+  return syncRecordedFlexFolderRowsForDateChange(
+    folders,
+    newBaseDocNumber,
+    formattedDate,
+    formattedDate,
+    (folder) => {
+      if (folder.folder_type !== "tourdate" || !folder.department) {
+        return null;
       }
 
-      console.log(
-        `[syncFlexElements] Processing folder ${folder.element_id} (${folder.department}): ${allElements.length} elements`
-      );
-
-      // Update each element
-      for (const element of allElements) {
-        try {
-          // Build new document number preserving the suffix
-          const suffix = element.documentNumber
-            ? extractDocumentNumberSuffix(element.documentNumber)
-            : "";
-          const newDocNumber = `${newBaseDocNumber}${suffix}`;
-
-          // Build array of updates to batch
-          const updates: Promise<void>[] = [
-            updateFlexElementHeader(element.elementId, "documentNumber", newDocNumber),
-            updateFlexElementHeader(element.elementId, "plannedStartDate", formattedDate),
-            updateFlexElementHeader(element.elementId, "plannedEndDate", formattedDate),
-          ];
-
-          // Update name for main tourdate folders (they include date in name)
-          // Only update if this is the root folder and it's a tourdate type
-          let newName: string | null = null;
-          if (
-            folder.folder_type === "tourdate" &&
-            element.elementId === folder.element_id &&
-            folder.department
-          ) {
-            const deptLabel = capitalize(folder.department);
-            newName = `${locationName} - ${displayDate} - ${deptLabel}`;
-            updates.push(updateFlexElementHeader(element.elementId, "name", newName));
-          }
-
-          // Execute all updates for this element in parallel
-          await Promise.all(updates);
-
-          if (newName) {
-            console.log(
-              `[syncFlexElements] Updated folder name: ${element.displayName || "(unknown)"} -> ${newName}`
-            );
-          }
-
-          results.success++;
-          console.log(
-            `[syncFlexElements] Updated element ${element.elementId}: ${element.documentNumber || "(no doc#)"} -> ${newDocNumber}`
-          );
-        } catch (elementError: unknown) {
-          results.failed++;
-          const errorMsg = `Element ${element.elementId}: ${getErrorMessage(elementError)}`;
-          results.errors.push(errorMsg);
-          console.error(`[syncFlexElements] ${errorMsg}`);
-        }
-      }
-    } catch (treeError: unknown) {
-      results.failed++;
-      const errorMsg = `Folder ${folder.element_id}: ${getErrorMessage(treeError)}`;
-      results.errors.push(errorMsg);
-      console.error(`[syncFlexElements] ${errorMsg}`);
-    }
-  }
-
-  console.log(
-    `[syncFlexElements] Sync complete: ${results.success} succeeded, ${results.failed} failed`
+      const deptLabel = capitalize(folder.department);
+      return `${locationName} - ${displayDate} - ${deptLabel}`;
+    },
+    "tour date"
   );
-
-  return results;
 }


### PR DESCRIPTION
## Summary
- scope tour-date Flex date sync to recorded `flex_folders` rows instead of updating every node returned by Flex tree traversal
- apply the same recorded-row path to tourdate jobs edited through the job dialog
- add regression coverage ensuring nested unrelated Flex tree elements are ignored

## Tests
- `npx.cmd vitest run src/utils/flex-folders/__tests__/syncDateChange.tourdate.test.ts src/utils/flex-folders/__tests__/syncDateChange.dryhire.test.ts`
- `npm.cmd run lint` (0 errors, existing 439 warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for tour-date synchronization, ensuring changes are scoped to recorded rows and nested elements remain untouched.

* **Refactor**
  * Centralized date-change handling with tree-aware batch updates for tour-date folders; preserves document-number suffixes, batches updates to document number and planned dates, and supports optional folder renaming via a name generator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->