### PR TITLE
[codex] Backport matrix workflow visibility toggles

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -14,7 +14,12 @@ This file provides working guidance for coding agents operating in this reposito
 ## Non-Negotiable Rules
 
 1. **Branch discipline**
-   - Work from `dev` unless explicitly instructed otherwise.
+   - Default to a new feature branch from the current remote `main`:
+     ```bash
+     git fetch origin main
+     git switch -c codex/<short-description> origin/main
+     ```
+   - Work from `dev` only when explicitly requested for preview-environment work.
    - Never commit directly to `main`.
 
 2. **Dependency install**
@@ -88,6 +93,30 @@ If changes affect mobile runtime behavior, ensure Capacitor sync path remains va
 ```bash
 npm run cap:sync
 ```
+
+## Production PR Workflow
+
+Use this workflow for production-bound work unless the user explicitly requests a different release path:
+
+1. Start from the current remote `main` on a new branch:
+   ```bash
+   git fetch origin main
+   git switch -c codex/<short-description> origin/main
+   ```
+2. Keep the change focused. Do not cherry-pick broad historical PRs when only a subset of behavior is needed; backport the intended behavior onto current `main`.
+3. Run the relevant local validation from the checklist above. For broad or shared UI/data changes, prefer the full trio:
+   ```bash
+   npm run lint
+   npm run test:run
+   npm run build
+   ```
+4. Commit, push the branch, and open a PR to `main`.
+5. Wait for all GitHub CI checks and CodeRabbit to finish. Inspect CodeRabbit summary, inline comments, and pre-merge checks.
+6. Address every actionable CI or CodeRabbit issue with follow-up commits, rerun relevant local validation, push, and wait again until clean.
+7. Before merging:
+   - If the PR includes Supabase migrations, run a production `supabase db push --dry-run`, apply the pending migrations to the linked production project, and confirm a follow-up dry run reports the remote database is up to date.
+   - If the PR has no database migration, no Supabase production push is required; merging `main` is the production deploy path.
+8. Merge only after CI, CodeRabbit, and any required production migration/deploy steps are clean. Verify the PR is merged and the local worktree is clean.
 
 ## Operational Notes
 

