### PR TITLE
[codex] Fix tour personnel date display

### DIFF
--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -66,6 +66,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
           ),
           timesheets(technician_id, date, is_active, is_schedule_only),
           job_date_types(date, type),
+          tour_date:tour_dates(date, start_date, end_date, tour_date_type),
           job_documents(id, file_name, file_path, uploaded_at, file_size, visible_to_tech, read_only, template_type),
           logistics_events(id, event_type, transport_type, event_date, event_time, license_plate)
         `

--- a/src/components/jobs/cards/JobCardAssignments.tsx
+++ b/src/components/jobs/cards/JobCardAssignments.tsx
@@ -10,17 +10,22 @@ import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { es } from "date-fns/locale";
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { cn } from "@/lib/utils";
-import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from "@/utils/assignmentWorkDates";
+import {
+  getScheduledWorkDateKeys,
+  resolveAssignmentWorkDateKeys,
+  type JobScheduleLike,
+} from "@/utils/assignmentWorkDates";
 
 const MADRID_TIME_ZONE = "Europe/Madrid";
 
 interface JobCardAssignmentsProps {
   assignments: any[];
   department: Department;
-  jobTimesheets?: { technician_id: string; status: string }[];
+  jobTimesheets?: { technician_id: string; status: string; date?: string | null }[];
   jobDateTypes?: Array<{ date?: string | null; type?: string | null }> | null;
   jobStartTime?: string | null;
   jobEndTime?: string | null;
+  jobTourDate?: JobScheduleLike["tour_date"];
 }
 
 export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
@@ -30,12 +35,26 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
   jobDateTypes,
   jobStartTime,
   jobEndTime,
+  jobTourDate,
 }) => {
   const scheduledWorkDateKeys = React.useMemo(() => getScheduledWorkDateKeys({
     job_date_types: jobDateTypes,
     start_time: jobStartTime,
     end_time: jobEndTime,
-  }), [jobDateTypes, jobStartTime, jobEndTime]);
+    tour_date: jobTourDate,
+  }), [jobDateTypes, jobStartTime, jobEndTime, jobTourDate]);
+
+  const timesheetDateKeysByTech = React.useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const timesheet of jobTimesheets) {
+      if (!timesheet.technician_id || !timesheet.date) continue;
+      if (!map.has(timesheet.technician_id)) {
+        map.set(timesheet.technician_id, new Set());
+      }
+      map.get(timesheet.technician_id)?.add(timesheet.date);
+    }
+    return map;
+  }, [jobTimesheets]);
 
   // Determine overall timesheet state for a technician
   const getTechTimesheetState = (techId: string): 'none' | 'draft' | 'partial' | 'submitted' | 'approved' | 'rejected' => {
@@ -102,7 +121,12 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
     const key = assignment.technician_id ? `tech:${assignment.technician_id}` : `ext:${name}`;
     const roleLabel = roleCode ? labelForCode(roleCode) : null;
     const isFromTour = assignment.assignment_source === 'tour';
-    const datesToAdd = resolveAssignmentWorkDateKeys(assignment, { scheduledDateKeys: scheduledWorkDateKeys });
+    const datesToAdd = resolveAssignmentWorkDateKeys(assignment, {
+      timesheetDateKeys: assignment.technician_id
+        ? timesheetDateKeysByTech.get(assignment.technician_id)
+        : null,
+      scheduledDateKeys: scheduledWorkDateKeys,
+    });
 
     if (!grouped.has(key)) {
       grouped.set(key, {

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -535,25 +535,25 @@ function JobCardNewFull({
     [assignments]
   );
 
-  // Fetch timesheet statuses per technician for this job (for badge color coding)
+  // Fetch active timesheet rows per technician for badge color coding and exact date display.
   const { data: jobTimesheets } = useQuery({
     queryKey: queryKeys.scope("job-timesheets-status", job.id),
     queryFn: async () => {
       const { data, error } = await dataLayerClient.from('timesheets')
-        .select('technician_id, status')
+        .select('technician_id, status, date')
         .eq('job_id', job.id)
         .eq('is_active', true);
       if (error) throw error;
-      return data as { technician_id: string; status: string }[];
+      return data as { technician_id: string; status: string; date: string | null }[];
     },
-    enabled: hasAssignedTechnicians && job.job_type !== 'dryhire' && job.job_type !== 'tourdate',
+    enabled: hasAssignedTechnicians && job.job_type !== 'dryhire',
     staleTime: 60_000
   });
 
   // Realtime invalidation when timesheets change
   useEffect(() => {
     if (!hasAssignedTechnicians) return;
-    if (job.job_type === 'dryhire' || job.job_type === 'tourdate') return;
+    if (job.job_type === 'dryhire') return;
 
     const channel = dataLayerClient.channel(`job-timesheets-${job.id}`)
       .on('postgres_changes',

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -459,6 +459,7 @@ export function JobCardNewView({
                     jobDateTypes={job.job_date_types || []}
                     jobStartTime={job.start_time || null}
                     jobEndTime={job.end_time || null}
+                    jobTourDate={job.tour_date || null}
                   />
                 )}
 

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -70,6 +70,7 @@ export const useJobs = () => {
                 date,
                 start_date,
                 end_date,
+                tour_date_type,
                 is_tour_pack_only,
                 tour: tours(
                   id,

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -79,7 +79,8 @@ export const useOptimizedJobCard = (
     job_date_types: job?.job_date_types,
     start_time: job?.start_time,
     end_time: job?.end_time,
-  }), [job?.job_date_types, job?.start_time, job?.end_time]);
+    tour_date: job?.tour_date,
+  }), [job?.job_date_types, job?.start_time, job?.end_time, job?.tour_date]);
 
   // Helper to fetch and update assignments for this job
   // job_assignments are the base; timesheets add per-day date info (with RLS-safe fallback)
@@ -151,6 +152,7 @@ export const useOptimizedJobCard = (
         job_date_types: jobDateTypes || job?.job_date_types || [],
         start_time: job?.start_time,
         end_time: job?.end_time,
+        tour_date: job?.tour_date,
       });
       const scheduledWorkDates = computedScheduledWorkDates.length > 0
         ? computedScheduledWorkDates
@@ -187,7 +189,7 @@ export const useOptimizedJobCard = (
     } catch (err) {
       console.warn('Error refreshing assignments', err);
     }
-  }, [job?.id, job?.job_assignments, job?.job_date_types, job?.start_time, job?.end_time, jobScheduledWorkDates]);
+  }, [job?.id, job?.job_assignments, job?.job_date_types, job?.start_time, job?.end_time, job?.tour_date, jobScheduledWorkDates]);
 
   // Keep local state in sync with incoming job prop updates for instant UI
   useEffect(() => {

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -31,6 +31,7 @@ export const useOptimizedJobs = (
     { table: 'job_documents', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'flex_folders', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'locations', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
+    { table: 'tour_dates', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'tours', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
   ]);
 
@@ -91,6 +92,12 @@ export const useOptimizedJobs = (
         job_date_types(
           date,
           type
+        ),
+        tour_date:tour_dates(
+          date,
+          start_date,
+          end_date,
+          tour_date_type
         ),
         flex_folders(
           id,

--- a/src/utils/__tests__/assignmentWorkDates.test.ts
+++ b/src/utils/__tests__/assignmentWorkDates.test.ts
@@ -21,6 +21,37 @@ describe('assignment work date resolution', () => {
     })).toEqual(['2026-06-02', '2026-06-03']);
   });
 
+  it('uses tour date ranges when legacy job date types only contain one day', () => {
+    expect(getScheduledWorkDateKeys({
+      start_time: '2026-05-20T06:00:00',
+      end_time: '2026-05-21T21:59:59',
+      job_date_types: [
+        { date: '2026-05-21', type: 'show' },
+      ],
+      tour_date: {
+        date: '2026-05-20',
+        start_date: '2026-05-20',
+        end_date: '2026-05-21',
+        tour_date_type: 'show',
+      },
+    })).toEqual(['2026-05-20', '2026-05-21']);
+  });
+
+  it('does not re-add explicit non-working job date types from the tour date fallback', () => {
+    expect(getScheduledWorkDateKeys({
+      job_date_types: [
+        { date: '2026-05-20', type: 'travel' },
+        { date: '2026-05-21', type: 'show' },
+      ],
+      tour_date: {
+        date: '2026-05-20',
+        start_date: '2026-05-20',
+        end_date: '2026-05-21',
+        tour_date_type: 'show',
+      },
+    })).toEqual(['2026-05-21']);
+  });
+
   it('keeps exact timesheet days for partial multi-day assignments', () => {
     expect(resolveAssignmentWorkDateKeys(
       {
@@ -32,15 +63,51 @@ describe('assignment work date resolution', () => {
     )).toEqual(['2026-06-02', '2026-06-04']);
   });
 
-  it('uses scheduled dates for full multi-day tour assignments even when old schedule-only timesheets are incomplete', () => {
+  it('uses scheduled dates for full multi-day tour assignments when timesheets are unavailable', () => {
     expect(resolveAssignmentWorkDateKeys(
       {
         single_day: false,
         assignment_date: null,
-        _timesheet_dates: ['2026-06-02'],
+        _timesheet_dates: [],
       },
       { scheduledDateKeys: ['2026-06-02', '2026-06-03', '2026-06-04'] },
     )).toEqual(['2026-06-02', '2026-06-03', '2026-06-04']);
+  });
+
+  it('prefers active timesheet dates over scheduled dates for tour assignments', () => {
+    expect(resolveAssignmentWorkDateKeys(
+      {
+        assignment_source: 'tour',
+        single_day: true,
+        assignment_date: '2026-05-21',
+        _timesheet_dates: ['2026-05-20', '2026-05-21'],
+      },
+      { scheduledDateKeys: ['2026-05-20', '2026-05-21', '2026-05-22'] },
+    )).toEqual(['2026-05-20', '2026-05-21']);
+  });
+
+  it('uses scheduled dates for tour-sourced assignments even when the row still says single-day', () => {
+    expect(resolveAssignmentWorkDateKeys(
+      {
+        assignment_source: 'tour',
+        single_day: true,
+        assignment_date: '2026-05-21',
+        _timesheet_dates: [],
+      },
+      { scheduledDateKeys: ['2026-05-20', '2026-05-21'] },
+    )).toEqual(['2026-05-20', '2026-05-21']);
+  });
+
+  it('does not expand direct single-day assignments to the full job schedule', () => {
+    expect(resolveAssignmentWorkDateKeys(
+      {
+        assignment_source: 'direct',
+        single_day: true,
+        assignment_date: '2026-05-21',
+        _timesheet_dates: [],
+      },
+      { scheduledDateKeys: ['2026-05-20', '2026-05-21'] },
+    )).toEqual(['2026-05-21']);
   });
 
   it('falls back to the assignment date for legacy single-day rows without timesheets', () => {

--- a/src/utils/assignmentWorkDates.ts
+++ b/src/utils/assignmentWorkDates.ts
@@ -10,13 +10,23 @@ export interface JobDateTypeLike {
   type?: string | null;
 }
 
+export interface TourDateLike {
+  date?: DateValue;
+  start_date?: DateValue;
+  end_date?: DateValue;
+  tour_date_type?: string | null;
+  type?: string | null;
+}
+
 export interface JobScheduleLike {
   job_date_types?: JobDateTypeLike[] | null;
   start_time?: DateValue;
   end_time?: DateValue;
+  tour_date?: TourDateLike | TourDateLike[] | null;
 }
 
 export interface AssignmentDateLike {
+  assignment_source?: string | null;
   single_day?: boolean | null;
   assignment_date?: DateValue;
   _timesheet_dates?: DateValue[] | null;
@@ -89,19 +99,55 @@ function buildDateRange(startKey: string, endKey: string): string[] {
   return dates;
 }
 
+function normalizeTourDateRows(tourDate: JobScheduleLike["tour_date"]): TourDateLike[] {
+  if (!tourDate) return [];
+  return (Array.isArray(tourDate) ? tourDate : [tourDate]).filter(Boolean);
+}
+
+function getTourDateWorkDateKeys(tourDate: JobScheduleLike["tour_date"]): string[] {
+  const dates: string[] = [];
+
+  for (const row of normalizeTourDateRows(tourDate)) {
+    const dateType = row.tour_date_type ?? row.type;
+    if (isNonWorkingDateType(dateType)) continue;
+
+    const startKey = normalizeDateKey(row.start_date ?? row.date);
+    if (!startKey) continue;
+
+    const endKey = normalizeDateKey(row.end_date) ?? normalizeDateKey(row.date) ?? startKey;
+    dates.push(...buildDateRange(startKey, endKey));
+  }
+
+  return uniqueSortedDateKeys(dates);
+}
+
 /** Returns the working dates for a job, excluding travel/off date types when present. */
 export function getScheduledWorkDateKeys(job: JobScheduleLike | null | undefined): string[] {
   if (!job) return [];
 
   const dateTypeRows = Array.isArray(job.job_date_types) ? job.job_date_types : [];
   const typedRowsWithDates = dateTypeRows.filter((row) => Boolean(normalizeDateKey(row?.date)));
+  const tourDateWorkDates = getTourDateWorkDateKeys(job.tour_date);
 
   if (typedRowsWithDates.length > 0) {
-    return uniqueSortedDateKeys(
+    const nonWorkingTypedDates = new Set(
+      uniqueSortedDateKeys(
+        typedRowsWithDates
+          .filter((row) => isNonWorkingDateType(row?.type))
+          .map((row) => row.date),
+      ),
+    );
+    const typedWorkDates = uniqueSortedDateKeys(
       typedRowsWithDates
         .filter((row) => !isNonWorkingDateType(row?.type))
         .map((row) => row.date),
     );
+    const fallbackTourDates = tourDateWorkDates.filter((dateKey) => !nonWorkingTypedDates.has(dateKey));
+    return uniqueSortedDateKeys([...typedWorkDates, ...fallbackTourDates]);
+  }
+
+  if (tourDateWorkDates.length > 0) {
+    return tourDateWorkDates;
   }
 
   const startKey = normalizeDateKey(job.start_time);
@@ -127,9 +173,13 @@ export function resolveAssignmentWorkDateKeys(
   const scheduledDates = uniqueSortedDateKeys([...assignmentScheduledDates, ...optionScheduledDates]);
 
   const assignmentDate = normalizeDateKey(assignment.assignment_date);
+  const isTourAssignment = assignment.assignment_source === "tour";
 
-  if (assignment.single_day) {
-    if (timesheetDates.length > 0) return timesheetDates;
+  if (timesheetDates.length > 0) {
+    return timesheetDates;
+  }
+
+  if (assignment.single_day && !isTourAssignment) {
     return assignmentDate ? [assignmentDate] : [];
   }
 


### PR DESCRIPTION
## Summary
- Prefer active timesheet dates when rendering personnel work-day badges in job cards and details.
- Fetch tourdate card timesheet rows with dates instead of skipping tourdate jobs.
- Keep schedule and tour-date range data as fallback for legacy rows when timesheets are unavailable.

## Root Cause
Tour-sourced assignment rows can carry stale `single_day` / `assignment_date` metadata. The display resolver could collapse those rows to one day even when active timesheets and the matrix represented the actual multi-day work.

## Validation
- `npm run test:run -- src/utils/__tests__/assignmentWorkDates.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tour-based job scheduling with improved date tracking and timesheet integration across assignments.

* **Tests**
  * Expanded test coverage for assignment work date resolution logic, including tour-based and timesheet scenarios.

* **Refactor**
  * Improved internal date resolution and query logic to incorporate tour date information in job scheduling and assignment calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->