### PR TITLE
Keep auto-staffing availability waves progressing

### DIFF
--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -882,6 +882,14 @@ async function tickCampaign(
     // Assigned counts (matches JobAssignmentMatrix logic)
     const assignedCounts = new Map<string, number>();
     const assignedProfilesByRole = new Map<string, Set<string>>();
+    const anonymousAssignedCountsByRole = new Map<string, number>();
+    const refreshAssignedCount = (roleCode: string) => {
+      assignedCounts.set(
+        roleCode,
+        (assignedProfilesByRole.get(roleCode)?.size || 0) +
+          (anonymousAssignedCountsByRole.get(roleCode) || 0),
+      );
+    };
     (assignments || []).forEach((row: any) => {
       const status = String(row.status || '').toLowerCase();
       if (status === 'declined') return;
@@ -894,9 +902,10 @@ async function tickCampaign(
         const profiles = assignedProfilesByRole.get(key) || new Set<string>();
         profiles.add(profileId);
         assignedProfilesByRole.set(key, profiles);
-        assignedCounts.set(key, profiles.size);
+        refreshAssignedCount(key);
       } else {
-        assignedCounts.set(key, (assignedCounts.get(key) || 0) + 1);
+        anonymousAssignedCountsByRole.set(key, (anonymousAssignedCountsByRole.get(key) || 0) + 1);
+        refreshAssignedCount(key);
       }
     });
 
@@ -953,6 +962,7 @@ async function tickCampaign(
     const contactedProfilesByRole = new Map<string, Set<string>>();
     const offerRequestProfilesByRole = new Map<string, Set<string>>();
     const offerRequestProfilesForJob = new Set<string>();
+    const activeOfferProfilesForJob = new Set<string>();
 
     for (const r of requestRows) {
       const roleCode = requestIdToRole.get(String(r.id));
@@ -965,6 +975,9 @@ async function tickCampaign(
 
       if (phase === 'offer' && ['pending', 'confirmed', 'declined'].includes(status)) {
         offerRequestProfilesForJob.add(profileId);
+      }
+      if (phase === 'offer' && ['pending', 'confirmed'].includes(status)) {
+        activeOfferProfilesForJob.add(profileId);
       }
 
       if (phase === 'availability') {
@@ -1038,7 +1051,8 @@ async function tickCampaign(
         .filter((profileId) =>
           !assignedProfiles.has(profileId) &&
           !acceptedOfferProfiles.has(profileId) &&
-          !pendingOfferProfiles.has(profileId)
+          !pendingOfferProfiles.has(profileId) &&
+          !activeOfferProfilesForJob.has(profileId)
         )
         .length;
       const hasConfirmedAvailabilityForRole = matchingRequestedRole.some((request: any) => {

--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -860,7 +860,7 @@ async function tickCampaign(
         .eq('department', campaign.department),
       supabase
         .from('job_assignments')
-        .select(`status, ${assignmentColumn}`)
+        .select(`status, technician_id, ${assignmentColumn}`)
         .eq('job_id', campaign.job_id),
       supabase
         .from('staffing_requests')
@@ -881,6 +881,7 @@ async function tickCampaign(
 
     // Assigned counts (matches JobAssignmentMatrix logic)
     const assignedCounts = new Map<string, number>();
+    const assignedProfilesByRole = new Map<string, Set<string>>();
     (assignments || []).forEach((row: any) => {
       const status = String(row.status || '').toLowerCase();
       if (status === 'declined') return;
@@ -888,7 +889,15 @@ async function tickCampaign(
       if (!roleCode) return;
       const key = String(roleCode).trim();
       if (!key) return;
-      assignedCounts.set(key, (assignedCounts.get(key) || 0) + 1);
+      const profileId = String(row.technician_id || '');
+      if (profileId) {
+        const profiles = assignedProfilesByRole.get(key) || new Set<string>();
+        profiles.add(profileId);
+        assignedProfilesByRole.set(key, profiles);
+        assignedCounts.set(key, profiles.size);
+      } else {
+        assignedCounts.set(key, (assignedCounts.get(key) || 0) + 1);
+      }
     });
 
     // Resolve role_code per staffing_request via the latest send event (email/whatsapp)
@@ -1005,25 +1014,51 @@ async function tickCampaign(
     for (const role of (campaignRoles || []) as any[]) {
       const roleCode = String(role.role_code).trim();
       const required = requiredByRole.get(roleCode) || 0;
+      const assignedProfiles = assignedProfilesByRole.get(roleCode) || new Set<string>();
       const assigned = assignedCounts.get(roleCode) || 0;
-      let pendingAvailability = countsByRole[roleCode]?.availability.pending.size || 0;
+      const pendingAvailabilityProfiles = countsByRole[roleCode]?.availability.pending || new Set<string>();
+      const pendingOfferProfiles = countsByRole[roleCode]?.offer.pending || new Set<string>();
+      const acceptedOfferProfiles = countsByRole[roleCode]?.offer.confirmed || new Set<string>();
+      let pendingAvailability = pendingAvailabilityProfiles.size;
       const matchingRequestedRole = confirmedAvailabilityByRequestedRole.get(roleCode) || [];
       const confirmedAvailability = new Set(
         matchingRequestedRole
           .map((request: any) => String(request.profile_id || ''))
           .filter(Boolean),
       ).size;
-      let pendingOffers = countsByRole[roleCode]?.offer.pending.size || 0;
-      const acceptedOffers = countsByRole[roleCode]?.offer.confirmed.size || 0;
+      let pendingOffers = pendingOfferProfiles.size;
+      const acceptedOffers = acceptedOfferProfiles.size;
+      const acceptedOffersNotAssigned = Array.from(acceptedOfferProfiles)
+        .filter((profileId) => !assignedProfiles.has(profileId))
+        .length;
+      const pendingOffersForCapacity = Array.from(pendingOfferProfiles)
+        .filter((profileId) => !assignedProfiles.has(profileId) && !acceptedOfferProfiles.has(profileId))
+        .length;
+      const pendingAvailabilityForCapacity = Array.from(pendingAvailabilityProfiles)
+        .filter((profileId) =>
+          !assignedProfiles.has(profileId) &&
+          !acceptedOfferProfiles.has(profileId) &&
+          !pendingOfferProfiles.has(profileId)
+        )
+        .length;
       const hasConfirmedAvailabilityForRole = matchingRequestedRole.some((request: any) => {
         const profileId = String(request.profile_id || '');
-        return profileId && !offerRequestProfilesForJob.has(profileId);
+        return profileId && !assignedProfiles.has(profileId) && !offerRequestProfilesForJob.has(profileId);
       });
+      const confirmedAvailabilityReadyCount = new Set(
+        matchingRequestedRole
+          .map((request: any) => String(request.profile_id || ''))
+          .filter((profileId) =>
+            profileId &&
+            !assignedProfiles.has(profileId) &&
+            !offerRequestProfilesForJob.has(profileId)
+          ),
+      ).size;
 
       let stage = 'idle';
       if (required <= 0 || assigned >= required) {
         stage = 'filled';
-      } else if (pendingOffers > 0 || acceptedOffers > 0 || hasConfirmedAvailabilityForRole) {
+      } else if (pendingOffersForCapacity > 0 || acceptedOffersNotAssigned > 0 || hasConfirmedAvailabilityForRole) {
         stage = 'offer';
       } else {
         stage = 'availability';
@@ -1033,21 +1068,26 @@ async function tickCampaign(
 
       let nextWaveNumber = Number(role.wave_number || 0);
       let nextLastWaveAt = role.last_wave_at || null;
+      const pipelineCoverage = assigned +
+        acceptedOffersNotAssigned +
+        pendingOffersForCapacity +
+        confirmedAvailabilityReadyCount +
+        pendingAvailabilityForCapacity;
+      const availabilityShortfall = Math.max(0, required - pipelineCoverage);
 
       if (
         campaign.mode === 'auto' &&
-        stage === 'availability' &&
+        stage !== 'filled' &&
         (policy.waves?.auto_send_next_wave ?? true) &&
-        pendingAvailability === 0
+        availabilityShortfall > 0
       ) {
         const alreadyContacted = contactedProfilesByRole.get(roleCode) || new Set<string>();
-        const remainingNeeded = Math.max(0, required - assigned - acceptedOffers);
         const waveMode = policy.waves?.mode || 'controlled_waves';
         const waveBuffer = Number(policy.waves?.buffer ?? policy.offer_buffer ?? 1);
         const fixedWaveSize = Math.max(1, Number(policy.waves?.fixed_size || 50));
         const waveSize = waveMode === 'blast_all_eligible'
           ? fixedWaveSize
-          : Math.max(1, remainingNeeded + waveBuffer);
+          : Math.max(1, availabilityShortfall + waveBuffer);
 
         const { data: rankedCandidates, error: rankError } = await supabase.rpc('rank_staffing_candidates', {
           p_job_id: campaign.job_id,
@@ -1149,12 +1189,12 @@ async function tickCampaign(
       }
 
       if (shouldPrioritizeAssistedHandoff && stage === 'offer') {
-        const capacity = Math.max(0, required - assigned - acceptedOffers - pendingOffers);
+        const capacity = Math.max(0, required - assigned - acceptedOffersNotAssigned - pendingOffersForCapacity);
         const profilesWithOffer = offerRequestProfilesByRole.get(roleCode) || new Set<string>();
         const confirmedAvailabilityRows = matchingRequestedRole
           .filter((request: any) => {
             const profileId = String(request.profile_id || '');
-            return profileId && !profilesWithOffer.has(profileId) && !offerRequestProfilesForJob.has(profileId);
+            return profileId && !assignedProfiles.has(profileId) && !profilesWithOffer.has(profileId) && !offerRequestProfilesForJob.has(profileId);
           })
           .sort((a: any, b: any) => {
             const aTime = new Date(a.updated_at || 0).getTime();


### PR DESCRIPTION
## Summary\n- keep auto campaigns sending availability waves when open role demand is not covered by the active staffing pipeline\n- avoid double-counting confirmed offers that already created assignments when calculating auto capacity\n- allow offer handoff and availability outreach to progress in parallel for assisted-to-auto campaigns\n\n## Validation\n- npm install --legacy-peer-deps\n- npm run lint:functions\n- deno check skipped: deno not available locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced role-based assignment tracking to accurately prevent duplicate offers and assignments for each role
  * Improved automated contact wave logic to make smarter decisions about when to initiate availability and offer outreach
  * Refined staffing stage calculations to use more accurate pipeline coverage and capacity-based metrics
  * Strengthened candidate filtering to exclude profiles already assigned or currently in the offer pipeline

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->