### PR TITLE
[codex] Phase 2 component data layer slice

### DIFF
--- a/src/components/CompanyLogoUploader.tsx
+++ b/src/components/CompanyLogoUploader.tsx
@@ -3,8 +3,7 @@ import { useState } from "react";
 import { Button } from "./ui/button";
 import { Upload, Image as ImageIcon } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
-
+import { dataLayerClient } from "@/services/dataLayerClient";
 export const CompanyLogoUploader = () => {
   const [isUploading, setIsUploading] = useState(false);
 
@@ -21,7 +20,7 @@ export const CompanyLogoUploader = () => {
 
     setIsUploading(true);
     try {
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from('company-assets')
         .upload('sector-pro-logo.png', file, {
           upsert: true,

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -6,8 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
-import { supabase } from "@/lib/supabase";
-
+import { dataLayerClient } from "@/services/dataLayerClient";
 interface ResetPasswordFormProps {
   onSuccess: () => void;
 }
@@ -34,7 +33,7 @@ export const ResetPasswordForm = ({ onSuccess }: ResetPasswordFormProps) => {
         if (href.includes('code=')) {
           console.log('[ResetPassword] Exchanging code for session...');
           try {
-            await supabase.auth.exchangeCodeForSession(href);
+            await dataLayerClient.auth.exchangeCodeForSession(href);
             console.log('[ResetPassword] Code exchange successful');
           } catch (ex) {
             console.warn('[ResetPassword] Code exchange failed:', ex);
@@ -50,14 +49,14 @@ export const ResetPasswordForm = ({ onSuccess }: ResetPasswordFormProps) => {
         if (accessToken && refreshToken) {
           console.log('[ResetPassword] Found tokens in URL, setting session...');
           try {
-            await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken });
+            await dataLayerClient.auth.setSession({ access_token: accessToken, refresh_token: refreshToken });
           } catch (ex) {
             console.warn('[ResetPassword] setSession failed:', ex);
           }
         }
 
         // 3) Check session now
-        const { data: { session } } = await supabase.auth.getSession();
+        const { data: { session } } = await dataLayerClient.auth.getSession();
         if (session) {
           console.log('[ResetPassword] Valid session found');
           resolved = true;
@@ -67,7 +66,7 @@ export const ResetPasswordForm = ({ onSuccess }: ResetPasswordFormProps) => {
 
         // 4) Wait briefly for async auth url detection
         console.log('[ResetPassword] Waiting for auth state change...');
-        const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, sess) => {
+        const { data: { subscription } } = dataLayerClient.auth.onAuthStateChange((_event, sess) => {
           if (sess && !resolved) {
             console.log('[ResetPassword] Session arrived via onAuthStateChange');
             resolved = true;
@@ -79,7 +78,7 @@ export const ResetPasswordForm = ({ onSuccess }: ResetPasswordFormProps) => {
         // Give it a short window then fail
         setTimeout(async () => {
           if (resolved) return;
-          const { data: { session: s2 } } = await supabase.auth.getSession();
+          const { data: { session: s2 } } = await dataLayerClient.auth.getSession();
           if (s2) {
             resolved = true;
             setHasValidSession(true);

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Loader2, ArrowLeft } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ACTIVE_DEPARTMENTS, DEPARTMENT_LABELS } from "@/types/department";
@@ -81,7 +81,7 @@ export const SignUpForm = ({ onBack, preventAutoLogin = false }: SignUpFormProps
       // Optionally send onboarding email
       if (created && sendOnboarding) {
         try {
-          const { data, error } = await supabase.functions.invoke('send-onboarding-email', {
+          const { data, error } = await dataLayerClient.functions.invoke('send-onboarding-email', {
             body: {
               email: formData.email,
               firstName: formData.firstName,
@@ -301,7 +301,7 @@ export const SignUpForm = ({ onBack, preventAutoLogin = false }: SignUpFormProps
                 onClick={async () => {
                   try {
                     setIsFetchingFlex(true);
-                    const { data, error } = await supabase.functions.invoke('fetch-flex-contact-info', {
+                    const { data, error } = await dataLayerClient.functions.invoke('fetch-flex-contact-info', {
                       body: formData.flexResourceId
                         ? { contact_id: formData.flexResourceId }
                         : { url: formData.flexUrl }

--- a/src/components/dashboard/CalendarSection.tsx
+++ b/src/components/dashboard/CalendarSection.tsx
@@ -7,7 +7,7 @@ import { CalendarGrid } from "./calendar-section/CalendarGrid";
 import { CalendarJobCard } from "./calendar-section/CalendarJobCard";
 import { PrintDialog } from "./calendar-section/PrintDialog";
 import type { CalendarExportRange, PrintSettings } from "./calendar-section/types";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { loadJsPDF } from "@/utils/pdf/lazyPdf";
 import { loadExceljs } from "@/utils/lazyExceljs";
 import { saveWorkbook, toArgb, tintColor, thinBorder, hexToRgb, getContrastHexColor } from "@/utils/excelExport";
@@ -102,10 +102,9 @@ export const CalendarSection: React.FC<CalendarSectionProps> = ({
   useEffect(() => {
     const loadUserPreferences = async () => {
       try {
-        const { data: { session } } = await supabase.auth.getSession();
+        const { data: { session } } = await dataLayerClient.auth.getSession();
         if (!session?.user?.id) return;
-        const { data: profile, error } = await supabase
-          .from("profiles")
+        const { data: profile, error } = await dataLayerClient.from("profiles")
           .select("selected_job_types, selected_job_statuses")
           .eq("id", session.user.id)
           .single();
@@ -128,15 +127,14 @@ export const CalendarSection: React.FC<CalendarSectionProps> = ({
 
   const saveUserPreferences = async (types: string[], statuses?: string[]) => {
     try {
-      const { data: { session } } = await supabase.auth.getSession();
+      const { data: { session } } = await dataLayerClient.auth.getSession();
       if (!session?.user?.id) return;
 
       const updateData = statuses !== undefined
         ? { selected_job_types: types, selected_job_statuses: statuses }
         : { selected_job_types: types };
 
-      const { error } = await supabase
-        .from("profiles")
+      const { error } = await dataLayerClient.from("profiles")
         .update(updateData)
         .eq("id", session.user.id);
       if (error) {

--- a/src/components/dashboard/DashboardMobileHub.tsx
+++ b/src/components/dashboard/DashboardMobileHub.tsx
@@ -17,7 +17,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { formatInJobTimezone } from "@/utils/timezoneUtils";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { getOptimizedProfilePictureUrl } from "@/utils/imageOptimization";
@@ -72,11 +72,10 @@ export const DashboardMobileHub: React.FC<DashboardMobileHubProps> = ({
   useEffect(() => {
     const loadUserPreferences = async () => {
       try {
-        const { data: { session } } = await supabase.auth.getSession();
+        const { data: { session } } = await dataLayerClient.auth.getSession();
         if (!session?.user?.id) return;
 
-        const { data: profile, error } = await supabase
-          .from("profiles")
+        const { data: profile, error } = await dataLayerClient.from("profiles")
           .select("selected_job_types, selected_job_statuses, first_name, last_name, profile_picture_url")
           .eq("id", session.user.id)
           .single();
@@ -109,15 +108,14 @@ export const DashboardMobileHub: React.FC<DashboardMobileHubProps> = ({
   // Save user preferences to profiles
   const saveUserPreferences = async (types: string[], statuses?: string[]) => {
     try {
-      const { data: { session } } = await supabase.auth.getSession();
+      const { data: { session } } = await dataLayerClient.auth.getSession();
       if (!session?.user?.id) return;
 
       const updateData = statuses !== undefined
         ? { selected_job_types: types, selected_job_statuses: statuses }
         : { selected_job_types: types };
 
-      const { error } = await supabase
-        .from("profiles")
+      const { error } = await dataLayerClient.from("profiles")
         .update(updateData)
         .eq("id", session.user.id);
 

--- a/src/components/dashboard/DateTypeContextMenu.tsx
+++ b/src/components/dashboard/DateTypeContextMenu.tsx
@@ -1,7 +1,7 @@
 import { DateType, DATE_TYPE_OPTIONS, getDateTypeMeta, isNonWorkingDateType } from "@/constants/dateTypes";
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { ExternalLink, Loader2 } from "lucide-react";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { toast } from "@/hooks/use-toast";
 import { format, startOfDay } from "date-fns";
 import { useQueryClient } from "@tanstack/react-query";
@@ -10,6 +10,8 @@ import { useFlexUuidLazy } from "@/hooks/useFlexUuidLazy";
 import { openFlexElement } from "@/utils/flex-folders";
 import type { ReactNode } from "react";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface DateTypeContextMenuProps {
   children: ReactNode;
   jobId: string;
@@ -43,8 +45,7 @@ export const DateTypeContextMenu = ({ children, jobId, date, onTypeChange }: Dat
         return { ...old, [key]: { type, job_id: jobId, date: formattedDate } };
       });
 
-      const { error } = await supabase
-        .from('job_date_types')
+      const { error } = await dataLayerClient.from('job_date_types')
         .upsert({
           job_id: jobId,
           date: formattedDate,
@@ -58,8 +59,7 @@ export const DateTypeContextMenu = ({ children, jobId, date, onTypeChange }: Dat
       // Void timesheets when marking date as 'off' or 'travel'
       // This hides them from all users while the date type is set
       if (isNonWorkingDateType(type)) {
-        const { error: voidError } = await supabase
-          .from('timesheets')
+        const { error: voidError } = await dataLayerClient.from('timesheets')
           .update({ is_active: false })
           .eq('job_id', jobId)
           .eq('date', formattedDate);
@@ -70,8 +70,7 @@ export const DateTypeContextMenu = ({ children, jobId, date, onTypeChange }: Dat
         }
       } else {
         // Restore timesheets when changing from 'off'/'travel' to another type
-        const { error: restoreError } = await supabase
-          .from('timesheets')
+        const { error: restoreError } = await dataLayerClient.from('timesheets')
           .update({ is_active: true })
           .eq('job_id', jobId)
           .eq('date', formattedDate)
@@ -85,7 +84,7 @@ export const DateTypeContextMenu = ({ children, jobId, date, onTypeChange }: Dat
 
       // Broadcast push: job date type changed (per-job, per-day)
       try {
-        void supabase.functions.invoke('push', {
+        void dataLayerClient.functions.invoke('push', {
           body: {
             action: 'broadcast',
             type: `jobdate.type.changed.${type}`,
@@ -115,7 +114,7 @@ export const DateTypeContextMenu = ({ children, jobId, date, onTypeChange }: Dat
         description: "Failed to set date type",
         variant: "destructive",
       });
-      queryClient.invalidateQueries({ queryKey: ['job-date-types', jobId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-date-types', jobId) });
       queryClient.invalidateQueries({
         predicate: (q) => Array.isArray(q.queryKey) && q.queryKey[0] === 'date-types'
       });

--- a/src/components/dashboard/DepartmentSchedule.tsx
+++ b/src/components/dashboard/DepartmentSchedule.tsx
@@ -7,6 +7,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface DepartmentScheduleProps {
   name: Department;
   icon: LucideIcon;
@@ -37,7 +39,7 @@ export const DepartmentSchedule = ({
       console.log(`Refreshing ${name} department schedule...`);
       // Invalidate and refetch the jobs query
       await queryClient.invalidateQueries({
-        queryKey: ["jobs"],
+        queryKey: queryKeys.scope("jobs"),
         refetchType: "active",
         exact: false
       });

--- a/src/components/dashboard/JobDocuments.tsx
+++ b/src/components/dashboard/JobDocuments.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Download, Trash2, FileText } from "lucide-react";
 import { format } from "date-fns";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { toast } from "@/hooks/use-toast";
 import { Department } from "@/types/department";
 import { SubscriptionIndicator } from "../ui/subscription-indicator";
@@ -48,7 +48,7 @@ export const JobDocuments = ({
       console.log('Starting download for document:', jobDocument.file_name);
 
       const { bucket, path } = resolveJobDocLocation(jobDocument.file_path);
-      const { data, error } = await supabase.storage
+      const { data, error } = await dataLayerClient.storage
         .from(bucket)
         .download(path);
 
@@ -82,7 +82,7 @@ export const JobDocuments = ({
       console.log('Starting view for document:', jobDocument.file_name);
       
       const { bucket, path } = resolveJobDocLocation(jobDocument.file_path);
-      const { data: { signedUrl }, error } = await supabase.storage
+      const { data: { signedUrl }, error } = await dataLayerClient.storage
         .from(bucket)
         .createSignedUrl(path, 60 * 60);
 

--- a/src/components/dashboard/MobileDayCalendar.tsx
+++ b/src/components/dashboard/MobileDayCalendar.tsx
@@ -18,7 +18,7 @@ import { Calendar as CalendarComponent } from "@/components/ui/calendar";
 import { DateTypeContextMenu } from "./DateTypeContextMenu";
 import { MobileJobCard } from "./MobileJobCard";
 import { Department } from "@/types/department";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { PrintDialog, PrintSettings } from "./PrintDialog";
 import {
   format,
@@ -52,6 +52,8 @@ import { formatInJobTimezone, isJobOnDate } from "@/utils/timezoneUtils";
 import { useMobileDayCalendarSubscriptions } from "@/hooks/useMobileRealtimeSubscriptions";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface MobileDayCalendarProps {
   date: Date | undefined;
   onDateSelect: (date: Date | undefined) => void;
@@ -100,7 +102,7 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
 }) => {
   const [currentDate, setCurrentDate] = useState(date);
   const queryClient = useQueryClient();
-  
+
   // Set up realtime subscriptions for all mobile calendar data
   useMobileDayCalendarSubscriptions();
   const [showPrintDialog, setShowPrintDialog] = useState(false);
@@ -152,7 +154,7 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
 
   // Use realtime query for date types instead of manual fetch
   const { data: dateTypes = {} } = useQuery({
-    queryKey: ['job_date_types', format(currentDate, 'yyyy-MM-dd')],
+    queryKey: queryKeys.scope('job_date_types', format(currentDate, 'yyyy-MM-dd')),
     queryFn: async () => {
       const dayJobs = getJobsForDate(currentDate);
       const jobIds = dayJobs.map(job => job.id);
@@ -162,8 +164,7 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
         return {};
       }
 
-      const { data, error } = await supabase
-        .from("job_date_types")
+      const { data, error } = await dataLayerClient.from("job_date_types")
         .select("*")
         .in("job_id", jobIds)
         .eq("date", formattedDate);
@@ -226,8 +227,8 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
         date={currentDate}
         onTypeChange={() => {
           // Invalidate and refetch date types query
-          queryClient.invalidateQueries({ 
-            queryKey: ['job_date_types', format(currentDate, 'yyyy-MM-dd')] 
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.scope('job_date_types', format(currentDate, 'yyyy-MM-dd'))
           });
           // Also call the parent callback
           onDateTypeChange();
@@ -240,8 +241,8 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
           dateTypes={dateTypes}
           onDateTypeChange={() => {
             // Invalidate and refetch date types query
-            queryClient.invalidateQueries({ 
-              queryKey: ['job_date_types', format(currentDate, 'yyyy-MM-dd')] 
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.scope('job_date_types', format(currentDate, 'yyyy-MM-dd'))
             });
             // Also call the parent callback
             onDateTypeChange();
@@ -262,7 +263,7 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
           <Button variant="ghost" size="sm" onClick={navigateToPrevious} className="p-2">
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          
+
           <div className="text-center flex-1">
             <div className="text-lg font-semibold">
               {format(currentDate, 'EEEE')}
@@ -274,12 +275,12 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
               {format(currentDate, 'MMM d, yyyy')}
             </div>
           </div>
-          
+
           <div className="flex gap-1">
             <Button variant="outline" size="sm" onClick={navigateToToday}>
               <Target className="h-4 w-4" />
             </Button>
-            
+
             <Popover>
               <PopoverTrigger asChild>
                 <Button variant="outline" size="sm">
@@ -302,7 +303,7 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
               </PopoverContent>
             </Popover>
           </div>
-          
+
           <Button variant="ghost" size="sm" onClick={navigateToNext} className="p-2">
             <ChevronRight className="h-4 w-4" />
           </Button>
@@ -324,8 +325,8 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
                     )}
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent 
-                  align="start" 
+                <DropdownMenuContent
+                  align="start"
                   className="w-48 z-50 bg-background border shadow-lg"
                   sideOffset={4}
                 >
@@ -356,8 +357,8 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
                     )}
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent 
-                  align="start" 
+                <DropdownMenuContent
+                  align="start"
                   className="w-48 z-50 bg-background border shadow-lg"
                   sideOffset={4}
                 >
@@ -375,7 +376,7 @@ export const MobileDayCalendar: React.FC<MobileDayCalendarProps> = ({
               </DropdownMenu>
             ) : null}
           </div>
-          
+
           <Button variant="outline" size="sm" onClick={() => setShowPrintDialog(true)}>
             <Printer className="h-4 w-4 mr-1" />
             Print

--- a/src/components/dashboard/MobileJobCard.tsx
+++ b/src/components/dashboard/MobileJobCard.tsx
@@ -10,7 +10,7 @@ import { useOptimizedJobCard } from '@/hooks/useOptimizedJobCard';
 import { useJobActions } from '@/hooks/useJobActions';
 import { useFolderExistence } from "@/hooks/useFolderExistence";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { format } from "date-fns";
 import { 
   MoreVertical, 
@@ -44,6 +44,8 @@ import { openFlexElement } from "@/utils/flex-folders";
 import { isFestivalLikeJobType } from "@/utils/jobType";
 import { DateType, DATE_TYPE_OPTIONS, getDateTypeMeta } from "@/constants/dateTypes";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface MobileJobCardProps {
   job: any;
   department?: Department;
@@ -166,8 +168,7 @@ export function MobileJobCard({
     try {
       const dateStr = format(currentDate, 'yyyy-MM-dd');
       
-      const { error } = await supabase
-        .from('job_date_types')
+      const { error } = await dataLayerClient.from('job_date_types')
         .upsert({
           job_id: job.id,
           date: dateStr,
@@ -184,7 +185,7 @@ export function MobileJobCard({
       });
 
       // Ensure both mobile and desktop calendars refresh their caches
-      queryClient.invalidateQueries({ queryKey: ['job_date_types', dateStr] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job_date_types', dateStr) });
       queryClient.invalidateQueries({
         predicate: (q) => Array.isArray(q.queryKey) && q.queryKey[0] === 'date-types'
       });

--- a/src/components/dashboard/TourChips.tsx
+++ b/src/components/dashboard/TourChips.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Button } from "@/components/ui/button";
 import { Plus, Eye, EyeOff, ChevronDown, ChevronUp, MoreVertical } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -13,6 +13,8 @@ import { useTourSubscription } from "@/hooks/useTourSubscription";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface TourChipsProps {
   onTourClick?: (tourId: string) => void;
   readOnly?: boolean;
@@ -31,11 +33,10 @@ export const TourChips = ({ onTourClick, readOnly = false }: TourChipsProps) => 
   useTourSubscription();
 
   const { data: tours = [], refetch: refetchTours } = useQuery({
-    queryKey: ["tours"],
+    queryKey: queryKeys.scope("tours"),
     queryFn: async () => {
       console.log("Fetching tours...");
-      const { data: toursData, error: toursError } = await supabase
-        .from("tours")
+      const { data: toursData, error: toursError } = await dataLayerClient.from("tours")
         .select(`
           id,
           name,

--- a/src/components/department/DepartmentMobileHub.tsx
+++ b/src/components/department/DepartmentMobileHub.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Badge } from "@/components/ui/badge";
 import { isManagementRole } from "@/utils/permissions";
 
@@ -113,11 +113,10 @@ export const DepartmentMobileHub: React.FC<DepartmentMobileHubProps> = ({
   useEffect(() => {
     const loadUserPreferences = async () => {
       try {
-        const { data: { session } } = await supabase.auth.getSession();
+        const { data: { session } } = await dataLayerClient.auth.getSession();
         if (!session?.user?.id) return;
 
-        const { data: profile, error } = await supabase
-          .from("profiles")
+        const { data: profile, error } = await dataLayerClient.from("profiles")
           .select("selected_job_types, selected_job_statuses")
           .eq("id", session.user.id)
           .single();
@@ -143,15 +142,14 @@ export const DepartmentMobileHub: React.FC<DepartmentMobileHubProps> = ({
   // Save user preferences to profiles
   const saveUserPreferences = async (types: string[], statuses?: string[]) => {
     try {
-      const { data: { session } } = await supabase.auth.getSession();
+      const { data: { session } } = await dataLayerClient.auth.getSession();
       if (!session?.user?.id) return;
 
       const updateData = statuses !== undefined
         ? { selected_job_types: types, selected_job_statuses: statuses }
         : { selected_job_types: types };
 
-      const { error } = await supabase
-        .from("profiles")
+      const { error } = await dataLayerClient.from("profiles")
         .update(updateData)
         .eq("id", session.user.id);
 

--- a/src/components/department/EnhancedJobDetailsModal.tsx
+++ b/src/components/department/EnhancedJobDetailsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
@@ -24,6 +24,8 @@ import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 import { canManagePayouts, isManagementRole } from '@/utils/permissions';
 import { getVisibleFinancialTechnicianIds } from '@/components/jobs/financialViewerScope';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface EnhancedJobDetailsModalProps {
     theme: {
         bg: string;
@@ -73,11 +75,10 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
 
     // Fetch full job details with location
     const { data: jobDetails, isLoading: jobDetailsLoading } = useQuery({
-        queryKey: ['job-details-modal', job?.id],
+        queryKey: queryKeys.scope('job-details-modal', job?.id),
         queryFn: async () => {
             if (!job?.id) return null;
-            const { data, error } = await supabase
-                .from('jobs')
+            const { data, error } = await dataLayerClient.from('jobs')
                 .select(`
           *,
           locations(id, name, formatted_address, latitude, longitude)
@@ -101,11 +102,10 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
 
     // Fetch staff assignments
     const { data: staffAssignments = [], isLoading: staffLoading } = useQuery({
-        queryKey: ['job-staff', job?.id],
+        queryKey: queryKeys.scope('job-staff', job?.id),
         queryFn: async () => {
             if (!job?.id) return [];
-            const { data, error } = await supabase
-                .from('job_assignments')
+            const { data, error } = await dataLayerClient.from('job_assignments')
                 .select(`
           sound_role,
           lights_role,
@@ -115,14 +115,19 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
                 .eq('job_id', job.id)
                 .eq('status', 'confirmed');
             if (error) throw error;
-            return data || [];
+            return ((data || []) as unknown as StaffAssignment[]).map((assignment) => ({
+                ...assignment,
+                technician: Array.isArray(assignment.technician)
+                    ? assignment.technician[0] ?? null
+                    : assignment.technician ?? null,
+            }));
         },
         enabled: !!job?.id,
     });
 
     // Fetch restaurants
     const { data: restaurants = [], isLoading: isRestaurantsLoading } = useQuery({
-        queryKey: ['job-restaurants-modal', job?.id, jobDetails?.locations?.formatted_address],
+        queryKey: queryKeys.scope('job-restaurants-modal', job?.id, jobDetails?.locations?.formatted_address),
         queryFn: async () => {
             const locationData = jobDetails?.locations;
             const address = locationData?.formatted_address || locationData?.name;
@@ -192,12 +197,12 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
 
     const invalidateJobQueries = () => {
         if (!resolvedJobId) return;
-        queryClient.invalidateQueries({ queryKey: ['job-details-modal', resolvedJobId] });
-        queryClient.invalidateQueries({ queryKey: ['job-approval-status', resolvedJobId] });
-        queryClient.invalidateQueries({ queryKey: ['job-rates-approval', resolvedJobId] });
-        queryClient.invalidateQueries({ queryKey: ['job-rates-approval-map'] });
-        queryClient.invalidateQueries({ queryKey: ['optimized-jobs'] });
-        queryClient.invalidateQueries({ queryKey: ['jobs'] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-details-modal', resolvedJobId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-approval-status', resolvedJobId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-rates-approval', resolvedJobId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-rates-approval-map') });
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('optimized-jobs') });
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('jobs') });
     };
 
     const handleApproveRates = async () => {
@@ -210,9 +215,8 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
 
         setIsApproving(true);
         try {
-            const { data: u } = await supabase.auth.getUser();
-            const { error } = await supabase
-                .from('jobs')
+            const { data: u } = await dataLayerClient.auth.getUser();
+            const { error } = await dataLayerClient.from('jobs')
                 .update({
                     rates_approved: true,
                     rates_approved_at: new Date().toISOString(),
@@ -234,8 +238,7 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
         if (!resolvedJobId || isApproving) return;
         setIsApproving(true);
         try {
-            const { error } = await supabase
-                .from('jobs')
+            const { error } = await dataLayerClient.from('jobs')
                 .update({ rates_approved: false, rates_approved_at: null, rates_approved_by: null } as any)
                 .eq('id', resolvedJobId);
             if (error) throw error;
@@ -264,7 +267,7 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
 
                 setIsMapLoading(true);
 
-                const { data, error } = await supabase.functions.invoke('get-google-maps-key');
+                const { data, error } = await dataLayerClient.functions.invoke('get-google-maps-key');
                 if (error || !data?.apiKey) {
                     setMapPreviewUrl(null);
                     setIsMapLoading(false);
@@ -302,7 +305,7 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
         const docId = doc.id;
         setDocumentLoading(prev => new Set(prev).add(docId));
         try {
-            const url = await createSignedUrl(supabase, doc.file_path, 60);
+            const url = await createSignedUrl(dataLayerClient, doc.file_path, 60);
             window.open(url, '_blank');
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : 'Error desconocido';
@@ -316,7 +319,7 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
         const docId = doc.id;
         setDocumentLoading(prev => new Set(prev).add(docId));
         try {
-            const url = await createSignedUrl(supabase, doc.file_path, 60);
+            const url = await createSignedUrl(dataLayerClient, doc.file_path, 60);
             const link = document.createElement('a');
             link.href = url;
             link.download = doc.file_name;

--- a/src/components/department/MobileAssignmentsDialog.tsx
+++ b/src/components/department/MobileAssignmentsDialog.tsx
@@ -12,10 +12,12 @@ import { roleOptionsForDiscipline, labelForCode } from '@/utils/roles';
 import { format, eachDayOfInterval } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useTechnicianTheme } from '@/hooks/useTechnicianTheme';
 import { canManageJobAssignments } from '@/utils/permissions';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface MobileAssignmentsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -61,11 +63,10 @@ export const MobileAssignmentsDialog: React.FC<MobileAssignmentsDialogProps> = (
   } = useJobAssignmentsRealtime(jobId);
 
   const { data: jobMeta } = useQuery({
-    queryKey: ['mobile-job-meta', jobId],
+    queryKey: queryKeys.scope('mobile-job-meta', jobId),
     enabled: open && !!jobId,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('id, start_time, end_time, job_date_types(date, type)')
         .eq('id', jobId)
         .single();

--- a/src/components/disponibilidad/AvailabilityActions.tsx
+++ b/src/components/disponibilidad/AvailabilityActions.tsx
@@ -9,11 +9,13 @@ import {
 } from '@/components/ui/card';
 import { useToast } from '@/components/ui/use-toast';
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import type { AvailabilityStatus } from '@/types/availability';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { format } from 'date-fns';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface AvailabilityActionsProps {
   selectedDate?: Date;
 }
@@ -29,8 +31,7 @@ export function AvailabilityActions({ selectedDate }: AvailabilityActionsProps) 
         throw new Error('Missing required data');
       }
 
-      const { data, error } = await supabase
-        .from('availability_schedules')
+      const { data, error } = await dataLayerClient.from('availability_schedules')
         .upsert({
           user_id: session.user.id,
           department: userDepartment,
@@ -45,7 +46,7 @@ export function AvailabilityActions({ selectedDate }: AvailabilityActionsProps) 
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['availability', session?.user?.id, userDepartment]
+        queryKey: queryKeys.scope('availability', session?.user?.id, userDepartment)
       });
       toast({
         title: "Success",

--- a/src/components/disponibilidad/DisponibilidadCalendar.tsx
+++ b/src/components/disponibilidad/DisponibilidadCalendar.tsx
@@ -12,8 +12,7 @@ import { Calendar as CalendarIcon } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabase';
-
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { format } from 'date-fns';
 import type { PresetWithItems } from '@/types/equipment';
 import { getCategoriesForDepartment, type Department } from '@/types/equipment';
@@ -24,6 +23,8 @@ import { useRef } from 'react';
 import { useDayRender } from 'react-day-picker';
 import { cn } from '@/lib/utils';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface DisponibilidadCalendarProps {
   selectedDate?: Date;
   onDateSelect?: (date: Date | undefined) => void;
@@ -39,12 +40,11 @@ export function DisponibilidadCalendar({ selectedDate, onDateSelect, className }
 
   // Fetch equipment base stock (base_quantity) for this department's categories
   const { data: stockData } = useQuery({
-    queryKey: ['equipment-base-stock', department],
+    queryKey: queryKeys.scope('equipment-base-stock', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('equipment_availability_with_rentals')
+      const { data, error } = await dataLayerClient.from('equipment_availability_with_rentals')
         .select('equipment_id, equipment_name, category, base_quantity')
-        .in('category', departmentCategories as string[])
+        .in('category', departmentCategories)
         .order('category')
         .order('equipment_name');
 
@@ -55,10 +55,9 @@ export function DisponibilidadCalendar({ selectedDate, onDateSelect, className }
 
   // Fetch all preset assignments for the department (removed user_id filter)
   const { data: presetAssignments, isLoading: isLoadingAssignments } = useQuery({
-    queryKey: ['preset-assignments', userDepartment],
+    queryKey: queryKeys.scope('preset-assignments', userDepartment),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('day_preset_assignments')
+      const { data, error } = await dataLayerClient.from('day_preset_assignments')
         .select(`
           *,
           preset:presets!inner (
@@ -90,8 +89,7 @@ export function DisponibilidadCalendar({ selectedDate, onDateSelect, className }
     mutationFn: async ({ date, presetId }: { date: Date; presetId: string }) => {
       if (!session?.user?.id) throw new Error('Must be logged in');
 
-      const { error } = await supabase
-        .from('day_preset_assignments')
+      const { error } = await dataLayerClient.from('day_preset_assignments')
         .insert({
           date: format(date, 'yyyy-MM-dd'),
           preset_id: presetId,
@@ -102,7 +100,7 @@ export function DisponibilidadCalendar({ selectedDate, onDateSelect, className }
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['preset-assignments'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('preset-assignments') });
       toast({
         title: "Success",
         description: "Preset assigned successfully"
@@ -134,11 +132,10 @@ export function DisponibilidadCalendar({ selectedDate, onDateSelect, className }
 
   // Fetch sub-rentals overlapping the assignments range for this department
   const { data: subRentals = [] } = useQuery({
-    queryKey: ['sub-rentals-range', userDepartment, assignmentsRange.start, assignmentsRange.end],
+    queryKey: queryKeys.scope('sub-rentals-range', userDepartment, assignmentsRange.start, assignmentsRange.end),
     queryFn: async () => {
       if (!assignmentsRange.start || !assignmentsRange.end) return [] as any[];
-      const { data, error } = await supabase
-        .from('sub_rentals')
+      const { data, error } = await dataLayerClient.from('sub_rentals')
         .select('equipment_id, quantity, start_date, end_date, department')
         .eq('department', (userDepartment || '').toString())
         .lte('start_date', assignmentsRange.end)

--- a/src/components/disponibilidad/PresetManagement.tsx
+++ b/src/components/disponibilidad/PresetManagement.tsx
@@ -3,9 +3,11 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+
+import { queryKeys } from "@/lib/react-query";
 const DAYS_OF_WEEK = [
   'Sunday',
   'Monday',
@@ -30,14 +32,14 @@ export function PresetManagement() {
   const { session, userDepartment } = useOptimizedAuth();
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const legacyClient = dataLayerClient as any;
 
   const { data: presets, isLoading } = useQuery({
-    queryKey: ['availability-presets', session?.user?.id, userDepartment],
+    queryKey: queryKeys.scope('availability-presets', session?.user?.id, userDepartment),
     queryFn: async () => {
       if (!session?.user?.id || !userDepartment) return null;
 
-      const { data, error } = await supabase
-        .from('availability_preferences')
+      const { data, error } = await legacyClient.from('availability_preferences')
         .select('*')
         .eq('user_id', session.user.id)
         .eq('department', userDepartment);
@@ -62,8 +64,7 @@ export function PresetManagement() {
         throw new Error('User not authenticated');
       }
 
-      const { data, error } = await supabase
-        .from('availability_preferences')
+      const { data, error } = await legacyClient.from('availability_preferences')
         .upsert({
           user_id: session.user.id,
           department: userDepartment,
@@ -78,7 +79,7 @@ export function PresetManagement() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['availability-presets', session?.user?.id, userDepartment]
+        queryKey: queryKeys.scope('availability-presets', session?.user?.id, userDepartment)
       });
       toast({
         title: "Success",
@@ -101,8 +102,7 @@ export function PresetManagement() {
         throw new Error('User not authenticated');
       }
 
-      const { error } = await supabase
-        .from('availability_preferences')
+      const { error } = await legacyClient.from('availability_preferences')
         .delete()
         .eq('user_id', session.user.id)
         .eq('department', userDepartment)
@@ -112,7 +112,7 @@ export function PresetManagement() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['availability-presets', session?.user?.id, userDepartment]
+        queryKey: queryKeys.scope('availability-presets', session?.user?.id, userDepartment)
       });
       toast({
         title: "Success",

--- a/src/components/disponibilidad/QuickPresetAssignment.tsx
+++ b/src/components/disponibilidad/QuickPresetAssignment.tsx
@@ -4,13 +4,15 @@ import { Card } from "@/components/ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useToast } from "@/hooks/use-toast";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { PresetWithItems, mapPresetWithItemsRow } from "@/types/equipment";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format, isValid } from "date-fns";
 import { Calendar, Loader2, Trash2 } from "lucide-react";
 import { useDepartment } from '@/contexts/DepartmentContext';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface QuickPresetAssignmentProps {
   selectedDate: Date;
   onAssign?: () => void;
@@ -28,12 +30,11 @@ export function QuickPresetAssignment({ selectedDate, onAssign, className }: Qui
 
   // Fetch presets with their items
   const { data: presets = [] } = useQuery({
-    queryKey: ['presets', department],
+    queryKey: queryKeys.scope('presets', department),
     queryFn: async () => {
       if (!session?.user?.id) return [];
       
-      const { data, error } = await supabase
-        .from('presets')
+      const { data, error } = await dataLayerClient.from('presets')
         .select(`
           *,
           items:preset_items (
@@ -52,12 +53,11 @@ export function QuickPresetAssignment({ selectedDate, onAssign, className }: Qui
 
   // Fetch current assignments
   const { data: currentAssignments = [] } = useQuery({
-    queryKey: ['preset-assignments', department, selectedDate],
+    queryKey: queryKeys.scope('preset-assignments', department, selectedDate),
     queryFn: async () => {
       if (!isValidDate) return [];
 
-      const { data, error } = await supabase
-        .from('day_preset_assignments')
+      const { data, error } = await dataLayerClient.from('day_preset_assignments')
         .select('*, preset:presets!inner(name, department)')
         .eq('preset.department', department)
         .eq('date', format(selectedDate, 'yyyy-MM-dd'))
@@ -78,8 +78,7 @@ export function QuickPresetAssignment({ selectedDate, onAssign, className }: Qui
       const maxOrder = currentAssignments?.reduce((max, assignment) => 
         Math.max(max, assignment.order || 0), -1) || -1;
 
-      const { error } = await supabase
-        .from('day_preset_assignments')
+      const { error } = await dataLayerClient.from('day_preset_assignments')
         .insert({
           date: format(selectedDate, 'yyyy-MM-dd'),
           preset_id: presetId,
@@ -90,7 +89,7 @@ export function QuickPresetAssignment({ selectedDate, onAssign, className }: Qui
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['preset-assignments'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('preset-assignments') });
       toast({
         title: "Success",
         description: "Preset assigned successfully"
@@ -111,15 +110,14 @@ export function QuickPresetAssignment({ selectedDate, onAssign, className }: Qui
       if (!session?.user?.id) throw new Error('Must be logged in');
       if (!isValidDate) throw new Error('Invalid date selected');
 
-      const { error } = await supabase
-        .from('day_preset_assignments')
+      const { error } = await dataLayerClient.from('day_preset_assignments')
         .delete()
         .eq('id', assignmentId);
 
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['preset-assignments'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('preset-assignments') });
       toast({
         title: "Success",
         description: "Preset assignment removed"

--- a/src/components/disponibilidad/StockCreationManager.tsx
+++ b/src/components/disponibilidad/StockCreationManager.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { StockEntry, Equipment, getCategoriesForDepartment, allCategoryLabels, AllCategories } from '@/types/equipment';
+import { StockEntry, Equipment, getCategoriesForDepartment, allCategoryLabels, AllCategories, EquipmentCategory } from '@/types/equipment';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
@@ -7,13 +7,15 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Plus, Trash2, Pencil, Search, ChevronDown, ChevronRight, Check, X, Loader2, Link, ClipboardPaste, Download, Settings2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
+
+import { queryKeys } from "@/lib/react-query";
 // UUID regex for extracting Flex resource IDs
 const UUID_REGEX = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/;
 
@@ -123,7 +125,7 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
         setIsFetchingFlex(true);
       }
 
-      const { data, error } = await supabase.functions.invoke('fetch-flex-inventory-model', {
+      const { data, error } = await dataLayerClient.functions.invoke('fetch-flex-inventory-model', {
         body: { model_id: idToFetch }
       });
 
@@ -191,10 +193,9 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
 
   // Fetch equipment list
   const { data: equipmentList = [], refetch: refetchEquipment } = useQuery<Equipment[]>({
-    queryKey: ['equipment', department],
+    queryKey: queryKeys.scope('equipment', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('equipment')
+      const { data, error } = await dataLayerClient.from('equipment')
         .select('*')
         .in('category', categories)
         .order('category')
@@ -207,10 +208,9 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
 
   // Fetch current stock levels
   const { data: currentStockLevels = [] } = useQuery({
-    queryKey: ['current-stock-levels', department],
+    queryKey: queryKeys.scope('current-stock-levels', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('current_stock_levels')
+      const { data, error } = await dataLayerClient.from('current_stock_levels')
         .select('*')
         .in('category', categories);
 
@@ -269,11 +269,10 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
       if (!newName.trim()) throw new Error('Name is required');
 
       // Create equipment
-      const { data: equipment, error: eqError } = await supabase
-        .from('equipment')
+      const { data: equipment, error: eqError } = await dataLayerClient.from('equipment')
         .insert({
           name: newName.trim(),
-          category: newCategory,
+          category: newCategory as EquipmentCategory,
           manufacturer: newManufacturer.trim() || null,
           resource_id: newResourceId.trim() || null,
           image_id: newImageId.trim() || null
@@ -285,8 +284,7 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
 
       // Create stock entry if quantity > 0
       if (newQuantity > 0) {
-        const { error: stockError } = await supabase
-          .from('global_stock_entries')
+        const { error: stockError } = await dataLayerClient.from('global_stock_entries')
           .insert({
             equipment_id: equipment.id,
             base_quantity: newQuantity
@@ -298,8 +296,8 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
       return equipment;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['equipment', department] });
-      queryClient.invalidateQueries({ queryKey: ['current-stock-levels', department] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('equipment', department) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('current-stock-levels', department) });
       resetAddForm();
       toast({ title: 'Equipo creado correctamente' });
     },
@@ -311,15 +309,14 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
   // Update equipment mutation (inline quick edit)
   const updateEquipmentMutation = useMutation({
     mutationFn: async ({ id, name, category }: { id: string; name: string; category: string }) => {
-      const { error } = await supabase
-        .from('equipment')
-        .update({ name, category })
+      const { error } = await dataLayerClient.from('equipment')
+        .update({ name, category: category as EquipmentCategory })
         .eq('id', id);
 
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['equipment', department] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('equipment', department) });
       setEditingItemId(null);
       toast({ title: 'Equipo actualizado' });
     },
@@ -333,11 +330,10 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
     mutationFn: async () => {
       if (!advancedEditItem) throw new Error('No item selected');
 
-      const { error } = await supabase
-        .from('equipment')
+      const { error } = await dataLayerClient.from('equipment')
         .update({
           name: advEditName.trim(),
-          category: advEditCategory,
+          category: advEditCategory as EquipmentCategory,
           manufacturer: advEditManufacturer.trim() || null,
           resource_id: advEditResourceId.trim() || null,
           image_id: advEditImageId.trim() || null
@@ -347,7 +343,7 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['equipment', department] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('equipment', department) });
       closeAdvancedEdit();
       toast({ title: 'Equipo actualizado' });
     },
@@ -360,24 +356,22 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
   const deleteEquipmentMutation = useMutation({
     mutationFn: async (id: string) => {
       // Delete dependent rows first (do not ignore failures)
-      const { error: stockEntriesError } = await supabase
-        .from('global_stock_entries')
+      const { error: stockEntriesError } = await dataLayerClient.from('global_stock_entries')
         .delete()
         .eq('equipment_id', id);
       if (stockEntriesError) throw stockEntriesError;
 
-      const { error: stockMovementsError } = await supabase
-        .from('stock_movements')
+      const { error: stockMovementsError } = await dataLayerClient.from('stock_movements')
         .delete()
         .eq('equipment_id', id);
       if (stockMovementsError) throw stockMovementsError;
 
-      const { error } = await supabase.from('equipment').delete().eq('id', id);
+      const { error } = await dataLayerClient.from('equipment').delete().eq('id', id);
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['equipment', department] });
-      queryClient.invalidateQueries({ queryKey: ['current-stock-levels', department] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('equipment', department) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('current-stock-levels', department) });
       setDeletingItemId(null);
       toast({ title: 'Equipo eliminado' });
     },
@@ -392,27 +386,24 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
       setSavingQuantityId(equipmentId);
 
       // Get existing stock entry
-      const { data: existing } = await supabase
-        .from('global_stock_entries')
+      const { data: existing } = await dataLayerClient.from('global_stock_entries')
         .select('id')
         .eq('equipment_id', equipmentId)
         .maybeSingle();
 
       if (existing) {
-        const { error } = await supabase
-          .from('global_stock_entries')
+        const { error } = await dataLayerClient.from('global_stock_entries')
           .update({ base_quantity: quantity })
           .eq('id', existing.id);
         if (error) throw error;
       } else {
-        const { error } = await supabase
-          .from('global_stock_entries')
+        const { error } = await dataLayerClient.from('global_stock_entries')
           .insert({ equipment_id: equipmentId, base_quantity: quantity });
         if (error) throw error;
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['current-stock-levels', department] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('current-stock-levels', department) });
       setSavingQuantityId(null);
     },
     onError: (error) => {

--- a/src/components/disponibilidad/WeeklySummary.tsx
+++ b/src/components/disponibilidad/WeeklySummary.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, ChevronRight, ChevronsUpDown, Download, Filter } from 'luc
 import { format, startOfWeek, endOfWeek, eachDayOfInterval, addWeeks, subWeeks } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { SUPABASE_URL } from '@/lib/api-config';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { useToast } from '@/hooks/use-toast';
@@ -26,6 +26,8 @@ import { safeGetJSON, safeSetJSON } from '@/lib/storage';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface WeeklySummaryProps {
   selectedDate: Date;
   onDateChange: (date: Date) => void;
@@ -64,7 +66,7 @@ function FlexImage({
 
     const fetchImage = async () => {
       try {
-        const { data: { session } } = await supabase.auth.getSession();
+        const { data: { session } } = await dataLayerClient.auth.getSession();
         if (!session?.access_token) {
           setError(true);
           return;
@@ -157,20 +159,19 @@ export function WeeklySummary({ selectedDate, onDateChange }: WeeklySummaryProps
 
   // Realtime: subscribe to tables that affect stock and assignments
   useOptimizedTableSubscriptions([
-    { table: 'current_stock_levels', queryKey: ['equipment-with-stock', department], priority: 'high' },
-    { table: 'equipment', queryKey: ['equipment-with-stock', department], priority: 'medium' },
-    { table: 'sub_rentals', queryKey: ['equipment-with-stock', department], priority: 'high' },
-    { table: 'day_preset_assignments', queryKey: ['week-preset-assignments', department, format(currentWeekStart, 'yyyy-MM-dd')], priority: 'high' },
-    { table: 'preset_items', queryKey: ['week-preset-assignments', department, format(currentWeekStart, 'yyyy-MM-dd')], priority: 'medium' },
-    { table: 'presets', queryKey: ['week-preset-assignments', department, format(currentWeekStart, 'yyyy-MM-dd')], priority: 'low' },
+    { table: 'current_stock_levels', queryKey: queryKeys.scope('equipment-with-stock', department), priority: 'high' },
+    { table: 'equipment', queryKey: queryKeys.scope('equipment-with-stock', department), priority: 'medium' },
+    { table: 'sub_rentals', queryKey: queryKeys.scope('equipment-with-stock', department), priority: 'high' },
+    { table: 'day_preset_assignments', queryKey: queryKeys.scope('week-preset-assignments', department, format(currentWeekStart, 'yyyy-MM-dd')), priority: 'high' },
+    { table: 'preset_items', queryKey: queryKeys.scope('week-preset-assignments', department, format(currentWeekStart, 'yyyy-MM-dd')), priority: 'medium' },
+    { table: 'presets', queryKey: queryKeys.scope('week-preset-assignments', department, format(currentWeekStart, 'yyyy-MM-dd')), priority: 'low' },
   ]);
 
   // Fetch base stock (without per-day rentals). We use the view but only read base_quantity.
   const { data: stockWithEquipment = [], refetch: refetchStock } = useQuery({
-    queryKey: ['equipment-with-stock', department],
+    queryKey: queryKeys.scope('equipment-with-stock', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('equipment_availability_with_rentals')
+      const { data, error } = await dataLayerClient.from('equipment_availability_with_rentals')
         .select(`
           *
         `)
@@ -202,10 +203,9 @@ export function WeeklySummary({ selectedDate, onDateChange }: WeeklySummaryProps
   const weekEnd = endOfWeek(currentWeekStart);
 
   const { data: weekSubRentals = [], refetch: refetchSubRentals } = useQuery({
-    queryKey: ['sub-rentals-week', department, weekStart.toISOString()],
+    queryKey: queryKeys.scope('sub-rentals-week', department, weekStart.toISOString()),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('sub_rentals')
+      const { data, error } = await dataLayerClient.from('sub_rentals')
         .select('equipment_id, quantity, start_date, end_date, department, notes')
         .eq('department', department)
         .lte('start_date', format(weekEnd, 'yyyy-MM-dd'))
@@ -243,13 +243,12 @@ export function WeeklySummary({ selectedDate, onDateChange }: WeeklySummaryProps
 
   // Fetch all assignments for the week (removed user_id filter for department-wide view)
   const { data: weekAssignments, refetch: refetchAssignments } = useQuery({
-    queryKey: ['week-preset-assignments', department, currentWeekStart],
+    queryKey: queryKeys.scope('week-preset-assignments', department, currentWeekStart),
     queryFn: async () => {
       const assignments = [];
 
       for (const date of weekDates) {
-        const { data, error } = await supabase
-          .from('day_preset_assignments')
+        const { data, error } = await dataLayerClient.from('day_preset_assignments')
           .select(`
             *,
             preset:presets!inner (

--- a/src/components/emails/CorporateEmailComposer.tsx
+++ b/src/components/emails/CorporateEmailComposer.tsx
@@ -17,7 +17,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { X, Upload, FileText, Image as ImageIcon, Send, Users } from "lucide-react";
 import DOMPurify from "dompurify";
@@ -30,6 +30,8 @@ import type {
   PdfAttachment,
 } from "@/types/corporate-email";
 
+
+import { queryKeys } from "@/lib/react-query";
 export function CorporateEmailComposer() {
   const { toast } = useToast();
   const [subject, setSubject] = useState("");
@@ -47,10 +49,9 @@ export function CorporateEmailComposer() {
 
   // Fetch profiles for recipient picker
   const { data: profiles = [] } = useQuery({
-    queryKey: ["profiles", recipientSearch],
+    queryKey: queryKeys.scope("profiles", recipientSearch),
     queryFn: async () => {
-      let query = supabase
-        .from("profiles")
+      let query = dataLayerClient.from("profiles")
         .select("id, first_name, last_name, email, department, role")
         .not("email", "is", null)
         .order("first_name");
@@ -71,7 +72,7 @@ export function CorporateEmailComposer() {
   // Send email mutation
   const sendEmailMutation = useMutation({
     mutationFn: async (request: SendCorporateEmailRequest) => {
-      const { data, error } = await supabase.functions.invoke<SendCorporateEmailResponse>(
+      const { data, error } = await dataLayerClient.functions.invoke<SendCorporateEmailResponse>(
         "send-corporate-email",
         {
           body: request,

--- a/src/components/equipment/EquipmentCreationManager.tsx
+++ b/src/components/equipment/EquipmentCreationManager.tsx
@@ -2,12 +2,12 @@
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { Equipment, AllCategories } from '@/types/equipment';
+import type { Equipment, AllCategories, EquipmentCategory } from '@/types/equipment';
 import { allCategoryLabels, getCategoriesForDepartment, SOUND_CATEGORIES, LIGHTS_CATEGORIES, Department } from '@/types/equipment';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Plus, Trash2, Pencil, Loader2, ClipboardPaste, Link, Download } from 'lucide-react';
@@ -81,7 +81,7 @@ function EditEquipmentDialog({ equipment, open, onOpenChange, onSave }: EditEqui
 
     try {
       setIsFetchingFlex(true);
-      const { data, error } = await supabase.functions.invoke('fetch-flex-inventory-model', {
+      const { data, error } = await dataLayerClient.functions.invoke('fetch-flex-inventory-model', {
         body: { model_id: idToFetch }
       });
 
@@ -279,7 +279,7 @@ export function EquipmentCreationManager({ onEquipmentChange, department: propDe
 
     try {
       setIsFetchingFlex(true);
-      const { data, error } = await supabase.functions.invoke('fetch-flex-inventory-model', {
+      const { data, error } = await dataLayerClient.functions.invoke('fetch-flex-inventory-model', {
         body: { model_id: idToFetch }
       });
 
@@ -313,8 +313,7 @@ export function EquipmentCreationManager({ onEquipmentChange, department: propDe
   const { data: equipmentList } = useQuery({
     queryKey: department ? ['equipment', department] : ['equipment'],
     queryFn: async () => {
-      let query = supabase
-        .from('equipment')
+      let query = dataLayerClient.from('equipment')
         .select('*');
 
       if (department) {
@@ -336,11 +335,10 @@ export function EquipmentCreationManager({ onEquipmentChange, department: propDe
       if (!session?.user?.id) throw new Error('Must be logged in');
       if (!equipmentName.trim()) throw new Error('Equipment name is required');
 
-      const { data: equipment, error } = await supabase
-        .from('equipment')
+      const { data: equipment, error } = await dataLayerClient.from('equipment')
         .insert({
           name: equipmentName,
-          category: category,
+          category: category as EquipmentCategory,
           manufacturer: manufacturer.trim() || null,
           resource_id: resourceId.trim() || null,
           image_id: imageId.trim() || null
@@ -379,8 +377,7 @@ export function EquipmentCreationManager({ onEquipmentChange, department: propDe
     mutationFn: async (equipment: Partial<Equipment>) => {
       if (!equipment.id) throw new Error('Equipment ID is required');
 
-      const { error } = await supabase
-        .from('equipment')
+      const { error } = await dataLayerClient.from('equipment')
         .update({
           name: equipment.name,
           category: equipment.category,
@@ -411,8 +408,7 @@ export function EquipmentCreationManager({ onEquipmentChange, department: propDe
 
   const deleteEquipmentMutation = useMutation({
     mutationFn: async (equipmentId: string) => {
-      const { error } = await supabase
-        .from('equipment')
+      const { error } = await dataLayerClient.from('equipment')
         .delete()
         .eq('id', equipmentId);
 

--- a/src/components/equipment/InventoryManagementDialog.tsx
+++ b/src/components/equipment/InventoryManagementDialog.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { StockEntry, getCategoriesForDepartment } from '@/types/equipment';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { StockCreationManager } from '@/components/disponibilidad/StockCreationManager';
 import { AlertCircle, Box } from 'lucide-react';
@@ -16,6 +16,8 @@ import {
     DialogTrigger,
 } from "@/components/ui/dialog";
 
+
+import { queryKeys } from "@/lib/react-query";
 export function InventoryManagementDialog() {
     const [open, setOpen] = useState(false);
     const auth = useOptimizedAuth();
@@ -24,14 +26,13 @@ export function InventoryManagementDialog() {
 
     // Fetch current stock entries filtered by user department categories
     const { data: stockEntries = [], error: stockError } = useQuery({
-        queryKey: ['stock-entries', userDepartment],
+        queryKey: queryKeys.scope('stock-entries', userDepartment),
         queryFn: async () => {
             if (!session?.user?.id || !userDepartment) return [];
 
             const categories = getCategoriesForDepartment(userDepartment as any);
 
-            const { data, error } = await supabase
-                .from('global_stock_entries')
+            const { data, error } = await dataLayerClient.from('global_stock_entries')
                 .select('*, equipment!inner(category)')
                 .in('equipment.category', categories);
 

--- a/src/components/equipment/JobPresetManager.tsx
+++ b/src/components/equipment/JobPresetManager.tsx
@@ -8,7 +8,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Equipment, PresetItem } from '@/types/equipment';
 import { useToast } from '@/hooks/use-toast';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { Plus, Minus, Save, Upload } from 'lucide-react';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -19,13 +19,26 @@ import { pushEquipmentToPullsheet, EquipmentItem, getJobPullsheetsWithFlexApi, J
 import { extractFlexElementId, isFlexUrl } from '@/utils/flexUrlParser';
 
 
+
+import { queryKeys } from "@/lib/react-query";
 interface JobPresetManagerProps {
   jobId: string;
 }
 
+type JobPresetItemWithEquipment = PresetItem & {
+  equipment: Equipment;
+};
+
+type JobEquipmentPreset = {
+  id: string;
+  job_id: string;
+  items: JobPresetItemWithEquipment[];
+};
+
 export const JobPresetManager = ({ jobId }: JobPresetManagerProps) => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const legacyClient = dataLayerClient as any;
   const [localItems, setLocalItems] = useState<Record<string, number>>({});
 
   // Push to Flex state
@@ -41,20 +54,18 @@ export const JobPresetManager = ({ jobId }: JobPresetManagerProps) => {
   const [isLoadingPullsheets, setIsLoadingPullsheets] = useState(false);
 
   // Fetch job preset and items
-  const { data: preset } = useQuery({
-    queryKey: ['job-preset', jobId],
+  const { data: preset } = useQuery<JobEquipmentPreset | null>({
+    queryKey: queryKeys.scope('job-preset', jobId),
     queryFn: async () => {
-      const { data: presetData, error: presetError } = await supabase
-        .from('job_equipment_presets')
+      const { data: presetData, error: presetError } = await legacyClient.from('job_equipment_presets')
         .select('*')
         .eq('job_id', jobId)
-        .single();
+        .maybeSingle();
 
       if (presetError) throw presetError;
 
       if (presetData) {
-        const { data: items, error: itemsError } = await supabase
-          .from('job_preset_items')
+        const { data: items, error: itemsError } = await legacyClient.from('job_preset_items')
           .select(`
             *,
             equipment:equipment (*)
@@ -65,7 +76,7 @@ export const JobPresetManager = ({ jobId }: JobPresetManagerProps) => {
 
         return {
           ...presetData,
-          items: items || []
+          items: (items || []) as JobPresetItemWithEquipment[]
         };
       }
 
@@ -75,10 +86,9 @@ export const JobPresetManager = ({ jobId }: JobPresetManagerProps) => {
 
   // Fetch available equipment
   const { data: equipmentList = [] } = useQuery<Equipment[]>({
-    queryKey: ['equipment'],
+    queryKey: queryKeys.scope('equipment'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('equipment')
+      const { data, error } = await dataLayerClient.from('equipment')
         .select('*')
         .order('category')
         .order('name');
@@ -89,15 +99,15 @@ export const JobPresetManager = ({ jobId }: JobPresetManagerProps) => {
   });
 
   // Initialize local items from preset
-  useState(() => {
+  useEffect(() => {
     if (preset?.items) {
       const initialItems: Record<string, number> = {};
-      preset.items.forEach((item: PresetItem) => {
+      preset.items.forEach((item) => {
         initialItems[item.equipment_id] = item.quantity;
       });
       setLocalItems(initialItems);
     }
-  });
+  }, [preset?.items]);
 
   // Save preset mutation
   const savePresetMutation = useMutation({
@@ -105,8 +115,7 @@ export const JobPresetManager = ({ jobId }: JobPresetManagerProps) => {
       // Create preset if it doesn't exist
       let presetId = preset?.id;
       if (!presetId) {
-        const { data: newPreset, error: presetError } = await supabase
-          .from('job_equipment_presets')
+        const { data: newPreset, error: presetError } = await legacyClient.from('job_equipment_presets')
           .insert({ job_id: jobId })
           .select()
           .single();
@@ -126,22 +135,20 @@ export const JobPresetManager = ({ jobId }: JobPresetManagerProps) => {
       }));
 
       // Delete existing items
-      const { error: deleteError } = await supabase
-        .from('job_preset_items')
+      const { error: deleteError } = await legacyClient.from('job_preset_items')
         .delete()
         .eq('preset_id', presetId);
 
       if (deleteError) throw deleteError;
 
       // Insert new items
-      const { error: insertError } = await supabase
-        .from('job_preset_items')
+      const { error: insertError } = await legacyClient.from('job_preset_items')
         .insert(items);
 
       if (insertError) throw insertError;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['job-preset'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-preset') });
       toast({
         title: "Success",
         description: "Preset saved successfully"
@@ -252,8 +259,8 @@ export const JobPresetManager = ({ jobId }: JobPresetManagerProps) => {
     try {
       // Convert preset items to EquipmentItem format
       const equipmentItems: EquipmentItem[] = preset.items
-        .filter((item: { equipment?: { resource_id?: string | null }; quantity: number }) => item.equipment?.resource_id && item.quantity > 0)
-        .map((item: { equipment: { resource_id?: string | null; name: string; category: string }; quantity: number }) => ({
+        .filter((item) => item.equipment?.resource_id && item.quantity > 0)
+        .map((item) => ({
           resourceId: item.equipment.resource_id!,
           quantity: item.quantity,
           name: item.equipment.name,

--- a/src/components/equipment/PresetCreationManager.tsx
+++ b/src/components/equipment/PresetCreationManager.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { PresetEditor } from './PresetEditor';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -15,6 +15,8 @@ import { endOfDay, startOfDay } from 'date-fns';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { AmplifierTool } from '@/components/sound/AmplifierTool';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface PresetCreationManagerProps {
   onClose?: () => void;
   selectedDate?: Date;
@@ -40,12 +42,11 @@ export function PresetCreationManager({ onClose, selectedDate }: PresetCreationM
   }, [selectedDate]);
 
   const { data: jobsForSelectedDate = [] } = useQuery({
-    queryKey: ['jobs-for-preset-push', department, dayRange?.start, dayRange?.end],
+    queryKey: queryKeys.scope('jobs-for-preset-push', department, dayRange?.start, dayRange?.end),
     queryFn: async () => {
       if (!department || !dayRange) return [];
 
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select(
           `
             id,
@@ -87,12 +88,11 @@ export function PresetCreationManager({ onClose, selectedDate }: PresetCreationM
 
   // Fetch all presets for the department (shared access)
   const { data: presets } = useQuery({
-    queryKey: ['presets', department],
+    queryKey: queryKeys.scope('presets', department),
     queryFn: async () => {
       if (!session?.user?.id) return [];
       
-      const { data, error } = await supabase
-        .from('presets')
+      const { data, error } = await dataLayerClient.from('presets')
         .select(`
           *,
           items:preset_items (
@@ -113,23 +113,21 @@ export function PresetCreationManager({ onClose, selectedDate }: PresetCreationM
   const deletePresetMutation = useMutation({
     mutationFn: async (presetId: string) => {
       // Delete preset items first
-      const { error: itemsError } = await supabase
-        .from('preset_items')
+      const { error: itemsError } = await dataLayerClient.from('preset_items')
         .delete()
         .eq('preset_id', presetId);
 
       if (itemsError) throw itemsError;
 
       // Then delete the preset
-      const { error: presetError } = await supabase
-        .from('presets')
+      const { error: presetError } = await dataLayerClient.from('presets')
         .delete()
         .eq('id', presetId);
 
       if (presetError) throw presetError;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['presets', department] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('presets', department) });
       toast({
         title: "Success",
         description: "Preset deleted successfully"
@@ -151,16 +149,14 @@ export function PresetCreationManager({ onClose, selectedDate }: PresetCreationM
 
       if (editingPreset) {
         // Update existing preset
-        const { error: presetError } = await supabase
-          .from('presets')
+        const { error: presetError } = await dataLayerClient.from('presets')
           .update({ name, tour_id: tourId ?? null })
           .eq('id', editingPreset.id);
 
         if (presetError) throw presetError;
 
         // Delete existing items
-        const { error: deleteError } = await supabase
-          .from('preset_items')
+        const { error: deleteError } = await dataLayerClient.from('preset_items')
           .delete()
           .eq('preset_id', editingPreset.id);
 
@@ -168,8 +164,7 @@ export function PresetCreationManager({ onClose, selectedDate }: PresetCreationM
 
         // Insert updated items
         if (items.length > 0) {
-          const { error: itemsError } = await supabase
-            .from('preset_items')
+          const { error: itemsError } = await dataLayerClient.from('preset_items')
             .insert(
               items.map(item => ({
                 ...item,
@@ -181,8 +176,7 @@ export function PresetCreationManager({ onClose, selectedDate }: PresetCreationM
         }
       } else {
         // Create new preset (now using created_by, user_id is nullable for shared presets)
-        const { data: preset, error: presetError } = await supabase
-          .from('presets')
+        const { data: preset, error: presetError } = await dataLayerClient.from('presets')
           .insert({
             name,
             created_by: session.user.id,
@@ -198,8 +192,7 @@ export function PresetCreationManager({ onClose, selectedDate }: PresetCreationM
 
         // Insert new items
         if (items.length > 0) {
-          const { error: itemsError } = await supabase
-            .from('preset_items')
+          const { error: itemsError } = await dataLayerClient.from('preset_items')
             .insert(
               items.map(item => ({
                 ...item,
@@ -211,7 +204,7 @@ export function PresetCreationManager({ onClose, selectedDate }: PresetCreationM
         }
       }
 
-      queryClient.invalidateQueries({ queryKey: ['presets', department] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('presets', department) });
       setEditingPreset(null);
       setCopyingPreset(null);
       setIsCreating(false);

--- a/src/components/equipment/PresetEditor.tsx
+++ b/src/components/equipment/PresetEditor.tsx
@@ -6,7 +6,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PresetWithItems, Equipment, PresetItem, PresetSubsystem, resolveSubsystemForEquipment } from '@/types/equipment';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { Save, X, Upload, Search } from 'lucide-react';
 import { PushPresetToFlexDialog } from './PushPresetToFlexDialog';
 import {
@@ -19,6 +19,8 @@ import {
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { useDepartment } from '@/contexts/DepartmentContext';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface PresetEditorProps {
   preset?: PresetWithItems;
   isCopy?: boolean;
@@ -54,10 +56,9 @@ export const PresetEditor = ({ preset, isCopy = false, onSave, onCancel, fixedTo
   });
 
   const { data: equipmentList } = useQuery({
-    queryKey: ['equipment', department],
+    queryKey: queryKeys.scope('equipment', department),
     queryFn: async () => {
-      const { data: equipment, error } = await supabase
-        .from('equipment')
+      const { data: equipment, error } = await dataLayerClient.from('equipment')
         .select('*')
         .eq('department', department)
         .order('name');
@@ -83,10 +84,9 @@ export const PresetEditor = ({ preset, isCopy = false, onSave, onCancel, fixedTo
 
   // Fetch tours when no fixed tour is enforced
   const { data: tours } = useQuery({
-    queryKey: ['tours'],
+    queryKey: queryKeys.scope('tours'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('tours')
+      const { data, error } = await dataLayerClient.from('tours')
         .select('id, name, status')
         .order('name');
       if (error) throw error;

--- a/src/components/equipment/StockManagement.tsx
+++ b/src/components/equipment/StockManagement.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Equipment } from '@/types/equipment';
@@ -9,6 +9,8 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Plus, Minus } from 'lucide-react';
 import { StockMovementDialog } from './StockMovementDialog';
 
+
+import { queryKeys } from "@/lib/react-query";
 export function StockManagement() {
   const { session } = useOptimizedAuth();
   const { toast } = useToast();
@@ -18,10 +20,9 @@ export function StockManagement() {
 
   // Fetch equipment list and current stock levels from the view
   const { data: equipmentWithStock } = useQuery({
-    queryKey: ['current-stock-levels'],
+    queryKey: queryKeys.scope('current-stock-levels'),
     queryFn: async () => {
-      const { data: stockLevels, error } = await supabase
-        .from('current_stock_levels')
+      const { data: stockLevels, error } = await dataLayerClient.from('current_stock_levels')
         .select('*')
         .order('equipment_name');
 

--- a/src/components/equipment/StockMovementDialog.tsx
+++ b/src/components/equipment/StockMovementDialog.tsx
@@ -7,9 +7,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Equipment } from "@/types/equipment";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface StockMovementDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -36,8 +38,7 @@ export function StockMovementDialog({
       if (!session?.user?.id) throw new Error('Not authenticated');
       
       // Get current stock entry
-      const { data: stockEntry } = await supabase
-        .from('global_stock_entries')
+      const { data: stockEntry } = await dataLayerClient.from('global_stock_entries')
         .select('*')
         .eq('equipment_id', equipment.id)
         .maybeSingle();
@@ -53,8 +54,7 @@ export function StockMovementDialog({
       }
 
       // Begin transaction
-      const { error: stockMovementError } = await supabase
-        .from('stock_movements')
+      const { error: stockMovementError } = await dataLayerClient.from('stock_movements')
         .insert({
           equipment_id: equipment.id,
           quantity: movementQty,
@@ -67,15 +67,13 @@ export function StockMovementDialog({
 
       // Update or insert stock entry
       if (stockEntry) {
-        const { error: updateError } = await supabase
-          .from('global_stock_entries')
+        const { error: updateError } = await dataLayerClient.from('global_stock_entries')
           .update({ base_quantity: newBaseQty })
           .eq('id', stockEntry.id);
 
         if (updateError) throw updateError;
       } else {
-        const { error: insertError } = await supabase
-          .from('global_stock_entries')
+        const { error: insertError } = await dataLayerClient.from('global_stock_entries')
           .insert({
             equipment_id: equipment.id,
             base_quantity: newBaseQty
@@ -86,9 +84,9 @@ export function StockMovementDialog({
     },
     onSuccess: () => {
       // Invalidate queries to refresh the UI - use partial match to catch all department variants
-      queryClient.invalidateQueries({ queryKey: ['current-stock-levels'], exact: false });
-      queryClient.invalidateQueries({ queryKey: ['stock-movements'], exact: false });
-      queryClient.invalidateQueries({ queryKey: ['equipment-with-stock'], exact: false });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('current-stock-levels'), exact: false });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('stock-movements'), exact: false });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('equipment-with-stock'), exact: false });
       toast({
         title: "Success",
         description: `Stock ${isAddition ? 'added' : 'removed'} successfully`

--- a/src/components/equipment/StockMovementHistory.tsx
+++ b/src/components/equipment/StockMovementHistory.tsx
@@ -1,6 +1,6 @@
 
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import {
   Table,
   TableBody,
@@ -11,9 +11,12 @@ import {
 } from "@/components/ui/table";
 import { format } from "date-fns";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface StockMovement {
   id: string;
   equipment_id: string;
+  user_id: string;
   quantity: number;
   movement_type: 'addition' | 'subtraction';
   notes: string | null;
@@ -29,19 +32,47 @@ interface StockMovement {
 
 export function StockMovementHistory() {
   const { data: movements, isLoading } = useQuery({
-    queryKey: ['stock-movements'],
+    queryKey: queryKeys.scope('stock-movements'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('stock_movements')
+      const { data, error } = await dataLayerClient.from('stock_movements')
         .select(`
           *,
-          equipment (name),
-          profiles (first_name, last_name)
+          equipment (name)
         `)
         .order('created_at', { ascending: false });
 
       if (error) throw error;
-      return data as StockMovement[];
+
+      const rows = (data || []) as Array<Omit<StockMovement, 'profiles'> & {
+        equipment: { name: string } | null;
+      }>;
+      const userIds = Array.from(new Set(rows.map((movement) => movement.user_id).filter(Boolean)));
+
+      let profiles: Array<{ id: string; first_name: string | null; last_name: string | null }> = [];
+      if (userIds.length) {
+        const { data: profileRows, error: profilesError } = await dataLayerClient.from('profiles')
+          .select('id, first_name, last_name')
+          .in('id', userIds);
+
+        if (profilesError) throw profilesError;
+        profiles = profileRows || [];
+      }
+
+      const profilesById = new Map(
+        (profiles || []).map((profile) => [
+          profile.id,
+          {
+            first_name: profile.first_name || '',
+            last_name: profile.last_name || '',
+          },
+        ])
+      );
+
+      return rows.map((movement) => ({
+        ...movement,
+        equipment: movement.equipment || { name: '-' },
+        profiles: profilesById.get(movement.user_id) || { first_name: '', last_name: '' },
+      }));
     }
   });
 

--- a/src/components/equipment/SubRentalManager.tsx
+++ b/src/components/equipment/SubRentalManager.tsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { useToast } from '@/hooks/use-toast';
 import { format } from 'date-fns';
@@ -28,6 +28,8 @@ import {
 } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface SubRental {
   id: string;
   batch_id?: string;
@@ -66,15 +68,14 @@ export function SubRentalManager() {
 
   // Realtime: refresh sub-rentals list and stock view when changes occur elsewhere
   useOptimizedTableSubscriptions([
-    { table: 'sub_rentals', queryKey: ['sub-rentals', department], priority: 'high' },
-    { table: 'sub_rentals', queryKey: ['equipment-with-stock', department], priority: 'medium' },
+    { table: 'sub_rentals', queryKey: queryKeys.scope('sub-rentals', department), priority: 'high' },
+    { table: 'sub_rentals', queryKey: queryKeys.scope('equipment-with-stock', department), priority: 'medium' },
   ]);
 
   const { data: equipmentList } = useQuery({
-    queryKey: ['equipment', department],
+    queryKey: queryKeys.scope('equipment', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('equipment')
+      const { data, error } = await dataLayerClient.from('equipment')
         .select('*')
         .eq('department', department)
         .order('name');
@@ -86,10 +87,9 @@ export function SubRentalManager() {
 
   // Query for jobs that are available (not archived/cancelled) for linking
   const { data: availableJobs } = useQuery({
-    queryKey: ['jobs-for-subrental', department],
+    queryKey: queryKeys.scope('jobs-for-subrental', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('id, title, event_date, locations(name)')
         .gte('event_date', format(new Date(), 'yyyy-MM-dd'))
         .order('event_date', { ascending: true })
@@ -101,10 +101,9 @@ export function SubRentalManager() {
   });
 
   const { data: subRentals = [] } = useQuery({
-    queryKey: ['sub-rentals', department],
+    queryKey: queryKeys.scope('sub-rentals', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('sub_rentals')
+      const { data, error } = await dataLayerClient.from('sub_rentals')
         .select(`
           *,
           equipment:equipment!inner (
@@ -166,8 +165,7 @@ export function SubRentalManager() {
         is_stock_extension: isStockExtension,
       }));
 
-      const { data: insertedRentals, error } = await supabase
-        .from('sub_rentals')
+      const { data: insertedRentals, error } = await dataLayerClient.from('sub_rentals')
         .insert(payload)
         .select('id');
 
@@ -179,7 +177,7 @@ export function SubRentalManager() {
           const vendor_name = notes || 'Vendor';
           const description = `Subrental pickup: ${vendor_name}`;
 
-          const { error: transportErr } = await supabase.functions.invoke('create-transport-request', {
+          const { error: transportErr } = await dataLayerClient.functions.invoke('create-transport-request', {
             body: {
               job_id: jobId,
               subrental_id: insertedRentals[0].id, // Use first item as reference
@@ -210,10 +208,10 @@ export function SubRentalManager() {
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sub-rentals'] });
-      queryClient.invalidateQueries({ queryKey: ['sub-rentals-week'] });
-      queryClient.invalidateQueries({ queryKey: ['equipment-with-stock'] });
-      queryClient.invalidateQueries({ queryKey: ['transport-requests-all'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('sub-rentals') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('sub-rentals-week') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('equipment-with-stock') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-requests-all') });
       // Only show success toast if we didn't already show one in the mutation
       if (!autoCreateTransport || !jobId) {
         toast({
@@ -243,17 +241,16 @@ export function SubRentalManager() {
   // Delete sub-rental mutation
   const deleteSubRentalMutation = useMutation({
     mutationFn: async (id: string) => {
-      const { error } = await supabase
-        .from('sub_rentals')
+      const { error } = await dataLayerClient.from('sub_rentals')
         .delete()
         .eq('id', id);
 
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sub-rentals'] });
-      queryClient.invalidateQueries({ queryKey: ['sub-rentals-week'] });
-      queryClient.invalidateQueries({ queryKey: ['equipment-with-stock'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('sub-rentals') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('sub-rentals-week') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('equipment-with-stock') });
       toast({
         title: "Success",
         description: "Sub-rental removed"

--- a/src/components/expenses/ExpenseList.tsx
+++ b/src/components/expenses/ExpenseList.tsx
@@ -11,7 +11,7 @@ import { expenseCopy } from './expenseCopy';
 import { formatCurrency } from '@/lib/utils';
 import type { JobExpense } from '@/hooks/useJobExpenses';
 import { useJobExpenseMutations } from '@/hooks/useJobExpenses';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast';
 import {
   AlertDialog,
@@ -45,7 +45,7 @@ export const ExpenseList: React.FC<ExpenseListProps> = ({
 
   const handleViewReceipt = async (receiptPath: string) => {
     try {
-      const { data, error } = await supabase.storage
+      const { data, error } = await dataLayerClient.storage
         .from('expense-receipts')
         .createSignedUrl(receiptPath, 3600); // 1 hour expiry
 

--- a/src/components/expenses/PendingExpensesSummary.tsx
+++ b/src/components/expenses/PendingExpensesSummary.tsx
@@ -4,11 +4,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Receipt, ArrowRight, Clock } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { formatCurrency } from '@/lib/utils';
 import { useNavigate } from 'react-router-dom';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface ExpenseResponse {
   job_id: string;
   amount_eur: number | null;
@@ -28,12 +30,11 @@ export const PendingExpensesSummary: React.FC = () => {
   const navigate = useNavigate();
 
   const { data: pendingExpenses = [], isLoading } = useQuery({
-    queryKey: ['pending-expenses-summary', user?.id],
+    queryKey: queryKeys.scope('pending-expenses-summary', user?.id),
     queryFn: async () => {
       if (!user?.id) return [];
 
-      const { data, error } = await supabase
-        .from('job_expenses')
+      const { data, error } = await dataLayerClient.from('job_expenses')
         .select(`
           job_id,
           amount_eur,
@@ -45,9 +46,14 @@ export const PendingExpensesSummary: React.FC = () => {
 
       if (error) throw error;
 
+      const expenses = ((data || []) as unknown as ExpenseResponse[]).map((expense) => ({
+        ...expense,
+        job: Array.isArray(expense.job) ? expense.job[0] ?? null : expense.job,
+      }));
+
       // Group by job
       const grouped = new Map<string, PendingExpense>();
-      (data || []).forEach((expense: ExpenseResponse) => {
+      expenses.forEach((expense) => {
         const existing = grouped.get(expense.job_id) || {
           job_id: expense.job_id,
           job_title: expense.job?.title || 'Sin título',

--- a/src/components/feedback/AdminPanel.tsx
+++ b/src/components/feedback/AdminPanel.tsx
@@ -45,6 +45,8 @@ import { ExternalLink, Trash2, Edit, CheckCircle, Eye } from "lucide-react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 
+
+import { queryKeys } from "@/lib/react-query";
 type BugReport = {
   id: string;
   title: string;
@@ -114,7 +116,7 @@ export function AdminPanel() {
 
   // Fetch bug reports (excluding heavy fields for list view)
   const { data: bugReports = [], isLoading: loadingBugs } = useQuery({
-    queryKey: ["bug_reports"],
+    queryKey: queryKeys.scope("bug_reports"),
     queryFn: async () => {
       const { data, error } = await supabase
         .from("bug_reports")
@@ -127,7 +129,7 @@ export function AdminPanel() {
 
   // Fetch feature requests
   const { data: featureRequests = [], isLoading: loadingFeatures } = useQuery({
-    queryKey: ["feature_requests"],
+    queryKey: queryKeys.scope("feature_requests"),
     queryFn: async () => {
       const { data, error } = await supabase
         .from("feature_requests")
@@ -140,7 +142,7 @@ export function AdminPanel() {
 
   // Fetch full bug report details when dialog opens (including heavy fields)
   const { data: fullBugDetails, isLoading: loadingFullBug } = useQuery({
-    queryKey: ["bug_report", selectedBug?.id],
+    queryKey: queryKeys.scope("bug_report", selectedBug?.id),
     queryFn: async () => {
       if (!selectedBug?.id) return null;
       const { data, error } = await supabase
@@ -218,7 +220,7 @@ export function AdminPanel() {
     },
     onSettled: () => {
       // Always refetch to ensure UI is in sync with server
-      queryClient.invalidateQueries({ queryKey: ["bug_reports"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("bug_reports") });
     },
     onSuccess: () => {
       toast({ title: "Bug report updated successfully" });
@@ -233,7 +235,7 @@ export function AdminPanel() {
     },
     onMutate: async ({ id, updates }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: ["feature_requests"] });
+      await queryClient.cancelQueries({ queryKey: queryKeys.scope("feature_requests") });
 
       // Snapshot the current state before mutation
       const previousFeature = selectedFeature;
@@ -260,7 +262,7 @@ export function AdminPanel() {
     },
     onSettled: () => {
       // Always refetch to ensure UI is in sync with server
-      queryClient.invalidateQueries({ queryKey: ["feature_requests"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("feature_requests") });
     },
     onSuccess: () => {
       toast({ title: "Feature request updated successfully" });
@@ -274,7 +276,7 @@ export function AdminPanel() {
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["bug_reports"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("bug_reports") });
       toast({ title: "Bug report deleted successfully" });
       setShowBugDialog(false);
     },
@@ -294,7 +296,7 @@ export function AdminPanel() {
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["feature_requests"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("feature_requests") });
       toast({ title: "Feature request deleted successfully" });
       setShowFeatureDialog(false);
     },

--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -4,7 +4,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { useState, useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { FileText, Loader2, Trash2, Upload, Eye, X } from "lucide-react";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { ViewFileDialog } from "./ViewFileDialog";
@@ -27,8 +27,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
 
   const fetchFiles = async () => {
     try {
-      const { data, error } = await supabase
-        .from("festival_artist_files")
+      const { data, error } = await dataLayerClient.from("festival_artist_files")
         .select("*")
         .eq("artist_id", artistId);
 
@@ -69,7 +68,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       const filePath = `${artistId}/${crypto.randomUUID()}.${fileExt}`;
 
       // First upload the file to storage
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from('festival_artist_files')
         .upload(filePath, file);
 
@@ -79,8 +78,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       }
 
       // Then create the database record
-      const { error: dbError } = await supabase
-        .from('festival_artist_files')
+      const { error: dbError } = await dataLayerClient.from('festival_artist_files')
         .insert({
           artist_id: artistId,
           file_name: file.name,
@@ -117,7 +115,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
 
     try {
       // First delete from storage
-      const { error: storageError } = await supabase.storage
+      const { error: storageError } = await dataLayerClient.storage
         .from('festival_artist_files')
         .remove([selectedFile.file_path]);
 
@@ -127,8 +125,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       }
 
       // Then delete the database record
-      const { error: dbError } = await supabase
-        .from('festival_artist_files')
+      const { error: dbError } = await dataLayerClient.from('festival_artist_files')
         .delete()
         .eq('id', selectedFile.id);
 
@@ -158,7 +155,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
 
   const downloadFile = async (file: any) => {
     try {
-      const { data, error } = await supabase.storage
+      const { data, error } = await dataLayerClient.storage
         .from('festival_artist_files')
         .download(file.file_path);
 
@@ -185,7 +182,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
 
   const handleViewFile = async (file: any) => {
     try {
-      const { data } = await supabase.storage
+      const { data } = await dataLayerClient.storage
         .from('festival_artist_files')
         .createSignedUrl(file.file_path, 3600); // URL valid for 1 hour
 

--- a/src/components/festival/ArtistForm.tsx
+++ b/src/components/festival/ArtistForm.tsx
@@ -6,13 +6,14 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { ArtistWirelessSetupSection } from "./form/sections/ArtistWirelessSetupSection";
 import { MicKitSection } from "./form/sections/MicKitSection";
 import { ArtistFormData } from "@/types/festival";
 import { useEquipmentModels } from "@/hooks/useEquipmentModels";
 import { WiredMic } from "./gear-setup/WiredMicConfig";
 import { FESTIVAL_CONSOLE_OPTIONS } from "@/constants/festivalConsoleOptions";
+import type { Json } from "@/integrations/supabase/types";
 
 export const ArtistForm = () => {
   const { token } = useParams();
@@ -105,8 +106,7 @@ export const ArtistForm = () => {
     setIsLoading(true);
     try {
       // First verify the form token is valid and get the form details
-      const { data: formInfo, error: formError } = await supabase
-        .from('festival_artist_forms')
+      const { data: formInfo, error: formError } = await dataLayerClient.from('festival_artist_forms')
         .select('id, artist_id, status, expires_at')
         .eq('token', token)
         .single();
@@ -138,12 +138,11 @@ export const ArtistForm = () => {
       console.log('Submitting form data:', submissionData);
 
       // Create form submission using the actual form ID
-      const { error: submissionError } = await supabase
-        .from('festival_artist_form_submissions')
+      const { error: submissionError } = await dataLayerClient.from('festival_artist_form_submissions')
         .insert({
           form_id: formInfo.id,
           artist_id: formInfo.artist_id,
-          form_data: submissionData,
+          form_data: submissionData as unknown as Json,
           status: 'submitted',
           submitted_at: new Date().toISOString(),
         });
@@ -154,8 +153,7 @@ export const ArtistForm = () => {
       }
 
       // Update the artist record with the form data (only fields that exist in the table)
-      const { error: updateError } = await supabase
-        .from('festival_artists')
+      const { error: updateError } = await dataLayerClient.from('festival_artists')
         .update({
           name: formData.name,
           stage: formData.stage,
@@ -173,9 +171,9 @@ export const ArtistForm = () => {
           monitors_from_foh: formData.monitors_from_foh,
           mon_waves_outboard: formData.mon_waves_outboard,
           mon_tech: formData.mon_tech,
-          wireless_systems: formData.wireless_systems,
+          wireless_systems: formData.wireless_systems as unknown as Json,
           wireless_provided_by: formData.wireless_provided_by,
-          iem_systems: formData.iem_systems,
+          iem_systems: formData.iem_systems as unknown as Json,
           iem_provided_by: formData.iem_provided_by,
           monitors_enabled: formData.monitors_enabled,
           monitors_quantity: formData.monitors_quantity,
@@ -208,9 +206,8 @@ export const ArtistForm = () => {
       }
 
       // Mark the form as completed
-      const { error: updateFormError } = await supabase
-        .from('festival_artist_forms')
-        .update({ status: 'completed' })
+      const { error: updateFormError } = await dataLayerClient.from('festival_artist_forms')
+        .update({ status: 'submitted' })
         .eq('id', formInfo.id);
 
       if (updateFormError) throw updateFormError;

--- a/src/components/festival/ArtistFormLinkDialog.tsx
+++ b/src/components/festival/ArtistFormLinkDialog.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Copy, Mail, Printer, RefreshCcw } from "lucide-react";
 import { useState, useEffect } from "react";
 import { addDays } from "date-fns";
@@ -82,8 +82,7 @@ export const ArtistFormLinkDialog = ({
     setIsLoading(true);
     try {
       // First, mark any existing pending forms for THIS ARTIST as expired
-      const { error: updateError } = await supabase
-        .from('festival_artist_forms')
+      const { error: updateError } = await dataLayerClient.from('festival_artist_forms')
         .update({
           status: 'expired',
           expires_at: new Date().toISOString() // Expire immediately
@@ -99,8 +98,7 @@ export const ArtistFormLinkDialog = ({
       // Create a new form entry that expires in 7 days
       const expiresAt = addDays(new Date(), 7);
       
-      const { data, error } = await supabase
-        .from('festival_artist_forms')
+      const { data, error } = await dataLayerClient.from('festival_artist_forms')
         .insert({
           artist_id: artistId,
           expires_at: expiresAt.toISOString(),
@@ -189,8 +187,7 @@ export const ArtistFormLinkDialog = ({
       throw new Error("Se requiere el ID del artista");
     }
 
-    const { data: artistData, error: artistError } = await supabase
-      .from("festival_artists")
+    const { data: artistData, error: artistError } = await dataLayerClient.from("festival_artists")
       .select("name, stage, date, show_start, show_end, soundcheck, soundcheck_start, soundcheck_end")
       .eq("id", artistId)
       .maybeSingle();
@@ -204,8 +201,7 @@ export const ArtistFormLinkDialog = ({
     let publicFormQrDataUrl = "";
 
     if (!publicFormUrl) {
-      const { data: existingForm, error: existingFormError } = await supabase
-        .from("festival_artist_forms")
+      const { data: existingForm, error: existingFormError } = await dataLayerClient.from("festival_artist_forms")
         .select("token")
         .eq("artist_id", artistId)
         .eq("status", "pending")
@@ -302,8 +298,7 @@ export const ArtistFormLinkDialog = ({
 
   const saveArtistLanguage = async (nextLanguage: "es" | "en") => {
     setArtistLanguage(nextLanguage);
-    const { error } = await supabase
-      .from("festival_artists")
+    const { error } = await dataLayerClient.from("festival_artists")
       .update({ form_language: nextLanguage })
       .eq("id", artistId);
 
@@ -399,7 +394,7 @@ export const ArtistFormLinkDialog = ({
         </p>
       `;
 
-      const { data, error } = await supabase.functions.invoke("send-corporate-email", {
+      const { data, error } = await dataLayerClient.functions.invoke("send-corporate-email", {
         body: {
           subject:
             artistLanguage === "en"
@@ -483,8 +478,7 @@ export const ArtistFormLinkDialog = ({
       // Check for existing unexpired form link for THIS SPECIFIC ARTIST
       const checkExistingLink = async () => {
         try {
-          const { data: artistData, error: artistError } = await supabase
-            .from("festival_artists")
+          const { data: artistData, error: artistError } = await dataLayerClient.from("festival_artists")
             .select("form_language")
             .eq("id", artistId)
             .maybeSingle();
@@ -497,8 +491,7 @@ export const ArtistFormLinkDialog = ({
             setArtistLanguage("es");
           }
 
-          const { data, error } = await supabase
-            .from('festival_artist_forms')
+          const { data, error } = await dataLayerClient.from('festival_artist_forms')
             .select('token, expires_at')
             .eq('artist_id', artistId) // Only check THIS artist's forms
             .eq('status', 'pending')

--- a/src/components/festival/ArtistFormLinksDialog.tsx
+++ b/src/components/festival/ArtistFormLinksDialog.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Button } from "@/components/ui/button";
 import { useState, useEffect, useCallback } from "react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Loader2, Copy, RefreshCcw, Printer } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { addDays, format, isAfter } from "date-fns";
@@ -48,8 +48,7 @@ export const ArtistFormLinksDialog = ({
   const fetchArtistLinks = useCallback(async () => {
     setIsLoading(true);
     try {
-      const { data: artistsData, error: artistsError } = await supabase
-        .from('festival_artists')
+      const { data: artistsData, error: artistsError } = await dataLayerClient.from('festival_artists')
         .select('id, name, stage, date, form_language')
         .eq('job_id', jobId)
         .not('date', 'is', null)
@@ -66,8 +65,7 @@ export const ArtistFormLinksDialog = ({
 
       const artistIds = artistsData.map((artist) => artist.id);
 
-      const { data: formsData, error: formsError } = await supabase
-        .from('festival_artist_forms')
+      const { data: formsData, error: formsError } = await dataLayerClient.from('festival_artist_forms')
         .select('artist_id, token, expires_at, status, updated_at, created_at')
         .in('artist_id', artistIds)
         .order('updated_at', { ascending: false, nullsFirst: false })
@@ -159,8 +157,7 @@ export const ArtistFormLinksDialog = ({
       for (const artist of filteredArtistLinks) {
         if (!artist.token || 
             (artist.expires_at && !isAfter(new Date(artist.expires_at), new Date()))) {
-          await supabase
-            .from('festival_artist_forms')
+          await dataLayerClient.from('festival_artist_forms')
             .update({
               status: 'expired',
               expires_at: new Date().toISOString()
@@ -169,8 +166,7 @@ export const ArtistFormLinksDialog = ({
             .eq('status', 'pending');
 
           const expiresAt = addDays(new Date(), 7);
-          await supabase
-            .from('festival_artist_forms')
+          await dataLayerClient.from('festival_artist_forms')
             .insert({
               artist_id: artist.artistId,
               expires_at: expiresAt.toISOString(),

--- a/src/components/festival/ArtistFormSubmissionDialog.tsx
+++ b/src/components/festival/ArtistFormSubmissionDialog.tsx
@@ -4,7 +4,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { format } from "date-fns";
 import { Download, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { loadJsPDF } from "@/utils/pdf/lazyPdf";
@@ -40,8 +40,7 @@ export const ArtistFormSubmissionDialog = ({
       setIsLoading(true);
       try {
         // First get the form ID
-        const { data: formData } = await supabase
-          .from('festival_artist_forms')
+        const { data: formData } = await dataLayerClient.from('festival_artist_forms')
           .select('id')
           .eq('artist_id', artistId)
           .order('created_at', { ascending: false })
@@ -49,8 +48,7 @@ export const ArtistFormSubmissionDialog = ({
           .maybeSingle();
 
         if (formData?.id) {
-          const { data: submissionData } = await supabase
-            .from('festival_artist_form_submissions')
+          const { data: submissionData } = await dataLayerClient.from('festival_artist_form_submissions')
             .select('*')
             .eq('form_id', formData.id)
             .order('submitted_at', { ascending: false })

--- a/src/components/festival/ArtistManagementForm.tsx
+++ b/src/components/festival/ArtistManagementForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { BasicInfoSection } from "./form/sections/BasicInfoSection";
 import { ConsoleSetupSection } from "./form/sections/ConsoleSetupSection";
 import { WirelessSetupSection } from "./form/sections/WirelessSetupSection";
@@ -150,8 +150,7 @@ export const ArtistManagementForm = ({
       setIsLoading(true);
       const fetchArtist = async () => {
         try {
-          const { data, error } = await supabase
-            .from("festival_artists")
+          const { data, error } = await dataLayerClient.from("festival_artists")
             .select("*")
             .eq("id", artist.id)
             .single();

--- a/src/components/festival/ArtistRequirementsForm.tsx
+++ b/src/components/festival/ArtistRequirementsForm.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { BasicInfoSection } from "./form/sections/BasicInfoSection";
 import { ConsoleSetupSection } from "./form/sections/ConsoleSetupSection";
 import { ArtistWirelessSetupSection } from "./form/sections/ArtistWirelessSetupSection";
@@ -210,7 +210,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
     }
 
     try {
-      const { data: signedData, error: signedError } = await supabase.storage
+      const { data: signedData, error: signedError } = await dataLayerClient.storage
         .from("festival-logos")
         .createSignedUrl(normalizedPath, 60 * 60);
 
@@ -221,7 +221,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
       console.warn("Could not create signed logo URL:", error);
     }
 
-    const { data } = supabase.storage.from("festival-logos").getPublicUrl(normalizedPath);
+    const { data } = dataLayerClient.storage.from("festival-logos").getPublicUrl(normalizedPath);
     if (data?.publicUrl) {
       return data.publicUrl;
     }
@@ -247,8 +247,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
           return;
         }
 
-        const { data: gearData } = await supabase
-          .from("festival_gear_setups")
+        const { data: gearData } = await dataLayerClient.from("festival_gear_setups")
           .select("*")
           .eq("job_id", blankJobId)
           .maybeSingle();
@@ -258,8 +257,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
           setGearSetup(mapFestivalGearSetup(gearData));
         }
 
-        const { data: stagesData } = await supabase
-          .from("festival_stages")
+        const { data: stagesData } = await dataLayerClient.from("festival_stages")
           .select("number, name")
           .eq("job_id", blankJobId);
 
@@ -273,8 +271,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
           setStageNames(stageMap);
         }
 
-        const { data: logoData } = await supabase
-          .from("festival_logos")
+        const { data: logoData } = await dataLayerClient.from("festival_logos")
           .select("file_path")
           .eq("job_id", blankJobId)
           .maybeSingle();
@@ -305,7 +302,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
 
       setStageNames({});
 
-      const { data, error } = await supabase.rpc("get_public_artist_form_context", {
+      const { data, error } = await dataLayerClient.rpc("get_public_artist_form_context", {
         p_token: token,
       });
 
@@ -514,8 +511,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
       if (Object.keys(stageMapFromContext).length > 0) {
         setStageNames(stageMapFromContext);
       } else if (artistJobId) {
-        const { data: stagesData } = await supabase
-          .from("festival_stages")
+        const { data: stagesData } = await dataLayerClient.from("festival_stages")
           .select("number, name")
           .eq("job_id", artistJobId);
 
@@ -581,7 +577,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
 
     setIsSubmitting(true);
     try {
-      const { data, error } = await supabase.functions.invoke("submit-public-artist-form", {
+      const { data, error } = await dataLayerClient.functions.invoke("submit-public-artist-form", {
         body: {
           token,
           formData,
@@ -681,7 +677,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
   const openRiderFile = useCallback(
     async (file: RiderFileRecord) => {
       try {
-        const { data, error } = await supabase.storage
+        const { data, error } = await dataLayerClient.storage
           .from("festival_artist_files")
           .createSignedUrl(file.file_path, 60 * 60);
 
@@ -705,7 +701,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
   const downloadRiderFile = useCallback(
     async (file: RiderFileRecord) => {
       try {
-        const { data, error } = await supabase.storage
+        const { data, error } = await dataLayerClient.storage
           .from("festival_artist_files")
           .download(file.file_path);
 
@@ -756,7 +752,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
         payload.append("token", token);
         selectedFiles.forEach((file) => payload.append("files", file));
 
-        const { data, error } = await supabase.functions.invoke("upload-public-artist-rider", {
+        const { data, error } = await dataLayerClient.functions.invoke("upload-public-artist-rider", {
           body: payload,
         });
 
@@ -834,7 +830,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
       setDeletingRiderId(file.id);
 
       try {
-        const { data, error } = await supabase.functions.invoke("delete-public-artist-rider", {
+        const { data, error } = await dataLayerClient.functions.invoke("delete-public-artist-rider", {
           body: {
             token,
             fileId: file.id,

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -10,7 +10,7 @@ import { ArtistFileDialog } from "./ArtistFileDialog";
 import { exportArtistPDF, ArtistPdfData } from "@/utils/artistPdfExport";
 import { sortArtistsChronologically } from "@/utils/artistSorting";
 import { toast } from "sonner";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { fetchJobLogo } from "@/utils/pdf/logoUtils";
@@ -168,8 +168,7 @@ export const ArtistTable = ({
     const fetchStageNames = async () => {
       if (!jobId) return;
       
-      const { data: stages, error } = await supabase
-        .from('festival_stages')
+      const { data: stages, error } = await dataLayerClient.from('festival_stages')
         .select('number, name')
         .eq('job_id', jobId);
         
@@ -195,8 +194,7 @@ export const ArtistTable = ({
 
       try {
         // Fetch main festival gear setup
-        const { data: mainSetup, error: mainError } = await supabase
-          .from('festival_gear_setups')
+        const { data: mainSetup, error: mainError } = await dataLayerClient.from('festival_gear_setups')
           .select('*')
           .eq('job_id', jobId)
           .single();
@@ -210,8 +208,7 @@ export const ArtistTable = ({
 
         // Fetch stage-specific setups if main setup exists
         if (mainSetup) {
-          const { data: stageSetups, error: stageError } = await supabase
-            .from('festival_stage_gear_setups')
+          const { data: stageSetups, error: stageError } = await dataLayerClient.from('festival_stage_gear_setups')
             .select('*')
             .eq('gear_setup_id', mainSetup.id);
 
@@ -305,7 +302,7 @@ export const ArtistTable = ({
       await Promise.all(
         artistsWithPlot.map(async (artist) => {
           if (!artist.stage_plot_file_path) return;
-          const { data, error } = await supabase.storage
+          const { data, error } = await dataLayerClient.storage
             .from("festival_artist_files")
             .createSignedUrl(artist.stage_plot_file_path, 60 * 60);
 
@@ -344,7 +341,7 @@ export const ArtistTable = ({
       const fileExtension = file.name.split(".").pop() || "jpg";
       const nextFilePath = `${artist.id}/stage-plots/${Date.now()}-${crypto.randomUUID()}.${fileExtension}`;
 
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from("festival_artist_files")
         .upload(nextFilePath, file, {
           contentType: file.type,
@@ -355,8 +352,7 @@ export const ArtistTable = ({
         throw uploadError;
       }
 
-      const { error: updateError } = await supabase
-        .from("festival_artists")
+      const { error: updateError } = await dataLayerClient.from("festival_artists")
         .update({
           stage_plot_file_path: nextFilePath,
           stage_plot_file_name: file.name,
@@ -366,7 +362,7 @@ export const ArtistTable = ({
         .eq("id", artist.id);
 
       if (updateError) {
-        await supabase.storage.from("festival_artist_files").remove([nextFilePath]);
+        await dataLayerClient.storage.from("festival_artist_files").remove([nextFilePath]);
         throw updateError;
       }
 
@@ -374,7 +370,7 @@ export const ArtistTable = ({
         artist.stage_plot_file_path &&
         artist.stage_plot_file_path !== nextFilePath
       ) {
-        await supabase.storage
+        await dataLayerClient.storage
           .from("festival_artist_files")
           .remove([artist.stage_plot_file_path]);
       }
@@ -458,8 +454,7 @@ export const ArtistTable = ({
     try {
       const currentPath = artist.stage_plot_file_path;
 
-      const { error: updateError } = await supabase
-        .from("festival_artists")
+      const { error: updateError } = await dataLayerClient.from("festival_artists")
         .update({
           stage_plot_file_path: null,
           stage_plot_file_name: null,
@@ -472,7 +467,7 @@ export const ArtistTable = ({
         throw updateError;
       }
 
-      await supabase.storage.from("festival_artist_files").remove([currentPath]);
+      await dataLayerClient.storage.from("festival_artist_files").remove([currentPath]);
 
       setStagePlotUrls((previous) => {
         const updated = { ...previous };
@@ -612,7 +607,7 @@ export const ArtistTable = ({
 
     if (artist.stage_plot_file_path) {
       try {
-        const { data: stagePlotData, error: stagePlotError } = await supabase.storage
+        const { data: stagePlotData, error: stagePlotError } = await dataLayerClient.storage
           .from("festival_artist_files")
           .createSignedUrl(artist.stage_plot_file_path, 60 * 60);
 

--- a/src/components/festival/ArtistTablePrintDialog.tsx
+++ b/src/components/festival/ArtistTablePrintDialog.tsx
@@ -15,7 +15,7 @@ import { exportArtistTablePDF, ArtistTablePdfData } from "@/utils/artistTablePdf
 import { sortArtistsChronologically } from "@/utils/artistSorting";
 import { fetchJobLogo } from "@/utils/pdf/logoUtils";
 import { compareArtistRequirements, calculateEquipmentNeeds } from "@/utils/gearComparisonService";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { FestivalGearSetup, StageGearSetup } from "@/types/festival";
 import { mapFestivalGearSetup, mapStageGearSetups } from "@/utils/festivalGearMappers";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -167,8 +167,7 @@ export const ArtistTablePrintDialog = ({
 
       if (jobId) {
         try {
-          const { data: mainSetup, error: mainError } = await supabase
-            .from('festival_gear_setups')
+          const { data: mainSetup, error: mainError } = await dataLayerClient.from('festival_gear_setups')
             .select('*')
             .eq('job_id', jobId)
             .single();
@@ -179,8 +178,7 @@ export const ArtistTablePrintDialog = ({
             festivalGearSetup = mapFestivalGearSetup(mainSetup);
 
             if (mainSetup) {
-              const { data: stageSetups, error: stageError } = await supabase
-                .from('festival_stage_gear_setups')
+              const { data: stageSetups, error: stageError } = await dataLayerClient.from('festival_stage_gear_setups')
                 .select('*')
                 .eq('gear_setup_id', mainSetup.id);
 

--- a/src/components/festival/CopyArtistsDialog.tsx
+++ b/src/components/festival/CopyArtistsDialog.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { CalendarIcon, Users, Clock } from "lucide-react";
 import { format } from "date-fns";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { toast } from "sonner";
 
 interface Festival {
@@ -73,8 +73,7 @@ export const CopyArtistsDialog = ({
   const loadFestivals = async () => {
     setIsLoading(true);
     try {
-      const { data, error } = await supabase
-        .from("jobs")
+      const { data, error } = await dataLayerClient.from("jobs")
         .select("id, title, start_time, end_time")
         .in("job_type", ["festival", "ciclo"])
         .neq("id", currentJobId)
@@ -92,8 +91,7 @@ export const CopyArtistsDialog = ({
 
   const loadAvailableDates = async (festivalId: string) => {
     try {
-      const { data, error } = await supabase
-        .from("festival_artists")
+      const { data, error } = await dataLayerClient.from("festival_artists")
         .select("date")
         .eq("job_id", festivalId)
         .not("date", "is", null);
@@ -111,8 +109,7 @@ export const CopyArtistsDialog = ({
   const loadArtists = async () => {
     setIsLoading(true);
     try {
-      const { data, error } = await supabase
-        .from("festival_artists")
+      const { data, error } = await dataLayerClient.from("festival_artists")
         .select("id, name, stage, date, show_start, show_end")
         .eq("job_id", selectedFestival)
         .eq("date", selectedSourceDate)
@@ -162,8 +159,7 @@ export const CopyArtistsDialog = ({
     setIsCopying(true);
     try {
       // Fetch full artist data for selected artists
-      const { data: artistsData, error: fetchError } = await supabase
-        .from("festival_artists")
+      const { data: artistsData, error: fetchError } = await dataLayerClient.from("festival_artists")
         .select("*")
         .in("id", selectedArtists);
 
@@ -199,8 +195,7 @@ export const CopyArtistsDialog = ({
       }) || [];
 
       // Insert copied artists
-      const { error: insertError } = await supabase
-        .from("festival_artists")
+      const { error: insertError } = await dataLayerClient.from("festival_artists")
         .insert(artistsToCopy);
 
       if (insertError) throw insertError;

--- a/src/components/festival/FestivalGearSetupForm.tsx
+++ b/src/components/festival/FestivalGearSetupForm.tsx
@@ -2,10 +2,11 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Save, Upload } from "lucide-react";
 import { GearSetupFormData } from "@/types/festival-gear";
-import { StageGearSetup } from "@/types/festival";
+import { FestivalGearSetup } from "@/types/festival";
+import type { Database, Json } from "@/integrations/supabase/types";
 import { ConsoleSetupSection } from "./form/sections/ConsoleSetupSection";
 import { WirelessSetupSection } from "./form/sections/WirelessSetupSection";
 import { MonitorSetupSection } from "./form/sections/MonitorSetupSection";
@@ -54,6 +55,39 @@ const buildEmptyStageSetup = (maxStages = 1): GearSetupFormData => ({
   notes: "",
 });
 
+type FestivalGearSetupRow = Database["public"]["Tables"]["festival_gear_setups"]["Row"];
+
+const jsonArrayOrEmpty = <T,>(value: Json | null | undefined): T[] => (
+  Array.isArray(value) ? value as unknown as T[] : []
+);
+
+const toJson = (value: unknown): Json => value as Json;
+
+const mapGearSetupRow = (row: FestivalGearSetupRow): FestivalGearSetup => ({
+  id: row.id,
+  job_id: row.job_id || "",
+  max_stages: row.max_stages || 1,
+  foh_consoles: jsonArrayOrEmpty<GearSetupFormData["foh_consoles"][number]>(row.foh_consoles),
+  mon_consoles: jsonArrayOrEmpty<GearSetupFormData["mon_consoles"][number]>(row.mon_consoles),
+  foh_waves_outboard: row.foh_waves_outboard,
+  mon_waves_outboard: row.mon_waves_outboard,
+  wireless_systems: normalizeWirelessSystems(row.wireless_systems, "wireless"),
+  iem_systems: normalizeWirelessSystems(row.iem_systems, "iem"),
+  wired_mics: jsonArrayOrEmpty<GearSetupFormData["wired_mics"][number]>(row.wired_mics),
+  available_monitors: row.available_monitors || 0,
+  has_side_fills: row.has_side_fills || false,
+  has_drum_fills: row.has_drum_fills || false,
+  has_dj_booths: row.has_dj_booths || false,
+  available_cat6_runs: row.available_cat6_runs || 0,
+  available_hma_runs: row.available_hma_runs || 0,
+  available_coax_runs: row.available_coax_runs || 0,
+  available_analog_runs: row.available_analog_runs || 0,
+  available_opticalcon_duo_runs: row.available_opticalcon_duo_runs || 0,
+  notes: row.notes || undefined,
+  created_at: row.created_at || undefined,
+  updated_at: row.updated_at || undefined,
+});
+
 export const FestivalGearSetupForm = ({
   jobId,
   stageNumber = 1,
@@ -62,7 +96,7 @@ export const FestivalGearSetupForm = ({
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [setup, setSetup] = useState<GearSetupFormData>(buildEmptyStageSetup());
-  const [globalSetup, setGlobalSetup] = useState(null);
+  const [globalSetup, setGlobalSetup] = useState<FestivalGearSetup | null>(null);
   const [existingSetupId, setExistingSetupId] = useState<string | null>(null);
   const [stageSetupId, setStageSetupId] = useState<string | null>(null);
   const [hasStageSpecificSetup, setHasStageSpecificSetup] = useState(false);
@@ -75,8 +109,7 @@ export const FestivalGearSetupForm = ({
         setIsLoading(true);
         
         // Fetch the main gear setup (no date filter needed)
-        const { data: setupData, error: setupError } = await supabase
-          .from('festival_gear_setups')
+        const { data: setupData, error: setupError } = await dataLayerClient.from('festival_gear_setups')
           .select('*')
           .eq('job_id', jobId)
           .single();
@@ -100,13 +133,12 @@ export const FestivalGearSetupForm = ({
           console.log('Found existing global setup:', setupData);
           console.log('Global setup wired_mics:', setupData.wired_mics);
           // Store the gear setup for validation purposes
-          setGlobalSetup(setupData);
+          setGlobalSetup(mapGearSetupRow(setupData));
           setExistingSetupId(setupData.id);
           
           // For non-primary stages, check for stage-specific setup
           if (!isPrimaryStage) {
-            const { data: stageSetupData, error: stageError } = await supabase
-              .from('festival_stage_gear_setups')
+            const { data: stageSetupData, error: stageError } = await dataLayerClient.from('festival_stage_gear_setups')
               .select('*')
               .eq('gear_setup_id', setupData.id)
               .eq('stage_number', stageNumber)
@@ -126,13 +158,13 @@ export const FestivalGearSetupForm = ({
               // Update form with stage-specific data
               setSetup({
                 max_stages: setupData.max_stages || 1,
-                foh_consoles: stageSetupData.foh_consoles || [],
-                mon_consoles: stageSetupData.mon_consoles || [],
+                foh_consoles: jsonArrayOrEmpty<GearSetupFormData["foh_consoles"][number]>(stageSetupData.foh_consoles),
+                mon_consoles: jsonArrayOrEmpty<GearSetupFormData["mon_consoles"][number]>(stageSetupData.mon_consoles),
                 foh_waves_outboard: stageSetupData.foh_waves_outboard || "",
                 mon_waves_outboard: stageSetupData.mon_waves_outboard || "",
                 wireless_systems: normalizeWirelessSystems(stageSetupData.wireless_systems, "wireless"),
                 iem_systems: normalizeWirelessSystems(stageSetupData.iem_systems, "iem"),
-                wired_mics: stageSetupData.wired_mics || [],
+                wired_mics: jsonArrayOrEmpty<GearSetupFormData["wired_mics"][number]>(stageSetupData.wired_mics),
                 monitors_enabled: stageSetupData.monitors_enabled || false,
                 monitors_quantity: stageSetupData.monitors_quantity || 0,
                 extras_sf: stageSetupData.extras_sf || false,
@@ -165,13 +197,13 @@ export const FestivalGearSetupForm = ({
             // Update form values with global data
             setSetup({
               max_stages: setupData.max_stages || 1,
-              foh_consoles: setupData.foh_consoles || [],
-              mon_consoles: setupData.mon_consoles || [],
+              foh_consoles: jsonArrayOrEmpty<GearSetupFormData["foh_consoles"][number]>(setupData.foh_consoles),
+              mon_consoles: jsonArrayOrEmpty<GearSetupFormData["mon_consoles"][number]>(setupData.mon_consoles),
               foh_waves_outboard: setupData.foh_waves_outboard || "",
               mon_waves_outboard: setupData.mon_waves_outboard || "",
               wireless_systems: normalizeWirelessSystems(setupData.wireless_systems, "wireless"),
               iem_systems: normalizeWirelessSystems(setupData.iem_systems, "iem"),
-              wired_mics: setupData.wired_mics || [],
+              wired_mics: jsonArrayOrEmpty<GearSetupFormData["wired_mics"][number]>(setupData.wired_mics),
               monitors_enabled: setupData.available_monitors > 0,
               monitors_quantity: setupData.available_monitors || 0,
               extras_sf: setupData.has_side_fills || false,
@@ -258,13 +290,13 @@ export const FestivalGearSetupForm = ({
           id: existingSetupId ?? undefined,
           job_id: jobId,
           max_stages: setup.max_stages,
-          foh_consoles: setup.foh_consoles,
-          mon_consoles: setup.mon_consoles,
+          foh_consoles: toJson(setup.foh_consoles),
+          mon_consoles: toJson(setup.mon_consoles),
           foh_waves_outboard: setup.foh_waves_outboard,
           mon_waves_outboard: setup.mon_waves_outboard,
-          wireless_systems: setup.wireless_systems,
-          iem_systems: setup.iem_systems,
-          wired_mics: sanitizedWiredMics, // Use sanitized version
+          wireless_systems: toJson(setup.wireless_systems),
+          iem_systems: toJson(setup.iem_systems),
+          wired_mics: toJson(sanitizedWiredMics), // Use sanitized version
           has_side_fills: setup.extras_sf,
           has_drum_fills: setup.extras_df,
           has_dj_booths: setup.extras_djbooth,
@@ -286,8 +318,7 @@ export const FestivalGearSetupForm = ({
         console.log('Payload wired_mics serialized:', JSON.stringify(setupPayload.wired_mics, null, 2));
 
         // Upsert the global setup
-        const { data: globalData, error: globalError } = await supabase
-          .from('festival_gear_setups')
+        const { data: globalData, error: globalError } = await dataLayerClient.from('festival_gear_setups')
           .upsert(setupPayload, { 
             onConflict: 'job_id' 
           })
@@ -306,7 +337,7 @@ export const FestivalGearSetupForm = ({
         // Update the existingSetupId with the new ID if this was a new record
         if (globalData && globalData.length > 0) {
           setExistingSetupId(globalData[0].id);
-          setGlobalSetup(globalData[0]);
+          setGlobalSetup(mapGearSetupRow(globalData[0]));
         }
       } else {
         // For non-primary stages, we need to make sure the global setup exists first
@@ -319,8 +350,7 @@ export const FestivalGearSetupForm = ({
             max_stages: Math.max(setup.max_stages, stageNumber || 1)
           };
           
-          const { data: newGlobalSetup, error: newGlobalError } = await supabase
-            .from('festival_gear_setups')
+          const { data: newGlobalSetup, error: newGlobalError } = await dataLayerClient.from('festival_gear_setups')
             .upsert(basicGlobalSetup, { 
               onConflict: 'job_id' 
             })
@@ -333,11 +363,10 @@ export const FestivalGearSetupForm = ({
           
           globalSetupId = newGlobalSetup[0].id;
           setExistingSetupId(globalSetupId);
-          setGlobalSetup(newGlobalSetup[0]);
+          setGlobalSetup(mapGearSetupRow(newGlobalSetup[0]));
         } else {
           // Update only the max_stages on the global setup if needed
-          const { error: updateMaxStagesError } = await supabase
-            .from('festival_gear_setups')
+          const { error: updateMaxStagesError } = await dataLayerClient.from('festival_gear_setups')
             .update({
               max_stages: Math.max(globalSetup?.max_stages || 1, stageNumber)
             })
@@ -348,19 +377,23 @@ export const FestivalGearSetupForm = ({
             // Non-critical error, continue with stage setup
           }
         }
+
+        if (!globalSetupId) {
+          throw new Error('No global gear setup ID available');
+        }
         
         // STEP 2: For non-primary stages, create/update stage-specific setup
         const stagePayload = {
           id: stageSetupId ?? undefined,
           gear_setup_id: globalSetupId,
           stage_number: stageNumber,
-          foh_consoles: setup.foh_consoles,
-          mon_consoles: setup.mon_consoles,
+          foh_consoles: toJson(setup.foh_consoles),
+          mon_consoles: toJson(setup.mon_consoles),
           foh_waves_outboard: setup.foh_waves_outboard,
           mon_waves_outboard: setup.mon_waves_outboard,
-          wireless_systems: setup.wireless_systems,
-          iem_systems: setup.iem_systems,
-          wired_mics: sanitizedWiredMics, // Use sanitized version
+          wireless_systems: toJson(setup.wireless_systems),
+          iem_systems: toJson(setup.iem_systems),
+          wired_mics: toJson(sanitizedWiredMics), // Use sanitized version
           monitors_enabled: setup.monitors_enabled,
           monitors_quantity: setup.monitors_quantity,
           extras_sf: setup.extras_sf,
@@ -386,8 +419,7 @@ export const FestivalGearSetupForm = ({
         console.log('Stage payload wired_mics type:', typeof stagePayload.wired_mics);
         
         // Upsert the stage setup
-        const { data: stageData, error: stageError } = await supabase
-          .from('festival_stage_gear_setups')
+        const { data: stageData, error: stageError } = await dataLayerClient.from('festival_stage_gear_setups')
           .upsert(stagePayload)
           .select();
         

--- a/src/components/festival/FestivalLogoManager.tsx
+++ b/src/components/festival/FestivalLogoManager.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Image, Upload, X } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 
 interface FestivalLogoManagerProps {
@@ -26,8 +26,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
         return;
       }
 
-      const { data, error } = await supabase
-        .from('festival_logos')
+      const { data, error } = await dataLayerClient.from('festival_logos')
         .select('file_path')
         .eq('job_id', jobId)
         .maybeSingle();
@@ -41,7 +40,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
       if (data?.file_path) {
         try {
           // Try signed URL first for private bucket
-          const { data: signedUrlData } = await supabase.storage
+          const { data: signedUrlData } = await dataLayerClient.storage
             .from('festival-logos')
             .createSignedUrl(data.file_path, 60 * 60); // 1 hour expiry
             
@@ -50,8 +49,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
             setLogoUrl(signedUrlData.signedUrl);
           } else {
             // Fallback to public URL
-            const { data: publicUrlData } = supabase
-              .storage
+            const { data: publicUrlData } = dataLayerClient.storage
               .from('festival-logos')
               .getPublicUrl(data.file_path);
               
@@ -105,7 +103,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
       console.log("Authenticated user:", userId);
       
       // Check auth status before proceeding
-      const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+      const { data: sessionData, error: sessionError } = await dataLayerClient.auth.getSession();
       if (sessionError || !sessionData.session) {
         throw new Error("Authentication error: " + (sessionError?.message || "Session not found"));
       }
@@ -114,8 +112,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
       const filePath = `${jobId}.${fileExt}`;
 
       // First, delete any existing logo
-      const { data: existingLogo, error: fetchError } = await supabase
-        .from('festival_logos')
+      const { data: existingLogo, error: fetchError } = await dataLayerClient.from('festival_logos')
         .select('file_path')
         .eq('job_id', jobId)
         .maybeSingle();
@@ -127,7 +124,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
 
       if (existingLogo?.file_path) {
         console.log("Removing existing logo from storage:", existingLogo.file_path);
-        const { error: removeError } = await supabase.storage
+        const { error: removeError } = await dataLayerClient.storage
           .from('festival-logos')
           .remove([existingLogo.file_path]);
           
@@ -139,7 +136,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
 
       // Upload new logo
       console.log("Uploading new logo to storage:", filePath);
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from('festival-logos')
         .upload(filePath, file, {
           upsert: true,
@@ -152,8 +149,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
       }
 
       // Update or insert logo record
-      const { error: dbError } = await supabase
-        .from('festival_logos')
+      const { error: dbError } = await dataLayerClient.from('festival_logos')
         .upsert({
           job_id: jobId,
           file_path: filePath,
@@ -169,7 +165,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
       }
 
       // Get signed URL for private bucket
-      const { data: signedUrlData } = await supabase.storage
+      const { data: signedUrlData } = await dataLayerClient.storage
         .from('festival-logos')
         .createSignedUrl(filePath, 60 * 60); // 1 hour expiry
 
@@ -178,8 +174,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
         setLogoUrl(signedUrlData.signedUrl);
       } else {
         // Fallback to public URL
-        const { data: { publicUrl } } = supabase
-          .storage
+        const { data: { publicUrl } } = dataLayerClient.storage
           .from('festival-logos')
           .getPublicUrl(filePath);
         console.log("Uploaded new festival logo, public URL:", publicUrl);
@@ -221,13 +216,12 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
       console.log("Deleting logo as user:", userId);
       
       // Check auth status before proceeding
-      const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+      const { data: sessionData, error: sessionError } = await dataLayerClient.auth.getSession();
       if (sessionError || !sessionData.session) {
         throw new Error("Authentication error: " + (sessionError?.message || "Session not found"));
       }
       
-      const { data, error: fetchError } = await supabase
-        .from('festival_logos')
+      const { data, error: fetchError } = await dataLayerClient.from('festival_logos')
         .select('file_path')
         .eq('job_id', jobId)
         .maybeSingle();
@@ -239,7 +233,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
 
       if (data?.file_path) {
         console.log("Removing logo from storage:", data.file_path);
-        const { error: storageError } = await supabase.storage
+        const { error: storageError } = await dataLayerClient.storage
           .from('festival-logos')
           .remove([data.file_path]);
 
@@ -249,8 +243,7 @@ export const FestivalLogoManager = ({ jobId }: FestivalLogoManagerProps) => {
         }
 
         console.log("Deleting logo record from database");
-        const { error: dbError } = await supabase
-          .from('festival_logos')
+        const { error: dbError } = await dataLayerClient.from('festival_logos')
           .delete()
           .eq('job_id', jobId);
 

--- a/src/components/festival/PushToFlexPullsheetDialog.tsx
+++ b/src/components/festival/PushToFlexPullsheetDialog.tsx
@@ -9,7 +9,7 @@ import { Loader2, CheckCircle2, XCircle, AlertTriangle, Upload } from 'lucide-re
 import { GearSetupFormData } from '@/types/festival-gear';
 import { extractFlexElementId } from '@/utils/flexUrlParser';
 import { pushEquipmentToPullsheet, EquipmentItem, getJobPullsheetsWithFlexApi, JobPullsheet } from '@/services/flexPullsheets';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Switch } from '@/components/ui/switch';
@@ -171,8 +171,7 @@ export function PushToFlexPullsheetDialog({
     const loadPaPresets = async () => {
       setIsLoadingPaPresets(true);
       try {
-        const { data, error } = await supabase
-          .from('presets')
+        const { data, error } = await dataLayerClient.from('presets')
           .select('id, name, job_id')
           .eq('department', 'sound')
           .or(`job_id.eq.${jobId},job_id.is.null`)
@@ -297,8 +296,7 @@ export function PushToFlexPullsheetDialog({
     const lookupEquipment = async () => {
       setIsLookingUp(true);
       try {
-        const { data, error } = await supabase
-          .from('equipment')
+        const { data, error } = await dataLayerClient.from('equipment')
           .select('name, resource_id, department, id')
           .in('name', allModelNames)
           .not('resource_id', 'is', null);
@@ -408,8 +406,7 @@ export function PushToFlexPullsheetDialog({
     const lookupPaPreset = async () => {
       setIsLookingUpPaPreset(true);
       try {
-        const { data, error } = await supabase
-          .from('preset_items')
+        const { data, error } = await dataLayerClient.from('preset_items')
           .select('quantity, subsystem, equipment:equipment(id, name, category, resource_id)')
           .eq('preset_id', selectedPaPresetId);
 

--- a/src/components/festival/gear-setup/MicrophoneNeedsCalculator.tsx
+++ b/src/components/festival/gear-setup/MicrophoneNeedsCalculator.tsx
@@ -6,48 +6,67 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Badge } from "@/components/ui/badge";
 import { Calculator, Download, FileText } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { WiredMic } from "./WiredMicConfig";
 import { exportWiredMicrophoneMatrixPDF, WiredMicrophoneMatrixData, organizeArtistsByDateAndStage } from "@/utils/wiredMicrophoneNeedsPdfExport";
 import { buildReadableFilename } from "@/utils/fileName";
+import type { Json } from "@/integrations/supabase/types";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface MicrophoneNeedsCalculatorProps {
   jobId: string;
 }
+
+type ArtistMicRow = {
+  id: string;
+  name: string | null;
+  stage: number | null;
+  date: string | null;
+  show_start: string | null;
+  show_end: string | null;
+  wired_mics: Json | null;
+  mic_kit: string | null;
+};
+
+type ArtistWithWiredMics = Omit<ArtistMicRow, "wired_mics"> & {
+  wired_mics: WiredMic[];
+};
+
+const readWiredMics = (value: Json | null | undefined): WiredMic[] => (
+  Array.isArray(value) ? value as unknown as WiredMic[] : []
+);
 
 export const MicrophoneNeedsCalculator = ({ jobId }: MicrophoneNeedsCalculatorProps) => {
   const [open, setOpen] = useState(false);
 
   const { data: artists = [], isLoading } = useQuery({
-    queryKey: ['festival-artists-mics', jobId],
+    queryKey: queryKeys.scope('festival-artists-mics', jobId),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('festival_artists')
+      const { data, error } = await dataLayerClient.from('festival_artists')
         .select('id, name, stage, date, show_start, show_end, wired_mics, mic_kit')
         .eq('job_id', jobId)
         .in('mic_kit', ['festival', 'mixed'])
         .not('wired_mics', 'is', null);
       
       if (error) throw error;
-      return data || [];
+      return (data || []) as ArtistMicRow[];
     },
     enabled: open && !!jobId
   });
 
   // Query for job details to get title and logo for PDF export
   const { data: jobDetails } = useQuery({
-    queryKey: ['job-details', jobId],
+    queryKey: queryKeys.scope('job-details', jobId),
     queryFn: async () => {
-      const { data: job, error: jobError } = await supabase
-        .from('jobs')
+      const { data: job, error: jobError } = await dataLayerClient.from('jobs')
         .select('title')
         .eq('id', jobId)
         .single();
       
       if (jobError) throw jobError;
 
-      const { data: logo, error: logoError } = await supabase
-        .from('festival_logos')
+      const { data: logo, error: logoError } = await dataLayerClient.from('festival_logos')
         .select('file_path')
         .eq('job_id', jobId)
         .maybeSingle();
@@ -61,11 +80,12 @@ export const MicrophoneNeedsCalculator = ({ jobId }: MicrophoneNeedsCalculatorPr
   });
 
   // Filter artists with valid wired microphone data
-  const validArtists = artists.filter(artist => 
-    artist.wired_mics && 
-    Array.isArray(artist.wired_mics) && 
-    artist.wired_mics.length > 0
-  );
+  const validArtists: ArtistWithWiredMics[] = artists
+    .map((artist) => ({
+      ...artist,
+      wired_mics: readWiredMics(artist.wired_mics),
+    }))
+    .filter((artist) => artist.wired_mics.length > 0);
 
   // Get unique microphone models for preview
   const getMicrophoneModels = () => {

--- a/src/components/festival/mobile/MobileArtistConfigEditor.tsx
+++ b/src/components/festival/mobile/MobileArtistConfigEditor.tsx
@@ -9,7 +9,7 @@ import { ExtraRequirementsSection } from "../form/sections/ExtraRequirementsSect
 import { InfrastructureSection } from "../form/sections/InfrastructureSection";
 import { NotesSection } from "../form/sections/NotesSection";
 import { useCombinedGearSetup } from "@/hooks/useCombinedGearSetup";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { toast } from "sonner";
 import { formatBandOptionLabel, getBandOptionsEU, isFrequencyBandSelection } from "@/lib/frequencyBands";
 import type { MobileArtistRiderFile, MobileConfigCategory } from "./MobileArtistCard";
@@ -425,8 +425,7 @@ export const MobileArtistConfigEditor = ({
   useEffect(() => {
     const fetchFreshData = async () => {
       try {
-        const { data, error } = await supabase
-          .from("festival_artists")
+        const { data, error } = await dataLayerClient.from("festival_artists")
           .select("*")
           .eq("id", artist.id)
           .single();
@@ -514,8 +513,7 @@ export const MobileArtistConfigEditor = ({
           break;
       }
 
-      const { error } = await supabase
-        .from("festival_artists")
+      const { error } = await dataLayerClient.from("festival_artists")
         .update(updatePayload)
         .eq("id", artist.id);
 

--- a/src/components/festival/mobile/MobileArtistFormSheet.tsx
+++ b/src/components/festival/mobile/MobileArtistFormSheet.tsx
@@ -10,7 +10,7 @@ import { ExtraRequirementsSection } from "../form/sections/ExtraRequirementsSect
 import { InfrastructureSection } from "../form/sections/InfrastructureSection";
 import { NotesSection } from "../form/sections/NotesSection";
 import { useCombinedGearSetup } from "@/hooks/useCombinedGearSetup";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import type { LucideIcon } from "lucide-react";
 
 type FormSection = 'hub' | 'consoles' | 'wireless' | 'microphones' | 'monitors' | 'infrastructure' | 'notes';
@@ -181,8 +181,7 @@ export const MobileArtistFormSheet = ({
     setIsLoading(true);
     const fetchArtist = async () => {
       try {
-        const { data, error } = await supabase
-          .from("festival_artists")
+        const { data, error } = await dataLayerClient.from("festival_artists")
           .select("*")
           .eq("id", artist.id)
           .single();

--- a/src/components/festival/pdf/PrintOptionsDialog.tsx
+++ b/src/components/festival/pdf/PrintOptionsDialog.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useState } from "react";
 import { Download, Mail } from "lucide-react";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { exportMissingRiderReportPDF, MissingRiderReportData } from "@/utils/missingRiderReportPdfExport";
 import { exportArtistTablePDF, ArtistTablePdfData } from "@/utils/artistTablePdfExport";
 import { exportShiftsTablePDF, ShiftsTablePdfData } from "@/utils/shiftsTablePdfExport";
@@ -251,8 +251,7 @@ export const PrintOptionsDialog = ({
     console.log('Generating Missing Rider Report for job:', jobId);
     
     // Fetch festival artists
-    const { data: artists, error } = await supabase
-      .from('festival_artists')
+    const { data: artists, error } = await dataLayerClient.from('festival_artists')
       .select('*')
       .eq('job_id', jobId);
 
@@ -266,8 +265,7 @@ export const PrintOptionsDialog = ({
       Boolean(artist.rider_missing)
     ) || [];
 
-    const { data: stageRows } = await supabase
-      .from('festival_stages')
+    const { data: stageRows } = await dataLayerClient.from('festival_stages')
       .select('number, name')
       .eq('job_id', jobId);
     const stageNameByNumber = new Map<number, string>(
@@ -359,7 +357,7 @@ export const PrintOptionsDialog = ({
         </p>
       `;
 
-      const { data, error } = await supabase.functions.invoke("send-corporate-email", {
+      const { data, error } = await dataLayerClient.functions.invoke("send-corporate-email", {
         body: {
           subject: `Reporte Riders Faltantes - ${jobTitle}`,
           bodyHtml,
@@ -458,8 +456,7 @@ export const PrintOptionsDialog = ({
       
       const logoUrl = (await fetchJobLogo(jobId)) || (await fetchLogoUrl(jobId));
 
-      const { data: shifts, error } = await supabase
-        .from('festival_shifts')
+      const { data: shifts, error } = await dataLayerClient.from('festival_shifts')
         .select('id, job_id, name, date, start_time, end_time, department, stage')
         .eq('job_id', jobId)
         .order('date')
@@ -475,8 +472,7 @@ export const PrintOptionsDialog = ({
       }
 
       const shiftIds = filteredShifts.map((shift) => shift.id);
-      const { data: assignments, error: assignmentsError } = await supabase
-        .from('festival_shift_assignments')
+      const { data: assignments, error: assignmentsError } = await dataLayerClient.from('festival_shift_assignments')
         .select('id, shift_id, technician_id, external_technician_name, role')
         .in('shift_id', shiftIds);
 
@@ -500,8 +496,7 @@ export const PrintOptionsDialog = ({
       }>();
 
       if (technicianIds.length > 0) {
-        const { data: profiles, error: profilesError } = await supabase
-          .from('profiles')
+        const { data: profiles, error: profilesError } = await dataLayerClient.from('profiles')
           .select('id, first_name, last_name, email, department, role')
           .in('id', technicianIds);
         if (profilesError) throw profilesError;
@@ -567,8 +562,7 @@ export const PrintOptionsDialog = ({
       const logoUrl = (await fetchJobLogo(jobId)) || (await fetchLogoUrl(jobId));
       
       // Fetch artists data
-      const { data: artists, error } = await supabase
-        .from('festival_artists')
+      const { data: artists, error } = await dataLayerClient.from('festival_artists')
         .select('*')
         .eq('job_id', jobId)
         .in('stage', options.artistTableStages)
@@ -583,8 +577,7 @@ export const PrintOptionsDialog = ({
       }
 
       const sortedArtists = sortArtistsChronologically(artists);
-      const { data: stageRows, error: stageError } = await supabase
-        .from('festival_stages')
+      const { data: stageRows, error: stageError } = await dataLayerClient.from('festival_stages')
         .select('number, name')
         .eq('job_id', jobId);
       if (stageError) throw stageError;
@@ -655,8 +648,7 @@ export const PrintOptionsDialog = ({
       const logoUrl = (await fetchJobLogo(jobId)) || (await fetchLogoUrl(jobId));
       
       // Fetch artists data
-      const { data: artists, error } = await supabase
-        .from('festival_artists')
+      const { data: artists, error } = await dataLayerClient.from('festival_artists')
         .select('*')
         .eq('job_id', jobId)
         .in('stage', options.rfIemTableStages)
@@ -710,8 +702,7 @@ export const PrintOptionsDialog = ({
       const logoUrl = (await fetchJobLogo(jobId)) || (await fetchLogoUrl(jobId));
       
       // Fetch artists data
-      const { data: artists, error } = await supabase
-        .from('festival_artists')
+      const { data: artists, error } = await dataLayerClient.from('festival_artists')
         .select('*')
         .eq('job_id', jobId)
         .in('stage', options.infrastructureTableStages)
@@ -765,8 +756,7 @@ export const PrintOptionsDialog = ({
       const logoUrl = await fetchLogoUrl(jobId);
       
       // Fetch artists data
-      const { data: artists, error } = await supabase
-        .from('festival_artists')
+      const { data: artists, error } = await dataLayerClient.from('festival_artists')
         .select('*')
         .eq('job_id', jobId)
         .in('stage', options.wiredMicNeedsStages)

--- a/src/components/festival/scheduling/CopyShiftsDialog.tsx
+++ b/src/components/festival/scheduling/CopyShiftsDialog.tsx
@@ -5,8 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { format } from "date-fns";
 import { toast } from "sonner";
-import { supabase } from "@/lib/supabase";
-
+import { dataLayerClient } from "@/services/dataLayerClient";
 interface CopyShiftsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -38,8 +37,7 @@ export const CopyShiftsDialog = ({
       console.log(`Starting copy operation from ${sourceDate} to ${targetDate} for job ${jobId}`);
 
       // Fetch source shifts and their assignments
-      const { data: shifts, error: shiftsError } = await supabase
-        .from("festival_shifts")
+      const { data: shifts, error: shiftsError } = await dataLayerClient.from("festival_shifts")
         .select(`
           id,
           name,
@@ -68,8 +66,7 @@ export const CopyShiftsDialog = ({
       for (const shift of shifts) {
         console.log(`Copying shift: ${shift.name} (ID: ${shift.id})`);
         
-        const { data: newShift, error: newShiftError } = await supabase
-          .from("festival_shifts")
+        const { data: newShift, error: newShiftError } = await dataLayerClient.from("festival_shifts")
           .insert({
             name: shift.name,
             start_time: shift.start_time,
@@ -91,8 +88,7 @@ export const CopyShiftsDialog = ({
         console.log(`Created new shift with ID: ${newShift.id}`);
 
         // Get assignments for the source shift
-        const { data: assignments, error: assignmentsError } = await supabase
-          .from("festival_shift_assignments")
+        const { data: assignments, error: assignmentsError } = await dataLayerClient.from("festival_shift_assignments")
           .select("*")
           .eq("shift_id", shift.id);
 
@@ -114,8 +110,7 @@ export const CopyShiftsDialog = ({
 
           console.log("Creating new assignments:", newAssignments);
 
-          const { error: insertError } = await supabase
-            .from("festival_shift_assignments")
+          const { error: insertError } = await dataLayerClient.from("festival_shift_assignments")
             .insert(newAssignments);
 
           if (insertError) {

--- a/src/components/festival/scheduling/CreateShiftDialog.tsx
+++ b/src/components/festival/scheduling/CreateShiftDialog.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -80,7 +80,7 @@ export const CreateShiftDialog = ({
       
       console.log("Submitting shift data:", shiftData);
       
-      const { data, error } = await supabase.from("festival_shifts").insert(shiftData).select();
+      const { data, error } = await dataLayerClient.from("festival_shifts").insert(shiftData).select();
 
       if (error) {
         console.error("Error creating shift:", error);

--- a/src/components/festival/scheduling/EditShiftDialog.tsx
+++ b/src/components/festival/scheduling/EditShiftDialog.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -61,8 +61,7 @@ export const EditShiftDialog = ({
   const handleSubmit = async (values: FormValues) => {
     setIsSubmitting(true);
     try {
-      const { error } = await supabase
-        .from("festival_shifts")
+      const { error } = await dataLayerClient.from("festival_shifts")
         .update({
           name: values.name,
           start_time: values.start_time,

--- a/src/components/festival/scheduling/FestivalScheduling.tsx
+++ b/src/components/festival/scheduling/FestivalScheduling.tsx
@@ -5,7 +5,7 @@ import { Plus, FileDown, RefreshCw } from "lucide-react";
 import { format } from "date-fns";
 import { SubscriptionIndicator } from "@/components/ui/subscription-indicator";
 import { useFestivalShifts } from "@/hooks/festival/useFestivalShifts";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { FestivalDateNavigation } from "@/components/festival/FestivalDateNavigation";
 import { ShiftsList } from "./ShiftsList";
@@ -13,6 +13,8 @@ import { CreateShiftDialog } from "./CreateShiftDialog";
 import { ShiftsTable } from "./ShiftsTable";
 import { useQuery } from "@tanstack/react-query";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface FestivalSchedulingProps {
   jobId: string;
   jobDates: Date[];
@@ -40,12 +42,11 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
 
   // Fetch festival settings for day start time
   const { data: festivalSettings } = useQuery({
-    queryKey: ['festival-settings', jobId],
+    queryKey: queryKeys.scope('festival-settings', jobId),
     queryFn: async () => {
       if (!jobId) return null;
 
-      const { data: existingSettings, error: fetchError } = await supabase
-        .from('festival_settings')
+      const { data: existingSettings, error: fetchError } = await dataLayerClient.from('festival_settings')
         .select('*')
         .eq('job_id', jobId)
         .maybeSingle();
@@ -68,12 +69,11 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
 
   // Fetch date types for navigation
   const { data: dateTypeData, refetch: refetchDateTypes } = useQuery({
-    queryKey: ['job-date-types', jobId],
+    queryKey: queryKeys.scope('job-date-types', jobId),
     queryFn: async () => {
       if (!jobId) return {};
 
-      const { data, error } = await supabase
-        .from('job_date_types')
+      const { data, error } = await dataLayerClient.from('job_date_types')
         .select('*')
         .eq('job_id', jobId);
 
@@ -149,13 +149,11 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
       setIsRefreshing(true);
       
       // Delete shift assignments first to avoid foreign key constraints
-      await supabase
-        .from("festival_shift_assignments")
+      await dataLayerClient.from("festival_shift_assignments")
         .delete()
         .eq("shift_id", shiftId);
 
-      const { error } = await supabase
-        .from("festival_shifts")
+      const { error } = await dataLayerClient.from("festival_shifts")
         .delete()
         .eq("id", shiftId);
 

--- a/src/components/festival/scheduling/ManageAssignmentsDialog.tsx
+++ b/src/components/festival/scheduling/ManageAssignmentsDialog.tsx
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import {
   Dialog,
@@ -21,6 +21,8 @@ import { Department } from "@/types/department";
 import { roleOptionsForDiscipline, labelForCode } from '@/utils/roles';
 import { Switch } from "@/components/ui/switch";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface ManageAssignmentsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -70,13 +72,12 @@ export const ManageAssignmentsDialog = ({
   }, [open, shift.department]);
 
   const { data: technicians, isLoading: isLoadingTechnicians, error: techniciansError } = useQuery({
-    queryKey: ["job-technicians", shift.job_id, shift.department],
+    queryKey: queryKeys.scope("job-technicians", shift.job_id, shift.department),
     queryFn: async () => {
       const departmentFilter = shift.department || "sound";
       
       // First, get assigned technicians for this job and department
-      const { data, error } = await supabase
-        .from("job_assignments")
+      const { data, error } = await dataLayerClient.from("job_assignments")
         .select(`
           technician_id,
           profiles (
@@ -140,8 +141,7 @@ export const ManageAssignmentsDialog = ({
         throw new Error("Shift ID is required");
       }
 
-      const { data, error } = await supabase
-        .from("festival_shift_assignments")
+      const { data, error } = await dataLayerClient.from("festival_shift_assignments")
         .insert([assignment]);
 
       if (error) {
@@ -151,7 +151,7 @@ export const ManageAssignmentsDialog = ({
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["festivalShifts"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("festivalShifts") });
       onAssignmentsUpdated();
       toast({
         title: "Éxito",
@@ -170,8 +170,7 @@ export const ManageAssignmentsDialog = ({
 
   const removeAssignmentMutation = useMutation({
     mutationFn: async (assignmentId: string) => {
-      const { data, error } = await supabase
-        .from("festival_shift_assignments")
+      const { data, error } = await dataLayerClient.from("festival_shift_assignments")
         .delete()
         .eq("id", assignmentId);
 
@@ -182,7 +181,7 @@ export const ManageAssignmentsDialog = ({
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["festivalShifts"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("festivalShifts") });
       onAssignmentsUpdated();
       toast({
         title: "Éxito",

--- a/src/components/festival/scheduling/ShiftsTable.tsx
+++ b/src/components/festival/scheduling/ShiftsTable.tsx
@@ -13,7 +13,7 @@ import { Trash2, FileDown, Edit, Users, Copy } from "lucide-react";
 import { ShiftWithAssignments } from "@/types/festival-scheduling";
 import { useToast } from "@/hooks/use-toast";
 import { exportShiftsTablePDF, ShiftsTablePdfData } from "@/utils/shiftsTablePdfExport";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { EditShiftDialog } from "./EditShiftDialog";
 import { ManageAssignmentsDialog } from "./ManageAssignmentsDialog";
 import { CopyShiftsDialog } from "./CopyShiftsDialog";
@@ -53,8 +53,7 @@ export const ShiftsTable = ({
       if (!jobId) return;
       
       try {
-        const { data: jobData, error: jobError } = await supabase
-          .from("jobs")
+        const { data: jobData, error: jobError } = await dataLayerClient.from("jobs")
           .select("title")
           .eq("id", jobId)
           .single();
@@ -65,19 +64,18 @@ export const ShiftsTable = ({
           setJobTitle(jobData.title);
         }
         
-        const { data, error } = await supabase
-          .from("festival_settings")
-          .select("logo_url")
+        const { data, error } = await dataLayerClient.from("festival_logos")
+          .select("file_path")
           .eq("job_id", jobId)
-          .single();
+          .maybeSingle();
           
         if (error) {
           console.error("Error fetching festival logo:", error);
           return;
         }
         
-        if (data?.logo_url) {
-          const logoPath = data.logo_url;
+        if (data?.file_path) {
+          const logoPath = data.file_path;
           console.log("Retrieved logo path:", logoPath);
           
           if (logoPath.startsWith('http')) {
@@ -85,7 +83,7 @@ export const ShiftsTable = ({
           } 
           else {
             try {
-              let bucket = 'festival-assets';
+              let bucket = 'festival-logos';
               let path = logoPath;
               
               if (logoPath.includes('/')) {
@@ -95,7 +93,17 @@ export const ShiftsTable = ({
               }
               
               console.log(`Getting public URL for bucket: ${bucket}, path: ${path}`);
-              const { data: publicUrlData } = supabase.storage
+              const { data: signedUrlData } = await dataLayerClient.storage
+                .from(bucket)
+                .createSignedUrl(path, 60 * 60);
+
+              if (signedUrlData?.signedUrl) {
+                console.log("Generated signed URL:", signedUrlData.signedUrl);
+                setLogoUrl(signedUrlData.signedUrl);
+                return;
+              }
+
+              const { data: publicUrlData } = dataLayerClient.storage
                 .from(bucket)
                 .getPublicUrl(path);
                 

--- a/src/components/flex/FlexElementSelectorDialog.tsx
+++ b/src/components/flex/FlexElementSelectorDialog.tsx
@@ -29,6 +29,8 @@ import {
   type TreeFilterPredicate,
 } from "@/utils/flex-folders";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface FlexElementSelectorDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -63,7 +65,7 @@ export const FlexElementSelectorDialog: React.FC<
     error,
     refetch,
   } = useQuery<FlexElementNode[], Error>({
-    queryKey: ["flexElementTree", mainElementId],
+    queryKey: queryKeys.scope("flexElementTree", mainElementId),
     queryFn: () => getElementTree(mainElementId),
     enabled: open && !!mainElementId,
     retry: 1,

--- a/src/components/hoja-de-ruta/components/ProfileAutocomplete.tsx
+++ b/src/components/hoja-de-ruta/components/ProfileAutocomplete.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { User, Search } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
 
@@ -45,8 +45,7 @@ export const ProfileAutocomplete: React.FC<ProfileAutocompleteProps> = ({
 
     setLoading(true);
     try {
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name, dni, department, role')
         .or(`first_name.ilike.%${searchTerm}%,last_name.ilike.%${searchTerm}%,dni.ilike.%${searchTerm}%`)
         .limit(10);

--- a/src/components/hoja-de-ruta/sections/ModernStaffSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernStaffSection.tsx
@@ -8,8 +8,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Users, Plus, Trash2, User, IdCard, Briefcase } from "lucide-react";
 import { EventData } from "@/types/hoja-de-ruta";
 import { ProfileAutocomplete } from "../components/ProfileAutocomplete";
-import { supabase } from "@/integrations/supabase/client";
-
+import { dataLayerClient } from "@/services/dataLayerClient";
 interface ModernStaffSectionProps {
   eventData: EventData;
   onStaffChange: (index: number, field: string, value: string) => void;
@@ -42,8 +41,7 @@ export const ModernStaffSection: React.FC<ModernStaffSectionProps> = ({
     if (!dni && profile.id) {
       // Fallback: fetch full profile to ensure DNI is loaded
       try {
-        const { data: p, error } = await supabase
-          .from('profiles')
+        const { data: p, error } = await dataLayerClient.from('profiles')
           .select('dni, role, first_name, last_name')
           .eq('id', profile.id)
           .maybeSingle();

--- a/src/components/hoja-de-ruta/sections/ModernTransportSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernTransportSection.tsx
@@ -8,7 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { motion, AnimatePresence } from "framer-motion";
 import { Truck, Plus, Trash2, Download } from "lucide-react";
 import { Transport } from "@/types/hoja-de-ruta";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import {
   LOGISTICS_HOJA_CATEGORY_LABELS,
@@ -110,8 +110,7 @@ export const ModernTransportSection: React.FC<ModernTransportSectionProps> = ({
 
     setIsImporting(true);
     try {
-      const { data: logisticsEvents, error } = await supabase
-        .from('logistics_events')
+      const { data: logisticsEvents, error } = await dataLayerClient.from('logistics_events')
         .select('*')
         .eq('job_id', jobId)
         .eq('is_hoja_relevant', true)

--- a/src/components/incident-reports/IncidentReportsManagement.tsx
+++ b/src/components/incident-reports/IncidentReportsManagement.tsx
@@ -9,8 +9,7 @@ import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { useIncidentReports } from "@/hooks/useIncidentReports";
 import { IncidentReportsNotificationBadge } from "./IncidentReportsNotificationBadge";
-import { supabase } from "@/integrations/supabase/client";
-
+import { dataLayerClient } from "@/services/dataLayerClient";
 export const IncidentReportsManagement = () => {
   const { reports, isLoading, deleteReport, isDeleting, downloadReport } = useIncidentReports();
   const [searchTerm, setSearchTerm] = useState("");
@@ -26,10 +25,9 @@ export const IncidentReportsManagement = () => {
   // Get user role for notifications
   React.useEffect(() => {
     const getUserRole = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: { user } } = await dataLayerClient.auth.getUser();
       if (user) {
-        const { data: profile } = await supabase
-          .from('profiles')
+        const { data: profile } = await dataLayerClient.from('profiles')
           .select('role')
           .eq('id', user.id)
           .single();

--- a/src/components/incident-reports/IncidentReportsNotificationBadge.tsx
+++ b/src/components/incident-reports/IncidentReportsNotificationBadge.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { ClipboardList } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useNavigate } from "react-router-dom";
 import { useAppBadgeSource } from "@/hooks/useAppBadgeSource";
 import { isManagementRole } from "@/utils/permissions";
@@ -30,8 +30,7 @@ export const IncidentReportsNotificationBadge = ({
       setIsLoading(true);
       console.log("Checking for new incident reports...");
 
-      let query = supabase
-        .from('job_documents')
+      let query = dataLayerClient.from('job_documents')
         .select('id, uploaded_at')
         .like('file_path', 'incident-reports/%');
 
@@ -79,8 +78,7 @@ export const IncidentReportsNotificationBadge = ({
     }, 1000);
 
     // Set up real-time subscription for job_documents changes
-    const channel = supabase
-      .channel('incident-reports-notifications')
+    const channel = dataLayerClient.channel('incident-reports-notifications')
       .on(
         'postgres_changes',
         { 
@@ -102,7 +100,7 @@ export const IncidentReportsNotificationBadge = ({
     return () => {
       clearTimeout(timeoutId);
       console.log("Cleaning up incident reports subscription");
-      supabase.removeChannel(channel);
+      dataLayerClient.removeChannel(channel);
     };
   }, [fetchNewIncidentReports, isEligibleForBadge]);
 

--- a/src/components/incident-reports/__tests__/IncidentReportsManagement.test.tsx
+++ b/src/components/incident-reports/__tests__/IncidentReportsManagement.test.tsx
@@ -21,6 +21,10 @@ vi.mock("@/integrations/supabase/client", () => ({
   supabase: mockSupabase,
 }));
 
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: mockSupabase,
+}));
+
 vi.mock("../IncidentReportsNotificationBadge", () => ({
   IncidentReportsNotificationBadge: ({ userRole }: { userRole: string }) => {
     badgeMock(userRole);


### PR DESCRIPTION
## Summary
- Port the next Phase 2 component slice from direct Supabase ownership to the shared data-layer client/query-key boundary.
- Cover auth, dashboard, department, availability, equipment, expenses, feedback, festival, Flex, hoja de ruta, incident reports, email, and logo support components.
- Fix strict generated Supabase typing fallout for legacy tables, JSON payloads, equipment category enums, stock movement users, and festival logo lookup.

## Validation
- npm install --legacy-peer-deps
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- npm run cap:sync
- git diff --check
- git diff --cached --check

## Notes
- No Supabase migrations.
- No docs update in this slice; docs remain for the final Phase 2 wrap-up PR.