--- a/src/components/matrix/OptimizedAssignmentMatrix.tsx
+++ b/src/components/matrix/OptimizedAssignmentMatrix.tsx
@@ -38,7 +38,9 @@ export const OptimizedAssignmentMatrix = ({
   cellHeight,
   technicianWidth,
   headerHeight,
-  mobile = false
+  mobile = false,
+  hideStaffingEmailButtons = false,
+  hideStaffingWhatsappButtons = false,
 }: OptimizedAssignmentMatrixExtendedProps) => {
   const [cellAction, setCellAction] = useState<CellAction | null>(null);
   const [selectedCells, setSelectedCells] = useState<Set<string>>(new Set());
@@ -1250,7 +1252,9 @@ export const OptimizedAssignmentMatrix = ({
     TECHNICIAN_WIDTH, HEADER_HEIGHT, CELL_WIDTH, CELL_HEIGHT, matrixWidth, matrixHeight,
     dateHeadersRef, technicianScrollRef, mainScrollRef, visibleCols, visibleRows,
     dates, technicians, orderedTechnicians,
-    fridgeSet, allowDirectAssign, allowMarkUnavailable, mobile, canNavLeft, canNavRight, handleMobileNav,
+    fridgeSet, allowDirectAssign, allowMarkUnavailable, mobile,
+    hideStaffingEmailButtons, hideStaffingWhatsappButtons,
+    canNavLeft, canNavRight, handleMobileNav,
     handleDateHeadersScroll, handleTechnicianScroll, handleMainScroll, cycleTechSort, getSortLabel,
     isManagementUser, setCreateUserOpen, createUserOpen, qc, setSortJobId,
     getJobsForDate, getAssignmentForCell, getAvailabilityForCell, selectedCells, staffingMaps,

--- a/src/components/matrix/OptimizedMatrixCell.tsx
+++ b/src/components/matrix/OptimizedMatrixCell.tsx
@@ -71,6 +71,8 @@ interface OptimizedMatrixCellProps {
   profileNamesMap?: Map<string, string>;
   isFridge?: boolean;
   mobile?: boolean;
+  hideStaffingEmailButtons?: boolean;
+  hideStaffingWhatsappButtons?: boolean;
 }
 
 const EMPTY_PROFILE_NAMES_MAP = new Map<string, string>();
@@ -129,7 +131,9 @@ export const OptimizedMatrixCell = memo(({
   staffingStatusByDateProvided = null,
   profileNamesMap = EMPTY_PROFILE_NAMES_MAP,
   isFridge = false,
-  mobile = false
+  mobile = false,
+  hideStaffingEmailButtons = false,
+  hideStaffingWhatsappButtons = false,
 }: OptimizedMatrixCellProps) => {
   // Track cell renders for performance monitoring
   React.useEffect(() => {
@@ -139,9 +143,11 @@ export const OptimizedMatrixCell = memo(({
   const isTodayCell = isToday(date);
   const isWeekendCell = isWeekend(date);
   const hasAssignment = !!assignment;
-  const isDeclinedAssignment = hasAssignment && assignment.status === 'declined';
+  const assignmentStatus = hasAssignment ? normalizeStatus(assignment.status) : null;
+  const isConfirmedAssignment = assignmentStatus === 'confirmed';
+  const isDeclinedAssignment = assignmentStatus === 'declined';
   const isUnavailable = availability?.status === 'unavailable';
-  const confirmedBg = hasAssignment && assignment.status === 'confirmed' ? (assignment?.job?.color || null) : null;
+  const confirmedBg = isConfirmedAssignment ? (assignment?.job?.color || null) : null;
   const confirmedTextColor = confirmedBg ? pickTextColor(confirmedBg) : undefined;
   const confirmedSubTextColor = confirmedTextColor ? (rgbaFromHex(confirmedTextColor, 0.9) || confirmedTextColor) : undefined;
   const displayName = formatUserName(technician.first_name, technician.nickname, technician.last_name) || 'Técnico';
@@ -293,7 +299,7 @@ export const OptimizedMatrixCell = memo(({
   }, [assignment, technician.id, technician.department, multiDateRemoval.otherDatesCount, multiDateRemoval.currentDate]);
 
   // Use job-specific status for assigned cells, date-based status for empty cells
-  const staffingStatus = hasAssignment ? staffingStatusByJob : staffingStatusByDate;
+  const staffingStatus = isConfirmedAssignment ? null : (hasAssignment ? staffingStatusByJob : staffingStatusByDate);
 
   // Debug logging for staffing status changes
   React.useEffect(() => {
@@ -440,6 +446,13 @@ export const OptimizedMatrixCell = memo(({
   const canSendOffer = staffingStatus?.availability_status === 'confirmed' && (!staffingStatus?.offer_status || staffingStatus.offer_status === 'declined' || staffingStatus.offer_status === 'expired');
   // Manual progression: allow offering even if availability isn't in confirmed state
   const canOfferFallback = !hasAssignment && !isUnavailable && !canSendOffer;
+  const canShowOfferAction = canSendOffer || canOfferFallback;
+  const showAvailabilityEmail = canAskAvailability && !hideStaffingEmailButtons;
+  const showAvailabilityWhatsapp = canAskAvailability && !hideStaffingWhatsappButtons;
+  const showOfferEmail = canShowOfferAction && !hideStaffingEmailButtons;
+  const showOfferWhatsapp = canShowOfferAction && !hideStaffingWhatsappButtons;
+  const hasVisibleStaffingAction =
+    showAvailabilityEmail || showAvailabilityWhatsapp || showOfferEmail || showOfferWhatsapp;
 
   // Skip noisy debug logs in production
 
@@ -462,7 +475,7 @@ export const OptimizedMatrixCell = memo(({
             borderLeftColor: assignment?.job?.color,
             borderLeftWidth: hasAssignment && assignment?.job?.color ? '3px' : '1px',
             // If assignment is confirmed, paint background with the job color
-            background: hasAssignment && assignment.status === 'confirmed' && assignment?.job?.color
+            background: isConfirmedAssignment && assignment?.job?.color
               ? assignment.job.color
               : undefined
           }}
@@ -587,67 +600,75 @@ export const OptimizedMatrixCell = memo(({
           )}
 
           {/* Staffing Action Buttons */}
-          {(canAskAvailability || canSendOffer || canOfferFallback) && (
+          {hasVisibleStaffingAction && (
             <div className={`${actionButtonsPosClass} flex gap-1 z-10`}>
               {canAskAvailability && (
                 <>
-                  <Button
-                    variant="ghost"
-                    size={mobile ? 'default' : 'sm'}
-                    className={`${actionBtnSize} p-0 hover:bg-blue-100`}
-                    onClick={(e) => handleStaffingEmail(e, 'availability')}
-                    disabled={isSendingEmail}
-                    title="Solicitar disponibilidad"
-                  >
-                    <Mail className={`${mobile ? 'h-4 w-4' : 'h-3 w-3'} text-blue-600`} />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size={mobile ? 'default' : 'sm'}
-                    className={`${actionBtnSize} p-0 hover:bg-emerald-100`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onClick('availability-wa');
-                    }}
-                    disabled={isSendingEmail}
-                    title="Solicitar disponibilidad por WhatsApp"
-                  >
-                    <MessageCircle className={`${mobile ? 'h-4 w-4' : 'h-3 w-3'} text-emerald-600`} />
-                  </Button>
+                  {showAvailabilityEmail && (
+                    <Button
+                      variant="ghost"
+                      size={mobile ? 'default' : 'sm'}
+                      className={`${actionBtnSize} p-0 hover:bg-blue-100`}
+                      onClick={(e) => handleStaffingEmail(e, 'availability')}
+                      disabled={isSendingEmail}
+                      title="Solicitar disponibilidad"
+                    >
+                      <Mail className={`${mobile ? 'h-4 w-4' : 'h-3 w-3'} text-blue-600`} />
+                    </Button>
+                  )}
+                  {showAvailabilityWhatsapp && (
+                    <Button
+                      variant="ghost"
+                      size={mobile ? 'default' : 'sm'}
+                      className={`${actionBtnSize} p-0 hover:bg-emerald-100`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onClick('availability-wa');
+                      }}
+                      disabled={isSendingEmail}
+                      title="Solicitar disponibilidad por WhatsApp"
+                    >
+                      <MessageCircle className={`${mobile ? 'h-4 w-4' : 'h-3 w-3'} text-emerald-600`} />
+                    </Button>
+                  )}
                 </>
               )}
-              {(canSendOffer || canOfferFallback) && (
+              {canShowOfferAction && (
                 <>
-                  <Button
-                    variant="ghost"
-                    size={mobile ? 'default' : 'sm'}
-                    className={`${actionBtnSize} p-0 ${canSendOffer ? 'hover:bg-green-100' : 'opacity-80 hover:bg-muted'}`}
-                    onClick={(e) => handleStaffingEmail(e, 'offer')}
-                    disabled={isSendingEmail}
-                    title={canSendOffer ? 'Enviar oferta' : 'Enviar oferta (progreso manual)'}
-                  >
-                    <CheckCircle className={`${mobile ? 'h-4 w-4' : 'h-3 w-3'} ${canSendOffer ? 'text-green-600' : 'text-muted-foreground'}`} />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size={mobile ? 'default' : 'sm'}
-                    className={`${actionBtnSize} p-0 ${canSendOffer ? 'hover:bg-emerald-100' : 'opacity-80 hover:bg-muted'}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onClick('offer-details-wa', jobId || assignment?.job_id || undefined);
-                    }}
-                    disabled={isSendingEmail}
-                    title={canSendOffer ? 'Enviar oferta por WhatsApp' : 'Enviar oferta por WhatsApp (progreso manual)'}
-                  >
-                    <MessageCircle className={`${mobile ? 'h-4 w-4' : 'h-3 w-3'} ${canSendOffer ? 'text-emerald-600' : 'text-muted-foreground'}`} />
-                  </Button>
+                  {showOfferEmail && (
+                    <Button
+                      variant="ghost"
+                      size={mobile ? 'default' : 'sm'}
+                      className={`${actionBtnSize} p-0 ${canSendOffer ? 'hover:bg-green-100' : 'opacity-80 hover:bg-muted'}`}
+                      onClick={(e) => handleStaffingEmail(e, 'offer')}
+                      disabled={isSendingEmail}
+                      title={canSendOffer ? 'Enviar oferta' : 'Enviar oferta (progreso manual)'}
+                    >
+                      <CheckCircle className={`${mobile ? 'h-4 w-4' : 'h-3 w-3'} ${canSendOffer ? 'text-green-600' : 'text-muted-foreground'}`} />
+                    </Button>
+                  )}
+                  {showOfferWhatsapp && (
+                    <Button
+                      variant="ghost"
+                      size={mobile ? 'default' : 'sm'}
+                      className={`${actionBtnSize} p-0 ${canSendOffer ? 'hover:bg-emerald-100' : 'opacity-80 hover:bg-muted'}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onClick('offer-details-wa', jobId || assignment?.job_id || undefined);
+                      }}
+                      disabled={isSendingEmail}
+                      title={canSendOffer ? 'Enviar oferta por WhatsApp' : 'Enviar oferta por WhatsApp (progreso manual)'}
+                    >
+                      <MessageCircle className={`${mobile ? 'h-4 w-4' : 'h-3 w-3'} ${canSendOffer ? 'text-emerald-600' : 'text-muted-foreground'}`} />
+                    </Button>
+                  )}
                 </>
               )}
             </div>
           )}
           {/* Assignment Content */}
           {hasAssignment && (
-            <div className="flex-1 overflow-hidden">
+            <div className="flex-1 overflow-hidden pr-7">
               <div
                 className={cn('font-medium truncate text-xs', assignment.status !== 'confirmed' ? '' : '')}
                 style={{ color: assignment.status === 'confirmed' ? confirmedTextColor : undefined }}
@@ -691,14 +712,10 @@ export const OptimizedMatrixCell = memo(({
               )}
 
               {/* Status Badge - moved to not conflict with staffing badges */}
-              {hasAssignment && (
-                <div className="absolute bottom-1 right-1">
-                  <Badge
-                    variant={assignment.status === 'confirmed' ? 'default' : 'secondary'}
-                    className="text-xs px-1 py-0 h-4"
-                  >
-                    {assignment.status === 'confirmed' ? 'C' :
-                      assignment.status === 'declined' ? 'R' : 'P'}
+              {!isConfirmedAssignment && (
+                <div className="absolute bottom-1 right-1" title={assignmentStatusLabel(assignment.status)}>
+                  <Badge variant="secondary" className="text-xs px-1 py-0 h-4">
+                    {assignment.status === 'declined' ? 'R' : 'P'}
                   </Badge>
                 </div>
               )}

--- a/src/components/matrix/OptimizedMatrixCell.tsx
+++ b/src/components/matrix/OptimizedMatrixCell.tsx
@@ -715,7 +715,7 @@ export const OptimizedMatrixCell = memo(({
               {!isConfirmedAssignment && (
                 <div className="absolute bottom-1 right-1" title={assignmentStatusLabel(assignment.status)}>
                   <Badge variant="secondary" className="text-xs px-1 py-0 h-4">
-                    {assignment.status === 'declined' ? 'R' : 'P'}
+                    {isDeclinedAssignment ? 'R' : 'P'}
                   </Badge>
                 </div>
               )}

--- a/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
+++ b/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
@@ -180,8 +180,8 @@ describe('OptimizedMatrixCell', () => {
     expect(screen.queryByText('C')).not.toBeInTheDocument();
   });
 
-  it('shows declined status for declined assignment', () => {
-    const declinedAssignment = { ...mockAssignment, status: 'declined' };
+  it('shows declined status for normalized declined assignment', () => {
+    const declinedAssignment = { ...mockAssignment, status: ' Declined ' };
 
     render(
       <OptimizedMatrixCell

--- a/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
+++ b/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
@@ -163,7 +163,7 @@ describe('OptimizedMatrixCell', () => {
     expect(screen.getByText(/FOH/i)).toBeInTheDocument();
   });
 
-  it('displays confirmed status badge', () => {
+  it('does not render a redundant confirmed status badge', () => {
     render(
       <OptimizedMatrixCell
         technician={mockTechnician}
@@ -177,7 +177,7 @@ describe('OptimizedMatrixCell', () => {
       />
     );
 
-    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
   });
 
   it('shows declined status for declined assignment', () => {
@@ -351,6 +351,71 @@ describe('OptimizedMatrixCell', () => {
 
     expect(screen.getByTitle('Enviar oferta')).toBeInTheDocument();
     expect(screen.getByTitle('Enviar oferta por WhatsApp')).toBeInTheDocument();
+  });
+
+  it('can hide email staffing action buttons without hiding WhatsApp buttons', () => {
+    render(
+      <OptimizedMatrixCell
+        technician={mockTechnician}
+        date={mockDate}
+        width={160}
+        height={60}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onClick={vi.fn()}
+        hideStaffingEmailButtons={true}
+      />
+    );
+
+    expect(screen.queryByTitle('Solicitar disponibilidad')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Solicitar disponibilidad por WhatsApp')).toBeInTheDocument();
+  });
+
+  it('can hide WhatsApp staffing action buttons without hiding email buttons', () => {
+    render(
+      <OptimizedMatrixCell
+        technician={mockTechnician}
+        date={mockDate}
+        width={160}
+        height={60}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onClick={vi.fn()}
+        hideStaffingWhatsappButtons={true}
+      />
+    );
+
+    expect(screen.getByTitle('Solicitar disponibilidad')).toBeInTheDocument();
+    expect(screen.queryByTitle('Solicitar disponibilidad por WhatsApp')).not.toBeInTheDocument();
+  });
+
+  it('hides staffing badges and action buttons once the assignment is confirmed', () => {
+    const staleStaffingStatus = {
+      availability_status: 'confirmed',
+      offer_status: 'sent',
+    };
+
+    render(
+      <OptimizedMatrixCell
+        technician={mockTechnician}
+        date={mockDate}
+        assignment={mockAssignment}
+        width={160}
+        height={60}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onClick={vi.fn()}
+        staffingStatusProvided={staleStaffingStatus}
+      />
+    );
+
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
+    expect(screen.queryByText('A:✓')).not.toBeInTheDocument();
+    expect(screen.queryByText('O:?')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Enviar oferta')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Enviar oferta por WhatsApp')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Solicitar disponibilidad')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Solicitar disponibilidad por WhatsApp')).not.toBeInTheDocument();
   });
 
   it('displays fridge indicator when technician is in fridge', () => {

--- a/src/components/matrix/optimized-assignment-matrix/OptimizedAssignmentMatrixView.tsx
+++ b/src/components/matrix/optimized-assignment-matrix/OptimizedAssignmentMatrixView.tsx
@@ -40,6 +40,8 @@ export interface OptimizedAssignmentMatrixViewProps {
   allowDirectAssign: boolean;
   allowMarkUnavailable?: boolean;
   mobile: boolean;
+  hideStaffingEmailButtons?: boolean;
+  hideStaffingWhatsappButtons?: boolean;
   canNavLeft: boolean;
   canNavRight: boolean;
   handleMobileNav: (dir: "left" | "right") => void;
@@ -118,6 +120,8 @@ export const OptimizedAssignmentMatrixView: React.FC<OptimizedAssignmentMatrixVi
   allowDirectAssign,
   allowMarkUnavailable = false,
   mobile,
+  hideStaffingEmailButtons = false,
+  hideStaffingWhatsappButtons = false,
   canNavLeft,
   canNavRight,
   handleMobileNav,
@@ -387,6 +391,8 @@ export const OptimizedAssignmentMatrixView: React.FC<OptimizedAssignmentMatrixVi
                             profileNamesMap={profileNamesMap}
                             isFridge={fridgeSet?.has(technician.id) || false}
                             mobile={mobile}
+                            hideStaffingEmailButtons={hideStaffingEmailButtons}
+                            hideStaffingWhatsappButtons={hideStaffingWhatsappButtons}
                           />
                         </div>
                       );

--- a/src/components/matrix/optimized-assignment-matrix/types.ts
+++ b/src/components/matrix/optimized-assignment-matrix/types.ts
@@ -71,5 +71,6 @@ export interface OptimizedAssignmentMatrixExtendedProps extends OptimizedAssignm
   technicianWidth?: number;
   headerHeight?: number;
   mobile?: boolean;
+  hideStaffingEmailButtons?: boolean;
+  hideStaffingWhatsappButtons?: boolean;
 }
-

--- a/src/pages/JobAssignmentMatrix.tsx
+++ b/src/pages/JobAssignmentMatrix.tsx
@@ -39,6 +39,21 @@ import {
   type StaffingSummaryRow,
 } from './job-assignment-matrix/utils';
 
+const HIDE_STAFFING_EMAIL_BUTTONS_STORAGE_KEY = 'job-assignment-matrix:hide-staffing-email-buttons';
+const HIDE_STAFFING_WHATSAPP_BUTTONS_STORAGE_KEY = 'job-assignment-matrix:hide-staffing-whatsapp-buttons';
+
+const getUserScopedStorageKey = (baseKey: string, userId?: string | null) =>
+  userId ? `${baseKey}:${userId}` : baseKey;
+
+const readStoredBoolean = (key: string) => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(key) === 'true';
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Render the interactive job assignment matrix UI for viewing and managing technician assignments.
  *
@@ -52,7 +67,7 @@ import {
 export default function JobAssignmentMatrix() {
   const qc = useQueryClient();
   const prefetchStatusRef = React.useRef<Map<string, 'pending' | 'done'>>(new Map<string, 'pending' | 'done'>());
-  const { userDepartment, userRole } = useOptimizedAuth();
+  const { user, userDepartment, userRole } = useOptimizedAuth();
   const [defaultDepartment, setDefaultDepartment] = useState<Department>(FALLBACK_DEPARTMENT);
   const [selectedDepartment, setSelectedDepartment] = useState<Department>(FALLBACK_DEPARTMENT);
   const hasManualDepartmentSelection = React.useRef(false);
@@ -68,6 +83,8 @@ export default function JobAssignmentMatrix() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [allowDirectAssign, setAllowDirectAssign] = useState(false);
   const [allowMarkUnavailable, setAllowMarkUnavailable] = useState(false);
+  const [hideStaffingEmailButtons, setHideStaffingEmailButtons] = useState(false);
+  const [hideStaffingWhatsappButtons, setHideStaffingWhatsappButtons] = useState(false);
   const canMarkUnavailable = userRole === 'management' || userRole === 'admin';
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
   const [hideFridge, setHideFridge] = useState<boolean>(true);
@@ -78,6 +95,11 @@ export default function JobAssignmentMatrix() {
     jobTitle: string;
   }>(null);
   const [lastAcknowledgedHash, setLastAcknowledgedHash] = useState<string | null>(null);
+  const skipNextStaffingPreferencePersistRef = React.useRef(true);
+  const staffingPreferenceStorageKeys = React.useMemo(() => ({
+    email: getUserScopedStorageKey(HIDE_STAFFING_EMAIL_BUTTONS_STORAGE_KEY, user?.id),
+    whatsapp: getUserScopedStorageKey(HIDE_STAFFING_WHATSAPP_BUTTONS_STORAGE_KEY, user?.id),
+  }), [user?.id]);
 
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -90,6 +112,33 @@ export default function JobAssignmentMatrix() {
       console.warn('Failed to read outstanding hash from storage', error);
     }
   }, []);
+
+  React.useEffect(() => {
+    skipNextStaffingPreferencePersistRef.current = true;
+    setHideStaffingEmailButtons(readStoredBoolean(staffingPreferenceStorageKeys.email));
+    setHideStaffingWhatsappButtons(readStoredBoolean(staffingPreferenceStorageKeys.whatsapp));
+  }, [staffingPreferenceStorageKeys.email, staffingPreferenceStorageKeys.whatsapp]);
+
+  React.useEffect(() => {
+    if (skipNextStaffingPreferencePersistRef.current) {
+      skipNextStaffingPreferencePersistRef.current = false;
+      return;
+    }
+
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(staffingPreferenceStorageKeys.email, String(hideStaffingEmailButtons));
+      window.localStorage.setItem(staffingPreferenceStorageKeys.whatsapp, String(hideStaffingWhatsappButtons));
+    } catch (error) {
+      console.warn('Failed to persist staffing button visibility preferences', error);
+    }
+  }, [
+    hideStaffingEmailButtons,
+    hideStaffingWhatsappButtons,
+    staffingPreferenceStorageKeys.email,
+    staffingPreferenceStorageKeys.whatsapp,
+  ]);
+
   const specialtyOptions = React.useMemo(() => {
     if (selectedDepartment === 'lights') {
       return ['Operador (MA2)', 'Operador (MA3)', 'Operador (HOG)', 'Operador (AVO)', 'Dimmer', 'Rigging', 'Montador'] as const;
@@ -612,8 +661,19 @@ export default function JobAssignmentMatrix() {
     if (selectedSkills.length) c += selectedSkills.length;
     if (hideFridge) c++;
     if (allowDirectAssign) c++;
+    if (hideStaffingEmailButtons) c++;
+    if (hideStaffingWhatsappButtons) c++;
     return c;
-  }, [selectedDepartment, defaultDepartment, debouncedSearch, selectedSkills, hideFridge, allowDirectAssign]);
+  }, [
+    selectedDepartment,
+    defaultDepartment,
+    debouncedSearch,
+    selectedSkills,
+    hideFridge,
+    allowDirectAssign,
+    hideStaffingEmailButtons,
+    hideStaffingWhatsappButtons,
+  ]);
 
   const outstandingJobsCount = staffingReminderQuery.isSuccess ? outstandingJobs.length : null;
   const outstandingJobsDescription =
@@ -758,6 +818,22 @@ export default function JobAssignmentMatrix() {
                 />
               </div>
             )}
+            <div className="flex items-center gap-2 pr-2 border-r">
+              <span className="text-sm font-medium">Email</span>
+              <Switch
+                checked={!hideStaffingEmailButtons}
+                onCheckedChange={(v) => setHideStaffingEmailButtons(!v)}
+                aria-label="Mostrar botones de email"
+              />
+            </div>
+            <div className="flex items-center gap-2 pr-2 border-r">
+              <span className="text-sm font-medium">WhatsApp</span>
+              <Switch
+                checked={!hideStaffingWhatsappButtons}
+                onCheckedChange={(v) => setHideStaffingWhatsappButtons(!v)}
+                aria-label="Mostrar botones de WhatsApp"
+              />
+            </div>
             <Users className="h-4 w-4" />
             <Badge variant="secondary" className="text-xs">
               {filteredTechnicians.length} técnicos
@@ -835,6 +911,8 @@ export default function JobAssignmentMatrix() {
                     setSelectedSkills([]);
                     setHideFridge(false);
                     setAllowDirectAssign(false);
+                    setHideStaffingEmailButtons(false);
+                    setHideStaffingWhatsappButtons(false);
                   }}
                 >
                   Limpiar
@@ -898,6 +976,22 @@ export default function JobAssignmentMatrix() {
                 <Switch checked={allowMarkUnavailable} onCheckedChange={(v) => { setAllowMarkUnavailable(Boolean(v)); if (v) setAllowDirectAssign(false); }} aria-label="Alternar marcar no disponible" />
               </div>
             )}
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Mostrar email</span>
+              <Switch
+                checked={!hideStaffingEmailButtons}
+                onCheckedChange={(v) => setHideStaffingEmailButtons(!v)}
+                aria-label="Mostrar botones de email"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Mostrar WhatsApp</span>
+              <Switch
+                checked={!hideStaffingWhatsappButtons}
+                onCheckedChange={(v) => setHideStaffingWhatsappButtons(!v)}
+                aria-label="Mostrar botones de WhatsApp"
+              />
+            </div>
           </div>
         )}
       </div>
@@ -920,6 +1014,8 @@ export default function JobAssignmentMatrix() {
             fridgeSet={fridgeSet}
             allowDirectAssign={allowDirectAssign}
             allowMarkUnavailable={allowMarkUnavailable}
+            hideStaffingEmailButtons={hideStaffingEmailButtons}
+            hideStaffingWhatsappButtons={hideStaffingWhatsappButtons}
             mobile={isMobile}
             cellWidth={isMobile ? 140 : undefined}
             cellHeight={isMobile ? 80 : undefined}

--- a/src/pages/__tests__/JobAssignmentMatrix.test.tsx
+++ b/src/pages/__tests__/JobAssignmentMatrix.test.tsx
@@ -61,6 +61,8 @@ vi.mock('@/components/matrix/OptimizedAssignmentMatrix', () => ({
       <div data-testid="matrix-jobs">{props.jobs.length}</div>
       <div data-testid="allow-direct-assign">{String(props.allowDirectAssign)}</div>
       <div data-testid="allow-mark-unavailable">{String(props.allowMarkUnavailable)}</div>
+      <div data-testid="hide-staffing-email-buttons">{String(props.hideStaffingEmailButtons)}</div>
+      <div data-testid="hide-staffing-whatsapp-buttons">{String(props.hideStaffingWhatsappButtons)}</div>
     </div>
   ),
 }));
@@ -123,8 +125,10 @@ const mockDateRange = [
 
 beforeEach(() => {
   vi.clearAllMocks();
+  window.localStorage.clear();
 
   useOptimizedAuthMock.mockReturnValue({
+    user: { id: 'user-1' },
     userDepartment: 'sound',
     userRole: 'technician',
   });
@@ -273,8 +277,27 @@ describe('JobAssignmentMatrix', () => {
     });
   });
 
+  it('lets users hide staffing email and WhatsApp buttons and persists the preference per user', async () => {
+    const user = userEvent.setup();
+
+    render(<JobAssignmentMatrix />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('optimized-matrix')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('switch', { name: /mostrar botones de email/i })[0]);
+    await user.click(screen.getAllByRole('switch', { name: /mostrar botones de whatsapp/i })[0]);
+
+    expect(screen.getByTestId('hide-staffing-email-buttons')).toHaveTextContent('true');
+    expect(screen.getByTestId('hide-staffing-whatsapp-buttons')).toHaveTextContent('true');
+    expect(window.localStorage.getItem('job-assignment-matrix:hide-staffing-email-buttons:user-1')).toBe('true');
+    expect(window.localStorage.getItem('job-assignment-matrix:hide-staffing-whatsapp-buttons:user-1')).toBe('true');
+  });
+
   it('toggles mark unavailable mode for management users', async () => {
     useOptimizedAuthMock.mockReturnValue({
+      user: { id: 'manager-1' },
       userDepartment: 'sound',
       userRole: 'management',
     });
@@ -297,6 +320,7 @@ describe('JobAssignmentMatrix', () => {
 
   it('hides mark unavailable toggle for regular technicians', async () => {
     useOptimizedAuthMock.mockReturnValue({
+      user: { id: 'tech-1' },
       userDepartment: 'sound',
       userRole: 'technician',
     });


### PR DESCRIPTION
## Summary
- Backport the focused Matrix UI behavior from PR #588 without pulling in its broad unfinished refactor stack.
- Add persisted per-user Matrix visibility toggles for staffing Email and WhatsApp workflow buttons.
- Hide stale staffing badges/action buttons and the redundant `C` status badge once a job assignment is confirmed.
- Document the production PR workflow in `agents.md` so future agents branch from current `origin/main`, open PRs to `main`, wait for CI and CodeRabbit, address comments, apply production migrations when present, and merge only when clean.

## Investigation
- The matching historical PR is #588, specifically commit `e46834d9`.
- Direct cherry-pick was rejected after a probe because it conflicts across Matrix internals and resurrects modules that no longer exist on current `main`.
- This PR backports only the requested user-facing behavior onto current `main`.

## Validation
- `npm run test:run -- src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx src/pages/__tests__/JobAssignmentMatrix.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run test:run`

## Production
- No Supabase migration or manual production database push is required for this PR.
- Once CI and CodeRabbit are clean, merging `main` is the production deploy path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle visibility for staffing Email and WhatsApp buttons in the job assignment matrix, with per-user persistence and UI switches (desktop & mobile).

* **Bug Fixes**
  * Confirmed assignment status badges and related staffing actions no longer display redundantly.

* **Documentation**
  * Clarified branch discipline and added a Production PR workflow.

* **Tests**
  * Updated tests to cover visibility toggles, per-user persistence, and badge behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/612)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->