### PR TITLE
[codex] Improve auto-staffing status and handoff

### DIFF
--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsDocumentsTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsDocumentsTab.tsx
@@ -184,7 +184,7 @@ export const JobDetailsDocumentsTab: React.FC<JobDetailsDocumentsTabProps> = ({
               return (
                 <div
                   key={doc.id}
-                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3 bg-[#0f1219] border border-[#1f232e] rounded min-w-0"
+                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3 bg-slate-50 dark:bg-[#0f1219] border border-slate-200 dark:border-[#1f232e] rounded min-w-0"
                 >
                   <div className="min-w-0 flex-1">
                     <p className="font-medium flex items-center gap-2 break-words">
@@ -309,4 +309,3 @@ export const JobDetailsDocumentsTab: React.FC<JobDetailsDocumentsTabProps> = ({
     </TabsContent>
   );
 };
-

--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsDocumentsTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsDocumentsTab.tsx
@@ -268,7 +268,10 @@ export const JobDetailsDocumentsTab: React.FC<JobDetailsDocumentsTabProps> = ({
         ) : riderFiles.length > 0 ? (
           <div className="space-y-2">
             {riderFiles.map((file) => (
-              <div key={file.id} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3 bg-muted rounded min-w-0">
+              <div
+                key={file.id}
+                className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3 bg-slate-50 dark:bg-[#0f1219] border border-slate-200 dark:border-[#1f232e] rounded min-w-0"
+              >
                 <div className="min-w-0 flex-1">
                   <p className="font-medium break-words">{file.file_name}</p>
                   <p className="text-sm text-muted-foreground break-words">

--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsRestaurantsTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsRestaurantsTab.tsx
@@ -77,7 +77,10 @@ export const JobDetailsRestaurantsTab: React.FC<JobDetailsRestaurantsTabProps> =
         ) : restaurants && restaurants.length > 0 ? (
           <div className="space-y-3">
             {restaurants.map((restaurant: Restaurant) => (
-              <div key={restaurant.id} className="p-3 bg-[#0f1219] border border-[#1f232e] rounded">
+              <div
+                key={restaurant.id}
+                className="p-3 bg-slate-50 dark:bg-[#0f1219] border border-slate-200 dark:border-[#1f232e] rounded"
+              >
                 <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 min-w-0">
                   <div className="flex-1 min-w-0">
                     <p className="font-medium break-words">{restaurant.name}</p>
@@ -138,4 +141,3 @@ export const JobDetailsRestaurantsTab: React.FC<JobDetailsRestaurantsTabProps> =
     </TabsContent>
   );
 };
-

--- a/src/components/matrix/StaffingAutoModePanel.tsx
+++ b/src/components/matrix/StaffingAutoModePanel.tsx
@@ -13,12 +13,14 @@ import { queryKeys } from "@/lib/react-query";
 interface StaffingAutoModePanelProps {
   campaign: any
   campaignRoles: any[]
+  requiredByRole?: Map<string, number>
   onStatusChange?: () => void
 }
 
 export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
   campaign,
   campaignRoles,
+  requiredByRole,
   onStatusChange
 }) => {
   const { toast } = useToast()
@@ -252,59 +254,64 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
-              {campaignRoles.map((role: any) => (
-                <div
-                  key={role.id}
-                  className="p-3 bg-gray-50 rounded border border-gray-200"
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      <span className="text-lg">{getStageIcon(role.stage)}</span>
-                      <p className="font-semibold text-sm">{role.role_code}</p>
-                    </div>
-                    <Badge
-                      className={`text-xs ${
-                        role.stage === 'filled'
-                          ? 'bg-green-100 text-green-800'
-                          : role.stage === 'offer'
-                            ? 'bg-blue-100 text-blue-800'
-                            : role.stage === 'availability'
-                              ? 'bg-purple-100 text-purple-800'
-                              : 'bg-gray-100 text-gray-800'
-                      }`}
-                    >
-                      {role.stage}
-                    </Badge>
-                  </div>
+              {campaignRoles.map((role: any) => {
+                const requiredCount = requiredByRole?.get(role.role_code) ?? 0
 
-                  {/* Counters */}
-                  <div className="grid grid-cols-4 gap-2 text-xs">
-                    <div className="bg-white p-1 rounded text-center">
-                      <p className="text-gray-600">Assigned</p>
-                      <p className="font-bold">{role.assigned_count}</p>
+                return (
+                  <div
+                    key={role.id}
+                    className="p-3 bg-gray-50 rounded border border-gray-200"
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-lg">{getStageIcon(role.stage)}</span>
+                        <p className="font-semibold text-sm">{role.role_code}</p>
+                        <Badge variant="outline" className="text-xs">Required {requiredCount}</Badge>
+                      </div>
+                      <Badge
+                        className={`text-xs ${
+                          role.stage === 'filled'
+                            ? 'bg-green-100 text-green-800'
+                            : role.stage === 'offer'
+                              ? 'bg-blue-100 text-blue-800'
+                              : role.stage === 'availability'
+                                ? 'bg-purple-100 text-purple-800'
+                                : 'bg-gray-100 text-gray-800'
+                        }`}
+                      >
+                        {role.stage}
+                      </Badge>
                     </div>
-                    <div className="bg-white p-1 rounded text-center">
-                      <p className="text-gray-600">Avail ✓</p>
-                      <p className="font-bold">{role.confirmed_availability}</p>
-                    </div>
-                    <div className="bg-white p-1 rounded text-center">
-                      <p className="text-gray-600">Offers ⧐</p>
-                      <p className="font-bold">{role.pending_offers}</p>
-                    </div>
-                    <div className="bg-white p-1 rounded text-center">
-                      <p className="text-gray-600">Accept ✓</p>
-                      <p className="font-bold">{role.accepted_offers}</p>
-                    </div>
-                  </div>
 
-                  {/* Last wave info */}
-                  {role.last_wave_at && (
-                    <p className="text-xs text-gray-500 mt-2">
-                      Wave {role.wave_number} at {format(new Date(role.last_wave_at), 'HH:mm')}
-                    </p>
-                  )}
-                </div>
-              ))}
+                    {/* Counters */}
+                    <div className="grid grid-cols-4 gap-2 text-xs">
+                      <div className="bg-white p-1 rounded text-center">
+                        <p className="text-gray-600">Assigned</p>
+                        <p className="font-bold">{role.assigned_count}/{requiredCount || '—'}</p>
+                      </div>
+                      <div className="bg-white p-1 rounded text-center">
+                        <p className="text-gray-600">Avail ✓</p>
+                        <p className="font-bold">{role.confirmed_availability}</p>
+                      </div>
+                      <div className="bg-white p-1 rounded text-center">
+                        <p className="text-gray-600">Offers ⧐</p>
+                        <p className="font-bold">{role.pending_offers}</p>
+                      </div>
+                      <div className="bg-white p-1 rounded text-center">
+                        <p className="text-gray-600">Accept ✓</p>
+                        <p className="font-bold">{role.accepted_offers}</p>
+                      </div>
+                    </div>
+
+                    {/* Last wave info */}
+                    {role.last_wave_at && (
+                      <p className="text-xs text-gray-500 mt-2">
+                        Wave {role.wave_number} at {format(new Date(role.last_wave_at), 'HH:mm')}
+                      </p>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           </CardContent>
         </Card>

--- a/src/components/matrix/StaffingCampaignPanel.tsx
+++ b/src/components/matrix/StaffingCampaignPanel.tsx
@@ -65,7 +65,8 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
     availabilityTtl: 24,
     offerTtl: 4,
     offerMessage: '',
-    tickInterval: 300
+    tickInterval: 300,
+    channel: 'email' as 'email' | 'whatsapp'
   })
 
   // Fetch active campaign for this job+department
@@ -94,7 +95,8 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
         availabilityTtl: campaign.policy?.availability_ttl_hours ?? 24,
         offerTtl: campaign.policy?.offer_ttl_hours ?? 4,
         offerMessage: campaign.offer_message ?? '',
-        tickInterval: campaign.policy?.tick_interval_seconds ?? 300
+        tickInterval: campaign.policy?.tick_interval_seconds ?? 300,
+        channel: campaign.policy?.channel === 'whatsapp' ? 'whatsapp' : 'email'
       })
     }
   }, [campaign])
@@ -131,6 +133,8 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
         exclude_fridge: formData.excludeFridge,
         soft_conflict_policy: formData.softConflictPolicy,
         tick_interval_seconds: formData.tickInterval,
+        channel: formData.channel,
+        assisted_handoff_priority: true,
         escalation_steps: ['increase_wave', 'include_fridge', 'allow_soft_conflicts']
       }
 
@@ -195,6 +199,8 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
         exclude_fridge: formData.excludeFridge,
         soft_conflict_policy: formData.softConflictPolicy,
         tick_interval_seconds: formData.tickInterval,
+        channel: formData.channel,
+        assisted_handoff_priority: true,
         escalation_steps: ['increase_wave', 'include_fridge', 'allow_soft_conflicts']
       }
 
@@ -474,6 +480,18 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                   </select>
                 </div>
 
+                <div>
+                  <label className="text-sm font-medium">Send Channel</label>
+                  <select
+                    value={formData.channel}
+                    onChange={(e) => setFormData({ ...formData, channel: e.target.value as 'email' | 'whatsapp' })}
+                    className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+                  >
+                    <option value="email">Email</option>
+                    <option value="whatsapp">WhatsApp</option>
+                  </select>
+                </div>
+
                 {/* Fridge toggle */}
                 <label className="flex items-center gap-2 cursor-pointer">
                   <input
@@ -687,6 +705,23 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                 <option value="warn">Warn (Assisted mode)</option>
                 <option value="allow">Allow (Escalation only)</option>
               </select>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium">Send Channel</label>
+              <select
+                value={formData.channel}
+                onChange={(e) => setFormData({ ...formData, channel: e.target.value as 'email' | 'whatsapp' })}
+                className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+              >
+                <option value="email">Email</option>
+                <option value="whatsapp">WhatsApp</option>
+              </select>
+              {campaign.mode === 'assisted' && formData.mode === 'auto' && (
+                <p className="text-xs text-gray-600 mt-1">
+                  Auto mode will use existing assisted availability and offer responses before contacting new candidates.
+                </p>
+              )}
             </div>
 
             {/* Fridge toggle */}

--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -5,9 +5,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast'
-import { Info } from 'lucide-react'
+import { Info, Mail, MessageCircle } from 'lucide-react'
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -17,7 +18,13 @@ interface StaffingCandidateListProps {
   jobId: string
   department: string
   policy: any
+  requiredCount?: number
+  assignedCount?: number
+  confirmedAvailability?: number
+  pendingAvailability?: number
 }
+
+type StaffingChannel = 'email' | 'whatsapp'
 
 interface Candidate {
   profile_id: string
@@ -69,12 +76,17 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
   roleCode,
   jobId,
   department,
-  policy
+  policy,
+  requiredCount = 0,
+  assignedCount = 0,
+  confirmedAvailability = 0,
+  pendingAvailability = 0
 }) => {
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const [selectedCandidates, setSelectedCandidates] = useState<Set<string>>(new Set())
   const [expandedReasons, setExpandedReasons] = useState<string | null>(null)
+  const [channel, setChannel] = useState<StaffingChannel>('email')
 
   // Fetch ranked candidates
   const { data: candidates, isLoading } = useQuery({
@@ -185,8 +197,9 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
               profile_id: profileId,
               phase: 'availability',
               role: roleCode,
+              channel,
               require_no_conflicts: true,
-              idempotency_key: `campaign:${campaignId}:${roleCode}:${profileId}:availability`
+              idempotency_key: `campaign:${campaignId}:${roleCode}:${profileId}:availability:${channel}`
             })
           }
         )
@@ -210,7 +223,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
     onSuccess: (data: any) => {
       toast({
         title: 'Availability sent',
-        description: `Contacted ${data?.sent ?? selectedCandidates.size} candidates`
+        description: `Contacted ${data?.sent ?? selectedCandidates.size} candidates by ${channel}`
       })
       setSelectedCandidates(new Set())
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_requests', jobId) })
@@ -256,10 +269,22 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
     }
   }
 
+  const roleSummary = (
+    <div className="flex flex-wrap gap-2 pt-2">
+      <Badge variant="outline">Required {requiredCount}</Badge>
+      <Badge variant="secondary">{assignedCount}/{requiredCount || '—'} assigned</Badge>
+      <Badge variant="outline">{confirmedAvailability} available</Badge>
+      {pendingAvailability > 0 && (
+        <Badge variant="outline">{pendingAvailability} pending</Badge>
+      )}
+    </div>
+  )
+
   if (isLoading) {
     return (
       <Card>
         <CardContent className="pt-6">
+          {roleSummary}
           <p className="text-muted-foreground">Loading candidates...</p>
         </CardContent>
       </Card>
@@ -270,6 +295,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
     return (
       <Card>
         <CardContent className="pt-6">
+          {roleSummary}
           <p className="text-muted-foreground">No candidates available for {roleCode}</p>
         </CardContent>
       </Card>
@@ -283,9 +309,26 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
         <CardDescription>
           Top {candidates.length} candidatos clasificados por habilidades, experiencia en el rol, proximidad y confiabilidad
         </CardDescription>
+        {roleSummary}
       </CardHeader>
 
       <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded border bg-background p-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            {channel === 'whatsapp' ? <MessageCircle size={16} /> : <Mail size={16} />}
+            Send availability by
+          </div>
+          <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
+            <SelectTrigger className="w-[160px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="email">Email</SelectItem>
+              <SelectItem value="whatsapp">WhatsApp</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
         {/* Select all checkbox */}
         <div className="flex items-center gap-2 p-2 bg-muted rounded">
           <Checkbox
@@ -407,7 +450,9 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
             onClick={() => sendAvailabilityMutation.mutate()}
             disabled={selectedCandidates.size === 0 || sendAvailabilityMutation.isPending}
           >
-            {sendAvailabilityMutation.isPending ? 'Sending...' : `Send Availability (${selectedCandidates.size})`}
+            {sendAvailabilityMutation.isPending
+              ? 'Sending...'
+              : `Send Availability (${selectedCandidates.size}) by ${channel === 'whatsapp' ? 'WhatsApp' : 'Email'}`}
           </Button>
         </div>
       </CardContent>

--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -319,7 +319,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
             Send availability by
           </div>
           <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
-            <SelectTrigger className="w-[160px]">
+            <SelectTrigger aria-label="Select availability channel" className="w-[160px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/matrix/StaffingOfferList.tsx
+++ b/src/components/matrix/StaffingOfferList.tsx
@@ -4,9 +4,11 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast'
 import { format } from 'date-fns'
+import { Mail, MessageCircle } from 'lucide-react'
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -16,7 +18,15 @@ interface StaffingOfferListProps {
   jobId: string
   department: string
   offerMessage?: string
+  requiredCount?: number
+  assignedCount?: number
+  confirmedAvailability?: number
+  pendingAvailability?: number
+  acceptedOffers?: number
+  pendingOffers?: number
 }
+
+type StaffingChannel = 'email' | 'whatsapp'
 
 interface AvailabilityResponse {
   profile_id: string
@@ -30,42 +40,24 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
   roleCode,
   jobId,
   department,
-  offerMessage
+  offerMessage,
+  requiredCount = 0,
+  assignedCount = 0,
+  confirmedAvailability = 0,
+  pendingAvailability = 0,
+  acceptedOffers = 0,
+  pendingOffers = 0
 }) => {
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const [selectedForOffer, setSelectedForOffer] = useState<Set<string>>(new Set())
+  const [channel, setChannel] = useState<StaffingChannel>('email')
 
   // Fetch availability responses for this role
   const { data: responses, isLoading } = useQuery({
     queryKey: queryKeys.scope('staffing_availability_responses', jobId, roleCode),
     queryFn: async () => {
-      // Role information is stored in staffing_events.meta.role (from send-staffing-email).
-      const { data: sentEvents, error: sentError } = await dataLayerClient.from('staffing_events')
-        .select('staffing_request_id')
-        .in('event', ['email_sent', 'whatsapp_sent'])
-        .contains('meta', { phase: 'availability', role: roleCode })
-        .order('created_at', { ascending: false })
-        .limit(500)
-
-      if (sentError) throw sentError
-
-      const requestIds = Array.from(
-        new Set((sentEvents || []).map((e: any) => e.staffing_request_id).filter(Boolean))
-      )
-
-      if (requestIds.length === 0) return [] as AvailabilityResponse[]
-
-      const { data, error } = await dataLayerClient.from('staffing_requests')
-        .select('id, profile_id, status, created_at, updated_at, profiles(first_name,last_name,nickname)')
-        .in('id', requestIds)
-        .eq('job_id', jobId)
-        .eq('phase', 'availability')
-        .order('updated_at', { ascending: false })
-
-      if (error) throw error
-
-      return (data || []).map((item: any) => {
+      const mapRequestToResponse = (item: any): AvailabilityResponse => {
         const profiles = item.profiles || {}
         const fullName = `${profiles.first_name || ''} ${profiles.last_name || ''}`.trim()
         const respondedAt =
@@ -79,7 +71,59 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
           status: item.status,
           responded_at: respondedAt
         } as AvailabilityResponse
+      }
+
+      const { data: directRequests, error: directError } = await dataLayerClient.from('staffing_requests')
+        .select('id, profile_id, status, role_code, created_at, updated_at, profiles(first_name,last_name,nickname)')
+        .eq('job_id', jobId)
+        .eq('phase', 'availability')
+        .eq('role_code', roleCode)
+        .order('updated_at', { ascending: false })
+
+      if (directError) throw directError
+
+      const directRows = (directRequests || [])
+        .filter((item: any) => String(item.role_code || '').trim() === roleCode)
+
+      const responsesByRequestId = new Map<string, AvailabilityResponse>()
+      directRows.forEach((item: any) => {
+        if (!item.id) return
+        responsesByRequestId.set(String(item.id), mapRequestToResponse(item))
       })
+
+      // Legacy rows may only have role information in staffing_events.meta.role.
+      const { data: sentEvents, error: sentError } = await dataLayerClient.from('staffing_events')
+        .select('staffing_request_id')
+        .in('event', ['email_sent', 'whatsapp_sent'])
+        .contains('meta', { phase: 'availability', role: roleCode })
+        .order('created_at', { ascending: false })
+        .limit(500)
+
+      if (sentError) throw sentError
+
+      const requestIds = Array.from(
+        new Set((sentEvents || []).map((e: any) => e.staffing_request_id).filter(Boolean))
+      ).filter((id) => !responsesByRequestId.has(String(id)))
+
+      if (requestIds.length === 0) {
+        return Array.from(responsesByRequestId.values())
+      }
+
+      const { data: legacyRequests, error } = await dataLayerClient.from('staffing_requests')
+        .select('id, profile_id, status, role_code, created_at, updated_at, profiles(first_name,last_name,nickname)')
+        .in('id', requestIds)
+        .eq('job_id', jobId)
+        .eq('phase', 'availability')
+        .order('updated_at', { ascending: false })
+
+      if (error) throw error
+
+      ;(legacyRequests || []).forEach((item: any) => {
+        if (!item.id) return
+        responsesByRequestId.set(String(item.id), mapRequestToResponse(item))
+      })
+
+      return Array.from(responsesByRequestId.values())
     }
   })
 
@@ -109,7 +153,8 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
               phase: 'offer',
               role: roleCode,
               message: offerMessage || null,
-              idempotency_key: `campaign:${campaignId}:${roleCode}:${profileId}:offer`
+              channel,
+              idempotency_key: `campaign:${campaignId}:${roleCode}:${profileId}:offer:${channel}`
             })
           }
         )
@@ -133,7 +178,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
     onSuccess: (data: any) => {
       toast({
         title: 'Offers sent',
-        description: `Sent offers to ${data?.sent ?? selectedForOffer.size} candidates`
+        description: `Sent offers to ${data?.sent ?? selectedForOffer.size} candidates by ${channel}`
       })
       setSelectedForOffer(new Set())
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId, roleCode) })
@@ -151,6 +196,23 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
   const confirmedResponses = responses?.filter((r: any) => r.status === 'confirmed') || []
   const declinedResponses = responses?.filter((r: any) => r.status === 'declined') || []
   const pendingResponses = responses?.filter((r: any) => r.status === 'pending') || []
+  const hasResponseRows = Boolean(responses && responses.length > 0)
+  const displayedConfirmedAvailability = hasResponseRows ? confirmedResponses.length : confirmedAvailability
+  const displayedPendingAvailability = hasResponseRows ? pendingResponses.length : pendingAvailability
+  const displayedDeclinedAvailability = hasResponseRows ? declinedResponses.length : 0
+
+  const statusSummary = (
+    <div className="flex flex-wrap gap-2 pt-2">
+      <Badge variant="outline">Required {requiredCount}</Badge>
+      <Badge variant="secondary">{assignedCount}/{requiredCount || '—'} assigned</Badge>
+      <Badge variant="outline">Availability: {displayedConfirmedAvailability} yes</Badge>
+      <Badge variant="outline">{displayedPendingAvailability} pending</Badge>
+      <Badge variant="outline">{displayedDeclinedAvailability} no</Badge>
+      {(acceptedOffers > 0 || pendingOffers > 0) && (
+        <Badge variant="outline">Offers: {acceptedOffers} accepted / {pendingOffers} pending</Badge>
+      )}
+    </div>
+  )
 
   const toggleForOffer = (profileId: string) => {
     const newSelected = new Set(selectedForOffer)
@@ -166,6 +228,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
     return (
       <Card>
         <CardContent className="pt-6">
+          {statusSummary}
           <p className="text-gray-500">Loading responses...</p>
         </CardContent>
       </Card>
@@ -179,9 +242,26 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
         <CardDescription>
           Manage offers for candidates who confirmed availability
         </CardDescription>
+        {statusSummary}
       </CardHeader>
 
       <CardContent className="space-y-6">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded border bg-background p-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            {channel === 'whatsapp' ? <MessageCircle size={16} /> : <Mail size={16} />}
+            Send offers by
+          </div>
+          <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
+            <SelectTrigger className="w-[160px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="email">Email</SelectItem>
+              <SelectItem value="whatsapp">WhatsApp</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
         {/* Confirmed responses */}
         <div>
           <div className="flex items-center gap-2 mb-3">
@@ -199,11 +279,15 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                   className="flex items-center gap-3 p-2 bg-white rounded hover:bg-green-50 cursor-pointer"
                 >
                   <Checkbox
+                    aria-label={`Select ${response.full_name} for offer`}
                     checked={selectedForOffer.has(response.profile_id)}
                     onCheckedChange={() => toggleForOffer(response.profile_id)}
                   />
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-sm">{response.full_name}</p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium text-sm">{response.full_name}</p>
+                      <Badge className="bg-green-100 text-green-800">Availability yes</Badge>
+                    </div>
                     <p className="text-xs text-gray-600">
                       {response.responded_at
                         ? format(new Date(response.responded_at), 'PPp')
@@ -234,7 +318,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                   className="flex items-center justify-between p-2 bg-white rounded"
                 >
                   <p className="text-sm font-medium">{response.full_name}</p>
-                  <span className="text-xs text-gray-600">Waiting for response...</span>
+                  <Badge className="bg-yellow-100 text-yellow-800">Availability pending</Badge>
                 </div>
               ))}
             </div>
@@ -257,7 +341,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                   className="flex items-center justify-between p-2 bg-white rounded"
                 >
                   <p className="text-sm font-medium">{response.full_name}</p>
-                  <span className="text-xs text-gray-600">Declined</span>
+                  <Badge className="bg-red-100 text-red-800">Availability no</Badge>
                 </div>
               ))}
             </div>
