### PR TITLE
Fix tour multiplier breakdown display

### DIFF
--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
@@ -21,6 +21,8 @@ vi.mock("@/components/jobs/payout-totals/usePayoutActions", () => ({
 
 import { JobPayoutTotalsPanel } from "../JobPayoutTotalsPanel";
 
+const normalizeCurrencyText = (value: string) => value.replace(/\s+/g, "");
+
 describe("JobPayoutTotalsPanel tourdate payouts", () => {
   const buildPayoutData = () => ({
     jobMeta: {
@@ -144,12 +146,11 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
   it("renders mapped tour payouts with totals and extras", () => {
     renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
 
-    const normalize = (value: string) => value.replace(/\s+/g, "");
     const grandTotals = screen.getAllByText(
-      (content) => normalize(content) === normalize(formatCurrency(175)),
+      (content) => normalizeCurrencyText(content) === normalizeCurrencyText(formatCurrency(175)),
     );
     const baseTotals = screen.getAllByText(
-      (content) => normalize(content) === normalize(formatCurrency(150)),
+      (content) => normalizeCurrencyText(content) === normalizeCurrencyText(formatCurrency(150)),
     );
 
     expect(grandTotals.length).toBeGreaterThan(0);
@@ -289,7 +290,12 @@ describe("JobPayoutTotalsPanel tourdate payouts", () => {
 
     renderWithProviders(<JobPayoutTotalsPanel jobId="job-tour-1" />);
 
-    expect(screen.getByText(/estándar: 2 x/i)).toBeInTheDocument();
+    expect(screen.getByText(
+      (content) => normalizeCurrencyText(content) === normalizeCurrencyText(`Estándar: 2 x ${formatCurrency(360)}`),
+    )).toBeInTheDocument();
+    expect(screen.getByText(
+      (content) => normalizeCurrencyText(content) === normalizeCurrencyText(formatCurrency(720)),
+    )).toBeInTheDocument();
     expect(screen.getByText(/multiplicador gira: 1 día con factor 1,5x/i)).toBeInTheDocument();
     expect(screen.getByText(/\+240/)).toBeInTheDocument();
   });

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -26,6 +26,10 @@ const categoryLabels: Record<string, string> = {
   'otros': 'Otros',
 };
 
+function roundCurrencyValue(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
 interface TechnicianPayoutCardProps {
   payout: JobPayoutTotals;
   tourQuote?: TourJobRateQuote;
@@ -176,6 +180,13 @@ export function TechnicianPayoutCard({
   const standardDayRate = Number(quoteBreakdown?.standard_day_rate_eur ?? 0);
   const multipliedStandardDays = Number(quoteBreakdown?.multiplied_standard_days ?? 0);
   const standardMultiplierBonus = Number(quoteBreakdown?.standard_multiplier_bonus_eur ?? 0);
+  const standardTotalWithMultiplier = roundCurrencyValue(standardDays * standardDayRate);
+  const standardBaseTotal = standardDays > 0
+    ? Math.max(0, roundCurrencyValue(standardTotalWithMultiplier - standardMultiplierBonus))
+    : 0;
+  const standardBaseDayRate = standardDays > 0
+    ? roundCurrencyValue(standardBaseTotal / standardDays)
+    : 0;
   const multiplierFactor = Number(
     quoteBreakdown?.per_job_multiplier
       ?? tourQuote?.per_job_multiplier
@@ -352,8 +363,8 @@ export function TechnicianPayoutCard({
 
             {standardDays > 0 && (
               <div className="flex justify-between gap-3 text-xs text-muted-foreground">
-                <span>Estándar: {standardDays} x {formatCurrency(standardDayRate)}</span>
-                <span>{formatCurrency(standardDays * standardDayRate)}</span>
+                <span>Estándar: {standardDays} x {formatCurrency(standardBaseDayRate)}</span>
+                <span>{formatCurrency(standardBaseTotal)}</span>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- show the unmultiplied standard base line in tour payout breakdowns
- keep the tour multiplier as a separate bonus line so the expanded UI rows add up to the displayed total
- add regression coverage for the display math

## Validation
- npm run test:run -- src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx src/utils/__tests__/tour-job-rate-payroll-cases.test.ts src/utils/__tests__/tour-job-rate-multiplier-guard.test.ts src/utils/__tests__/tour-job-rate-two-day-display-multiplier-guard.test.ts
- npm run lint -- --quiet
- git diff --check