### PR TITLE
[codex] Add explicit Supabase Data API grants

### DIFF
--- a/src/utils/__tests__/data-api-grants-guard.test.ts
+++ b/src/utils/__tests__/data-api-grants-guard.test.ts
@@ -16,6 +16,9 @@ const createTablePattern =
 const directGrantPattern =
   /\bGRANT\b[\s\S]*?\bON\s+(?!ALL\s+TABLES\b|SCHEMA\b|FUNCTION\b|SEQUENCE\b|TYPE\b|DATABASE\b|LANGUAGE\b)(?:TABLE\s+)?([\s\S]*?)\s+\bTO\b/gi;
 
+/**
+ * Removes SQL comments while preserving line count for useful diagnostics.
+ */
 function stripSqlComments(sql: string): string {
   const withoutBlockComments = sql.replace(/\/\*[\s\S]*?\*\//g, (match) =>
     '\n'.repeat(match.split('\n').length - 1),
@@ -24,6 +27,9 @@ function stripSqlComments(sql: string): string {
   return withoutBlockComments.replace(/--.*$/gm, '');
 }
 
+/**
+ * Normalizes relation references and treats unqualified names as public schema.
+ */
 function normalizeRelationName(rawName: string): string {
   const parts = rawName
     .split('.')
@@ -37,6 +43,9 @@ function normalizeRelationName(rawName: string): string {
   return `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
 }
 
+/**
+ * Splits the relation list from a direct GRANT statement.
+ */
 function splitGrantRelations(rawRelations: string): string[] {
   return rawRelations
     .split(',')
@@ -44,6 +53,9 @@ function splitGrantRelations(rawRelations: string): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Finds public schema tables created by a migration file.
+ */
 function findPublicTableCreates(file: string, sql: string): PublicTableCreate[] {
   const creates: PublicTableCreate[] = [];
   const codeOnly = stripSqlComments(sql);
@@ -64,6 +76,9 @@ function findPublicTableCreates(file: string, sql: string): PublicTableCreate[] 
   return creates;
 }
 
+/**
+ * Finds public schema tables referenced by direct table GRANT statements.
+ */
 function findDirectTableGrants(sql: string): Set<string> {
   const grants = new Set<string>();
   const codeOnly = stripSqlComments(sql);

--- a/src/utils/__tests__/data-api-grants-guard.test.ts
+++ b/src/utils/__tests__/data-api-grants-guard.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+type PublicTableCreate = {
+  table: string;
+  file: string;
+  line: number;
+};
+
+const migrationsDir = join(__dirname, '..', '..', '..', 'supabase', 'migrations');
+
+const createTablePattern =
+  /\bCREATE\s+(?:UNLOGGED\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?((?:"[^"]+"|[a-z_][\w$]*)(?:\s*\.\s*(?:"[^"]+"|[a-z_][\w$]*))?)/gi;
+
+const directGrantPattern =
+  /\bGRANT\b[\s\S]*?\bON\s+(?!ALL\s+TABLES\b|SCHEMA\b|FUNCTION\b|SEQUENCE\b|TYPE\b|DATABASE\b|LANGUAGE\b)(?:TABLE\s+)?([\s\S]*?)\s+\bTO\b/gi;
+
+function stripSqlComments(sql: string): string {
+  const withoutBlockComments = sql.replace(/\/\*[\s\S]*?\*\//g, (match) =>
+    '\n'.repeat(match.split('\n').length - 1),
+  );
+
+  return withoutBlockComments.replace(/--.*$/gm, '');
+}
+
+function normalizeRelationName(rawName: string): string {
+  const parts = rawName
+    .split('.')
+    .map((part) => part.trim().replace(/^"|"$/g, '').toLowerCase())
+    .filter(Boolean);
+
+  if (parts.length === 1) {
+    return `public.${parts[0]}`;
+  }
+
+  return `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+}
+
+function splitGrantRelations(rawRelations: string): string[] {
+  return rawRelations
+    .split(',')
+    .map((relation) => relation.trim())
+    .filter(Boolean);
+}
+
+function findPublicTableCreates(file: string, sql: string): PublicTableCreate[] {
+  const creates: PublicTableCreate[] = [];
+  const codeOnly = stripSqlComments(sql);
+
+  for (const match of codeOnly.matchAll(createTablePattern)) {
+    const table = normalizeRelationName(match[1]);
+    const matchIndex = match.index ?? 0;
+
+    if (!table.startsWith('public.')) continue;
+
+    creates.push({
+      table,
+      file,
+      line: codeOnly.slice(0, matchIndex).split('\n').length,
+    });
+  }
+
+  return creates;
+}
+
+function findDirectTableGrants(sql: string): Set<string> {
+  const grants = new Set<string>();
+  const codeOnly = stripSqlComments(sql);
+
+  for (const statement of codeOnly.split(';')) {
+    if (!/\bGRANT\b/i.test(statement)) continue;
+    if (/\bALTER\s+DEFAULT\s+PRIVILEGES\b/i.test(statement)) continue;
+
+    directGrantPattern.lastIndex = 0;
+    const match = directGrantPattern.exec(statement);
+
+    if (!match) continue;
+
+    for (const rawRelation of splitGrantRelations(match[1])) {
+      const relation = normalizeRelationName(rawRelation);
+      if (relation.startsWith('public.')) {
+        grants.add(relation);
+      }
+    }
+  }
+
+  return grants;
+}
+
+describe('Supabase Data API table grant guard', () => {
+  const migrationFiles = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  it('gives every public table created by migrations an explicit direct table grant', () => {
+    const publicTableCreates: PublicTableCreate[] = [];
+    const directTableGrants = new Set<string>();
+
+    for (const file of migrationFiles) {
+      const content = readFileSync(join(migrationsDir, file), 'utf-8');
+
+      publicTableCreates.push(...findPublicTableCreates(file, content));
+      for (const table of findDirectTableGrants(content)) {
+        directTableGrants.add(table);
+      }
+    }
+
+    const missingGrantCreates = publicTableCreates.filter(
+      ({ table }) => !directTableGrants.has(table),
+    );
+
+    expect(
+      missingGrantCreates,
+      [
+        'Public tables exposed through Supabase Data API must have explicit direct GRANT statements.',
+        'Do not rely on ALTER DEFAULT PRIVILEGES for newly created tables.',
+        ...missingGrantCreates.map(({ file, line, table }) => `- ${file}:${line} ${table}`),
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/supabase/migrations/20260513120000_data_api_explicit_table_grants.sql
+++ b/supabase/migrations/20260513120000_data_api_explicit_table_grants.sql
@@ -1,0 +1,23 @@
+-- Explicit Data API grants for public tables that previously relied on
+-- default privileges. RLS policies continue to control row-level access.
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.staffing_campaigns TO authenticated;
+GRANT ALL ON TABLE public.staffing_campaigns TO service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.staffing_campaign_roles TO authenticated;
+GRANT ALL ON TABLE public.staffing_campaign_roles TO service_role;
+
+GRANT SELECT ON TABLE public.staffing_campaign_events TO authenticated;
+GRANT ALL ON TABLE public.staffing_campaign_events TO service_role;
+
+GRANT SELECT, INSERT, DELETE ON TABLE public.job_rehearsal_dates TO authenticated;
+GRANT ALL ON TABLE public.job_rehearsal_dates TO service_role;
+
+GRANT SELECT ON TABLE public.achievements TO authenticated;
+GRANT ALL ON TABLE public.achievements TO service_role;
+
+GRANT SELECT ON TABLE public.achievement_progress TO authenticated;
+GRANT ALL ON TABLE public.achievement_progress TO service_role;
+
+GRANT SELECT, UPDATE ON TABLE public.achievement_unlocks TO authenticated;
+GRANT ALL ON TABLE public.achievement_unlocks TO service_role;


### PR DESCRIPTION
## Summary
- Add an additive Supabase migration with explicit Data API table grants for 7 public tables that previously relied on default privileges.
- Add a Vitest migration guard to require direct table grants for future public `CREATE TABLE` migrations.
- Keep access scoped to `authenticated` and `service_role`; no `anon` grants are added because the existing RLS policies are authenticated-only.

## Migration Impact
- Schema migration required: yes, additive grants only.
- Affected tables: `staffing_campaigns`, `staffing_campaign_roles`, `staffing_campaign_events`, `job_rehearsal_dates`, `achievements`, `achievement_progress`, `achievement_unlocks`.
- Runtime behavior: no RLS policy, schema shape, generated TypeScript type, or app behavior changes.
- Production apply plan: run Supabase migration before merge so production has the explicit Data API grants in place.

## Risk Assessment
- Risk level: low.
- Main risk: grant scope accidentally exceeding existing RLS intent. Mitigation: grants are limited to `authenticated` and `service_role`; no `anon` grants are introduced.
- Secondary risk: migration replay mismatch. Mitigation: migration is additive and direct table grants do not depend on default privileges.

## Validation Evidence
- Local: `npm run test:run -- src/utils/__tests__/data-api-grants-guard.test.ts` passed.
- Local: `npm run lint` passed with existing warnings only.
- Local: `npm run test:run` passed, 103 test files and 703 tests.
- Local: `npm run build` passed.
- CI: `npm run lint`, `npm run test:critical`, `npm run test:run`, `npm run build`, smoke e2e, Cloudflare Pages, and CodeRabbit are passing.

## Rollback
- Revert this PR to remove the guard and add a follow-up Supabase migration that revokes only these explicit grants if rollback is required.
- Example rollback pattern: `revoke <privileges> on table public.<table_name> from authenticated;` and `revoke all privileges on table public.<table_name> from service_role;`.

## Notes
- Local `npx supabase db reset` was not run because Docker is not available in this environment.
