### PR TITLE
[codex] fix festival date defaults

### DIFF
--- a/src/components/festival/FestivalDateNavigation.tsx
+++ b/src/components/festival/FestivalDateNavigation.tsx
@@ -14,7 +14,7 @@ import { Calendar as CalendarComponent } from "@/components/ui/calendar";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { getDateTypeMeta, isKeyFestivalDateType } from "@/constants/dateTypes";
+import { getDateTypeMeta, getEffectiveFestivalDateType, isKeyFestivalDateType } from "@/constants/dateTypes";
 
 interface FestivalDateNavigationProps {
   jobDates: Date[];
@@ -58,7 +58,7 @@ export const FestivalDateNavigation = ({
     return jobDates.filter(date => {
       const formattedDate = format(date, 'yyyy-MM-dd');
       const key = `${jobId}-${formattedDate}`;
-      const dateType = dateTypes[key];
+      const dateType = getEffectiveFestivalDateType(dateTypes[key]);
       return isKeyFestivalDateType(dateType);
     });
   }, [jobDates, showOnlyShowDates, dateTypes, jobId]);
@@ -94,7 +94,7 @@ export const FestivalDateNavigation = ({
   const getDateTypeColor = (date: Date) => {
     const formattedDate = format(date, 'yyyy-MM-dd');
     const key = `${jobId}-${formattedDate}`;
-    const meta = getDateTypeMeta(dateTypes[key]);
+    const meta = getDateTypeMeta(getEffectiveFestivalDateType(dateTypes[key]));
     if (!meta) return "border-gray-300";
     return `${meta.festivalBorderClassName} ${meta.festivalBackgroundClassName}`;
   };
@@ -102,7 +102,7 @@ export const FestivalDateNavigation = ({
   const getDateTypeBadge = (date: Date) => {
     const formattedDate = format(date, 'yyyy-MM-dd');
     const key = `${jobId}-${formattedDate}`;
-    const meta = getDateTypeMeta(dateTypes[key]);
+    const meta = getDateTypeMeta(getEffectiveFestivalDateType(dateTypes[key]));
     if (!meta) return null;
     
     return (
@@ -317,7 +317,7 @@ export const FestivalDateNavigation = ({
                         <div className="text-center">
                           <p>El día del festival es de {dayStartTime} a {dayStartTime} del día siguiente</p>
                           <p>Fecha: {formattedDateValue}</p>
-                          <p>Tipo: {dateTypes[`${jobId}-${formattedDateValue}`] || 'No configurado'}</p>
+                          <p>Tipo: {getEffectiveFestivalDateType(dateTypes[`${jobId}-${formattedDateValue}`])}</p>
                         </div>
                       </TooltipContent>
                     </Tooltip>

--- a/src/components/festival/__tests__/FestivalDateNavigation.test.tsx
+++ b/src/components/festival/__tests__/FestivalDateNavigation.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FestivalDateNavigation } from "@/components/festival/FestivalDateNavigation";
+
+vi.mock("@/components/dashboard/DateTypeContextMenu", () => ({
+  DateTypeContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("FestivalDateNavigation", () => {
+  it("keeps unconfigured festival dates visible as default show dates", () => {
+    render(
+      <FestivalDateNavigation
+        jobDates={[
+          new Date(2026, 5, 4),
+          new Date(2026, 5, 5),
+          new Date(2026, 5, 6),
+        ]}
+        selectedDate="2026-06-04"
+        onDateChange={vi.fn()}
+        dateTypes={{
+          "job-1-2026-06-04": "setup",
+        }}
+        jobId="job-1"
+        onTypeChange={vi.fn()}
+        dayStartTime="07:00"
+      />,
+    );
+
+    expect(screen.getByText("Thu, Jun 4")).toBeInTheDocument();
+    expect(screen.getByText("Fri, Jun 5")).toBeInTheDocument();
+    expect(screen.getByText("Sat, Jun 6")).toBeInTheDocument();
+  });
+});

--- a/src/constants/dateTypes.ts
+++ b/src/constants/dateTypes.ts
@@ -157,6 +157,10 @@ export function isKeyFestivalDateType(value?: string | null): boolean {
   return getDateTypeMeta(value)?.isKeyFestivalDay ?? false;
 }
 
+export function getEffectiveFestivalDateType(value?: string | null): DateType {
+  return getDateTypeMeta(value)?.value ?? "show";
+}
+
 export const DATE_TYPE_OPTIONS = DATE_TYPE_ORDER.map((type) => DATE_TYPE_META[type]);
 export const TOUR_DATE_TYPE_OPTIONS = TOUR_DATE_TYPE_ORDER.map((type) => ({
   ...DATE_TYPE_META[type],

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -21,6 +21,7 @@ import { CopyArtistsDialog } from "@/components/festival/CopyArtistsDialog";
 import { exportFullFestivalSchedulePDF, FullFestivalSchedulePdfData } from "@/utils/fullFestivalSchedulePdfExport";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { buildReadableFilename, formatDateForFilename } from "@/utils/fileName";
+import { getEffectiveFestivalDateType } from "@/constants/dateTypes";
 
 const DAY_START_HOUR = 7; // Festival day starts at 7:00 AM
 
@@ -341,13 +342,13 @@ const FestivalArtistManagement = () => {
   const isShowDate = (date: Date) => {
     const formattedDate = format(date, 'yyyy-MM-dd');
     const key = `${jobId}-${formattedDate}`;
-    return dateTypes[key] === 'show';
+    return getEffectiveFestivalDateType(dateTypes[key]) === 'show';
   };
   
   const getCurrentDateType = () => {
     if (!selectedDate || !jobId) return null;
     const key = `${jobId}-${selectedDate}`;
-    return dateTypes[key];
+    return getEffectiveFestivalDateType(dateTypes[key]);
   };
 
   const handlePrintTable = async () => {


### PR DESCRIPTION
## Summary
- Default missing festival `job_date_types` rows to effective `show` dates in festival date navigation.
- Apply the same effective date type handling to festival artist management controls.
- Add a regression test covering a multi-day festival where only the first date has a configured type.

## Root Cause
Festival screens filtered to show/key dates by reading only explicit `job_date_types` rows. When a festival spans multiple days but only the first date has a row, later dates were treated as not key dates and disappeared from the tabs, which also prevented users from changing their date type.

## Production Data Note
Subsonico was also backfilled directly in Supabase: `2026-06-05` and `2026-06-06` are now set to `show`.

## Validation
- `npm install --legacy-peer-deps`
- `npm run test:run -- src/components/festival/__tests__/FestivalDateNavigation.test.tsx`
- `npm run test:run`
- `npm run build`
- `npm run lint:app` (0 errors; existing warning backlog only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal date type resolution logic for more robust handling of festival date configurations.

* **Tests**
  * Added comprehensive test coverage for date navigation component.

**Note:** These changes enhance code reliability without affecting visible functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/604)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->