### PR TITLE
Project Management: tokenized, accent-insensitive search

### DIFF
--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -23,6 +23,15 @@ import { cn } from "@/lib/utils";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useCreateJobDialogStore } from "@/stores/useCreateJobDialogStore";
 
+const normalizeSearchText = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .trim();
+
+const buildSearchTokens = (query: string) => normalizeSearchText(query).split(/\s+/).filter(Boolean);
+
 const ProjectManagement = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -131,12 +140,13 @@ const ProjectManagement = () => {
       : (selectedJobTypes.length === 0 ||
         selectedJobTypes.map(t => t.toLowerCase()).includes(String(job.job_type || '').toLowerCase()));
     const matchesStatus = selectedJobStatuses.length === 0 || selectedJobStatuses.includes(job.status);
-    const q = debouncedQuery.trim().toLowerCase();
+    const tokens = buildSearchTokens(debouncedQuery);
+    const searchableValues = [job.title, job.client, job.location?.name, job.location?.formatted_address]
+      .filter(Boolean)
+      .map((value: string) => normalizeSearchText(value));
     const matchesSearch =
-      q.length === 0 ||
-      [job.title, job.client, job.location?.name, job.location?.formatted_address]
-        .filter(Boolean)
-        .some((s: string) => s.toLowerCase().includes(q));
+      tokens.length === 0 ||
+      tokens.every((token) => searchableValues.some((value) => value.includes(token)));
     return matchesType && matchesStatus && matchesSearch;
   });
 

--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -134,13 +134,13 @@ const ProjectManagement = () => {
   }, [optimizedJobs, canCreateItems, isSearching, toast]);
 
   // Filter jobs by selected job type and statuses with database-level optimization
+  const tokens = buildSearchTokens(debouncedQuery);
   const jobs = (optimizedJobs || []).filter((job: any) => {
     const matchesType = isSearching
       ? true // search overrides type filter
       : (selectedJobTypes.length === 0 ||
         selectedJobTypes.map(t => t.toLowerCase()).includes(String(job.job_type || '').toLowerCase()));
     const matchesStatus = selectedJobStatuses.length === 0 || selectedJobStatuses.includes(job.status);
-    const tokens = buildSearchTokens(debouncedQuery);
     const searchableValues = [job.title, job.client, job.location?.name, job.location?.formatted_address]
       .filter(Boolean)
       .map((value: string) => normalizeSearchText(value));


### PR DESCRIPTION
### Motivation
- The project management search required exact, case-sensitive phrase matches which made searching for jobs brittle (diacritics and word order blocked matches). 
- Users need to find jobs by entering key words in any order (e.g. `Alboran granada` should find `Pablo Alboran (plaza de toros de granada)`).

### Description
- Added `normalizeSearchText` to perform Unicode NFD normalization, strip diacritics, lowercase, and trim input. 
- Added `buildSearchTokens` to split the search query into space-separated tokens.
- Replaced the previous single-phrase `includes` check with tokenized matching so that every token must appear in at least one of the searchable fields (`title`, `client`, `location.name`, `location.formatted_address`) in any order and ignoring case/accents; change implemented in `src/pages/ProjectManagement.tsx`.

### Testing
- Ran `npm run -s lint` and the command completed successfully; repository pre-existing warnings remain unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0224248f8c8320b7a3ce2a50d810fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now ignores accents and special diacritics for more reliable matching.
  * Multi-word queries require each term to match somewhere in job details, improving multi-term search accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/606)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->