@@ -273,7 +357,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
             >
               {sendOffersMutation.isPending
                 ? 'Sending...'
-                : `Send Offers (${selectedForOffer.size})`}
+                : `Send Offers (${selectedForOffer.size}) by ${channel === 'whatsapp' ? 'WhatsApp' : 'Email'}`}
             </Button>
             <p className="text-xs text-gray-600 self-center">
               First candidate to accept will be auto-assigned

--- a/src/components/matrix/StaffingOfferList.tsx
+++ b/src/components/matrix/StaffingOfferList.tsx
@@ -53,77 +53,80 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
   const [selectedForOffer, setSelectedForOffer] = useState<Set<string>>(new Set())
   const [channel, setChannel] = useState<StaffingChannel>('email')
 
-  // Fetch availability responses for this role
+  // Availability responses are job-scoped, but the original send event carries
+  // manager intent for which role card should display the response.
   const { data: responses, isLoading } = useQuery({
     queryKey: queryKeys.scope('staffing_availability_responses', jobId, roleCode),
     queryFn: async () => {
-      const mapRequestToResponse = (item: any): AvailabilityResponse => {
-        const profiles = item.profiles || {}
-        const fullName = `${profiles.first_name || ''} ${profiles.last_name || ''}`.trim()
+      const { data: directRequests, error: directError } = await dataLayerClient.from('staffing_requests')
+        .select('id, profile_id, status, created_at, updated_at')
+        .eq('job_id', jobId)
+        .eq('phase', 'availability')
+        .order('updated_at', { ascending: false })
+
+      if (directError) throw directError
+
+      const requestRows = directRequests || []
+      const requestIds = requestRows.map((item: any) => item.id).filter(Boolean)
+      if (requestIds.length === 0) return []
+
+      const { data: sentEvents, error: sentEventsError } = await dataLayerClient.from('staffing_events')
+        .select('staffing_request_id, event, meta, created_at')
+        .in('staffing_request_id', requestIds)
+        .in('event', ['email_sent', 'whatsapp_sent'])
+        .order('created_at', { ascending: false })
+
+      if (sentEventsError) throw sentEventsError
+
+      const latestAvailabilityRoleByRequestId = new Map<string, string>()
+      ;[...(sentEvents || [])]
+        .sort((a: any, b: any) => (
+          new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime()
+        ))
+        .forEach((event: any) => {
+        const requestId = String(event.staffing_request_id || '')
+        const meta = event?.meta || {}
+        if (!requestId || latestAvailabilityRoleByRequestId.has(requestId)) return
+        if (meta.phase !== 'availability' || !meta.role) return
+        latestAvailabilityRoleByRequestId.set(requestId, String(meta.role))
+      })
+
+      const latestRequestByProfileId = new Map<string, any>()
+      requestRows.forEach((item: any) => {
+        if (latestAvailabilityRoleByRequestId.get(String(item.id)) !== roleCode) return
+        const profileId = String(item.profile_id || '')
+        if (!profileId || latestRequestByProfileId.has(profileId)) return
+        latestRequestByProfileId.set(profileId, item)
+      })
+
+      const profileIds = Array.from(latestRequestByProfileId.keys())
+      if (profileIds.length === 0) return []
+
+      const { data: profiles, error: profilesError } = await dataLayerClient.from('profiles')
+        .select('id, first_name, last_name, nickname, email')
+        .in('id', profileIds)
+
+      if (profilesError) throw profilesError
+
+      const profilesById = new Map(
+        (profiles || []).map((profile: any) => [String(profile.id), profile])
+      )
+
+      return Array.from(latestRequestByProfileId.entries()).map(([profileId, item]) => {
+        const profile: any = profilesById.get(profileId) || {}
+        const fullName = `${profile.first_name || ''} ${profile.last_name || ''}`.trim()
         const respondedAt =
           item.status && String(item.status).toLowerCase() !== 'pending'
             ? (item.updated_at || item.created_at)
             : null
 
         return {
-          profile_id: item.profile_id,
-          full_name: fullName || profiles.nickname || 'Unknown',
+          profile_id: profileId,
+          full_name: fullName || profile.nickname || profile.email || 'Unknown',
           status: item.status,
-          responded_at: respondedAt
+          responded_at: respondedAt,
         } as AvailabilityResponse
-      }
-
-      const { data: directRequests, error: directError } = await dataLayerClient.from('staffing_requests')
-        .select('id, profile_id, status, role_code, created_at, updated_at, profiles(first_name,last_name,nickname)')
-        .eq('job_id', jobId)
-        .eq('phase', 'availability')
-        .eq('role_code', roleCode)
-        .order('updated_at', { ascending: false })
-
-      if (directError) throw directError
-
-      const directRows = (directRequests || [])
-        .filter((item: any) => String(item.role_code || '').trim() === roleCode)
-
-      const responsesByRequestId = new Map<string, AvailabilityResponse>()
-      directRows.forEach((item: any) => {
-        if (!item.id) return
-        responsesByRequestId.set(String(item.id), mapRequestToResponse(item))
       })
-
-      // Legacy rows may only have role information in staffing_events.meta.role.
-      const { data: sentEvents, error: sentError } = await dataLayerClient.from('staffing_events')
-        .select('staffing_request_id')
-        .in('event', ['email_sent', 'whatsapp_sent'])
-        .contains('meta', { phase: 'availability', role: roleCode })
-        .order('created_at', { ascending: false })
-        .limit(500)
-
-      if (sentError) throw sentError
-
-      const requestIds = Array.from(
-        new Set((sentEvents || []).map((e: any) => e.staffing_request_id).filter(Boolean))
-      ).filter((id) => !responsesByRequestId.has(String(id)))
-
-      if (requestIds.length === 0) {
-        return Array.from(responsesByRequestId.values())
-      }
-
-      const { data: legacyRequests, error } = await dataLayerClient.from('staffing_requests')
-        .select('id, profile_id, status, role_code, created_at, updated_at, profiles(first_name,last_name,nickname)')
-        .in('id', requestIds)
-        .eq('job_id', jobId)
-        .eq('phase', 'availability')
-        .order('updated_at', { ascending: false })
-
-      if (error) throw error
-
-      ;(legacyRequests || []).forEach((item: any) => {
-        if (!item.id) return
-        responsesByRequestId.set(String(item.id), mapRequestToResponse(item))
-      })
-
-      return Array.from(responsesByRequestId.values())
     }
   })
 
@@ -182,6 +185,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
       })
       setSelectedForOffer(new Set())
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId, roleCode) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId) })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_requests', jobId) })
     },
     onError: (error: any) => {
@@ -287,6 +291,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                     <div className="flex flex-wrap items-center gap-2">
                       <p className="font-medium text-sm">{response.full_name}</p>
                       <Badge className="bg-green-100 text-green-800">Availability yes</Badge>
+                      <Badge variant="outline">Job availability</Badge>
                     </div>
                     <p className="text-xs text-gray-600">
                       {response.responded_at
@@ -318,7 +323,10 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                   className="flex items-center justify-between p-2 bg-white rounded"
                 >
                   <p className="text-sm font-medium">{response.full_name}</p>
-                  <Badge className="bg-yellow-100 text-yellow-800">Availability pending</Badge>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">Job availability</Badge>
+                    <Badge className="bg-yellow-100 text-yellow-800">Availability pending</Badge>
+                  </div>
                 </div>
               ))}
             </div>
