### PR TITLE
[codex] Make auto staffing waves execute automatically

### DIFF
--- a/src/components/matrix/StaffingAutoModePanel.tsx
+++ b/src/components/matrix/StaffingAutoModePanel.tsx
@@ -103,7 +103,7 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
       return payload
     },
     onSuccess: () => {
-      toast({ title: 'Campaign nudged', description: 'Next tick scheduled immediately' })
+      toast({ title: 'Campaign nudged', description: 'Auto staffing tick executed' })
       invalidateAll()
     },
     onError: (error: any) => {

--- a/src/components/matrix/StaffingCampaignPanel.tsx
+++ b/src/components/matrix/StaffingCampaignPanel.tsx
@@ -398,6 +398,10 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
       })
       setShowStartDialog(false)
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_campaign', jobId, department) })
+      if (data?.campaign?.id) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_campaign_roles', data.campaign.id) })
+      }
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId) })
     },
     onError: (error: any) => {
       toast({
@@ -412,8 +416,9 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
   const updateMutation = useMutation({
     mutationFn: async () => {
       const policy = buildPolicyPayload()
+      const switchingToAuto = formData.mode === 'auto' && campaign?.mode !== 'auto'
 
-      const nextRunUpdate = formData.mode === 'auto' && campaign?.mode === 'assisted'
+      const nextRunUpdate = switchingToAuto
         ? { next_run_at: new Date().toISOString() }
         : {}
 
@@ -430,11 +435,34 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
         .single()
 
       if (error) throw error
+
+      if (switchingToAuto) {
+        const response = await fetch(
+          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/staffing-orchestrator?action=nudge`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${(await dataLayerClient.auth.getSession()).data.session?.access_token}`
+            },
+            body: JSON.stringify({ campaign_id: campaign?.id })
+          }
+        )
+        const payload = await response.json().catch(() => ({}))
+        if (!response.ok) {
+          throw new Error(payload?.error || 'Failed to start auto staffing tick')
+        }
+      }
+
       return data
     },
     onSuccess: () => {
       toast({ title: 'Settings updated' })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_campaign', jobId, department) })
+      if (campaign?.id) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_campaign_roles', campaign.id) })
+      }
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId) })
     },
     onError: (error: any) => {
       toast({

--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -555,9 +555,18 @@ async function startCampaign(
       }
     }
 
+    let initialTickResult: Awaited<ReturnType<typeof tickCampaign>> | null = null;
+    if (normalizedMode === 'auto' && campaignRoles.length > 0) {
+      initialTickResult = await tickCampaign(supabase, campaign.id);
+    }
+
     return {
       status: 200,
-      body: { campaign, roles_created: campaignRoles.length }
+      body: {
+        campaign,
+        roles_created: campaignRoles.length,
+        auto_tick: initialTickResult?.body || null,
+      }
     };
   } catch (err) {
     console.error('[staffing-orchestrator] Start campaign error:', err);
@@ -746,7 +755,21 @@ async function nudgeCampaign(
       .select()
       .single();
 
-    return { status: 200, body: { message: 'Campaign nudged', campaign: updated } };
+    if (campaign.status !== 'active') {
+      return { status: 200, body: { message: 'Campaign nudged', campaign: updated } };
+    }
+
+    const tickResult = await tickCampaign(supabase, campaign_id);
+    return {
+      status: tickResult.status,
+      body: {
+        message: tickResult.status >= 200 && tickResult.status < 300
+          ? 'Campaign ticked'
+          : 'Campaign tick failed',
+        campaign: updated,
+        tick_result: tickResult.body,
+      },
+    };
   } catch (err) {
     console.error('[staffing-orchestrator] Nudge campaign error:', err);
     return { status: 500, body: { error: 'Internal server error' } };

--- a/supabase/migrations/20260520130000_schedule_staffing_sweeper.sql
+++ b/supabase/migrations/20260520130000_schedule_staffing_sweeper.sql
@@ -1,0 +1,59 @@
+-- Schedule auto-staffing campaign ticks so auto mode can advance waves without
+-- a manager manually nudging the campaign.
+CREATE OR REPLACE FUNCTION public.invoke_staffing_sweeper()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  cfg push_cron_config%ROWTYPE;
+  request_id bigint;
+BEGIN
+  SELECT * INTO cfg FROM push_cron_config WHERE id = 1;
+
+  IF cfg.supabase_url IS NULL OR cfg.service_role_key IS NULL THEN
+    RAISE WARNING '[staffing_sweeper] push_cron_config not configured - skipping.';
+    RETURN;
+  END IF;
+
+  SELECT net.http_post(
+    url := cfg.supabase_url || '/functions/v1/staffing-sweeper',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || cfg.service_role_key,
+      'apikey', cfg.service_role_key
+    ),
+    body := jsonb_build_object('triggered_by', 'pg_cron'),
+    timeout_milliseconds := 55000
+  ) INTO request_id;
+
+  RAISE LOG '[staffing_sweeper] Invoked edge function, net request_id=%', request_id;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING '[staffing_sweeper] Failed to invoke edge function: %', SQLERRM;
+END;
+$$;
+
+ALTER FUNCTION public.invoke_staffing_sweeper() OWNER TO postgres;
+COMMENT ON FUNCTION public.invoke_staffing_sweeper() IS
+  'Invoked by pg_cron every minute to run due auto-staffing campaign ticks.';
+GRANT EXECUTE ON FUNCTION public.invoke_staffing_sweeper() TO service_role;
+
+DO $$
+BEGIN
+  IF to_regnamespace('cron') IS NULL THEN
+    RAISE WARNING '[staffing_sweeper] pg_cron is not installed; skipping schedule setup.';
+    RETURN;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'staffing-sweeper') THEN
+    PERFORM cron.unschedule('staffing-sweeper');
+  END IF;
+
+  PERFORM cron.schedule(
+    'staffing-sweeper',
+    '* * * * *',
+    'SELECT public.invoke_staffing_sweeper()'
+  );
+END;
+$$;

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -27,6 +27,11 @@ const profileRateScoringMigration = readFileSync(
   "utf-8",
 );
 
+const staffingSweeperScheduleMigration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260520130000_schedule_staffing_sweeper.sql"),
+  "utf-8",
+);
+
 const sendStaffingEmailFunction = readFileSync(
   join(process.cwd(), "supabase/functions/send-staffing-email/index.ts"),
   "utf-8",
@@ -164,5 +169,15 @@ describe("smarter staffing recommendation migration", () => {
     expect(staffingOrchestratorFunction).toContain("idempotency_key: `campaign:${campaign_id}:${roleCode}:${profileId}:availability:auto:${autoChannel}`");
     expect(staffingOrchestratorFunction).toContain("contactedProfilesByRole");
     expect(staffingOrchestratorFunction).toContain("wave_number: nextWaveNumber");
+  });
+
+  it("executes auto mode immediately and keeps future waves scheduled", () => {
+    expect(staffingOrchestratorFunction).toContain("normalizedMode === 'auto'");
+    expect(staffingOrchestratorFunction).toContain("initialTickResult = await tickCampaign(supabase, campaign.id)");
+    expect(staffingOrchestratorFunction).toContain("const tickResult = await tickCampaign(supabase, campaign_id)");
+    expect(staffingSweeperScheduleMigration).toContain("CREATE OR REPLACE FUNCTION public.invoke_staffing_sweeper()");
+    expect(staffingSweeperScheduleMigration).toContain("'/functions/v1/staffing-sweeper'");
+    expect(staffingSweeperScheduleMigration).toContain("PERFORM cron.schedule(");
+    expect(staffingSweeperScheduleMigration).toContain("'* * * * *'");
   });
 });


### PR DESCRIPTION
## Summary
- execute the first auto-staffing tick immediately when an auto campaign starts
- execute a tick when an assisted campaign is switched to auto mode
- schedule the staffing sweeper every minute via pg_cron so future waves advance automatically
- refresh campaign role and availability queries after auto ticks

## Cause
Auto mode was only setting next_run_at and waiting for a sweeper. The sweeper had an Edge Function but no migration scheduling it, so campaigns could remain active without sending Wave 1.

## Validation
- npm install --legacy-peer-deps
- npx tsc --noEmit --pretty false
- npm run test:run -- tests/assignments/staffing-recommendations.test.ts
- npm run test:run
- npm run lint
- npm run lint:functions
- npm run build
- supabase db push --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto mode campaigns now execute immediately upon creation.
  * Nudge action now triggers active staffing operations for eligible campaigns.
  * Automated background maintenance task for staffing management runs every minute.

* **Bug Fixes**
  * Updated feedback message for staffing actions to reflect actual operations performed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->