### PR TITLE
[codex] Add crewing profiles and wave-aware staffing

### DIFF
--- a/src/components/matrix/StaffingCampaignPanel.tsx
+++ b/src/components/matrix/StaffingCampaignPanel.tsx
@@ -548,13 +548,13 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
     <div className="space-y-4 rounded border bg-muted/30 p-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div>
-          <p className="text-sm font-semibold">Auto Profile</p>
+          <p className="text-sm font-semibold">Perfil automático</p>
           <p className="text-xs text-muted-foreground">
-            Job type {jobMeta?.job_type || 'single'} suggests {JOB_PROFILE_LABELS[inferredJobProfile]}.
+            Tipo de trabajo {jobMeta?.job_type || 'single'}: perfil sugerido {JOB_PROFILE_LABELS[inferredJobProfile]}.
           </p>
         </div>
         {profileOverrideActive && (
-          <Badge variant="outline">Manual profile override active</Badge>
+          <Badge variant="outline">Perfil manual activo</Badge>
         )}
       </div>
 
@@ -564,18 +564,18 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
           checked={formData.inferProfileFromJobType}
           onChange={(e) => setFormData({ ...formData, inferProfileFromJobType: e.target.checked })}
         />
-        <span className="text-sm">Infer profile from job type and role</span>
+        <span className="text-sm">Inferir perfil por tipo de trabajo y rol</span>
       </label>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="text-sm font-medium">Suggested Job Profile</label>
+          <label className="text-sm font-medium">Perfil de trabajo sugerido</label>
           <div className="mt-1 rounded border bg-background px-2 py-1 text-sm">
             {JOB_PROFILE_LABELS[inferredJobProfile]}
           </div>
         </div>
         <div>
-          <label className="text-sm font-medium">Selected Job Profile</label>
+          <label className="text-sm font-medium">Perfil de trabajo seleccionado</label>
           <select
             value={formData.selectedJobProfile}
             onChange={(e) => applyProfileDefaults(e.target.value as JobProfileName)}
