### PR TITLE
[codex] Phase 2 remaining component slice

### DIFF
--- a/src/components/layout/AboutCard.tsx
+++ b/src/components/layout/AboutCard.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Info, Edit3, Save, X, Clock, Plus, Trash2, Bell } from "lucide-react"
-import { supabase } from "@/lib/supabase"
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast"
 import { getChangelogVersionAutofill } from "@/lib/changelog-version"
 import { isAdminRole, isManagementRole } from "@/utils/permissions"
@@ -111,8 +111,7 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
   useEffect(() => {
     const load = async () => {
       try {
-        const { data, error } = await supabase
-          .from('app_changelog')
+        const { data, error } = await dataLayerClient.from('app_changelog')
           .select('id, version, entry_date, content, last_updated')
           .order('entry_date', { ascending: false })
           .order('last_updated', { ascending: false })
@@ -173,8 +172,7 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
         toast({ title: 'Invalid date', description: 'Use format YYYY-MM-DD', variant: 'destructive' })
         return
       }
-      const { data, error } = await supabase
-        .from('app_changelog')
+      const { data, error } = await dataLayerClient.from('app_changelog')
         .update({ content: editContent, version: editVersion || defaultVersion, entry_date: dateStr })
         .eq('id', editingEntry)
         .select('id, version, entry_date, content, last_updated')
@@ -189,7 +187,7 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
 
         // Send push notification about changelog update if broadcast is enabled
         if (sendBroadcast) {
-          void supabase.functions.invoke('push', {
+          void dataLayerClient.functions.invoke('push', {
             body: {
               action: 'broadcast',
               type: 'changelog.updated',
@@ -215,8 +213,7 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
     const proceed = window.confirm('Delete this changelog entry?')
     if (!proceed) return
     try {
-      const { error } = await supabase
-        .from('app_changelog')
+      const { error } = await dataLayerClient.from('app_changelog')
         .delete()
         .eq('id', id)
       if (error) throw error
@@ -237,8 +234,7 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
     try {
       const today = new Date()
       const yyyy_mm_dd = today.toISOString().slice(0,10)
-      const { data: latest, error: latestError } = await supabase
-        .from('app_changelog')
+      const { data: latest, error: latestError } = await dataLayerClient.from('app_changelog')
         .select('version')
         .order('entry_date', { ascending: false })
         .order('last_updated', { ascending: false })
@@ -247,8 +243,7 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
       if (latestError) throw latestError
 
       const ver = getChangelogVersionAutofill(latest?.version, '1.0.0')
-      const { data, error } = await supabase
-        .from('app_changelog')
+      const { data, error } = await dataLayerClient.from('app_changelog')
         .insert({ version: ver, entry_date: yyyy_mm_dd, content: '' })
         .select('id, version, entry_date, content, last_updated')
         .maybeSingle()

--- a/src/components/layout/NotificationBadge.tsx
+++ b/src/components/layout/NotificationBadge.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom"
 
 import { Button } from "@/components/ui/button"
 import { useAppBadgeSource } from "@/hooks/useAppBadgeSource"
-import { supabase } from "@/lib/supabase"
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { cn } from "@/lib/utils"
 import { isDepartmentManagementRole } from "@/utils/permissions"
 
@@ -39,8 +39,7 @@ export const NotificationBadge = ({
     try {
       setIsLoading(true)
 
-      let deptQuery = supabase
-        .from("messages")
+      let deptQuery = dataLayerClient.from("messages")
         .select("id", { count: "exact", head: true })
         .eq("status", "unread")
 
@@ -50,8 +49,7 @@ export const NotificationBadge = ({
         deptQuery = deptQuery.eq("sender_id", userId)
       }
 
-      const directQuery = supabase
-        .from("direct_messages")
+      const directQuery = dataLayerClient.from("direct_messages")
         .select("id", { count: "exact", head: true })
         .eq("recipient_id", userId)
         .eq("status", "unread")

--- a/src/components/lights/LightMemoriaTecnica.tsx
+++ b/src/components/lights/LightMemoriaTecnica.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Upload, File, FilePlus, FileCheck, Loader2, Image as ImageIcon, Download } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -120,13 +120,13 @@ export const LightMemoriaTecnica = () => {
   };
 
   const uploadToStorage = async (file: File, path: string) => {
-    const { error: uploadError, data } = await supabase.storage
+    const { error: uploadError, data } = await dataLayerClient.storage
       .from('lights-memoria-tecnica')
       .upload(path, file);
 
     if (uploadError) throw uploadError;
 
-    const { data: { publicUrl } } = supabase.storage
+    const { data: { publicUrl } } = dataLayerClient.storage
       .from('lights-memoria-tecnica')
       .getPublicUrl(path);
 
@@ -207,7 +207,7 @@ export const LightMemoriaTecnica = () => {
 
       setProgress(60);
 
-      const response = await supabase.functions.invoke('generate-lights-memoria-tecnica', {
+      const response = await dataLayerClient.functions.invoke('generate-lights-memoria-tecnica', {
         body: { documentUrls, projectName, logoUrl }
       });
 
@@ -218,8 +218,7 @@ export const LightMemoriaTecnica = () => {
 
       setProgress(80);
 
-      const { error: dbError } = await supabase
-        .from('lights_memoria_tecnica_documents')
+      const { error: dbError } = await dataLayerClient.from('lights_memoria_tecnica_documents')
         .insert({
           project_name: projectName,
           logo_url: logoUrl,

--- a/src/components/lights/LightsTaskDialog.tsx
+++ b/src/components/lights/LightsTaskDialog.tsx
@@ -18,7 +18,7 @@ import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { Upload, Download, Trash2, Table } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
 import { TASK_TYPES } from "@/constants/taskTypes";
@@ -31,16 +31,32 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+
+import { queryKeys } from "@/lib/react-query";
+import type { Database } from "@/integrations/supabase/types";
 interface LightsTaskDialogProps {
   jobId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
+type TaskStatus = Database["public"]["Enums"]["task_status"];
+
 type TaskDocumentRow = {
   id: string;
   file_name: string;
   file_path: string;
+};
+
+type AssignedUser = {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+};
+
+type TaskRow = Database["public"]["Tables"]["lights_job_tasks"]["Row"] & {
+  assigned_to: AssignedUser | null;
+  task_documents: TaskDocumentRow[] | null;
 };
 
 export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialogProps) => {
@@ -49,10 +65,9 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
   const queryClient = useQueryClient();
 
   const { data: managementUsers } = useQuery({
-    queryKey: ['management-users'],
+    queryKey: queryKeys.scope('management-users'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name')
         .in('role', ['management', 'admin']);
       
@@ -62,15 +77,15 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
   });
 
   const { data: tasks, refetch: refetchTasks } = useQuery({
-    queryKey: ['lights-tasks', jobId],
+    queryKey: queryKeys.scope('lights-tasks', jobId),
     queryFn: async () => {
       if (!jobId) return null;
       
-      const { data, error } = await supabase
-        .from('lights_job_tasks')
+      const { data, error } = await dataLayerClient.from('lights_job_tasks')
         .select(`
           *,
-          assigned_to (
+          assigned_to:profiles!lights_job_tasks_assigned_to_fkey (
+            id,
             first_name,
             last_name
           ),
@@ -79,18 +94,17 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
         .eq('job_id', jobId);
       
       if (error) throw error;
-      return data;
+      return data as unknown as TaskRow[];
     },
     enabled: !!jobId
   });
 
   const { data: personnel } = useQuery({
-    queryKey: ['lights-personnel', jobId],
+    queryKey: queryKeys.scope('lights-personnel', jobId),
     queryFn: async () => {
       if (!jobId) return null;
 
-      const { data: existingData, error: fetchError } = await supabase
-        .from('lights_job_personnel')
+      const { data: existingData, error: fetchError } = await dataLayerClient.from('lights_job_personnel')
         .select('*')
         .eq('job_id', jobId)
         .maybeSingle();
@@ -98,8 +112,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
       if (fetchError && fetchError.code !== 'PGRST116') throw fetchError;
 
       if (!existingData) {
-        const { data: newData, error: insertError } = await supabase
-          .from('lights_job_personnel')
+        const { data: newData, error: insertError } = await dataLayerClient.from('lights_job_personnel')
           .insert({
             job_id: jobId,
             lighting_designers: 0,
@@ -124,14 +137,13 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
       setUploading(true);
       const filePath = `${taskId}/${crypto.randomUUID()}-${file.name}`;
       
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from('task_documents')
         .upload(filePath, file);
 
       if (uploadError) throw uploadError;
 
-      const { error: dbError } = await supabase
-        .from('task_documents')
+      const { error: dbError } = await dataLayerClient.from('task_documents')
         .insert({
           lights_task_id: taskId, // Updated to use lights_task_id
           file_name: file.name,
@@ -140,8 +152,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
 
       if (dbError) throw dbError;
 
-      await supabase
-        .from('lights_job_tasks')
+      await dataLayerClient.from('lights_job_tasks')
         .update({ 
           status: 'completed',
           progress: 100 
@@ -167,7 +178,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
 
   const handleDownload = async (filePath: string, fileName: string) => {
     try {
-      const { data, error } = await supabase.storage
+      const { data, error } = await dataLayerClient.storage
         .from('task_documents')
         .download(filePath);
 
@@ -192,7 +203,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
 
   const handleDeleteFile = async (taskId: string, documentId: string, filePath: string) => {
     try {
-      const { error: storageError } = await supabase.storage
+      const { error: storageError } = await dataLayerClient.storage
         .from('task_documents')
         .remove([filePath]);
   
@@ -200,8 +211,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
         throw new Error(`Failed to delete file from storage: ${storageError.message}`);
       }
   
-      const { error: dbError } = await supabase
-        .from('task_documents')
+      const { error: dbError } = await dataLayerClient.from('task_documents')
         .delete()
         .eq('id', documentId);
   
@@ -209,8 +219,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
         throw new Error(`Failed to delete file record: ${dbError.message}`);
       }
   
-      const { error: taskError } = await supabase
-        .from('lights_job_tasks')
+      const { error: taskError } = await dataLayerClient.from('lights_job_tasks')
         .update({ 
           status: 'in_progress',
           progress: 50 
@@ -236,12 +245,11 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
     }
   };
 
-  const updateTaskStatus = async (taskId: string, status: string) => {
+  const updateTaskStatus = async (taskId: string, status: TaskStatus) => {
     try {
       const progress = status === 'completed' ? 100 : status === 'in_progress' ? 50 : 0;
       
-      const { error } = await supabase
-        .from('lights_job_tasks')
+      const { error } = await dataLayerClient.from('lights_job_tasks')
         .update({ 
           status,
           progress,
@@ -313,8 +321,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                 min="0"
                 value={personnel?.lighting_designers || 0}
                 onChange={async (e) => {
-                  const { error } = await supabase
-                    .from('lights_job_personnel')
+                  const { error } = await dataLayerClient.from('lights_job_personnel')
                     .update({ lighting_designers: parseInt(e.target.value) })
                     .eq('id', personnel?.id);
                   
@@ -325,7 +332,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                       variant: "destructive",
                     });
                   }
-                  queryClient.invalidateQueries({ queryKey: ['lights-personnel', jobId] });
+                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('lights-personnel', jobId) });
                 }}
               />
             </div>
@@ -336,8 +343,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                 min="0"
                 value={personnel?.lighting_techs || 0}
                 onChange={async (e) => {
-                  const { error } = await supabase
-                    .from('lights_job_personnel')
+                  const { error } = await dataLayerClient.from('lights_job_personnel')
                     .update({ lighting_techs: parseInt(e.target.value) })
                     .eq('id', personnel?.id);
                   
@@ -348,7 +354,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                       variant: "destructive",
                     });
                   }
-                  queryClient.invalidateQueries({ queryKey: ['lights-personnel', jobId] });
+                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('lights-personnel', jobId) });
                 }}
               />
             </div>
@@ -359,8 +365,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                 min="0"
                 value={personnel?.spot_ops || 0}
                 onChange={async (e) => {
-                  const { error } = await supabase
-                    .from('lights_job_personnel')
+                  const { error } = await dataLayerClient.from('lights_job_personnel')
                     .update({ spot_ops: parseInt(e.target.value) })
                     .eq('id', personnel?.id);
                   
@@ -371,7 +376,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                       variant: "destructive",
                     });
                   }
-                  queryClient.invalidateQueries({ queryKey: ['lights-personnel', jobId] });
+                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('lights-personnel', jobId) });
                 }}
               />
             </div>
@@ -382,8 +387,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                 min="0"
                 value={personnel?.riggers || 0}
                 onChange={async (e) => {
-                  const { error } = await supabase
-                    .from('lights_job_personnel')
+                  const { error } = await dataLayerClient.from('lights_job_personnel')
                     .update({ riggers: parseInt(e.target.value) })
                     .eq('id', personnel?.id);
                   
@@ -394,7 +398,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                       variant: "destructive",
                     });
                   }
-                  queryClient.invalidateQueries({ queryKey: ['lights-personnel', jobId] });
+                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('lights-personnel', jobId) });
                 }}
               />
             </div>
@@ -437,8 +441,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                             value={task?.assigned_to?.id || ""}
                             onValueChange={async (value) => {
                               if (!task) {
-                                const { error } = await supabase
-                                  .from('lights_job_tasks')
+                                const { error } = await dataLayerClient.from('lights_job_tasks')
                                   .insert({
                                     job_id: jobId,
                                     task_type: taskType,
@@ -446,8 +449,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                                   });
                                 if (error) throw error;
                               } else {
-                                const { error } = await supabase
-                                  .from('lights_job_tasks')
+                                const { error } = await dataLayerClient.from('lights_job_tasks')
                                   .update({ assigned_to: value })
                                   .eq('id', task.id);
                                 if (error) throw error;
@@ -470,8 +472,8 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                         <TableCell>
                           {task && (
                             <Select
-                              value={task.status}
-                              onValueChange={(value) => updateTaskStatus(task.id, value)}
+                              value={task.status ?? 'not_started'}
+                              onValueChange={(value) => updateTaskStatus(task.id, value as TaskStatus)}
                             >
                               <SelectTrigger className="w-[120px]">
                                 <SelectValue />
@@ -488,10 +490,10 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                           {task && (
                             <div className="flex items-center gap-1">
                               <Progress 
-                                value={task.progress} 
-                                className={`h-2 ${getProgressColor(task.status)}`}
+                                value={task.progress || 0}
+                                className={`h-2 ${getProgressColor(task.status || 'not_started')}`}
                               />
-                              <span className="text-xs w-7">{task.progress}%</span>
+                              <span className="text-xs w-7">{task.progress || 0}%</span>
                             </div>
                           )}
                         </TableCell>

--- a/src/components/personal/VacationRequestHistory.tsx
+++ b/src/components/personal/VacationRequestHistory.tsx
@@ -9,7 +9,7 @@ import { History, CheckCircle, XCircle, Clock, Download, Send, CalendarDays, Che
 import { Button } from "@/components/ui/button";
 import { downloadVacationRequestPDF } from "@/utils/vacationRequestPdfExport";
 import type { VacationRequest } from "@/lib/vacation-requests";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Theme } from "@/components/technician/types";
@@ -33,10 +33,10 @@ export const VacationRequestHistory: React.FC<VacationRequestHistoryProps> = ({ 
   React.useEffect(() => {
     let cancelled = false;
     (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: { user } } = await dataLayerClient.auth.getUser();
       let role: string | null = (user?.app_metadata as any)?.role || (user?.user_metadata as any)?.role || null;
       if (!role && user?.id) {
-        const { data: prof } = await supabase.from('profiles').select('role').eq('id', user.id).maybeSingle();
+        const { data: prof } = await dataLayerClient.from('profiles').select('role').eq('id', user.id).maybeSingle();
         role = prof?.role ?? null;
       }
       if (!cancelled) setIsManager(isManagementRole(role));
@@ -55,7 +55,7 @@ export const VacationRequestHistory: React.FC<VacationRequestHistoryProps> = ({ 
   const handleResendEmail = async (request: VacationRequest) => {
     try {
       setSendingIds(prev => [...prev, request.id]);
-      const { error } = await supabase.functions.invoke('send-vacation-decision', {
+      const { error } = await dataLayerClient.functions.invoke('send-vacation-decision', {
         body: { request_id: request.id }
       });
       if (error) throw error;

--- a/src/components/personal/VacationRequestsTabs.tsx
+++ b/src/components/personal/VacationRequestsTabs.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useVacationRequests } from "@/hooks/useVacationRequests";
 import { format } from "date-fns";
@@ -109,8 +109,7 @@ export const VacationRequestsTabs: React.FC<VacationRequestsTabsProps> = ({
       try {
         const startRange = new Date(`${request.start_date}T00:00:00`);
         const endRange = new Date(`${request.end_date}T23:59:59.999`);
-        const { data, error } = await supabase
-          .from('job_assignments')
+        const { data, error } = await dataLayerClient.from('job_assignments')
           .select(`
             jobs!inner (
               id,

--- a/src/components/personal/hooks/usePersonalCalendarData.ts
+++ b/src/components/personal/hooks/usePersonalCalendarData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { startOfMonth, endOfMonth, subDays, addDays } from 'date-fns';
 
 export interface HouseTech {
@@ -57,8 +57,7 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
         const startDate = subDays(startOfMonth(currentMonth), 7);
         const endDate = addDays(endOfMonth(currentMonth), 7);
 
-        const { data: techsData, error: techsError } = await supabase
-          .from('profiles')
+        const { data: techsData, error: techsError } = await dataLayerClient.from('profiles')
           .select('id, first_name, last_name, department, phone')
           .eq('role', 'house_tech')
           .eq('warehouse_duty_exempt', false)
@@ -74,8 +73,7 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
 
         if (techIds.length > 0) {
           // Query timesheets as source of truth, joined with jobs for timeline info
-          const { data: timesheetData, error: timesheetsError } = await supabase
-            .from('timesheets')
+          const { data: timesheetData, error: timesheetsError } = await dataLayerClient.from('timesheets')
             .select(`
               technician_id,
               job_id,
@@ -159,8 +157,7 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
           if (baseAssignments.length > 0) {
             const jobIds = Array.from(new Set(baseAssignments.map((assignment) => assignment.job.id)));
             if (jobIds.length > 0) {
-              const { data: jobAssignmentData, error: jobAssignmentsError } = await supabase
-                .from('job_assignments')
+              const { data: jobAssignmentData, error: jobAssignmentsError } = await dataLayerClient.from('job_assignments')
                 .select(`
                   technician_id,
                   job_id,
@@ -215,8 +212,7 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
         let vacationResults: VacationPeriod[] = [];
 
         if (techIds.length > 0) {
-          const { data: vacationData, error: vacationError } = await supabase
-            .from('availability_schedules')
+          const { data: vacationData, error: vacationError } = await dataLayerClient.from('availability_schedules')
             .select('user_id, date, source, notes')
             .in('user_id', techIds)
             .eq('status', 'unavailable')
@@ -262,8 +258,7 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
 
     fetchData();
 
-    const timesheetChannel = supabase
-      .channel('personal-calendar-timesheets')
+    const timesheetChannel = dataLayerClient.channel('personal-calendar-timesheets')
       .on(
         'postgres_changes',
         {
@@ -278,8 +273,7 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
       )
       .subscribe();
 
-    const assignmentChannel = supabase
-      .channel('personal-calendar-job-assignments')
+    const assignmentChannel = dataLayerClient.channel('personal-calendar-job-assignments')
       .on(
         'postgres_changes',
         {
@@ -299,8 +293,8 @@ export const usePersonalCalendarData = (currentMonth: Date) => {
 
     return () => {
       isMounted = false;
-      supabase.removeChannel(timesheetChannel);
-      supabase.removeChannel(assignmentChannel);
+      dataLayerClient.removeChannel(timesheetChannel);
+      dataLayerClient.removeChannel(assignmentChannel);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [monthKey]); // Only refetch when the month changes, not every day selection

--- a/src/components/personal/hooks/useTechnicianAvailability.ts
+++ b/src/components/personal/hooks/useTechnicianAvailability.ts
@@ -1,18 +1,17 @@
 
 import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from 'react';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { format } from 'date-fns';
 import { useToast } from '@/hooks/use-toast';
 
 interface TechnicianAvailability {
-  id: string;
+  id: number;
   technician_id: string;
   date: string;
-  status: 'vacation' | 'travel' | 'sick' | 'day_off';
-  notes?: string;
-  created_at: string;
-  updated_at: string;
-  created_by?: string;
+  status: string;
+  created_at: string | null;
+  updated_at: string | null;
+  created_by: string | null;
 }
 
 interface AvailabilitySchedule {
@@ -29,6 +28,18 @@ interface AvailabilitySchedule {
 }
 
 type AvailabilityStatus = 'vacation' | 'travel' | 'sick' | 'day_off' | 'unavailable' | 'warehouse';
+
+const legacyAvailabilityStatuses = new Set<AvailabilityStatus>([
+  'vacation',
+  'travel',
+  'sick',
+  'day_off',
+  'unavailable',
+  'warehouse',
+]);
+
+const isAvailabilityStatus = (status: string): status is AvailabilityStatus =>
+  legacyAvailabilityStatuses.has(status as AvailabilityStatus);
 
 interface AvailabilityStore {
   data: Record<string, AvailabilityStatus>;
@@ -92,8 +103,7 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
         const endOfMonthFormatted = format(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0), 'yyyy-MM-dd');
 
         // Fetch technician_availability (legacy)
-        const { data: availabilityDataRaw, error: availabilityError } = await supabase
-          .from('technician_availability')
+        const { data: availabilityDataRaw, error: availabilityError } = await dataLayerClient.from('technician_availability')
           .select('*')
           .gte('date', startOfMonthFormatted)
           .lte('date', endOfMonthFormatted);
@@ -104,8 +114,7 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
         }
 
         // Fetch availability_schedules (new system with vacation integration)
-        const { data: schedulesData, error: schedulesError } = await supabase
-          .from('availability_schedules')
+        const { data: schedulesData, error: schedulesError } = await dataLayerClient.from('availability_schedules')
           .select('*')
           .gte('date', startOfMonthFormatted)
           .lte('date', endOfMonthFormatted);
@@ -123,7 +132,9 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
         // Process legacy technician_availability data
         availabilityDataRaw?.forEach((item: TechnicianAvailability) => {
           const key = `${item.technician_id}-${item.date}`;
-          availabilityMap[key] = item.status;
+          if (isAvailabilityStatus(item.status)) {
+            availabilityMap[key] = item.status;
+          }
         });
 
         // Process new availability_schedules data (includes vacation-based unavailability)
@@ -165,8 +176,7 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
     };
 
     // Set up real-time subscription for both tables
-    const availabilityChannel = supabase
-      .channel('technician-availability-updates')
+    const availabilityChannel = dataLayerClient.channel('technician-availability-updates')
       .on(
         'postgres_changes',
         {
@@ -181,8 +191,7 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
       )
       .subscribe();
 
-    const schedulesChannel = supabase
-      .channel('availability-schedules-updates')
+    const schedulesChannel = dataLayerClient.channel('availability-schedules-updates')
       .on(
         'postgres_changes',
         {
@@ -197,8 +206,7 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
       )
       .subscribe();
 
-    const vacationRequestsChannel = supabase
-      .channel('vacation-requests-updates')
+    const vacationRequestsChannel = dataLayerClient.channel('vacation-requests-updates')
       .on(
         'postgres_changes',
         {
@@ -215,9 +223,9 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
 
     return () => {
       clearTimeout(refetchTimeout);
-      supabase.removeChannel(availabilityChannel);
-      supabase.removeChannel(schedulesChannel);
-      supabase.removeChannel(vacationRequestsChannel);
+      dataLayerClient.removeChannel(availabilityChannel);
+      dataLayerClient.removeChannel(schedulesChannel);
+      dataLayerClient.removeChannel(vacationRequestsChannel);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [monthKey]); // Only refetch when month boundary changes
@@ -232,14 +240,12 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
       // Handle warehouse status by inserting into availability_schedules
       if (status === 'warehouse') {
         // Get user's department
-        const { data: profile } = await supabase
-          .from('profiles')
+        const { data: profile } = await dataLayerClient.from('profiles')
           .select('department')
           .eq('id', techId)
           .single();
 
-        const { error: scheduleError } = await supabase
-          .from('availability_schedules')
+        const { error: scheduleError } = await dataLayerClient.from('availability_schedules')
           .upsert({
             user_id: techId,
             department: profile?.department || 'unknown',
@@ -263,13 +269,12 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
         }
       } else {
         // Handle other statuses with legacy table
-        const { error } = await supabase
-          .from('technician_availability')
+        const { error } = await dataLayerClient.from('technician_availability')
           .upsert({
             technician_id: techId,
             date: dateStr,
             status,
-            created_by: (await supabase.auth.getUser()).data.user?.id
+            created_by: (await dataLayerClient.auth.getUser()).data.user?.id
           }, {
             onConflict: 'technician_id,date'
           });
@@ -313,14 +318,12 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
       // No optimistic update here - handled in HouseTechBadge component
 
       // Remove from both tables to ensure cleanup
-      const { error: legacyError } = await supabase
-        .from('technician_availability')
+      const { error: legacyError } = await dataLayerClient.from('technician_availability')
         .delete()
         .eq('technician_id', techId)
         .eq('date', dateStr);
 
-      const { error: scheduleError } = await supabase
-        .from('availability_schedules')
+      const { error: scheduleError } = await dataLayerClient.from('availability_schedules')
         .delete()
         .eq('user_id', techId)
         .eq('date', dateStr)

--- a/src/components/profile/ProfilePictureUpload.tsx
+++ b/src/components/profile/ProfilePictureUpload.tsx
@@ -3,7 +3,7 @@ import { Camera, Upload, X, Loader2 } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import {
   optimizeProfilePicture,
   validateImageFile,
@@ -89,12 +89,12 @@ export function ProfilePictureUpload({
       if (previewUrl && previewUrl.includes('/profile-pictures/')) {
         const oldPath = previewUrl.split('/profile-pictures/')[1];
         if (oldPath) {
-          await supabase.storage.from('profile-pictures').remove([oldPath]);
+          await dataLayerClient.storage.from('profile-pictures').remove([oldPath]);
         }
       }
 
       // Upload to storage
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from('profile-pictures')
         .upload(fileName, optimizedFile, {
           cacheControl: '3600',
@@ -110,8 +110,7 @@ export function ProfilePictureUpload({
       const publicUrl = getProfilePictureUrl(supabaseUrl, fileName);
 
       // Update profile in database
-      const { error: updateError } = await supabase
-        .from('profiles')
+      const { error: updateError } = await dataLayerClient.from('profiles')
         .update({ profile_picture_url: publicUrl })
         .eq('id', userId);
 
@@ -154,7 +153,7 @@ export function ProfilePictureUpload({
       // Delete from storage
       const filePath = previewUrl.split('/profile-pictures/')[1];
       if (filePath) {
-        const { error: deleteError } = await supabase.storage
+        const { error: deleteError } = await dataLayerClient.storage
           .from('profile-pictures')
           .remove([filePath]);
 
@@ -164,8 +163,7 @@ export function ProfilePictureUpload({
       }
 
       // Update profile in database
-      const { error: updateError } = await supabase
-        .from('profiles')
+      const { error: updateError } = await dataLayerClient.from('profiles')
         .update({ profile_picture_url: null })
         .eq('id', userId);
 

--- a/src/components/profile/ProfileSkillsEditor.tsx
+++ b/src/components/profile/ProfileSkillsEditor.tsx
@@ -7,8 +7,7 @@ import { Slider } from '@/components/ui/slider';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import { Plus, X } from 'lucide-react';
-import { supabase } from '@/lib/supabase';
-
+import { dataLayerClient } from '@/services/dataLayerClient';
 type Skill = { id: string; name: string; category: string | null };
 type ProfileSkill = { id: string; skill_id: string; name: string; category: string | null; proficiency: number | null; is_primary: boolean };
 
@@ -27,13 +26,13 @@ export const ProfileSkillsEditor: React.FC<ProfileSkillsEditorProps> = ({ profil
   const load = React.useCallback(async () => {
     setLoading(true);
     const [sres, psres, pres] = await Promise.all([
-      supabase.from('skills').select('id,name,category').eq('active', true).order('category').order('name'),
-      supabase.from('profile_skills')
+      dataLayerClient.from('skills').select('id,name,category').eq('active', true).order('category').order('name'),
+      dataLayerClient.from('profile_skills')
         .select('id,skill_id,proficiency,is_primary,skills:skill_id(name,category)')
         .eq('profile_id', profileId)
         .order('is_primary', { ascending: false })
         .order('proficiency', { ascending: false }),
-      supabase.from('profiles').select('department').eq('id', profileId).maybeSingle()
+      dataLayerClient.from('profiles').select('department').eq('id', profileId).maybeSingle()
     ]);
     if (!sres.error) setAllSkills(sres.data || []);
     if (!psres.error) {
@@ -63,8 +62,7 @@ export const ProfileSkillsEditor: React.FC<ProfileSkillsEditorProps> = ({ profil
   }, [availableAll, profileDepartment]);
 
   const addSkill = async (skill: Skill) => {
-    const { data, error } = await supabase
-      .from('profile_skills')
+    const { data, error } = await dataLayerClient.from('profile_skills')
       .insert({ profile_id: profileId, skill_id: skill.id, proficiency: 3, is_primary: false })
       .select('id')
       .maybeSingle();
@@ -75,8 +73,7 @@ export const ProfileSkillsEditor: React.FC<ProfileSkillsEditorProps> = ({ profil
   };
 
   const updateSkill = async (ps: ProfileSkill, patch: Partial<ProfileSkill>) => {
-    const { error } = await supabase
-      .from('profile_skills')
+    const { error } = await dataLayerClient.from('profile_skills')
       .update({
         proficiency: patch.proficiency ?? ps.proficiency,
         is_primary: patch.is_primary ?? ps.is_primary,
@@ -88,7 +85,7 @@ export const ProfileSkillsEditor: React.FC<ProfileSkillsEditorProps> = ({ profil
   };
 
   const removeSkill = async (ps: ProfileSkill) => {
-    const { error } = await supabase.from('profile_skills').delete().eq('id', ps.id);
+    const { error } = await dataLayerClient.from('profile_skills').delete().eq('id', ps.id);
     if (!error) setProfileSkills(prev => prev.filter(x => x.id !== ps.id));
   };
 

--- a/src/components/project-management/apiService.test.ts
+++ b/src/components/project-management/apiService.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { getElementTree, ElementTreeNode } from "./apiService";
-import { supabase } from "@/integrations/supabase/client";
-
-vi.mock("@/integrations/supabase/client", () => ({
-  supabase: {
+import { dataLayerClient } from "@/services/dataLayerClient";
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: {
     functions: {
       invoke: vi.fn(),
     },
@@ -22,7 +21,7 @@ describe("getElementTree", () => {
   });
 
   it("should throw error when auth token retrieval fails", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValueOnce({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValueOnce({
       data: { X_AUTH_TOKEN: null },
       error: { message: "Failed to get secret" } as any,
     } as any);
@@ -33,7 +32,7 @@ describe("getElementTree", () => {
   });
 
   it("should fetch element tree successfully with happy path data", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });
@@ -82,7 +81,7 @@ describe("getElementTree", () => {
   });
 
   it("should return empty array when API returns non-array data", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });
@@ -103,7 +102,7 @@ describe("getElementTree", () => {
   });
 
   it("should handle empty tree response", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });
@@ -120,7 +119,7 @@ describe("getElementTree", () => {
   });
 
   it("should throw error on 404 response", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });
@@ -138,7 +137,7 @@ describe("getElementTree", () => {
   });
 
   it("should throw error on 500 response", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });
@@ -156,7 +155,7 @@ describe("getElementTree", () => {
   });
 
   it("should throw error on 401 unauthorized response", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });
@@ -174,7 +173,7 @@ describe("getElementTree", () => {
   });
 
   it("should handle network errors gracefully", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });
@@ -187,7 +186,7 @@ describe("getElementTree", () => {
   });
 
   it("should handle complex nested tree structures", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });
@@ -245,7 +244,7 @@ describe("getElementTree", () => {
   });
 
   it("should make multiple fetch calls with the same auth token", async () => {
-    vi.mocked(supabase.functions.invoke).mockResolvedValue({
+    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
       data: { X_AUTH_TOKEN: "test-token" },
       error: null,
     });

--- a/src/components/project-management/apiService.ts
+++ b/src/components/project-management/apiService.ts
@@ -1,5 +1,4 @@
-import { supabase } from "@/integrations/supabase/client";
-
+import { dataLayerClient } from "@/services/dataLayerClient";
 export interface CreateLaborPORequest {
   name: string;
   plannedStartDate: string;
@@ -104,8 +103,7 @@ let cachedToken: string | null = null;
 const getAuthToken = async () => {
   if (cachedToken) return cachedToken;
   
-  const { data: { X_AUTH_TOKEN }, error } = await supabase
-    .functions.invoke('get-secret', {
+  const { data: { X_AUTH_TOKEN }, error } = await dataLayerClient.functions.invoke('get-secret', {
       body: { secretName: 'X_AUTH_TOKEN' }
     });
     

--- a/src/components/settings/HouseTechRateEditor.tsx
+++ b/src/components/settings/HouseTechRateEditor.tsx
@@ -8,8 +8,8 @@ import { Badge } from '@/components/ui/badge';
 import { Euro, Info, Save } from 'lucide-react';
 import { useHouseTechRate, useSaveHouseTechRate, useLogRateActivity } from '@/hooks/useHouseTechRates';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
-
+import { dataLayerClient } from '@/services/dataLayerClient';
+import { queryKeys } from "@/lib/react-query";
 interface HouseTechRateEditorProps {
   profileId: string;
   profileName: string;
@@ -47,10 +47,9 @@ export function HouseTechRateEditor({ profileId, profileName, category = 'tecnic
 
   // Get category defaults for context
   const { data: categoryDefaultsMap } = useQuery({
-    queryKey: ['rate-card-defaults', 'tecnico-especialista-responsable'],
+    queryKey: queryKeys.scope('rate-card-defaults', 'tecnico-especialista-responsable'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('rate_cards_2025')
+      const { data, error } = await dataLayerClient.from('rate_cards_2025')
         .select('category, base_day_eur, plus_10_12_eur, overtime_hour_eur')
         .in('category', RATE_CATEGORIES);
 

--- a/src/components/settings/PushNotificationMatrix.tsx
+++ b/src/components/settings/PushNotificationMatrix.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { toast } from '@/hooks/use-toast';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -245,7 +245,7 @@ export function PushNotificationMatrix() {
     try {
       if (next) {
         // create if not present
-        const { error } = await supabase.from('push_notification_routes').insert({
+        const { error } = await dataLayerClient.from('push_notification_routes').insert({
           event_code: ev,
           recipient_type: type,
           target_id: target,
@@ -255,8 +255,7 @@ export function PushNotificationMatrix() {
         toast({ title: 'Saved', description: 'Routing updated.' });
       } else {
         // delete matching rows
-        let q = supabase
-          .from('push_notification_routes')
+        let q = dataLayerClient.from('push_notification_routes')
           .delete()
           .eq('event_code', ev)
           .eq('recipient_type', type);
@@ -287,7 +286,7 @@ export function PushNotificationMatrix() {
 
     try {
       if (next) {
-        const { error } = await supabase.from('push_notification_routes').insert({
+        const { error } = await dataLayerClient.from('push_notification_routes').insert({
           event_code: ev,
           recipient_type: 'natural',
           target_id: null,
@@ -297,15 +296,13 @@ export function PushNotificationMatrix() {
         toast({ title: 'Enabled', description: 'Natural recipients will be included.' });
       } else {
         // remove any 'natural' rows and also clear include_natural flags on other rows for this event
-        const { error: delErr } = await supabase
-          .from('push_notification_routes')
+        const { error: delErr } = await dataLayerClient.from('push_notification_routes')
           .delete()
           .eq('event_code', ev)
           .eq('recipient_type', 'natural');
         if (delErr) throw delErr;
         // best-effort: set include_natural_recipients=false on remaining rows
-        await supabase
-          .from('push_notification_routes')
+        await dataLayerClient.from('push_notification_routes')
           .update({ include_natural_recipients: false })
           .eq('event_code', ev);
         toast({ title: 'Disabled', description: 'Natural recipients excluded for this event.' });
@@ -322,16 +319,13 @@ export function PushNotificationMatrix() {
     setRefreshing(true);
     try {
       const [usersRes, eventsRes, routesRes] = await Promise.all([
-        supabase
-          .from('profiles')
+        dataLayerClient.from('profiles')
           .select('id, first_name, last_name, nickname, email, department, role')
           .in('role', ['admin', 'management', 'oscar']),
-        supabase
-          .from('activity_catalog')
+        dataLayerClient.from('activity_catalog')
           .select('code, label')
           .order('code', { ascending: true }),
-        supabase
-          .from('push_notification_routes')
+        dataLayerClient.from('push_notification_routes')
           .select('id, event_code, recipient_type, target_id, include_natural_recipients'),
       ]);
 

--- a/src/components/sound/AmplifierTool.tsx
+++ b/src/components/sound/AmplifierTool.tsx
@@ -9,7 +9,7 @@ import { FileText } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { generateAmplifierPdf } from "@/utils/amplifierCalculationPdf";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useQueryClient } from "@tanstack/react-query";
 import { soundComponentDatabase, sectionSpeakers, speakerAmplifierConfig, isTFSpeaker } from "./amplifier-tool/constants";
 import type { AmplifierResults, SpeakerConfig, SpeakerSection } from "./amplifier-tool/types";
@@ -55,8 +55,7 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
     const loadPresets = async () => {
       setIsLoadingPresets(true);
       try {
-        const { data, error } = await supabase
-          .from('presets')
+        const { data, error } = await dataLayerClient.from('presets')
           .select('id, name')
           .eq('department', 'sound')
           .order('name');
@@ -85,8 +84,7 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
     const loadAmpEquipment = async () => {
       setIsLoadingAmpOptions(true);
       try {
-        const { data, error } = await supabase
-          .from('equipment')
+        const { data, error } = await dataLayerClient.from('equipment')
           .select('id, name, category')
           .eq('department', 'sound')
           .in('category', ['pa_amp', 'amplificacion']);
@@ -127,8 +125,7 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
 
     const loadSpeakerEquipment = async () => {
       try {
-        const { data, error } = await supabase
-          .from('equipment')
+        const { data, error } = await dataLayerClient.from('equipment')
           .select('id, name')
           .eq('department', 'sound');
 
@@ -415,7 +412,7 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
   };
 
   const cleanupNewlyCreatedPreset = async (presetId: string) => {
-    await supabase.from('presets').delete().eq('id', presetId);
+    await dataLayerClient.from('presets').delete().eq('id', presetId);
     setPresetOptions(prev => prev.filter(p => p.id !== presetId));
     setSelectedPresetId('');
     setCreateNewPreset(false);
@@ -496,13 +493,12 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
 
       // Create new preset if in create mode
       if (createNewPreset) {
-        const { data: session, error: sessionError } = await supabase.auth.getSession();
+        const { data: session, error: sessionError } = await dataLayerClient.auth.getSession();
         if (sessionError || !session?.session?.user?.id) {
           throw new Error('Usuario no autenticado');
         }
 
-        const { data: newPreset, error: createError } = await supabase
-          .from('presets')
+        const { data: newPreset, error: createError } = await dataLayerClient.from('presets')
           .insert({
             name: newPresetName.trim(),
             created_by: session.session.user.id,
@@ -525,8 +521,7 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
         setNewPresetName('');
 
         // Refresh preset list
-        const { data: updatedPresets } = await supabase
-          .from('presets')
+        const { data: updatedPresets } = await dataLayerClient.from('presets')
           .select('id, name')
           .eq('department', 'sound')
           .order('name');
@@ -535,8 +530,7 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
         }
       }
 
-      const { data: previousItems, error: fetchError } = await supabase
-        .from('preset_items')
+      const { data: previousItems, error: fetchError } = await dataLayerClient.from('preset_items')
         .select('preset_id, equipment_id, quantity, subsystem, source, notes')
         .eq('preset_id', targetPresetId)
         .eq('source', 'amp_calculator');
@@ -549,8 +543,7 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
         throw fetchError;
       }
 
-      const { error: deleteError } = await supabase
-        .from('preset_items')
+      const { error: deleteError } = await dataLayerClient.from('preset_items')
         .delete()
         .eq('preset_id', targetPresetId)
         .eq('source', 'amp_calculator');
@@ -641,13 +634,13 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
       }
 
       if (itemsToInsert.length > 0) {
-        const { error: insertError } = await supabase.from('preset_items').insert(itemsToInsert);
+        const { error: insertError } = await dataLayerClient.from('preset_items').insert(itemsToInsert);
         if (insertError) {
           let errorMessage = 'No se pudieron guardar los items en el preset.';
 
           // Attempt to restore previous items to avoid losing data
           if (previousItems && previousItems.length > 0) {
-            const { error: restoreError } = await supabase.from('preset_items').insert(
+            const { error: restoreError } = await dataLayerClient.from('preset_items').insert(
               previousItems.map((item) => ({
                 preset_id: item.preset_id,
                 equipment_id: item.equipment_id,

--- a/src/components/sound/MemoriaTecnica.tsx
+++ b/src/components/sound/MemoriaTecnica.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Upload, File, FilePlus, FileCheck, Loader2, Image as ImageIcon, Download } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -127,12 +127,12 @@ export const MemoriaTecnica = () => {
     let lastErr: Error | null = null;
     for (const bucket of STORAGE_BUCKET_CANDIDATES) {
       try {
-        const { error: uploadError } = await supabase.storage
+        const { error: uploadError } = await dataLayerClient.storage
           .from(bucket)
           .upload(safePath, file, { upsert: true });
         if (uploadError) throw uploadError;
 
-        const { data: signedUrlData, error: signUrlError } = await supabase.storage
+        const { data: signedUrlData, error: signUrlError } = await dataLayerClient.storage
           .from(bucket)
           .createSignedUrl(safePath, 3600);
         if (signUrlError) throw signUrlError;
@@ -219,7 +219,7 @@ export const MemoriaTecnica = () => {
 
       setProgress(60);
 
-      const response = await supabase.functions.invoke('generate-memoria-tecnica', {
+      const response = await dataLayerClient.functions.invoke('generate-memoria-tecnica', {
         body: { documentUrls, projectName, logoUrl, expiresIn: 3600 }
       });
 
@@ -230,8 +230,7 @@ export const MemoriaTecnica = () => {
 
       setProgress(80);
 
-      const { error: dbError } = await supabase
-        .from('memoria_tecnica_documents')
+      const { error: dbError } = await dataLayerClient.from('memoria_tecnica_documents')
         .insert({
           project_name: projectName,
           logo_url: logoUrl,

--- a/src/components/sound/SoundTaskDialog.tsx
+++ b/src/components/sound/SoundTaskDialog.tsx
@@ -19,7 +19,7 @@ import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { Upload, Download, Trash2, Table, X } from "lucide-react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { useState, useEffect } from "react";
 import { TASK_TYPES } from "@/constants/taskTypes";
@@ -32,6 +32,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface SoundTaskDialogProps {
   jobId: string;
   open: boolean;
@@ -73,11 +75,10 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
 
   // Fetch jobDetails from jobs table
   const { data: jobData } = useQuery({
-    queryKey: ['job-details', jobId],
+    queryKey: queryKeys.scope('job-details', jobId),
     queryFn: async () => {
       if (!jobId) return null;
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('*')
         .eq('id', jobId)
         .single();
@@ -95,11 +96,10 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
 
   // Fetch personnel details from sound_job_personnel table
   const { data: personnelData } = useQuery({
-    queryKey: ['job-personnel', jobId],
+    queryKey: queryKeys.scope('job-personnel', jobId),
     queryFn: async () => {
       if (!jobId) return null;
-      const { data, error } = await supabase
-        .from('sound_job_personnel')
+      const { data, error } = await dataLayerClient.from('sound_job_personnel')
         .select('*')
         .eq('job_id', jobId)
         .single();
@@ -121,10 +121,9 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
   }, [personnelData]);
 
   const { data: managementUsers } = useQuery({
-    queryKey: ['management-users'],
+    queryKey: queryKeys.scope('management-users'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name')
         .in('role', ['management', 'admin', 'oscar']);
       if (error) throw error;
@@ -133,14 +132,13 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
   });
 
   const { data: tasks, refetch: refetchTasks } = useQuery({
-    queryKey: ['sound-tasks', jobId],
+    queryKey: queryKeys.scope('sound-tasks', jobId),
     queryFn: async () => {
       if (!jobId) return null;
-      const { data, error } = await supabase
-        .from('sound_job_tasks')
+      const { data, error } = await dataLayerClient.from('sound_job_tasks')
         .select(`
           *,
-          assigned_to (
+          assigned_to:profiles!sound_job_tasks_assigned_to_fkey (
             id,
             first_name,
             last_name
@@ -149,15 +147,14 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
         `)
         .eq('job_id', jobId);
       if (error) throw error;
-      return data as Task[];
+      return data as unknown as Task[];
     },
     enabled: !!jobId
   });
 
   const updateFolderStatusMutation = useMutation({
     mutationFn: async () => {
-      const { error } = await supabase
-        .from('jobs')
+      const { error } = await dataLayerClient.from('jobs')
         .update({ flex_folders_created: true })
         .eq('id', jobId);
       if (error) throw error;
@@ -189,7 +186,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
         description: "Flex folders have been created successfully.",
       });
 
-      queryClient.invalidateQueries({ queryKey: ['job-details', jobId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-details', jobId) });
 
     } catch (error: any) {
       console.error('Error creating folders:', error);
@@ -208,7 +205,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
       const timestamp = new Date().getTime();
       const filePath = `${taskId}/${timestamp}_${sanitizedFileName}`;
 
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from('task_documents')
         .upload(filePath, file, {
           cacheControl: '3600',
@@ -216,18 +213,16 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
         });
       if (uploadError) throw uploadError;
 
-      const { error: dbError } = await supabase
-        .from('task_documents')
+      const { error: dbError } = await dataLayerClient.from('task_documents')
         .insert({
           sound_task_id: taskId,
           file_name: file.name,
           file_path: filePath,
-          uploaded_by: (await supabase.auth.getUser()).data.user?.id
+          uploaded_by: (await dataLayerClient.auth.getUser()).data.user?.id
         });
       if (dbError) throw dbError;
 
-      await supabase
-        .from('sound_job_tasks')
+      await dataLayerClient.from('sound_job_tasks')
         .update({ 
           status: 'completed',
           progress: 100,
@@ -254,19 +249,17 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
 
   const handleDeleteFile = async (taskId: string, docId: string, filePath: string) => {
     try {
-      const { error: storageError } = await supabase.storage
+      const { error: storageError } = await dataLayerClient.storage
         .from('task_documents')
         .remove([filePath]);
       if (storageError) throw storageError;
 
-      const { error: dbError } = await supabase
-        .from('task_documents')
+      const { error: dbError } = await dataLayerClient.from('task_documents')
         .delete()
         .eq('id', docId);
       if (dbError) throw dbError;
 
-      await supabase
-        .from('sound_job_tasks')
+      await dataLayerClient.from('sound_job_tasks')
         .update({ 
           status: 'in_progress',
           progress: 50 
@@ -294,8 +287,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
 
   const updatePersonnelField = async (field: string, value: number) => {
     try {
-      const { error } = await supabase
-        .from('sound_job_personnel')
+      const { error } = await dataLayerClient.from('sound_job_personnel')
         .update({ [field]: value })
         .eq('job_id', jobId);
       if (error) throw error;
@@ -330,11 +322,10 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
     }
   };
 
-  const updateTaskStatus = async (taskId: string, status: string) => {
+  const updateTaskStatus = async (taskId: string, status: Task['status']) => {
     try {
       const progress = status === 'completed' ? 100 : status === 'in_progress' ? 50 : 0;
-      const { error } = await supabase
-        .from('sound_job_tasks')
+      const { error } = await dataLayerClient.from('sound_job_tasks')
         .update({ 
           status,
           progress,
@@ -358,7 +349,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
 
   const handleDownload = async (filePath: string, fileName: string) => {
     try {
-      const { data, error } = await supabase.storage
+      const { data, error } = await dataLayerClient.storage
         .from('task_documents')
         .download(filePath);
       if (error) throw error;
@@ -502,8 +493,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
                               value={task?.assigned_to?.id || ""}
                               onValueChange={async (value) => {
                                 if (!task) {
-                                  const { error } = await supabase
-                                    .from('sound_job_tasks')
+                                  const { error } = await dataLayerClient.from('sound_job_tasks')
                                     .insert({
                                       job_id: jobId,
                                       task_type: taskType,
@@ -511,8 +501,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
                                     });
                                   if (error) throw error;
                                 } else {
-                                  const { error } = await supabase
-                                    .from('sound_job_tasks')
+                                  const { error } = await dataLayerClient.from('sound_job_tasks')
                                     .update({ assigned_to: value })
                                     .eq('id', task.id);
                                   if (error) throw error;
@@ -536,7 +525,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
                             {task && (
                               <Select
                                 value={task.status}
-                                onValueChange={(value) => updateTaskStatus(task.id, value)}
+                                onValueChange={(value) => updateTaskStatus(task.id, value as Task['status'])}
                               >
                                 <SelectTrigger className="w-[120px]">
                                   <SelectValue />

--- a/src/components/soundvision/SoundVisionDatabaseDialog.tsx
+++ b/src/components/soundvision/SoundVisionDatabaseDialog.tsx
@@ -7,6 +7,8 @@ import { useSoundVisionFiles } from '@/hooks/useSoundVisionFiles';
 import { Loader2 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 
+
+import { queryKeys } from "@/lib/react-query";
 export const SoundVisionDatabaseDialog = () => {
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState('browse');
@@ -34,8 +36,8 @@ export const SoundVisionDatabaseDialog = () => {
 
   const handleUploadComplete = async () => {
     // Wait for queries to refresh before switching tabs
-    await queryClient.invalidateQueries({ queryKey: ['soundvision-files'] });
-    await queryClient.refetchQueries({ queryKey: ['soundvision-files'] });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.scope('soundvision-files') });
+    await queryClient.refetchQueries({ queryKey: queryKeys.scope('soundvision-files') });
     
     // Small delay to ensure UI updates
     setTimeout(() => {

--- a/src/components/soundvision/SoundVisionFilesList.tsx
+++ b/src/components/soundvision/SoundVisionFilesList.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useDeleteSoundVisionFile, useDownloadSoundVisionFile, SoundVisionFile } from '@/hooks/useSoundVisionFiles';
 import { canDeleteSoundVisionFiles, isManagementRole } from '@/utils/permissions';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { formatDistanceToNow } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -29,6 +29,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { StarRating } from './StarRating';
 import { SoundVisionReviewDialog } from './SoundVisionReviewDialog';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface SoundVisionFilesListProps {
   files: SoundVisionFile[];
 }
@@ -38,13 +40,12 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
   const [selectedFile, setSelectedFile] = useState<SoundVisionFile | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const { data: profile } = useQuery({
-    queryKey: ['current-user-profile'],
+    queryKey: queryKeys.scope('current-user-profile'),
     queryFn: async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: { user } } = await dataLayerClient.auth.getUser();
       if (!user) return null;
       
-      const { data } = await supabase
-        .from('profiles')
+      const { data } = await dataLayerClient.from('profiles')
         .select('role')
         .eq('id', user.id)
         .single();
@@ -72,8 +73,8 @@ export const SoundVisionFilesList = ({ files }: SoundVisionFilesListProps) => {
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
-    await queryClient.invalidateQueries({ queryKey: ['soundvision-files'] });
-    await queryClient.refetchQueries({ queryKey: ['soundvision-files'] });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.scope('soundvision-files') });
+    await queryClient.refetchQueries({ queryKey: queryKeys.scope('soundvision-files') });
     setTimeout(() => setIsRefreshing(false), 500);
   };
 

--- a/src/components/soundvision/SoundVisionInteractiveMap.tsx
+++ b/src/components/soundvision/SoundVisionInteractiveMap.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { createQueryKey } from '@/lib/optimized-react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import {
     Loader2,
     Search,
@@ -44,6 +44,8 @@ import type { Map as MapboxMap } from 'mapbox-gl';
 import { Theme } from '@/components/technician/types';
 import { isManagementRole } from '@/utils/permissions';
 
+
+import { queryKeys } from "@/lib/react-query";
 export interface SoundVisionInteractiveMapProps {
     theme: Theme;
     isDark: boolean;
@@ -96,10 +98,9 @@ export const SoundVisionInteractiveMap = ({ theme, isDark, onClose }: SoundVisio
     const { data: profile } = useQuery({
         queryKey: createQueryKey.profiles.currentUser,
         queryFn: async () => {
-            const { data: { user } } = await supabase.auth.getUser();
+            const { data: { user } } = await dataLayerClient.auth.getUser();
             if (!user) return null;
-            const { data } = await supabase
-                .from('profiles')
+            const { data } = await dataLayerClient.from('profiles')
                 .select('role')
                 .eq('id', user.id)
                 .single();
@@ -489,7 +490,7 @@ export const SoundVisionInteractiveMap = ({ theme, isDark, onClose }: SoundVisio
                 setMapLoading(true);
                 setMapError(null);
 
-                const { data, error: tokenError } = await supabase.functions.invoke('get-mapbox-token');
+                const { data, error: tokenError } = await dataLayerClient.functions.invoke('get-mapbox-token');
 
                 if (tokenError) {
                     throw new Error(`Error al obtener el token de Mapbox: ${tokenError.message}`);
@@ -833,8 +834,8 @@ export const SoundVisionInteractiveMap = ({ theme, isDark, onClose }: SoundVisio
 
     const handleUploadComplete = async () => {
         // Refresh file list + venues so filters/markers update.
-        await queryClient.invalidateQueries({ queryKey: ['soundvision-files'] });
-        await queryClient.invalidateQueries({ queryKey: ['venues'] });
+        await queryClient.invalidateQueries({ queryKey: queryKeys.scope('soundvision-files') });
+        await queryClient.invalidateQueries({ queryKey: queryKeys.scope('venues') });
         await refetch();
         setUploadOpen(false);
     };

--- a/src/components/soundvision/SoundVisionMap.tsx
+++ b/src/components/soundvision/SoundVisionMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Map as MapboxMap, Marker as MapboxMarker } from 'mapbox-gl';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 import type { SoundVisionFile } from '@/hooks/useSoundVisionFiles';
@@ -47,7 +47,7 @@ export const SoundVisionMap = ({ files }: SoundVisionMapProps) => {
         if (!isMounted) return;
         mapboxglRef.current = mapboxgl;
 
-        const { data, error: tokenError } = await supabase.functions.invoke('get-mapbox-token');
+        const { data, error: tokenError } = await dataLayerClient.functions.invoke('get-mapbox-token');
 
         if (tokenError) {
           console.error('Token fetch error:', tokenError);

--- a/src/components/tasks/CreateGlobalTaskDialog.tsx
+++ b/src/components/tasks/CreateGlobalTaskDialog.tsx
@@ -8,12 +8,14 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Combobox, ComboboxGroup } from '@/components/ui/combobox';
 import { useGlobalTaskMutations } from '@/hooks/useGlobalTaskMutations';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useQuery } from '@tanstack/react-query';
 import { fromZonedTime } from 'date-fns-tz';
 import { type Dept } from '@/utils/tasks';
 import { TASK_TYPES } from '@/constants/taskTypes';
 
+
+import { queryKeys } from "@/lib/react-query";
 const ASSIGN_ALL_DEPARTMENT = '__all_department__';
 const ASSIGN_ALL_DEPARTMENT_HOUSE_TECH = '__all_department_house_tech__';
 const ASSIGN_SELECTED_DEPARTMENTS = '__selected_departments__';
@@ -66,10 +68,9 @@ export const CreateGlobalTaskDialog: React.FC<CreateGlobalTaskDialogProps> = ({
 
   // All eligible users, grouped by department-first vs others
   const { data: usersData } = useQuery<{ groups: ComboboxGroup[]; users: EligibleUser[] }>({
-    queryKey: ['assignable-users-grouped', userDepartment],
+    queryKey: queryKeys.scope('assignable-users-grouped', userDepartment),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name, role, department')
         .order('first_name');
       if (error) throw error;
@@ -94,10 +95,9 @@ export const CreateGlobalTaskDialog: React.FC<CreateGlobalTaskDialogProps> = ({
   const eligibleUsers = usersData?.users || [];
 
   const { data: departmentUsers } = useQuery<Array<{ id: string; role: string | null }>>({
-    queryKey: ['department-users-global-task', department],
+    queryKey: queryKeys.scope('department-users-global-task', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, role')
         .eq('department', department);
       if (error) throw error;
@@ -106,10 +106,9 @@ export const CreateGlobalTaskDialog: React.FC<CreateGlobalTaskDialogProps> = ({
   });
 
   const { data: jobItems } = useQuery({
-    queryKey: ['jobs-for-linking'],
+    queryKey: queryKeys.scope('jobs-for-linking'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('id, title')
         .in('status', ['Tentativa', 'Confirmado'])
         .order('start_time', { ascending: false })
@@ -120,10 +119,9 @@ export const CreateGlobalTaskDialog: React.FC<CreateGlobalTaskDialogProps> = ({
   });
 
   const { data: tourItems } = useQuery({
-    queryKey: ['tours-for-linking'],
+    queryKey: queryKeys.scope('tours-for-linking'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('tours')
+      const { data, error } = await dataLayerClient.from('tours')
         .select('id, name')
         .order('created_at', { ascending: false })
         .limit(200);

--- a/src/components/tasks/LinkJobDialog.tsx
+++ b/src/components/tasks/LinkJobDialog.tsx
@@ -6,10 +6,12 @@ import { Label } from '@/components/ui/label';
 import { Combobox } from '@/components/ui/combobox';
 import { useGlobalTaskMutations } from '@/hooks/useGlobalTaskMutations';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useQuery } from '@tanstack/react-query';
 import { getErrorMessage } from '@/utils/errorMessage';
 
+
+import { queryKeys } from "@/lib/react-query";
 type Dept = 'sound' | 'lights' | 'video' | 'production' | 'administrative';
 
 interface LinkJobDialogProps {
@@ -46,10 +48,9 @@ export const LinkJobDialog: React.FC<LinkJobDialogProps> = ({
   }, [open, currentJobId, currentTourId]);
 
   const { data: jobItems } = useQuery({
-    queryKey: ['jobs-for-linking'],
+    queryKey: queryKeys.scope('jobs-for-linking'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('id, title')
         .in('status', ['Tentativa', 'Confirmado'])
         .order('start_time', { ascending: false })
@@ -60,10 +61,9 @@ export const LinkJobDialog: React.FC<LinkJobDialogProps> = ({
   });
 
   const { data: tourItems } = useQuery({
-    queryKey: ['tours-for-linking'],
+    queryKey: queryKeys.scope('tours-for-linking'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('tours')
+      const { data, error } = await dataLayerClient.from('tours')
         .select('id, name')
         .order('created_at', { ascending: false })
         .limit(200);

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -8,10 +8,12 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Progress } from '@/components/ui/progress';
 import { Upload, Download, Trash2, Plus } from 'lucide-react';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useQuery } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
 import { TASK_TYPES } from '@/constants/taskTypes';
+
+import { queryKeys } from "@/lib/react-query";
 const DEPARTMENT_NAME: Record<'sound' | 'lights' | 'video', string> = {
   sound: 'sonido',
   lights: 'luces',
@@ -54,7 +56,7 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
 
   React.useEffect(() => {
     (async () => {
-      const { data } = await supabase.auth.getUser();
+      const { data } = await dataLayerClient.auth.getUser();
       setCurrentUserId(data.user?.id || null);
     })();
   }, []);
@@ -363,10 +365,9 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
 
 function useManagementUsers() {
   return useQuery({
-    queryKey: ['management-users'],
+    queryKey: queryKeys.scope('management-users'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name')
         .in('role', ['management', 'admin', 'logistics', 'oscar']);
       if (error) throw error;
@@ -377,10 +378,9 @@ function useManagementUsers() {
 
 function useDepartmentUsers(department: Dept) {
   return useQuery({
-    queryKey: ['department-users', department],
+    queryKey: queryKeys.scope('department-users', department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name, role')
         .eq('department', department);
       if (error) throw error;
@@ -390,7 +390,7 @@ function useDepartmentUsers(department: Dept) {
 }
 
 async function viewDoc(doc: { file_path: string; file_name: string }) {
-  const { data } = await supabase.storage.from('task_documents').createSignedUrl(doc.file_path, 3600);
+  const { data } = await dataLayerClient.storage.from('task_documents').createSignedUrl(doc.file_path, 3600);
   if (data?.signedUrl) {
     window.open(data.signedUrl, '_blank', 'noopener');
   }

--- a/src/components/technician/AboutModal.tsx
+++ b/src/components/technician/AboutModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { X, Info, Clock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { Theme } from './types';
 
 // Get the version from Vite's env variables
@@ -59,8 +59,7 @@ export const AboutModal = ({ theme, isDark, onClose }: AboutModalProps) => {
   useEffect(() => {
     const load = async () => {
       try {
-        const { data, error } = await supabase
-          .from('app_changelog')
+        const { data, error } = await dataLayerClient.from('app_changelog')
           .select('id, version, entry_date, content, last_updated')
           .order('entry_date', { ascending: false })
           .order('last_updated', { ascending: false });

--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -17,7 +17,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { labelForCode } from '@/utils/roles';
 import { createSignedUrl } from '@/utils/jobDocuments';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { OBLIQUE_STRATEGIES } from "./obliqueStrategies";
 import { getCategoryFromAssignment } from '@/utils/roleCategory';
 
@@ -123,7 +123,7 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
     const docId = doc.id;
     setDocumentLoading(prev => new Set(prev).add(docId));
     try {
-      const url = await createSignedUrl(supabase, doc.file_path, 60);
+      const url = await createSignedUrl(dataLayerClient, doc.file_path, 60);
       window.open(url, '_blank');
     } catch (err: any) {
       toast({ title: 'Error', description: `No se pudo abrir el documento: ${err.message}`, variant: 'destructive' });
@@ -136,7 +136,7 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
     const docId = doc.id;
     setDocumentLoading(prev => new Set(prev).add(docId));
     try {
-      const url = await createSignedUrl(supabase, doc.file_path, 60);
+      const url = await createSignedUrl(dataLayerClient, doc.file_path, 60);
       const link = document.createElement('a');
       link.href = url;
       link.download = doc.file_name;

--- a/src/components/technician/AvailabilityView.tsx
+++ b/src/components/technician/AvailabilityView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { toast } from 'sonner';
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, addMonths, parseISO } from 'date-fns';
 import { es } from 'date-fns/locale';
@@ -12,12 +12,14 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sh
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Theme } from './types';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface AvailabilityBlock {
-    id: string;
+    id: number;
     technician_id: string;
     date: string;
-    status: 'vacation' | 'travel' | 'sick' | 'day_off';
-    created_at: string;
+    status: string;
+    created_at: string | null;
 }
 
 interface AvailabilityViewProps {
@@ -32,20 +34,19 @@ export const AvailabilityView = ({ theme, isDark }: AvailabilityViewProps) => {
     const [showAddSheet, setShowAddSheet] = useState(false);
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
-    const [deletingId, setDeletingId] = useState<string | null>(null);
+    const [deletingId, setDeletingId] = useState<number | null>(null);
 
     // Fetch unavailability blocks
     const { data: blocks = [], isLoading } = useQuery<AvailabilityBlock[]>({
-        queryKey: ['my-unavailability', user?.id],
+        queryKey: queryKeys.scope('my-unavailability', user?.id),
         queryFn: async () => {
             if (!user?.id) return [];
-            const { data, error } = await supabase
-                .from('technician_availability')
+            const { data, error } = await dataLayerClient.from('technician_availability')
                 .select('id, technician_id, date, status, created_at')
                 .eq('technician_id', user.id)
                 .order('date', { ascending: true });
             if (error) throw error;
-            return (data as AvailabilityBlock[]) || [];
+            return (data as unknown as AvailabilityBlock[]) || [];
         },
         enabled: !!user?.id,
     });
@@ -72,14 +73,13 @@ export const AvailabilityView = ({ theme, isDark }: AvailabilityViewProps) => {
                 const dateStr = spanishDateFormatter.format(d);
                 rows.push({ technician_id: user.id, date: dateStr, status: 'day_off' });
             }
-            const { error } = await supabase
-                .from('technician_availability')
+            const { error } = await dataLayerClient.from('technician_availability')
                 .upsert(rows, { onConflict: 'technician_id,date' });
             if (error) throw error;
         },
         onSuccess: () => {
             toast.success('Fechas marcadas como no disponibles');
-            queryClient.invalidateQueries({ queryKey: ['my-unavailability'] });
+            queryClient.invalidateQueries({ queryKey: queryKeys.scope('my-unavailability') });
             setShowAddSheet(false);
             setStartDate('');
             setEndDate('');
@@ -92,8 +92,8 @@ export const AvailabilityView = ({ theme, isDark }: AvailabilityViewProps) => {
 
     // Delete mutation
     const deleteMutation = useMutation({
-        mutationFn: async (id: string) => {
-            const { error } = await supabase.from('technician_availability').delete().eq('id', id);
+        mutationFn: async (id: number) => {
+            const { error } = await dataLayerClient.from('technician_availability').delete().eq('id', id);
             if (error) throw error;
         },
         onMutate: (id) => {
@@ -101,7 +101,7 @@ export const AvailabilityView = ({ theme, isDark }: AvailabilityViewProps) => {
         },
         onSuccess: () => {
             toast.success('Disponibilidad restaurada');
-            queryClient.invalidateQueries({ queryKey: ['my-unavailability'] });
+            queryClient.invalidateQueries({ queryKey: queryKeys.scope('my-unavailability') });
         },
         onError: (e: unknown) => {
             const message = e instanceof Error ? e.message : 'No se pudo eliminar';

--- a/src/components/technician/DetailsModal.tsx
+++ b/src/components/technician/DetailsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { toast } from 'sonner';
 import { format, parseISO } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
@@ -22,6 +22,8 @@ import type { TourDocument } from '@/hooks/useTourDocuments';
 import type { Restaurant, WeatherData } from '@/types/hoja-de-ruta';
 import type { JobDocument, JobWithLocationAndDocs, StaffAssignment } from '@/types/job';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface DetailsModalProps {
     theme: Theme;
     isDark: boolean;
@@ -144,11 +146,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch full job details with location
     const { data: jobDetails, isLoading: jobDetailsLoading } = useQuery({
-        queryKey: ['job-details-modal', job?.id],
+        queryKey: queryKeys.scope('job-details-modal', job?.id),
         queryFn: async () => {
             if (!job?.id) return null;
-            const { data, error } = await supabase
-                .from('jobs')
+            const { data, error } = await dataLayerClient.from('jobs')
                 .select(`
           *,
           locations(id, name, formatted_address, latitude, longitude)
@@ -167,11 +168,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch staff assignments for this job
     const { data: staffAssignments = [], isLoading: staffLoading } = useQuery({
-        queryKey: ['job-staff', job?.id],
+        queryKey: queryKeys.scope('job-staff', job?.id),
         queryFn: async () => {
             if (!job?.id) return [];
-            const { data, error } = await supabase
-                .from('job_assignments')
+            const { data, error } = await dataLayerClient.from('job_assignments')
                 .select(`
           sound_role,
           lights_role,
@@ -181,18 +181,22 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
                 .eq('job_id', job.id)
                 .eq('status', 'confirmed');
             if (error) throw error;
-            return data || [];
+            return ((data || []) as unknown as StaffAssignment[]).map((assignment) => ({
+                ...assignment,
+                technician: Array.isArray(assignment.technician)
+                    ? assignment.technician[0] ?? undefined
+                    : assignment.technician ?? undefined,
+            }));
         },
         enabled: !!job?.id,
     });
 
     // Fetch technician's assigned dates from timesheets
     const { data: assignedDates = [], isLoading: assignedDatesLoading } = useQuery({
-        queryKey: ['tech-assigned-dates', job?.id, user?.id],
+        queryKey: queryKeys.scope('tech-assigned-dates', job?.id, user?.id),
         queryFn: async () => {
             if (!job?.id || !user?.id) return [];
-            const { data, error } = await supabase
-                .from('timesheets')
+            const { data, error } = await dataLayerClient.from('timesheets')
                 .select('date')
                 .eq('job_id', job.id)
                 .eq('technician_id', user.id)
@@ -206,11 +210,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch stage names (if this job has festival stages configured)
     const { data: festivalStages = [] } = useQuery({
-        queryKey: ['technician-job-festival-stages', job?.id],
+        queryKey: queryKeys.scope('technician-job-festival-stages', job?.id),
         queryFn: async () => {
             if (!job?.id) return [];
-            const { data, error } = await supabase
-                .from('festival_stages')
+            const { data, error } = await dataLayerClient.from('festival_stages')
                 .select('number, name')
                 .eq('job_id', job.id);
             if (error) throw error;
@@ -221,12 +224,11 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch this technician's shift assignments for the job (used to enrich Info tab)
     const { data: techShiftAssignments = [], isLoading: techShiftAssignmentsLoading } = useQuery({
-        queryKey: ['technician-job-shift-assignments', job?.id, user?.id],
+        queryKey: queryKeys.scope('technician-job-shift-assignments', job?.id, user?.id),
         queryFn: async () => {
             if (!job?.id || !user?.id) return [];
 
-            const { data: shifts, error: shiftsError } = await supabase
-                .from('festival_shifts')
+            const { data: shifts, error: shiftsError } = await dataLayerClient.from('festival_shifts')
                 .select('id, job_id, date, name, start_time, end_time, stage, department')
                 .eq('job_id', job.id);
 
@@ -235,8 +237,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
             const shiftIds = (shifts || []).map((shift) => shift.id);
             if (shiftIds.length === 0) return [];
 
-            const { data: assignments, error: assignmentsError } = await supabase
-                .from('festival_shift_assignments')
+            const { data: assignments, error: assignmentsError } = await dataLayerClient.from('festival_shift_assignments')
                 .select('id, role, shift_id')
                 .eq('technician_id', user.id)
                 .in('shift_id', shiftIds);
@@ -263,11 +264,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch job date types for this job
     const { data: jobDateTypes = [], isLoading: jobDateTypesLoading } = useQuery({
-        queryKey: ['job-date-types', job?.id],
+        queryKey: queryKeys.scope('job-date-types', job?.id),
         queryFn: async () => {
             if (!job?.id) return [];
-            const { data, error } = await supabase
-                .from('job_date_types')
+            const { data, error } = await dataLayerClient.from('job_date_types')
                 .select('date, type')
                 .eq('job_id', job.id);
             if (error) throw error;
@@ -278,11 +278,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch tour documents (visible to technicians) when the job belongs to a tour
     const { data: tourDocuments = [], isLoading: tourDocumentsLoading } = useQuery({
-        queryKey: ['tour-documents-for-job', tourId],
+        queryKey: queryKeys.scope('tour-documents-for-job', tourId),
         queryFn: async () => {
             if (!tourId) return [];
-            const { data, error } = await supabase
-                .from('tour_documents')
+            const { data, error } = await dataLayerClient.from('tour_documents')
                 .select('id, file_name, file_path, uploaded_at, file_type')
                 .eq('tour_id', tourId)
                 .eq('visible_to_tech', true)
@@ -295,11 +294,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch artists linked to this job, then their rider files
     const { data: jobArtists = [], isLoading: isArtistsLoading, error: jobArtistsError } = useQuery({
-        queryKey: ['technician-job-artists', job?.id],
+        queryKey: queryKeys.scope('technician-job-artists', job?.id),
         queryFn: async () => {
             if (!job?.id) return [];
-            const { data, error } = await supabase
-                .from('festival_artists')
+            const { data, error } = await dataLayerClient.from('festival_artists')
                 .select('id, name, stage')
                 .eq('job_id', job.id);
             if (error) throw error;
@@ -313,11 +311,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
     const artistStageMap = useMemo(() => new Map(jobArtists.map((artist) => [artist.id, artist.stage])), [jobArtists]);
 
     const { data: riderFiles = [], isLoading: isRidersLoading, error: riderFilesError } = useQuery({
-        queryKey: ['technician-job-rider-files', job?.id, artistIdList],
+        queryKey: queryKeys.scope('technician-job-rider-files', job?.id, artistIdList),
         queryFn: async () => {
             if (artistIdList.length === 0) return [];
-            const { data, error } = await supabase
-                .from('festival_artist_files')
+            const { data, error } = await dataLayerClient.from('festival_artist_files')
                 .select('id, file_name, file_path, uploaded_at, artist_id')
                 .in('artist_id', artistIdList)
                 .order('uploaded_at', { ascending: false });
@@ -329,11 +326,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch hoja de ruta metadata (if linked to this job)
     const { data: hojaDeRutaMeta, isLoading: hojaDeRutaLoading } = useQuery({
-        queryKey: ['technician-hoja-de-ruta-meta', job?.id],
+        queryKey: queryKeys.scope('technician-hoja-de-ruta-meta', job?.id),
         queryFn: async () => {
             if (!job?.id) return null;
-            const { data, error } = await supabase
-                .from('hoja_de_ruta')
+            const { data, error } = await dataLayerClient.from('hoja_de_ruta')
                 .select('id')
                 .eq('job_id', job.id)
                 .maybeSingle();
@@ -352,11 +348,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch accommodations + rooming from hoja de ruta
     const { data: hojaAccommodations = [], isLoading: hojaAccommodationsLoading } = useQuery({
-        queryKey: ['technician-hoja-accommodations', hojaDeRutaId],
+        queryKey: queryKeys.scope('technician-hoja-accommodations', hojaDeRutaId),
         queryFn: async () => {
             if (!hojaDeRutaId) return [];
-            const { data, error } = await supabase
-                .from('hoja_de_ruta_accommodations')
+            const { data, error } = await dataLayerClient.from('hoja_de_ruta_accommodations')
                 .select(`
                     id,
                     hotel_name,
@@ -386,11 +381,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch travel arrangements from hoja de ruta
     const { data: hojaTravelArrangements = [], isLoading: hojaTravelLoading } = useQuery({
-        queryKey: ['technician-hoja-travel-arrangements', hojaDeRutaId],
+        queryKey: queryKeys.scope('technician-hoja-travel-arrangements', hojaDeRutaId),
         queryFn: async () => {
             if (!hojaDeRutaId) return [];
-            const { data, error } = await supabase
-                .from('hoja_de_ruta_travel_arrangements')
+            const { data, error } = await dataLayerClient.from('hoja_de_ruta_travel_arrangements')
                 .select(`
                     id,
                     transportation_type,
@@ -419,11 +413,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch logistics transport from hoja de ruta
     const { data: hojaTransportEntries = [], isLoading: hojaTransportLoading } = useQuery({
-        queryKey: ['technician-hoja-logistics-transport', hojaDeRutaId],
+        queryKey: queryKeys.scope('technician-hoja-logistics-transport', hojaDeRutaId),
         queryFn: async () => {
             if (!hojaDeRutaId) return [];
-            const { data, error } = await supabase
-                .from('hoja_de_ruta_transport')
+            const { data, error } = await dataLayerClient.from('hoja_de_ruta_transport')
                 .select(`
                     id,
                     transport_type,
@@ -452,7 +445,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
     // Fetch nearby restaurants using Google Places API
     const { data: restaurants = [], isLoading: isRestaurantsLoading } = useQuery({
-        queryKey: ['job-restaurants-modal', job?.id, jobDetails?.locations?.formatted_address],
+        queryKey: queryKeys.scope('job-restaurants-modal', job?.id, jobDetails?.locations?.formatted_address),
         queryFn: async () => {
             const locationData = jobDetails?.locations;
             const address = locationData?.formatted_address || locationData?.name;
@@ -518,7 +511,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
 
                 setIsMapLoading(true);
 
-                const { data, error } = await supabase.functions.invoke('get-google-maps-key');
+                const { data, error } = await dataLayerClient.functions.invoke('get-google-maps-key');
                 if (error || !data?.apiKey) {
                     setMapPreviewUrl(null);
                     setIsMapLoading(false);
@@ -556,7 +549,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
         const docId = doc.id;
         setDocumentLoading(prev => new Set(prev).add(docId));
         try {
-            const url = await createSignedUrl(supabase, doc.file_path, 60);
+            const url = await createSignedUrl(dataLayerClient, doc.file_path, 60);
             window.open(url, '_blank');
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : 'Error desconocido';
@@ -570,7 +563,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
         const docId = doc.id;
         setDocumentLoading(prev => new Set(prev).add(docId));
         try {
-            const url = await createSignedUrl(supabase, doc.file_path, 60);
+            const url = await createSignedUrl(dataLayerClient, doc.file_path, 60);
             const link = document.createElement('a');
             link.href = url;
             link.download = doc.file_name;
@@ -589,7 +582,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
         const key = `tour:${doc.id}`;
         setDocumentLoading(prev => new Set(prev).add(key));
         try {
-            const { data, error } = await supabase.storage
+            const { data, error } = await dataLayerClient.storage
                 .from('tour-documents')
                 .createSignedUrl(doc.file_path, 60);
             if (error || !data?.signedUrl) {
@@ -608,7 +601,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
         const key = `tour:${doc.id}`;
         setDocumentLoading(prev => new Set(prev).add(key));
         try {
-            const { data, error } = await supabase.storage
+            const { data, error } = await dataLayerClient.storage
                 .from('tour-documents')
                 .createSignedUrl(doc.file_path, 60);
             if (error || !data?.signedUrl) {
@@ -632,7 +625,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
         const key = `rider:${file.id}`;
         setDocumentLoading(prev => new Set(prev).add(key));
         try {
-            const { data, error } = await supabase.storage
+            const { data, error } = await dataLayerClient.storage
                 .from('festival_artist_files')
                 .createSignedUrl(file.file_path, 60);
             if (error || !data?.signedUrl) {
@@ -651,7 +644,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
         const key = `rider:${file.id}`;
         setDocumentLoading(prev => new Set(prev).add(key));
         try {
-            const { data, error } = await supabase.storage
+            const { data, error } = await dataLayerClient.storage
                 .from('festival_artist_files')
                 .download(file.file_path);
             if (error || !data) {
@@ -822,11 +815,10 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
     );
 
     const { data: roomOccupantProfiles = [], isLoading: roomOccupantsLoading } = useQuery({
-        queryKey: ['technician-hoja-room-occupants', roomStaffProfileIds],
+        queryKey: queryKeys.scope('technician-hoja-room-occupants', roomStaffProfileIds),
         queryFn: async () => {
             if (roomStaffProfileIds.length === 0) return [];
-            const { data, error } = await supabase
-                .from('profiles')
+            const { data, error } = await dataLayerClient.from('profiles')
                 .select('id, first_name, last_name, nickname')
                 .in('id', roomStaffProfileIds);
 
@@ -1775,7 +1767,7 @@ export const DetailsModal = ({ theme, isDark, job, onClose }: DetailsModalProps)
                                                 tourId={tourId}
                                                 onSuccess={() => {
                                                     setIsUploadingTourDocument(false);
-                                                    queryClient.invalidateQueries({ queryKey: ['tour-documents-for-job', tourId] });
+                                                    queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents-for-job', tourId) });
                                                 }}
                                                 onCancel={() => setIsUploadingTourDocument(false)}
                                             />

--- a/src/components/technician/ProfileView.tsx
+++ b/src/components/technician/ProfileView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { toast } from 'sonner';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -12,6 +12,8 @@ import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { ProfilePictureUpload } from '@/components/profile/ProfilePictureUpload';
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from '@/lib/api-config';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface ProfileUser {
     id: string;
     email?: string;
@@ -94,8 +96,7 @@ export const ProfileView = ({ theme, isDark, user, userProfile, toggleTheme }: P
     useEffect(() => {
         const load = async () => {
             try {
-                const { data, error } = await supabase
-                    .from('app_changelog')
+                const { data, error } = await dataLayerClient.from('app_changelog')
                     .select('version')
                     .order('entry_date', { ascending: false })
                     .order('last_updated', { ascending: false })
@@ -135,7 +136,7 @@ export const ProfileView = ({ theme, isDark, user, userProfile, toggleTheme }: P
     const deptLabel = deptLabels[userProfile?.department?.toLowerCase()] || userProfile?.department || '';
 
     const handleSignOut = async () => {
-        await supabase.auth.signOut();
+        await dataLayerClient.auth.signOut();
         navigate('/');
     };
 
@@ -154,7 +155,7 @@ export const ProfileView = ({ theme, isDark, user, userProfile, toggleTheme }: P
         setPasswordLoading(true);
         try {
             // First verify the current password
-            const { error: signInError } = await supabase.auth.signInWithPassword({
+            const { error: signInError } = await dataLayerClient.auth.signInWithPassword({
                 email: user?.email || '',
                 password: passwordForm.currentPassword,
             });
@@ -165,7 +166,7 @@ export const ProfileView = ({ theme, isDark, user, userProfile, toggleTheme }: P
             }
 
             // Update the password
-            const { error: updateError } = await supabase.auth.updateUser({
+            const { error: updateError } = await dataLayerClient.auth.updateUser({
                 password: passwordForm.newPassword
             });
 
@@ -189,7 +190,7 @@ export const ProfileView = ({ theme, isDark, user, userProfile, toggleTheme }: P
 
     // Handle calendar token generation/rotation
     const generateCalendarToken = async (): Promise<string> => {
-        const { data, error } = await supabase.rpc('rotate_my_calendar_ics_token');
+        const { data, error } = await dataLayerClient.rpc('rotate_my_calendar_ics_token');
         if (error) throw error;
         const newToken = data as string;
 
@@ -264,8 +265,7 @@ export const ProfileView = ({ theme, isDark, user, userProfile, toggleTheme }: P
                 residencia,
                 bg_color: selectedColor,
             };
-            const { data, error } = await supabase
-                .from('profiles')
+            const { data, error } = await dataLayerClient.from('profiles')
                 .update(updateData)
                 .eq('id', user.id)
                 .select()
@@ -281,7 +281,7 @@ export const ProfileView = ({ theme, isDark, user, userProfile, toggleTheme }: P
                 ...data,
             }));
             // Also invalidate to ensure consistency
-            queryClient.invalidateQueries({ queryKey: ['user-profile', user?.id] });
+            queryClient.invalidateQueries({ queryKey: queryKeys.scope('user-profile', user?.id) });
         },
         onError: (err: unknown) => {
             const message = err instanceof Error ? err.message : 'Error desconocido';

--- a/src/components/technician/TechJobCard.tsx
+++ b/src/components/technician/TechJobCard.tsx
@@ -9,9 +9,11 @@ import { Button } from '@/components/ui/button';
 import { useExpensePermissions, isPermissionActive } from '@/hooks/useExpensePermissions';
 import { useJobExpenses } from '@/hooks/useJobExpenses';
 import { ExpenseForm, ExpenseList, ExpenseSummaryCard } from '@/components/expenses';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { JobCardProps } from './types';
 
+
+import { queryKeys } from "@/lib/react-query";
 export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techName, onOpenObliqueStrategy }: JobCardProps) => {
     const jobData = job.jobs || job;
     const [expenseDialogOpen, setExpenseDialogOpen] = useState(false);
@@ -66,11 +68,10 @@ export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techNam
     const shouldFetchArtistCountFallback = jobData?.artist_count == null && Boolean(jobData?.id);
 
     const { data: artistCountFallback = 0 } = useQuery({
-        queryKey: ['tech-job-artist-count-fallback', jobData?.id],
+        queryKey: queryKeys.scope('tech-job-artist-count-fallback', jobData?.id),
         queryFn: async () => {
             if (!jobData?.id) return 0;
-            const { count, error } = await supabase
-                .from('festival_artists')
+            const { count, error } = await dataLayerClient.from('festival_artists')
                 .select('id', { count: 'exact', head: true })
                 .eq('job_id', jobData.id);
 

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -4,7 +4,7 @@ import { format, parseISO } from "date-fns";
 import { es } from "date-fns/locale";
 import { toZonedTime } from "date-fns-tz";
 import { ChevronDown, Loader2, SlidersHorizontal, Users, X } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -144,8 +144,7 @@ export function TechnicianArtistReadOnlyModal({
   const { data: artists = [], isLoading: artistsLoading } = useQuery({
     queryKey: createQueryKey.technician.technicianReadonlyArtists(job?.id),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from("festival_artists")
+      const { data, error } = await dataLayerClient.from("festival_artists")
         .select("*")
         .eq("job_id", job?.id)
         .order("date", { ascending: true });
@@ -164,8 +163,7 @@ export function TechnicianArtistReadOnlyModal({
   const { data: festivalStages = [] } = useQuery({
     queryKey: createQueryKey.technician.technicianReadonlyFestivalStages(job?.id),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from("festival_stages")
+      const { data, error } = await dataLayerClient.from("festival_stages")
         .select("number, name")
         .eq("job_id", job?.id);
       if (error) {
@@ -200,7 +198,7 @@ export function TechnicianArtistReadOnlyModal({
       await Promise.all(
         artistsWithPlot.map(async (artist) => {
           if (!artist.stage_plot_file_path) return;
-          const { data, error } = await supabase.storage
+          const { data, error } = await dataLayerClient.storage
             .from("festival_artist_files")
             .createSignedUrl(artist.stage_plot_file_path, 60 * 60);
 
@@ -233,8 +231,7 @@ export function TechnicianArtistReadOnlyModal({
         return;
       }
 
-      let query = supabase
-        .from("festival_artist_files")
+      let query = dataLayerClient.from("festival_artist_files")
         .select("id, file_name, file_path, uploaded_at, artist_id")
         .order("uploaded_at", { ascending: false });
 
@@ -276,7 +273,7 @@ export function TechnicianArtistReadOnlyModal({
 
   const handleDownloadRiderFile = async (file: { file_path: string; file_name: string }) => {
     try {
-      const { data, error } = await supabase.storage.from("festival_artist_files").download(file.file_path);
+      const { data, error } = await dataLayerClient.storage.from("festival_artist_files").download(file.file_path);
       if (error || !data) {
         toast.error("Error al descargar el archivo", { description: error?.message || "No se pudo obtener el archivo" });
         return;

--- a/src/components/technician/TechnicianRfTableModal.tsx
+++ b/src/components/technician/TechnicianRfTableModal.tsx
@@ -15,7 +15,7 @@ import {
   Wifi,
   X,
 } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import type { Tables } from "@/integrations/supabase/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -488,8 +488,7 @@ export function TechnicianRfTableModal({
     queryKey: createQueryKey.technician.rfTableArtists(job?.id),
     queryFn: async () => {
       if (!job?.id) return [];
-      const { data, error } = await supabase
-        .from("festival_artists")
+      const { data, error } = await dataLayerClient.from("festival_artists")
         .select("*")
         .eq("job_id", job?.id)
         .order("date", { ascending: true });
@@ -503,8 +502,7 @@ export function TechnicianRfTableModal({
     queryKey: createQueryKey.technician.rfTableStages(job?.id),
     queryFn: async () => {
       if (!job?.id) return [];
-      const { data, error } = await supabase
-        .from("festival_stages")
+      const { data, error } = await dataLayerClient.from("festival_stages")
         .select("number, name")
         .eq("job_id", job?.id);
       if (error) return [];

--- a/src/components/technician/TourDetailView.tsx
+++ b/src/components/technician/TourDetailView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/button';
 import { Theme } from './types';
 import { fetchTourLogo } from '@/utils/pdf/logoUtils';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface TourDateLocation {
     id: string;
     name: string;
@@ -53,10 +55,9 @@ export const TourDetailView = ({ tourId, theme, isDark, onClose, onOpenJob }: To
 
     // Fetch tour details with correct schema
     const { data: tourData, isLoading: tourLoading } = useQuery({
-        queryKey: ['tour-detail-tech', tourId],
+        queryKey: queryKeys.scope('tour-detail-tech', tourId),
         queryFn: async () => {
-            const { data, error } = await supabase
-                .from('tours')
+            const { data, error } = await dataLayerClient.from('tours')
                 .select(`
           id, name, description, color, status, start_date, end_date,
           tour_dates (
@@ -83,10 +84,9 @@ export const TourDetailView = ({ tourId, theme, isDark, onClose, onOpenJob }: To
 
     // Fetch recent tour documents (correct schema - no document_type column)
     const { data: tourDocs = [] } = useQuery({
-        queryKey: ['tour-docs-tech', tourId],
+        queryKey: queryKeys.scope('tour-docs-tech', tourId),
         queryFn: async () => {
-            const { data, error } = await supabase
-                .from('tour_documents')
+            const { data, error } = await dataLayerClient.from('tour_documents')
                 .select('id, file_name, file_path, uploaded_at, file_type')
                 .eq('tour_id', tourId)
                 .order('uploaded_at', { ascending: false })
@@ -117,7 +117,10 @@ export const TourDetailView = ({ tourId, theme, isDark, onClose, onOpenJob }: To
         );
     }
 
-    const tourDates: TourDate[] = (tourData.tour_dates as TourDate[]) || [];
+    const tourDates: TourDate[] = ((tourData.tour_dates || []) as unknown as TourDate[]).map((date) => ({
+        ...date,
+        location: Array.isArray(date.location) ? date.location[0] ?? null : date.location ?? null,
+    }));
     const now = new Date();
     const completedDates = tourDates.filter((d) => new Date(d.date) < now);
     const upcomingDates = tourDates
@@ -145,7 +148,7 @@ export const TourDetailView = ({ tourId, theme, isDark, onClose, onOpenJob }: To
     const handleDownloadDoc = async (doc: TourDocument) => {
         try {
             // Tour documents use the tour-documents bucket, not job-documents
-            const { data, error } = await supabase.storage
+            const { data, error } = await dataLayerClient.storage
                 .from('tour-documents')
                 .createSignedUrl(doc.file_path, 60);
             if (error || !data?.signedUrl) throw error || new Error('Failed to generate URL');

--- a/src/components/technician/__tests__/AvailabilityView.test.tsx
+++ b/src/components/technician/__tests__/AvailabilityView.test.tsx
@@ -22,6 +22,8 @@ vi.mock("@/lib/supabase", () => ({
 
 import { AvailabilityView } from "../AvailabilityView";
 
+
+import { queryKeys } from "@/lib/react-query";
 const theme = {
   bg: "bg-slate-950",
   nav: "bg-slate-900",
@@ -118,7 +120,7 @@ describe("AvailabilityView", () => {
       );
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["my-unavailability"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.scope("my-unavailability") });
   });
 
   it("renders month-scoped blocks using string date comparisons", async () => {

--- a/src/components/timesheet/MyJobTotal.tsx
+++ b/src/components/timesheet/MyJobTotal.tsx
@@ -7,10 +7,12 @@ import { useJobPayoutTotals } from '@/hooks/useJobPayoutTotals';
 import { formatCurrency } from '@/lib/utils';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useJobRatesApproval } from '@/hooks/useJobRatesApproval';
 import { isTechnicianRole } from '@/utils/permissions';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface MyJobTotalProps {
   jobId: string;
   filterTechnicianId?: string;
@@ -25,10 +27,9 @@ export function MyJobTotal({ jobId, filterTechnicianId }: MyJobTotalProps) {
 
   // For management, fetch names to display in selector
   const { data: assignments = [] } = useQuery({
-    queryKey: ['job-assignments-names', jobId],
+    queryKey: queryKeys.scope('job-assignments-names', jobId),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('job_assignments')
+      const { data, error } = await dataLayerClient.from('job_assignments')
         .select(`technician_id, profiles:technician_id ( first_name, last_name )`)
         .eq('job_id', jobId);
       if (error) throw error;

--- a/src/components/timesheet/TimesheetReminderSettings.tsx
+++ b/src/components/timesheet/TimesheetReminderSettings.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { AlertTriangle, Bell, RefreshCw } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { createQueryKey } from "@/lib/optimized-react-query";
 
@@ -20,7 +20,7 @@ const DEPARTMENTS = [
 type DepartmentKey = (typeof DEPARTMENTS)[number]["key"];
 
 // Keep this copy aligned with the scheduler declared in:
-// supabase/migrations/20260223100000_auto_timesheet_reminders.sql
+// dataLayerClient/migrations/20260223100000_auto_timesheet_reminders.sql
 const AUTO_REMINDER_SCHEDULE_COPY =
   "Programado diariamente mediante pg_cron.";
 
@@ -33,8 +33,7 @@ interface DeptSetting {
 // ─── Data helpers ─────────────────────────────────────────────────────────────
 
 async function fetchSettings(): Promise<DeptSetting[]> {
-  const { data, error } = await supabase
-    .from("timesheet_reminder_settings")
+  const { data, error } = await dataLayerClient.from("timesheet_reminder_settings")
     .select("department, auto_reminders_enabled, reminder_frequency_days");
   if (error) throw error;
   return (data ?? []) as DeptSetting[];
@@ -43,16 +42,15 @@ async function fetchSettings(): Promise<DeptSetting[]> {
 async function updateDeptSetting(patch: Partial<DeptSetting> & { department: DepartmentKey }): Promise<void> {
   // Use upsert so the call is idempotent: inserts when the row is missing
   // (e.g. a new department added after the seed) and updates otherwise.
-  const { error } = await supabase
-    .from("timesheet_reminder_settings")
+  const { error } = await dataLayerClient.from("timesheet_reminder_settings")
     .upsert({ ...patch }, { onConflict: "department" });
   if (error) throw error;
 }
 
 async function triggerManualBatch(): Promise<{ sent: number; failed: number; skipped_dept: number }> {
-  const { data: { session } } = await supabase.auth.getSession();
+  const { data: { session } } = await dataLayerClient.auth.getSession();
   if (!session) throw new Error("Sin sesión activa");
-  const { data, error } = await supabase.functions.invoke("auto-send-timesheet-reminders", {
+  const { data, error } = await dataLayerClient.functions.invoke("auto-send-timesheet-reminders", {
     body: { triggered_by: "manual" },
   });
   if (error) throw error;

--- a/src/components/timesheet/TimesheetView.tsx
+++ b/src/components/timesheet/TimesheetView.tsx
@@ -20,7 +20,7 @@ import { format, parseISO } from "date-fns";
 import { es } from "date-fns/locale";
 import { useToast } from "@/hooks/use-toast";
 import { sendTimesheetReminder } from "@/lib/timesheet-reminder-email";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { isJobPastClosureWindow } from "@/utils/jobClosureUtils";
 import {
   AlertDialog,
@@ -72,8 +72,7 @@ export const TimesheetView = ({
     queryKey: createQueryKey.jobs.meta(jobId),
     enabled: !!jobId,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('id, end_time, timezone')
         .eq('id', jobId)
         .maybeSingle();

--- a/src/components/tours/BulkTourFolderActions.tsx
+++ b/src/components/tours/BulkTourFolderActions.tsx
@@ -6,8 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { FolderPlus, Loader2, RefreshCw, ChevronDown, ChevronUp } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { createTourRootFolders } from "@/utils/tourFolders";
-import { supabase } from "@/lib/supabase";
-
+import { dataLayerClient } from "@/services/dataLayerClient";
 interface BulkTourFolderActionsProps {
   tours: any[];
   onRefresh: () => void;
@@ -61,8 +60,7 @@ export const BulkTourFolderActions = ({
         if (tour.flex_main_folder_id) {
           console.log(`Tour ${tour.name} has main folder ID: ${tour.flex_main_folder_id}, updating flag`);
 
-          const { error } = await supabase
-            .from('tours')
+          const { error } = await dataLayerClient.from('tours')
             .update({ flex_folders_created: true })
             .eq('id', tour.id);
 

--- a/src/components/tours/RequestTourAvailabilityDialog.tsx
+++ b/src/components/tours/RequestTourAvailabilityDialog.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { buildTourSchedulePdfBlob } from '@/lib/tourPdfExport';
 import { uploadTourPdfWithRecord } from '@/utils/tourDocumentsUpload';
 import { isDepartmentManagementRole, isTechnicianRole } from '@/utils/permissions';
@@ -31,7 +31,7 @@ export const RequestTourAvailabilityDialog: React.FC<Props> = ({ open, onOpenCha
     // Load technicians using the same RPC as the matrix to keep consistency
     (async () => {
       try {
-        const { data, error } = await supabase.rpc('get_profiles_with_skills');
+        const { data, error } = await dataLayerClient.rpc('get_profiles_with_skills');
         if (error) throw error;
         const filtered = (data || [])
           .filter((t: any) => isTechnicianRole(t.role) || (isDepartmentManagementRole(t.role) && t.assignable_as_tech))
@@ -47,8 +47,7 @@ export const RequestTourAvailabilityDialog: React.FC<Props> = ({ open, onOpenCha
     (async () => {
       try {
         if (tourDates && tourDates.length) { setDates(tourDates); return; }
-        const { data, error } = await supabase
-          .from('tour_dates')
+        const { data, error } = await dataLayerClient.from('tour_dates')
           .select('id, date, is_tour_pack_only, location:locations(name)')
           .eq('tour_id', tourId)
           .order('date', { ascending: true });
@@ -69,7 +68,7 @@ export const RequestTourAvailabilityDialog: React.FC<Props> = ({ open, onOpenCha
     setLoading(true);
     try {
       // Fetch tour name
-      const { data: tourRow, error: tourErr } = await supabase.from('tours').select('id,name').eq('id', tourId).maybeSingle();
+      const { data: tourRow, error: tourErr } = await dataLayerClient.from('tours').select('id,name').eq('id', tourId).maybeSingle();
       if (tourErr || !tourRow) throw tourErr || new Error('Tour not found');
 
       // Build PDF blob
@@ -81,7 +80,7 @@ export const RequestTourAvailabilityDialog: React.FC<Props> = ({ open, onOpenCha
       const { file_path } = await uploadTourPdfWithRecord(tourId, pdfBlob, suggestedName);
 
       // Send a single tour‑wide availability inquiry (no per‑date staffing requests)
-      const { data, error: fnErr } = await supabase.functions.invoke('send-tour-availability', {
+      const { data, error: fnErr } = await dataLayerClient.functions.invoke('send-tour-availability', {
         body: { tour_id: tourId, profile_id: selectedTechId, channel, tour_pdf_path: file_path }
       });
       if (fnErr || (data && (data as any).error)) {

--- a/src/components/tours/TourAssignmentDialog.tsx
+++ b/src/components/tours/TourAssignmentDialog.tsx
@@ -9,13 +9,15 @@ import { Badge } from "@/components/ui/badge";
 import { Trash2, Plus, Users, Eye, Info, Target, Send } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { toast } from "sonner";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { roleOptionsForDiscipline, labelForCode } from '@/utils/roles';
 import { TourRequirementsDialog } from '@/components/tours/TourRequirementsDialog';
 import { RequestTourAvailabilityDialog } from '@/components/tours/RequestTourAvailabilityDialog';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface TourAssignment {
   id: string;
   tour_id: string;
@@ -75,13 +77,12 @@ export const TourAssignmentDialog = ({
 
   // Fetch existing tour assignments
   const { data: assignments = [], refetch } = useQuery({
-    queryKey: ['tour-assignments', tourId],
+    queryKey: queryKeys.scope('tour-assignments', tourId),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('tour_assignments')
+      const { data, error } = await dataLayerClient.from('tour_assignments')
         .select(`
           *,
-          profiles:technician_id (
+          profiles:profiles!tour_assignments_technician_id_fkey (
             first_name,
             last_name,
             email
@@ -91,19 +92,18 @@ export const TourAssignmentDialog = ({
         .order('department', { ascending: true });
 
       if (error) throw error;
-      return data as TourAssignment[];
+      return data as unknown as TourAssignment[];
     },
     enabled: open && !!tourId
   });
 
   // Fetch available technicians for selected department
   const { data: technicians = [] } = useQuery({
-    queryKey: ['technicians', selectedDepartment],
+    queryKey: queryKeys.scope('technicians', selectedDepartment),
     queryFn: async () => {
       if (!selectedDepartment) return [];
       
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name, email, department, role, assignable_as_tech')
         .eq('department', selectedDepartment)
         .or('role.in.(technician,house_tech),and(role.eq.management,assignable_as_tech.eq.true)')
@@ -118,8 +118,7 @@ export const TourAssignmentDialog = ({
   // Create assignment mutation
   const createAssignmentMutation = useMutation({
     mutationFn: async (assignmentData: any) => {
-      const { error } = await supabase
-        .from('tour_assignments')
+      const { error } = await dataLayerClient.from('tour_assignments')
         .insert({
           tour_id: tourId,
           technician_id: assignmentType === 'internal' ? selectedTechnician : null,
@@ -137,7 +136,7 @@ export const TourAssignmentDialog = ({
       refetch();
       resetForm();
       // Invalidate job assignments as they're automatically synced
-      queryClient.invalidateQueries({ queryKey: ['job-assignments'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-assignments') });
     },
     onError: (error: any) => {
       toast.error(`Failed to create assignment: ${error.message}`);
@@ -147,8 +146,7 @@ export const TourAssignmentDialog = ({
   // Delete assignment mutation
   const deleteAssignmentMutation = useMutation({
     mutationFn: async (assignmentId: string) => {
-      const { error } = await supabase
-        .from('tour_assignments')
+      const { error } = await dataLayerClient.from('tour_assignments')
         .delete()
         .eq('id', assignmentId);
 
@@ -158,10 +156,10 @@ export const TourAssignmentDialog = ({
       toast.success('Assignment removed successfully - automatically removed from all tour jobs');
       refetch();
       // Invalidate job assignments and job details as they're automatically synced
-      queryClient.invalidateQueries({ queryKey: ['job-assignments'] });
-      queryClient.invalidateQueries({ queryKey: ['job-details'] });
-      queryClient.invalidateQueries({ queryKey: ['jobs'] });
-      queryClient.invalidateQueries({ queryKey: ['optimized-jobs'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-assignments') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-details') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('jobs') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('optimized-jobs') });
     },
     onError: (error: any) => {
       toast.error(`Failed to remove assignment: ${error.message}`);

--- a/src/components/tours/TourCard.tsx
+++ b/src/components/tours/TourCard.tsx
@@ -10,13 +10,52 @@ import { createSafeFolderName, sanitizeFolderName } from "@/utils/folderNameSani
 import { memo, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { TourManagementDialog } from "./TourManagementDialog";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { createAllFoldersForJob } from "@/utils/flex-folders";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { createTourRootFolders, createTourDateFolders, createTourRootFoldersManual } from "@/utils/tourFolders";
 import { useQueryClient } from "@tanstack/react-query";
 import { canUseCustomFolderStructure } from "@/utils/permissions";
+
+
+import { queryKeys } from "@/lib/react-query";
+
+type TourFolderConfig = string | {
+  name: string;
+  subfolders?: string[];
+};
+
+const normalizeTourFolderStructure = (value: unknown): TourFolderConfig[] | null => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const folders = value.flatMap((folder): TourFolderConfig[] => {
+    if (typeof folder === 'string') {
+      return [folder];
+    }
+
+    if (!folder || typeof folder !== 'object' || Array.isArray(folder) || !('name' in folder)) {
+      return [];
+    }
+
+    const name = (folder as { name?: unknown }).name;
+    if (typeof name !== 'string') {
+      return [];
+    }
+
+    const subfolders = (folder as { subfolders?: unknown }).subfolders;
+    return [{
+      name,
+      subfolders: Array.isArray(subfolders)
+        ? subfolders.filter((subfolder): subfolder is string => typeof subfolder === 'string')
+        : [],
+    }];
+  });
+
+  return folders.length > 0 ? folders : null;
+};
 
 // File System Access API types
 declare global {
@@ -48,8 +87,7 @@ export const TourCard = memo(function TourCard({ tour, onTourClick, onManageDate
     const fetchTourLogo = async () => {
       if (!tour.id) return;
 
-      const { data, error } = await supabase
-        .from('tour_logos')
+      const { data, error } = await dataLayerClient.from('tour_logos')
         .select('file_path')
         .eq('tour_id', tour.id)
         .maybeSingle();
@@ -57,8 +95,7 @@ export const TourCard = memo(function TourCard({ tour, onTourClick, onManageDate
       if (!error && data?.file_path) {
         try {
           // Try signed URL first
-          const { data: signedUrlData } = await supabase
-            .storage
+          const { data: signedUrlData } = await dataLayerClient.storage
             .from('tour-logos')
             .createSignedUrl(data.file_path, 60 * 60); // 1 hour expiry
 
@@ -66,8 +103,7 @@ export const TourCard = memo(function TourCard({ tour, onTourClick, onManageDate
             setLogoUrl(signedUrlData.signedUrl);
           } else {
             // Fallback to public URL
-            const { data: publicUrlData } = supabase
-              .storage
+            const { data: publicUrlData } = dataLayerClient.storage
               .from('tour-logos')
               .getPublicUrl(data.file_path);
 
@@ -77,8 +113,7 @@ export const TourCard = memo(function TourCard({ tour, onTourClick, onManageDate
           }
         } catch (e) {
           // Fallback to public URL on error
-          const { data: publicUrlData } = supabase
-            .storage
+          const { data: publicUrlData } = dataLayerClient.storage
             .from('tour-logos')
             .getPublicUrl(data.file_path);
 
@@ -235,19 +270,18 @@ export const TourCard = memo(function TourCard({ tour, onTourClick, onManageDate
       const rootDirHandle = await baseDirHandle.getDirectoryHandle(rootFolderName, { create: true });
 
       // Get current user's custom folder structure or use default
-      const { data: { user } } = await supabase.auth.getUser();
-      let folderStructure = null;
+      const { data: { user } } = await dataLayerClient.auth.getUser();
+      let folderStructure: TourFolderConfig[] | null = null;
 
       if (user) {
-        const { data: profile } = await supabase
-          .from('profiles')
+        const { data: profile } = await dataLayerClient.from('profiles')
           .select('custom_tour_folder_structure, role')
           .eq('id', user.id)
           .single();
 
         // Only use custom tour structure for management users
         if (profile && canUseCustomFolderStructure(profile.role) && profile.custom_tour_folder_structure) {
-          folderStructure = profile.custom_tour_folder_structure;
+          folderStructure = normalizeTourFolderStructure(profile.custom_tour_folder_structure);
         }
       }
 
@@ -411,16 +445,15 @@ export const TourCard = memo(function TourCard({ tour, onTourClick, onManageDate
     const actionWord = newStatus === 'cancelled' ? 'cancel' : 'reactivate';
 
     try {
-      const { error } = await supabase
-        .from('tours')
+      const { error } = await dataLayerClient.from('tours')
         .update({ status: newStatus })
         .eq('id', tour.id);
 
       if (error) throw error;
 
       // Invalidate queries to refresh the UI
-      await queryClient.invalidateQueries({ queryKey: ['tours'] });
-      await queryClient.invalidateQueries({ queryKey: ['tour', tour.id] });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.scope('tours') });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour', tour.id) });
 
       toast({
         title: "Success",

--- a/src/components/tours/TourDateForm.tsx
+++ b/src/components/tours/TourDateForm.tsx
@@ -1,12 +1,14 @@
 
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface TourDateFormProps {
   tourId: string;
   initialData?: any;
@@ -30,8 +32,7 @@ export const TourDateForm = ({
 
       // Create or find location if name is provided
       if (locationName.trim()) {
-        const { data: existingLocation } = await supabase
-          .from('locations')
+        const { data: existingLocation } = await dataLayerClient.from('locations')
           .select('id')
           .eq('name', locationName.trim())
           .single();
@@ -39,8 +40,7 @@ export const TourDateForm = ({
         if (existingLocation) {
           locationId = existingLocation.id;
         } else {
-          const { data: newLocation, error: locationError } = await supabase
-            .from('locations')
+          const { data: newLocation, error: locationError } = await dataLayerClient.from('locations')
             .insert({
               name: locationName.trim(),
               formatted_address: locationName.trim()
@@ -55,10 +55,11 @@ export const TourDateForm = ({
 
       if (initialData?.id) {
         // Update existing tour date
-        const { error } = await supabase
-          .from('tour_dates')
+        const { error } = await dataLayerClient.from('tour_dates')
           .update({
             date,
+            start_date: date,
+            end_date: date,
             location_id: locationId
           })
           .eq('id', initialData.id);
@@ -66,11 +67,12 @@ export const TourDateForm = ({
         if (error) throw error;
       } else {
         // Create new tour date
-        const { error } = await supabase
-          .from('tour_dates')
+        const { error } = await dataLayerClient.from('tour_dates')
           .insert({
             tour_id: tourId,
             date,
+            start_date: date,
+            end_date: date,
             location_id: locationId
           });
 
@@ -78,9 +80,9 @@ export const TourDateForm = ({
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tour-dates', tourId] });
-      queryClient.invalidateQueries({ queryKey: ['tours'] });
-      queryClient.invalidateQueries({ queryKey: ['my-tours'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-dates', tourId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tours') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('my-tours') });
       toast.success(initialData ? 'Tour date updated successfully' : 'Tour date created successfully');
       onSuccess();
     },

--- a/src/components/tours/TourDateManagementDialog.tsx
+++ b/src/components/tours/TourDateManagementDialog.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useQueryClient, useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import {
@@ -44,10 +44,12 @@ import {
   TOUR_DATE_TYPE_OPTIONS,
 } from "@/constants/dateTypes";
 
+
+import { queryKeys } from "@/lib/react-query";
 type TourDateTableType = Exclude<DateType, "prep_day">;
 type DynamicSupabaseClient = { from: (table: string) => any };
 
-const dynamicSupabase = supabase as unknown as DynamicSupabaseClient;
+const dynamicSupabase = dataLayerClient as unknown as DynamicSupabaseClient;
 const fromDynamicTable = (table: string) => dynamicSupabase.from(table);
 const toTourDateTableType = (type: DateType): TourDateTableType =>
   type === "prep_day" ? "show" : type;
@@ -103,7 +105,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
   useEffect(() => {
     if (open && tourId) {
       console.log('Dialog opened, refreshing tour data');
-      queryClient.invalidateQueries({ queryKey: ['tour', tourId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour', tourId) });
     }
   }, [open, tourId, queryClient]);
 
@@ -125,12 +127,11 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
   const [editLocationDetails, setEditLocationDetails] = useState<LocationDetails | null>(null);
 
   const { data: foldersExistenceMap } = useQuery({
-    queryKey: ["flex-folders-existence", tourDateIds],
+    queryKey: queryKeys.scope("flex-folders-existence", tourDateIds),
     queryFn: async () => {
       if (!tourDates.length) return {};
 
-      const { data, error } = await supabase
-        .from("flex_folders")
+      const { data, error } = await dataLayerClient.from("flex_folders")
         .select("tour_date_id")
         .in("tour_date_id", tourDateIds);
 
@@ -168,8 +169,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         locationId = await getOrCreateLocation(location);
       }
       console.log("Location ID:", locationId);
-      const { data: newTourDate, error: tourDateError } = await supabase
-        .from("tour_dates")
+      const { data: newTourDate, error: tourDateError } = await dataLayerClient.from("tour_dates")
         .insert({
           tour_id: tourId,
           date: startDate, // Keep for backward compatibility
@@ -201,8 +201,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
       console.log("Tour date created:", newTourDate);
 
       // ... keep existing code (job creation and department assignment)
-      const { data: tourData, error: tourError } = await supabase
-        .from("tours")
+      const { data: tourData, error: tourError } = await dataLayerClient.from("tours")
         .select(`
           name,
           color,
@@ -221,8 +220,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         throw tourError;
       }
 
-      const { data: newJob, error: jobError } = await supabase
-        .from("jobs")
+      const { data: newJob, error: jobError } = await dataLayerClient.from("jobs")
         .insert({
           title: buildTourDateJobTitle(tourData.name, location, tourDateType),
           start_time: `${startDate}T06:00:00`,
@@ -249,8 +247,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         job_id: newJob.id,
         department,
       }));
-      const { error: deptError } = await supabase
-        .from("job_departments")
+      const { error: deptError } = await dataLayerClient.from("job_departments")
         .insert(jobDepartments);
       if (deptError) {
         console.error("Error creating job departments:", deptError);
@@ -264,8 +261,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         type: tourDateType,
       }));
 
-      const { error: dateTypeError } = await supabase
-        .from("job_date_types")
+      const { error: dateTypeError } = await dataLayerClient.from("job_date_types")
         .insert(jobDateTypes);
       if (dateTypeError) {
         console.error("Error creating job date types:", dateTypeError);
@@ -278,12 +274,12 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
 
       // Force refresh all related queries after successful creation
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["tour", tourId] }),
-        queryClient.invalidateQueries({ queryKey: ["tours"] }),
-        queryClient.invalidateQueries({ queryKey: ["optimized-jobs"] }),
-        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
-        queryClient.invalidateQueries({ queryKey: ["job-assignments"] }),
-        queryClient.invalidateQueries({ queryKey: ["flex-folders-existence"] }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour", tourId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tours") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("optimized-jobs") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("job-assignments") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("flex-folders-existence") }),
       ]);
 
       toast({
@@ -323,8 +319,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         locationId = await getOrCreateLocation(newLocation);
       }
 
-      const { data: tourData, error: tourError } = await supabase
-        .from("tours")
+      const { data: tourData, error: tourError } = await dataLayerClient.from("tours")
         .select("name")
         .eq("id", tourId)
         .single();
@@ -334,8 +329,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         throw tourError;
       }
 
-      const { data: updatedDate, error: dateError } = await supabase
-        .from("tour_dates")
+      const { data: updatedDate, error: dateError } = await dataLayerClient.from("tour_dates")
         .update({
           date: startDate,
           start_date: startDate,
@@ -368,7 +362,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
       // Send push notification if tour date type changed
       if (editingTourDate && editingTourDate.tour_date_type !== tourDateType) {
         try {
-          void supabase.functions.invoke('push', {
+          void dataLayerClient.functions.invoke('push', {
             body: {
               action: 'broadcast',
               type: `tourdate.type.changed.${tourDateType}`,
@@ -386,8 +380,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         }
       }
 
-      const { data: jobs, error: jobsError } = await supabase
-        .from("jobs")
+      const { data: jobs, error: jobsError } = await dataLayerClient.from("jobs")
         .update({
           title: buildTourDateJobTitle(tourData.name, newLocation, tourDateType),
           start_time: `${startDate}T06:00:00`,
@@ -408,8 +401,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
       if (jobs && jobs.length > 0) {
         for (const job of jobs) {
           // Delete existing job date types for this job
-          await supabase
-            .from("job_date_types")
+          await dataLayerClient.from("job_date_types")
             .delete()
             .eq("job_id", job.id);
 
@@ -421,8 +413,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
           }));
 
           if (jobDateTypes.length > 0) {
-            const { error: dateTypeError } = await supabase
-              .from("job_date_types")
+            const { error: dateTypeError } = await dataLayerClient.from("job_date_types")
               .insert(jobDateTypes);
             if (dateTypeError) {
               console.error("Error updating job date types:", dateTypeError);
@@ -482,10 +473,10 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
 
       // Force refresh all related queries after successful edit
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["tour", tourId] }),
-        queryClient.invalidateQueries({ queryKey: ["tours"] }),
-        queryClient.invalidateQueries({ queryKey: ["optimized-jobs"] }),
-        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour", tourId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tours") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("optimized-jobs") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") }),
       ]);
 
       // Only show success toast if flex sync didn't have warnings or errors
@@ -516,8 +507,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
 
       // Step 1: Delete flex folders first
       console.log("Deleting flex folders...");
-      const { error: flexFoldersError } = await supabase
-        .from("flex_folders")
+      const { error: flexFoldersError } = await dataLayerClient.from("flex_folders")
         .delete()
         .eq("tour_date_id", dateId);
 
@@ -528,8 +518,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
 
       // Step 2: Get all jobs for this tour date
       console.log("Fetching jobs for tour date...");
-      const { data: jobs, error: jobsError } = await supabase
-        .from("jobs")
+      const { data: jobs, error: jobsError } = await dataLayerClient.from("jobs")
         .select("id")
         .eq("tour_date_id", dateId);
 
@@ -657,8 +646,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
 
         // Finally delete the jobs themselves
         console.log("Deleting jobs...");
-        const { error: jobsDeleteError } = await supabase
-          .from("jobs")
+        const { error: jobsDeleteError } = await dataLayerClient.from("jobs")
           .delete()
           .in("id", jobIds);
 
@@ -671,14 +659,13 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
       // Step 4: Delete tour date overrides
       console.log("Deleting tour date overrides...");
       await Promise.all([
-        supabase.from("tour_date_power_overrides").delete().eq("tour_date_id", dateId),
-        supabase.from("tour_date_weight_overrides").delete().eq("tour_date_id", dateId)
+        dataLayerClient.from("tour_date_power_overrides").delete().eq("tour_date_id", dateId),
+        dataLayerClient.from("tour_date_weight_overrides").delete().eq("tour_date_id", dateId)
       ]);
 
       // Step 5: Finally delete the tour date itself
       console.log("Deleting tour date...");
-      const { error: dateError } = await supabase
-        .from("tour_dates")
+      const { error: dateError } = await dataLayerClient.from("tour_dates")
         .delete()
         .eq("id", dateId);
 
@@ -691,12 +678,12 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
 
       // Force refresh all related queries after successful deletion
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["tour", tourId] }),
-        queryClient.invalidateQueries({ queryKey: ["tours"] }),
-        queryClient.invalidateQueries({ queryKey: ["tours-with-dates"] }),
-        queryClient.invalidateQueries({ queryKey: ["optimized-jobs"] }),
-        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
-        queryClient.invalidateQueries({ queryKey: ["flex-folders-existence"] }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour", tourId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tours") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tours-with-dates") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("optimized-jobs") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("flex-folders-existence") }),
       ]);
 
       toast({

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -7,7 +7,7 @@ import { useToast } from "@/hooks/use-toast";
 import { FileText, Weight, Calculator, Trash2, Download, Calendar } from "lucide-react";
 import { exportToPDF } from "@/utils/pdfExport";
 import { fetchTourLogo } from "@/utils/pdf/logoUtils";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import type { Database } from "@/integrations/supabase/types";
 import { useTourPowerDefaults } from "@/hooks/useTourPowerDefaults";
 import { useTourWeightDefaults } from "@/hooks/useTourWeightDefaults";
@@ -202,8 +202,7 @@ export const TourDefaultsManager = ({
     const fetchTourDates = async () => {
       if (!tour?.id) return;
       
-      const { data, error } = await supabase
-        .from('tour_dates')
+      const { data, error } = await dataLayerClient.from('tour_dates')
         .select(`
           id,
           date,
@@ -596,8 +595,7 @@ export const TourDefaultsManager = ({
 
     // Check for any overrides for this tour date
     const overrideTable = type === 'power' ? 'tour_date_power_overrides' : 'tour_date_weight_overrides';
-    const { data: overrides, error: overridesError } = await supabase
-      .from(overrideTable)
+    const { data: overrides, error: overridesError } = await dataLayerClient.from(overrideTable)
       .select('*')
       .eq('tour_date_id', tourDate.id)
       .eq('department', department);

--- a/src/components/tours/TourLogisticsDialog.tsx
+++ b/src/components/tours/TourLogisticsDialog.tsx
@@ -7,11 +7,13 @@ import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { REQUEST_TRANSPORT_OPTIONS } from '@/constants/transportOptions'
 import { useQuery } from '@tanstack/react-query'
-import { supabase } from '@/lib/supabase'
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { format } from 'date-fns'
 import { useToast } from '@/hooks/use-toast'
 import type { Database, Json } from '@/integrations/supabase/types'
 
+
+import { queryKeys } from "@/lib/react-query";
 type Department = 'sound' | 'lights' | 'video'
 type JobRow = Database['public']['Tables']['jobs']['Row']
 type TransportRequestRow = Database['public']['Tables']['transport_requests']['Row']
@@ -62,11 +64,10 @@ export function TourLogisticsDialog({ open, onOpenChange, tourId }: TourLogistic
 
   // Load tour jobs (tour dates)
   const { data: tourJobs = [] } = useQuery({
-    queryKey: ['tour-logistics-jobs', tourId],
+    queryKey: queryKeys.scope('tour-logistics-jobs', tourId),
     enabled: open && !!tourId,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('id, title, start_time, job_type, status')
         .eq('tour_id', tourId)
         .eq('job_type', 'tourdate')
@@ -80,11 +81,10 @@ export function TourLogisticsDialog({ open, onOpenChange, tourId }: TourLogistic
 
   // Load existing requests for current department
   const { data: existingReqs = [], refetch: refetchRequests } = useQuery({
-    queryKey: ['tour-logistics-requests', tourId, department, jobIds.join(',')],
+    queryKey: queryKeys.scope('tour-logistics-requests', tourId, department, jobIds.join(',')),
     enabled: open && jobIds.length > 0,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('transport_requests')
+      const { data, error } = await dataLayerClient.from('transport_requests')
         .select('id, job_id, department, note, status, created_by, items:transport_request_items(transport_type, leftover_space_meters)')
         .in('job_id', jobIds)
         .eq('department', department)
@@ -137,7 +137,7 @@ export function TourLogisticsDialog({ open, onOpenChange, tourId }: TourLogistic
   const saveAll = async () => {
     try {
       // Ensure we have auth
-      const { data: userData } = await supabase.auth.getUser()
+      const { data: userData } = await dataLayerClient.auth.getUser()
       const userId = userData.user?.id
       if (!userId) throw new Error('Not authenticated')
 
@@ -147,7 +147,7 @@ export function TourLogisticsDialog({ open, onOpenChange, tourId }: TourLogistic
 
         // Find existing request for job+department
         const existing = existingReqs.find(r => r.job_id === jobId)
-        const { error } = await supabase.rpc('replace_transport_request_with_items', {
+        const { error } = await dataLayerClient.rpc('replace_transport_request_with_items', {
           p_request_id: existing?.id || null,
           p_job_id: jobId,
           p_department: department,

--- a/src/components/tours/TourLogoManager.tsx
+++ b/src/components/tours/TourLogoManager.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Image, Upload, X } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 
 interface TourLogoManagerProps {
@@ -26,8 +26,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
         return;
       }
       
-      const { data, error } = await supabase
-        .from('tour_logos')
+      const { data, error } = await dataLayerClient.from('tour_logos')
         .select('file_path')
         .eq('tour_id', tourId)
         .maybeSingle();
@@ -40,8 +39,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
 
       if (data?.file_path) {
         try {
-          const { data: signedUrlData } = await supabase
-            .storage
+          const { data: signedUrlData } = await dataLayerClient.storage
             .from('tour-logos')
             .createSignedUrl(data.file_path, 60 * 60); // 1 hour expiry
             
@@ -50,8 +48,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
             setLogoUrl(signedUrlData.signedUrl);
           } else {
             // Fallback to public URL
-            const { data: publicUrlData } = supabase
-              .storage
+            const { data: publicUrlData } = dataLayerClient.storage
               .from('tour-logos')
               .getPublicUrl(data.file_path);
               
@@ -105,7 +102,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
       console.log("Authenticated user:", userId);
       
       // Check auth status before proceeding
-      const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+      const { data: sessionData, error: sessionError } = await dataLayerClient.auth.getSession();
       if (sessionError || !sessionData.session) {
         throw new Error("Authentication error: " + (sessionError?.message || "Session not found"));
       }
@@ -115,8 +112,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
 
       console.log("Checking for existing logo in database");
       // First, check if there's an existing logo
-      const { data: existingLogo, error: fetchError } = await supabase
-        .from('tour_logos')
+      const { data: existingLogo, error: fetchError } = await dataLayerClient.from('tour_logos')
         .select('file_path')
         .eq('tour_id', tourId)
         .maybeSingle();
@@ -129,7 +125,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
       // If there's an existing logo, remove it from storage
       if (existingLogo?.file_path) {
         console.log("Removing existing logo from storage:", existingLogo.file_path);
-        const { error: removeError } = await supabase.storage
+        const { error: removeError } = await dataLayerClient.storage
           .from('tour-logos')
           .remove([existingLogo.file_path]);
           
@@ -141,7 +137,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
 
       // Upload new logo
       console.log("Uploading new logo to storage:", filePath);
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from('tour-logos')
         .upload(filePath, file, {
           upsert: true,
@@ -155,8 +151,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
 
       // Insert or update the database record
       console.log("Updating tour_logos table");
-      const { error: dbError } = await supabase
-        .from('tour_logos')
+      const { error: dbError } = await dataLayerClient.from('tour_logos')
         .upsert({
           tour_id: tourId,
           file_path: filePath,
@@ -172,13 +167,11 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
       }
 
       // Get signed URL for uploaded logo
-      const { data: signedUrlData } = await supabase
-        .storage
+      const { data: signedUrlData } = await dataLayerClient.storage
         .from('tour-logos')
         .createSignedUrl(filePath, 60 * 60); // 1 hour expiry
 
-      const logoUrl = signedUrlData?.signedUrl || supabase
-        .storage
+      const logoUrl = signedUrlData?.signedUrl || dataLayerClient.storage
         .from('tour-logos')
         .getPublicUrl(filePath).data.publicUrl;
 
@@ -221,13 +214,12 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
       console.log("Deleting logo as user:", userId);
       
       // Check auth status before proceeding
-      const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+      const { data: sessionData, error: sessionError } = await dataLayerClient.auth.getSession();
       if (sessionError || !sessionData.session) {
         throw new Error("Authentication error: " + (sessionError?.message || "Session not found"));
       }
       
-      const { data, error: fetchError } = await supabase
-        .from('tour_logos')
+      const { data, error: fetchError } = await dataLayerClient.from('tour_logos')
         .select('file_path')
         .eq('tour_id', tourId)
         .maybeSingle();
@@ -239,7 +231,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
 
       if (data?.file_path) {
         console.log("Removing logo from storage:", data.file_path);
-        const { error: storageError } = await supabase.storage
+        const { error: storageError } = await dataLayerClient.storage
           .from('tour-logos')
           .remove([data.file_path]);
 
@@ -249,8 +241,7 @@ export const TourLogoManager = ({ tourId }: TourLogoManagerProps) => {
         }
 
         console.log("Deleting logo record from database");
-        const { error: dbError } = await supabase
-          .from('tour_logos')
+        const { error: dbError } = await dataLayerClient.from('tour_logos')
           .delete()
           .eq('tour_id', tourId);
 

--- a/src/components/tours/TourManagementDialog.tsx
+++ b/src/components/tours/TourManagementDialog.tsx
@@ -15,23 +15,13 @@ import { useState } from "react";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
-import type { InvoicingCompany } from "@/types/job";
 
 
 import { queryKeys } from "@/lib/react-query";
-interface Tour {
-  id: string;
-  name: string;
-  status?: string | null;
-  color?: string | null;
-  description?: string | null;
-  invoicing_company?: InvoicingCompany | null;
-}
-
 interface TourManagementDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  tour: Tour;
+  tour: any;
   tourDateId?: string; // Add optional tour date ID for override mode
 }
 
@@ -150,7 +140,9 @@ export const TourManagementDialog = ({
           .update({ status: 'Cancelado' })
           .eq('tour_id', tour.id)
           .eq('job_type', 'tourdate');
-        if (jobsErr) throw jobsErr;
+        if (jobsErr) {
+          console.warn('Failed to mark tour jobs as Cancelado:', jobsErr);
+        }
       }
 
       // Refresh tour data

--- a/src/components/tours/TourManagementWrapper.tsx
+++ b/src/components/tours/TourManagementWrapper.tsx
@@ -1,12 +1,14 @@
 
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import TourManagement from "@/pages/TourManagement";
 import { Card, CardContent } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";
 
+
+import { queryKeys } from "@/lib/react-query";
 export const TourManagementWrapper = () => {
   const { tourId } = useParams();
   const { user } = useOptimizedAuth();
@@ -16,12 +18,11 @@ export const TourManagementWrapper = () => {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["tour", tourId],
+    queryKey: queryKeys.scope("tour", tourId),
     queryFn: async () => {
       if (!tourId) throw new Error("Tour ID is required");
 
-      const { data, error } = await supabase
-        .from("tours")
+      const { data, error } = await dataLayerClient.from("tours")
         .select(`
           *,
           tour_dates (
@@ -35,8 +36,7 @@ export const TourManagementWrapper = () => {
       if (error) throw error;
       if (!data) throw new Error("Tour not found");
 
-      const { data: jobData, error: jobError } = await supabase
-        .from("jobs")
+      const { data: jobData, error: jobError } = await dataLayerClient.from("jobs")
         .select("id")
         .eq("tour_id", tourId)
         .eq("job_type", "tour")

--- a/src/components/tours/TourPresetManagerDialog.tsx
+++ b/src/components/tours/TourPresetManagerDialog.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Copy, Pencil, Trash2, Calculator } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/lib/supabase';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast';
 import { PresetEditor } from '@/components/equipment/PresetEditor';
 import { PresetItem, PresetWithItems, mapPresetWithItemsRow } from '@/types/equipment';
@@ -13,6 +13,8 @@ import { Department } from '@/types/equipment';
 import { DepartmentProvider } from '@/contexts/DepartmentContext';
 import { AmplifierTool } from '@/components/sound/AmplifierTool';
 
+
+import { queryKeys } from "@/lib/react-query";
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -30,10 +32,9 @@ export function TourPresetManagerDialog({ open, onOpenChange, tourId }: Props) {
   const [showCalculator, setShowCalculator] = useState(false);
 
   const { data: presets = [] } = useQuery({
-    queryKey: ['tour-presets', tourId, department],
+    queryKey: queryKeys.scope('tour-presets', tourId, department),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('presets')
+      const { data, error } = await dataLayerClient.from('presets')
         .select(`
           *,
           items:preset_items (
@@ -52,20 +53,18 @@ export function TourPresetManagerDialog({ open, onOpenChange, tourId }: Props) {
 
   const deletePresetMutation = useMutation({
     mutationFn: async (presetId: string) => {
-      const { error: itemsError } = await supabase
-        .from('preset_items')
+      const { error: itemsError } = await dataLayerClient.from('preset_items')
         .delete()
         .eq('preset_id', presetId);
       if (itemsError) throw itemsError;
 
-      const { error: presetError } = await supabase
-        .from('presets')
+      const { error: presetError } = await dataLayerClient.from('presets')
         .delete()
         .eq('id', presetId);
       if (presetError) throw presetError;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tour-presets', tourId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-presets', tourId) });
       toast({ title: 'Éxito', description: 'Preset eliminado' });
     },
     onError: (e: any) => {
@@ -76,41 +75,36 @@ export function TourPresetManagerDialog({ open, onOpenChange, tourId }: Props) {
   const handleSavePreset = async (name: string, items: Omit<PresetItem, 'id' | 'preset_id'>[], fixedTourId?: string | null) => {
     try {
       if (editingPreset) {
-        const { error: presetError } = await supabase
-          .from('presets')
+        const { error: presetError } = await dataLayerClient.from('presets')
           .update({ name })
           .eq('id', editingPreset.id);
         if (presetError) throw presetError;
 
-        const { error: delError } = await supabase
-          .from('preset_items')
+        const { error: delError } = await dataLayerClient.from('preset_items')
           .delete()
           .eq('preset_id', editingPreset.id);
         if (delError) throw delError;
 
         if (items.length > 0) {
-          const { error: itemsError } = await supabase
-            .from('preset_items')
+          const { error: itemsError } = await dataLayerClient.from('preset_items')
             .insert(items.map(i => ({ ...i, preset_id: editingPreset.id })));
           if (itemsError) throw itemsError;
         }
       } else {
-        const { data: created, error: createErr } = await supabase
-          .from('presets')
+        const { data: created, error: createErr } = await dataLayerClient.from('presets')
           .insert({ name, department, tour_id: tourId })
           .select()
           .single();
         if (createErr) throw createErr;
 
         if (items.length > 0) {
-          const { error: itemsError } = await supabase
-            .from('preset_items')
+          const { error: itemsError } = await dataLayerClient.from('preset_items')
             .insert(items.map(i => ({ ...i, preset_id: created.id })));
           if (itemsError) throw itemsError;
         }
       }
 
-      queryClient.invalidateQueries({ queryKey: ['tour-presets', tourId] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-presets', tourId) });
       setEditingPreset(null);
       setCopyingPreset(null);
       setIsCreating(false);

--- a/src/components/tours/TourRatesManagerDialog.tsx
+++ b/src/components/tours/TourRatesManagerDialog.tsx
@@ -11,7 +11,7 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@/comp
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Euro, AlertTriangle, Calendar, Users, ShieldCheck, ShieldX, FileDown, Info } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { useManagerJobQuotes } from '@/hooks/useManagerJobQuotes';
@@ -33,6 +33,8 @@ import { isManagementRole } from '@/utils/permissions';
 import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 import type { Database } from '@/integrations/supabase/types';
 
+
+import { queryKeys } from "@/lib/react-query";
 type TourRatesManagerDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -57,10 +59,9 @@ const isTimesheetCategory = (value: string): value is TimesheetCategory =>
 export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRatesManagerDialogProps) {
   // Fetch tour jobs (include tour dates + single/festival; exclude dryhire)
   const { data: tourJobs = [] } = useQuery<TourRatesJob[]>({
-    queryKey: ['tour-jobs-for-rates', tourId],
+    queryKey: queryKeys.scope('tour-jobs-for-rates', tourId),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('id, title, start_time, end_time, timezone, job_type, tour_id')
         .eq('tour_id', tourId)
         .neq('job_type', 'dryhire')
@@ -93,12 +94,11 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
 
   // Fetch profiles for names
   const { data: profiles = [] } = useQuery<RateProfile[]>({
-    queryKey: ['profiles-for-rates-manager', quotes.map(q => q.technician_id)],
+    queryKey: queryKeys.scope('profiles-for-rates-manager', quotes.map(q => q.technician_id)),
     queryFn: async () => {
       if (!quotes.length) return [];
       const techIds = [...new Set(quotes.map(q => q.technician_id))];
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name, email, default_timesheet_category, role, assignable_as_tech')
         .in('id', techIds);
       if (error) throw error;
@@ -161,12 +161,11 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
 
   // House rates in bulk (to show current values when fixing)
   const { data: houseRates = [] } = useQuery({
-    queryKey: ['house-tech-rates-bulk', quotes.map(q => q.technician_id)],
+    queryKey: queryKeys.scope('house-tech-rates-bulk', quotes.map(q => q.technician_id)),
     queryFn: async () => {
       if (!quotes.length) return [] as HouseRateRow[];
       const techIds = [...new Set(quotes.map(q => q.technician_id))];
-      const { data, error } = await supabase
-        .from('custom_tech_rates')
+      const { data, error } = await dataLayerClient.from('custom_tech_rates')
         .select('profile_id, base_day_eur, travel_half_day_eur, travel_full_day_eur')
         .in('profile_id', techIds);
       if (error) throw error;
@@ -185,16 +184,15 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
   const saveHouseRate = useSaveHouseTechRate();
   const fixCategoryMutation = useMutation({
     mutationFn: async ({ technicianId, category }: { technicianId: string; category: 'tecnico' | 'especialista' | 'responsable' }) => {
-      const { error } = await supabase
-        .from('profiles')
+      const { error } = await dataLayerClient.from('profiles')
         .update({ default_timesheet_category: category })
         .eq('id', technicianId);
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['profiles-for-rates-manager'] });
-      queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes'] });
-      queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes-manager'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('profiles-for-rates-manager') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes-manager') });
     }
   });
 
@@ -217,10 +215,9 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
       }
 
       if (approve) {
-        const { data: user } = await supabase.auth.getUser();
+        const { data: user } = await dataLayerClient.auth.getUser();
         const approver = user?.user?.id || null;
-        const { error } = await supabase
-          .from('jobs')
+        const { error } = await dataLayerClient.from('jobs')
           .update({
             rates_approved: true,
             rates_approved_at: new Date().toISOString(),
@@ -238,8 +235,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
         }
         return { jobId, approve, syncResult, syncError };
       } else {
-        const { error } = await supabase
-          .from('jobs')
+        const { error } = await dataLayerClient.from('jobs')
           .update({
             rates_approved: false,
             rates_approved_at: null,
@@ -252,11 +248,11 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
     },
     onSuccess: (data, { jobId }) => {
       invalidateRatesContext(queryClient);
-      queryClient.invalidateQueries({ queryKey: ['job-rates-approval', jobId] });
-      queryClient.invalidateQueries({ queryKey: ['job-rates-approval-map'] });
-      queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes-manager', jobId] });
-      queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes-manager', jobId, tourId] });
-      queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes-manager'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-rates-approval', jobId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-rates-approval-map') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes-manager', jobId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes-manager', jobId, tourId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes-manager') });
       if (data?.approve) {
         if (data?.syncResult?.created) {
           toast.success(`Órdenes de trabajo creadas en Flex: ${data.syncResult.created}`);
@@ -293,15 +289,13 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                 onClick={async () => {
                   setExportingTour(true);
                   try {
-                    const { data: tourData } = await supabase
-                      .from('tours')
+                    const { data: tourData } = await dataLayerClient.from('tours')
                       .select('name')
                       .eq('id', tourId)
                       .single();
 
                     // Fetch all eligible jobs for export (include 'single'/'festival' linked to this tour; exclude dryhire)
-                    const { data: allJobs, error: jobsError } = await supabase
-                      .from('jobs')
+                    const { data: allJobs, error: jobsError } = await dataLayerClient.from('jobs')
                       .select('id, title, start_time, end_time, job_type')
                       .eq('tour_id', tourId)
                       .order('start_time', { ascending: true });
@@ -348,8 +342,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                   variant="outline"
                   size="sm"
                   onClick={async () => {
-                    const { error } = await supabase
-                      .from('tours')
+                    const { error } = await dataLayerClient.from('tours')
                       .update({ rates_approved: false, rates_approved_at: null, rates_approved_by: null })
                       .eq('id', tourId);
                     if (!error) {
@@ -365,10 +358,9 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                   variant="default"
                   size="sm"
                   onClick={async () => {
-                    const { data: user } = await supabase.auth.getUser();
+                    const { data: user } = await dataLayerClient.auth.getUser();
                     const approver = user?.user?.id || null;
-                    const { error } = await supabase
-                      .from('tours')
+                    const { error } = await dataLayerClient.from('tours')
                       .update({ rates_approved: true, rates_approved_at: new Date().toISOString(), rates_approved_by: approver })
                       .eq('id', tourId);
                     if (!error) {
@@ -434,8 +426,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                       const job = tourJobs.find((j) => j.id === selectedJobId);
                       if (!job) return;
                       
-                      const { data: lpoRows } = await supabase
-                        .from('flex_work_orders')
+                      const { data: lpoRows } = await dataLayerClient.from('flex_work_orders')
                         .select('technician_id, lpo_number')
                         .eq('job_id', selectedJobId);
                       
@@ -460,7 +451,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                       try {
                         const result = await sendTourJobEmails({
                           jobId: selectedJobId,
-                          supabase,
+                          supabase: dataLayerClient,
                           quotes,
                           profiles,
                         });
@@ -556,7 +547,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                               try {
                                 const result = await sendTourJobEmails({
                                   jobId: selectedJobId,
-                                  supabase,
+                                  supabase: dataLayerClient,
                                   quotes: quotes.filter(qq => qq.technician_id === q.technician_id),
                                   profiles,
                                   technicianIds: [q.technician_id],
@@ -635,8 +626,8 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                                     const val = parseFloat((e.target as HTMLInputElement).value);
                                     if (!isNaN(val)) {
                                       await saveHouseRate.mutateAsync({ profile_id: q.technician_id, base_day_eur: val, plus_10_12_eur: null, overtime_hour_eur: null });
-                                      queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes'] });
-                                      queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes-manager'] });
+                                      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
+                                      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes-manager') });
                                     }
                                   }
                                 }}
@@ -646,8 +637,8 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                                 const val = parseFloat(el?.value || '');
                                 if (!isNaN(val)) {
                                   await saveHouseRate.mutateAsync({ profile_id: q.technician_id, base_day_eur: val, plus_10_12_eur: null, overtime_hour_eur: null });
-                                  queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes'] });
-                                  queryClient.invalidateQueries({ queryKey: ['tour-job-rate-quotes-manager'] });
+                                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
+                                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes-manager') });
                                 }
                               }}>Guardar</Button>
                               {houseRateMap[q.technician_id] !== undefined && (

--- a/src/components/tours/TourRatesPanel.tsx
+++ b/src/components/tours/TourRatesPanel.tsx
@@ -11,7 +11,7 @@ import { useManagerJobQuotes } from "@/hooks/useManagerJobQuotes";
 import { useToggleTechnicianPayoutApproval } from "@/hooks/useToggleTechnicianPayoutApproval";
 import { TourJobRateQuote } from "@/types/tourRates";
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { calculateQuoteTotal, formatMultiplier, getPerJobMultiplier, shouldDisplayMultiplier } from "@/lib/tourRateMath";
 import { formatCurrency } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,8 @@ import { getAutonomoBadgeLabel } from "@/utils/autonomo";
 import { isJobPastClosureWindow } from "@/utils/jobClosureUtils";
 import type { TechnicianProfile } from "@/utils/rates-pdf-export";
 
+
+import { queryKeys } from "@/lib/react-query";
 interface TourRatesPanelProps {
   jobId: string;
   jobType?: string | null;
@@ -68,11 +70,10 @@ export const TourRatesPanel: React.FC<TourRatesPanelProps> = ({
   const toggleApprovalMutation = useToggleTechnicianPayoutApproval();
 
   const { data: jobMeta } = useQuery({
-    queryKey: ['tour-rates-job-meta', jobId],
+    queryKey: queryKeys.scope('tour-rates-job-meta', jobId),
     enabled: !!jobId,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('jobs')
+      const { data, error } = await dataLayerClient.from('jobs')
         .select('id, title, start_time, end_time, timezone, tour_id, job_type, rates_approved')
         .eq('id', jobId)
         .maybeSingle();
@@ -126,13 +127,12 @@ export const TourRatesPanel: React.FC<TourRatesPanelProps> = ({
   type ProfileWithEmail = TechnicianProfile & { email?: string | null };
 
   const { data: profiles = [] } = useQuery({
-    queryKey: ['profiles-for-tour-rates', quotes.map(q => q.technician_id)],
+    queryKey: queryKeys.scope('profiles-for-tour-rates', quotes.map(q => q.technician_id)),
     queryFn: async () => {
       if (!quotes.length) return [];
 
       const techIds = [...new Set(quotes.map(q => q.technician_id))];
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name, role, email, autonomo')
         .in('id', techIds);
 
@@ -155,11 +155,10 @@ export const TourRatesPanel: React.FC<TourRatesPanelProps> = ({
   );
 
   const { data: approvalMap = new Map<string, boolean>() } = useQuery({
-    queryKey: ['tour-rates-approvals', jobIds],
+    queryKey: queryKeys.scope('tour-rates-approvals', jobIds),
     enabled: jobIds.length > 0,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('timesheets')
+      const { data, error } = await dataLayerClient.from('timesheets')
         .select('job_id, technician_id, approved_by_manager')
         .in('job_id', jobIds);
 
@@ -285,7 +284,7 @@ export const TourRatesPanel: React.FC<TourRatesPanelProps> = ({
                 setIsSendingEmails(true);
                 const result = await sendTourJobEmails({
                   jobId,
-                  supabase,
+                  supabase: dataLayerClient,
                   quotes: approvedQuotes,
                   profiles: typedProfiles
                 });
@@ -460,7 +459,7 @@ export const TourRatesPanel: React.FC<TourRatesPanelProps> = ({
 
                               const result = await sendTourJobEmails({
                                 jobId,
-                                supabase,
+                                supabase: dataLayerClient,
                                 quotes: approvedQuotesForTech,
                                 profiles: typedProfiles,
                                 technicianIds: [quote.technician_id],

--- a/src/components/tours/TourRequirementsDialog.tsx
+++ b/src/components/tours/TourRequirementsDialog.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { roleOptionsForDiscipline } from '@/types/roles'
-import { supabase } from '@/lib/supabase'
+import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast'
 import type { Json } from '@/integrations/supabase/types'
 
@@ -69,8 +69,7 @@ export const TourRequirementsDialog: React.FC<TourRequirementsDialogProps> = ({ 
       }
 
       // 1) Fetch all jobs for this tour
-      const { data: jobs, error: jobsErr } = await supabase
-        .from('jobs')
+      const { data: jobs, error: jobsErr } = await dataLayerClient.from('jobs')
         .select('id')
         .eq('tour_id', tourId)
 
@@ -92,7 +91,7 @@ export const TourRequirementsDialog: React.FC<TourRequirementsDialogProps> = ({ 
           }))
         )
 
-        const { error: replaceErr } = await supabase.rpc('replace_job_required_roles', {
+        const { error: replaceErr } = await dataLayerClient.rpc('replace_job_required_roles', {
           p_job_id: jobId,
           p_departments: selectedDepts,
           p_rows: rows as unknown as Json,

--- a/src/components/tours/TourSchedulingDialog.tsx
+++ b/src/components/tours/TourSchedulingDialog.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import {
   Calendar,
   Clock,
@@ -81,8 +81,7 @@ export const TourSchedulingDialog: React.FC<TourSchedulingDialogProps> = ({
     setIsLoading(true);
     try {
       // Load tour with dates and locations
-      const { data: tour, error: tourError } = await supabase
-        .from('tours')
+      const { data: tour, error: tourError } = await dataLayerClient.from('tours')
         .select(`
           *,
           tour_dates (
@@ -97,16 +96,14 @@ export const TourSchedulingDialog: React.FC<TourSchedulingDialogProps> = ({
 
       // Load hoja de ruta records for each tour date
       const dateIds = tour.tour_dates?.map((d: any) => d.id) || [];
-      const { data: hojaDeRutaRecords, error: hojaError } = await supabase
-        .from('hoja_de_ruta' as any)
+      const { data: hojaDeRutaRecords, error: hojaError } = await dataLayerClient.from('hoja_de_ruta' as any)
         .select('*')
         .in('tour_date_id', dateIds);
 
       if (hojaError) throw hojaError;
 
       // Load accommodations for the tour
-      const { data: accommodationsData, error: accommodationsError } = await supabase
-        .from('tour_accommodations' as any)
+      const { data: accommodationsData, error: accommodationsError } = await dataLayerClient.from('tour_accommodations' as any)
         .select('*')
         .eq('tour_id', tourId);
 
@@ -117,7 +114,7 @@ export const TourSchedulingDialog: React.FC<TourSchedulingDialogProps> = ({
       }
 
       // Fetch Mapbox token
-      const { data: tokenData, error: tokenError } = await supabase.functions.invoke('get-mapbox-token');
+      const { data: tokenData, error: tokenError } = await dataLayerClient.functions.invoke('get-mapbox-token');
       if (tokenError) {
         console.error('Error fetching Mapbox token:', tokenError);
       } else if (tokenData?.token) {

--- a/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
+++ b/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
@@ -27,6 +27,10 @@ vi.mock("@/integrations/supabase/client", () => ({
   supabase: mockSupabase,
 }));
 
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: mockSupabase,
+}));
+
 vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: toastMock }),
 }));

--- a/src/components/tours/scheduling/EnhancedTourTravelPlanner.tsx
+++ b/src/components/tours/scheduling/EnhancedTourTravelPlanner.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import {
   Route,
   MapPin,
@@ -302,8 +302,7 @@ export const EnhancedTourTravelPlanner: React.FC<
 
     setIsSaving(true);
     try {
-      const { error } = await supabase
-        .from("tours")
+      const { error } = await dataLayerClient.from("tours")
         .update({ travel_plan: travelPlan } as any)
         .eq("id", tourId);
 

--- a/src/components/tours/scheduling/TourAccommodationsManager.tsx
+++ b/src/components/tours/scheduling/TourAccommodationsManager.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import {
   Hotel,
   Plus,
@@ -111,8 +111,7 @@ export const TourAccommodationsManager: React.FC<TourAccommodationsManagerProps>
   const loadAccommodations = async () => {
     setIsLoading(true);
     try {
-      const { data, error } = await supabase
-        .from('tour_accommodations' as any)
+      const { data, error } = await dataLayerClient.from('tour_accommodations' as any)
         .select('*')
         .eq('tour_id', tourId)
         .order('check_in', { ascending: true });
@@ -135,7 +134,7 @@ export const TourAccommodationsManager: React.FC<TourAccommodationsManagerProps>
   const loadStaff = async () => {
     try {
       // Load staff members from profiles who are active
-      const result = await (supabase as any)
+      const result = await (dataLayerClient as any)
         .from('profiles')
         .select('id, full_name, role')
         .eq('is_active', true)
@@ -218,8 +217,7 @@ export const TourAccommodationsManager: React.FC<TourAccommodationsManagerProps>
 
       if (editingAccommodation) {
         // Update existing accommodation
-        const { error } = await supabase
-          .from('tour_accommodations' as any)
+        const { error } = await dataLayerClient.from('tour_accommodations' as any)
           .update(accommodationData)
           .eq('id', editingAccommodation.id);
 
@@ -231,8 +229,7 @@ export const TourAccommodationsManager: React.FC<TourAccommodationsManagerProps>
         });
       } else {
         // Create new accommodation
-        const { error } = await supabase
-          .from('tour_accommodations' as any)
+        const { error } = await dataLayerClient.from('tour_accommodations' as any)
           .insert([accommodationData]);
 
         if (error) throw error;
@@ -273,8 +270,7 @@ export const TourAccommodationsManager: React.FC<TourAccommodationsManagerProps>
     }
 
     try {
-      const { error } = await supabase
-        .from('tour_accommodations' as any)
+      const { error } = await dataLayerClient.from('tour_accommodations' as any)
         .delete()
         .eq('id', accommodationId);
 

--- a/src/components/tours/scheduling/TourContactsManager.tsx
+++ b/src/components/tours/scheduling/TourContactsManager.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import {
   Users,
   Plus,
@@ -186,8 +186,7 @@ export const TourContactsManager: React.FC<TourContactsManagerProps> = ({
 
     setIsSaving(true);
     try {
-      const { error } = await supabase
-        .from("tours")
+      const { error } = await dataLayerClient.from("tours")
         .update({ tour_contacts: contacts } as any)
         .eq("id", tourId);
 

--- a/src/components/tours/scheduling/TourItineraryBuilder.tsx
+++ b/src/components/tours/scheduling/TourItineraryBuilder.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import {
   Calendar,
   Clock,
@@ -88,8 +88,7 @@ export const TourItineraryBuilder: React.FC<TourItineraryBuilderProps> = ({
     setLoading(true);
     try {
       // First, try to find existing hoja de ruta for this tour date
-      const { data: existingHoja, error: fetchError } = await supabase
-        .from('hoja_de_ruta')
+      const { data: existingHoja, error: fetchError } = await dataLayerClient.from('hoja_de_ruta')
         .select('*')
         .eq('tour_date_id', selectedDateId)
         .maybeSingle();
@@ -130,8 +129,7 @@ export const TourItineraryBuilder: React.FC<TourItineraryBuilderProps> = ({
     setSaving(true);
     try {
       // Get the job associated with this tour date
-      const { data: job, error: jobError } = await supabase
-        .from('jobs')
+      const { data: job, error: jobError } = await dataLayerClient.from('jobs')
         .select('id')
         .eq('tour_date_id', selectedDateId)
         .maybeSingle();
@@ -150,16 +148,14 @@ export const TourItineraryBuilder: React.FC<TourItineraryBuilderProps> = ({
 
       if (hojaDeRuta?.id) {
         // Update existing
-        const { error: updateError } = await supabase
-          .from('hoja_de_ruta')
+        const { error: updateError } = await dataLayerClient.from('hoja_de_ruta')
           .update(hojaData)
           .eq('id', hojaDeRuta.id);
 
         if (updateError) throw updateError;
       } else {
         // Create new
-        const { data: newHoja, error: insertError } = await supabase
-          .from('hoja_de_ruta')
+        const { data: newHoja, error: insertError } = await dataLayerClient.from('hoja_de_ruta')
           .insert(hojaData)
           .select()
           .single();
@@ -193,8 +189,7 @@ export const TourItineraryBuilder: React.FC<TourItineraryBuilderProps> = ({
     try {
       const promises = sortedDates.map(async (date) => {
         // Check if hoja de ruta exists
-        const result = await supabase
-          .from('hoja_de_ruta')
+        const result = await dataLayerClient.from('hoja_de_ruta')
           .select('id')
           .eq('tour_date_id', date.id)
           .maybeSingle();
@@ -206,8 +201,7 @@ export const TourItineraryBuilder: React.FC<TourItineraryBuilderProps> = ({
         if (existing) return; // Skip if already exists
 
         // Get job
-        const { data: job, error: jobError } = await supabase
-          .from('jobs')
+        const { data: job, error: jobError } = await dataLayerClient.from('jobs')
           .select('id')
           .eq('tour_date_id', date.id)
           .maybeSingle();
@@ -215,8 +209,7 @@ export const TourItineraryBuilder: React.FC<TourItineraryBuilderProps> = ({
         if (jobError) throw jobError;
 
         // Create hoja de ruta with empty schedule
-        const { error: insertError } = await supabase
-          .from('hoja_de_ruta')
+        const { error: insertError } = await dataLayerClient.from('hoja_de_ruta')
           .insert({
             job_id: job?.id || null,
             tour_date_id: date.id,

--- a/src/components/tours/scheduling/TourMapView.tsx
+++ b/src/components/tours/scheduling/TourMapView.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Map, MapPin, Home, Loader2, AlertCircle } from "lucide-react";
 
 interface TourMapViewProps {
@@ -31,7 +31,7 @@ export const TourMapView: React.FC<TourMapViewProps> = ({
   useEffect(() => {
     const fetchApiKey = async () => {
       try {
-        const { data, error } = await supabase.functions.invoke('get-google-maps-key');
+        const { data, error } = await dataLayerClient.functions.invoke('get-google-maps-key');
 
         if (error) {
           console.error('Failed to fetch Google Maps API key:', error);

--- a/src/components/tours/scheduling/TourSettingsPanel.tsx
+++ b/src/components/tours/scheduling/TourSettingsPanel.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { PlaceAutocomplete } from "@/components/maps/PlaceAutocomplete";
 import {
   Home,
@@ -121,8 +121,7 @@ export const TourSettingsPanel: React.FC<TourSettingsPanelProps> = ({
         defaultReturnTime: settings.defaultReturnTime,
       };
 
-      const { error } = await supabase
-        .from("tours")
+      const { error } = await dataLayerClient.from("tours")
         .update({ tour_settings: tourSettings } as any)
         .eq("id", tourId);
 

--- a/src/components/users/EditUserDialog.tsx
+++ b/src/components/users/EditUserDialog.tsx
@@ -10,7 +10,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { supabase } from "@/integrations/supabase/client";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { toast } from "@/hooks/use-toast";
 import { HouseTechRateEditor } from "@/components/settings/HouseTechRateEditor";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
@@ -120,7 +120,7 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
     }
     try {
       setIsSendingOnboarding(true);
-      const { error } = await supabase.functions.invoke('send-onboarding-email', {
+      const { error } = await dataLayerClient.functions.invoke('send-onboarding-email', {
         body: {
           email: user.email,
           firstName: user.first_name || undefined,

--- a/src/components/users/UsersList.tsx
+++ b/src/components/users/UsersList.tsx
@@ -1,6 +1,6 @@
 
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Profile } from "./types";
 import { UsersListContent } from "./UsersListContent";
 import { useTabVisibility } from "@/hooks/useTabVisibility";
@@ -24,6 +24,10 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 
+
+import { queryKeys } from "@/lib/react-query";
+import type { Database } from "@/integrations/supabase/types";
+import type { Department } from "@/types/department";
 interface UsersListProps {
   searchQuery?: string;
   roleFilter?: string;
@@ -35,6 +39,8 @@ interface QueryResult {
   data: Profile[];
   count: number;
 }
+
+type UserRole = Database["public"]["Enums"]["user_role"];
 
 const PAGE_SIZE = 10;
 
@@ -53,10 +59,10 @@ export const UsersList = ({
 
   useEffect(() => {
     const checkAuth = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
+      const { data: { session } } = await dataLayerClient.auth.getSession();
       setIsAuthenticated(!!session);
 
-      const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      const { data: { subscription } } = dataLayerClient.auth.onAuthStateChange((_event, session) => {
         setIsAuthenticated(!!session);
       });
 
@@ -67,7 +73,7 @@ export const UsersList = ({
   }, []);
 
   const { data: users, isLoading, error, isFetching, refetch } = useQuery<QueryResult>({
-    queryKey: ['profiles', searchQuery, roleFilter, departmentFilter, currentPage, sortBy, sortOrder],
+    queryKey: queryKeys.scope('profiles', searchQuery, roleFilter, departmentFilter, currentPage, sortBy, sortOrder),
     queryFn: async () => {
       if (!isAuthenticated) {
         console.log("Not authenticated, skipping profiles fetch");
@@ -79,13 +85,12 @@ export const UsersList = ({
       });
       
       try {
-        let query = supabase
-          .from('profiles')
+        let query = dataLayerClient.from('profiles')
           .select('id, first_name, nickname, last_name, email, role, phone, department, dni, residencia, assignable_as_tech, warehouse_duty_exempt, flex_resource_id, soundvision_access_enabled, autonomo', { count: 'exact' });
 
         // Apply filters
         if (roleFilter) {
-          query = query.eq('role', roleFilter);
+          query = query.eq('role', roleFilter as UserRole);
         }
 
         if (departmentFilter) {
@@ -119,7 +124,13 @@ export const UsersList = ({
           return { data: [], count: 0 };
         }
 
-        const validProfiles = profileData.filter(profile => profile && profile.id);
+        const validProfiles: Profile[] = profileData
+          .filter(profile => profile && profile.id)
+          .map(profile => ({
+            ...profile,
+            role: profile.role,
+            department: profile.department as Department | null,
+          }));
         console.log("Profiles fetch successful:", validProfiles);
         return { data: validProfiles, count: count || 0 };
       } catch (error) {

--- a/src/components/users/UsersListContent.tsx
+++ b/src/components/users/UsersListContent.tsx
@@ -1,9 +1,9 @@
 
 import { useState } from "react";
-import { Profile } from "@/components/users/types";
-import { UserCard } from "@/components/users/UserCard";
-import { EditUserDialog } from "@/components/users/EditUserDialog";
-import { DeleteUserDialog } from "@/components/users/DeleteUserDialog";
+import { Profile } from "./types";
+import { UserCard } from "./UserCard";
+import { EditUserDialog } from "./EditUserDialog";
+import { DeleteUserDialog } from "./DeleteUserDialog";
 import { useUserManagement } from "@/hooks/users/useUserManagement";
 import { Badge } from "@/components/ui/badge";
 import {

--- a/src/components/users/__tests__/EditUserDialog.test.tsx
+++ b/src/components/users/__tests__/EditUserDialog.test.tsx
@@ -21,6 +21,10 @@ vi.mock("@/integrations/supabase/client", () => ({
   supabase: mockSupabase,
 }));
 
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: mockSupabase,
+}));
+
 vi.mock("@/hooks/use-toast", () => ({
   toast: (...args: any[]) => toastMock(...args),
 }));

--- a/src/components/users/import/ImportUsersDialog.tsx
+++ b/src/components/users/import/ImportUsersDialog.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Loader2, Download } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
@@ -51,7 +51,7 @@ export const ImportUsersDialog = ({ open, onOpenChange }: ImportUsersDialogProps
       const formData = new FormData();
       formData.append("file", file);
 
-      const { data, error: uploadError } = await supabase.functions.invoke("import-users", {
+      const { data, error: uploadError } = await dataLayerClient.functions.invoke("import-users", {
         body: formData,
       });
 

--- a/src/components/video/VideoMemoriaTecnica.tsx
+++ b/src/components/video/VideoMemoriaTecnica.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Upload, File, FilePlus, FileCheck, Loader2, Image as ImageIcon, Download } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -119,13 +119,13 @@ export const VideoMemoriaTecnica = () => {
   };
 
   const uploadToStorage = async (file: File, path: string) => {
-    const { error: uploadError, data } = await supabase.storage
+    const { error: uploadError, data } = await dataLayerClient.storage
       .from('video-memoria-tecnica')
       .upload(path, file);
 
     if (uploadError) throw uploadError;
 
-    const { data: { publicUrl } } = supabase.storage
+    const { data: { publicUrl } } = dataLayerClient.storage
       .from('video-memoria-tecnica')
       .getPublicUrl(path);
 
@@ -202,7 +202,7 @@ export const VideoMemoriaTecnica = () => {
 
       setProgress(60);
 
-      const response = await supabase.functions.invoke('generate-video-memoria-tecnica', {
+      const response = await dataLayerClient.functions.invoke('generate-video-memoria-tecnica', {
         body: { documentUrls, projectName, logoUrl }
       });
 
@@ -213,8 +213,7 @@ export const VideoMemoriaTecnica = () => {
 
       setProgress(80);
 
-      const { error: dbError } = await supabase
-        .from('video_memoria_tecnica_documents')
+      const { error: dbError } = await dataLayerClient.from('video_memoria_tecnica_documents')
         .insert({
           project_name: projectName,
           logo_url: logoUrl,

--- a/src/components/video/VideoTaskDialog.tsx
+++ b/src/components/video/VideoTaskDialog.tsx
@@ -18,7 +18,7 @@ import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { Upload, Download, Trash2, Table } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/lib/supabase";
+import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
 import { TASK_TYPES } from "@/constants/taskTypes";
@@ -31,16 +31,32 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+
+import { queryKeys } from "@/lib/react-query";
+import type { Database } from "@/integrations/supabase/types";
 interface VideoTaskDialogProps {
   jobId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
+type TaskStatus = Database["public"]["Enums"]["task_status"];
+
 type TaskDocumentRow = {
   id: string;
   file_name: string;
   file_path: string;
+};
+
+type AssignedUser = {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+};
+
+type TaskRow = Database["public"]["Tables"]["video_job_tasks"]["Row"] & {
+  assigned_to: AssignedUser | null;
+  task_documents: TaskDocumentRow[] | null;
 };
 
 export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogProps) => {
@@ -49,10 +65,9 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
   const queryClient = useQueryClient();
 
   const { data: managementUsers } = useQuery({
-    queryKey: ['management-users'],
+    queryKey: queryKeys.scope('management-users'),
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('profiles')
+      const { data, error } = await dataLayerClient.from('profiles')
         .select('id, first_name, last_name')
         .in('role', ['management', 'admin']);
       
@@ -62,15 +77,15 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
   });
 
   const { data: tasks, refetch: refetchTasks } = useQuery({
-    queryKey: ['video-tasks', jobId],
+    queryKey: queryKeys.scope('video-tasks', jobId),
     queryFn: async () => {
       if (!jobId) return null;
       
-      const { data, error } = await supabase
-        .from('video_job_tasks')
+      const { data, error } = await dataLayerClient.from('video_job_tasks')
         .select(`
           *,
-          assigned_to (
+          assigned_to:profiles!video_job_tasks_assigned_to_fkey (
+            id,
             first_name,
             last_name
           ),
@@ -79,18 +94,17 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
         .eq('job_id', jobId);
       
       if (error) throw error;
-      return data;
+      return data as unknown as TaskRow[];
     },
     enabled: !!jobId
   });
 
   const { data: personnel } = useQuery({
-    queryKey: ['video-personnel', jobId],
+    queryKey: queryKeys.scope('video-personnel', jobId),
     queryFn: async () => {
       if (!jobId) return null;
 
-      const { data: existingData, error: fetchError } = await supabase
-        .from('video_job_personnel')
+      const { data: existingData, error: fetchError } = await dataLayerClient.from('video_job_personnel')
         .select('*')
         .eq('job_id', jobId)
         .maybeSingle();
@@ -98,8 +112,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
       if (fetchError && fetchError.code !== 'PGRST116') throw fetchError;
 
       if (!existingData) {
-        const { data: newData, error: insertError } = await supabase
-          .from('video_job_personnel')
+        const { data: newData, error: insertError } = await dataLayerClient.from('video_job_personnel')
           .insert({
             job_id: jobId,
             video_directors: 0,
@@ -124,14 +137,13 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
       setUploading(true);
       const filePath = `${taskId}/${crypto.randomUUID()}-${file.name}`;
       
-      const { error: uploadError } = await supabase.storage
+      const { error: uploadError } = await dataLayerClient.storage
         .from('task_documents')
         .upload(filePath, file);
 
       if (uploadError) throw uploadError;
 
-      const { error: dbError } = await supabase
-        .from('task_documents')
+      const { error: dbError } = await dataLayerClient.from('task_documents')
         .insert({
           task_id: taskId,
           file_name: file.name,
@@ -140,8 +152,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
 
       if (dbError) throw dbError;
 
-      await supabase
-        .from('video_job_tasks')
+      await dataLayerClient.from('video_job_tasks')
         .update({ 
           status: 'completed',
           progress: 100 
@@ -167,7 +178,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
 
   const handleDownload = async (filePath: string, fileName: string) => {
     try {
-      const { data, error } = await supabase.storage
+      const { data, error } = await dataLayerClient.storage
         .from('task_documents')
         .download(filePath);
 
@@ -192,7 +203,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
 
   const handleDeleteFile = async (taskId: string, documentId: string, filePath: string) => {
     try {
-      const { error: storageError } = await supabase.storage
+      const { error: storageError } = await dataLayerClient.storage
         .from('task_documents')
         .remove([filePath]);
   
@@ -200,8 +211,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
         throw new Error(`Failed to delete file from storage: ${storageError.message}`);
       }
   
-      const { error: dbError } = await supabase
-        .from('task_documents')
+      const { error: dbError } = await dataLayerClient.from('task_documents')
         .delete()
         .eq('id', documentId);
   
@@ -209,8 +219,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
         throw new Error(`Failed to delete file record: ${dbError.message}`);
       }
   
-      const { error: taskError } = await supabase
-        .from('video_job_tasks')
+      const { error: taskError } = await dataLayerClient.from('video_job_tasks')
         .update({ 
           status: 'in_progress',
           progress: 50 
@@ -236,12 +245,11 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
     }
   };
 
-  const updateTaskStatus = async (taskId: string, status: string) => {
+  const updateTaskStatus = async (taskId: string, status: TaskStatus) => {
     try {
       const progress = status === 'completed' ? 100 : status === 'in_progress' ? 50 : 0;
       
-      const { error } = await supabase
-        .from('video_job_tasks')
+      const { error } = await dataLayerClient.from('video_job_tasks')
         .update({ 
           status,
           progress,
@@ -313,8 +321,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                 min="0"
                 value={personnel?.video_directors || 0}
                 onChange={async (e) => {
-                  const { error } = await supabase
-                    .from('video_job_personnel')
+                  const { error } = await dataLayerClient.from('video_job_personnel')
                     .update({ video_directors: parseInt(e.target.value) })
                     .eq('id', personnel?.id);
                   
@@ -325,7 +332,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                       variant: "destructive",
                     });
                   }
-                  queryClient.invalidateQueries({ queryKey: ['video-personnel', jobId] });
+                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('video-personnel', jobId) });
                 }}
               />
             </div>
@@ -336,8 +343,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                 min="0"
                 value={personnel?.camera_ops || 0}
                 onChange={async (e) => {
-                  const { error } = await supabase
-                    .from('video_job_personnel')
+                  const { error } = await dataLayerClient.from('video_job_personnel')
                     .update({ camera_ops: parseInt(e.target.value) })
                     .eq('id', personnel?.id);
                   
@@ -348,7 +354,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                       variant: "destructive",
                     });
                   }
-                  queryClient.invalidateQueries({ queryKey: ['video-personnel', jobId] });
+                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('video-personnel', jobId) });
                 }}
               />
             </div>
@@ -359,8 +365,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                 min="0"
                 value={personnel?.playback_techs || 0}
                 onChange={async (e) => {
-                  const { error } = await supabase
-                    .from('video_job_personnel')
+                  const { error } = await dataLayerClient.from('video_job_personnel')
                     .update({ playback_techs: parseInt(e.target.value) })
                     .eq('id', personnel?.id);
                   
@@ -371,7 +376,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                       variant: "destructive",
                     });
                   }
-                  queryClient.invalidateQueries({ queryKey: ['video-personnel', jobId] });
+                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('video-personnel', jobId) });
                 }}
               />
             </div>
@@ -382,8 +387,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                 min="0"
                 value={personnel?.video_techs || 0}
                 onChange={async (e) => {
-                  const { error } = await supabase
-                    .from('video_job_personnel')
+                  const { error } = await dataLayerClient.from('video_job_personnel')
                     .update({ video_techs: parseInt(e.target.value) })
                     .eq('id', personnel?.id);
                   
@@ -394,7 +398,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                       variant: "destructive",
                     });
                   }
-                  queryClient.invalidateQueries({ queryKey: ['video-personnel', jobId] });
+                  queryClient.invalidateQueries({ queryKey: queryKeys.scope('video-personnel', jobId) });
                 }}
               />
             </div>
@@ -437,8 +441,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                             value={task?.assigned_to?.id || ""}
                             onValueChange={async (value) => {
                               if (!task) {
-                                const { error } = await supabase
-                                  .from('video_job_tasks')
+                                const { error } = await dataLayerClient.from('video_job_tasks')
                                   .insert({
                                     job_id: jobId,
                                     task_type: taskType,
@@ -446,8 +449,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                                   });
                                 if (error) throw error;
                               } else {
-                                const { error } = await supabase
-                                  .from('video_job_tasks')
+                                const { error } = await dataLayerClient.from('video_job_tasks')
                                   .update({ assigned_to: value })
                                   .eq('id', task.id);
                                 if (error) throw error;
@@ -470,8 +472,8 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                         <TableCell>
                           {task && (
                             <Select
-                              value={task.status}
-                              onValueChange={(value) => updateTaskStatus(task.id, value)}
+                              value={task.status ?? 'not_started'}
+                              onValueChange={(value) => updateTaskStatus(task.id, value as TaskStatus)}
                             >
                               <SelectTrigger className="w-[120px]">
                                 <SelectValue />
@@ -488,10 +490,10 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                           {task && (
                             <div className="flex items-center gap-1">
                               <Progress 
-                                value={task.progress} 
-                                className={`h-2 ${getProgressColor(task.status)}`}
+                                value={task.progress || 0}
+                                className={`h-2 ${getProgressColor(task.status || 'not_started')}`}
                               />
-                              <span className="text-xs w-7">{task.progress}%</span>
+                              <span className="text-xs w-7">{task.progress || 0}%</span>
                             </div>
                           )}
                         </TableCell>

--- a/src/services/dataLayerClient.ts
+++ b/src/services/dataLayerClient.ts
@@ -1,4 +1,5 @@
-import { supabase } from "@/integrations/supabase/client";
+import { supabase as runtimeSupabase } from "@/lib/supabase";
+import type { supabase as typedSupabase } from "@/integrations/supabase/client";
 
 /**
  * Shared data-layer client for legacy component/page code that still owns query
@@ -6,4 +7,4 @@ import { supabase } from "@/integrations/supabase/client";
  * boundary removes direct Supabase client ownership from UI modules while Phase
  * 2 migration continues across the largest surfaces.
  */
-export const dataLayerClient: typeof supabase = supabase;
+export const dataLayerClient: typeof typedSupabase = runtimeSupabase as typeof typedSupabase;


### PR DESCRIPTION
## Summary
- Port the remaining untouched Phase 2 component directories to the shared data-layer/query-key boundary.
- Fix strict typing fallout for department task joins/statuses, technician availability IDs, tour assignment joins, tour folder JSON, tour date inserts, and user profile department filters.
- Keep dataLayerClient typed while routing through the established shared Supabase runtime export so existing tests and runtime use the same client boundary.
- No Supabase migrations; Phase 2 documentation updates are deferred to the final wrap-up slice.

## Validation
- npm install --legacy-peer-deps
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- npm run cap:sync
- git diff --check
- git diff --cached --check