### PR TITLE
Fix tour weekly multiplier count from timesheets

### DIFF
--- a/src/utils/__tests__/tour-job-rate-multiplier-guard.test.ts
+++ b/src/utils/__tests__/tour-job-rate-multiplier-guard.test.ts
@@ -60,8 +60,8 @@ describe('tour job quote multiplier regression guard', () => {
     expect(codeOnly).toMatch(/raw\.type <> 'rigging'/i);
     expect(codeOnly).toMatch(/rja\.technician_id = _tech_id[\s\S]*?COALESCE\(rja\.single_day, FALSE\)[\s\S]*?rja\.assignment_date = raw\.payable_date/i);
     expect(codeOnly).toMatch(/rt\.job_id = _job_id[\s\S]*?rt\.technician_id = _tech_id[\s\S]*?rt\.date = raw\.payable_date[\s\S]*?COALESCE\(rt\.is_active, TRUE\)/i);
-    expect(codeOnly).toMatch(/NOT COALESCE\(ja\.single_day, FALSE\)[\s\S]*?AND pd\.type <> 'rigging'/i);
-    expect(codeOnly).toMatch(/COALESCE\(ja\.single_day, FALSE\) AND ja\.assignment_date = pd\.date/i);
+    expect(codeOnly).toMatch(/JOIN technician_job_assignments tja[\s\S]*?ON tja\.job_id = raw\.job_id[\s\S]*?WHERE raw\.type <> 'rigging'/i);
+    expect(codeOnly).toMatch(/ja\.technician_id = _tech_id[\s\S]*?COALESCE\(ja\.single_day, FALSE\)[\s\S]*?ja\.assignment_date IS NOT NULL/i);
     expect(codeOnly).toMatch(/'rigging_dates_scoped_to_assigned_techs', true/i);
   });
 
@@ -69,9 +69,12 @@ describe('tour job quote multiplier regression guard', () => {
     const { codeOnly } = latestTourQuoteMigration();
 
     expect(codeOnly).toMatch(/CROSS JOIN LATERAL public\.iso_year_week_madrid\(spd\.payable_date::timestamptz\) iw/i);
-    expect(codeOnly).toMatch(/CROSS JOIN LATERAL public\.iso_year_week_madrid\(pd\.date::timestamptz\) other_iw/i);
+    expect(codeOnly).toMatch(/counted_payable_dates AS/i);
+    expect(codeOnly).toMatch(/FROM active_timesheet_dates\s+UNION\s+SELECT job_id, payable_date\s+FROM single_day_assignment_dates\s+UNION\s+SELECT job_id, payable_date\s+FROM scheduled_job_date_type_dates/is);
+    expect(codeOnly).toMatch(/CROSS JOIN LATERAL public\.iso_year_week_madrid\(cpd\.payable_date::timestamptz\) other_iw/i);
     expect(codeOnly).toMatch(/other_iw\.iso_year = iw\.iso_year/i);
     expect(codeOnly).toMatch(/other_iw\.iso_week = iw\.iso_week/i);
+    expect(codeOnly).toMatch(/'weekly_multiplier_count_uses_timesheets', true/i);
     expect(codeOnly).not.toMatch(/iso_year_week_madrid\(j\.start_time\)/i);
   });
 });

--- a/src/utils/__tests__/tour-job-rate-payroll-cases.test.ts
+++ b/src/utils/__tests__/tour-job-rate-payroll-cases.test.ts
@@ -324,6 +324,23 @@ const cases: PayrollCase[] = [
       combinedPayout: 300,
     },
   },