@@ -341,7 +349,10 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                   className="flex items-center justify-between p-2 bg-white rounded"
                 >
                   <p className="text-sm font-medium">{response.full_name}</p>
-                  <Badge className="bg-red-100 text-red-800">Availability no</Badge>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">Job availability</Badge>
+                    <Badge className="bg-red-100 text-red-800">Availability no</Badge>
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/components/matrix/StaffingOfferList.tsx
+++ b/src/components/matrix/StaffingOfferList.tsx
@@ -256,7 +256,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
             Send offers by
           </div>
           <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
-            <SelectTrigger className="w-[160px]">
+            <SelectTrigger aria-label="Select offer channel" className="w-[160px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/matrix/StaffingOrchestratorPanel.tsx
+++ b/src/components/matrix/StaffingOrchestratorPanel.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { StaffingCampaignPanel } from './StaffingCampaignPanel'
 import { StaffingCandidateList } from './StaffingCandidateList'
 import { StaffingOfferList } from './StaffingOfferList'
 import { StaffingAutoModePanel } from './StaffingAutoModePanel'
+import { parseSummaryRow } from '@/pages/job-assignment-matrix/utils'
 import {
   useStaffingCampaignRealtime,
   useStaffingCampaignRolesRealtime,
@@ -34,6 +36,18 @@ interface Campaign {
   updated_at: string
   last_run_at?: string
   next_run_at?: string
+}
+
+interface CampaignRole {
+  id: string
+  campaign_id: string
+  role_code: string
+  assigned_count: number
+  pending_availability: number
+  confirmed_availability: number
+  pending_offers: number
+  accepted_offers: number
+  stage: string
 }
 
 export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps> = ({
@@ -73,10 +87,32 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
         .select('*')
         .eq('campaign_id', campaign.id)
         .order('role_code')
-      return data || []
+      return (data || []) as CampaignRole[]
     },
     enabled: !!campaign?.id
   })
