### PR TITLE
[codex] Show tour personnel work dates

### DIFF
--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -61,10 +61,11 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
           job_assignments(
             job_id, technician_id, assigned_by, assigned_at,
             sound_role, lights_role, video_role, status,
-            single_day, assignment_date,
+            single_day, assignment_date, assignment_source,
             profiles!job_assignments_technician_id_fkey(id, first_name, last_name, department, role, profile_picture_url)
           ),
-          timesheets(technician_id, date),
+          timesheets(technician_id, date, is_active, is_schedule_only),
+          job_date_types(date, type),
           job_documents(id, file_name, file_path, uploaded_at, file_size, visible_to_tech, read_only, template_type),
           logistics_events(id, event_type, transport_type, event_date, event_time, license_plate)
         `

--- a/src/components/jobs/cards/JobCardAssignments.tsx
+++ b/src/components/jobs/cards/JobCardAssignments.tsx
@@ -5,11 +5,14 @@ import { Users } from "lucide-react";
 import { Department } from "@/types/department";
 import { labelForCode } from '@/utils/roles';
 import { formatUserName } from '@/utils/userName';
-import { format } from "date-fns";
+import { differenceInCalendarDays, parseISO } from "date-fns";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { es } from "date-fns/locale";
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { cn } from "@/lib/utils";
 import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from "@/utils/assignmentWorkDates";
+
+const MADRID_TIME_ZONE = "Europe/Madrid";
 
 interface JobCardAssignmentsProps {
   assignments: any[];
@@ -119,6 +122,15 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
     }
   }
 
+  const formatDateKey = (dateKey: string, pattern: string) => (
+    formatInTimeZone(
+      fromZonedTime(`${dateKey}T00:00:00`, MADRID_TIME_ZONE),
+      MADRID_TIME_ZONE,
+      pattern,
+      { locale: es },
+    )
+  );
+
   const assignedTechnicians = Array.from(grouped.values());
 
   if (assignedTechnicians.length === 0) {
@@ -133,7 +145,7 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
           // Format single/multi-day suffix compactly
           const dateList = Array.from(tech.dates).sort();
           let dateSuffix: string | null = null;
-          const formatCompactDate = (dateKey: string) => format(new Date(`${dateKey}T00:00:00`), 'd MMM', { locale: es });
+          const formatCompactDate = (dateKey: string) => formatDateKey(dateKey, 'd MMM');
           if (dateList.length === 1) {
             try { dateSuffix = ` • ${formatCompactDate(dateList[0])}`; } catch { dateSuffix = ` • ${dateList[0]}`; }
           } else if (dateList.length > 1 && dateList.length <= 3) {
@@ -144,17 +156,22 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
             }
           } else if (dateList.length > 1) {
             // Detect contiguous range; otherwise show count
-            const ds = dateList.map(d => new Date(`${d}T00:00:00`)).sort((a, b) => a.getTime() - b.getTime());
+            const ds = dateList.map((d) => parseISO(d)).sort((a, b) => a.getTime() - b.getTime());
             let contiguous = true;
             for (let i = 1; i < ds.length; i++) {
-              const diff = (ds[i].getTime() - ds[i - 1].getTime()) / (24 * 3600 * 1000);
-              if (diff !== 1) { contiguous = false; break; }
+              if (differenceInCalendarDays(ds[i], ds[i - 1]) !== 1) {
+                contiguous = false;
+                break;
+              }
             }
             if (contiguous) {
-              const first = ds[0];
-              const last = ds[ds.length - 1];
-              const sameMonth = first.getMonth() === last.getMonth() && first.getFullYear() === last.getFullYear();
-              dateSuffix = ` • ${format(first, 'd MMM', { locale: es })}${sameMonth ? '–' + format(last, 'd', { locale: es }) : '–' + format(last, 'd MMM', { locale: es })}`;
+              const firstKey = dateList[0];
+              const lastKey = dateList[dateList.length - 1];
+              const sameMonth = (
+                formatDateKey(firstKey, 'M') === formatDateKey(lastKey, 'M') &&
+                formatDateKey(firstKey, 'yyyy') === formatDateKey(lastKey, 'yyyy')
+              );
+              dateSuffix = ` • ${formatCompactDate(firstKey)}${sameMonth ? '–' + formatDateKey(lastKey, 'd') : '–' + formatCompactDate(lastKey)}`;
             } else {
               try {
                 dateSuffix = ` • ${formatCompactDate(dateList[0])} +${dateList.length - 1} días`;
@@ -168,7 +185,7 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
             if (dateList.length === 0) return null;
             try {
               const pretty = dateList
-                .map(d => format(new Date(`${d}T00:00:00`), 'PPP', { locale: es }))
+                .map(d => formatDateKey(d, 'PPP'))
                 .join('\n');
               return pretty;
             } catch {

--- a/src/components/jobs/cards/JobCardAssignments.tsx
+++ b/src/components/jobs/cards/JobCardAssignments.tsx
@@ -6,16 +6,34 @@ import { Department } from "@/types/department";
 import { labelForCode } from '@/utils/roles';
 import { formatUserName } from '@/utils/userName';
 import { format } from "date-fns";
+import { es } from "date-fns/locale";
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { cn } from "@/lib/utils";
+import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from "@/utils/assignmentWorkDates";
 
 interface JobCardAssignmentsProps {
   assignments: any[];
   department: Department;
   jobTimesheets?: { technician_id: string; status: string }[];
+  jobDateTypes?: Array<{ date?: string | null; type?: string | null }> | null;
+  jobStartTime?: string | null;
+  jobEndTime?: string | null;
 }
 
-export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({ assignments, department, jobTimesheets = [] }) => {
+export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
+  assignments,
+  department,
+  jobTimesheets = [],
+  jobDateTypes,
+  jobStartTime,
+  jobEndTime,
+}) => {
+  const scheduledWorkDateKeys = React.useMemo(() => getScheduledWorkDateKeys({
+    job_date_types: jobDateTypes,
+    start_time: jobStartTime,
+    end_time: jobEndTime,
+  }), [jobDateTypes, jobStartTime, jobEndTime]);
+
   // Determine overall timesheet state for a technician
   const getTechTimesheetState = (techId: string): 'none' | 'draft' | 'partial' | 'submitted' | 'approved' | 'rejected' => {
     const list = jobTimesheets.filter(t => t.technician_id === techId);
@@ -81,16 +99,7 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({ assignme
     const key = assignment.technician_id ? `tech:${assignment.technician_id}` : `ext:${name}`;
     const roleLabel = roleCode ? labelForCode(roleCode) : null;
     const isFromTour = assignment.assignment_source === 'tour';
-    // Use timesheet dates if available (from useOptimizedJobCard), otherwise fall back to assignment date
-    const timesheetDates = assignment._timesheet_dates;
-    const assignmentDate = assignment.single_day && assignment.assignment_date ? assignment.assignment_date : null;
-
-    const datesToAdd = new Set<string>();
-    if (Array.isArray(timesheetDates) && timesheetDates.length > 0) {
-      timesheetDates.forEach(d => datesToAdd.add(d));
-    } else if (assignmentDate) {
-      datesToAdd.add(assignmentDate);
-    }
+    const datesToAdd = resolveAssignmentWorkDateKeys(assignment, { scheduledDateKeys: scheduledWorkDateKeys });
 
     if (!grouped.has(key)) {
       grouped.set(key, {
@@ -99,14 +108,14 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({ assignme
         role: roleLabel,
         isFromTour,
         isExternal,
-        dates: datesToAdd
+        dates: new Set(datesToAdd)
       });
     } else {
       const g = grouped.get(key)!;
       // Preserve first non-null role label; otherwise keep existing
       if (!g.role && roleLabel) g.role = roleLabel;
       if (isFromTour) g.isFromTour = true;
-      datesToAdd.forEach(d => g.dates.add(d));
+      datesToAdd.forEach((d) => g.dates.add(d));
     }
   }
 
@@ -122,10 +131,17 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({ assignme
       <div className="flex flex-wrap gap-1">
         {assignedTechnicians.map((tech, index) => {
           // Format single/multi-day suffix compactly
-          const dateList = Array.from(tech.dates);
+          const dateList = Array.from(tech.dates).sort();
           let dateSuffix: string | null = null;
+          const formatCompactDate = (dateKey: string) => format(new Date(`${dateKey}T00:00:00`), 'd MMM', { locale: es });
           if (dateList.length === 1) {
-            try { dateSuffix = ` • ${format(new Date(`${dateList[0]}T00:00:00`), 'MMM d')}`; } catch { dateSuffix = ` • ${dateList[0]}`; }
+            try { dateSuffix = ` • ${formatCompactDate(dateList[0])}`; } catch { dateSuffix = ` • ${dateList[0]}`; }
+          } else if (dateList.length > 1 && dateList.length <= 3) {
+            try {
+              dateSuffix = ` • ${dateList.map(formatCompactDate).join(', ')}`;
+            } catch {
+              dateSuffix = ` • ${dateList.join(', ')}`;
+            }
           } else if (dateList.length > 1) {
             // Detect contiguous range; otherwise show count
             const ds = dateList.map(d => new Date(`${d}T00:00:00`)).sort((a, b) => a.getTime() - b.getTime());
@@ -138,9 +154,13 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({ assignme
               const first = ds[0];
               const last = ds[ds.length - 1];
               const sameMonth = first.getMonth() === last.getMonth() && first.getFullYear() === last.getFullYear();
-              dateSuffix = ` • ${format(first, 'MMM d')}${sameMonth ? '–' + format(last, 'd') : '–' + format(last, 'MMM d')}`;
+              dateSuffix = ` • ${format(first, 'd MMM', { locale: es })}${sameMonth ? '–' + format(last, 'd', { locale: es }) : '–' + format(last, 'd MMM', { locale: es })}`;
             } else {
-              dateSuffix = ` • ${dateList.length}d`;
+              try {
+                dateSuffix = ` • ${formatCompactDate(dateList[0])} +${dateList.length - 1} días`;
+              } catch {
+                dateSuffix = ` • ${dateList.length} días`;
+              }
             }
           }
           // Build tooltip content with the exact dates list
@@ -148,7 +168,7 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({ assignme
             if (dateList.length === 0) return null;
             try {
               const pretty = dateList
-                .map(d => format(new Date(`${d}T00:00:00`), 'PPP'))
+                .map(d => format(new Date(`${d}T00:00:00`), 'PPP', { locale: es }))
                 .join('\n');
               return pretty;
             } catch {

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -452,7 +452,14 @@ export function JobCardNewView({
             {job.job_type !== "dryhire" && (
               <>
                 {assignments.length > 0 && (
-                  <JobCardAssignments assignments={assignments} department={department} jobTimesheets={jobTimesheets || []} />
+                  <JobCardAssignments
+                    assignments={assignments}
+                    department={department}
+                    jobTimesheets={jobTimesheets || []}
+                    jobDateTypes={job.job_date_types || []}
+                    jobStartTime={job.start_time || null}
+                    jobEndTime={job.end_time || null}
+                  />
                 )}
 
                 {documents.length > 0 && (

--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { format } from "date-fns";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { es } from "date-fns/locale";
 import { Users } from "lucide-react";
 
@@ -9,6 +9,8 @@ import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { labelForCode } from "@/utils/roles";
 import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from "@/utils/assignmentWorkDates";
+
+const MADRID_TIME_ZONE = "Europe/Madrid";
 
 interface JobDetailsPersonnelTabProps {
   jobDetails: any;
@@ -71,7 +73,12 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
   ), [filteredAssignments, scheduledWorkDateKeys, technicianDatesMap]);
 
   const formatDateKey = (dateKey: string, pattern: string) => (
-    format(new Date(`${dateKey}T00:00:00`), pattern, { locale: es })
+    formatInTimeZone(
+      fromZonedTime(`${dateKey}T00:00:00`, MADRID_TIME_ZONE),
+      MADRID_TIME_ZONE,
+      pattern,
+      { locale: es },
+    )
   );
 
   return (

--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { labelForCode } from "@/utils/roles";
+import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from "@/utils/assignmentWorkDates";
 
 interface JobDetailsPersonnelTabProps {
   jobDetails: any;
@@ -45,6 +46,7 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
     const map = new Map<string, Set<string>>();
     if (jobDetails?.timesheets) {
       jobDetails.timesheets.forEach((t: any) => {
+        if (t?.is_active === false) return;
         if (t.technician_id && t.date) {
           if (!map.has(t.technician_id)) {
             map.set(t.technician_id, new Set());
@@ -55,6 +57,22 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
     }
     return map;
   }, [jobDetails?.timesheets]);
+
+  const scheduledWorkDateKeys = useMemo(() => getScheduledWorkDateKeys(jobDetails), [jobDetails]);
+
+  const assignmentsWithDates = useMemo<Array<{ assignment: any; workDateKeys: string[] }>>(() => (
+    filteredAssignments.map((assignment: any) => ({
+      assignment,
+      workDateKeys: resolveAssignmentWorkDateKeys(assignment, {
+        timesheetDateKeys: technicianDatesMap.get(assignment.technician_id),
+        scheduledDateKeys: scheduledWorkDateKeys,
+      }),
+    }))
+  ), [filteredAssignments, scheduledWorkDateKeys, technicianDatesMap]);
+
+  const formatDateKey = (dateKey: string, pattern: string) => (
+    format(new Date(`${dateKey}T00:00:00`), pattern, { locale: es })
+  );
 
   return (
     <TabsContent value="personnel" className="space-y-4 min-w-0 overflow-x-hidden">
@@ -68,9 +86,9 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
           <div className="flex items-center justify-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
           </div>
-        ) : filteredAssignments.length > 0 ? (
+        ) : assignmentsWithDates.length > 0 ? (
           <div className="space-y-3">
-            {filteredAssignments.map((assignment: any) => (
+            {assignmentsWithDates.map(({ assignment, workDateKeys }) => (
               <div
                 key={assignment.technician_id}
                 className="flex flex-col md:flex-row md:items-start md:justify-between gap-2 p-3 bg-muted rounded min-w-0"
@@ -96,22 +114,14 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
                         : assignment.external_technician_name || "Desconocido"}
                     </p>
                     <p className="text-sm text-muted-foreground">{assignment.profiles?.department || "Externo"}</p>
-                    {assignment.single_day && (
-                      <p className="text-xs text-muted-foreground break-words">
-                        {(() => {
-                          const dates = technicianDatesMap.get(assignment.technician_id);
-                          if (dates && dates.size > 0) {
-                            const sortedDates = Array.from(dates).sort();
-                            if (sortedDates.length === 1) {
-                              return `Solo día: ${format(new Date(sortedDates[0]), "PPP", { locale: es })}`;
-                            }
-                            return `Días: ${sortedDates.map((d) => format(new Date(d), "dd/MM")).join(", ")}`;
-                          }
-                          return assignment.assignment_date
-                            ? `Solo día: ${format(new Date(assignment.assignment_date), "PPP", { locale: es })}`
-                            : "Sin fecha definida";
-                        })()}
-                      </p>
+                    {workDateKeys.length > 0 && (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {workDateKeys.map((dateKey) => (
+                          <Badge key={dateKey} variant="secondary" className="text-[11px] font-normal">
+                            {formatDateKey(dateKey, "d MMM")}
+                          </Badge>
+                        ))}
+                      </div>
                     )}
                   </div>
                 </div>
@@ -131,15 +141,9 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
                       Vídeo: {labelForCode(assignment.video_role)}
                     </Badge>
                   )}
-                  {assignment.single_day && (
+                  {workDateKeys.length > 0 && (
                     <Badge variant="secondary" className="text-xs">
-                      {(() => {
-                        const dates = technicianDatesMap.get(assignment.technician_id);
-                        if (dates && dates.size > 0) {
-                          return dates.size === 1 ? "Día único" : "Varios días";
-                        }
-                        return "Día único";
-                      })()}
+                      {workDateKeys.length === 1 ? "1 día" : `${workDateKeys.length} días`}
                     </Badge>
                   )}
                 </div>
@@ -156,4 +160,3 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
     </TabsContent>
   );
 };
-

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -13,6 +13,7 @@ export const useJobs = () => {
     { table: 'jobs', queryKey: queryKeys.scope('jobs'), priority: 'high' },
     { table: 'job_assignments', queryKey: queryKeys.scope('jobs'), priority: 'medium' },
     { table: 'job_departments', queryKey: queryKeys.scope('jobs'), priority: 'medium' },
+    { table: 'job_date_types', queryKey: queryKeys.scope('jobs'), priority: 'medium' },
     // Documents and tour dates change less frequently; keep lower priority
     { table: 'job_documents', queryKey: queryKeys.scope('jobs'), priority: 'low' },
     { table: 'tour_dates', queryKey: queryKeys.scope('jobs'), priority: 'low' },
@@ -50,6 +51,10 @@ export const useJobs = () => {
                   nickname,
                   department
                 )
+              ),
+              job_date_types(
+                date,
+                type
               ),
               job_documents(
                 id,

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -3,10 +3,10 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { supabase } from '@/lib/supabase';
 import { useTheme } from 'next-themes';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { format } from 'date-fns';
 import { createQueryKey } from '@/lib/optimized-react-query';
 import { useRequiredRoleSummary } from '@/hooks/useJobRequiredRoles';
 import { resolveJobDocLocation } from '@/utils/jobDocuments';
+import { getScheduledWorkDateKeys } from '@/utils/assignmentWorkDates';
 import {
   canCreateFolders,
   canEditJobs as canEditJobsForRole,
@@ -75,6 +75,11 @@ export const useOptimizedJobCard = (
   }, [job.job_documents]);
 
   const normalizeProfile = (p: any) => Array.isArray(p) ? p[0] : p;
+  const jobScheduledWorkDates = useMemo(() => getScheduledWorkDateKeys({
+    job_date_types: job?.job_date_types,
+    start_time: job?.start_time,
+    end_time: job?.end_time,
+  }), [job?.job_date_types, job?.start_time, job?.end_time]);
 
   // Helper to fetch and update assignments for this job
   // job_assignments are the base; timesheets add per-day date info (with RLS-safe fallback)
@@ -133,10 +138,26 @@ export const useOptimizedJobCard = (
         normalizedTimesheetsByTech.set(techId, uniqueSorted);
       });
 
+      const { data: jobDateTypes, error: dateTypesError } = await supabase
+        .from('job_date_types')
+        .select('date, type')
+        .eq('job_id', job.id);
+
+      if (dateTypesError) {
+        console.warn('Error fetching job date types for job card:', dateTypesError);
+      }
+
+      const scheduledWorkDates = getScheduledWorkDateKeys({
+        job_date_types: jobDateTypes || job?.job_date_types || [],
+        start_time: job?.start_time,
+        end_time: job?.end_time,
+      }) || jobScheduledWorkDates;
+
       const mergedAssignments: any[] = (baseAssignments || []).map((a: any) => ({
         ...a,
         profiles: normalizeProfile(a.profiles),
         _timesheet_dates: normalizedTimesheetsByTech.get(a.technician_id) || [],
+        _scheduled_work_dates: scheduledWorkDates,
       }));
 
       // If timesheets exist for technicians not in job_assignments (edge cases), include them so badges still appear
@@ -155,6 +176,7 @@ export const useOptimizedJobCard = (
           assignment_date: null,
           assigned_at: null,
           _timesheet_dates: dates,
+          _scheduled_work_dates: scheduledWorkDates,
         });
       });
 
@@ -162,12 +184,18 @@ export const useOptimizedJobCard = (
     } catch (err) {
       console.warn('Error refreshing assignments', err);
     }
-  }, [job?.id, job?.job_assignments]);
+  }, [job?.id, job?.job_assignments, job?.job_date_types, job?.start_time, job?.end_time, jobScheduledWorkDates]);
 
   // Keep local state in sync with incoming job prop updates for instant UI
   useEffect(() => {
-    setAssignments(job.job_assignments || []);
-  }, [job.job_assignments]);
+    const nextAssignments = Array.isArray(job.job_assignments)
+      ? job.job_assignments.map((assignment: any) => ({
+        ...assignment,
+        _scheduled_work_dates: jobScheduledWorkDates,
+      }))
+      : [];
+    setAssignments(nextAssignments);
+  }, [job.job_assignments, jobScheduledWorkDates]);
 
   // One-time load refresh for contexts that must show current assignment badges immediately
   useEffect(() => {

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -147,11 +147,14 @@ export const useOptimizedJobCard = (
         console.warn('Error fetching job date types for job card:', dateTypesError);
       }
 
-      const scheduledWorkDates = getScheduledWorkDateKeys({
+      const computedScheduledWorkDates = getScheduledWorkDateKeys({
         job_date_types: jobDateTypes || job?.job_date_types || [],
         start_time: job?.start_time,
         end_time: job?.end_time,
-      }) || jobScheduledWorkDates;
+      });
+      const scheduledWorkDates = computedScheduledWorkDates.length > 0
+        ? computedScheduledWorkDates
+        : jobScheduledWorkDates;
 
       const mergedAssignments: any[] = (baseAssignments || []).map((a: any) => ({
         ...a,

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -27,6 +27,7 @@ export const useOptimizedJobs = (
     { table: 'jobs', queryKey: queryKeys.scope('optimized-jobs'), priority: 'high' },
     { table: 'job_assignments', queryKey: queryKeys.scope('optimized-jobs'), priority: 'high' },
     { table: 'job_departments', queryKey: queryKeys.scope('optimized-jobs'), priority: 'medium' },
+    { table: 'job_date_types', queryKey: queryKeys.scope('optimized-jobs'), priority: 'medium' },
     { table: 'job_documents', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'flex_folders', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'locations', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
@@ -63,6 +64,7 @@ export const useOptimizedJobs = (
           sound_role,
           lights_role,
           video_role,
+          assignment_source,
           single_day,
           assignment_date,
           status,
@@ -85,6 +87,10 @@ export const useOptimizedJobs = (
           uploaded_at,
           read_only,
           template_type
+        ),
+        job_date_types(
+          date,
+          type
         ),
         flex_folders(
           id,

--- a/src/utils/__tests__/assignmentWorkDates.test.ts
+++ b/src/utils/__tests__/assignmentWorkDates.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from '../assignmentWorkDates';
+import { getScheduledWorkDateKeys, normalizeDateKey, resolveAssignmentWorkDateKeys } from '@/utils/assignmentWorkDates';
 
 describe('assignment work date resolution', () => {
+  it('normalizes timestamp values using the Madrid calendar day', () => {
+    expect(normalizeDateKey('2026-06-01T22:30:00Z')).toBe('2026-06-02');
+    expect(normalizeDateKey('2026-06-01')).toBe('2026-06-01');
+  });
+
   it('uses working job date types as the scheduled job span', () => {
     expect(getScheduledWorkDateKeys({
       start_time: '2026-06-01T06:00:00',

--- a/src/utils/__tests__/assignmentWorkDates.test.ts
+++ b/src/utils/__tests__/assignmentWorkDates.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from '../assignmentWorkDates';
+
+describe('assignment work date resolution', () => {
+  it('uses working job date types as the scheduled job span', () => {
+    expect(getScheduledWorkDateKeys({
+      start_time: '2026-06-01T06:00:00',
+      end_time: '2026-06-04T22:00:00',
+      job_date_types: [
+        { date: '2026-06-01', type: 'travel' },
+        { date: '2026-06-02', type: 'show' },
+        { date: '2026-06-03', type: 'rehearsal' },
+        { date: '2026-06-04', type: 'off' },
+      ],
+    })).toEqual(['2026-06-02', '2026-06-03']);
+  });
+
+  it('keeps exact timesheet days for partial multi-day assignments', () => {
+    expect(resolveAssignmentWorkDateKeys(
+      {
+        single_day: true,
+        assignment_date: '2026-06-02',
+        _timesheet_dates: ['2026-06-04', '2026-06-02'],
+      },
+      { scheduledDateKeys: ['2026-06-02', '2026-06-03', '2026-06-04'] },
+    )).toEqual(['2026-06-02', '2026-06-04']);
+  });
+
+  it('uses scheduled dates for full multi-day tour assignments even when old schedule-only timesheets are incomplete', () => {
+    expect(resolveAssignmentWorkDateKeys(
+      {
+        single_day: false,
+        assignment_date: null,
+        _timesheet_dates: ['2026-06-02'],
+      },
+      { scheduledDateKeys: ['2026-06-02', '2026-06-03', '2026-06-04'] },
+    )).toEqual(['2026-06-02', '2026-06-03', '2026-06-04']);
+  });
+
+  it('falls back to the assignment date for legacy single-day rows without timesheets', () => {
+    expect(resolveAssignmentWorkDateKeys({
+      single_day: true,
+      assignment_date: '2026-06-02',
+      _timesheet_dates: [],
+    })).toEqual(['2026-06-02']);
+  });
+});

--- a/src/utils/assignmentWorkDates.ts
+++ b/src/utils/assignmentWorkDates.ts
@@ -1,3 +1,6 @@
+import { isValid, parseISO } from "date-fns";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
+
 import { isNonWorkingDateType } from "@/constants/dateTypes";
 
 type DateValue = string | Date | null | undefined;
@@ -25,18 +28,17 @@ export interface ResolveAssignmentWorkDateOptions {
   scheduledDateKeys?: Iterable<DateValue> | null;
 }
 
-const DATE_KEY_PATTERN = /^(\d{4}-\d{2}-\d{2})/;
+const MADRID_TIME_ZONE = "Europe/Madrid";
+const DATE_KEY_PATTERN = /^(\d{4}-\d{2}-\d{2})$/;
+const TIME_ZONE_PATTERN = /(Z|[+-]\d{2}:?\d{2})$/;
 
+/** Normalizes date-like values to the Madrid calendar date key used by job scheduling. */
 export function normalizeDateKey(value: DateValue): string | null {
   if (!value) return null;
 
   if (value instanceof Date) {
     if (Number.isNaN(value.getTime())) return null;
-    return [
-      value.getFullYear(),
-      String(value.getMonth() + 1).padStart(2, "0"),
-      String(value.getDate()).padStart(2, "0"),
-    ].join("-");
+    return formatInTimeZone(value, MADRID_TIME_ZONE, "yyyy-MM-dd");
   }
 
   const trimmed = String(value).trim();
@@ -47,16 +49,15 @@ export function normalizeDateKey(value: DateValue): string | null {
     return dateKeyMatch[1];
   }
 
-  const parsed = new Date(trimmed);
-  if (Number.isNaN(parsed.getTime())) return null;
+  const parsed = TIME_ZONE_PATTERN.test(trimmed)
+    ? parseISO(trimmed)
+    : fromZonedTime(trimmed, MADRID_TIME_ZONE);
+  if (!isValid(parsed)) return null;
 
-  return [
-    parsed.getFullYear(),
-    String(parsed.getMonth() + 1).padStart(2, "0"),
-    String(parsed.getDate()).padStart(2, "0"),
-  ].join("-");
+  return formatInTimeZone(parsed, MADRID_TIME_ZONE, "yyyy-MM-dd");
 }
 
+/** Deduplicates and sorts date-like values after normalizing them to date keys. */
 export function uniqueSortedDateKeys(values: Iterable<DateValue> | null | undefined): string[] {
   if (!values) return [];
 
@@ -88,6 +89,7 @@ function buildDateRange(startKey: string, endKey: string): string[] {
   return dates;
 }
 
+/** Returns the working dates for a job, excluding travel/off date types when present. */
 export function getScheduledWorkDateKeys(job: JobScheduleLike | null | undefined): string[] {
   if (!job) return [];
 
@@ -109,6 +111,7 @@ export function getScheduledWorkDateKeys(job: JobScheduleLike | null | undefined
   return buildDateRange(startKey, endKey);
 }
 
+/** Resolves the exact work dates that should be displayed for a personnel assignment. */
 export function resolveAssignmentWorkDateKeys(
   assignment: AssignmentDateLike | null | undefined,
   options: ResolveAssignmentWorkDateOptions = {},

--- a/src/utils/assignmentWorkDates.ts
+++ b/src/utils/assignmentWorkDates.ts
@@ -1,0 +1,142 @@
+import { isNonWorkingDateType } from "@/constants/dateTypes";
+
+type DateValue = string | Date | null | undefined;
+
+export interface JobDateTypeLike {
+  date?: DateValue;
+  type?: string | null;
+}
+
+export interface JobScheduleLike {
+  job_date_types?: JobDateTypeLike[] | null;
+  start_time?: DateValue;
+  end_time?: DateValue;
+}
+
+export interface AssignmentDateLike {
+  single_day?: boolean | null;
+  assignment_date?: DateValue;
+  _timesheet_dates?: DateValue[] | null;
+  _scheduled_work_dates?: DateValue[] | null;
+}
+
+export interface ResolveAssignmentWorkDateOptions {
+  timesheetDateKeys?: Iterable<DateValue> | null;
+  scheduledDateKeys?: Iterable<DateValue> | null;
+}
+
+const DATE_KEY_PATTERN = /^(\d{4}-\d{2}-\d{2})/;
+
+export function normalizeDateKey(value: DateValue): string | null {
+  if (!value) return null;
+
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    return [
+      value.getFullYear(),
+      String(value.getMonth() + 1).padStart(2, "0"),
+      String(value.getDate()).padStart(2, "0"),
+    ].join("-");
+  }
+
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+
+  const dateKeyMatch = trimmed.match(DATE_KEY_PATTERN);
+  if (dateKeyMatch) {
+    return dateKeyMatch[1];
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  return [
+    parsed.getFullYear(),
+    String(parsed.getMonth() + 1).padStart(2, "0"),
+    String(parsed.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+export function uniqueSortedDateKeys(values: Iterable<DateValue> | null | undefined): string[] {
+  if (!values) return [];
+
+  const keys = new Set<string>();
+  for (const value of values) {
+    const key = normalizeDateKey(value);
+    if (key) keys.add(key);
+  }
+
+  return Array.from(keys).sort();
+}
+
+function addDays(dateKey: string, amount: number): string {
+  const date = new Date(`${dateKey}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + amount);
+  return date.toISOString().slice(0, 10);
+}
+
+function buildDateRange(startKey: string, endKey: string): string[] {
+  if (endKey < startKey) return [startKey];
+
+  const dates: string[] = [];
+  let cursor = startKey;
+  while (cursor <= endKey) {
+    dates.push(cursor);
+    cursor = addDays(cursor, 1);
+  }
+
+  return dates;
+}
+
+export function getScheduledWorkDateKeys(job: JobScheduleLike | null | undefined): string[] {
+  if (!job) return [];
+
+  const dateTypeRows = Array.isArray(job.job_date_types) ? job.job_date_types : [];
+  const typedRowsWithDates = dateTypeRows.filter((row) => Boolean(normalizeDateKey(row?.date)));
+
+  if (typedRowsWithDates.length > 0) {
+    return uniqueSortedDateKeys(
+      typedRowsWithDates
+        .filter((row) => !isNonWorkingDateType(row?.type))
+        .map((row) => row.date),
+    );
+  }
+
+  const startKey = normalizeDateKey(job.start_time);
+  if (!startKey) return [];
+
+  const endKey = normalizeDateKey(job.end_time) ?? startKey;
+  return buildDateRange(startKey, endKey);
+}
+
+export function resolveAssignmentWorkDateKeys(
+  assignment: AssignmentDateLike | null | undefined,
+  options: ResolveAssignmentWorkDateOptions = {},
+): string[] {
+  if (!assignment) return [];
+
+  const assignmentTimesheetDates = uniqueSortedDateKeys(assignment._timesheet_dates);
+  const optionTimesheetDates = uniqueSortedDateKeys(options.timesheetDateKeys);
+  const timesheetDates = uniqueSortedDateKeys([...assignmentTimesheetDates, ...optionTimesheetDates]);
+
+  const assignmentScheduledDates = uniqueSortedDateKeys(assignment._scheduled_work_dates);
+  const optionScheduledDates = uniqueSortedDateKeys(options.scheduledDateKeys);
+  const scheduledDates = uniqueSortedDateKeys([...assignmentScheduledDates, ...optionScheduledDates]);
+
+  const assignmentDate = normalizeDateKey(assignment.assignment_date);
+
+  if (assignment.single_day) {
+    if (timesheetDates.length > 0) return timesheetDates;
+    return assignmentDate ? [assignmentDate] : [];
+  }
+
+  if (scheduledDates.length > 0) {
+    return scheduledDates;
+  }
+
+  if (timesheetDates.length > 0) {
+    return timesheetDates;
+  }
+
+  return assignmentDate ? [assignmentDate] : [];
+}


### PR DESCRIPTION
## Summary
- Resolve assignment work dates from scheduled job date types for full tour assignments, while preserving exact timesheet dates for partial assignments.
- Show per-technician work-day badges in the job details personnel section.
- Show compact Spanish date chips and full date tooltips on job cards.

## Risk Assessment
Low. The change is UI/data-shaping only, scoped to assignment work-date display and existing job/date-type query payloads. It does not change assignment writes, timesheet writes, RLS, or database schema.

## Test Evidence
- npm run typecheck: passed
- npm run lint: passed with existing warnings only
- npm run test:run -- src/utils/__tests__/assignmentWorkDates.test.ts: passed, 5 tests
- npm run test:run: passed, 118 files / 777 tests
- npm run build: passed

## Rollback Plan
Revert this PR to return personnel chips and the details personnel tab to the previous date display behavior. No migration rollback is required.

## Migration Impact
No Supabase migration, schema change, or production database push is included.