### PR TITLE
[codex] Refresh matrix technicians on profile changes

### DIFF
--- a/src/pages/JobAssignmentMatrix.tsx
+++ b/src/pages/JobAssignmentMatrix.tsx
@@ -220,6 +220,21 @@ export default function JobAssignmentMatrix() {
     return () => { try { (dataLayerClient as any).removeChannel(ch); } catch { } };
   }, [qc]);
 
+  // Keep the technician roster fresh when users are added or edited in settings.
+  React.useEffect(() => {
+    const ch = (dataLayerClient as any)
+      .channel('rt-matrix-profiles')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'profiles' }, () => {
+        qc.invalidateQueries({ queryKey: queryKeys.scope('optimized-matrix-technicians') });
+        qc.invalidateQueries({ queryKey: queryKeys.scope('technician-fridge-status') });
+      })
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'profile_skills' }, () => {
+        qc.invalidateQueries({ queryKey: queryKeys.scope('optimized-matrix-technicians') });
+      })
+      .subscribe();
+    return () => { try { (dataLayerClient as any).removeChannel(ch); } catch { } };
+  }, [qc]);
+
   // Filter technicians based on search term
   const filteredTechnicians = useMemo(() => {
     const arr = technicians.filter((tech: any) => {
@@ -563,6 +578,11 @@ export default function JobAssignmentMatrix() {
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
+
+    await Promise.all([
+      qc.invalidateQueries({ queryKey: queryKeys.scope('optimized-matrix-technicians') }),
+      qc.invalidateQueries({ queryKey: queryKeys.scope('technician-fridge-status') }),
+    ]);
 
     // Dispatch the assignment update event to force refresh
     window.dispatchEvent(new CustomEvent('assignment-updated'));

--- a/src/pages/__tests__/JobAssignmentMatrix.test.tsx
+++ b/src/pages/__tests__/JobAssignmentMatrix.test.tsx
@@ -10,11 +10,17 @@ const {
   useQueryMock,
   useOptimizedAuthMock,
   useVirtualizedDateRangeMock,
+  queryClientMock,
   supabaseMock,
 } = vi.hoisted(() => ({
   useQueryMock: vi.fn(),
   useOptimizedAuthMock: vi.fn(),
   useVirtualizedDateRangeMock: vi.fn(),
+  queryClientMock: {
+    invalidateQueries: vi.fn(),
+    prefetchQuery: vi.fn(),
+    getQueryData: vi.fn(),
+  },
   supabaseMock: {
     from: vi.fn(),
     rpc: vi.fn(),
@@ -33,11 +39,7 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
   return {
     ...actual,
     useQuery: useQueryMock,
-    useQueryClient: () => ({
-      invalidateQueries: vi.fn(),
-      prefetchQuery: vi.fn(),
-      getQueryData: vi.fn(),
-    }),
+    useQueryClient: () => queryClientMock,
   };
 });
 
@@ -382,7 +384,16 @@ describe('JobAssignmentMatrix', () => {
     const refreshButton = screen.getByText(/Refrescar/i);
     await user.click(refreshButton);
 
-    // Should dispatch assignment-updated event
+    // Should refresh the roster queries before dispatching assignment-updated.
+    await waitFor(() => {
+      expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['optimized-matrix-technicians'],
+      });
+      expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['technician-fridge-status'],
+      });
+    });
+
     await waitFor(() => {
       expect(refreshButton).not.toBeDisabled();
     });


### PR DESCRIPTION
## Summary
- refresh matrix technician and fridge query caches when profiles or profile skills change
- make the matrix refresh button invalidate the technician roster, not only assignments
- add regression coverage for refresh invalidating roster queries

## Cause
Paula Dorado exists in production and passes the lights/search filters, but the matrix was holding the old optimized technician roster cache after the user profile update.

## Validation
- npm install --legacy-peer-deps
- npm run lint
- npm run test:run
- npm run build