@@ -590,11 +590,11 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
 
       {profileOverrideActive && (
         <div>
-          <label className="text-sm font-medium">Override reason</label>
+          <label className="text-sm font-medium">Motivo del cambio</label>
           <input
             value={formData.profileOverrideReason}
             onChange={(e) => setFormData({ ...formData, profileOverrideReason: e.target.value })}
-            placeholder="Why this campaign should use a different profile"
+            placeholder="Por qué esta campaña debe usar otro perfil"
             className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
           />
         </div>
@@ -602,7 +602,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
 
       {roleCodes.length > 0 && (
         <div>
-          <p className="text-sm font-medium">Role-Level Profiles</p>
+          <p className="text-sm font-medium">Perfiles por rol</p>
           <div className="mt-2 space-y-2">
             {roleCodes.map((roleCode) => {
               const roleProfile = roleProfiles[roleCode]
@@ -613,11 +613,11 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                   <div>
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="text-sm font-medium">{roleCode}</span>
-                      <Badge variant="outline">Required {roleProfile.required_count}</Badge>
-                      {roleProfile.is_critical && <Badge variant="secondary">Critical</Badge>}
+                      <Badge variant="outline">Requeridos {roleProfile.required_count}</Badge>
+                      {roleProfile.is_critical && <Badge variant="secondary">Crítico</Badge>}
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      Suggested: {JOB_PROFILE_LABELS[roleProfile.inferred_profile]}
+                      Sugerido: {JOB_PROFILE_LABELS[roleProfile.inferred_profile]}
                     </p>
                   </div>
                   <select
@@ -637,16 +637,16 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
       )}
 
       <div className="rounded border bg-background p-3">
-        <p className="text-sm font-medium">Profile Weights</p>
+        <p className="text-sm font-medium">Pesos del perfil</p>
         <div className="mt-2 grid grid-cols-2 md:grid-cols-4 gap-2 text-xs text-muted-foreground">
-          <span>Role skill: {selectedProfileDefaults.weights.roleSkill.toFixed(2)}</span>
-          <span>Reliability: {formData.historyWeight.toFixed(2)}</span>
-          <span>Fairness: {selectedProfileDefaults.weights.fairness.toFixed(2)}</span>
-          <span>Proximity: {formData.proximityWeight.toFixed(2)}</span>
-          <span>Cost: {selectedProfileDefaults.weights.costEfficiency.toFixed(2)}</span>
-          <span>House tech: {selectedProfileDefaults.weights.houseTechBonus.toFixed(2)}</span>
-          <span>Progression: {selectedProfileDefaults.weights.roleProgression.toFixed(2)}</span>
-          <span>Availability: {selectedProfileDefaults.weights.availabilityConfidence.toFixed(2)}</span>
+          <span>Habilidad de rol: {selectedProfileDefaults.weights.roleSkill.toFixed(2)}</span>
+          <span>Fiabilidad: {formData.historyWeight.toFixed(2)}</span>
+          <span>Equidad: {selectedProfileDefaults.weights.fairness.toFixed(2)}</span>
+          <span>Proximidad: {formData.proximityWeight.toFixed(2)}</span>
+          <span>Coste: {selectedProfileDefaults.weights.costEfficiency.toFixed(2)}</span>
+          <span>Técnico de casa: {selectedProfileDefaults.weights.houseTechBonus.toFixed(2)}</span>
+          <span>Progresión: {selectedProfileDefaults.weights.roleProgression.toFixed(2)}</span>
+          <span>Disponibilidad: {selectedProfileDefaults.weights.availabilityConfidence.toFixed(2)}</span>
         </div>
       </div>
     </div>
@@ -654,32 +654,32 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
 
   const renderCostAndWaveSettings = () => (
     <div className="space-y-4 rounded border bg-muted/30 p-3">
-      <p className="text-sm font-semibold">Cost / Rate Scoring</p>
+      <p className="text-sm font-semibold">Puntuación de coste/tarifa</p>
       <label className="flex items-center gap-2 cursor-pointer">
         <input
           type="checkbox"
           checked={formData.costScoringEnabled}
           onChange={(e) => setFormData({ ...formData, costScoringEnabled: e.target.checked })}
         />
-        <span className="text-sm">Apply custom rate adjustment</span>
+        <span className="text-sm">Aplicar ajuste por tarifa personalizada</span>
       </label>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="text-sm font-medium">Rate penalty strength</label>
+          <label className="text-sm font-medium">Intensidad de penalización de tarifa</label>
           <select
             value={formData.ratePenaltyStrength}
             onChange={(e) => setFormData({ ...formData, ratePenaltyStrength: e.target.value as RatePenaltyStrength })}
             className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
           >
-            <option value="disabled">Disabled</option>
-            <option value="low">Low</option>
+            <option value="disabled">Desactivado</option>
+            <option value="low">Baja</option>
             <option value="normal">Normal</option>
-            <option value="high">High</option>
+            <option value="high">Alta</option>
           </select>
         </div>
         <div>
-          <label className="text-sm font-medium">Maximum rate penalty</label>
+          <label className="text-sm font-medium">Penalización máxima de tarifa</label>
           <input
             type="number"
             min="0"
@@ -691,22 +691,22 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
         </div>
       </div>
 
-      <p className="text-sm font-semibold pt-2">Contact Waves</p>
+      <p className="text-sm font-semibold pt-2">Oleadas de contacto</p>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="text-sm font-medium">Wave Mode</label>
+          <label className="text-sm font-medium">Modo de oleada</label>
           <select
             value={formData.waveMode}
             onChange={(e) => setFormData({ ...formData, waveMode: e.target.value as WaveMode })}
             className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
           >
-            <option value="manual_selection">Manual Selection</option>
-            <option value="controlled_waves">Controlled Waves</option>
-            <option value="blast_all_eligible">Blast All Eligible</option>
+            <option value="manual_selection">Selección manual</option>
+            <option value="controlled_waves">Oleadas controladas</option>
+            <option value="blast_all_eligible">Contactar todos los elegibles</option>
           </select>
         </div>
         <div>
-          <label className="text-sm font-medium">Wave Size</label>
+          <label className="text-sm font-medium">Tamaño de oleada</label>
           <input
             type="number"
             min="0"
@@ -715,10 +715,10 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
             onChange={(e) => setFormData({ ...formData, waveBuffer: parseInt(e.target.value) })}
             className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
           />
-          <p className="text-xs text-muted-foreground mt-1">Required count + this buffer</p>
+          <p className="text-xs text-muted-foreground mt-1">Requeridos + este margen</p>
         </div>
         <div>
-          <label className="text-sm font-medium">Wave Wait Window (minutes)</label>
+          <label className="text-sm font-medium">Espera entre oleadas (minutos)</label>
           <input
             type="number"
             min="3"
@@ -729,7 +729,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
           />
         </div>
         <div>
-          <label className="text-sm font-medium">Max Waves</label>
+          <label className="text-sm font-medium">Máximo de oleadas</label>
           <input
             type="number"
             min="1"
@@ -747,11 +747,11 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
           checked={formData.autoSendNextWave}
           onChange={(e) => setFormData({ ...formData, autoSendNextWave: e.target.checked })}
         />
-        <span className="text-sm">Auto-send next wave in Auto mode</span>
+        <span className="text-sm">Enviar siguiente oleada automáticamente en modo Auto</span>
       </label>
 
       <div className="rounded border bg-background p-3 text-xs text-muted-foreground">
-        Auto-close is enabled: close filled roles, stop future waves, block extra acceptances, confirm booked crew, and notify late or pending responders.
+        Cierre automático activo: cierra roles completos, detiene futuras oleadas, bloquea aceptaciones extra, confirma el equipo reservado y avisa a respuestas tardías o pendientes.
       </div>
     </div>
   )

--- a/src/components/matrix/StaffingCampaignPanel.tsx
+++ b/src/components/matrix/StaffingCampaignPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
@@ -7,6 +7,19 @@ import { Badge } from '@/components/ui/badge'
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast'
 import { format } from 'date-fns'
+import {
+  JOB_PROFILE_LABELS,
+  PROFILE_DEFAULTS,
+  PROFILE_OPTIONS,
+  RatePenaltyStrength,
+  SoftConflictPolicy,
+  StaffingChannel,
+  WaveMode,
+  buildCampaignPolicy,
+  buildRoleProfiles,
+  inferJobProfile,
+  JobProfileName,
+} from '@/features/staffing/crewingProfiles'
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -46,6 +59,19 @@ interface CampaignRole {
   last_wave_at?: string
 }
 
+interface JobMeta {
+  id: string
+  title?: string | null
+  job_type?: string | null
+  start_time?: string | null
+  end_time?: string | null
+}
+
+interface RequiredRole {
+  role_code: string
+  quantity: number
+}
+
 export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
   jobId,
   department,
@@ -55,18 +81,31 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
   const { toast } = useToast()
   const queryClient = useQueryClient()
   const [showStartDialog, setShowStartDialog] = useState(false)
+  const [profileDefaultsApplied, setProfileDefaultsApplied] = useState(false)
   const [formData, setFormData] = useState({
     mode: 'assisted' as 'assisted' | 'auto',
     scope: 'outstanding' as 'outstanding' | 'all',
     proximityWeight: 0.1,
     historyWeight: 0.2, // Will be mapped to reliability
-    softConflictPolicy: 'block' as 'warn' | 'block' | 'allow',
+    softConflictPolicy: 'block' as SoftConflictPolicy,
     excludeFridge: true,
     availabilityTtl: 24,
     offerTtl: 4,
     offerMessage: '',
     tickInterval: 300,
-    channel: 'email' as 'email' | 'whatsapp'
+    channel: 'email' as StaffingChannel,
+    inferProfileFromJobType: true,
+    selectedJobProfile: 'standard' as JobProfileName,
+    profileOverrideReason: '',
+    roleProfileOverrides: {} as Record<string, JobProfileName>,
+    costScoringEnabled: true,
+    ratePenaltyStrength: 'normal' as RatePenaltyStrength,
+    maxRatePenalty: 10,
+    waveMode: 'controlled_waves' as WaveMode,
+    waveBuffer: 2,
+    waveWaitMinutes: 20,
+    maxWaves: 3,
+    autoSendNextWave: false
   })
 
   // Fetch active campaign for this job+department
@@ -82,24 +121,28 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
     }
   })
 
-  // Initialize formData from active campaign
-  useEffect(() => {
-    if (campaign) {
-      setFormData({
-        mode: campaign.mode,
-        scope: 'outstanding',
-        proximityWeight: campaign.policy?.weights?.proximity ?? 0.1,
-        historyWeight: campaign.policy?.weights?.reliability ?? 0.2,
-        softConflictPolicy: campaign.policy?.soft_conflict_policy ?? 'block',
-        excludeFridge: campaign.policy?.exclude_fridge ?? true,
-        availabilityTtl: campaign.policy?.availability_ttl_hours ?? 24,
-        offerTtl: campaign.policy?.offer_ttl_hours ?? 4,
-        offerMessage: campaign.offer_message ?? '',
-        tickInterval: campaign.policy?.tick_interval_seconds ?? 300,
-        channel: campaign.policy?.channel === 'whatsapp' ? 'whatsapp' : 'email'
-      })
+  const { data: jobMeta } = useQuery({
+    queryKey: queryKeys.scope('staffing_job_meta', jobId),
+    queryFn: async () => {
+      const { data } = await dataLayerClient.from('jobs')
+        .select('id, title, job_type, start_time, end_time')
+        .eq('id', jobId)
+        .maybeSingle()
+      return data as JobMeta | null
     }
-  }, [campaign])
+  })
+
+  const { data: requiredRoles } = useQuery({
+    queryKey: queryKeys.scope('staffing_required_role_rows', jobId, department),
+    queryFn: async () => {
+      const { data } = await dataLayerClient.from('job_required_roles')
+        .select('role_code, quantity')
+        .eq('job_id', jobId)
+        .eq('department', department)
+        .order('role_code')
+      return (data || []) as RequiredRole[]
+    }
+  })
 
   // Fetch campaign roles if campaign exists
   const { data: campaignRoles } = useQuery({
@@ -115,28 +158,212 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
     enabled: !!campaign?.id
   })
 
+  const requiredByRole = useMemo(() => (
+    (requiredRoles || []).reduce<Record<string, number>>((acc, role) => {
+      if (role.role_code) acc[String(role.role_code).trim()] = Number(role.quantity || 0)
+      return acc
+    }, {})
+  ), [requiredRoles])
+
+  const assignedByRole = useMemo(() => (
+    (campaignRoles || []).reduce<Record<string, number>>((acc, role) => {
+      if (role.role_code) acc[String(role.role_code).trim()] = Number(role.assigned_count || 0)
+      return acc
+    }, {})
+  ), [campaignRoles])
+
+  const roleCodes = useMemo(() => {
+    const codes = new Set<string>()
+    ;(requiredRoles || []).forEach((role) => {
+      const code = String(role.role_code || '').trim()
+      if (code) codes.add(code)
+    })
+    ;(campaignRoles || []).forEach((role) => {
+      const code = String(role.role_code || '').trim()
+      if (code) codes.add(code)
+    })
+    return Array.from(codes).sort()
+  }, [campaignRoles, requiredRoles])
+
+  const totalRequired = useMemo(
+    () => Object.values(requiredByRole).reduce((sum, quantity) => sum + quantity, 0),
+    [requiredByRole]
+  )
+
+  const inferredJobProfile = useMemo(() => inferJobProfile({
+    jobType: jobMeta?.job_type,
+    startTime: jobMeta?.start_time,
+    endTime: jobMeta?.end_time,
+    requiredCrewCount: totalRequired
+  }), [jobMeta?.end_time, jobMeta?.job_type, jobMeta?.start_time, totalRequired])
+
+  const roleProfiles = useMemo(() => buildRoleProfiles({
+    roleCodes,
+    requiredByRole,
+    assignedByRole,
+    selectedJobProfile: formData.selectedJobProfile,
+    startTime: jobMeta?.start_time,
+    overrides: formData.roleProfileOverrides
+  }), [
+    assignedByRole,
+    formData.roleProfileOverrides,
+    formData.selectedJobProfile,
+    jobMeta?.start_time,
+    requiredByRole,
+    roleCodes
+  ])
+
+  // Initialize formData from active campaign
+  useEffect(() => {
+    if (campaign) {
+      const selectedProfile = campaign.policy?.profile?.selected_job_profile || 'standard'
+      const selectedDefaults = PROFILE_DEFAULTS[selectedProfile as JobProfileName] || PROFILE_DEFAULTS.standard
+      const savedRoleProfiles = campaign.policy?.role_profiles || {}
+      const roleProfileOverrides = Object.entries(savedRoleProfiles).reduce<Record<string, JobProfileName>>(
+        (acc, [roleCode, profile]: [string, any]) => {
+          const selected = profile?.selected_profile as JobProfileName | undefined
+          const inferred = profile?.inferred_profile as JobProfileName | undefined
+          if (selected && selected !== inferred) acc[roleCode] = selected
+          return acc
+        },
+        {}
+      )
+
+      setFormData({
+        mode: campaign.mode,
+        scope: 'outstanding',
+        proximityWeight: campaign.policy?.weights?.proximity ?? selectedDefaults.weights.proximity,
+        historyWeight: campaign.policy?.weights?.reliability ?? selectedDefaults.weights.reliability,
+        softConflictPolicy: (campaign.policy?.soft_conflict_policy ?? 'block') as SoftConflictPolicy,
+        excludeFridge: campaign.policy?.exclude_fridge ?? true,
+        availabilityTtl: campaign.policy?.availability_ttl_hours ?? 24,
+        offerTtl: campaign.policy?.offer_ttl_hours ?? 4,
+        offerMessage: campaign.offer_message ?? '',
+        tickInterval: campaign.policy?.tick_interval_seconds ?? 300,
+        channel: campaign.policy?.channel === 'whatsapp' ? 'whatsapp' : 'email',
+        inferProfileFromJobType: campaign.policy?.profile?.infer_from_job_type ?? true,
+        selectedJobProfile: selectedProfile as JobProfileName,
+        profileOverrideReason: campaign.policy?.profile?.override_reason ?? '',
+        roleProfileOverrides,
+        costScoringEnabled: campaign.policy?.cost_scoring?.enabled ?? true,
+        ratePenaltyStrength: (campaign.policy?.cost_scoring?.penalty_strength ?? 'normal') as RatePenaltyStrength,
+        maxRatePenalty: campaign.policy?.cost_scoring?.max_rate_penalty ?? 10,
+        waveMode: (campaign.policy?.waves?.mode ?? 'controlled_waves') as WaveMode,
+        waveBuffer: campaign.policy?.waves?.buffer ?? selectedDefaults.waveBuffer,
+        waveWaitMinutes: campaign.policy?.waves?.wait_minutes ?? selectedDefaults.waveWaitMinutes,
+        maxWaves: campaign.policy?.waves?.max_waves ?? selectedDefaults.maxWaves,
+        autoSendNextWave: campaign.policy?.waves?.auto_send_next_wave ?? campaign.mode === 'auto'
+      })
+      setProfileDefaultsApplied(true)
+    }
+  }, [campaign])
+
+  useEffect(() => {
+    if (campaign || profileDefaultsApplied || !jobMeta || requiredRoles === undefined) return
+
+    const defaults = PROFILE_DEFAULTS[inferredJobProfile] || PROFILE_DEFAULTS.standard
+    setFormData((current) => ({
+      ...current,
+      selectedJobProfile: inferredJobProfile,
+      proximityWeight: defaults.weights.proximity,
+      historyWeight: defaults.weights.reliability,
+      availabilityTtl: defaults.availabilityTtlHours,
+      offerTtl: defaults.offerTtlHours,
+      softConflictPolicy: defaults.defaultSoftConflictPolicy,
+      waveBuffer: defaults.waveBuffer,
+      waveWaitMinutes: defaults.waveWaitMinutes,
+      maxWaves: defaults.maxWaves,
+      autoSendNextWave: current.mode === 'auto'
+    }))
+    setProfileDefaultsApplied(true)
+  }, [campaign, inferredJobProfile, jobMeta, profileDefaultsApplied, requiredRoles])
+
+  const selectedProfileDefaults = PROFILE_DEFAULTS[formData.selectedJobProfile] || PROFILE_DEFAULTS.standard
+  const profileOverrideActive = formData.selectedJobProfile !== inferredJobProfile
+
+  const applyProfileDefaults = (profile: JobProfileName) => {
+    const defaults = PROFILE_DEFAULTS[profile] || PROFILE_DEFAULTS.standard
+    setFormData((current) => ({
+      ...current,
+      selectedJobProfile: profile,
+      proximityWeight: defaults.weights.proximity,
+      historyWeight: defaults.weights.reliability,
+      availabilityTtl: defaults.availabilityTtlHours,
+      offerTtl: defaults.offerTtlHours,
+      softConflictPolicy: defaults.defaultSoftConflictPolicy,
+      waveBuffer: defaults.waveBuffer,
+      waveWaitMinutes: defaults.waveWaitMinutes,
+      maxWaves: defaults.maxWaves,
+      autoSendNextWave: current.mode === 'auto'
+    }))
+  }
+
+  const updateMode = (mode: 'assisted' | 'auto') => {
+    setFormData((current) => ({
+      ...current,
+      mode,
+      autoSendNextWave: mode === 'auto',
+      softConflictPolicy: mode === 'auto' && current.softConflictPolicy === 'warn'
+        ? 'block'
+        : current.softConflictPolicy
+    }))
+  }
+
+  const updateRoleProfileOverride = (roleCode: string, profile: JobProfileName) => {
+    setFormData((current) => {
+      const inferred = roleProfiles[roleCode]?.inferred_profile
+      const next = { ...current.roleProfileOverrides }
+
+      if (!inferred || profile === inferred) {
+        delete next[roleCode]
+      } else {
+        next[roleCode] = profile
+      }
+
+      return { ...current, roleProfileOverrides: next }
+    })
+  }
+
+  const buildPolicyPayload = () => buildCampaignPolicy({
+    mode: formData.mode,
+    jobType: jobMeta?.job_type,
+    jobStartTime: jobMeta?.start_time,
+    jobEndTime: jobMeta?.end_time,
+    requiredCrewCount: totalRequired,
+    selectedJobProfile: formData.selectedJobProfile,
+    inferredJobProfile,
+    inferProfileFromJobType: formData.inferProfileFromJobType,
+    profileOverrideReason: formData.profileOverrideReason,
+    roleProfiles,
+    roleProfileOverrides: formData.roleProfileOverrides,
+    availabilityTtlHours: formData.availabilityTtl,
+    offerTtlHours: formData.offerTtl,
+    softConflictPolicy: formData.softConflictPolicy,
+    excludeFridge: formData.excludeFridge,
+    sendChannel: formData.channel,
+    costScoring: {
+      enabled: formData.costScoringEnabled,
+      penaltyStrength: formData.ratePenaltyStrength,
+      maxRatePenalty: formData.maxRatePenalty
+    },
+    waves: {
+      mode: formData.waveMode,
+      buffer: formData.waveBuffer,
+      waitMinutes: formData.waveWaitMinutes,
+      maxWaves: formData.maxWaves,
+      autoSendNextWave: formData.autoSendNextWave
+    },
+    tickIntervalSeconds: formData.tickInterval,
+    weightOverrides: {
+      proximity: formData.proximityWeight,
+      reliability: formData.historyWeight
+    }
+  })
+
   // Start campaign mutation
   const startMutation = useMutation({
     mutationFn: async () => {
-      const policy = {
-        weights: {
-          skills: 0.5,
-          proximity: formData.proximityWeight,
-          reliability: formData.historyWeight,
-          fairness: 0.1,
-          experience: 0.1
-        },
-        availability_ttl_hours: formData.availabilityTtl,
-        offer_ttl_hours: formData.offerTtl,
-        availability_multiplier: 4,
-        offer_buffer: 1,
-        exclude_fridge: formData.excludeFridge,
-        soft_conflict_policy: formData.softConflictPolicy,
-        tick_interval_seconds: formData.tickInterval,
-        channel: formData.channel,
-        assisted_handoff_priority: true,
-        escalation_steps: ['increase_wave', 'include_fridge', 'allow_soft_conflicts']
-      }
+      const policy = buildPolicyPayload()
 
       const response = await fetch(
         `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/staffing-orchestrator?action=start`,
@@ -184,25 +411,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
   // Update campaign settings mutation
   const updateMutation = useMutation({
     mutationFn: async () => {
-      const policy = {
-        weights: {
-          skills: 0.5,
-          proximity: formData.proximityWeight,
-          reliability: formData.historyWeight,
-          fairness: 0.1,
-          experience: 0.1
-        },
-        availability_ttl_hours: formData.availabilityTtl,
-        offer_ttl_hours: formData.offerTtl,
-        availability_multiplier: 4,
-        offer_buffer: 1,
-        exclude_fridge: formData.excludeFridge,
-        soft_conflict_policy: formData.softConflictPolicy,
-        tick_interval_seconds: formData.tickInterval,
-        channel: formData.channel,
-        assisted_handoff_priority: true,
-        escalation_steps: ['increase_wave', 'include_fridge', 'allow_soft_conflicts']
-      }
+      const policy = buildPolicyPayload()
 
       const nextRunUpdate = formData.mode === 'auto' && campaign?.mode === 'assisted'
         ? { next_run_at: new Date().toISOString() }
@@ -335,6 +544,218 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
     }
   }
 
+  const renderCrewingProfileSettings = () => (
+    <div className="space-y-4 rounded border bg-muted/30 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="text-sm font-semibold">Auto Profile</p>
+          <p className="text-xs text-muted-foreground">
+            Job type {jobMeta?.job_type || 'single'} suggests {JOB_PROFILE_LABELS[inferredJobProfile]}.
+          </p>
+        </div>
+        {profileOverrideActive && (
+          <Badge variant="outline">Manual profile override active</Badge>
+        )}
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={formData.inferProfileFromJobType}
+          onChange={(e) => setFormData({ ...formData, inferProfileFromJobType: e.target.checked })}
+        />
+        <span className="text-sm">Infer profile from job type and role</span>
+      </label>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="text-sm font-medium">Suggested Job Profile</label>
+          <div className="mt-1 rounded border bg-background px-2 py-1 text-sm">
+            {JOB_PROFILE_LABELS[inferredJobProfile]}
+          </div>
+        </div>
+        <div>
+          <label className="text-sm font-medium">Selected Job Profile</label>
+          <select
+            value={formData.selectedJobProfile}
+            onChange={(e) => applyProfileDefaults(e.target.value as JobProfileName)}
+            className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+          >
+            {PROFILE_OPTIONS.map((profile) => (
+              <option key={profile} value={profile}>{JOB_PROFILE_LABELS[profile]}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {profileOverrideActive && (
+        <div>
+          <label className="text-sm font-medium">Override reason</label>
+          <input
+            value={formData.profileOverrideReason}
+            onChange={(e) => setFormData({ ...formData, profileOverrideReason: e.target.value })}
+            placeholder="Why this campaign should use a different profile"
+            className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+          />
+        </div>
+      )}
+
+      {roleCodes.length > 0 && (
+        <div>
+          <p className="text-sm font-medium">Role-Level Profiles</p>
+          <div className="mt-2 space-y-2">
+            {roleCodes.map((roleCode) => {
+              const roleProfile = roleProfiles[roleCode]
+              if (!roleProfile) return null
+
+              return (
+                <div key={roleCode} className="grid grid-cols-1 md:grid-cols-[1fr_220px] gap-2 items-center rounded border bg-background p-2">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium">{roleCode}</span>
+                      <Badge variant="outline">Required {roleProfile.required_count}</Badge>
+                      {roleProfile.is_critical && <Badge variant="secondary">Critical</Badge>}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Suggested: {JOB_PROFILE_LABELS[roleProfile.inferred_profile]}
+                    </p>
+                  </div>
+                  <select
+                    value={roleProfile.selected_profile}
+                    onChange={(e) => updateRoleProfileOverride(roleCode, e.target.value as JobProfileName)}
+                    className="w-full px-2 py-1 border rounded text-sm bg-background"
+                  >
+                    {PROFILE_OPTIONS.map((profile) => (
+                      <option key={profile} value={profile}>{JOB_PROFILE_LABELS[profile]}</option>
+                    ))}
+                  </select>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="rounded border bg-background p-3">
+        <p className="text-sm font-medium">Profile Weights</p>
+        <div className="mt-2 grid grid-cols-2 md:grid-cols-4 gap-2 text-xs text-muted-foreground">
+          <span>Role skill: {selectedProfileDefaults.weights.roleSkill.toFixed(2)}</span>
+          <span>Reliability: {formData.historyWeight.toFixed(2)}</span>
+          <span>Fairness: {selectedProfileDefaults.weights.fairness.toFixed(2)}</span>
+          <span>Proximity: {formData.proximityWeight.toFixed(2)}</span>
+          <span>Cost: {selectedProfileDefaults.weights.costEfficiency.toFixed(2)}</span>
+          <span>House tech: {selectedProfileDefaults.weights.houseTechBonus.toFixed(2)}</span>
+          <span>Progression: {selectedProfileDefaults.weights.roleProgression.toFixed(2)}</span>
+          <span>Availability: {selectedProfileDefaults.weights.availabilityConfidence.toFixed(2)}</span>
+        </div>
+      </div>
+    </div>
+  )
+
+  const renderCostAndWaveSettings = () => (
+    <div className="space-y-4 rounded border bg-muted/30 p-3">
+      <p className="text-sm font-semibold">Cost / Rate Scoring</p>
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={formData.costScoringEnabled}
+          onChange={(e) => setFormData({ ...formData, costScoringEnabled: e.target.checked })}
+        />
+        <span className="text-sm">Apply custom rate adjustment</span>
+      </label>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="text-sm font-medium">Rate penalty strength</label>
+          <select
+            value={formData.ratePenaltyStrength}
+            onChange={(e) => setFormData({ ...formData, ratePenaltyStrength: e.target.value as RatePenaltyStrength })}
+            className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+          >
+            <option value="disabled">Disabled</option>
+            <option value="low">Low</option>
+            <option value="normal">Normal</option>
+            <option value="high">High</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-sm font-medium">Maximum rate penalty</label>
+          <input
+            type="number"
+            min="0"
+            max="20"
+            value={formData.maxRatePenalty}
+            onChange={(e) => setFormData({ ...formData, maxRatePenalty: parseFloat(e.target.value) })}
+            className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+          />
+        </div>
+      </div>
+
+      <p className="text-sm font-semibold pt-2">Contact Waves</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="text-sm font-medium">Wave Mode</label>
+          <select
+            value={formData.waveMode}
+            onChange={(e) => setFormData({ ...formData, waveMode: e.target.value as WaveMode })}
+            className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+          >
+            <option value="manual_selection">Manual Selection</option>
+            <option value="controlled_waves">Controlled Waves</option>
+            <option value="blast_all_eligible">Blast All Eligible</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-sm font-medium">Wave Size</label>
+          <input
+            type="number"
+            min="0"
+            max="20"
+            value={formData.waveBuffer}
+            onChange={(e) => setFormData({ ...formData, waveBuffer: parseInt(e.target.value) })}
+            className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+          />
+          <p className="text-xs text-muted-foreground mt-1">Required count + this buffer</p>
+        </div>
+        <div>
+          <label className="text-sm font-medium">Wave Wait Window (minutes)</label>
+          <input
+            type="number"
+            min="3"
+            max="120"
+            value={formData.waveWaitMinutes}
+            onChange={(e) => setFormData({ ...formData, waveWaitMinutes: parseInt(e.target.value) })}
+            className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+          />
+        </div>
+        <div>
+          <label className="text-sm font-medium">Max Waves</label>
+          <input
+            type="number"
+            min="1"
+            max="10"
+            value={formData.maxWaves}
+            onChange={(e) => setFormData({ ...formData, maxWaves: parseInt(e.target.value) })}
+            className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
+          />
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={formData.autoSendNextWave}
+          onChange={(e) => setFormData({ ...formData, autoSendNextWave: e.target.checked })}
+        />
+        <span className="text-sm">Auto-send next wave in Auto mode</span>
+      </label>
+
+      <div className="rounded border bg-background p-3 text-xs text-muted-foreground">
+        Auto-close is enabled: close filled roles, stop future waves, block extra acceptances, confirm booked crew, and notify late or pending responders.
+      </div>
+    </div>
+  )
+
   if (!campaign) {
     return (
       <Card>
@@ -349,7 +770,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
           <Button onClick={() => setShowStartDialog(true)}>Start Campaign</Button>
 
           <Dialog open={showStartDialog} onOpenChange={setShowStartDialog}>
-            <DialogContent className="max-w-2xl">
+            <DialogContent className="max-w-4xl max-h-[85vh] overflow-y-auto">
               <DialogHeader>
                 <DialogTitle>Start Staffing Campaign</DialogTitle>
                 <DialogDescription>
@@ -368,7 +789,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                         name="mode"
                         value="assisted"
                         checked={formData.mode === 'assisted'}
-                        onChange={() => setFormData({ ...formData, mode: 'assisted' })}
+                        onChange={() => updateMode('assisted')}
                       />
                       <span className="text-sm">Assisted (Manager-controlled)</span>
                     </label>
@@ -378,7 +799,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                         name="mode"
                         value="auto"
                         checked={formData.mode === 'auto'}
-                        onChange={() => setFormData({ ...formData, mode: 'auto' })}
+                        onChange={() => updateMode('auto')}
                       />
                       <span className="text-sm">Auto (System-driven)</span>
                     </label>
@@ -411,6 +832,8 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                     </label>
                   </div>
                 </div>
+
+                {renderCrewingProfileSettings()}
 
                 {/* Weights */}
                 <div className="grid grid-cols-2 gap-4">
@@ -466,6 +889,8 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                   </div>
                 </div>
 
+                {renderCostAndWaveSettings()}
+
                 {/* Conflict policy */}
                 <div>
                   <label className="text-sm font-medium">Soft Conflict Policy</label>
@@ -476,7 +901,9 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                   >
                     <option value="block">Block (Auto mode default)</option>
                     <option value="warn">Warn (Assisted mode)</option>
-                    <option value="allow">Allow (Escalation only)</option>
+                    <option value="manager_approval">Manager approval</option>
+                    <option value="ignore">Ignore</option>
+                    <option value="allow">Allow (legacy escalation)</option>
                   </select>
                 </div>
 
@@ -484,7 +911,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                   <label className="text-sm font-medium">Send Channel</label>
                   <select
                     value={formData.channel}
-                    onChange={(e) => setFormData({ ...formData, channel: e.target.value as 'email' | 'whatsapp' })}
+                    onChange={(e) => setFormData({ ...formData, channel: e.target.value as StaffingChannel })}
                     className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
                   >
                     <option value="email">Email</option>
@@ -622,7 +1049,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                     name="active_mode"
                     value="assisted"
                     checked={formData.mode === 'assisted'}
-                    onChange={() => setFormData({ ...formData, mode: 'assisted' })}
+                    onChange={() => updateMode('assisted')}
                   />
                   <span className="text-sm">Assisted (Manager-controlled)</span>
                 </label>
@@ -632,12 +1059,14 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                     name="active_mode"
                     value="auto"
                     checked={formData.mode === 'auto'}
-                    onChange={() => setFormData({ ...formData, mode: 'auto' })}
+                    onChange={() => updateMode('auto')}
                   />
                   <span className="text-sm">Auto (System-driven)</span>
                 </label>
               </div>
             </div>
+
+            {renderCrewingProfileSettings()}
 
             {/* Weights */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -693,6 +1122,8 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
               </div>
             </div>
 
+            {renderCostAndWaveSettings()}
+
             {/* Conflict policy */}
             <div>
               <label className="text-sm font-medium">Soft Conflict Policy</label>
@@ -703,7 +1134,9 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
               >
                 <option value="block">Block (Auto mode default)</option>
                 <option value="warn">Warn (Assisted mode)</option>
-                <option value="allow">Allow (Escalation only)</option>
+                <option value="manager_approval">Manager approval</option>
+                <option value="ignore">Ignore</option>
+                <option value="allow">Allow (legacy escalation)</option>
               </select>
             </div>
 
@@ -711,7 +1144,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
               <label className="text-sm font-medium">Send Channel</label>
               <select
                 value={formData.channel}
-                onChange={(e) => setFormData({ ...formData, channel: e.target.value as 'email' | 'whatsapp' })}
+                onChange={(e) => setFormData({ ...formData, channel: e.target.value as StaffingChannel })}
                 className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
               >
                 <option value="email">Email</option>

--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -56,24 +56,24 @@ interface RolelessConsultation {
 }
 
 const ROLELESS_PHASE_LABELS: Record<string, string> = {
-  availability: 'availability',
-  offer: 'offer'
+  availability: 'disponibilidad',
+  offer: 'oferta'
 }
 
 const ROLELESS_STATUS_LABELS: Record<string, string> = {
-  pending: 'pending',
-  confirmed: 'confirmed',
-  declined: 'declined'
+  pending: 'pendiente',
+  confirmed: 'confirmada',
+  declined: 'rechazada'
 }
 
 const getRolelessConsultationLabel = (consultation: RolelessConsultation) => {
   const phase = ROLELESS_PHASE_LABELS[consultation.phase] ?? consultation.phase
   const status = ROLELESS_STATUS_LABELS[consultation.status] ?? consultation.status
   const scope = consultation.single_day && consultation.target_date
-    ? ` for ${consultation.target_date}`
+    ? ` para ${consultation.target_date}`
     : ''
 
-  return `Prior manager ${phase} request without role is ${status}${scope}`
+  return `Solicitud previa de ${phase} sin rol: ${status}${scope}`
 }
 
 export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
@@ -280,11 +280,11 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
 
   const roleSummary = (
     <div className="flex flex-wrap gap-2 pt-2">
-      <Badge variant="outline">Required {requiredCount}</Badge>
-      <Badge variant="secondary">{assignedCount}/{requiredCount || '—'} assigned</Badge>
-      <Badge variant="outline">{confirmedAvailability} available</Badge>
+      <Badge variant="outline">Requeridos {requiredCount}</Badge>
+      <Badge variant="secondary">{assignedCount}/{requiredCount || '—'} asignados</Badge>
+      <Badge variant="outline">{confirmedAvailability} disponibles</Badge>
       {pendingAvailability > 0 && (
-        <Badge variant="outline">{pendingAvailability} pending</Badge>
+        <Badge variant="outline">{pendingAvailability} pendientes</Badge>
       )}
     </div>
   )
@@ -298,10 +298,10 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
   const waveMode = String(policy?.waves?.mode || 'manual_selection')
   const maxWaves = Number(policy?.waves?.max_waves || 3)
   const waveLabelForIndex = (index: number) => {
-    if (waveMode === 'blast_all_eligible') return 'All eligible'
-    if (waveMode === 'manual_selection') return 'Manual wave'
+    if (waveMode === 'blast_all_eligible') return 'Todos elegibles'
+    if (waveMode === 'manual_selection') return 'Oleada manual'
     const wave = recommendedWaveNumber(index, requiredCount, waveBuffer)
-    return wave > maxWaves ? `After Wave ${maxWaves}` : `Wave ${wave}`
+    return wave > maxWaves ? `Tras oleada ${maxWaves}` : `Oleada ${wave}`
   }
 
   if (isLoading) {
@@ -309,7 +309,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
       <Card>
         <CardContent className="pt-6">
           {roleSummary}
-          <p className="text-muted-foreground">Loading candidates...</p>
+          <p className="text-muted-foreground">Cargando candidatos...</p>
         </CardContent>
       </Card>
     )
@@ -320,7 +320,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
       <Card>
         <CardContent className="pt-6">
           {roleSummary}
-          <p className="text-muted-foreground">No candidates available for {roleCode}</p>
+          <p className="text-muted-foreground">No hay candidatos disponibles para {roleCode}</p>
         </CardContent>
       </Card>
     )
@@ -329,9 +329,9 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{roleCode} - Candidate Recommendations</CardTitle>
+        <CardTitle>{roleCode} - Recomendaciones de candidatos</CardTitle>
         <CardDescription>
-          Top {candidates.length} candidatos clasificados por habilidades, experiencia en el rol, proximidad y confiabilidad
+          Los {candidates.length} candidatos mejor clasificados por habilidades, experiencia en el rol, proximidad y confiabilidad
         </CardDescription>
         {roleSummary}
       </CardHeader>
@@ -340,10 +340,10 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
         <div className="flex flex-wrap items-center justify-between gap-3 rounded border bg-background p-3">
           <div className="flex items-center gap-2 text-sm font-medium">
             {channel === 'whatsapp' ? <MessageCircle size={16} /> : <Mail size={16} />}
-            Send availability by
+            Enviar disponibilidad por
           </div>
           <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
-            <SelectTrigger aria-label="Select availability channel" className="w-[160px]">
+            <SelectTrigger aria-label="Seleccionar canal de disponibilidad" className="w-[160px]">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -356,12 +356,12 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
         {/* Select all checkbox */}
         <div className="flex items-center gap-2 p-2 bg-muted rounded">
           <Checkbox
-            aria-label="Select all candidates"
+            aria-label="Seleccionar todos los candidatos"
             checked={selectedCandidates.size === candidates.length && candidates.length > 0}
             onCheckedChange={toggleSelectAll}
           />
           <span className="text-sm font-medium">
-            Select all ({selectedCandidates.size} selected)
+            Seleccionar todos ({selectedCandidates.size} seleccionados)
           </span>
         </div>
 
@@ -379,7 +379,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                 className="flex items-start gap-3 p-3 border rounded hover:bg-muted"
               >
                 <Checkbox
-                  aria-label={`Select ${candidate.full_name}`}
+                  aria-label={`Seleccionar ${candidate.full_name}`}
                   checked={selectedCandidates.has(candidate.profile_id)}
                   onCheckedChange={() => toggleCandidate(candidate.profile_id)}
                   className="mt-1"
@@ -398,15 +398,15 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                 <div className="flex-1 min-w-0">
                   <div className="flex flex-wrap items-center gap-2 mb-1">
                     <p className="font-medium text-sm">{candidate.full_name}</p>
-                    <Badge variant="outline">Rank #{index + 1}</Badge>
-                    <Badge variant="secondary">Profile: {JOB_PROFILE_LABELS[roleProfileName] || roleProfileName}</Badge>
+                    <Badge variant="outline">Puesto #{index + 1}</Badge>
+                    <Badge variant="secondary">Perfil: {JOB_PROFILE_LABELS[roleProfileName] || roleProfileName}</Badge>
                     <Badge variant="outline">{waveLabel}</Badge>
-                    <Badge variant="outline">Status: Not contacted</Badge>
+                    <Badge variant="outline">Estado: No contactado</Badge>
                     {candidate.final_score >= 80 && (
-                      <Badge className="bg-green-100 text-green-800">⭐ Top</Badge>
+                      <Badge className="bg-green-100 text-green-800">⭐ Destacado</Badge>
                     )}
                     {candidate.soft_conflict && (
-                      <Badge className="bg-yellow-100 text-yellow-800">⚠ Soft Conflict</Badge>
+                      <Badge className="bg-yellow-100 text-yellow-800">⚠ Conflicto blando</Badge>
                     )}
                     {rolelessConsultation && (
                       <Badge
@@ -414,16 +414,16 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                         className="text-[10px]"
                         title={getRolelessConsultationLabel(rolelessConsultation)}
                       >
-                        No-role request
+                        Solicitud sin rol
                       </Badge>
                     )}
                   </div>
 
                   <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground mb-2">
-                    <div>Skills: <span className="font-semibold">{candidate.skills_score}</span>pts</div>
-                    <div>Reliability: <span className="font-semibold">{candidate.reliability_score}</span>pts</div>
+                    <div>Habilidades: <span className="font-semibold">{candidate.skills_score}</span>pts</div>
+                    <div>Fiabilidad: <span className="font-semibold">{candidate.reliability_score}</span>pts</div>
                     <div>
-                      Proximity:{' '}
+                      Proximidad:{' '}
                       <span className="font-semibold">
                         {typeof candidate.distance_to_madrid_km === 'number'
                           ? candidate.distance_to_madrid_km.toFixed(1)
@@ -431,12 +431,12 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                       </span>
                       km
                     </div>
-                    <div>Fairness: <span className="font-semibold">{candidate.fairness_score}</span>pts</div>
-                    <div>Experience: <span className="font-semibold">{candidate.experience_score}</span>pts</div>
+                    <div>Equidad: <span className="font-semibold">{candidate.fairness_score}</span>pts</div>
+                    <div>Experiencia: <span className="font-semibold">{candidate.experience_score}</span>pts</div>
                     <div>
-                      Rate:{' '}
+                      Tarifa:{' '}
                       <span className="font-semibold">
-                        {rateReason ? rateReason.replace(/^Rate adjustment:\s*/i, '') : 'standard'}
+                        {rateReason ? rateReason.replace(/^Rate adjustment:\s*/i, '') : 'estándar'}
                       </span>
                     </div>
                   </div>
@@ -465,20 +465,20 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                       className="text-xs text-blue-600 hover:text-blue-800 mt-1 flex items-center gap-1"
                     >
                       <Info size={14} />
-                      {expandedReasons === candidate.profile_id ? 'Hide' : 'Show'} reasons
+                      {expandedReasons === candidate.profile_id ? 'Ocultar' : 'Ver'} motivos
                     </button>
                   )}
 
                   {expandedReasons === candidate.profile_id && (
                     <div className="mt-2 p-2 bg-blue-500/10 rounded text-xs space-y-1">
-                      <p className="font-semibold text-foreground">Score Breakdown</p>
+                      <p className="font-semibold text-foreground">Desglose de puntuación</p>
                       {reasons.map((reason, idx) => (
                         <div key={idx} className="text-muted-foreground">• {reason}</div>
                       ))}
-                      <p className="pt-2 font-semibold text-foreground">Plain Explanation</p>
+                      <p className="pt-2 font-semibold text-foreground">Explicación</p>
                       <p className="text-muted-foreground">
-                        Ranked with the {JOB_PROFILE_LABELS[roleProfileName] || roleProfileName} profile using role skill,
-                        reliability, fairness, proximity, completed role history, availability signals, and configured cost rules.
+                        Clasificado con el perfil {JOB_PROFILE_LABELS[roleProfileName] || roleProfileName} usando habilidad de rol,
+                        fiabilidad, equidad, proximidad, historial completado, señales de disponibilidad y reglas de coste configuradas.
                       </p>
                     </div>
                   )}
@@ -495,8 +495,8 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
             disabled={selectedCandidates.size === 0 || sendAvailabilityMutation.isPending}
           >
             {sendAvailabilityMutation.isPending
-              ? 'Sending...'
-              : `Send Availability (${selectedCandidates.size}) by ${channel === 'whatsapp' ? 'WhatsApp' : 'Email'}`}
+              ? 'Enviando...'
+              : `Enviar disponibilidad (${selectedCandidates.size}) por ${channel === 'whatsapp' ? 'WhatsApp' : 'Email'}`}
           </Button>
         </div>
       </CardContent>

--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -9,6 +9,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast'
 import { Info, Mail, MessageCircle } from 'lucide-react'
+import {
+  JOB_PROFILE_LABELS,
+  JobProfileName,
+  recommendedWaveNumber,
+} from '@/features/staffing/crewingProfiles'
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -87,6 +92,10 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
   const [selectedCandidates, setSelectedCandidates] = useState<Set<string>>(new Set())
   const [expandedReasons, setExpandedReasons] = useState<string | null>(null)
   const [channel, setChannel] = useState<StaffingChannel>('email')
+
+  useEffect(() => {
+    setChannel(policy?.channel === 'whatsapp' ? 'whatsapp' : 'email')
+  }, [policy?.channel])
 
   // Fetch ranked candidates
   const { data: candidates, isLoading } = useQuery({
@@ -280,6 +289,21 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
     </div>
   )
 
+  const roleProfileName = (
+    policy?.role_profiles?.[roleCode]?.selected_profile ||
+    policy?.profile?.selected_job_profile ||
+    'standard'
+  ) as JobProfileName
+  const waveBuffer = Number(policy?.waves?.buffer ?? policy?.offer_buffer ?? 1)
+  const waveMode = String(policy?.waves?.mode || 'manual_selection')
+  const maxWaves = Number(policy?.waves?.max_waves || 3)
+  const waveLabelForIndex = (index: number) => {
+    if (waveMode === 'blast_all_eligible') return 'All eligible'
+    if (waveMode === 'manual_selection') return 'Manual wave'
+    const wave = recommendedWaveNumber(index, requiredCount, waveBuffer)
+    return wave > maxWaves ? `After Wave ${maxWaves}` : `Wave ${wave}`
+  }
+
   if (isLoading) {
     return (
       <Card>
@@ -343,8 +367,11 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
 
         {/* Candidate list */}
         <div className="space-y-2 max-h-96 overflow-y-auto">
-          {candidates.map((candidate) => {
+          {candidates.map((candidate, index) => {
             const rolelessConsultation = rolelessConsultations[candidate.profile_id]
+            const reasons = Array.isArray(candidate.reasons) ? candidate.reasons.map(String) : []
+            const rateReason = reasons.find((reason) => /rate adjustment|custom rate|candidate rate|standard role rate/i.test(reason))
+            const waveLabel = waveLabelForIndex(index)
 
             return (
               <div
@@ -371,6 +398,10 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                 <div className="flex-1 min-w-0">
                   <div className="flex flex-wrap items-center gap-2 mb-1">
                     <p className="font-medium text-sm">{candidate.full_name}</p>
+                    <Badge variant="outline">Rank #{index + 1}</Badge>
+                    <Badge variant="secondary">Profile: {JOB_PROFILE_LABELS[roleProfileName] || roleProfileName}</Badge>
+                    <Badge variant="outline">{waveLabel}</Badge>
+                    <Badge variant="outline">Status: Not contacted</Badge>
                     {candidate.final_score >= 80 && (
                       <Badge className="bg-green-100 text-green-800">⭐ Top</Badge>
                     )}
@@ -401,6 +432,13 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                       km
                     </div>
                     <div>Fairness: <span className="font-semibold">{candidate.fairness_score}</span>pts</div>
+                    <div>Experience: <span className="font-semibold">{candidate.experience_score}</span>pts</div>
+                    <div>
+                      Rate:{' '}
+                      <span className="font-semibold">
+                        {rateReason ? rateReason.replace(/^Rate adjustment:\s*/i, '') : 'standard'}
+                      </span>
+                    </div>
                   </div>
 
                   <div className="flex items-center gap-1">
@@ -419,7 +457,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                     </p>
                   )}
 
-                  {(Array.isArray(candidate.reasons) ? candidate.reasons : []).length > 0 && (
+                  {reasons.length > 0 && (
                     <button
                       onClick={() => setExpandedReasons(
                         expandedReasons === candidate.profile_id ? null : candidate.profile_id
@@ -433,9 +471,15 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
 
                   {expandedReasons === candidate.profile_id && (
                     <div className="mt-2 p-2 bg-blue-500/10 rounded text-xs space-y-1">
-                      {(Array.isArray(candidate.reasons) ? candidate.reasons : []).map((reason, idx) => (
+                      <p className="font-semibold text-foreground">Score Breakdown</p>
+                      {reasons.map((reason, idx) => (
                         <div key={idx} className="text-muted-foreground">• {reason}</div>
                       ))}
+                      <p className="pt-2 font-semibold text-foreground">Plain Explanation</p>
+                      <p className="text-muted-foreground">
+                        Ranked with the {JOB_PROFILE_LABELS[roleProfileName] || roleProfileName} profile using role skill,
+                        reliability, fairness, proximity, completed role history, availability signals, and configured cost rules.
+                      </p>
                     </div>
                   )}
                 </div>

--- a/src/features/staffing/__tests__/crewingProfiles.test.ts
+++ b/src/features/staffing/__tests__/crewingProfiles.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCampaignPolicy,
+  buildRoleProfiles,
+  inferJobProfile,
+  inferRoleProfile,
+  recommendedWaveNumber,
+} from '../crewingProfiles';
+
+describe('crewing profile inference', () => {
+  it('maps stored job types to operational default profiles', () => {
+    expect(inferJobProfile({ jobType: 'single' })).toBe('standard');
+    expect(inferJobProfile({ jobType: 'evento' })).toBe('standard');
+    expect(inferJobProfile({ jobType: 'festival' })).toBe('high_risk_critical');
+    expect(inferJobProfile({ jobType: 'ciclo' })).toBe('multi_day_tour');
+    expect(inferJobProfile({ jobType: 'tourdate' })).toBe('multi_day_tour');
+  });
+
+  it('escalates near-start unfilled roles to emergency fill', () => {
+    const now = new Date('2026-05-20T08:00:00Z');
+    const startTime = '2026-05-20T12:00:00Z';
+
+    expect(inferJobProfile({ jobType: 'single', startTime, now })).toBe('emergency_fill');
+    expect(
+      inferRoleProfile({
+        jobProfile: 'standard',
+        roleCode: 'SND-FOH-R',
+        requiredCount: 2,
+        assignedCount: 1,
+        startsWithinHours: 18,
+      }),
+    ).toBe('emergency_fill');
+  });
+
+  it('lets role criticality override a broad job profile', () => {
+    expect(
+      inferRoleProfile({
+        jobProfile: 'standard',
+        roleCode: 'SND-PA-T',
+        requiredCount: 1,
+        assignedCount: 0,
+      }),
+    ).toBe('high_risk_critical');
+
+    expect(
+      inferRoleProfile({
+        jobProfile: 'standard',
+        roleCode: 'Runner',
+        requiredCount: 1,
+        assignedCount: 0,
+      }),
+    ).toBe('training_friendly');
+  });
+
+  it('builds a backward-compatible campaign policy with profile, wave, and cost metadata', () => {
+    const roleProfiles = buildRoleProfiles({
+      roleCodes: ['SND-PA-T', 'Runner'],
+      requiredByRole: { 'SND-PA-T': 2, Runner: 1 },
+      selectedJobProfile: 'high_risk_critical',
+    });
+
+    const policy = buildCampaignPolicy({
+      mode: 'assisted',
+      jobType: 'festival',
+      selectedJobProfile: 'high_risk_critical',
+      inferProfileFromJobType: true,
+      roleProfiles,
+      roleProfileOverrides: { Runner: 'training_friendly' },
+      availabilityTtlHours: 24,
+      offerTtlHours: 2,
+      softConflictPolicy: 'block',
+      excludeFridge: true,
+      sendChannel: 'whatsapp',
+      costScoring: {
+        enabled: true,
+        penaltyStrength: 'normal',
+        maxRatePenalty: 10,
+      },
+      waves: {
+        mode: 'controlled_waves',
+        buffer: 1,
+        waitMinutes: 15,
+        maxWaves: 3,
+        autoSendNextWave: false,
+      },
+      tickIntervalSeconds: 300,
+    });
+
+    expect(policy.profile.selected_job_profile).toBe('high_risk_critical');
+    expect(policy.role_profiles.Runner.selected_profile).toBe('training_friendly');
+    expect(policy.weights.skills).toBe(0.4);
+    expect(policy.weights.cost_efficiency).toBe(0.03);
+    expect(policy.cost_scoring.enabled).toBe(true);
+    expect(policy.waves).toMatchObject({
+      mode: 'controlled_waves',
+      buffer: 1,
+      wait_minutes: 15,
+      max_waves: 3,
+    });
+    expect(policy.channel).toBe('whatsapp');
+  });
+
+  it('groups ranked candidates into recommended waves from required count plus buffer', () => {
+    expect(recommendedWaveNumber(0, 2, 1)).toBe(1);
+    expect(recommendedWaveNumber(2, 2, 1)).toBe(1);
+    expect(recommendedWaveNumber(3, 2, 1)).toBe(2);
+  });
+});
+

--- a/src/features/staffing/crewingProfiles.ts
+++ b/src/features/staffing/crewingProfiles.ts
@@ -82,19 +82,19 @@ export type BuildCampaignPolicyInput = {
 };
 
 export const JOB_PROFILE_LABELS: Record<JobProfileName, string> = {
-  standard: 'Standard',
-  high_risk_critical: 'High-Risk / Critical',
-  training_friendly: 'Training-Friendly',
-  emergency_fill: 'Emergency Fill',
-  local_low_complexity: 'Local Low-Complexity',
-  multi_day_tour: 'Multi-Day / Tour',
-  custom: 'Custom',
+  standard: 'Estándar',
+  high_risk_critical: 'Alto riesgo / Crítico',
+  training_friendly: 'Apto para formación',
+  emergency_fill: 'Cobertura urgente',
+  local_low_complexity: 'Local baja complejidad',
+  multi_day_tour: 'Multi-día / Gira',
+  custom: 'Personalizado',
 };
 
 export const PROFILE_DEFAULTS: Record<JobProfileName, ProfileDefaults> = {
   standard: {
     label: JOB_PROFILE_LABELS.standard,
-    description: 'Balanced one-off crew selection.',
+    description: 'Selección equilibrada para trabajos puntuales.',
     weights: {
       roleSkill: 0.32,
       reliability: 0.23,
@@ -115,7 +115,7 @@ export const PROFILE_DEFAULTS: Record<JobProfileName, ProfileDefaults> = {
   },
   high_risk_critical: {
     label: JOB_PROFILE_LABELS.high_risk_critical,
-    description: 'Prioritizes proven people for complex or critical roles.',
+    description: 'Prioriza personal probado para roles complejos o críticos.',
     weights: {
       roleSkill: 0.4,
       reliability: 0.35,
@@ -136,7 +136,7 @@ export const PROFILE_DEFAULTS: Record<JobProfileName, ProfileDefaults> = {
   },
   training_friendly: {
     label: JOB_PROFILE_LABELS.training_friendly,
-    description: 'Biases toward rotation and role progression on low-risk work.',
+    description: 'Favorece rotación y progresión de rol en trabajos de bajo riesgo.',
     weights: {
       roleSkill: 0.23,
       reliability: 0.18,
@@ -157,7 +157,7 @@ export const PROFILE_DEFAULTS: Record<JobProfileName, ProfileDefaults> = {
   },
   emergency_fill: {
     label: JOB_PROFILE_LABELS.emergency_fill,
-    description: 'Favors fast, close, available, reliable responders.',
+    description: 'Favorece respuestas rápidas, cercanas, disponibles y fiables.',
     weights: {
       roleSkill: 0.15,
       reliability: 0.3,
@@ -178,7 +178,7 @@ export const PROFILE_DEFAULTS: Record<JobProfileName, ProfileDefaults> = {
   },
   local_low_complexity: {
     label: JOB_PROFILE_LABELS.local_low_complexity,
-    description: 'Avoids overusing top-tier or premium-rate crew on simple local work.',
+    description: 'Evita sobreusar personal premium en trabajo local sencillo.',
     weights: {
       roleSkill: 0.18,
       reliability: 0.18,
@@ -199,7 +199,7 @@ export const PROFILE_DEFAULTS: Record<JobProfileName, ProfileDefaults> = {
   },
   multi_day_tour: {
     label: JOB_PROFILE_LABELS.multi_day_tour,
-    description: 'Prioritizes continuity and commitment across repeated dates.',
+    description: 'Prioriza continuidad y compromiso en fechas repetidas.',
     weights: {
       roleSkill: 0.28,
       reliability: 0.28,
@@ -220,7 +220,7 @@ export const PROFILE_DEFAULTS: Record<JobProfileName, ProfileDefaults> = {
   },
   custom: {
     label: JOB_PROFILE_LABELS.custom,
-    description: 'Manager-tuned settings.',
+    description: 'Ajustes personalizados por gestión.',
     weights: {
       roleSkill: 0.32,
       reliability: 0.23,

--- a/src/features/staffing/crewingProfiles.ts
+++ b/src/features/staffing/crewingProfiles.ts
@@ -1,0 +1,489 @@
+export type StaffingJobType = 'single' | 'evento' | 'festival' | 'ciclo' | 'tourdate';
+
+export type JobProfileName =
+  | 'standard'
+  | 'high_risk_critical'
+  | 'training_friendly'
+  | 'emergency_fill'
+  | 'local_low_complexity'
+  | 'multi_day_tour'
+  | 'custom';
+
+export type WaveMode = 'manual_selection' | 'controlled_waves' | 'blast_all_eligible';
+export type RatePenaltyStrength = 'disabled' | 'low' | 'normal' | 'high';
+export type StaffingChannel = 'email' | 'whatsapp';
+export type SoftConflictPolicy = 'block' | 'warn' | 'manager_approval' | 'ignore' | 'allow';
+
+export type ScoringWeights = {
+  roleSkill: number;
+  reliability: number;
+  fairness: number;
+  proximity: number;
+  costEfficiency: number;
+  houseTechBonus: number;
+  roleProgression: number;
+  availabilityConfidence: number;
+};
+
+export type ProfileDefaults = {
+  label: string;
+  description: string;
+  weights: ScoringWeights;
+  availabilityTtlHours: number;
+  offerTtlHours: number;
+  waveWaitMinutes: number;
+  waveBuffer: number;
+  maxWaves: number;
+  minimumAutoBookScore: number;
+  defaultSoftConflictPolicy: SoftConflictPolicy;
+};
+
+export type RoleProfilePolicy = {
+  role_code: string;
+  inferred_profile: JobProfileName;
+  selected_profile: JobProfileName;
+  manual_override: boolean;
+  required_count: number;
+  assigned_count: number;
+  is_critical: boolean;
+};
+
+export type BuildCampaignPolicyInput = {
+  mode: 'assisted' | 'auto';
+  jobType?: string | null;
+  jobStartTime?: string | null;
+  jobEndTime?: string | null;
+  requiredCrewCount?: number;
+  selectedJobProfile: JobProfileName;
+  inferredJobProfile?: JobProfileName;
+  inferProfileFromJobType: boolean;
+  profileOverrideReason?: string;
+  roleProfiles: Record<string, RoleProfilePolicy>;
+  roleProfileOverrides?: Record<string, JobProfileName>;
+  availabilityTtlHours: number;
+  offerTtlHours: number;
+  softConflictPolicy: SoftConflictPolicy;
+  excludeFridge: boolean;
+  sendChannel: StaffingChannel;
+  costScoring: {
+    enabled: boolean;
+    penaltyStrength: RatePenaltyStrength;
+    maxRatePenalty: number;
+  };
+  waves: {
+    mode: WaveMode;
+    buffer: number;
+    waitMinutes: number;
+    maxWaves: number;
+    autoSendNextWave: boolean;
+  };
+  tickIntervalSeconds: number;
+  weightOverrides?: Partial<ScoringWeights>;
+};
+
+export const JOB_PROFILE_LABELS: Record<JobProfileName, string> = {
+  standard: 'Standard',
+  high_risk_critical: 'High-Risk / Critical',
+  training_friendly: 'Training-Friendly',
+  emergency_fill: 'Emergency Fill',
+  local_low_complexity: 'Local Low-Complexity',
+  multi_day_tour: 'Multi-Day / Tour',
+  custom: 'Custom',
+};
+
+export const PROFILE_DEFAULTS: Record<JobProfileName, ProfileDefaults> = {
+  standard: {
+    label: JOB_PROFILE_LABELS.standard,
+    description: 'Balanced one-off crew selection.',
+    weights: {
+      roleSkill: 0.32,
+      reliability: 0.23,
+      fairness: 0.15,
+      proximity: 0.1,
+      costEfficiency: 0.08,
+      houseTechBonus: 0.05,
+      roleProgression: 0.04,
+      availabilityConfidence: 0.03,
+    },
+    availabilityTtlHours: 24,
+    offerTtlHours: 4,
+    waveWaitMinutes: 20,
+    waveBuffer: 2,
+    maxWaves: 3,
+    minimumAutoBookScore: 70,
+    defaultSoftConflictPolicy: 'warn',
+  },
+  high_risk_critical: {
+    label: JOB_PROFILE_LABELS.high_risk_critical,
+    description: 'Prioritizes proven people for complex or critical roles.',
+    weights: {
+      roleSkill: 0.4,
+      reliability: 0.35,
+      fairness: 0.05,
+      proximity: 0.05,
+      costEfficiency: 0.03,
+      houseTechBonus: 0.1,
+      roleProgression: 0.02,
+      availabilityConfidence: 0,
+    },
+    availabilityTtlHours: 24,
+    offerTtlHours: 2,
+    waveWaitMinutes: 15,
+    waveBuffer: 1,
+    maxWaves: 3,
+    minimumAutoBookScore: 75,
+    defaultSoftConflictPolicy: 'block',
+  },
+  training_friendly: {
+    label: JOB_PROFILE_LABELS.training_friendly,
+    description: 'Biases toward rotation and role progression on low-risk work.',
+    weights: {
+      roleSkill: 0.23,
+      reliability: 0.18,
+      fairness: 0.25,
+      proximity: 0.05,
+      costEfficiency: 0.08,
+      houseTechBonus: 0.03,
+      roleProgression: 0.18,
+      availabilityConfidence: 0,
+    },
+    availabilityTtlHours: 24,
+    offerTtlHours: 4,
+    waveWaitMinutes: 30,
+    waveBuffer: 3,
+    maxWaves: 3,
+    minimumAutoBookScore: 65,
+    defaultSoftConflictPolicy: 'warn',
+  },
+  emergency_fill: {
+    label: JOB_PROFILE_LABELS.emergency_fill,
+    description: 'Favors fast, close, available, reliable responders.',
+    weights: {
+      roleSkill: 0.15,
+      reliability: 0.3,
+      fairness: 0,
+      proximity: 0.2,
+      costEfficiency: 0.02,
+      houseTechBonus: 0.03,
+      roleProgression: 0,
+      availabilityConfidence: 0.3,
+    },
+    availabilityTtlHours: 4,
+    offerTtlHours: 1,
+    waveWaitMinutes: 5,
+    waveBuffer: 4,
+    maxWaves: 4,
+    minimumAutoBookScore: 60,
+    defaultSoftConflictPolicy: 'manager_approval',
+  },
+  local_low_complexity: {
+    label: JOB_PROFILE_LABELS.local_low_complexity,
+    description: 'Avoids overusing top-tier or premium-rate crew on simple local work.',
+    weights: {
+      roleSkill: 0.18,
+      reliability: 0.18,
+      fairness: 0.23,
+      proximity: 0.23,
+      costEfficiency: 0.12,
+      houseTechBonus: 0.02,
+      roleProgression: 0.04,
+      availabilityConfidence: 0,
+    },
+    availabilityTtlHours: 24,
+    offerTtlHours: 3,
+    waveWaitMinutes: 20,
+    waveBuffer: 2,
+    maxWaves: 3,
+    minimumAutoBookScore: 65,
+    defaultSoftConflictPolicy: 'warn',
+  },
+  multi_day_tour: {
+    label: JOB_PROFILE_LABELS.multi_day_tour,
+    description: 'Prioritizes continuity and commitment across repeated dates.',
+    weights: {
+      roleSkill: 0.28,
+      reliability: 0.28,
+      fairness: 0.04,
+      proximity: 0.04,
+      costEfficiency: 0.1,
+      houseTechBonus: 0.08,
+      roleProgression: 0,
+      availabilityConfidence: 0.18,
+    },
+    availabilityTtlHours: 48,
+    offerTtlHours: 4,
+    waveWaitMinutes: 30,
+    waveBuffer: 1,
+    maxWaves: 3,
+    minimumAutoBookScore: 72,
+    defaultSoftConflictPolicy: 'block',
+  },
+  custom: {
+    label: JOB_PROFILE_LABELS.custom,
+    description: 'Manager-tuned settings.',
+    weights: {
+      roleSkill: 0.32,
+      reliability: 0.23,
+      fairness: 0.15,
+      proximity: 0.1,
+      costEfficiency: 0.08,
+      houseTechBonus: 0.05,
+      roleProgression: 0.04,
+      availabilityConfidence: 0.03,
+    },
+    availabilityTtlHours: 24,
+    offerTtlHours: 4,
+    waveWaitMinutes: 20,
+    waveBuffer: 2,
+    maxWaves: 3,
+    minimumAutoBookScore: 70,
+    defaultSoftConflictPolicy: 'warn',
+  },
+};
+
+export const PROFILE_OPTIONS = Object.keys(PROFILE_DEFAULTS) as JobProfileName[];
+
+const CRITICAL_ROLE_PATTERNS = [
+  /\bA1\b/i,
+  /\bV1\b/i,
+  /\bPM\b/i,
+  /\bRF\b/i,
+  /CREW[\s_-]*CHIEF/i,
+  /SYSTEM/i,
+  /LEAD/i,
+  /^SND-PA(?:-|$)/i,
+  /^LGT-MON(?:-|$)/i,
+];
+
+const TRAINING_ROLE_PATTERNS = [
+  /ASSIST/i,
+  /HELP/i,
+  /RUNNER/i,
+  /STAGEHAND/i,
+  /AUX/i,
+];
+
+export function normalizeStaffingJobType(jobType?: string | null): StaffingJobType {
+  const normalized = String(jobType || 'single').toLowerCase();
+  if (normalized === 'festival') return 'festival';
+  if (normalized === 'ciclo') return 'ciclo';
+  if (normalized === 'tourdate') return 'tourdate';
+  if (normalized === 'evento') return 'evento';
+  return 'single';
+}
+
+export function hoursUntil(startTime?: string | null, now = new Date()): number | null {
+  if (!startTime) return null;
+  const startsAt = new Date(startTime);
+  if (Number.isNaN(startsAt.getTime())) return null;
+  return (startsAt.getTime() - now.getTime()) / 36e5;
+}
+
+export function spansMultipleDates(startTime?: string | null, endTime?: string | null): boolean {
+  if (!startTime || !endTime) return false;
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return false;
+  return start.toDateString() !== end.toDateString();
+}
+
+export function isCriticalRole(roleCode: string): boolean {
+  return CRITICAL_ROLE_PATTERNS.some((pattern) => pattern.test(roleCode));
+}
+
+export function isTrainingFriendlyRole(roleCode: string): boolean {
+  return TRAINING_ROLE_PATTERNS.some((pattern) => pattern.test(roleCode));
+}
+
+export function inferJobProfile(input: {
+  jobType?: string | null;
+  startTime?: string | null;
+  endTime?: string | null;
+  requiredCrewCount?: number;
+  manualUrgency?: boolean;
+  now?: Date;
+}): JobProfileName {
+  const startsWithinHours = hoursUntil(input.startTime, input.now);
+  const jobType = normalizeStaffingJobType(input.jobType);
+
+  if (input.manualUrgency || (startsWithinHours !== null && startsWithinHours <= 6)) {
+    return 'emergency_fill';
+  }
+
+  if (jobType === 'tourdate' || jobType === 'ciclo' || spansMultipleDates(input.startTime, input.endTime)) {
+    return 'multi_day_tour';
+  }
+
+  if (jobType === 'festival' || Number(input.requiredCrewCount || 0) >= 10) {
+    return 'high_risk_critical';
+  }
+
+  return 'standard';
+}
+
+export function inferRoleProfile(input: {
+  jobProfile: JobProfileName;
+  roleCode: string;
+  requiredCount?: number;
+  assignedCount?: number;
+  startsWithinHours?: number | null;
+}): JobProfileName {
+  const required = Number(input.requiredCount || 0);
+  const assigned = Number(input.assignedCount || 0);
+  const unfilled = assigned < required;
+
+  if (input.startsWithinHours !== null && input.startsWithinHours !== undefined) {
+    if (input.startsWithinHours <= 6 || (input.startsWithinHours <= 24 && unfilled)) {
+      return 'emergency_fill';
+    }
+  }
+
+  if (input.jobProfile === 'multi_day_tour') return 'multi_day_tour';
+  if (isCriticalRole(input.roleCode)) return 'high_risk_critical';
+  if (isTrainingFriendlyRole(input.roleCode) && input.jobProfile !== 'emergency_fill') {
+    return 'training_friendly';
+  }
+  return input.jobProfile;
+}
+
+export function toLegacyRankWeights(weights: ScoringWeights) {
+  return {
+    skills: weights.roleSkill,
+    role_skill: weights.roleSkill,
+    reliability: weights.reliability,
+    fairness: weights.fairness,
+    proximity: weights.proximity,
+    experience: weights.roleProgression,
+    cost_efficiency: weights.costEfficiency,
+    house_tech_bonus: weights.houseTechBonus,
+    role_progression: weights.roleProgression,
+    availability_confidence: weights.availabilityConfidence,
+  };
+}
+
+export function buildRoleProfiles(input: {
+  roleCodes: string[];
+  requiredByRole?: Record<string, number>;
+  assignedByRole?: Record<string, number>;
+  selectedJobProfile: JobProfileName;
+  startTime?: string | null;
+  overrides?: Record<string, JobProfileName>;
+  now?: Date;
+}): Record<string, RoleProfilePolicy> {
+  const starts = hoursUntil(input.startTime, input.now);
+
+  return input.roleCodes.reduce<Record<string, RoleProfilePolicy>>((acc, roleCode) => {
+    const required = Number(input.requiredByRole?.[roleCode] || 0);
+    const assigned = Number(input.assignedByRole?.[roleCode] || 0);
+    const inferred = inferRoleProfile({
+      jobProfile: input.selectedJobProfile,
+      roleCode,
+      requiredCount: required,
+      assignedCount: assigned,
+      startsWithinHours: starts,
+    });
+    const selected = input.overrides?.[roleCode] || inferred;
+
+    acc[roleCode] = {
+      role_code: roleCode,
+      inferred_profile: inferred,
+      selected_profile: selected,
+      manual_override: selected !== inferred,
+      required_count: required,
+      assigned_count: assigned,
+      is_critical: isCriticalRole(roleCode),
+    };
+    return acc;
+  }, {});
+}
+
+export function buildCampaignPolicy(input: BuildCampaignPolicyInput) {
+  const inferredJobProfile =
+    input.inferredJobProfile ||
+    inferJobProfile({
+      jobType: input.jobType,
+      startTime: input.jobStartTime,
+      endTime: input.jobEndTime,
+      requiredCrewCount: input.requiredCrewCount,
+    });
+  const selectedDefaults = PROFILE_DEFAULTS[input.selectedJobProfile] || PROFILE_DEFAULTS.standard;
+  const weights = {
+    ...selectedDefaults.weights,
+    ...input.weightOverrides,
+  };
+  const roleProfiles = Object.fromEntries(
+    Object.entries(input.roleProfiles).map(([roleCode, profile]) => {
+      const selected = input.roleProfileOverrides?.[roleCode] || profile.selected_profile || profile.inferred_profile;
+      return [
+        roleCode,
+        {
+          ...profile,
+          selected_profile: selected,
+          manual_override: selected !== profile.inferred_profile,
+        },
+      ];
+    }),
+  );
+
+  return {
+    profile: {
+      infer_from_job_type: input.inferProfileFromJobType,
+      job_type: normalizeStaffingJobType(input.jobType),
+      inferred_job_profile: inferredJobProfile,
+      selected_job_profile: input.selectedJobProfile,
+      manual_profile_override: input.selectedJobProfile !== inferredJobProfile,
+      override_reason: input.profileOverrideReason || null,
+    },
+    role_profiles: roleProfiles,
+    weights: toLegacyRankWeights(weights),
+    availability_ttl_hours: input.availabilityTtlHours,
+    offer_ttl_hours: input.offerTtlHours,
+    availability_multiplier: Math.max(1, input.waves.buffer + 1),
+    offer_buffer: Math.max(0, input.waves.buffer),
+    exclude_fridge: input.excludeFridge,
+    soft_conflict_policy: input.softConflictPolicy,
+    tick_interval_seconds: input.tickIntervalSeconds,
+    channel: input.sendChannel,
+    assisted_handoff_priority: true,
+    cost_scoring: input.costScoring,
+    waves: {
+      mode: input.waves.mode,
+      size_mode: input.waves.mode === 'blast_all_eligible' ? 'all' : 'required_plus_buffer',
+      buffer: input.waves.buffer,
+      wait_minutes: input.waves.waitMinutes,
+      max_waves: input.waves.maxWaves,
+      auto_send_next_wave: input.waves.autoSendNextWave,
+    },
+    auto_close: {
+      close_when_filled: true,
+      stop_future_waves: true,
+      block_extra_acceptances: true,
+      confirm_booked_crew: true,
+      notify_late_responders: true,
+      notify_pending_contacted: true,
+    },
+    escalation: {
+      escalate_after_wave: selectedDefaults.maxWaves,
+      minimum_auto_book_score: selectedDefaults.minimumAutoBookScore,
+      escalate_soft_conflicts: true,
+      escalate_weak_critical_pool: true,
+      require_manager_approval_for_low_confidence: true,
+    },
+    audit: {
+      log_inferred_profile: true,
+      log_profile_override: true,
+      log_score_breakdown: true,
+      log_eligibility_failures: true,
+      log_wave_contact_history: true,
+      log_rate_adjustment: true,
+      require_manual_override_reason: true,
+      generate_crew_facing_explanation: true,
+    },
+    escalation_steps: ['increase_wave', 'include_fridge', 'allow_soft_conflicts'],
+  };
+}
+
+export function recommendedWaveNumber(index: number, requiredCount: number, buffer: number): number {
+  const waveSize = Math.max(1, Number(requiredCount || 0) + Number(buffer || 0));
+  return Math.floor(index / waveSize) + 1;
+}

--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -16,21 +16,290 @@ const corsHeaders = {
 interface CampaignPolicy {
   weights: {
     skills: number;
+    role_skill?: number;
     proximity: number;
     reliability: number;
     fairness: number;
     experience: number;
+    cost_efficiency?: number;
+    house_tech_bonus?: number;
+    role_progression?: number;
+    availability_confidence?: number;
   };
   availability_ttl_hours: number;
   offer_ttl_hours: number;
   availability_multiplier: number;
   offer_buffer: number;
   exclude_fridge: boolean;
-  soft_conflict_policy: 'warn' | 'block' | 'allow';
+  soft_conflict_policy: 'warn' | 'block' | 'allow' | 'manager_approval' | 'ignore';
   tick_interval_seconds: number;
   channel?: 'email' | 'whatsapp';
   assisted_handoff_priority?: boolean;
+  profile?: Record<string, unknown>;
+  role_profiles?: Record<string, unknown>;
+  cost_scoring?: {
+    enabled?: boolean;
+    penalty_strength?: 'disabled' | 'low' | 'normal' | 'high';
+    max_rate_penalty?: number;
+  };
+  waves?: {
+    mode?: 'manual_selection' | 'controlled_waves' | 'blast_all_eligible';
+    size_mode?: 'required_plus_buffer' | 'fixed' | 'all';
+    buffer?: number;
+    fixed_size?: number;
+    max_waves?: number;
+    wait_minutes?: number;
+    auto_send_next_wave?: boolean;
+  };
+  auto_close?: Record<string, boolean>;
+  audit?: Record<string, boolean>;
+  escalation?: Record<string, unknown>;
   escalation_steps: string[];
+}
+
+type JobProfileName =
+  | 'standard'
+  | 'high_risk_critical'
+  | 'training_friendly'
+  | 'emergency_fill'
+  | 'local_low_complexity'
+  | 'multi_day_tour'
+  | 'custom';
+
+const PROFILE_WEIGHTS: Record<JobProfileName, CampaignPolicy['weights']> = {
+  standard: {
+    skills: 0.32,
+    role_skill: 0.32,
+    reliability: 0.23,
+    fairness: 0.15,
+    proximity: 0.1,
+    experience: 0.04,
+    role_progression: 0.04,
+    cost_efficiency: 0.08,
+    house_tech_bonus: 0.05,
+    availability_confidence: 0.03,
+  },
+  high_risk_critical: {
+    skills: 0.4,
+    role_skill: 0.4,
+    reliability: 0.35,
+    fairness: 0.05,
+    proximity: 0.05,
+    experience: 0.02,
+    role_progression: 0.02,
+    cost_efficiency: 0.03,
+    house_tech_bonus: 0.1,
+    availability_confidence: 0,
+  },
+  training_friendly: {
+    skills: 0.23,
+    role_skill: 0.23,
+    reliability: 0.18,
+    fairness: 0.25,
+    proximity: 0.05,
+    experience: 0.18,
+    role_progression: 0.18,
+    cost_efficiency: 0.08,
+    house_tech_bonus: 0.03,
+    availability_confidence: 0,
+  },
+  emergency_fill: {
+    skills: 0.15,
+    role_skill: 0.15,
+    reliability: 0.3,
+    fairness: 0,
+    proximity: 0.2,
+    experience: 0,
+    role_progression: 0,
+    cost_efficiency: 0.02,
+    house_tech_bonus: 0.03,
+    availability_confidence: 0.3,
+  },
+  local_low_complexity: {
+    skills: 0.18,
+    role_skill: 0.18,
+    reliability: 0.18,
+    fairness: 0.23,
+    proximity: 0.23,
+    experience: 0.04,
+    role_progression: 0.04,
+    cost_efficiency: 0.12,
+    house_tech_bonus: 0.02,
+    availability_confidence: 0,
+  },
+  multi_day_tour: {
+    skills: 0.28,
+    role_skill: 0.28,
+    reliability: 0.28,
+    fairness: 0.04,
+    proximity: 0.04,
+    experience: 0,
+    role_progression: 0,
+    cost_efficiency: 0.1,
+    house_tech_bonus: 0.08,
+    availability_confidence: 0.18,
+  },
+  custom: {
+    skills: 0.32,
+    role_skill: 0.32,
+    reliability: 0.23,
+    fairness: 0.15,
+    proximity: 0.1,
+    experience: 0.04,
+    role_progression: 0.04,
+    cost_efficiency: 0.08,
+    house_tech_bonus: 0.05,
+    availability_confidence: 0.03,
+  },
+};
+
+const PROFILE_TIMING: Record<JobProfileName, { availability: number; offer: number; waveWait: number; buffer: number; maxWaves: number }> = {
+  standard: { availability: 24, offer: 4, waveWait: 20, buffer: 2, maxWaves: 3 },
+  high_risk_critical: { availability: 24, offer: 2, waveWait: 15, buffer: 1, maxWaves: 3 },
+  training_friendly: { availability: 24, offer: 4, waveWait: 30, buffer: 3, maxWaves: 3 },
+  emergency_fill: { availability: 4, offer: 1, waveWait: 5, buffer: 4, maxWaves: 4 },
+  local_low_complexity: { availability: 24, offer: 3, waveWait: 20, buffer: 2, maxWaves: 3 },
+  multi_day_tour: { availability: 48, offer: 4, waveWait: 30, buffer: 1, maxWaves: 3 },
+  custom: { availability: 24, offer: 4, waveWait: 20, buffer: 2, maxWaves: 3 },
+};
+
+function normalizeProfileName(value: unknown): JobProfileName {
+  const name = String(value || 'standard') as JobProfileName;
+  return Object.prototype.hasOwnProperty.call(PROFILE_WEIGHTS, name) ? name : 'standard';
+}
+
+function inferJobProfile(job: any, totalRequired: number): JobProfileName {
+  const startsAt = job?.start_time ? new Date(job.start_time) : null;
+  const startsWithinHours = startsAt && !Number.isNaN(startsAt.getTime())
+    ? (startsAt.getTime() - Date.now()) / 36e5
+    : null;
+  const type = String(job?.job_type || 'single').toLowerCase();
+
+  if (startsWithinHours !== null && startsWithinHours <= 6) return 'emergency_fill';
+  if (type === 'tourdate' || type === 'ciclo') return 'multi_day_tour';
+  if (type === 'festival' || totalRequired >= 10) return 'high_risk_critical';
+  return 'standard';
+}
+
+function isCriticalRole(roleCode: string): boolean {
+  return [
+    /\bA1\b/i,
+    /\bV1\b/i,
+    /\bPM\b/i,
+    /\bRF\b/i,
+    /CREW[\s_-]*CHIEF/i,
+    /SYSTEM/i,
+    /LEAD/i,
+    /^SND-PA(?:-|$)/i,
+    /^LGT-MON(?:-|$)/i,
+  ].some((pattern) => pattern.test(roleCode));
+}
+
+function inferRoleProfile(jobProfile: JobProfileName, roleCode: string): JobProfileName {
+  if (jobProfile === 'multi_day_tour') return 'multi_day_tour';
+  if (isCriticalRole(roleCode)) return 'high_risk_critical';
+  if (/ASSIST|HELP|RUNNER|STAGEHAND|AUX/i.test(roleCode) && jobProfile !== 'emergency_fill') {
+    return 'training_friendly';
+  }
+  return jobProfile;
+}
+
+function normalizeCampaignPolicy(
+  policy: Partial<CampaignPolicy> | null | undefined,
+  job: any,
+  roles: any[],
+  mode: 'assisted' | 'auto',
+): CampaignPolicy {
+  const basePolicy = policy || {};
+  const totalRequired = roles.reduce((sum, role) => sum + Number(role.quantity || 0), 0);
+  const inferredJobProfile = inferJobProfile(job, totalRequired);
+  const selectedJobProfile = normalizeProfileName((basePolicy.profile as any)?.selected_job_profile || inferredJobProfile);
+  const timing = PROFILE_TIMING[selectedJobProfile];
+  const roleProfiles = roles.reduce<Record<string, unknown>>((acc, role) => {
+    const roleCode = String(role.role_code || '').trim();
+    if (!roleCode) return acc;
+    const existing = (basePolicy.role_profiles as Record<string, any> | undefined)?.[roleCode];
+    const inferred = normalizeProfileName(existing?.inferred_profile || inferRoleProfile(selectedJobProfile, roleCode));
+    const selected = normalizeProfileName(existing?.selected_profile || inferred);
+    acc[roleCode] = {
+      role_code: roleCode,
+      inferred_profile: inferred,
+      selected_profile: selected,
+      manual_override: selected !== inferred,
+      required_count: Number(role.quantity || 0),
+      assigned_count: Number(existing?.assigned_count || 0),
+      is_critical: isCriticalRole(roleCode),
+    };
+    return acc;
+  }, {});
+
+  return {
+    ...basePolicy,
+    profile: {
+      infer_from_job_type: (basePolicy.profile as any)?.infer_from_job_type ?? true,
+      job_type: String(job?.job_type || 'single').toLowerCase(),
+      inferred_job_profile: inferredJobProfile,
+      selected_job_profile: selectedJobProfile,
+      manual_profile_override: selectedJobProfile !== inferredJobProfile,
+      override_reason: (basePolicy.profile as any)?.override_reason || null,
+    },
+    role_profiles: roleProfiles,
+    weights: {
+      ...PROFILE_WEIGHTS[selectedJobProfile],
+      ...(basePolicy.weights || {}),
+    },
+    availability_ttl_hours: Number(basePolicy.availability_ttl_hours || timing.availability),
+    offer_ttl_hours: Number(basePolicy.offer_ttl_hours || timing.offer),
+    availability_multiplier: Number(basePolicy.availability_multiplier || timing.buffer + 1),
+    offer_buffer: Number(basePolicy.offer_buffer ?? timing.buffer),
+    exclude_fridge: basePolicy.exclude_fridge ?? true,
+    soft_conflict_policy: basePolicy.soft_conflict_policy || (mode === 'auto' ? 'block' : 'warn'),
+    tick_interval_seconds: Number(basePolicy.tick_interval_seconds || 300),
+    channel: basePolicy.channel === 'whatsapp' ? 'whatsapp' : 'email',
+    assisted_handoff_priority: basePolicy.assisted_handoff_priority !== false,
+    cost_scoring: {
+      enabled: basePolicy.cost_scoring?.enabled ?? true,
+      penalty_strength: basePolicy.cost_scoring?.penalty_strength || 'normal',
+      max_rate_penalty: Number(basePolicy.cost_scoring?.max_rate_penalty || 10),
+    },
+    waves: {
+      mode: basePolicy.waves?.mode || 'controlled_waves',
+      size_mode: basePolicy.waves?.size_mode || 'required_plus_buffer',
+      buffer: Number(basePolicy.waves?.buffer ?? timing.buffer),
+      max_waves: Number(basePolicy.waves?.max_waves || timing.maxWaves),
+      wait_minutes: Number(basePolicy.waves?.wait_minutes || timing.waveWait),
+      auto_send_next_wave: basePolicy.waves?.auto_send_next_wave ?? mode === 'auto',
+    },
+    auto_close: {
+      close_when_filled: true,
+      stop_future_waves: true,
+      block_extra_acceptances: true,
+      confirm_booked_crew: true,
+      notify_late_responders: true,
+      notify_pending_contacted: true,
+      ...(basePolicy.auto_close || {}),
+    },
+    escalation: {
+      escalate_after_wave: timing.maxWaves,
+      minimum_auto_book_score: selectedJobProfile === 'high_risk_critical' ? 75 : 70,
+      escalate_soft_conflicts: true,
+      escalate_weak_critical_pool: true,
+      require_manager_approval_for_low_confidence: true,
+      ...(basePolicy.escalation || {}),
+    },
+    audit: {
+      log_inferred_profile: true,
+      log_profile_override: true,
+      log_score_breakdown: true,
+      log_eligibility_failures: true,
+      log_wave_contact_history: true,
+      log_rate_adjustment: true,
+      require_manual_override_reason: true,
+      generate_crew_facing_explanation: true,
+      ...(basePolicy.audit || {}),
+    },
+    escalation_steps: basePolicy.escalation_steps || ['increase_wave', 'include_fridge', 'allow_soft_conflicts'],
+  };
 }
 
 function assignmentRoleColumnForDepartment(department: string): string | null {
@@ -183,7 +452,7 @@ async function startCampaign(
     console.log('[staffing-orchestrator] Fetching job:', job_id);
     const { data: job, error: jobError } = await supabase
       .from('jobs')
-      .select('id, start_time, title')
+      .select('id, start_time, end_time, title, job_type')
       .eq('id', job_id)
       .single();
 
@@ -194,32 +463,16 @@ async function startCampaign(
       return { status: 404, body: { error: 'Job not found', job_id, jobError: jobError?.message || null, debug: { received_body: body } } };
     }
 
-    // Create campaign
-    const { data: campaign, error: createError } = await supabase
-      .from('staffing_campaigns')
-      .insert({
-        job_id,
-        department,
-        created_by: user.user_id,
-        mode,
-        status: 'active',
-        policy,
-        offer_message,
-        next_run_at: new Date().toISOString()
-      })
-      .select()
-      .single();
-
-    if (createError) {
-      return { status: 400, body: { error: createError.message } };
-    }
-
     // Get required roles for this job+department
-    const { data: requiredRoles } = await supabase
+    const { data: requiredRoles, error: requiredRolesError } = await supabase
       .from('job_required_roles')
       .select('role_code, quantity')
       .eq('job_id', job_id)
       .eq('department', department);
+
+    if (requiredRolesError) {
+      return { status: 400, body: { error: requiredRolesError.message } };
+    }
 
     // Filter to outstanding roles only if scope='outstanding'
     let rolesToCreate = requiredRoles || [];
@@ -254,6 +507,29 @@ async function startCampaign(
         const assigned = assignedCounts.get(String(r.role_code).trim()) || 0;
         return assigned < required;
       });
+    }
+
+    const normalizedMode = mode === 'auto' ? 'auto' : 'assisted';
+    const normalizedPolicy = normalizeCampaignPolicy(policy, job, rolesToCreate, normalizedMode);
+
+    // Create campaign
+    const { data: campaign, error: createError } = await supabase
+      .from('staffing_campaigns')
+      .insert({
+        job_id,
+        department,
+        created_by: user.user_id,
+        mode: normalizedMode,
+        status: 'active',
+        policy: normalizedPolicy,
+        offer_message,
+        next_run_at: new Date().toISOString()
+      })
+      .select()
+      .single();
+
+    if (createError) {
+      return { status: 400, body: { error: createError.message } };
     }
 
     // Create campaign roles
@@ -642,6 +918,7 @@ async function tickCampaign(
 
     const confirmedAvailabilityRowsForJob: any[] = [];
     const confirmedAvailabilityByRequestedRole = new Map<string, any[]>();
+    const contactedProfilesByRole = new Map<string, Set<string>>();
     const offerRequestProfilesByRole = new Map<string, Set<string>>();
     const offerRequestProfilesForJob = new Set<string>();
 
@@ -660,6 +937,11 @@ async function tickCampaign(
 
       if (phase === 'availability') {
         const availabilityRow = { ...r, requested_role_code: roleCode || null };
+        if (roleCode && campaignRoleCodes.has(roleCode)) {
+          const contactedProfiles = contactedProfilesByRole.get(roleCode) || new Set<string>();
+          contactedProfiles.add(profileId);
+          contactedProfilesByRole.set(roleCode, contactedProfiles);
+        }
         if (status === 'confirmed') {
           confirmedAvailabilityRowsForJob.push(availabilityRow);
           if (roleCode && campaignRoleCodes.has(roleCode)) {
@@ -675,6 +957,10 @@ async function tickCampaign(
       }
 
       if (!campaignRoleCodes.has(roleCode)) continue;
+
+      const contactedProfiles = contactedProfilesByRole.get(roleCode) || new Set<string>();
+      contactedProfiles.add(profileId);
+      contactedProfilesByRole.set(roleCode, contactedProfiles);
 
       if (status === 'pending') countsByRole[roleCode][phase].pending.add(profileId);
       if (status === 'confirmed') countsByRole[roleCode][phase].confirmed.add(profileId);
@@ -697,7 +983,7 @@ async function tickCampaign(
       const roleCode = String(role.role_code).trim();
       const required = requiredByRole.get(roleCode) || 0;
       const assigned = assignedCounts.get(roleCode) || 0;
-      const pendingAvailability = countsByRole[roleCode]?.availability.pending.size || 0;
+      let pendingAvailability = countsByRole[roleCode]?.availability.pending.size || 0;
       const matchingRequestedRole = confirmedAvailabilityByRequestedRole.get(roleCode) || [];
       const confirmedAvailability = new Set(
         matchingRequestedRole
@@ -721,6 +1007,119 @@ async function tickCampaign(
       }
 
       if (stage !== 'filled') allFilled = false;
+
+      let nextWaveNumber = Number(role.wave_number || 0);
+      let nextLastWaveAt = role.last_wave_at || null;
+
+      if (
+        campaign.mode === 'auto' &&
+        stage === 'availability' &&
+        (policy.waves?.auto_send_next_wave ?? true) &&
+        pendingAvailability === 0
+      ) {
+        const alreadyContacted = contactedProfilesByRole.get(roleCode) || new Set<string>();
+        const remainingNeeded = Math.max(0, required - assigned - acceptedOffers);
+        const waveMode = policy.waves?.mode || 'controlled_waves';
+        const waveBuffer = Number(policy.waves?.buffer ?? policy.offer_buffer ?? 1);
+        const waveSize = waveMode === 'blast_all_eligible'
+          ? 50
+          : Math.max(1, remainingNeeded + waveBuffer);
+
+        const { data: rankedCandidates, error: rankError } = await supabase.rpc('rank_staffing_candidates', {
+          p_job_id: campaign.job_id,
+          p_department: campaign.department,
+          p_role_code: roleCode,
+          p_mode: 'auto',
+          p_policy: policy,
+        });
+
+        if (rankError) {
+          autoActions.push({
+            role_code: roleCode,
+            profile_id: '',
+            phase: 'availability',
+            channel: autoChannel,
+            status: 'failed',
+            error: rankError.message,
+          });
+        } else {
+          const candidatesToContact = ((rankedCandidates || []) as any[])
+            .filter((candidate) => {
+              const profileId = String(candidate.profile_id || '');
+              return profileId && !alreadyContacted.has(profileId);
+            })
+            .slice(0, waveSize);
+
+          let sentInWave = 0;
+          for (const candidate of candidatesToContact) {
+            const profileId = String(candidate.profile_id || '');
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+            try {
+              const response = await fetch(SEND_STAFFING_EMAIL_URL, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': `Bearer ${SERVICE_ROLE}`,
+                  'apikey': SERVICE_ROLE,
+                },
+                body: JSON.stringify({
+                  job_id: campaign.job_id,
+                  profile_id: profileId,
+                  phase: 'availability',
+                  role: roleCode,
+                  channel: autoChannel,
+                  require_no_conflicts: true,
+                  actor_id: campaign.created_by || null,
+                  idempotency_key: `campaign:${campaign_id}:${roleCode}:${profileId}:availability:auto:${autoChannel}`,
+                }),
+                signal: controller.signal,
+              });
+
+              const payload = await response.json().catch(() => ({}));
+              if (!response.ok) {
+                autoActions.push({
+                  role_code: roleCode,
+                  profile_id: profileId,
+                  phase: 'availability',
+                  channel: autoChannel,
+                  status: 'failed',
+                  error: payload?.error || `HTTP ${response.status}`,
+                });
+                continue;
+              }
+
+              alreadyContacted.add(profileId);
+              sentInWave += 1;
+              pendingAvailability += 1;
+              autoActions.push({
+                role_code: roleCode,
+                profile_id: profileId,
+                phase: 'availability',
+                channel: autoChannel,
+                status: 'sent',
+              });
+            } catch (err) {
+              autoActions.push({
+                role_code: roleCode,
+                profile_id: profileId,
+                phase: 'availability',
+                channel: autoChannel,
+                status: 'failed',
+                error: err instanceof Error ? err.message : String(err),
+              });
+            } finally {
+              clearTimeout(timeoutId);
+            }
+          }
+
+          if (sentInWave > 0) {
+            nextWaveNumber += 1;
+            nextLastWaveAt = now.toISOString();
+          }
+        }
+      }
 
       if (shouldPrioritizeAssistedHandoff && stage === 'offer') {
         const capacity = Math.max(0, required - assigned - acceptedOffers - pendingOffers);
@@ -816,6 +1215,8 @@ async function tickCampaign(
         pending_offers: pendingOffers,
         accepted_offers: acceptedOffers,
         stage,
+        wave_number: nextWaveNumber,
+        last_wave_at: nextLastWaveAt,
         updated_at: now.toISOString(),
       });
     }
@@ -831,6 +1232,8 @@ async function tickCampaign(
           pending_offers: update.pending_offers,
           accepted_offers: update.accepted_offers,
           stage: update.stage,
+          wave_number: update.wave_number,
+          last_wave_at: update.last_wave_at,
           updated_at: update.updated_at,
         })
         .eq('id', update.id);
@@ -841,7 +1244,11 @@ async function tickCampaign(
     }
 
     const tickIntervalSeconds = Number(campaign.policy?.tick_interval_seconds || 300);
-    const nextRun = allFilled ? null : new Date(now.getTime() + tickIntervalSeconds * 1000);
+    const waveWaitSeconds = Number(campaign.policy?.waves?.wait_minutes || 0) * 60;
+    const runIntervalSeconds = campaign.mode === 'auto' && waveWaitSeconds > 0
+      ? waveWaitSeconds
+      : tickIntervalSeconds;
+    const nextRun = allFilled ? null : new Date(now.getTime() + runIntervalSeconds * 1000);
 
     const { error: campaignUpdateError } = await supabase
       .from('staffing_campaigns')

--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -1021,8 +1021,9 @@ async function tickCampaign(
         const remainingNeeded = Math.max(0, required - assigned - acceptedOffers);
         const waveMode = policy.waves?.mode || 'controlled_waves';
         const waveBuffer = Number(policy.waves?.buffer ?? policy.offer_buffer ?? 1);
+        const fixedWaveSize = Math.max(1, Number(policy.waves?.fixed_size || 50));
         const waveSize = waveMode === 'blast_all_eligible'
-          ? 50
+          ? fixedWaveSize
           : Math.max(1, remainingNeeded + waveBuffer);
 
         const { data: rankedCandidates, error: rankError } = await supabase.rpc('rank_staffing_candidates', {

--- a/supabase/migrations/20260520110000_crewing_profile_rate_scoring.sql
+++ b/supabase/migrations/20260520110000_crewing_profile_rate_scoring.sql
@@ -1,0 +1,234 @@
+-- Add profile-era cost/rate scoring to rank_staffing_candidates without
+-- changing the RPC signature or returned columns.
+
+DO $$
+DECLARE
+  v_sql text;
+BEGIN
+  SELECT pg_get_functiondef('public.rank_staffing_candidates(uuid,text,text,text,jsonb)'::regprocedure)
+  INTO v_sql;
+
+  v_sql := replace(
+    v_sql,
+$old$
+  w_experience numeric := COALESCE((p_policy->'weights'->>'experience')::numeric, 0.1);
+  w_sum numeric;
+$old$,
+$new$
+  w_experience numeric := COALESCE((p_policy->'weights'->>'role_progression')::numeric, COALESCE((p_policy->'weights'->>'experience')::numeric, 0.1));
+  w_cost_efficiency numeric := COALESCE((p_policy->'weights'->>'cost_efficiency')::numeric, 0);
+  w_sum numeric;
+  v_apply_rate_adjustment boolean := COALESCE((p_policy->'cost_scoring'->>'enabled')::boolean, false);
+  v_rate_penalty_multiplier numeric := CASE COALESCE(p_policy->'cost_scoring'->>'penalty_strength', 'normal')
+    WHEN 'disabled' THEN 0
+    WHEN 'low' THEN 0.5
+    WHEN 'high' THEN 1.5
+    ELSE 1
+  END;
+  v_max_rate_penalty numeric := COALESCE((p_policy->'cost_scoring'->>'max_rate_penalty')::numeric, 10);
+  v_rate_category text;
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+  v_role_prefix := public.staffing_role_prefix(v_normalized_role_code);
+$old$,
+$new$
+  v_role_prefix := public.staffing_role_prefix(v_normalized_role_code);
+  v_rate_category := CASE
+    WHEN v_normalized_role_code ~ '-R$'
+      OR v_normalized_role_code ~* '(RESP|LEAD|CHIEF|PM)'
+    THEN 'responsable'
+    WHEN v_normalized_role_code ~ '-E$' THEN 'especialista'
+    ELSE 'tecnico'
+  END;
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+  w_sum := w_skills + w_proximity + w_reliability + w_fairness + w_experience;
+$old$,
+$new$
+  w_sum := w_skills + w_proximity + w_reliability + w_fairness + w_experience + w_cost_efficiency;
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+    w_experience := 0.1;
+    w_sum := 1;
+$old$,
+$new$
+    w_experience := 0.1;
+    w_cost_efficiency := 0;
+    w_sum := 1;
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+  w_experience := w_experience / w_sum;
+$old$,
+$new$
+  w_experience := w_experience / w_sum;
+  w_cost_efficiency := w_cost_efficiency / w_sum;
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+  role_declines AS (
+$old$,
+$new$
+  rate_adjustments AS (
+    SELECT
+      b.profile_id,
+      COALESCE(std.base_day_eur, 0)::numeric AS standard_role_rate,
+      COALESCE(
+        CASE v_rate_category
+          WHEN 'responsable' THEN COALESCE(ctr.base_day_responsable_eur, ctr.base_day_especialista_eur, ctr.base_day_eur)
+          WHEN 'especialista' THEN COALESCE(ctr.base_day_especialista_eur, ctr.base_day_eur)
+          ELSE ctr.base_day_eur
+        END,
+        std.base_day_eur,
+        0
+      )::numeric AS candidate_rate,
+      ctr.profile_id IS NOT NULL AS has_custom_rate_override
+    FROM base b
+    LEFT JOIN public.rate_cards_2025 std ON std.category = v_rate_category
+    LEFT JOIN public.custom_tech_rates ctr ON ctr.profile_id = b.profile_id
+  ),
+  role_declines AS (
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+      )::int AS role_decline_penalty
+    FROM base b
+    LEFT JOIN skill_scores ss ON ss.profile_id = b.profile_id
+    LEFT JOIN role_experience re ON re.profile_id = b.profile_id
+    LEFT JOIN role_declines rd ON rd.profile_id = b.profile_id
+    LEFT JOIN reliability_stats rs ON rs.profile_id = b.profile_id
+$old$,
+$new$
+      )::int AS role_decline_penalty,
+      COALESCE(ra.standard_role_rate, 0)::numeric AS standard_role_rate,
+      COALESCE(ra.candidate_rate, ra.standard_role_rate, 0)::numeric AS candidate_rate,
+      COALESCE(ra.has_custom_rate_override, false) AS has_custom_rate_override,
+      CASE
+        WHEN COALESCE(ra.standard_role_rate, 0) > 0
+        THEN COALESCE(ra.candidate_rate, ra.standard_role_rate, 0)::numeric / ra.standard_role_rate
+        ELSE 1
+      END AS rate_ratio,
+      CASE
+        WHEN v_apply_rate_adjustment
+          AND COALESCE(ra.standard_role_rate, 0) > 0
+          AND COALESCE(ra.candidate_rate, ra.standard_role_rate, 0) > ra.standard_role_rate
+        THEN LEAST(
+          ((COALESCE(ra.candidate_rate, ra.standard_role_rate, 0)::numeric / ra.standard_role_rate) - 1) * 25 * v_rate_penalty_multiplier,
+          v_max_rate_penalty
+        )
+        ELSE 0
+      END AS rate_penalty
+    FROM base b
+    LEFT JOIN skill_scores ss ON ss.profile_id = b.profile_id
+    LEFT JOIN role_experience re ON re.profile_id = b.profile_id
+    LEFT JOIN role_declines rd ON rd.profile_id = b.profile_id
+    LEFT JOIN rate_adjustments ra ON ra.profile_id = b.profile_id
+    LEFT JOIN reliability_stats rs ON rs.profile_id = b.profile_id
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+      wr.role_declined_requests,
+      wr.role_decline_penalty,
+      wr.jobs_worked,
+$old$,
+$new$
+      wr.role_declined_requests,
+      wr.role_decline_penalty,
+      wr.standard_role_rate,
+      wr.candidate_rate,
+      wr.has_custom_rate_override,
+      wr.rate_ratio,
+      wr.rate_penalty,
+      GREATEST(0, 100 - ROUND(wr.rate_penalty * 10)::int) AS cost_efficiency_score,
+      wr.jobs_worked,
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+          (f.fairness_score::numeric * 10) * w_fairness +
+          (f.experience_score::numeric * 10) * w_experience
+$old$,
+$new$
+          (f.fairness_score::numeric * 10) * w_fairness +
+          (f.experience_score::numeric * 10) * w_experience +
+          (f.cost_efficiency_score::numeric) * w_cost_efficiency
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+    (CASE
+      WHEN f.user_role = 'house_tech' AND f.current_month_days < 4
+      THEN jsonb_build_array('House tech boost (+30%)')
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE WHEN f.soft_conflict THEN jsonb_build_array('Same-day job (different time)') ELSE '[]'::jsonb END) AS reasons
+$old$,
+$new$
+    (CASE
+      WHEN f.user_role = 'house_tech' AND f.current_month_days < 4
+      THEN jsonb_build_array('House tech boost (+30%)')
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE
+      WHEN f.standard_role_rate > 0
+      THEN jsonb_build_array(
+        'Standard role rate: €' || ROUND(f.standard_role_rate::numeric, 2),
+        'Candidate rate: €' || ROUND(f.candidate_rate::numeric, 2),
+        'Custom rate override: ' || CASE WHEN f.has_custom_rate_override THEN 'Yes' ELSE 'No' END
+      )
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE
+      WHEN f.rate_penalty > 0
+      THEN jsonb_build_array(
+        'Rate adjustment: -' || ROUND(f.rate_penalty::numeric, 1) ||
+        ' (' || ROUND(((f.rate_ratio - 1) * 100)::numeric, 0) || '% above standard)'
+      )
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE WHEN f.soft_conflict THEN jsonb_build_array('Same-day job (different time)') ELSE '[]'::jsonb END) AS reasons
+$new$
+  );
+
+  IF v_sql NOT LIKE '%rate_adjustments AS%'
+    OR v_sql NOT LIKE '%cost_efficiency_score%'
+    OR v_sql NOT LIKE '%Rate adjustment:%'
+    OR v_sql NOT LIKE '%custom_tech_rates%'
+  THEN
+    RAISE EXCEPTION 'Failed to patch rank_staffing_candidates with profile cost/rate scoring';
+  END IF;
+
+  EXECUTE v_sql;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO service_role;

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -22,6 +22,11 @@ const declinedPenaltyMigration = readFileSync(
   "utf-8",
 );
 
+const profileRateScoringMigration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260520110000_crewing_profile_rate_scoring.sql"),
+  "utf-8",
+);
+
 const sendStaffingEmailFunction = readFileSync(
   join(process.cwd(), "supabase/functions/send-staffing-email/index.ts"),
   "utf-8",
@@ -77,6 +82,18 @@ describe("smarter staffing recommendation migration", () => {
     expect(declinedPenaltyMigration).toContain("Declined role requests:");
   });
 
+  it("applies profile cost/rate scoring without changing the candidate RPC shape", () => {
+    expect(profileRateScoringMigration).toContain("rank_staffing_candidates(uuid,text,text,text,jsonb)");
+    expect(profileRateScoringMigration).not.toContain("RETURNS TABLE");
+    expect(profileRateScoringMigration).toContain("p_policy->'cost_scoring'->>'enabled'");
+    expect(profileRateScoringMigration).toContain("p_policy->'weights'->>'cost_efficiency'");
+    expect(profileRateScoringMigration).toContain("rate_adjustments AS");
+    expect(profileRateScoringMigration).toContain("custom_tech_rates");
+    expect(profileRateScoringMigration).toContain("rate_cards_2025");
+    expect(profileRateScoringMigration).toContain("cost_efficiency_score");
+    expect(profileRateScoringMigration).toContain("Rate adjustment:");
+  });
+
   it("filters hard collisions and unavailability before candidates are returned", () => {
     expect(smarterMigration).toMatch(/FROM technician_availability ta/);
     expect(smarterMigration).toMatch(/JOIN target_dates td ON td\.target_date = ta\.date/);
@@ -126,6 +143,11 @@ describe("smarter staffing recommendation migration", () => {
 
   it("prioritizes confirmed assisted availability before auto mode contacts new candidates", () => {
     expect(staffingOrchestratorFunction).toContain("assisted_handoff_priority");
+    expect(staffingOrchestratorFunction).toContain("normalizeCampaignPolicy");
+    expect(staffingOrchestratorFunction).toContain("selected_job_profile");
+    expect(staffingOrchestratorFunction).toContain("role_profiles");
+    expect(staffingOrchestratorFunction).toContain("cost_scoring");
+    expect(staffingOrchestratorFunction).toContain("waveWaitSeconds");
     expect(staffingOrchestratorFunction).toContain("confirmedAvailabilityRowsForJob");
     expect(staffingOrchestratorFunction).toContain("confirmedAvailabilityByRequestedRole");
     expect(staffingOrchestratorFunction).toContain(".order('created_at', { ascending: false })");
@@ -134,5 +156,13 @@ describe("smarter staffing recommendation migration", () => {
     expect(staffingOrchestratorFunction).toContain("phase: 'offer'");
     expect(staffingOrchestratorFunction).toContain("require_no_conflicts: true");
     expect(staffingOrchestratorFunction).toContain("auto_actions");
+  });
+
+  it("lets auto mode send availability waves from the same ranked candidate workflow", () => {
+    expect(staffingOrchestratorFunction).toContain("rank_staffing_candidates");
+    expect(staffingOrchestratorFunction).toContain("phase: 'availability'");
+    expect(staffingOrchestratorFunction).toContain("idempotency_key: `campaign:${campaign_id}:${roleCode}:${profileId}:availability:auto:${autoChannel}`");
+    expect(staffingOrchestratorFunction).toContain("contactedProfilesByRole");
+    expect(staffingOrchestratorFunction).toContain("wave_number: nextWaveNumber");
   });
 });

--- a/tests/e2e/staffing-recommendations.spec.ts
+++ b/tests/e2e/staffing-recommendations.spec.ts
@@ -220,14 +220,14 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
 
   await page.getByRole("tab", { name: "Candidates" }).click();
 
-  await expect(page.getByText("SND-PA-T - Candidate Recommendations")).toBeVisible();
-  await expect(page.getByText("1 available")).toBeVisible();
-  await expect(page.getByText("1 pending")).toBeVisible();
+  await expect(page.getByText("SND-PA-T - Recomendaciones de candidatos")).toBeVisible();
+  await expect(page.getByText("1 disponibles")).toBeVisible();
+  await expect(page.getByText("1 pendientes")).toBeVisible();
   await expect(page.getByText("Roleless Pending")).toBeVisible();
   await expect(page.getByText("Expired Same Role")).toBeVisible();
-  await expect(page.getByText("No-role request")).toBeVisible();
-  await expect(page.getByText(/Prior manager availability request without role is pending/)).toBeVisible();
-  await page.getByRole("button", { name: /show reasons/i }).first().click();
+  await expect(page.getByText("Solicitud sin rol")).toBeVisible();
+  await expect(page.getByText(/Solicitud previa de disponibilidad sin rol: pendiente/)).toBeVisible();
+  await page.getByRole("button", { name: /ver motivos/i }).first().click();
   await expect(page.getByText("Role experience: 4 completed SND-PA jobs")).toBeVisible();
   await expect(page.getByText("Same Role Pending")).toHaveCount(0);
   await expect(page.getByText("Roleless Declined")).toHaveCount(0);
@@ -239,12 +239,12 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
     p_role_code: "SND-PA-T",
   });
 
-  await page.getByRole("combobox", { name: "Select availability channel" }).click();
+  await page.getByRole("combobox", { name: "Seleccionar canal de disponibilidad" }).click();
   await page.getByRole("option", { name: "WhatsApp" }).click();
-  await page.getByRole("checkbox", { name: /select all/i }).click();
-  await page.getByRole("button", { name: /send availability/i }).click();
+  await page.getByRole("checkbox", { name: /seleccionar todos/i }).click();
+  await page.getByRole("button", { name: /enviar disponibilidad/i }).click();
 
-  await expect(page.getByText("No candidates available for SND-PA-T")).toBeVisible();
+  await expect(page.getByText("No hay candidatos disponibles para SND-PA-T")).toBeVisible();
 
   await page.getByRole("tab", { name: "Offers" }).click();
   await expect(page.getByText("Availability: 1 yes")).toBeVisible();


### PR DESCRIPTION
## Summary
- add shared crewing profile inference for job type, role profile overrides, profile defaults, waves, auto-close, escalation, audit, and cost/rate settings
- wire campaign settings and candidate cards to show selected profiles, role-level profiles, wave metadata, cost/rate reasons, and score explanations
- normalize auto-mode campaigns through the same policy and send guarded ranked availability waves
- add DB scoring support for custom-rate cost adjustment while preserving the `rank_staffing_candidates` return shape

## Impact
- assisted staffing gains profile-based recommendations, wave controls, and clearer candidate explanations
- auto mode now uses the same ranked candidate/availability-send workflow as assisted mode
- custom rate overrides can softly lower ranking with explicit reasons instead of excluding candidates

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run test:run -- tests/assignments/staffing-recommendations.test.ts src/features/staffing/__tests__/crewingProfiles.test.ts`
- `npm run test:run`
- `npx playwright test tests/e2e/staffing-recommendations.spec.ts`
- `npm run build`
- `npm run lint`
- `npm run lint:functions`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic job profile inference with manual override options for campaigns
  * Introduced per-role profile selection and customization
  * Enhanced candidate cards with profile labels, wave assignments, and rate information
  * Added cost-efficiency and rate-based candidate scoring
  * Implemented auto-wave sending for availability outreach in campaigns
  * Added structured score breakdown with cost and experience details

* **Bug Fixes**
  * Improved wave tracking and contact history management for candidates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->