### PR TITLE
[codex] Fix staffing recommendations consultation guards

### DIFF
--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -33,6 +33,35 @@ interface Candidate {
   reasons: unknown
 }
 
+interface RolelessConsultation {
+  phase: string
+  status: string
+  target_date: string | null
+  single_day: boolean
+  updated_at: string | null
+}
+
+const ROLELESS_PHASE_LABELS: Record<string, string> = {
+  availability: 'availability',
+  offer: 'offer'
+}
+
+const ROLELESS_STATUS_LABELS: Record<string, string> = {
+  pending: 'pending',
+  confirmed: 'confirmed',
+  declined: 'declined'
+}
+
+const getRolelessConsultationLabel = (consultation: RolelessConsultation) => {
+  const phase = ROLELESS_PHASE_LABELS[consultation.phase] ?? consultation.phase
+  const status = ROLELESS_STATUS_LABELS[consultation.status] ?? consultation.status
+  const scope = consultation.single_day && consultation.target_date
+    ? ` for ${consultation.target_date}`
+    : ''
+
+  return `Prior manager ${phase} request without role is ${status}${scope}`
+}
+
 export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
   campaignId,
   roleCode,
@@ -94,6 +123,43 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
     enabled: candidateIds.length > 0
   })
 
+  const { data: rolelessConsultations = {} } = useQuery<Record<string, RolelessConsultation>>({
+    queryKey: ['staffing_roleless_consultations', jobId, candidateIds],
+    queryFn: async () => {
+      if (candidateIds.length === 0) return {}
+
+      const { data, error } = await supabase
+        .from('staffing_requests')
+        .select('profile_id, phase, status, target_date, single_day, updated_at')
+        .eq('job_id', jobId)
+        .in('profile_id', candidateIds)
+        .or('role_code.is.null,role_code.eq.')
+        .in('phase', ['availability', 'offer'])
+        .in('status', ['pending', 'confirmed', 'declined'])
+        .order('updated_at', { ascending: false })
+
+      if (error) {
+        console.error('Error fetching prior role-less staffing requests:', error)
+        return {}
+      }
+
+      return (data || []).reduce((acc, request) => {
+        if (!request.profile_id || acc[request.profile_id]) return acc
+
+        acc[request.profile_id] = {
+          phase: request.phase,
+          status: request.status,
+          target_date: request.target_date,
+          single_day: Boolean(request.single_day),
+          updated_at: request.updated_at
+        }
+
+        return acc
+      }, {} as Record<string, RolelessConsultation>)
+    },
+    enabled: candidateIds.length > 0
+  })
+
   // Send availability mutation
   const sendAvailabilityMutation = useMutation({
     mutationFn: async () => {
@@ -148,6 +214,8 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
       setSelectedCandidates(new Set())
       queryClient.invalidateQueries({ queryKey: ['staffing_requests', jobId] })
       queryClient.invalidateQueries({ queryKey: ['staffing_availability_responses', jobId] })
+      queryClient.invalidateQueries({ queryKey: ['staffing_candidates', jobId] })
+      queryClient.invalidateQueries({ queryKey: ['staffing_roleless_consultations', jobId] })
     },
     onError: (error: any) => {
       toast({
@@ -220,6 +288,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
         {/* Select all checkbox */}
         <div className="flex items-center gap-2 p-2 bg-muted rounded">
           <Checkbox
+            aria-label="Select all candidates"
             checked={selectedCandidates.size === candidates.length && candidates.length > 0}
             onCheckedChange={toggleSelectAll}
           />
@@ -230,85 +299,105 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
 
         {/* Candidate list */}
         <div className="space-y-2 max-h-96 overflow-y-auto">
-          {candidates.map((candidate) => (
-            <div
-              key={candidate.profile_id}
-              className="flex items-start gap-3 p-3 border rounded hover:bg-muted"
-            >
-              <Checkbox
-                checked={selectedCandidates.has(candidate.profile_id)}
-                onCheckedChange={() => toggleCandidate(candidate.profile_id)}
-                className="mt-1"
-              />
+          {candidates.map((candidate) => {
+            const rolelessConsultation = rolelessConsultations[candidate.profile_id]
 
-              <Avatar className="h-10 w-10 shrink-0">
-                <AvatarImage
-                  src={profilePictures?.[candidate.profile_id] || undefined}
-                  alt={candidate.full_name}
+            return (
+              <div
+                key={candidate.profile_id}
+                className="flex items-start gap-3 p-3 border rounded hover:bg-muted"
+              >
+                <Checkbox
+                  aria-label={`Select ${candidate.full_name}`}
+                  checked={selectedCandidates.has(candidate.profile_id)}
+                  onCheckedChange={() => toggleCandidate(candidate.profile_id)}
+                  className="mt-1"
                 />
-                <AvatarFallback className="text-xs">
-                  {getInitials(candidate.full_name)}
-                </AvatarFallback>
-              </Avatar>
 
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-1">
-                  <p className="font-medium text-sm">{candidate.full_name}</p>
-                  {candidate.final_score >= 80 && (
-                    <Badge className="bg-green-100 text-green-800">⭐ Top</Badge>
-                  )}
-                  {candidate.soft_conflict && (
-                    <Badge className="bg-yellow-100 text-yellow-800">⚠ Soft Conflict</Badge>
-                  )}
-                </div>
+                <Avatar className="h-10 w-10 shrink-0">
+                  <AvatarImage
+                    src={profilePictures?.[candidate.profile_id] || undefined}
+                    alt={candidate.full_name}
+                  />
+                  <AvatarFallback className="text-xs">
+                    {getInitials(candidate.full_name)}
+                  </AvatarFallback>
+                </Avatar>
 
-                <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground mb-2">
-                  <div>Skills: <span className="font-semibold">{candidate.skills_score}</span>pts</div>
-                  <div>Reliability: <span className="font-semibold">{candidate.reliability_score}</span>pts</div>
-                  <div>
-                    Proximity:{' '}
-                    <span className="font-semibold">
-                      {typeof candidate.distance_to_madrid_km === 'number'
-                        ? candidate.distance_to_madrid_km.toFixed(1)
-                        : '—'}
-                    </span>
-                    km
-                  </div>
-                  <div>Fairness: <span className="font-semibold">{candidate.fairness_score}</span>pts</div>
-                </div>
-
-                <div className="flex items-center gap-1">
-                  <div className="h-2 flex-1 bg-muted rounded overflow-hidden">
-                    <div
-                      className="h-full bg-blue-500"
-                      style={{ width: `${(candidate.final_score / 100) * 100}%` }}
-                    />
-                  </div>
-                  <span className="text-xs font-semibold text-foreground">{candidate.final_score}</span>
-                </div>
-
-                {(Array.isArray(candidate.reasons) ? candidate.reasons : []).length > 0 && (
-                  <button
-                    onClick={() => setExpandedReasons(
-                      expandedReasons === candidate.profile_id ? null : candidate.profile_id
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
+                    <p className="font-medium text-sm">{candidate.full_name}</p>
+                    {candidate.final_score >= 80 && (
+                      <Badge className="bg-green-100 text-green-800">⭐ Top</Badge>
                     )}
-                    className="text-xs text-blue-600 hover:text-blue-800 mt-1 flex items-center gap-1"
-                  >
-                    <Info size={14} />
-                    {expandedReasons === candidate.profile_id ? 'Hide' : 'Show'} reasons
-                  </button>
-                )}
-
-                {expandedReasons === candidate.profile_id && (
-                  <div className="mt-2 p-2 bg-blue-500/10 rounded text-xs space-y-1">
-                    {(Array.isArray(candidate.reasons) ? candidate.reasons : []).map((reason, idx) => (
-                      <div key={idx} className="text-muted-foreground">• {reason}</div>
-                    ))}
+                    {candidate.soft_conflict && (
+                      <Badge className="bg-yellow-100 text-yellow-800">⚠ Soft Conflict</Badge>
+                    )}
+                    {rolelessConsultation && (
+                      <Badge
+                        variant="outline"
+                        className="text-[10px]"
+                        title={getRolelessConsultationLabel(rolelessConsultation)}
+                      >
+                        No-role request
+                      </Badge>
+                    )}
                   </div>
-                )}
+
+                  <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground mb-2">
+                    <div>Skills: <span className="font-semibold">{candidate.skills_score}</span>pts</div>
+                    <div>Reliability: <span className="font-semibold">{candidate.reliability_score}</span>pts</div>
+                    <div>
+                      Proximity:{' '}
+                      <span className="font-semibold">
+                        {typeof candidate.distance_to_madrid_km === 'number'
+                          ? candidate.distance_to_madrid_km.toFixed(1)
+                          : '—'}
+                      </span>
+                      km
+                    </div>
+                    <div>Fairness: <span className="font-semibold">{candidate.fairness_score}</span>pts</div>
+                  </div>
+
+                  <div className="flex items-center gap-1">
+                    <div className="h-2 flex-1 bg-muted rounded overflow-hidden">
+                      <div
+                        className="h-full bg-blue-500"
+                        style={{ width: `${(candidate.final_score / 100) * 100}%` }}
+                      />
+                    </div>
+                    <span className="text-xs font-semibold text-foreground">{candidate.final_score}</span>
+                  </div>
+
+                  {rolelessConsultation && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {getRolelessConsultationLabel(rolelessConsultation)}
+                    </p>
+                  )}
+
+                  {(Array.isArray(candidate.reasons) ? candidate.reasons : []).length > 0 && (
+                    <button
+                      onClick={() => setExpandedReasons(
+                        expandedReasons === candidate.profile_id ? null : candidate.profile_id
+                      )}
+                      className="text-xs text-blue-600 hover:text-blue-800 mt-1 flex items-center gap-1"
+                    >
+                      <Info size={14} />
+                      {expandedReasons === candidate.profile_id ? 'Hide' : 'Show'} reasons
+                    </button>
+                  )}
+
+                  {expandedReasons === candidate.profile_id && (
+                    <div className="mt-2 p-2 bg-blue-500/10 rounded text-xs space-y-1">
+                      {(Array.isArray(candidate.reasons) ? candidate.reasons : []).map((reason, idx) => (
+                        <div key={idx} className="text-muted-foreground">• {reason}</div>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
 
         {/* Action buttons */}

--- a/src/hooks/useStaffingCampaignRealtime.ts
+++ b/src/hooks/useStaffingCampaignRealtime.ts
@@ -81,6 +81,12 @@ export function useStaffingRequestsRealtime(jobId: string) {
           queryClient.invalidateQueries({
             queryKey: ['staffing_requests', jobId]
           })
+          queryClient.invalidateQueries({
+            queryKey: ['staffing_candidates', jobId]
+          })
+          queryClient.invalidateQueries({
+            queryKey: ['staffing_roleless_consultations', jobId]
+          })
         }
       )
       .subscribe()

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -5822,6 +5822,7 @@ export type Database = {
           job_id: string
           phase: string
           profile_id: string
+          role_code: string | null
           single_day: boolean
           status: string
           target_date: string | null
@@ -5836,6 +5837,7 @@ export type Database = {
           job_id: string
           phase: string
           profile_id: string
+          role_code?: string | null
           single_day?: boolean
           status: string
           target_date?: string | null
@@ -5850,6 +5852,7 @@ export type Database = {
           job_id?: string
           phase?: string
           profile_id?: string
+          role_code?: string | null
           single_day?: boolean
           status?: string
           target_date?: string | null

--- a/src/pages/__tests__/jobAssignmentMatrixUtils.test.ts
+++ b/src/pages/__tests__/jobAssignmentMatrixUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  countMatrixAssignmentsForDepartment,
+  shouldShowMatrixJob,
+} from "../job-assignment-matrix/utils";
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {},
+}));
+
+describe("job assignment matrix utils", () => {
+  it("counts cancelled-job assignments only for the selected department", () => {
+    const assignments = [
+      { status: "confirmed", sound_role: null, lights_role: "LGT-OP" },
+      { status: "confirmed", sound_role: "SND-FOH", lights_role: null },
+      { status: "declined", sound_role: "SND-MON", lights_role: null },
+      { status: "confirmed", sound_role: "none", lights_role: null },
+    ];
+
+    expect(countMatrixAssignmentsForDepartment(assignments, "sound")).toBe(1);
+    expect(countMatrixAssignmentsForDepartment(assignments, "lights")).toBe(1);
+  });
+
+  it("hides a cancelled job when the current department has no assignments", () => {
+    const soundAssignmentCount = countMatrixAssignmentsForDepartment(
+      [{ status: "confirmed", sound_role: null, lights_role: "LGT-OP" }],
+      "sound",
+    );
+
+    expect(soundAssignmentCount).toBe(0);
+    expect(shouldShowMatrixJob({ status: "Cancelado", _assigned_count: soundAssignmentCount })).toBe(false);
+  });
+
+  it("keeps cancelled jobs visible when the current department still has assignments", () => {
+    const soundAssignmentCount = countMatrixAssignmentsForDepartment(
+      [{ status: "confirmed", sound_role: "SND-FOH", lights_role: null }],
+      "sound",
+    );
+
+    expect(soundAssignmentCount).toBe(1);
+    expect(shouldShowMatrixJob({ status: "Cancelado", _assigned_count: soundAssignmentCount })).toBe(true);
+  });
+
+  it("keeps active jobs visible without assignments", () => {
+    expect(shouldShowMatrixJob({ status: "Confirmado", _assigned_count: 0 })).toBe(true);
+  });
+});

--- a/src/pages/job-assignment-matrix/utils.ts
+++ b/src/pages/job-assignment-matrix/utils.ts
@@ -25,6 +25,42 @@ export type MatrixJob = {
   _assigned_count?: number;
 };
 
+type MatrixJobAssignment = {
+  status?: string | null;
+  sound_role?: string | null;
+  lights_role?: string | null;
+  video_role?: string | null;
+  production_role?: string | null;
+};
+
+const ROLE_FIELD_BY_DEPARTMENT = {
+  sound: "sound_role",
+  lights: "lights_role",
+  video: "video_role",
+  production: "production_role",
+} as const;
+
+function hasAssignedRole(role: string | null | undefined) {
+  if (!role) return false;
+  return role.trim().toLowerCase() !== "none";
+}
+
+export function countMatrixAssignmentsForDepartment(assignments: MatrixJobAssignment[], department: string) {
+  const activeAssignments = assignments.filter((assignment) => {
+    const status = (assignment.status || "").toLowerCase();
+    return status !== "declined";
+  });
+
+  const roleField = ROLE_FIELD_BY_DEPARTMENT[department as keyof typeof ROLE_FIELD_BY_DEPARTMENT];
+  if (!roleField) return activeAssignments.length;
+
+  return activeAssignments.filter((assignment) => hasAssignedRole(assignment[roleField])).length;
+}
+
+export function shouldShowMatrixJob(job: Pick<MatrixJob, "status" | "_assigned_count">) {
+  return job.status !== "Cancelado" || (job._assigned_count ?? 0) > 0;
+}
+
 export async function fetchJobsForWindow(start: Date, end: Date, department: string) {
   const windowRange = `[${start.toISOString()},${end.toISOString()}]`;
   const allowedJobTypes = ["single", "festival", "ciclo", "tourdate", "evento"];
@@ -35,7 +71,7 @@ export async function fetchJobsForWindow(start: Date, end: Date, department: str
       `
       id, title, start_time, end_time, color, status, job_type, job_date_types(date, type),
       job_departments!inner(department),
-      job_assignments!job_id(technician_id)
+      job_assignments!job_id(technician_id, status, sound_role, lights_role, video_role, production_role)
     `
     )
     .filter("time_range", "ov", windowRange)
@@ -56,7 +92,7 @@ export async function fetchJobsForWindow(start: Date, end: Date, department: str
       jobs!inner(
         id, title, start_time, end_time, color, status, job_type, job_date_types(date, type),
         job_departments!inner(department),
-        job_assignments!job_id(technician_id)
+        job_assignments!job_id(technician_id, status, sound_role, lights_role, video_role, production_role)
       )
     `
     )
@@ -101,10 +137,10 @@ export async function fetchJobsForWindow(start: Date, end: Date, department: str
         status: j.status,
         job_type: j.job_type,
         job_date_types: Array.isArray(j.job_date_types) ? j.job_date_types : [],
-        _assigned_count: assigns.length as number,
+        _assigned_count: countMatrixAssignmentsForDepartment(assigns, department),
       } as MatrixJob;
     })
-    .filter((j) => j.status !== "Cancelado" || (j._assigned_count ?? 0) > 0);
+    .filter(shouldShowMatrixJob);
 }
 
 export async function fetchAssignmentsForWindow(jobIds: string[], technicianIds: string[], jobs: MatrixJob[]) {

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -122,6 +122,8 @@ serve(async (req) => {
     console.log('📥 RECEIVED PAYLOAD:', JSON.stringify(body, null, 2));
 
     const { job_id, profile_id, phase, role, message, channel, tour_pdf_path, target_date, single_day, override_conflicts, idempotency_key } = body;
+    const roleCode = typeof role === 'string' && role.trim().length > 0 ? role.trim() : null;
+    const roleCodePatch = roleCode ? { role_code: roleCode } : {};
     const datesArrayRaw: unknown = (body as any)?.dates;
     const shouldOverrideConflicts = Boolean(override_conflicts);
     const desiredChannel = (typeof channel === 'string' && channel.toLowerCase() === 'whatsapp') ? 'whatsapp' : 'email';
@@ -151,7 +153,7 @@ serve(async (req) => {
       job_id: { value: job_id, type: typeof job_id, isValid: !!job_id },
       profile_id: { value: profile_id, type: typeof profile_id, isValid: !!profile_id },
       phase: { value: phase, type: typeof phase, isValidPhase: ["availability","offer"].includes(phase) },
-      role: { value: role ?? null },
+      role: { value: role ?? null, normalized: roleCode },
       message: { value: message ?? null },
       target_date: { value: target_date ?? null, normalized: normalizedTargetDate },
       single_day: { value: single_day ?? null, effective: isSingleDayRequest },
@@ -182,7 +184,7 @@ serve(async (req) => {
       
       const { data: existing, error: idempotencyError } = await supabase
         .from('staffing_requests')
-        .select('id, status, created_at')
+        .select('id, status, created_at, role_code')
         .eq('idempotency_key', idempotency_key)
         .gte('created_at', since24h)
         .maybeSingle();
@@ -190,6 +192,16 @@ serve(async (req) => {
       if (idempotencyError) {
         console.warn('⚠️ Idempotency check failed (non-blocking):', idempotencyError);
       } else if (existing) {
+        if (roleCode && !existing.role_code) {
+          const { error: roleUpdateError } = await supabase
+            .from('staffing_requests')
+            .update({ role_code: roleCode })
+            .eq('id', existing.id);
+          if (roleUpdateError) {
+            console.warn('⚠️ Failed to backfill role_code on idempotent request (non-blocking):', roleUpdateError);
+          }
+        }
+
         console.log('✅ IDEMPOTENT REQUEST DETECTED - returning cached response:', {
           request_id: existing.id,
           created_at: existing.created_at
@@ -566,6 +578,7 @@ serve(async (req) => {
               updated_at: new Date().toISOString(),
               batch_id: batchId,
               idempotency_key: idempotency_key || null,
+              ...roleCodePatch,
             })
             .eq('id', existingFirstRowId)
             .select('id')
@@ -590,6 +603,7 @@ serve(async (req) => {
             target_date: firstDate,
             batch_id: batchId,
             idempotency_key: idempotency_key || null,
+            ...roleCodePatch,
           });
           if (firstInsert.error) {
             const code = firstInsert.error.code;
@@ -638,6 +652,7 @@ serve(async (req) => {
                   updated_at: new Date().toISOString(),
                   batch_id: batchId,
                   idempotency_key: idempotency_key || null,
+                  ...roleCodePatch,
                 })
                 .eq('id', insertedId)
                 .select('id')
@@ -667,6 +682,7 @@ serve(async (req) => {
           single_day: true,
           target_date: d,
           batch_id: batchId,
+          ...roleCodePatch,
         }));
         if (rest.length) {
           console.log('📅 Inserting batch dates:', { count: rest.length, dates: rest.map(r => r.target_date) });
@@ -684,7 +700,7 @@ serve(async (req) => {
         try {
           const cohesion = await supabase
             .from('staffing_requests')
-            .update({ requested_by: actorId, batch_id: batchId, updated_at: new Date().toISOString() })
+            .update({ requested_by: actorId, batch_id: batchId, updated_at: new Date().toISOString(), ...roleCodePatch })
             .eq('job_id', job_id)
             .eq('profile_id', profile_id)
             .eq('phase', phase)
@@ -711,6 +727,7 @@ serve(async (req) => {
           single_day: isSingleDayRequest,
           target_date: normalizedTargetDate,
           idempotency_key: idempotency_key || null,
+          ...roleCodePatch,
         });
         if (insertRes.error && insertRes.error.code === "23505") {
           console.log('🔄 DUPLICATE FOUND, UPDATING...');
@@ -722,6 +739,7 @@ serve(async (req) => {
               token_hash,
               token_expires_at: exp,
               updated_at: new Date().toISOString(),
+              ...roleCodePatch,
               // keep existing shape; do not convert full-span to single-day or vice versa
             })
             .eq("job_id", job_id)
@@ -788,7 +806,7 @@ serve(async (req) => {
         token,
       );
 
-      const roleLabel = labelForRoleCode(role) || null;
+      const roleLabel = labelForRoleCode(roleCode) || null;
       const subject = phase === "availability"
         ? `Consulta de disponibilidad`
         : `Oferta: ${job.title}${roleLabel ? ` — ${roleLabel}` : ''}`;
@@ -1095,7 +1113,7 @@ serve(async (req) => {
           meta: {
             phase,
             status: waOk ? 200 : (lastStatus ?? 0),
-            role: role ?? null,
+            role: roleCode,
             single_day: isSingleDayRequest || isBatch,
             target_date: normalizedTargetDate,
             dates: normalizedDates,
@@ -1142,7 +1160,7 @@ serve(async (req) => {
           meta: {
             phase,
             status: sendRes.status,
-            role: role ?? null,
+            role: roleCode,
             message: message ?? null,
             single_day: isSingleDayRequest || isBatch,
             target_date: normalizedTargetDate,

--- a/supabase/migrations/20260512090000_staffing_request_role_code_candidates.sql
+++ b/supabase/migrations/20260512090000_staffing_request_role_code_candidates.sql
@@ -1,0 +1,428 @@
+-- Track the intended role on staffing requests so candidate ranking can avoid
+-- recommending technicians already consulted for that same job and role.
+
+ALTER TABLE public.staffing_requests
+  ADD COLUMN IF NOT EXISTS role_code text;
+
+COMMENT ON COLUMN public.staffing_requests.role_code
+  IS 'Role code requested for this staffing phase, when known. Used to de-dupe staffing recommendations by job, profile, and role.';
+
+WITH latest_role AS (
+  SELECT DISTINCT ON (se.staffing_request_id)
+    se.staffing_request_id,
+    NULLIF(BTRIM(se.meta->>'role'), '') AS role_code
+  FROM public.staffing_events se
+  WHERE se.meta ? 'role'
+    AND NULLIF(BTRIM(se.meta->>'role'), '') IS NOT NULL
+  ORDER BY se.staffing_request_id, se.created_at DESC
+)
+UPDATE public.staffing_requests sr
+SET role_code = latest_role.role_code
+FROM latest_role
+WHERE sr.id = latest_role.staffing_request_id
+  AND NULLIF(BTRIM(sr.role_code), '') IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_staffing_requests_active_role_consultations
+  ON public.staffing_requests (job_id, profile_id, role_code, phase, status)
+  WHERE role_code IS NOT NULL
+    AND status IN ('pending', 'confirmed', 'declined');
+
+CREATE INDEX IF NOT EXISTS idx_staffing_requests_roleless_declines
+  ON public.staffing_requests (job_id, profile_id, target_date)
+  WHERE role_code IS NULL
+    AND status = 'declined';
+
+CREATE OR REPLACE FUNCTION public.rank_staffing_candidates(
+  p_job_id uuid,
+  p_department text,
+  p_role_code text,
+  p_mode text,
+  p_policy jsonb
+) RETURNS TABLE (
+  profile_id uuid,
+  full_name text,
+  department text,
+  skills_score int,
+  distance_to_madrid_km double precision,
+  proximity_score int,
+  experience_score int,
+  reliability_score int,
+  fairness_score int,
+  soft_conflict boolean,
+  hard_conflict boolean,
+  final_score int,
+  reasons jsonb
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  w_skills numeric := COALESCE((p_policy->'weights'->>'skills')::numeric, 0.5);
+  w_proximity numeric := COALESCE((p_policy->'weights'->>'proximity')::numeric, 0.1);
+  w_reliability numeric := COALESCE((p_policy->'weights'->>'reliability')::numeric, 0.2);
+  w_fairness numeric := COALESCE((p_policy->'weights'->>'fairness')::numeric, 0.1);
+  w_experience numeric := COALESCE((p_policy->'weights'->>'experience')::numeric, 0.1);
+  w_sum numeric;
+  v_soft_conflict_policy text := COALESCE(p_policy->>'soft_conflict_policy', 'warn');
+  v_exclude_fridge boolean := COALESCE((p_policy->>'exclude_fridge')::boolean, true);
+  v_job_start timestamptz;
+  v_job_end timestamptz;
+  v_normalized_role_code text := NULLIF(BTRIM(p_role_code), '');
+  v_role_prefix text;
+  -- Madrid base coordinates (default map center used elsewhere in the app)
+  v_base_lat double precision := 40.4168;
+  v_base_lng double precision := -3.7038;
+BEGIN
+  -- Access control
+  IF auth.role() <> 'service_role' THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('admin', 'management', 'logistics')
+        AND (
+          p.role IN ('admin', 'logistics')
+          OR p.department IS NULL
+          OR p.department = p_department
+          OR (p_department = 'production' AND p.department = 'logistics')
+        )
+    ) THEN
+      RAISE EXCEPTION 'Not authorized to rank candidates';
+    END IF;
+  END IF;
+
+  -- Get job time range (venue location not required; proximity is relative to Madrid base)
+  SELECT
+    j.start_time,
+    j.end_time
+  INTO v_job_start, v_job_end
+  FROM jobs j
+  WHERE j.id = p_job_id;
+
+  IF v_job_start IS NULL THEN
+    RAISE EXCEPTION 'Job not found';
+  END IF;
+
+  -- Extract role prefix from role code (e.g., 'SND-FOH' from 'SND-FOH-R')
+  -- Format is DEPT-POSITION-LEVEL, we want DEPT-POSITION
+  v_role_prefix := CASE
+    WHEN v_normalized_role_code ~ '^([A-Z]+-[A-Z]+)-[RET]$'
+    THEN (regexp_match(v_normalized_role_code, '^([A-Z]+-[A-Z]+)-[RET]$'))[1]
+    ELSE v_normalized_role_code  -- Fallback to full code if format doesn't match
+  END;
+
+  w_sum := w_skills + w_proximity + w_reliability + w_fairness + w_experience;
+  IF w_sum <= 0 THEN
+    w_skills := 0.5;
+    w_proximity := 0.1;
+    w_reliability := 0.2;
+    w_fairness := 0.1;
+    w_experience := 0.1;
+    w_sum := 1;
+  END IF;
+
+  w_skills := w_skills / w_sum;
+  w_proximity := w_proximity / w_sum;
+  w_reliability := w_reliability / w_sum;
+  w_fairness := w_fairness / w_sum;
+  w_experience := w_experience / w_sum;
+
+  RETURN QUERY
+  WITH base AS (
+    SELECT
+      p.id AS profile_id,
+      NULLIF(TRIM(CONCAT_WS(' ', p.first_name, p.last_name)), '') AS full_name,
+      COALESCE(p.department, '') AS department,
+      p.role AS user_role,
+      p.home_latitude,
+      p.home_longitude,
+      COALESCE(tf.in_fridge, false) AS in_fridge,
+      (
+        SELECT MAX(ts.date)::date
+        FROM timesheets ts
+        WHERE ts.technician_id = p.id
+          AND ts.is_active = true
+      ) AS last_work_date,
+      (
+        SELECT COUNT(DISTINCT ts.job_id)
+        FROM timesheets ts
+        WHERE ts.technician_id = p.id
+          AND ts.is_active = true
+      ) AS jobs_worked,
+      (
+        SELECT COUNT(*)
+        FROM timesheets ts
+        WHERE ts.technician_id = p.id
+          AND ts.is_active = true
+          AND ts.date >= date_trunc('month', now())::date
+          AND ts.date < (date_trunc('month', now()) + interval '1 month')::date
+      ) AS current_month_days,
+      -- Check for overlapping job assignments (only confirmed/invited, not declined)
+      EXISTS (
+        SELECT 1
+        FROM job_assignments ja2
+        JOIN jobs j2 ON j2.id = ja2.job_id
+        WHERE ja2.technician_id = p.id
+          AND ja2.job_id != p_job_id
+          AND COALESCE(ja2.status, 'invited') NOT IN ('declined')
+          AND j2.time_range && tstzrange(v_job_start, v_job_end, '[]')
+      ) AS has_job_overlap,
+      -- Check for soft conflicts (jobs on same day but not overlapping)
+      EXISTS (
+        SELECT 1
+        FROM job_assignments ja2
+        JOIN jobs j2 ON j2.id = ja2.job_id
+        WHERE ja2.technician_id = p.id
+          AND ja2.job_id != p_job_id
+          AND COALESCE(ja2.status, 'invited') NOT IN ('declined')
+          AND j2.start_time::date = v_job_start::date
+          AND NOT (j2.time_range && tstzrange(v_job_start, v_job_end, '[]'))
+      ) AS has_same_day_job
+    FROM profiles p
+    LEFT JOIN technician_fridge tf ON tf.technician_id = p.id
+    WHERE
+      (
+        p.role IN ('technician', 'house_tech')
+        OR (p.role NOT IN ('technician', 'house_tech') AND p.assignable_as_tech = true)
+      )
+      AND (
+        (p_department <> 'production' AND p.department = p_department)
+        OR (p_department = 'production' AND p.department IN ('production', 'logistics'))
+      )
+      AND (NOT v_exclude_fridge OR COALESCE(tf.in_fridge, false) = false)
+      -- Filter out already assigned
+      AND NOT EXISTS (
+        SELECT 1
+        FROM job_assignments ja
+        WHERE ja.job_id = p_job_id
+          AND ja.technician_id = p.id
+          AND COALESCE(ja.status, 'invited') <> 'declined'
+      )
+      -- Filter out active same-role consultations, regardless of whether they came from
+      -- assisted campaigns, auto campaigns, or manual manager workflow sends.
+      AND (
+        v_normalized_role_code IS NULL
+        OR NOT EXISTS (
+          SELECT 1
+          FROM staffing_requests sr
+          WHERE sr.job_id = p_job_id
+            AND sr.profile_id = p.id
+            AND NULLIF(BTRIM(sr.role_code), '') = v_normalized_role_code
+            AND sr.phase IN ('availability', 'offer')
+            AND sr.status IN ('pending', 'confirmed', 'declined')
+        )
+      )
+      -- Role-less manager requests stay eligible, except declined rows that cover this job.
+      AND NOT EXISTS (
+        SELECT 1
+        FROM staffing_requests sr
+        WHERE sr.job_id = p_job_id
+          AND sr.profile_id = p.id
+          AND NULLIF(BTRIM(sr.role_code), '') IS NULL
+          AND sr.phase IN ('availability', 'offer')
+          AND sr.status = 'declined'
+          AND (
+            sr.single_day = false
+            OR sr.target_date IS NULL
+            OR sr.target_date BETWEEN v_job_start::date AND v_job_end::date
+          )
+      )
+      -- Filter out unavailable techs directly in WHERE clause
+      AND NOT EXISTS (
+        SELECT 1
+        FROM technician_availability ta
+        WHERE ta.technician_id = p.id::text
+          AND ta.date >= v_job_start::date
+          AND ta.date <= v_job_end::date
+      )
+  ),
+  -- Calculate skills score using the mapping table
+  skill_scores AS (
+    SELECT
+      b.profile_id,
+      COALESCE(
+        (
+          SELECT MAX(
+            LEAST(100,
+              (CASE WHEN ps.is_primary THEN 60 ELSE 40 END) +
+              (COALESCE(ps.proficiency, 0) * 8)
+            ) * rsm.weight
+          )::int
+          FROM profile_skills ps
+          JOIN skills s ON s.id = ps.skill_id AND s.active = true
+          JOIN role_skill_mapping rsm ON LOWER(rsm.skill_name) = LOWER(s.name)
+          WHERE ps.profile_id = b.profile_id
+            AND rsm.role_prefix = v_role_prefix
+            AND COALESCE(ps.proficiency, 0) > 0
+        ),
+        0
+      ) AS skills_score,
+      -- Get best matching skill info for reasons
+      (
+        SELECT jsonb_build_object(
+          'name', s.name,
+          'proficiency', ps.proficiency,
+          'is_primary', ps.is_primary,
+          'weight', rsm.weight
+        )
+        FROM profile_skills ps
+        JOIN skills s ON s.id = ps.skill_id AND s.active = true
+        JOIN role_skill_mapping rsm ON LOWER(rsm.skill_name) = LOWER(s.name)
+        WHERE ps.profile_id = b.profile_id
+          AND rsm.role_prefix = v_role_prefix
+          AND COALESCE(ps.proficiency, 0) > 0
+        ORDER BY
+          LEAST(100, (CASE WHEN ps.is_primary THEN 60 ELSE 40 END) + (COALESCE(ps.proficiency, 0) * 8)) * rsm.weight DESC
+        LIMIT 1
+      ) AS best_skill
+    FROM base b
+  ),
+  reliability_stats AS (
+    SELECT
+      sr.profile_id,
+      COUNT(*) FILTER (WHERE sr.phase = 'availability' AND sr.status = 'confirmed') AS avail_yes,
+      COUNT(*) FILTER (WHERE sr.phase = 'availability' AND sr.status IN ('confirmed', 'declined')) AS avail_total,
+      COUNT(*) FILTER (WHERE sr.phase = 'offer' AND sr.status = 'confirmed') AS offer_yes,
+      COUNT(*) FILTER (WHERE sr.phase = 'offer' AND sr.status IN ('confirmed', 'declined')) AS offer_total
+    FROM staffing_requests sr
+    GROUP BY sr.profile_id
+  ),
+  with_reliability AS (
+    SELECT
+      b.*,
+      ss.skills_score,
+      ss.best_skill,
+      COALESCE(rs.avail_yes, 0) AS avail_yes,
+      COALESCE(rs.avail_total, 0) AS avail_total,
+      COALESCE(rs.offer_yes, 0) AS offer_yes,
+      COALESCE(rs.offer_total, 0) AS offer_total
+    FROM base b
+    LEFT JOIN skill_scores ss ON ss.profile_id = b.profile_id
+    LEFT JOIN reliability_stats rs ON rs.profile_id = b.profile_id
+  ),
+  scored AS (
+    SELECT
+      wr.profile_id,
+      wr.full_name,
+      wr.department,
+      wr.user_role,
+      wr.skills_score,
+      wr.best_skill,
+      wr.jobs_worked,
+      wr.current_month_days,
+      -- Calculate distance to Madrid base (NULL if home location is missing)
+      CASE
+        WHEN wr.home_latitude IS NOT NULL
+          AND wr.home_longitude IS NOT NULL
+        THEN distance_km(wr.home_latitude, wr.home_longitude, v_base_lat, v_base_lng)
+        ELSE NULL
+      END AS distance_to_base_km,
+      LEAST(wr.jobs_worked, 10)::int AS experience_score,
+      (
+        CASE
+          WHEN wr.avail_total > 0 OR wr.offer_total > 0 THEN
+            ROUND(
+              COALESCE(wr.avail_yes::numeric / NULLIF(wr.avail_total, 0), 0) * 5 +
+              COALESCE(wr.offer_yes::numeric / NULLIF(wr.offer_total, 0), 0) * 5
+            )
+          ELSE 5
+        END
+      )::int AS reliability_score,
+      (
+        CASE
+          WHEN wr.user_role = 'house_tech' AND wr.current_month_days < 4 THEN 10
+          WHEN wr.last_work_date IS NULL THEN 10
+          WHEN (now()::date - wr.last_work_date) > 30 THEN 10
+          WHEN (now()::date - wr.last_work_date) > 14 THEN 7
+          ELSE 3
+        END
+      )::int AS fairness_score,
+      wr.has_same_day_job AS soft_conflict,
+      wr.has_job_overlap AS hard_conflict
+    FROM with_reliability wr
+  ),
+  with_proximity AS (
+    SELECT
+      s.*,
+      -- Convert distance to proximity score (0-10)
+      -- 0-25km = 10pts, 25-50km = 8pts, 50-100km = 6pts, 100-200km = 4pts, 200-400km = 2pts, >400km = 1pt
+      -- NULL distance (no location data) = 5pts (neutral)
+      CASE
+        WHEN s.distance_to_base_km IS NULL THEN 5
+        WHEN s.distance_to_base_km <= 25 THEN 10
+        WHEN s.distance_to_base_km <= 50 THEN 8
+        WHEN s.distance_to_base_km <= 100 THEN 6
+        WHEN s.distance_to_base_km <= 200 THEN 4
+        WHEN s.distance_to_base_km <= 400 THEN 2
+        ELSE 1
+      END AS proximity_score
+    FROM scored s
+  ),
+  filtered AS (
+    SELECT s.*
+    FROM with_proximity s
+    WHERE s.hard_conflict = false
+      AND (v_soft_conflict_policy <> 'block' OR s.soft_conflict = false)
+  )
+  SELECT
+    f.profile_id,
+    COALESCE(f.full_name, 'Unknown') AS full_name,
+    f.department,
+    f.skills_score,
+    f.distance_to_base_km AS distance_to_madrid_km,
+    f.proximity_score,
+    f.experience_score,
+    f.reliability_score,
+    f.fairness_score,
+    f.soft_conflict,
+    f.hard_conflict,
+    LEAST(
+      100,
+      ROUND(
+        (
+          (f.skills_score::numeric) * w_skills +
+          (f.proximity_score::numeric * 10) * w_proximity +
+          (f.reliability_score::numeric * 10) * w_reliability +
+          (f.fairness_score::numeric * 10) * w_fairness +
+          (f.experience_score::numeric * 10) * w_experience
+        ) * (
+          CASE
+            WHEN f.user_role = 'house_tech' AND f.current_month_days < 4 THEN 1.3
+            ELSE 1.0
+          END
+        )
+      )::int
+    ) AS final_score,
+    jsonb_build_array(
+      CASE
+        WHEN f.skills_score > 0 AND f.best_skill IS NOT NULL THEN
+          (CASE WHEN (f.best_skill->>'is_primary')::boolean THEN 'Primary skill: ' ELSE 'Skill: ' END) ||
+          (f.best_skill->>'name') || ' (lvl ' || (f.best_skill->>'proficiency') || ')' ||
+          (CASE WHEN (f.best_skill->>'weight')::numeric < 1 THEN ' [related]' ELSE '' END)
+        ELSE 'No matching skill for ' || v_role_prefix
+      END,
+      CASE
+        WHEN f.distance_to_base_km IS NOT NULL THEN
+          'Proximity: ' || ROUND(f.distance_to_base_km::numeric, 1) || 'km (' || f.proximity_score || '/10)'
+        ELSE 'Proximity: No location data'
+      END,
+      'Reliability: ' || f.reliability_score || '/10',
+      'Fairness: ' || f.fairness_score || '/10',
+      'Experience: ' || f.experience_score || '/10'
+    ) ||
+    (CASE
+      WHEN f.user_role = 'house_tech' AND f.current_month_days < 4
+      THEN jsonb_build_array('House tech boost (+30%)')
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE WHEN f.soft_conflict THEN jsonb_build_array('Same-day job (different time)') ELSE '[]'::jsonb END) AS reasons
+  FROM filtered f
+  ORDER BY final_score DESC, f.profile_id
+  LIMIT 50;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO service_role;

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260512090000_staffing_request_role_code_candidates.sql"),
+  "utf-8",
+);
+
+describe("staffing recommendation consultation guards", () => {
+  it("stores a structured role_code on staffing requests", () => {
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS role_code text");
+    expect(migration).toContain("NULLIF(BTRIM(se.meta->>'role'), '') AS role_code");
+  });
+
+  it("excludes active same-role requests but does not treat expired as active", () => {
+    expect(migration).toMatch(/NULLIF\(BTRIM\(sr\.role_code\), ''\) = v_normalized_role_code/);
+    expect(migration).toMatch(/sr\.phase IN \('availability', 'offer'\)/);
+    expect(migration).toMatch(/sr\.status IN \('pending', 'confirmed', 'declined'\)/);
+    expect(migration).not.toMatch(/sr\.status IN \('pending', 'confirmed', 'declined', 'expired'\)/);
+  });
+
+  it("keeps role-less requests eligible unless a declined request overlaps the job dates", () => {
+    expect(migration).toMatch(/NULLIF\(BTRIM\(sr\.role_code\), ''\) IS NULL/);
+    expect(migration).toMatch(/sr\.status = 'declined'/);
+    expect(migration).toMatch(/sr\.single_day = false/);
+    expect(migration).toMatch(/sr\.target_date BETWEEN v_job_start::date AND v_job_end::date/);
+  });
+});

--- a/tests/e2e/staffing-recommendations.spec.ts
+++ b/tests/e2e/staffing-recommendations.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test } from "@playwright/test";
+
+import { bootstrapApp } from "./support/app";
+
+const baseCandidate = {
+  department: "sound",
+  skills_score: 80,
+  distance_to_madrid_km: 4,
+  proximity_score: 10,
+  experience_score: 8,
+  reliability_score: 7,
+  fairness_score: 6,
+  soft_conflict: false,
+  hard_conflict: false,
+  final_score: 76,
+  reasons: ["Primary skill: PA technician (lvl 5)"],
+};
+
+test("auto-staffing shows role-less consultations and refreshes candidates after same-role sends", async ({
+  page,
+}) => {
+  let sentAvailability = false;
+
+  const calls = await bootstrapApp(page, {
+    auth: {
+      role: "management",
+      department: "sound",
+    },
+    tables: {
+      "jobs": [
+        {
+          id: "staffing-job-1",
+          title: "Staffing Smoke Job",
+          start_time: "2026-06-10T08:00:00.000Z",
+          end_time: "2026-06-11T20:00:00.000Z",
+          color: "#1d4ed8",
+          status: "Confirmado",
+          job_type: "single",
+          job_departments: [{ department: "sound" }],
+          job_assignments: [],
+        },
+      ],
+      "technician_fridge": [],
+      "availability_schedules": [],
+      "technician_availability": [],
+      "vacation_requests": [],
+      "timesheets": [],
+      "job_assignments": [],
+      "job_required_roles_summary": [
+        {
+          job_id: "staffing-job-1",
+          department: "sound",
+          roles: [{ role_code: "SND-PA-T", quantity: 2 }],
+        },
+      ],
+      "staffing_campaigns": [
+        {
+          id: "campaign-1",
+          job_id: "staffing-job-1",
+          department: "sound",
+          mode: "assisted",
+          status: "active",
+          policy: {
+            weights: {
+              skills: 0.5,
+              proximity: 0.1,
+              reliability: 0.2,
+              fairness: 0.1,
+              experience: 0.1,
+            },
+            soft_conflict_policy: "warn",
+            exclude_fridge: true,
+          },
+          offer_message: null,
+          created_at: "2026-05-12T10:00:00.000Z",
+          updated_at: "2026-05-12T10:00:00.000Z",
+        },
+      ],
+      "staffing_campaign_roles": [
+        {
+          id: "campaign-role-1",
+          campaign_id: "campaign-1",
+          role_code: "SND-PA-T",
+          assigned_count: 0,
+          pending_availability: 0,
+          confirmed_availability: 0,
+          pending_offers: 0,
+          accepted_offers: 0,
+          stage: "availability",
+          wave_number: 1,
+        },
+      ],
+      "profiles": [
+        { id: "roleless-pending", profile_picture_url: null },
+        { id: "expired-same-role", profile_picture_url: null },
+      ],
+      "staffing_requests": [
+        {
+          profile_id: "roleless-pending",
+          phase: "availability",
+          status: "pending",
+          target_date: null,
+          single_day: false,
+          updated_at: "2026-05-12T10:05:00.000Z",
+        },
+      ],
+    },
+    rpc: {
+      "get_profiles_with_skills": [],
+      "get_job_staffing_summary": [],
+      "get_active_timesheet_counts_by_technician": [],
+      "get_assignment_matrix_staffing": [],
+      "get_assignment_matrix_staffing_filtered": [],
+      "get_staffing_requests_matrix_filtered": [],
+      "rank_staffing_candidates": () => sentAvailability
+        ? []
+        : [
+          {
+            ...baseCandidate,
+            profile_id: "roleless-pending",
+            full_name: "Roleless Pending",
+          },
+          {
+            ...baseCandidate,
+            profile_id: "expired-same-role",
+            full_name: "Expired Same Role",
+            final_score: 70,
+          },
+        ],
+    },
+    functions: {
+      "send-staffing-email": ({ body }) => {
+        sentAvailability = true;
+        return {
+          success: true,
+          received: body,
+        };
+      },
+    },
+  });
+
+  await page.goto("/job-assignment-matrix");
+
+  await page.getByRole("button", { name: /ver recordatorio de staffing/i }).click();
+  await page.getByRole("button", { name: "Auto staffing" }).click();
+  await page.getByRole("tab", { name: "Candidates" }).click();
+
+  await expect(page.getByText("SND-PA-T - Candidate Recommendations")).toBeVisible();
+  await expect(page.getByText("Roleless Pending")).toBeVisible();
+  await expect(page.getByText("Expired Same Role")).toBeVisible();
+  await expect(page.getByText("No-role request")).toBeVisible();
+  await expect(page.getByText(/Prior manager availability request without role is pending/)).toBeVisible();
+  await expect(page.getByText("Same Role Pending")).toHaveCount(0);
+  await expect(page.getByText("Roleless Declined")).toHaveCount(0);
+
+  const rankCall = calls.rpcCalls.find((call) => call.name === "rank_staffing_candidates");
+  expect(rankCall?.body).toMatchObject({
+    p_job_id: "staffing-job-1",
+    p_department: "sound",
+    p_role_code: "SND-PA-T",
+  });
+
+  await page.getByRole("checkbox", { name: /select all/i }).click();
+  await page.getByRole("button", { name: /send availability/i }).click();
+
+  await expect(page.getByText("No candidates available for SND-PA-T")).toBeVisible();
+
+  expect(calls.functionCalls).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "send-staffing-email",
+        body: expect.objectContaining({
+          job_id: "staffing-job-1",
+          profile_id: "roleless-pending",
+          phase: "availability",
+          role: "SND-PA-T",
+        }),
+      }),
+    ]),
+  );
+});


### PR DESCRIPTION
## Summary
- Add `staffing_requests.role_code`, backfill it from staffing event metadata, and update `rank_staffing_candidates` so same-role active consultations are excluded while expired requests remain eligible.
- Keep role-less prior manager consultations eligible, except declined requests overlapping the ranked job dates, and surface eligible role-less consultations on candidate cards.
- Ensure new/refreshed staffing requests store the structured role code, and invalidate candidate recommendations after sends and request realtime events.
- Preserve the cancelled-job matrix fix so cancelled jobs only remain visible when the active department still has assignments.

## Validation
- `npm install --legacy-peer-deps`
- `npm run test:run -- src/pages/__tests__/jobAssignmentMatrixUtils.test.ts tests/assignments/staffing-recommendations.test.ts`
- `npx playwright test tests/e2e/staffing-recommendations.spec.ts --project=chromium`
- `npm run lint`
- `npm run lint:functions`
- `npm run build`

## Notes
- `npm run lint` and `npm run lint:functions` pass with existing warnings only.
- The migration is included for the production `main` deploy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Candidates with prior no-role requests now display contextual badges and descriptions
  * Improved job visibility filtering—cancelled jobs hidden when department has no assignments
  * Enhanced candidate ranking with multi-factor scoring: skill match, location proximity, reliability history, and fairness

* **Tests**
  * Added comprehensive test coverage for job assignment matrix utilities and staffing recommendation workflows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/609)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->