+
+  const { data: requiredRoleSummary } = useQuery({
+    queryKey: queryKeys.scope('staffing_required_roles', jobId, department),
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient.from('job_required_roles_summary')
+        .select('job_id, department, roles')
+        .eq('job_id', jobId)
+        .eq('department', department)
+        .maybeSingle()
+
+      if (error) throw error
+      return parseSummaryRow(data)
+    }
+  })
+
+  const requiredByRole = useMemo(() => {
+    return new Map(
+      (requiredRoleSummary?.roles || []).map((role) => [role.role_code, role.quantity])
+    )
+  }, [requiredRoleSummary])
+
+  const getRequiredCount = (roleCode: string) => requiredByRole.get(roleCode) ?? 0
 
   if (!campaign) {
     return (
@@ -122,25 +158,33 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
                 <div>
                   <h3 className="font-semibold text-sm mb-2">Roles to Fill</h3>
                   <div className="space-y-1 text-sm">
-                    {campaignRoles.map((role: any) => (
-                      <div
-                        key={role.id}
-                        className="flex justify-between items-center py-1"
-                      >
-                        <span className="text-gray-700">{role.role_code}</span>
-                        <span className="text-gray-600">
-                          {role.stage === 'filled' ? (
-                            <span className="text-green-600 font-semibold">✓ Filled</span>
-                          ) : (
-                            <span>
-                              {role.assigned_count} assigned
-                              {role.confirmed_availability > 0 &&
-                                ` • ${role.confirmed_availability} confirmed`}
-                            </span>
-                          )}
-                        </span>
-                      </div>
-                    ))}
+                    {campaignRoles.map((role) => {
+                      const requiredCount = getRequiredCount(role.role_code)
+                      const assignedCount = Number(role.assigned_count || 0)
+
+                      return (
+                        <div
+                          key={role.id}
+                          className="flex flex-wrap justify-between items-center gap-2 py-1"
+                        >
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="text-gray-700">{role.role_code}</span>
+                            <Badge variant="outline">Required {requiredCount}</Badge>
+                          </div>
+                          <span className="text-gray-600">
+                            {role.stage === 'filled' ? (
+                              <span className="text-green-600 font-semibold">✓ Filled</span>
+                            ) : (
+                              <span>
+                                {assignedCount}/{requiredCount || '—'} assigned
+                                {role.confirmed_availability > 0 &&
+                                  ` • ${role.confirmed_availability} confirmed`}
+                              </span>
+                            )}
+                          </span>
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               )}
@@ -157,6 +201,7 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
           <StaffingAutoModePanel
             campaign={campaign}
             campaignRoles={campaignRoles || []}
+            requiredByRole={requiredByRole}
             onStatusChange={() => refetchCampaign()}
           />
         )}
@@ -168,8 +213,8 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
           {campaignRoles && campaignRoles.length > 0 ? (
             <div className="space-y-4">
               {campaignRoles
-                .filter((r: any) => r.stage !== 'filled')
-                .map((role: any) => (
+                .filter((r) => r.stage !== 'filled')
+                .map((role) => (
                   <StaffingCandidateList
                     key={role.id}
                     campaignId={campaign.id}
@@ -177,9 +222,13 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
                     jobId={jobId}
                     department={department}
                     policy={campaign.policy}
+                    requiredCount={getRequiredCount(role.role_code)}
+                    assignedCount={Number(role.assigned_count || 0)}
+                    confirmedAvailability={Number(role.confirmed_availability || 0)}
+                    pendingAvailability={Number(role.pending_availability || 0)}
                   />
                 ))}
-              {campaignRoles.every((r: any) => r.stage === 'filled') && (
+              {campaignRoles.every((r) => r.stage === 'filled') && (
                 <Card>
                   <CardContent className="pt-6">
                     <p className="text-center text-gray-600">
@@ -204,7 +253,7 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
         <TabsContent value="offers" className="space-y-4">
           {campaignRoles && campaignRoles.length > 0 ? (
             <div className="space-y-4">
-              {campaignRoles.map((role: any) => (
+              {campaignRoles.map((role) => (
                 <StaffingOfferList
                   key={role.id}
                   campaignId={campaign.id}
@@ -212,6 +261,12 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
                   jobId={jobId}
                   department={department}
                   offerMessage={campaign.offer_message}
+                  requiredCount={getRequiredCount(role.role_code)}
+                  assignedCount={Number(role.assigned_count || 0)}
+                  confirmedAvailability={Number(role.confirmed_availability || 0)}
+                  pendingAvailability={Number(role.pending_availability || 0)}
+                  acceptedOffers={Number(role.accepted_offers || 0)}
+                  pendingOffers={Number(role.pending_offers || 0)}
                 />
               ))}
             </div>

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -178,7 +178,7 @@ serve(async (req) => {
 
     const { job_id, profile_id, phase, role, message, channel, tour_pdf_path, target_date, single_day, override_conflicts, require_no_conflicts, idempotency_key } = body;
     const roleCode = typeof role === 'string' && role.trim().length > 0 ? role.trim() : null;
-    const roleCodePatch = roleCode ? { role_code: roleCode } : {};
+    const roleCodePatch = roleCode && phase === 'offer' ? { role_code: roleCode } : {};
     const datesArrayRaw: unknown = (body as any)?.dates;
     const shouldOverrideConflicts = Boolean(override_conflicts);
     const shouldRequireNoConflicts = Boolean(require_no_conflicts);
@@ -249,7 +249,7 @@ serve(async (req) => {
       if (idempotencyError) {
         console.warn('⚠️ Idempotency check failed (non-blocking):', idempotencyError);
       } else if (existing) {
-        if (roleCode && !existing.role_code) {
+        if (phase === 'offer' && roleCode && !existing.role_code) {
           const { error: roleUpdateError } = await supabase
             .from('staffing_requests')
             .update({ role_code: roleCode })
@@ -443,6 +443,7 @@ serve(async (req) => {
           targetAssignmentResult,
           activeAssignmentResult,
           sameRoleRequestResult,
+          jobAvailabilityRequestResult,
           rolelessDeclineResult,
         ] = await Promise.all([
           supabase
@@ -462,7 +463,16 @@ serve(async (req) => {
               .eq('job_id', job_id)
               .eq('profile_id', profile_id)
               .eq('role_code', roleCode)
-              .in('phase', ['availability', 'offer'])
+              .in('phase', phase === 'offer' ? ['offer'] : ['availability', 'offer'])
+              .in('status', ['pending', 'confirmed', 'declined'])
+            : Promise.resolve({ data: [], error: null }),
+          phase === 'availability'
+            ? supabase
+              .from('staffing_requests')
+              .select('id, phase, status, role_code, target_date, single_day, updated_at')
+              .eq('job_id', job_id)
+              .eq('profile_id', profile_id)
+              .eq('phase', 'availability')
               .in('status', ['pending', 'confirmed', 'declined'])
             : Promise.resolve({ data: [], error: null }),
           supabase
@@ -479,6 +489,7 @@ serve(async (req) => {
           targetAssignmentResult.error,
           activeAssignmentResult.error,
           sameRoleRequestResult.error,
+          jobAvailabilityRequestResult.error,
           rolelessDeclineResult.error,
         ].filter(Boolean);
 
@@ -510,6 +521,13 @@ serve(async (req) => {
           ));
 
         const sameRoleRequests = sameRoleRequestResult.data || [];
+        const jobAvailabilityRequests = (jobAvailabilityRequestResult.data || [])
+          .filter((request: any) => (
+            request.status !== 'declined'
+            || request.single_day === false
+            || !request.target_date
+            || targetDates.includes(request.target_date)
+          ));
         const rolelessDeclines = (rolelessDeclineResult.data || [])
           .filter((request: any) => (
             request.single_day === false
@@ -521,6 +539,7 @@ serve(async (req) => {
           activeTargetAssignments.length > 0
           || overlappingAssignments.length > 0
           || sameRoleRequests.length > 0
+          || jobAvailabilityRequests.length > 0
           || rolelessDeclines.length > 0
         ) {
           const blockDetails = {
@@ -535,6 +554,7 @@ serve(async (req) => {
               end_time: assignment.job?.end_time,
             })),
             same_role_requests: sameRoleRequests,
+            job_availability_requests: jobAvailabilityRequests,
             roleless_declines: rolelessDeclines,
             target_dates: targetDates,
             target_job: {

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -145,6 +145,16 @@ async function resolveActorId(supabase: ReturnType<typeof createClient>, req: Re
   }
 }
 
+function isServiceRoleRequest(req: Request): boolean {
+  const authHeader = req.headers.get('Authorization') || '';
+  const apikey = req.headers.get('apikey') || '';
+  const token = authHeader.startsWith('Bearer ')
+    ? authHeader.slice('Bearer '.length).trim()
+    : '';
+
+  return token === SERVICE_ROLE || apikey === SERVICE_ROLE;
+}
+
 function b64url(u8: Uint8Array) {
   return btoa(String.fromCharCode(...u8)).replace(/\+/g,"-").replace(/\//g,"_").replace(/=+$/,"");
 }
@@ -159,8 +169,11 @@ serve(async (req) => {
   
   try {
     const supabase = createClient(SUPABASE_URL, SERVICE_ROLE);
-    const actorId = await resolveActorId(supabase, req);
+    let actorId = await resolveActorId(supabase, req);
     const body = await req.json();
+    if (!actorId && isServiceRoleRequest(req) && typeof body?.actor_id === 'string') {
+      actorId = body.actor_id;
+    }
     console.log('📥 RECEIVED PAYLOAD:', JSON.stringify(body, null, 2));
 
     const { job_id, profile_id, phase, role, message, channel, tour_pdf_path, target_date, single_day, override_conflicts, require_no_conflicts, idempotency_key } = body;

--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -745,6 +745,9 @@ async function tickCampaign(
           const profileId = String(request.profile_id || '');
           if (!profileId) continue;
 
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
           try {
             const response = await fetch(SEND_STAFFING_EMAIL_URL, {
               method: 'POST',
@@ -764,6 +767,7 @@ async function tickCampaign(
                 actor_id: campaign.created_by || null,
                 idempotency_key: `campaign:${campaign_id}:${roleCode}:${profileId}:offer:auto:${autoChannel}`,
               }),
+              signal: controller.signal,
             });
 
             const payload = await response.json().catch(() => ({}));
@@ -798,6 +802,8 @@ async function tickCampaign(
               status: 'failed',
               error: err instanceof Error ? err.message : String(err),
             });
+          } finally {
+            clearTimeout(timeoutId);
           }
         }
       }

--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -598,7 +598,9 @@ async function tickCampaign(
     const requestIdToRole = new Map<string, string>();
     requestRows.forEach((request) => {
       const directRole = typeof request.role_code === 'string' ? request.role_code.trim() : '';
-      if (request.id && directRole) requestIdToRole.set(String(request.id), directRole);
+      if (request.id && request.phase !== 'availability' && directRole) {
+        requestIdToRole.set(String(request.id), directRole);
+      }
     });
 
     if (requestIds.length > 0) {
@@ -607,7 +609,7 @@ async function tickCampaign(
         .select('staffing_request_id, meta, created_at, event')
         .in('staffing_request_id', requestIds)
         .in('event', ['email_sent', 'whatsapp_sent'])
-        .order('created_at', { ascending: true });
+        .order('created_at', { ascending: false });
 
       if (sendEventsError) {
         return { status: 500, body: { error: sendEventsError.message } };
@@ -638,12 +640,13 @@ async function tickCampaign(
       };
     }
 
-    const confirmedAvailabilityByRole = new Map<string, any[]>();
+    const confirmedAvailabilityRowsForJob: any[] = [];
+    const confirmedAvailabilityByRequestedRole = new Map<string, any[]>();
     const offerRequestProfilesByRole = new Map<string, Set<string>>();
+    const offerRequestProfilesForJob = new Set<string>();
 
     for (const r of requestRows) {
       const roleCode = requestIdToRole.get(String(r.id));
-      if (!roleCode || !campaignRoleCodes.has(roleCode)) continue;
       const phase = String(r.phase || '') as 'availability' | 'offer';
       if (phase !== 'availability' && phase !== 'offer') continue;
 
@@ -651,14 +654,30 @@ async function tickCampaign(
       const profileId = String(r.profile_id || '');
       if (!profileId) continue;
 
+      if (phase === 'offer' && ['pending', 'confirmed', 'declined'].includes(status)) {
+        offerRequestProfilesForJob.add(profileId);
+      }
+
+      if (phase === 'availability') {
+        const availabilityRow = { ...r, requested_role_code: roleCode || null };
+        if (status === 'confirmed') {
+          confirmedAvailabilityRowsForJob.push(availabilityRow);
+          if (roleCode && campaignRoleCodes.has(roleCode)) {
+            const rows = confirmedAvailabilityByRequestedRole.get(roleCode) || [];
+            rows.push(availabilityRow);
+            confirmedAvailabilityByRequestedRole.set(roleCode, rows);
+          }
+        }
+        if (roleCode && campaignRoleCodes.has(roleCode) && status === 'pending') {
+          countsByRole[roleCode].availability.pending.add(profileId);
+        }
+        continue;
+      }
+
+      if (!campaignRoleCodes.has(roleCode)) continue;
+
       if (status === 'pending') countsByRole[roleCode][phase].pending.add(profileId);
       if (status === 'confirmed') countsByRole[roleCode][phase].confirmed.add(profileId);
-
-      if (phase === 'availability' && status === 'confirmed') {
-        const rows = confirmedAvailabilityByRole.get(roleCode) || [];
-        rows.push(r);
-        confirmedAvailabilityByRole.set(roleCode, rows);
-      }
 
       if (phase === 'offer' && ['pending', 'confirmed', 'declined'].includes(status)) {
         const profiles = offerRequestProfilesByRole.get(roleCode) || new Set<string>();
@@ -679,14 +698,23 @@ async function tickCampaign(
       const required = requiredByRole.get(roleCode) || 0;
       const assigned = assignedCounts.get(roleCode) || 0;
       const pendingAvailability = countsByRole[roleCode]?.availability.pending.size || 0;
-      const confirmedAvailability = countsByRole[roleCode]?.availability.confirmed.size || 0;
+      const matchingRequestedRole = confirmedAvailabilityByRequestedRole.get(roleCode) || [];
+      const confirmedAvailability = new Set(
+        matchingRequestedRole
+          .map((request: any) => String(request.profile_id || ''))
+          .filter(Boolean),
+      ).size;
       let pendingOffers = countsByRole[roleCode]?.offer.pending.size || 0;
       const acceptedOffers = countsByRole[roleCode]?.offer.confirmed.size || 0;
+      const hasConfirmedAvailabilityForRole = matchingRequestedRole.some((request: any) => {
+        const profileId = String(request.profile_id || '');
+        return profileId && !offerRequestProfilesForJob.has(profileId);
+      });
 
       let stage = 'idle';
       if (required <= 0 || assigned >= required) {
         stage = 'filled';
-      } else if (pendingOffers > 0 || acceptedOffers > 0 || confirmedAvailability > 0) {
+      } else if (pendingOffers > 0 || acceptedOffers > 0 || hasConfirmedAvailabilityForRole) {
         stage = 'offer';
       } else {
         stage = 'availability';
@@ -697,15 +725,19 @@ async function tickCampaign(
       if (shouldPrioritizeAssistedHandoff && stage === 'offer') {
         const capacity = Math.max(0, required - assigned - acceptedOffers - pendingOffers);
         const profilesWithOffer = offerRequestProfilesByRole.get(roleCode) || new Set<string>();
-        const confirmedAvailabilityRows = (confirmedAvailabilityByRole.get(roleCode) || [])
+        const confirmedAvailabilityRows = matchingRequestedRole
           .filter((request: any) => {
             const profileId = String(request.profile_id || '');
-            return profileId && !profilesWithOffer.has(profileId);
+            return profileId && !profilesWithOffer.has(profileId) && !offerRequestProfilesForJob.has(profileId);
           })
           .sort((a: any, b: any) => {
             const aTime = new Date(a.updated_at || 0).getTime();
             const bTime = new Date(b.updated_at || 0).getTime();
             return aTime - bTime;
+          })
+          .filter((request: any, index: number, rows: any[]) => {
+            const profileId = String(request.profile_id || '');
+            return rows.findIndex((row: any) => String(row.profile_id || '') === profileId) === index;
           })
           .slice(0, capacity);
 
@@ -748,6 +780,7 @@ async function tickCampaign(
             }
 
             profilesWithOffer.add(profileId);
+            offerRequestProfilesForJob.add(profileId);
             pendingOffers += 1;
             autoActions.push({
               role_code: roleCode,

--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -3,6 +3,8 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const SEND_STAFFING_EMAIL_URL = Deno.env.get("SEND_STAFFING_EMAIL_URL") ||
+  `${SUPABASE_URL}/functions/v1/send-staffing-email`;
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -26,6 +28,8 @@ interface CampaignPolicy {
   exclude_fridge: boolean;
   soft_conflict_policy: 'warn' | 'block' | 'allow';
   tick_interval_seconds: number;
+  channel?: 'email' | 'whatsapp';
+  assisted_handoff_priority?: boolean;
   escalation_steps: string[];
 }
 
@@ -561,7 +565,7 @@ async function tickCampaign(
         .eq('job_id', campaign.job_id),
       supabase
         .from('staffing_requests')
-        .select('id, profile_id, phase, status, batch_id')
+        .select('id, profile_id, phase, status, batch_id, role_code, updated_at')
         .eq('job_id', campaign.job_id)
         .in('phase', ['availability', 'offer']),
     ]);
@@ -592,6 +596,10 @@ async function tickCampaign(
     const requestRows = (requests || []) as any[];
     const requestIds = requestRows.map((r) => r.id).filter(Boolean) as string[];
     const requestIdToRole = new Map<string, string>();
+    requestRows.forEach((request) => {
+      const directRole = typeof request.role_code === 'string' ? request.role_code.trim() : '';
+      if (request.id && directRole) requestIdToRole.set(String(request.id), directRole);
+    });
 
     if (requestIds.length > 0) {
       const { data: sendEvents, error: sendEventsError } = await supabase
@@ -608,6 +616,7 @@ async function tickCampaign(
       (sendEvents || []).forEach((evt: any) => {
         const role = (evt?.meta as any)?.role;
         if (!evt?.staffing_request_id || !role) return;
+        if (requestIdToRole.has(String(evt.staffing_request_id))) return;
         requestIdToRole.set(String(evt.staffing_request_id), String(role));
       });
     }
@@ -629,6 +638,9 @@ async function tickCampaign(
       };
     }
 
+    const confirmedAvailabilityByRole = new Map<string, any[]>();
+    const offerRequestProfilesByRole = new Map<string, Set<string>>();
+
     for (const r of requestRows) {
       const roleCode = requestIdToRole.get(String(r.id));
       if (!roleCode || !campaignRoleCodes.has(roleCode)) continue;
@@ -641,10 +653,26 @@ async function tickCampaign(
 
       if (status === 'pending') countsByRole[roleCode][phase].pending.add(profileId);
       if (status === 'confirmed') countsByRole[roleCode][phase].confirmed.add(profileId);
+
+      if (phase === 'availability' && status === 'confirmed') {
+        const rows = confirmedAvailabilityByRole.get(roleCode) || [];
+        rows.push(r);
+        confirmedAvailabilityByRole.set(roleCode, rows);
+      }
+
+      if (phase === 'offer' && ['pending', 'confirmed', 'declined'].includes(status)) {
+        const profiles = offerRequestProfilesByRole.get(roleCode) || new Set<string>();
+        profiles.add(profileId);
+        offerRequestProfilesByRole.set(roleCode, profiles);
+      }
     }
 
     const updates = [];
+    const autoActions: Array<{ role_code: string; profile_id: string; phase: string; channel: string; status: string; error?: string }> = [];
     let allFilled = true;
+    const policy = (campaign.policy || {}) as CampaignPolicy;
+    const autoChannel = policy.channel === 'whatsapp' ? 'whatsapp' : 'email';
+    const shouldPrioritizeAssistedHandoff = campaign.mode === 'auto' && policy.assisted_handoff_priority !== false;
 
     for (const role of (campaignRoles || []) as any[]) {
       const roleCode = String(role.role_code).trim();
@@ -652,19 +680,94 @@ async function tickCampaign(
       const assigned = assignedCounts.get(roleCode) || 0;
       const pendingAvailability = countsByRole[roleCode]?.availability.pending.size || 0;
       const confirmedAvailability = countsByRole[roleCode]?.availability.confirmed.size || 0;
-      const pendingOffers = countsByRole[roleCode]?.offer.pending.size || 0;
+      let pendingOffers = countsByRole[roleCode]?.offer.pending.size || 0;
       const acceptedOffers = countsByRole[roleCode]?.offer.confirmed.size || 0;
 
       let stage = 'idle';
       if (required <= 0 || assigned >= required) {
         stage = 'filled';
-      } else if (pendingOffers > 0 || acceptedOffers > 0 || confirmedAvailability >= required) {
+      } else if (pendingOffers > 0 || acceptedOffers > 0 || confirmedAvailability > 0) {
         stage = 'offer';
       } else {
         stage = 'availability';
       }
 
       if (stage !== 'filled') allFilled = false;
+
+      if (shouldPrioritizeAssistedHandoff && stage === 'offer') {
+        const capacity = Math.max(0, required - assigned - acceptedOffers - pendingOffers);
+        const profilesWithOffer = offerRequestProfilesByRole.get(roleCode) || new Set<string>();
+        const confirmedAvailabilityRows = (confirmedAvailabilityByRole.get(roleCode) || [])
+          .filter((request: any) => {
+            const profileId = String(request.profile_id || '');
+            return profileId && !profilesWithOffer.has(profileId);
+          })
+          .sort((a: any, b: any) => {
+            const aTime = new Date(a.updated_at || 0).getTime();
+            const bTime = new Date(b.updated_at || 0).getTime();
+            return aTime - bTime;
+          })
+          .slice(0, capacity);
+
+        for (const request of confirmedAvailabilityRows) {
+          const profileId = String(request.profile_id || '');
+          if (!profileId) continue;
+
+          try {
+            const response = await fetch(SEND_STAFFING_EMAIL_URL, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${SERVICE_ROLE}`,
+                'apikey': SERVICE_ROLE,
+              },
+              body: JSON.stringify({
+                job_id: campaign.job_id,
+                profile_id: profileId,
+                phase: 'offer',
+                role: roleCode,
+                message: campaign.offer_message || null,
+                channel: autoChannel,
+                require_no_conflicts: true,
+                actor_id: campaign.created_by || null,
+                idempotency_key: `campaign:${campaign_id}:${roleCode}:${profileId}:offer:auto:${autoChannel}`,
+              }),
+            });
+
+            const payload = await response.json().catch(() => ({}));
+            if (!response.ok) {
+              autoActions.push({
+                role_code: roleCode,
+                profile_id: profileId,
+                phase: 'offer',
+                channel: autoChannel,
+                status: 'failed',
+                error: payload?.error || `HTTP ${response.status}`,
+              });
+              continue;
+            }
+
+            profilesWithOffer.add(profileId);
+            pendingOffers += 1;
+            autoActions.push({
+              role_code: roleCode,
+              profile_id: profileId,
+              phase: 'offer',
+              channel: autoChannel,
+              status: 'sent',
+            });
+          } catch (err) {
+            autoActions.push({
+              role_code: roleCode,
+              profile_id: profileId,
+              phase: 'offer',
+              channel: autoChannel,
+              status: 'failed',
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      }
 
       updates.push({
         id: role.id,
@@ -724,6 +827,7 @@ async function tickCampaign(
         campaign_id,
         tick_completed: true,
         roles_processed: updates.length,
+        auto_actions: autoActions,
         all_filled: allFilled,
         next_run_at: nextRun?.toISOString() || null,
       },

--- a/supabase/migrations/20260519165000_job_scoped_staffing_availability.sql
+++ b/supabase/migrations/20260519165000_job_scoped_staffing_availability.sql
@@ -1,0 +1,109 @@
+-- Availability responses are job-scoped. Keep role context in send/event
+-- metadata for manager intent, but do not persist it on availability requests
+-- or use it to decide whether a technician has answered availability.
+
+UPDATE public.staffing_requests
+SET role_code = NULL
+WHERE phase = 'availability'
+  AND role_code IS NOT NULL;
+
+COMMENT ON COLUMN public.staffing_requests.role_code
+  IS 'Role code for role-specific staffing phases, primarily offers. Availability requests are job-scoped and should keep this null.';
+
+CREATE INDEX IF NOT EXISTS idx_staffing_requests_active_job_availability
+  ON public.staffing_requests (job_id, profile_id, status, target_date)
+  WHERE phase = 'availability'
+    AND status IN ('pending', 'confirmed', 'declined');
+
+DO $$
+DECLARE
+  v_sql text;
+BEGIN
+  SELECT pg_get_functiondef('public.rank_staffing_candidates(uuid,text,text,text,jsonb)'::regprocedure)
+  INTO v_sql;
+
+  v_sql := replace(
+    v_sql,
+$old$
+      AND (
+        v_normalized_role_code IS NULL
+        OR NOT EXISTS (
+          SELECT 1
+          FROM staffing_requests sr
+          WHERE sr.job_id = p_job_id
+            AND sr.profile_id = p.id
+            AND NULLIF(BTRIM(sr.role_code), '') = v_normalized_role_code
+            AND sr.phase IN ('availability', 'offer')
+            AND sr.status IN ('pending', 'confirmed', 'declined')
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM staffing_requests sr
+        WHERE sr.job_id = p_job_id
+          AND sr.profile_id = p.id
+          AND NULLIF(BTRIM(sr.role_code), '') IS NULL
+          AND sr.phase IN ('availability', 'offer')
+          AND sr.status = 'declined'
+          AND (
+            sr.single_day = false
+            OR sr.target_date IS NULL
+            OR sr.target_date BETWEEN v_job_start::date AND v_job_end::date
+          )
+      )
+$old$,
+$new$
+      -- Availability is job-scoped: once a technician has a pending or
+      -- confirmed availability response for this job, do not recommend another
+      -- availability request for any role. The role is only disclosed at offer time.
+      AND NOT EXISTS (
+        SELECT 1
+        FROM staffing_requests sr
+        WHERE sr.job_id = p_job_id
+          AND sr.profile_id = p.id
+          AND sr.phase = 'availability'
+          AND sr.status IN ('pending', 'confirmed')
+          AND (
+            sr.single_day = false
+            OR sr.target_date IS NULL
+            OR sr.target_date BETWEEN v_job_start::date AND v_job_end::date
+          )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM staffing_requests sr
+        WHERE sr.job_id = p_job_id
+          AND sr.profile_id = p.id
+          AND sr.phase = 'availability'
+          AND sr.status = 'declined'
+          AND (
+            sr.single_day = false
+            OR sr.target_date IS NULL
+            OR sr.target_date BETWEEN v_job_start::date AND v_job_end::date
+          )
+      )
+      AND (
+        v_normalized_role_code IS NULL
+        OR NOT EXISTS (
+          SELECT 1
+          FROM staffing_requests sr
+          WHERE sr.job_id = p_job_id
+            AND sr.profile_id = p.id
+            AND NULLIF(BTRIM(sr.role_code), '') = v_normalized_role_code
+            AND sr.phase = 'offer'
+            AND sr.status IN ('pending', 'confirmed', 'declined')
+        )
+      )
+$new$
+  );
+
+  IF v_sql NOT LIKE '%Availability is job-scoped:%'
+    OR v_sql NOT LIKE '%sr.phase = ''availability''%'
+    OR v_sql NOT LIKE '%sr.phase = ''offer''%'
+  THEN
+    RAISE EXCEPTION 'Failed to patch rank_staffing_candidates with job-scoped availability filtering';
+  END IF;
+
+  EXECUTE v_sql;
+END;
+$$;

--- a/supabase/migrations/20260519170000_declined_staffing_request_ranking_penalty.sql
+++ b/supabase/migrations/20260519170000_declined_staffing_request_ranking_penalty.sql
@@ -1,0 +1,127 @@
+-- Penalize repeated declined staffing requests for the same role prefix.
+-- Availability rows remain job-scoped; role intent for those rows comes from
+-- the latest send event metadata.
+
+DO $$
+DECLARE
+  v_sql text;
+BEGIN
+  SELECT pg_get_functiondef('public.rank_staffing_candidates(uuid,text,text,text,jsonb)'::regprocedure)
+  INTO v_sql;
+
+  v_sql := replace(
+    v_sql,
+$old$
+  reliability_stats AS (
+$old$,
+$new$
+  role_declines AS (
+    SELECT
+      b.profile_id,
+      COUNT(DISTINCT sr.id)::int AS role_declined_requests
+    FROM base b
+    JOIN staffing_requests sr ON sr.profile_id = b.profile_id
+      AND sr.status = 'declined'
+    LEFT JOIN LATERAL (
+      SELECT NULLIF(BTRIM(se.meta->>'role'), '') AS event_role_code
+      FROM staffing_events se
+      WHERE se.staffing_request_id = sr.id
+        AND se.event IN ('email_sent', 'whatsapp_sent')
+        AND se.meta->>'phase' = sr.phase
+        AND NULLIF(BTRIM(se.meta->>'role'), '') IS NOT NULL
+      ORDER BY se.created_at DESC
+      LIMIT 1
+    ) latest_role ON true
+    WHERE public.staffing_role_prefix(
+      COALESCE(NULLIF(BTRIM(sr.role_code), ''), latest_role.event_role_code)
+    ) = v_role_prefix
+    GROUP BY b.profile_id
+  ),
+  reliability_stats AS (
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+      COALESCE(rs.offer_yes, 0) AS offer_yes,
+      COALESCE(rs.offer_total, 0) AS offer_total
+    FROM base b
+    LEFT JOIN skill_scores ss ON ss.profile_id = b.profile_id
+    LEFT JOIN role_experience re ON re.profile_id = b.profile_id
+    LEFT JOIN reliability_stats rs ON rs.profile_id = b.profile_id
+$old$,
+$new$
+      COALESCE(rs.offer_yes, 0) AS offer_yes,
+      COALESCE(rs.offer_total, 0) AS offer_total,
+      COALESCE(rd.role_declined_requests, 0)::int AS role_declined_requests,
+      (
+        CASE
+          WHEN COALESCE(rd.role_declined_requests, 0) >= 5 THEN 30
+          WHEN COALESCE(rd.role_declined_requests, 0) >= 3 THEN 20
+          WHEN COALESCE(rd.role_declined_requests, 0) = 2 THEN 12
+          WHEN COALESCE(rd.role_declined_requests, 0) = 1 THEN 6
+          ELSE 0
+        END
+      )::int AS role_decline_penalty
+    FROM base b
+    LEFT JOIN skill_scores ss ON ss.profile_id = b.profile_id
+    LEFT JOIN role_experience re ON re.profile_id = b.profile_id
+    LEFT JOIN role_declines rd ON rd.profile_id = b.profile_id
+    LEFT JOIN reliability_stats rs ON rs.profile_id = b.profile_id
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+      GREATEST(wr.manual_skill_score, wr.role_experience_score)::int AS skills_score,
+      wr.manual_skill_score,
+      wr.best_skill,
+      wr.role_completed_jobs,
+      wr.role_experience_score,
+$old$,
+$new$
+      GREATEST(0, GREATEST(wr.manual_skill_score, wr.role_experience_score) - wr.role_decline_penalty)::int AS skills_score,
+      wr.manual_skill_score,
+      wr.best_skill,
+      wr.role_completed_jobs,
+      wr.role_experience_score,
+      wr.role_declined_requests,
+      wr.role_decline_penalty,
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+    (CASE
+      WHEN f.role_experience_score > f.manual_skill_score
+      THEN jsonb_build_array('Skill score boosted by completed role history')
+      ELSE '[]'::jsonb
+    END) ||
+$old$,
+$new$
+    (CASE
+      WHEN f.role_experience_score > f.manual_skill_score
+      THEN jsonb_build_array('Skill score boosted by completed role history')
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE
+      WHEN f.role_declined_requests > 0
+      THEN jsonb_build_array('Declined role requests: ' || f.role_declined_requests || ' previous ' || COALESCE(v_role_prefix, p_role_code) || ' declines (-' || f.role_decline_penalty || ' skill pts)')
+      ELSE '[]'::jsonb
+    END) ||
+$new$
+  );
+
+  IF v_sql NOT LIKE '%role_declines AS%'
+    OR v_sql NOT LIKE '%role_decline_penalty%'
+    OR v_sql NOT LIKE '%Declined role requests:%'
+  THEN
+    RAISE EXCEPTION 'Failed to patch rank_staffing_candidates with declined request penalty';
+  END IF;
+
+  EXECUTE v_sql;
+END;
+$$;

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -17,6 +17,11 @@ const sendStaffingEmailFunction = readFileSync(
   "utf-8",
 );
 
+const staffingOrchestratorFunction = readFileSync(
+  join(process.cwd(), "supabase/functions/staffing-orchestrator/index.ts"),
+  "utf-8",
+);
+
 describe("staffing recommendation consultation guards", () => {
   it("stores a structured role_code on staffing requests", () => {
     expect(migration).toContain("ADD COLUMN IF NOT EXISTS role_code text");
@@ -85,5 +90,19 @@ describe("smarter staffing recommendation migration", () => {
     expect(sendStaffingEmailFunction).toContain("same_role_requests");
     expect(sendStaffingEmailFunction).toContain("roleless_declines");
     expect(sendStaffingEmailFunction).toContain("status: 409");
+  });
+
+  it("lets service-role automation send WhatsApp as the campaign creator", () => {
+    expect(sendStaffingEmailFunction).toContain("isServiceRoleRequest");
+    expect(sendStaffingEmailFunction).toContain("body?.actor_id");
+    expect(staffingOrchestratorFunction).toContain("actor_id: campaign.created_by");
+  });
+
+  it("prioritizes confirmed assisted availability before auto mode contacts new candidates", () => {
+    expect(staffingOrchestratorFunction).toContain("assisted_handoff_priority");
+    expect(staffingOrchestratorFunction).toContain("confirmedAvailabilityByRole");
+    expect(staffingOrchestratorFunction).toContain("phase: 'offer'");
+    expect(staffingOrchestratorFunction).toContain("require_no_conflicts: true");
+    expect(staffingOrchestratorFunction).toContain("auto_actions");
   });
 });

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -12,6 +12,16 @@ const smarterMigration = readFileSync(
   "utf-8",
 );
 
+const jobScopedAvailabilityMigration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260519165000_job_scoped_staffing_availability.sql"),
+  "utf-8",
+);
+
+const declinedPenaltyMigration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260519170000_declined_staffing_request_ranking_penalty.sql"),
+  "utf-8",
+);
+
 const sendStaffingEmailFunction = readFileSync(
   join(process.cwd(), "supabase/functions/send-staffing-email/index.ts"),
   "utf-8",
@@ -23,23 +33,27 @@ const staffingOrchestratorFunction = readFileSync(
 );
 
 describe("staffing recommendation consultation guards", () => {
-  it("stores a structured role_code on staffing requests", () => {
+  it("stores a structured role_code for role-specific staffing requests", () => {
     expect(migration).toContain("ADD COLUMN IF NOT EXISTS role_code text");
     expect(migration).toContain("NULLIF(BTRIM(se.meta->>'role'), '') AS role_code");
+    expect(jobScopedAvailabilityMigration).toContain("WHERE phase = 'availability'");
+    expect(jobScopedAvailabilityMigration).toContain("SET role_code = NULL");
+    expect(sendStaffingEmailFunction).toContain("roleCode && phase === 'offer'");
   });
 
-  it("excludes active same-role requests but does not treat expired as active", () => {
-    expect(migration).toMatch(/NULLIF\(BTRIM\(sr\.role_code\), ''\) = v_normalized_role_code/);
-    expect(migration).toMatch(/sr\.phase IN \('availability', 'offer'\)/);
-    expect(migration).toMatch(/sr\.status IN \('pending', 'confirmed', 'declined'\)/);
-    expect(migration).not.toMatch(/sr\.status IN \('pending', 'confirmed', 'declined', 'expired'\)/);
+  it("excludes active job-level availability without treating expired as active", () => {
+    expect(jobScopedAvailabilityMigration).toContain("Availability is job-scoped");
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.phase = 'availability'/);
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.status IN \('pending', 'confirmed'\)/);
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.phase = 'offer'/);
+    expect(jobScopedAvailabilityMigration).not.toMatch(/sr\.status IN \('pending', 'confirmed', 'declined', 'expired'\)/);
   });
 
-  it("keeps role-less requests eligible unless a declined request overlaps the job dates", () => {
-    expect(migration).toMatch(/NULLIF\(BTRIM\(sr\.role_code\), ''\) IS NULL/);
-    expect(migration).toMatch(/sr\.status = 'declined'/);
-    expect(migration).toMatch(/sr\.single_day = false/);
-    expect(migration).toMatch(/sr\.target_date BETWEEN v_job_start::date AND v_job_end::date/);
+  it("blocks declined job-level availability when it overlaps the job dates", () => {
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.phase = 'availability'/);
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.status = 'declined'/);
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.single_day = false/);
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.target_date BETWEEN v_job_start::date AND v_job_end::date/);
   });
 });
 
@@ -53,6 +67,16 @@ describe("smarter staffing recommendation migration", () => {
     expect(smarterMigration).toContain("Role experience: ");
   });
 
+  it("penalizes prior declined requests for the same role prefix", () => {
+    expect(declinedPenaltyMigration).toContain("role_declines AS");
+    expect(declinedPenaltyMigration).toMatch(/sr\.status = 'declined'/);
+    expect(declinedPenaltyMigration).toMatch(/se\.meta->>'phase' = sr\.phase/);
+    expect(declinedPenaltyMigration).toMatch(/public\.staffing_role_prefix\(/);
+    expect(declinedPenaltyMigration).toContain("role_decline_penalty");
+    expect(declinedPenaltyMigration).toContain("GREATEST(0, GREATEST(wr.manual_skill_score, wr.role_experience_score) - wr.role_decline_penalty)");
+    expect(declinedPenaltyMigration).toContain("Declined role requests:");
+  });
+
   it("filters hard collisions and unavailability before candidates are returned", () => {
     expect(smarterMigration).toMatch(/FROM technician_availability ta/);
     expect(smarterMigration).toMatch(/JOIN target_dates td ON td\.target_date = ta\.date/);
@@ -62,11 +86,12 @@ describe("smarter staffing recommendation migration", () => {
     expect(smarterMigration).toMatch(/WHERE ja\.job_id = p_job_id\s+AND ja\.technician_id = p\.id/);
   });
 
-  it("dedupes active same-role requests without treating expired requests as active", () => {
-    expect(smarterMigration).toMatch(/NULLIF\(BTRIM\(sr\.role_code\), ''\) = v_normalized_role_code/);
-    expect(smarterMigration).toMatch(/sr\.phase IN \('availability', 'offer'\)/);
-    expect(smarterMigration).toMatch(/sr\.status IN \('pending', 'confirmed', 'declined'\)/);
-    expect(smarterMigration).not.toMatch(/sr\.status IN \('pending', 'confirmed', 'declined', 'expired'\)/);
+  it("dedupes job-level availability separately from role-specific offers", () => {
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.phase = 'availability'/);
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.status IN \('pending', 'confirmed'\)/);
+    expect(jobScopedAvailabilityMigration).toMatch(/NULLIF\(BTRIM\(sr\.role_code\), ''\) = v_normalized_role_code/);
+    expect(jobScopedAvailabilityMigration).toMatch(/sr\.phase = 'offer'/);
+    expect(jobScopedAvailabilityMigration).not.toMatch(/sr\.status IN \('pending', 'confirmed', 'declined', 'expired'\)/);
   });
 
   it("uses role-prefix mappings for manual skills", () => {
@@ -88,6 +113,7 @@ describe("smarter staffing recommendation migration", () => {
     expect(sendStaffingEmailFunction).toContain("RECOMMENDATION GUARD");
     expect(sendStaffingEmailFunction).toContain("overlapping_assignments");
     expect(sendStaffingEmailFunction).toContain("same_role_requests");
+    expect(sendStaffingEmailFunction).toContain("job_availability_requests");
     expect(sendStaffingEmailFunction).toContain("roleless_declines");
     expect(sendStaffingEmailFunction).toContain("status: 409");
   });
@@ -100,7 +126,11 @@ describe("smarter staffing recommendation migration", () => {
 
   it("prioritizes confirmed assisted availability before auto mode contacts new candidates", () => {
     expect(staffingOrchestratorFunction).toContain("assisted_handoff_priority");
-    expect(staffingOrchestratorFunction).toContain("confirmedAvailabilityByRole");
+    expect(staffingOrchestratorFunction).toContain("confirmedAvailabilityRowsForJob");
+    expect(staffingOrchestratorFunction).toContain("confirmedAvailabilityByRequestedRole");
+    expect(staffingOrchestratorFunction).toContain(".order('created_at', { ascending: false })");
+    expect(staffingOrchestratorFunction).toContain("const confirmedAvailabilityRows = matchingRequestedRole");
+    expect(staffingOrchestratorFunction).toContain("offerRequestProfilesForJob");
     expect(staffingOrchestratorFunction).toContain("phase: 'offer'");
     expect(staffingOrchestratorFunction).toContain("require_no_conflicts: true");
     expect(staffingOrchestratorFunction).toContain("auto_actions");

--- a/tests/e2e/staffing-recommendations.spec.ts
+++ b/tests/e2e/staffing-recommendations.spec.ts
@@ -96,6 +96,22 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
       "profiles": [
         { id: "roleless-pending", profile_picture_url: null },
         { id: "expired-same-role", profile_picture_url: null },
+        {
+          id: "confirmed-tech",
+          first_name: "Confirmed",
+          last_name: "Tech",
+          nickname: null,
+          email: "confirmed@example.com",
+          profile_picture_url: null,
+        },
+        {
+          id: "other-role-tech",
+          first_name: "Other",
+          last_name: "Role",
+          nickname: null,
+          email: "other@example.com",
+          profile_picture_url: null,
+        },
       ],
       "staffing_requests": [
         {
@@ -110,17 +126,53 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
           id: "availability-confirmed-1",
           job_id: "staffing-job-1",
           profile_id: "confirmed-tech",
-          role_code: "SND-PA-T",
+          role_code: null,
           phase: "availability",
           status: "confirmed",
           target_date: null,
           single_day: false,
           created_at: "2026-05-12T10:00:00.000Z",
           updated_at: "2026-05-12T10:10:00.000Z",
-          profiles: {
-            first_name: "Confirmed",
-            last_name: "Tech",
-            nickname: null,
+        },
+        {
+          id: "availability-confirmed-other-role",
+          job_id: "staffing-job-1",
+          profile_id: "other-role-tech",
+          role_code: null,
+          phase: "availability",
+          status: "confirmed",
+          target_date: null,
+          single_day: false,
+          created_at: "2026-05-12T10:00:00.000Z",
+          updated_at: "2026-05-12T10:12:00.000Z",
+        },
+      ],
+      "staffing_events": [
+        {
+          staffing_request_id: "availability-confirmed-1",
+          event: "email_sent",
+          created_at: "2026-05-12T09:55:00.000Z",
+          meta: {
+            phase: "availability",
+            role: "SND-FOH-R",
+          },
+        },
+        {
+          staffing_request_id: "availability-confirmed-1",
+          event: "whatsapp_sent",
+          created_at: "2026-05-12T10:00:00.000Z",
+          meta: {
+            phase: "availability",
+            role: "SND-PA-T",
+          },
+        },
+        {
+          staffing_request_id: "availability-confirmed-other-role",
+          event: "whatsapp_sent",
+          created_at: "2026-05-12T10:00:00.000Z",
+          meta: {
+            phase: "availability",
+            role: "SND-FOH-R",
           },
         },
       ],
@@ -197,11 +249,13 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
   await page.getByRole("tab", { name: "Offers" }).click();
   await expect(page.getByText("Availability: 1 yes")).toBeVisible();
   await expect(page.getByText("Confirmed Tech")).toBeVisible();
+  await expect(page.getByText("Other Role")).toHaveCount(0);
   await expect(page.getByText("Availability yes")).toBeVisible();
+  await expect(page.getByText("Job availability").first()).toBeVisible();
   await page.getByRole("checkbox", { name: /select confirmed tech for offer/i }).click();
   await page.getByRole("button", { name: /send offers \(1\) by email/i }).click();
 
-  expect(calls.functionCalls).toEqual(
+  await expect.poll(() => calls.functionCalls).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         name: "send-staffing-email",

--- a/tests/e2e/staffing-recommendations.spec.ts
+++ b/tests/e2e/staffing-recommendations.spec.ts
@@ -85,8 +85,8 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
           campaign_id: "campaign-1",
           role_code: "SND-PA-T",
           assigned_count: 0,
-          pending_availability: 0,
-          confirmed_availability: 0,
+          pending_availability: 1,
+          confirmed_availability: 1,
           pending_offers: 0,
           accepted_offers: 0,
           stage: "availability",
@@ -105,6 +105,23 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
           target_date: null,
           single_day: false,
           updated_at: "2026-05-12T10:05:00.000Z",
+        },
+        {
+          id: "availability-confirmed-1",
+          job_id: "staffing-job-1",
+          profile_id: "confirmed-tech",
+          role_code: "SND-PA-T",
+          phase: "availability",
+          status: "confirmed",
+          target_date: null,
+          single_day: false,
+          created_at: "2026-05-12T10:00:00.000Z",
+          updated_at: "2026-05-12T10:10:00.000Z",
+          profiles: {
+            first_name: "Confirmed",
+            last_name: "Tech",
+            nickname: null,
+          },
         },
       ],
     },
@@ -146,9 +163,14 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
 
   await page.getByRole("button", { name: /ver recordatorio de staffing/i }).click();
   await page.getByRole("button", { name: "Auto staffing" }).click();
+  await expect(page.getByText("Required 2")).toBeVisible();
+  await expect(page.getByText("0/2 assigned")).toBeVisible();
+
   await page.getByRole("tab", { name: "Candidates" }).click();
 
   await expect(page.getByText("SND-PA-T - Candidate Recommendations")).toBeVisible();
+  await expect(page.getByText("1 available")).toBeVisible();
+  await expect(page.getByText("1 pending")).toBeVisible();
   await expect(page.getByText("Roleless Pending")).toBeVisible();
   await expect(page.getByText("Expired Same Role")).toBeVisible();
   await expect(page.getByText("No-role request")).toBeVisible();
@@ -165,10 +187,19 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
     p_role_code: "SND-PA-T",
   });
 
+  await page.getByRole("combobox").click();
+  await page.getByRole("option", { name: "WhatsApp" }).click();
   await page.getByRole("checkbox", { name: /select all/i }).click();
   await page.getByRole("button", { name: /send availability/i }).click();
 
   await expect(page.getByText("No candidates available for SND-PA-T")).toBeVisible();
+
+  await page.getByRole("tab", { name: "Offers" }).click();
+  await expect(page.getByText("Availability: 1 yes")).toBeVisible();
+  await expect(page.getByText("Confirmed Tech")).toBeVisible();
+  await expect(page.getByText("Availability yes")).toBeVisible();
+  await page.getByRole("checkbox", { name: /select confirmed tech for offer/i }).click();
+  await page.getByRole("button", { name: /send offers \(1\) by email/i }).click();
 
   expect(calls.functionCalls).toEqual(
     expect.arrayContaining([
@@ -179,7 +210,18 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
           profile_id: "roleless-pending",
           phase: "availability",
           role: "SND-PA-T",
+          channel: "whatsapp",
           require_no_conflicts: true,
+        }),
+      }),
+      expect.objectContaining({
+        name: "send-staffing-email",
+        body: expect.objectContaining({
+          job_id: "staffing-job-1",
+          profile_id: "confirmed-tech",
+          phase: "offer",
+          role: "SND-PA-T",
+          channel: "email",
         }),
       }),
     ]),

--- a/tests/e2e/staffing-recommendations.spec.ts
+++ b/tests/e2e/staffing-recommendations.spec.ts
@@ -239,7 +239,7 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
     p_role_code: "SND-PA-T",
   });
 
-  await page.getByRole("combobox").click();
+  await page.getByRole("combobox", { name: "Select availability channel" }).click();
   await page.getByRole("option", { name: "WhatsApp" }).click();
   await page.getByRole("checkbox", { name: /select all/i }).click();
   await page.getByRole("button", { name: /send availability/i }).click();


### PR DESCRIPTION
## Summary
- show required role quantities and assignment progress in auto-staffing overview, candidates, offers, and auto-mode role cards
- add email/WhatsApp channel selection for assisted availability and offer sends
- make availability responses job-scoped while using latest send-event role metadata to filter each role's Offers card
- carry assisted availability into auto mode with the same role-metadata workflow so confirmed techs are first choices for their intended role
- penalize prior declined requests for the same role prefix in candidate ranking, alongside completed-role experience boosts
- fix light-mode contrast for job-detail Documents and Restaurants cards

## Validation
- npm run test:run -- tests/assignments/staffing-recommendations.test.ts
- npx playwright test tests/e2e/staffing-recommendations.spec.ts --project=chromium
- npm run lint
- npm run lint:functions
- npm run test:run
- npm run build

## Deploy
- Supabase dry-run before deploy showed pending migrations 20260519165000 and 20260519170000
- Applied both Supabase migrations to project syldobdcdsgfgjtbuwxm
- Follow-up Supabase dry-run reported the remote database is up to date
- Deployed Edge Functions: send-staffing-email, staffing-orchestrator