+  {
+    name: 'active timesheet date extends a one-date tour quote to the two-day weekly multiplier',
+    baseRate: 200,
+    scheduledDates: [{ date: '2026-05-04', type: 'show', week: '2026-W19' }],
+    assignments: [{ scope: 'whole-job' }],
+    activeTimesheetDates: ['2026-05-05'],
+    expected: {
+      quoteDays: 2,
+      standardDays: 2,
+      multipliedStandardDays: 2,
+      maxWeekCount: 2,
+      standardTotal: 450,
+      multiplierBonus: 50,
+      prepTotal: 0,
+      combinedPayout: 450,
+    },
+  },
 ];
 
 describe('tour payroll quote value cases', () => {

--- a/supabase/migrations/20260512111844_fix_tour_quote_timesheet_week_count.sql
+++ b/supabase/migrations/20260512111844_fix_tour_quote_timesheet_week_count.sql
@@ -1,0 +1,771 @@
+-- Keep tour quote weekly multiplier counts aligned with technician payable dates.
+-- The quote already includes active timesheet dates in its payable date set; the
+-- weekly multiplier count must do the same or a two-work-day tour date can be
+-- treated as a one-date week and overpaid at 1.5x instead of 1.125x.
+
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  et timestamptz;
+  job_start_date date;
+  job_end_date date;
+  tour_group uuid;
+  tour_date_ref uuid;
+  schedule_start date;
+  schedule_end date;
+  scheduled_days int := 1;
+  rehearsal_days int := 0;
+  standard_days int := 0;
+  technician_override_days int := 0;
+  cat text;
+  house boolean := false;
+  is_autonomo boolean := true;
+  is_reduced_rehearsal boolean := false;
+  standard_discount_per_day numeric(10,2) := 0;
+  rehearsal_discount_per_day numeric(10,2) := 0;
+  total_autonomo_discount numeric(10,2) := 0;
+  standard_base_before_discount numeric(10,2) := 0;
+  standard_after_discount numeric(10,2) := 0;
+  standard_multiplier_bonus numeric(10,2) := 0;
+  multiplied_standard_days int := 0;
+  rehearsal_base_before_discount numeric(10,2) := 0;
+  team_member boolean := false;
+  has_override boolean := false;
+  standard_base numeric(10,2);
+  standard_day_rate numeric(10,2) := 0;
+  rehearsal_day_rate numeric(10,2) := 0;
+  standard_total numeric(10,2) := 0;
+  rehearsal_total numeric(10,2) := 0;
+  total_base numeric(10,2) := 0;
+  base_calculation_total numeric(10,2) := 0;
+  after_discount_total numeric(10,2) := 0;
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  display_multiplier numeric(6,3) := 1.0;
+  display_per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  has_custom_standard_rate boolean := FALSE;
+  has_custom_rehearsal_rate boolean := FALSE;
+  has_custom_rate boolean := FALSE;
+  display_category text := 'rehearsal';
+  job_date_type_start date;
+  job_date_type_end date;
+  tour_date_start date;
+  tour_date_end date;
+  tour_date_legacy_date date;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT job_type, start_time, end_time, tour_id, tour_date_id
+  INTO jtype, st, et, tour_group, tour_date_ref
+  FROM public.jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  job_start_date := (st AT TIME ZONE 'Europe/Madrid')::date;
+  job_end_date := COALESCE((et AT TIME ZONE 'Europe/Madrid')::date, job_start_date);
+
+  SELECT MIN(jdt.date), MAX(jdt.date)
+  INTO job_date_type_start, job_date_type_end
+  FROM public.job_date_types jdt
+  WHERE jdt.job_id = _job_id
+    AND jdt.type <> 'prep_day';
+
+  SELECT td.start_date, td.end_date, td.date
+  INTO tour_date_start, tour_date_end, tour_date_legacy_date
+  FROM public.tour_dates td
+  WHERE td.id = tour_date_ref;
+
+  schedule_start := COALESCE(
+    job_date_type_start,
+    tour_date_start,
+    job_start_date,
+    tour_date_legacy_date
+  );
+  schedule_end := COALESCE(
+    job_date_type_end,
+    tour_date_end,
+    job_end_date,
+    tour_date_start,
+    tour_date_legacy_date,
+    job_start_date
+  );
+
+  schedule_start := COALESCE(schedule_start, job_start_date);
+  schedule_end := COALESCE(schedule_end, schedule_start, job_end_date, job_start_date);
+  IF schedule_end < schedule_start THEN
+    schedule_end := schedule_start;
+  END IF;
+
+  WITH raw_scheduled_job_date_type_dates AS (
+    SELECT DISTINCT jdt.date AS payable_date, jdt.type
+    FROM public.job_date_types jdt
+    WHERE jdt.job_id = _job_id
+      AND jdt.type <> 'prep_day'
+  ),
+  scheduled_job_date_type_dates AS (
+    SELECT raw.payable_date
+    FROM raw_scheduled_job_date_type_dates raw
+    WHERE raw.type <> 'rigging'
+       OR EXISTS (
+          SELECT 1
+          FROM public.job_assignments rja
+          WHERE rja.job_id = _job_id
+            AND rja.technician_id = _tech_id
+            AND COALESCE(rja.single_day, FALSE)
+            AND rja.assignment_date = raw.payable_date
+        )
+       OR EXISTS (
+          SELECT 1
+          FROM public.timesheets rt
+          WHERE rt.job_id = _job_id
+            AND rt.technician_id = _tech_id
+            AND rt.date = raw.payable_date
+            AND COALESCE(rt.is_active, TRUE)
+        )
+  ),
+  active_timesheet_dates AS (
+    SELECT DISTINCT t.date AS payable_date
+    FROM public.timesheets t
+    WHERE t.job_id = _job_id
+      AND t.technician_id = _tech_id
+      AND COALESCE(t.is_active, TRUE)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = t.job_id
+          AND prep_jdt.date = t.date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  single_day_assignment_dates AS (
+    SELECT DISTINCT ja.assignment_date AS payable_date
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id
+      AND ja.technician_id = _tech_id
+      AND COALESCE(ja.single_day, FALSE)
+      AND ja.assignment_date IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = ja.job_id
+          AND prep_jdt.date = ja.assignment_date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  fallback_schedule_dates AS (
+    SELECT generated_series.date_value::date AS payable_date
+    FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS generated_series(date_value)
+    WHERE NOT EXISTS (SELECT 1 FROM raw_scheduled_job_date_type_dates)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = _job_id
+          AND prep_jdt.date = generated_series.date_value::date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  payable_dates AS (
+    SELECT payable_date
+    FROM active_timesheet_dates
+    UNION
+    SELECT payable_date
+    FROM single_day_assignment_dates
+    UNION
+    SELECT payable_date
+    FROM scheduled_job_date_type_dates
+    WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+    UNION
+    SELECT payable_date
+    FROM fallback_schedule_dates
+    WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+  )
+  SELECT
+    COUNT(*)::int,
+    COUNT(*) FILTER (
+      WHERE COALESCE(trmd.use_rehearsal_rate, jrd.job_id IS NOT NULL)
+    )::int,
+    COUNT(*) FILTER (WHERE trmd.job_id IS NOT NULL)::int
+  INTO scheduled_days, rehearsal_days, technician_override_days
+  FROM payable_dates pd
+  LEFT JOIN public.job_technician_rate_mode_dates trmd
+    ON trmd.job_id = _job_id
+   AND trmd.technician_id = _tech_id
+   AND trmd.date = pd.payable_date
+  LEFT JOIN public.job_rehearsal_dates jrd
+    ON jrd.job_id = _job_id
+   AND jrd.date = pd.payable_date;
+
+  scheduled_days := COALESCE(scheduled_days, 0);
+  rehearsal_days := LEAST(COALESCE(rehearsal_days, 0), scheduled_days);
+  standard_days := GREATEST(0, scheduled_days - rehearsal_days);
+
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END,
+    COALESCE(role IN ('house_tech', 'admin', 'management'), false)
+  INTO house, is_autonomo, is_reduced_rehearsal
+  FROM public.profiles
+  WHERE id = _tech_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','profile_not_found','technician_id',_tech_id);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(bool_or(ja.use_tour_multipliers), FALSE)
+    INTO has_override
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+
+    has_override := COALESCE(has_override, FALSE);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(
+      EXISTS (
+        SELECT 1
+        FROM public.tour_assignments ta
+        WHERE ta.tour_id = tour_group
+          AND ta.technician_id = _tech_id
+      ) OR has_override,
+      FALSE
+    )
+    INTO team_member;
+
+    team_member := COALESCE(team_member, FALSE);
+  END IF;
+
+  SELECT iso_year, iso_week INTO y, w
+  FROM public.iso_year_week_madrid(st);
+
+  IF standard_days > 0 THEN
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM public.job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id
+    ORDER BY assigned_at DESC
+    LIMIT 1;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM public.profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+
+    IF cat = 'responsable' THEN
+      SELECT COALESCE(
+        tour_base_responsable_eur,
+        base_day_responsable_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSIF cat = 'especialista' THEN
+      SELECT COALESCE(
+        tour_base_especialista_eur,
+        tour_base_other_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      SELECT COALESCE(
+        tour_base_other_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    END IF;
+
+    IF standard_base IS NOT NULL THEN
+      has_custom_standard_rate := TRUE;
+      has_custom_rate := TRUE;
+    ELSE
+      SELECT base_day_eur INTO standard_base
+      FROM public.rate_cards_tour_2025
+      WHERE category = cat;
+
+      IF standard_base IS NULL THEN
+        RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+      END IF;
+    END IF;
+
+    standard_base_before_discount := standard_base;
+
+    IF NOT house AND NOT is_autonomo THEN
+      standard_discount_per_day := 30.00;
+      standard_base := standard_base - standard_discount_per_day;
+    END IF;
+
+    standard_after_discount := standard_base;
+    standard_day_rate := ROUND(standard_base * per_job_multiplier, 2);
+    standard_total := ROUND(standard_day_rate * standard_days, 2);
+
+    -- This deliberately duplicates the canonical payable-date CTEs above
+    -- because PL/pgSQL CTEs cannot be reused across separate statements. Keep
+    -- raw_scheduled_job_date_type_dates, scheduled_job_date_type_dates,
+    -- active_timesheet_dates, single_day_assignment_dates, and
+    -- fallback_schedule_dates in sync with the first copy, or refactor them
+    -- into a shared SQL function.
+    WITH raw_scheduled_job_date_type_dates AS (
+      SELECT DISTINCT jdt.date AS payable_date, jdt.type
+      FROM public.job_date_types jdt
+      WHERE jdt.job_id = _job_id
+        AND jdt.type <> 'prep_day'
+    ),
+    scheduled_job_date_type_dates AS (
+      SELECT raw.payable_date
+      FROM raw_scheduled_job_date_type_dates raw
+      WHERE raw.type <> 'rigging'
+         OR EXISTS (
+            SELECT 1
+            FROM public.job_assignments rja
+            WHERE rja.job_id = _job_id
+              AND rja.technician_id = _tech_id
+              AND COALESCE(rja.single_day, FALSE)
+              AND rja.assignment_date = raw.payable_date
+          )
+         OR EXISTS (
+            SELECT 1
+            FROM public.timesheets rt
+            WHERE rt.job_id = _job_id
+              AND rt.technician_id = _tech_id
+              AND rt.date = raw.payable_date
+              AND COALESCE(rt.is_active, TRUE)
+          )
+    ),
+    active_timesheet_dates AS (
+      SELECT DISTINCT t.date AS payable_date
+      FROM public.timesheets t
+      WHERE t.job_id = _job_id
+        AND t.technician_id = _tech_id
+        AND COALESCE(t.is_active, TRUE)
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = t.job_id
+            AND prep_jdt.date = t.date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    single_day_assignment_dates AS (
+      SELECT DISTINCT ja.assignment_date AS payable_date
+      FROM public.job_assignments ja
+      WHERE ja.job_id = _job_id
+        AND ja.technician_id = _tech_id
+        AND COALESCE(ja.single_day, FALSE)
+        AND ja.assignment_date IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = ja.job_id
+            AND prep_jdt.date = ja.assignment_date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    fallback_schedule_dates AS (
+      SELECT generated_series.date_value::date AS payable_date
+      FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS generated_series(date_value)
+      WHERE NOT EXISTS (SELECT 1 FROM raw_scheduled_job_date_type_dates)
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = _job_id
+            AND prep_jdt.date = generated_series.date_value::date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    payable_dates AS (
+      SELECT payable_date
+      FROM active_timesheet_dates
+      UNION
+      SELECT payable_date
+      FROM single_day_assignment_dates
+      UNION
+      SELECT payable_date
+      FROM scheduled_job_date_type_dates
+      WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+      UNION
+      SELECT payable_date
+      FROM fallback_schedule_dates
+      WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+    ),
+    standard_payable_dates AS (
+      SELECT pd.payable_date
+      FROM payable_dates pd
+      LEFT JOIN public.job_technician_rate_mode_dates trmd
+        ON trmd.job_id = _job_id
+       AND trmd.technician_id = _tech_id
+       AND trmd.date = pd.payable_date
+      LEFT JOIN public.job_rehearsal_dates jrd
+        ON jrd.job_id = _job_id
+       AND jrd.date = pd.payable_date
+      WHERE NOT COALESCE(trmd.use_rehearsal_rate, jrd.job_id IS NOT NULL)
+    ),
+    date_multipliers AS (
+      SELECT
+        spd.payable_date,
+        CASE
+          WHEN NOT team_member THEN 1
+          ELSE GREATEST(COALESCE(weekly_counts.cnt, 0), 1)
+        END AS week_count,
+        CASE
+          WHEN NOT team_member THEN 1.0::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 1 THEN 1.5::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 2 THEN 1.125::numeric
+          ELSE 1.0::numeric
+        END AS week_multiplier,
+        CASE
+          WHEN NOT team_member THEN 1.0::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 1 THEN 1.5::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 2 THEN 1.125::numeric
+          ELSE 1.0::numeric
+        END AS date_multiplier
+      FROM standard_payable_dates spd
+      CROSS JOIN LATERAL public.iso_year_week_madrid(spd.payable_date::timestamptz) iw
+      LEFT JOIN LATERAL (
+        WITH tour_jobs AS (
+          SELECT
+            j.id AS job_id,
+            j.start_time,
+            j.end_time,
+            j.tour_date_id
+          FROM public.jobs j
+          WHERE j.job_type = 'tourdate'
+            AND j.tour_id = tour_group
+            AND j.status != 'Cancelado'
+        ),
+        technician_job_assignments AS (
+          SELECT DISTINCT ja.job_id
+          FROM public.job_assignments ja
+          JOIN tour_jobs tj
+            ON tj.job_id = ja.job_id
+          WHERE ja.technician_id = _tech_id
+        ),
+        raw_scheduled_job_date_type_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            jdt.date AS payable_date,
+            jdt.type
+          FROM tour_jobs tj
+          JOIN public.job_date_types jdt
+            ON jdt.job_id = tj.job_id
+           AND jdt.type <> 'prep_day'
+        ),
+        scheduled_job_date_type_dates AS (
+          SELECT raw.job_id, raw.payable_date
+          FROM raw_scheduled_job_date_type_dates raw
+          JOIN technician_job_assignments tja
+            ON tja.job_id = raw.job_id
+          WHERE raw.type <> 'rigging'
+             OR EXISTS (
+                SELECT 1
+                FROM public.job_assignments rja
+                WHERE rja.job_id = raw.job_id
+                  AND rja.technician_id = _tech_id
+                  AND COALESCE(rja.single_day, FALSE)
+                  AND rja.assignment_date = raw.payable_date
+              )
+             OR EXISTS (
+                SELECT 1
+                FROM public.timesheets rt
+                WHERE rt.job_id = raw.job_id
+                  AND rt.technician_id = _tech_id
+                  AND rt.date = raw.payable_date
+                  AND COALESCE(rt.is_active, TRUE)
+              )
+        ),
+        active_timesheet_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            t.date AS payable_date
+          FROM tour_jobs tj
+          JOIN public.timesheets t
+            ON t.job_id = tj.job_id
+           AND t.technician_id = _tech_id
+           AND COALESCE(t.is_active, TRUE)
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM public.job_date_types prep_jdt
+            WHERE prep_jdt.job_id = t.job_id
+              AND prep_jdt.date = t.date
+              AND prep_jdt.type = 'prep_day'
+          )
+        ),
+        single_day_assignment_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            ja.assignment_date AS payable_date
+          FROM tour_jobs tj
+          JOIN public.job_assignments ja
+            ON ja.job_id = tj.job_id
+           AND ja.technician_id = _tech_id
+           AND COALESCE(ja.single_day, FALSE)
+           AND ja.assignment_date IS NOT NULL
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM public.job_date_types prep_jdt
+            WHERE prep_jdt.job_id = ja.job_id
+              AND prep_jdt.date = ja.assignment_date
+              AND prep_jdt.type = 'prep_day'
+          )
+        ),
+        jobs_with_single_day_assignments AS (
+          SELECT DISTINCT job_id
+          FROM single_day_assignment_dates
+        ),
+        job_ranges AS (
+          SELECT
+            tj.job_id,
+            COALESCE(
+              MIN(raw.payable_date),
+              td.start_date,
+              (tj.start_time AT TIME ZONE 'Europe/Madrid')::date,
+              td.date
+            ) AS schedule_start,
+            COALESCE(
+              MAX(raw.payable_date),
+              td.end_date,
+              (tj.end_time AT TIME ZONE 'Europe/Madrid')::date,
+              td.start_date,
+              td.date,
+              (tj.start_time AT TIME ZONE 'Europe/Madrid')::date
+            ) AS schedule_end
+          FROM tour_jobs tj
+          LEFT JOIN public.tour_dates td
+            ON td.id = tj.tour_date_id
+          LEFT JOIN raw_scheduled_job_date_type_dates raw
+            ON raw.job_id = tj.job_id
+          GROUP BY
+            tj.job_id,
+            tj.start_time,
+            tj.end_time,
+            td.start_date,
+            td.end_date,
+            td.date
+        ),
+        fallback_schedule_dates AS (
+          SELECT
+            jr.job_id,
+            generated_series.date_value::date AS payable_date
+          FROM job_ranges jr
+          JOIN technician_job_assignments tja
+            ON tja.job_id = jr.job_id
+          CROSS JOIN LATERAL generate_series(
+            jr.schedule_start,
+            GREATEST(jr.schedule_start, jr.schedule_end),
+            INTERVAL '1 day'
+          ) AS generated_series(date_value)
+          WHERE NOT EXISTS (
+              SELECT 1
+              FROM raw_scheduled_job_date_type_dates raw
+              WHERE raw.job_id = jr.job_id
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.job_date_types prep_jdt
+              WHERE prep_jdt.job_id = jr.job_id
+                AND prep_jdt.date = generated_series.date_value::date
+                AND prep_jdt.type = 'prep_day'
+            )
+        ),
+        counted_payable_dates AS (
+          SELECT job_id, payable_date
+          FROM active_timesheet_dates
+          UNION
+          SELECT job_id, payable_date
+          FROM single_day_assignment_dates
+          UNION
+          SELECT job_id, payable_date
+          FROM scheduled_job_date_type_dates scheduled
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM jobs_with_single_day_assignments single_day_jobs
+            WHERE single_day_jobs.job_id = scheduled.job_id
+          )
+          UNION
+          SELECT job_id, payable_date
+          FROM fallback_schedule_dates fallback
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM jobs_with_single_day_assignments single_day_jobs
+            WHERE single_day_jobs.job_id = fallback.job_id
+          )
+        )
+        SELECT COUNT(DISTINCT cpd.payable_date)::int AS cnt
+        FROM counted_payable_dates cpd
+        CROSS JOIN LATERAL public.iso_year_week_madrid(cpd.payable_date::timestamptz) other_iw
+        WHERE other_iw.iso_year = iw.iso_year
+          AND other_iw.iso_week = iw.iso_week
+      ) weekly_counts ON TRUE
+    )
+    SELECT
+      ROUND(COALESCE(SUM(standard_after_discount * dm.date_multiplier), 0), 2),
+      ROUND(COALESCE(SUM((standard_after_discount * dm.date_multiplier) - standard_after_discount), 0), 2),
+      COUNT(*) FILTER (WHERE dm.date_multiplier > 1.0)::int,
+      GREATEST(COALESCE(MAX(dm.week_count), 1), 1)::int,
+      COALESCE(ROUND(SUM(dm.week_multiplier * dm.week_count) / NULLIF(SUM(dm.week_count), 0), 3), 1.0),
+      COALESCE(ROUND(SUM(dm.date_multiplier * dm.week_count) / NULLIF(SUM(dm.week_count), 0), 3), 1.0)
+    INTO standard_total, standard_multiplier_bonus, multiplied_standard_days, cnt, display_multiplier, display_per_job_multiplier
+    FROM date_multipliers dm;
+
+    per_job_multiplier := display_per_job_multiplier;
+    mult := display_multiplier;
+    standard_day_rate := ROUND(standard_total / GREATEST(standard_days, 1), 2);
+    display_category := cat;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+    display_multiplier := 1.0;
+    display_per_job_multiplier := 1.0;
+  END IF;
+
+  IF rehearsal_days > 0 THEN
+    SELECT rehearsal_day_eur INTO rehearsal_day_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF rehearsal_day_rate IS NOT NULL THEN
+      has_custom_rehearsal_rate := TRUE;
+      has_custom_rate := TRUE;
+      rehearsal_base_before_discount := rehearsal_day_rate;
+    ELSE
+      IF is_reduced_rehearsal THEN
+        rehearsal_day_rate := 60.00;
+        rehearsal_base_before_discount := 60.00;
+      ELSE
+        rehearsal_day_rate := 180.00;
+        rehearsal_base_before_discount := 180.00;
+      END IF;
+    END IF;
+
+    IF NOT is_autonomo AND NOT is_reduced_rehearsal THEN
+      rehearsal_discount_per_day := 30.00;
+      rehearsal_day_rate := rehearsal_day_rate - rehearsal_discount_per_day;
+    END IF;
+
+    rehearsal_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+
+    IF standard_days = 0 THEN
+      display_category := 'rehearsal';
+    END IF;
+  END IF;
+
+  total_base := ROUND(standard_total + rehearsal_total, 2);
+  total_autonomo_discount := ROUND(
+    (standard_discount_per_day * standard_days) + (rehearsal_discount_per_day * rehearsal_days),
+    2
+  );
+  base_calculation_total := ROUND(
+    (standard_base_before_discount * standard_days) + (rehearsal_base_before_discount * rehearsal_days),
+    2
+  );
+
+  IF standard_days > 0 THEN
+    after_discount_total := ROUND(
+      (standard_after_discount * standard_days) + (rehearsal_day_rate * rehearsal_days),
+      2
+    );
+  ELSE
+    after_discount_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+  END IF;
+
+  extras := public.extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(total_base + extras_total, 2);
+
+  disclaimer := public.needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,
+    'category', display_category,
+    'base_day_eur', total_base,
+    'has_custom_rate', has_custom_rate,
+    'autonomo_discount_eur', total_autonomo_discount,
+    'base_day_before_discount_eur', base_calculation_total,
+    'week_count', cnt,
+    'multiplier', ROUND(display_multiplier, 3),
+    'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', total_base,
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', final_total,
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', base_calculation_total,
+      'autonomo_discount', total_autonomo_discount,
+      'after_discount', after_discount_total,
+      'multiplier', ROUND(display_multiplier, 3),
+      'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+      'final_base', total_base,
+      'has_custom_rate', has_custom_rate,
+      'has_custom_standard_rate', has_custom_standard_rate,
+      'has_custom_rehearsal_rate', has_custom_rehearsal_rate,
+      'scheduled_days', scheduled_days,
+      'rehearsal_days', rehearsal_days,
+      'standard_days', standard_days,
+      'technician_override_days', technician_override_days,
+      'multiplied_standard_days', multiplied_standard_days,
+      'standard_multiplier_bonus_eur', standard_multiplier_bonus,
+      'rehearsal_rate_eur', CASE WHEN rehearsal_days > 0 THEN rehearsal_day_rate ELSE NULL END,
+      'standard_day_rate_eur', CASE WHEN standard_days > 0 THEN standard_day_rate ELSE NULL END,
+      'forced_rehearsal_rate', (rehearsal_days > 0),
+      'prep_days_excluded_from_multiplier', true,
+      'rigging_dates_scoped_to_assigned_techs', true,
+      'weekly_multiplier_rule', '1_date_1_5x__2_dates_1_125x__3_plus_1x',
+      'per_payable_date_weekly_multipliers', true,
+      'weekly_multiplier_count_uses_timesheets', true
+    )
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) FROM PUBLIC;
+
+COMMENT ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) IS
+  'Calculates tour job rate quotes. Scheduled non-prep job_date_types and active technician timesheets define payable dates, rigging dates count only for assigned technicians, and returned multipliers are per payable date (1 date 1.5x, 2 dates 1.125x each, 3+ dates 1x). Prep days are fixed-rate timesheets and excluded from quote counts.';


### PR DESCRIPTION
## Summary
- update the tour quote RPC so weekly multiplier counts use the technician payable-date set, including active timesheets
- prevent two worked dates from being treated as a one-date week and paid at 1.5x instead of 1.125x
- add regression coverage for active timesheet dates extending a tour quote to the two-day multiplier

## Production
- Applied migration to linked production project: 20260512111844_fix_tour_quote_timesheet_week_count.sql
- Verified remote migration history includes 20260512111844

## Validation
- npm run test:run -- src/utils/__tests__/tour-job-rate-payroll-cases.test.ts src/utils/__tests__/tour-job-rate-multiplier-guard.test.ts src/utils/__tests__/tour-job-rate-two-day-display-multiplier-guard.test.ts src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx
- npm run lint -- --quiet
- npm run build
- git diff --check
- npx supabase db push --linked --dry-run --include-all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed weekly multiplier calculation for tour job rate quotes to properly handle scenarios where active timesheet dates extend single-show tours into multiple-day weekly multiplier periods.
* Improved rate quote accuracy by refining how technician-scoped payable dates are determined for weekly multiplier calculations, ensuring multi-day tour assignments are not incorrectly classified as single-week work.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/610)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->