### PR TITLE
[codex] Optimize staffing status queries

### DIFF
--- a/src/components/matrix/DateHeader.tsx
+++ b/src/components/matrix/DateHeader.tsx
@@ -51,9 +51,10 @@ function useJobEngagementCounts(jobId: string, technicianIds: string[] | undefin
       let offers = 0;      // offer sent
 
       const { data: staffingData, error: staffingErr } = await supabase
-        .rpc('get_assignment_matrix_staffing')
-        .eq('job_id', jobId)
-        .in('profile_id', technicianIds);
+        .rpc('get_assignment_matrix_staffing_filtered', {
+          p_job_ids: [jobId],
+          p_profile_ids: technicianIds,
+        });
 
       if (staffingErr) {
         console.warn('Counts staffing RPC error', staffingErr);

--- a/src/components/matrix/OptimizedAssignmentMatrix.tsx
+++ b/src/components/matrix/OptimizedAssignmentMatrix.tsx
@@ -127,9 +127,10 @@ export const OptimizedAssignmentMatrix = ({
       const map = new Map<string, { availability_status: string | null; offer_status: string | null }>();
       for (const b of batches) {
         const { data, error } = await supabase
-          .rpc('get_assignment_matrix_staffing')
-          .eq('job_id', sortJobId)
-          .in('profile_id', b);
+          .rpc('get_assignment_matrix_staffing_filtered', {
+            p_job_ids: [sortJobId],
+            p_profile_ids: b,
+          });
         if (error) {
           console.warn('Sort job statuses RPC error', error);
           continue;

--- a/src/components/matrix/OptimizedAssignmentMatrix.tsx
+++ b/src/components/matrix/OptimizedAssignmentMatrix.tsx
@@ -181,44 +181,27 @@ export const OptimizedAssignmentMatrix = ({
       // Get start of current year
       const now = new Date();
       const yearStart = new Date(now.getFullYear(), 0, 1).toISOString().split('T')[0];
+      const yearEnd = new Date(now.getFullYear(), 11, 31).toISOString().split('T')[0];
 
-      // Get active timesheets from this year for ALL technicians
-      const { data: timesheetData, error: timesheetError } = await supabase
-        .from('timesheets')
-        .select('technician_id')
-        .eq('is_active', true)
-        .gte('date', yearStart);
+      const { data: countRows, error: timesheetError } = await supabase
+        .rpc('get_active_timesheet_counts_by_technician', {
+          p_start_date: yearStart,
+          p_end_date: yearEnd,
+        });
 
       if (timesheetError) {
         console.warn('Failed to fetch timesheet counts', timesheetError);
         return { counts: new Map<string, number>(), departments: new Map<string, string>() };
       }
 
-      // Count timesheets per technician
       const countMap = new Map<string, number>();
-      (timesheetData || []).forEach((timesheet: any) => {
-        const current = countMap.get(timesheet.technician_id) || 0;
-        countMap.set(timesheet.technician_id, current + 1);
-      });
-
-      // Fetch departments for all technicians who have timesheets
-      const techIds = Array.from(countMap.keys());
       const departmentMap = new Map<string, string>();
-
-      if (techIds.length > 0) {
-        const { data: profileData, error: profileError } = await supabase
-          .from('profiles')
-          .select('id, department')
-          .in('id', techIds);
-
-        if (!profileError && profileData) {
-          profileData.forEach((profile: any) => {
-            if (profile.department) {
-              departmentMap.set(profile.id, profile.department);
-            }
-          });
+      (countRows || []).forEach(row => {
+        countMap.set(row.technician_id, Number(row.timesheet_count || 0));
+        if (row.department) {
+          departmentMap.set(row.technician_id, row.department);
         }
-      }
+      });
 
       return { counts: countMap, departments: departmentMap };
     },
@@ -238,44 +221,25 @@ export const OptimizedAssignmentMatrix = ({
       const yearStart = new Date(lastYear, 0, 1).toISOString().split('T')[0];
       const yearEnd = new Date(lastYear, 11, 31).toISOString().split('T')[0];
 
-      // Get active timesheets from last year for ALL technicians
-      const { data: timesheetData, error: timesheetError } = await supabase
-        .from('timesheets')
-        .select('technician_id')
-        .eq('is_active', true)
-        .gte('date', yearStart)
-        .lte('date', yearEnd);
+      const { data: countRows, error: timesheetError } = await supabase
+        .rpc('get_active_timesheet_counts_by_technician', {
+          p_start_date: yearStart,
+          p_end_date: yearEnd,
+        });
 
       if (timesheetError) {
         console.warn('Failed to fetch last year timesheet counts', timesheetError);
         return { counts: new Map<string, number>(), departments: new Map<string, string>() };
       }
 
-      // Count timesheets per technician
       const countMap = new Map<string, number>();
-      (timesheetData || []).forEach((timesheet: any) => {
-        const current = countMap.get(timesheet.technician_id) || 0;
-        countMap.set(timesheet.technician_id, current + 1);
-      });
-
-      // Fetch departments for all technicians who have timesheets
-      const techIds = Array.from(countMap.keys());
       const departmentMap = new Map<string, string>();
-
-      if (techIds.length > 0) {
-        const { data: profileData, error: profileError } = await supabase
-          .from('profiles')
-          .select('id, department')
-          .in('id', techIds);
-
-        if (!profileError && profileData) {
-          profileData.forEach((profile: any) => {
-            if (profile.department) {
-              departmentMap.set(profile.id, profile.department);
-            }
-          });
+      (countRows || []).forEach(row => {
+        countMap.set(row.technician_id, Number(row.timesheet_count || 0));
+        if (row.department) {
+          departmentMap.set(row.technician_id, row.department);
         }
-      }
+      });
 
       return { counts: countMap, departments: departmentMap };
     },

--- a/src/features/staffing/hooks/useStaffing.ts
+++ b/src/features/staffing/hooks/useStaffing.ts
@@ -9,9 +9,10 @@ export function useStaffingStatus(jobId: string, profileId: string) {
 
       // Use the RPC function which reflects the latest statuses
       const { data, error } = await supabase
-        .rpc('get_assignment_matrix_staffing')
-        .eq('job_id', jobId)
-        .eq('profile_id', profileId)
+        .rpc('get_assignment_matrix_staffing_filtered', {
+          p_job_ids: [jobId],
+          p_profile_ids: [profileId],
+        })
         .maybeSingle()
 
       if (error) {

--- a/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
+++ b/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
@@ -145,30 +145,21 @@ export function useStaffingMatrixStatuses(
       // 2) Date-based statuses derived from staffing_requests across visible jobs
       const reqRows: StaffingRequestRow[] = []
       try {
-        const techBatches = chunk(technicianIds, 20)
-        const jobBatches = chunk(jobIds, 20)
-        const promises: Promise<any>[] = []
-        for (const tb of techBatches) {
-          for (const jb of jobBatches) {
-            promises.push(
-              Promise.resolve(supabase
-                .from('staffing_requests')
-                .select('job_id, profile_id, phase, status, updated_at, single_day, target_date, created_at, requested_by')
-                .in('profile_id', tb)
-                .in('job_id', jb))
-            )
-          }
+        const { data, error } = await supabase
+          .rpc('get_staffing_requests_matrix_filtered', {
+            p_job_ids: jobIds,
+            p_profile_ids: technicianIds
+          })
+
+        if (error) {
+          console.warn('Staffing matrix requests RPC error:', error)
+        } else if (data?.length) {
+          data.forEach(row => {
+            reqRows.push(row as StaffingRequestRow)
+          })
         }
-        const results = await Promise.all(promises)
-        results.forEach(res => {
-          if (res.error) {
-            console.warn('Staffing matrix requests error (batch):', res.error)
-            return
-          }
-          if (res.data?.length) reqRows.push(...res.data)
-        })
       } catch (e) {
-        console.warn('Staffing matrix requests batch error:', e)
+        console.warn('Staffing matrix requests RPC error:', e)
       }
 
       // Build job lookup with parsed dates for overlap check

--- a/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
+++ b/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
@@ -89,19 +89,21 @@ export function useStaffingMatrixStatuses(
         return out
       }
 
-      // 1) Job-based statuses from aggregated view
+      // 1) Job-based statuses from bounded RPC. Avoid filtering the all-table
+      // staffing status rollup client-side; each call is scoped before DISTINCT ON.
       const mapByJob = new Map<string, ByJobStatus>()
       try {
-        const techBatches = chunk(technicianIds, 20)
-        const jobBatches = chunk(jobIds, 20)
+        const techBatches = chunk(technicianIds, 100)
+        const jobBatches = chunk(jobIds, 100)
         const promises: Promise<any>[] = []
         for (const tb of techBatches) {
           for (const jb of jobBatches) {
             promises.push(
               Promise.resolve(supabase
-                .rpc('get_assignment_matrix_staffing')
-                .in('job_id', jb)
-                .in('profile_id', tb))
+                .rpc('get_assignment_matrix_staffing_filtered', {
+                  p_job_ids: jb,
+                  p_profile_ids: tb
+                }))
             )
           }
         }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -8541,6 +8541,18 @@ export type Database = {
           profile_id: string
         }[]
       }
+      get_assignment_matrix_staffing_filtered: {
+        Args: { p_job_ids: string[]; p_profile_ids: string[] }
+        Returns: {
+          availability_status: string | null
+          availability_updated_at: string | null
+          job_id: string
+          last_change: string
+          offer_status: string | null
+          offer_updated_at: string | null
+          profile_id: string
+        }[]
+      }
       get_current_user_role: { Args: never; Returns: string }
       get_job_total_amounts: {
         Args: { _job_id: string; _user_role?: string }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -8529,6 +8529,14 @@ export type Database = {
         Args: { _job_id: string; _tech_id: string }
         Returns: Json
       }
+      get_active_timesheet_counts_by_technician: {
+        Args: { p_start_date: string; p_end_date: string }
+        Returns: {
+          department: string | null
+          technician_id: string
+          timesheet_count: number
+        }[]
+      }
       get_assignment_matrix_staffing: {
         Args: never
         Returns: {
@@ -8551,6 +8559,20 @@ export type Database = {
           offer_status: string | null
           offer_updated_at: string | null
           profile_id: string
+        }[]
+      }
+      get_staffing_requests_matrix_filtered: {
+        Args: { p_job_ids: string[]; p_profile_ids: string[] }
+        Returns: {
+          created_at: string
+          job_id: string
+          phase: string
+          profile_id: string
+          requested_by: string | null
+          single_day: boolean
+          status: string
+          target_date: string | null
+          updated_at: string
         }[]
       }
       get_current_user_role: { Args: never; Returns: string }

--- a/supabase/migrations/20260511213000_optimize_staffing_status_queries.sql
+++ b/supabase/migrations/20260511213000_optimize_staffing_status_queries.sql
@@ -1,0 +1,78 @@
+-- Reduce assignment matrix load by letting callers constrain staffing status
+-- rollups before DISTINCT ON sorts the staffing_requests table.
+
+CREATE INDEX IF NOT EXISTS idx_staffing_requests_matrix_latest
+  ON public.staffing_requests (job_id, profile_id, phase, updated_at DESC, created_at DESC)
+  INCLUDE (status, single_day, target_date, requested_by);
+
+CREATE OR REPLACE FUNCTION public.get_assignment_matrix_staffing_filtered(
+  p_job_ids uuid[],
+  p_profile_ids uuid[]
+)
+RETURNS TABLE(
+  job_id uuid,
+  profile_id uuid,
+  availability_status text,
+  availability_updated_at timestamptz,
+  offer_status text,
+  offer_updated_at timestamptz,
+  last_change timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH authorized AS (
+    SELECT auth.role() = 'service_role' OR public.is_admin_or_management() AS allowed
+  ),
+  latest AS (
+    SELECT DISTINCT ON (sr.job_id, sr.profile_id, sr.phase)
+      sr.job_id,
+      sr.profile_id,
+      sr.phase,
+      sr.status,
+      sr.updated_at,
+      sr.created_at
+    FROM public.staffing_requests sr
+    CROSS JOIN authorized a
+    WHERE a.allowed
+      AND sr.job_id = ANY(p_job_ids)
+      AND sr.profile_id = ANY(p_profile_ids)
+    ORDER BY
+      sr.job_id,
+      sr.profile_id,
+      sr.phase,
+      sr.updated_at DESC NULLS LAST,
+      sr.created_at DESC NULLS LAST
+  ),
+  pivoted AS (
+    SELECT
+      l.job_id,
+      l.profile_id,
+      max(l.status) FILTER (WHERE l.phase = 'availability') AS availability_status,
+      max(l.updated_at) FILTER (WHERE l.phase = 'availability') AS availability_updated_at,
+      max(l.status) FILTER (WHERE l.phase = 'offer') AS offer_status,
+      max(l.updated_at) FILTER (WHERE l.phase = 'offer') AS offer_updated_at
+    FROM latest l
+    GROUP BY l.job_id, l.profile_id
+  )
+  SELECT
+    p.job_id,
+    p.profile_id,
+    p.availability_status,
+    p.availability_updated_at,
+    p.offer_status,
+    p.offer_updated_at,
+    GREATEST(
+      COALESCE(p.availability_updated_at, '1970-01-01 00:00:00+00'::timestamptz),
+      COALESCE(p.offer_updated_at, '1970-01-01 00:00:00+00'::timestamptz)
+    ) AS last_change
+  FROM pivoted p;
+$function$;
+
+COMMENT ON FUNCTION public.get_assignment_matrix_staffing_filtered(uuid[], uuid[])
+  IS 'Returns latest staffing availability/offer status for bounded job/profile sets. Use instead of filtering get_assignment_matrix_staffing() client-side.';
+
+GRANT EXECUTE ON FUNCTION public.get_assignment_matrix_staffing_filtered(uuid[], uuid[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_assignment_matrix_staffing_filtered(uuid[], uuid[]) TO service_role;

--- a/supabase/migrations/20260511224500_optimize_matrix_db_reads.sql
+++ b/supabase/migrations/20260511224500_optimize_matrix_db_reads.sql
@@ -1,0 +1,94 @@
+-- Further reduce matrix load by aggregating common read patterns in SQL and
+-- backing the remaining high-frequency filters with narrower partial indexes.
+
+CREATE INDEX IF NOT EXISTS idx_staffing_requests_profile_job_latest
+  ON public.staffing_requests (profile_id, job_id, phase, updated_at DESC, created_at DESC)
+  INCLUDE (status, single_day, target_date, requested_by);
+
+CREATE INDEX IF NOT EXISTS idx_timesheets_active_date_tech_job
+  ON public.timesheets (date, technician_id, job_id)
+  WHERE is_active = true;
+
+CREATE OR REPLACE FUNCTION public.get_staffing_requests_matrix_filtered(
+  p_job_ids uuid[],
+  p_profile_ids uuid[]
+)
+RETURNS TABLE(
+  job_id uuid,
+  profile_id uuid,
+  phase text,
+  status text,
+  updated_at timestamptz,
+  single_day boolean,
+  target_date date,
+  created_at timestamptz,
+  requested_by uuid
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH authorized AS (
+    SELECT auth.role() = 'service_role' OR public.is_admin_or_management() AS allowed
+  )
+  SELECT
+    sr.job_id,
+    sr.profile_id,
+    sr.phase,
+    sr.status,
+    sr.updated_at,
+    sr.single_day,
+    sr.target_date,
+    sr.created_at,
+    sr.requested_by
+  FROM public.staffing_requests sr
+  CROSS JOIN authorized a
+  WHERE a.allowed
+    AND sr.job_id = ANY(p_job_ids)
+    AND sr.profile_id = ANY(p_profile_ids)
+  ORDER BY sr.profile_id, sr.job_id, sr.phase, sr.updated_at DESC NULLS LAST, sr.created_at DESC NULLS LAST;
+$function$;
+
+COMMENT ON FUNCTION public.get_staffing_requests_matrix_filtered(uuid[], uuid[])
+  IS 'Returns raw staffing request rows for bounded matrix job/profile sets so callers do not fan out many PostgREST reads.';
+
+GRANT EXECUTE ON FUNCTION public.get_staffing_requests_matrix_filtered(uuid[], uuid[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_staffing_requests_matrix_filtered(uuid[], uuid[]) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.get_active_timesheet_counts_by_technician(
+  p_start_date date,
+  p_end_date date
+)
+RETURNS TABLE(
+  technician_id uuid,
+  department text,
+  timesheet_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH authorized AS (
+    SELECT auth.role() = 'service_role' OR public.is_admin_or_management() AS allowed
+  )
+  SELECT
+    t.technician_id,
+    p.department,
+    count(*)::bigint AS timesheet_count
+  FROM public.timesheets t
+  JOIN public.profiles p ON p.id = t.technician_id
+  CROSS JOIN authorized a
+  WHERE a.allowed
+    AND t.is_active = true
+    AND t.date >= p_start_date
+    AND t.date <= p_end_date
+  GROUP BY t.technician_id, p.department;
+$function$;
+
+COMMENT ON FUNCTION public.get_active_timesheet_counts_by_technician(date, date)
+  IS 'Aggregates active timesheet counts by technician and department for matrix medals without returning every timesheet row to the client.';
+
+GRANT EXECUTE ON FUNCTION public.get_active_timesheet_counts_by_technician(date, date) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_active_timesheet_counts_by_technician(date, date) TO service_role;

--- a/tests/e2e/assignments-matrix.spec.ts
+++ b/tests/e2e/assignments-matrix.spec.ts
@@ -48,6 +48,7 @@ test("renders the assignments matrix and lets management toggle direct assign mo
       ],
       "get_job_staffing_summary": [],
       "get_assignment_matrix_staffing": [],
+      "get_assignment_matrix_staffing_filtered": [],
     },
   });
 

--- a/tests/e2e/assignments-matrix.spec.ts
+++ b/tests/e2e/assignments-matrix.spec.ts
@@ -47,8 +47,10 @@ test("renders the assignments matrix and lets management toggle direct assign mo
         },
       ],
       "get_job_staffing_summary": [],
+      "get_active_timesheet_counts_by_technician": [],
       "get_assignment_matrix_staffing": [],
       "get_assignment_matrix_staffing_filtered": [],
+      "get_staffing_requests_matrix_filtered": [],
     },
   });
 


### PR DESCRIPTION
## Summary
- add bounded Supabase RPCs for assignment-matrix staffing reads and active timesheet count aggregation
- add targeted indexes for latest staffing request lookups and active timesheet date-range scans
- switch matrix callers away from client-side fanout/full-row reads toward database-side filtered/aggregated reads

## Why
The remote stats showed the largest historical sequential tuple reads on `staffing_requests`, `timesheets`, and `technician_availability`, with the matrix/status paths repeatedly querying small tables in expensive shapes. The first migration stopped the all-table staffing status rollup. The follow-up migration goes deeper by removing a remaining `staffing_requests` fanout path and avoiding full-year active timesheet row downloads just to compute medal counts.

## Migration
Applied to the linked remote Supabase project with `npx supabase db push --linked --yes`.
Confirmed remote migration history includes:
- `20260511213000_optimize_staffing_status_queries.sql`
- `20260511224500_optimize_matrix_db_reads.sql`

## Validation
- `npm run lint:app`
- `npm run test:run -- src/components/matrix/__tests__/OptimizedAssignmentMatrix.test.tsx src/pages/__tests__/JobAssignmentMatrix.test.tsx`
- `npm run test:run`
- `npm run build`
