### PR TITLE
Brand auto-staffing notifications as C.A.R.L.O.S.

### DIFF
--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -20,6 +20,7 @@ import { JobDetailsPersonnelTab } from "./job-details-dialog/tabs/JobDetailsPers
 import { JobDetailsRestaurantsTab } from "./job-details-dialog/tabs/JobDetailsRestaurantsTab";
 import { JobDetailsWeatherTab } from "./job-details-dialog/tabs/JobDetailsWeatherTab";
 import { StaffingOrchestratorPanel } from "@/components/matrix/StaffingOrchestratorPanel";
+import { CARLOS_AGENT_NAME } from "@/features/staffing/carlos";
 import { useJobExpenses } from "@/hooks/useJobExpenses";
 import { canAccessExpenses, canAssignPersonnel, canManagePayouts, isManagementRole, isTechnicianRole } from "@/utils/permissions";
 import { getVisibleFinancialTechnicianIds } from "@/components/jobs/financialViewerScope";
@@ -237,7 +238,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
               )}
               {!isDryhire && canSeeAutoStaffing && (
                 <TabsTrigger value="staffing" className="py-2">
-                  Auto staffing
+                  {CARLOS_AGENT_NAME}
                 </TabsTrigger>
               )}
               {!isDryhire && (

--- a/src/components/matrix/StaffingAutoModePanel.tsx
+++ b/src/components/matrix/StaffingAutoModePanel.tsx
@@ -7,9 +7,14 @@ import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast'
 import { format } from 'date-fns'
 import { Play, Pause, Square, Zap } from 'lucide-react'
+import {
+  CARLOS_AGENT_DESCRIPTION,
+  CARLOS_AGENT_NAME,
+} from '@/features/staffing/carlos'
 
 
 import { queryKeys } from "@/lib/react-query";
+
 interface StaffingAutoModePanelProps {
   campaign: any
   campaignRoles: any[]
@@ -55,7 +60,7 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
       return payload
     },
     onSuccess: () => {
-      toast({ title: 'Campaign paused' })
+      toast({ title: `${CARLOS_AGENT_NAME} pausado` })
       invalidateAll()
     },
     onError: (error: any) => {
@@ -79,7 +84,7 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
       return payload
     },
     onSuccess: () => {
-      toast({ title: 'Campaign resumed' })
+      toast({ title: `${CARLOS_AGENT_NAME} reanudado` })
       invalidateAll()
     },
     onError: (error: any) => {
@@ -103,7 +108,10 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
       return payload
     },
     onSuccess: () => {
-      toast({ title: 'Campaign nudged', description: 'Auto staffing tick executed' })
+      toast({
+        title: `Oleada de ${CARLOS_AGENT_NAME} ejecutada`,
+        description: `Se ejecutó un ciclo de ${CARLOS_AGENT_NAME}`,
+      })
       invalidateAll()
     },
     onError: (error: any) => {
@@ -127,7 +135,7 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
       return payload
     },
     onSuccess: () => {
-      toast({ title: 'Campaign stopped' })
+      toast({ title: `${CARLOS_AGENT_NAME} detenido` })
       invalidateAll()
     },
     onError: (error: any) => {
@@ -154,7 +162,10 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
       return response.json()
     },
     onSuccess: () => {
-      toast({ title: 'Campaign escalated', description: 'Next escalation step activated' })
+      toast({
+        title: `${CARLOS_AGENT_NAME} escalado`,
+        description: 'Siguiente nivel de escalado activado',
+      })
       setShowEscalationWarning(false)
       invalidateAll()
     },
@@ -197,8 +208,8 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle>Auto Mode Campaign</CardTitle>
-              <CardDescription>System-driven staffing automation</CardDescription>
+              <CardTitle>{CARLOS_AGENT_NAME}</CardTitle>
+              <CardDescription>{CARLOS_AGENT_DESCRIPTION}</CardDescription>
             </div>
             <div className="text-right">
               <Badge className="mb-2 block bg-blue-100 text-blue-800">

--- a/src/components/matrix/StaffingCampaignPanel.tsx
+++ b/src/components/matrix/StaffingCampaignPanel.tsx
@@ -20,9 +20,14 @@ import {
   inferJobProfile,
   JobProfileName,
 } from '@/features/staffing/crewingProfiles'
+import {
+  CARLOS_AGENT_NAME,
+  CARLOS_AUTO_MODE_LABEL,
+} from '@/features/staffing/carlos'
 
 
 import { queryKeys } from "@/lib/react-query";
+
 interface StaffingCampaignPanelProps {
   jobId: string
   department: string
@@ -450,7 +455,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
         )
         const payload = await response.json().catch(() => ({}))
         if (!response.ok) {
-          throw new Error(payload?.error || 'Failed to start auto staffing tick')
+          throw new Error(payload?.error || `No se pudo iniciar el ciclo de ${CARLOS_AGENT_NAME}`)
         }
       }
 
@@ -775,7 +780,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
           checked={formData.autoSendNextWave}
           onChange={(e) => setFormData({ ...formData, autoSendNextWave: e.target.checked })}
         />
-        <span className="text-sm">Enviar siguiente oleada automáticamente en modo Auto</span>
+        <span className="text-sm">Enviar siguiente oleada automáticamente con {CARLOS_AGENT_NAME}</span>
       </label>
 
       <div className="rounded border bg-background p-3 text-xs text-muted-foreground">
@@ -810,9 +815,10 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                 {/* Mode Selection */}
                 <div>
                   <label className="text-sm font-medium">Mode</label>
-                  <div className="flex gap-4 mt-2">
-                    <label className="flex items-center gap-2 cursor-pointer">
+                  <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:gap-4">
+                    <label className="flex min-w-0 items-start gap-2 cursor-pointer">
                       <input
+                        className="mt-1"
                         type="radio"
                         name="mode"
                         value="assisted"
@@ -821,15 +827,16 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                       />
                       <span className="text-sm">Assisted (Manager-controlled)</span>
                     </label>
-                    <label className="flex items-center gap-2 cursor-pointer">
+                    <label className="flex min-w-0 items-start gap-2 cursor-pointer">
                       <input
+                        className="mt-1"
                         type="radio"
                         name="mode"
                         value="auto"
                         checked={formData.mode === 'auto'}
                         onChange={() => updateMode('auto')}
                       />
-                      <span className="text-sm">Auto (System-driven)</span>
+                      <span className="text-sm leading-snug">{CARLOS_AUTO_MODE_LABEL}</span>
                     </label>
                   </div>
                 </div>
@@ -927,11 +934,11 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                     onChange={(e) => setFormData({ ...formData, softConflictPolicy: e.target.value as any })}
                     className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
                   >
-                    <option value="block">Block (Auto mode default)</option>
-                    <option value="warn">Warn (Assisted mode)</option>
-                    <option value="manager_approval">Manager approval</option>
-                    <option value="ignore">Ignore</option>
-                    <option value="allow">Allow (legacy escalation)</option>
+                    <option value="block">Bloquear (predeterminado de {CARLOS_AGENT_NAME})</option>
+                    <option value="warn">Avisar (modo asistido)</option>
+                    <option value="manager_approval">Aprobación de responsable</option>
+                    <option value="ignore">Ignorar</option>
+                    <option value="allow">Permitir (escalado heredado)</option>
                   </select>
                 </div>
 
@@ -1020,7 +1027,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
         <div className="grid grid-cols-2 gap-4 text-sm">
           <div>
             <p className="text-gray-600">Mode</p>
-            <p className="font-medium">{campaign.mode === 'assisted' ? 'Assisted' : 'Automatic'}</p>
+            <p className="font-medium">{campaign.mode === 'assisted' ? 'Asistido' : CARLOS_AGENT_NAME}</p>
           </div>
           <div>
             <p className="text-gray-600">Created</p>
@@ -1070,9 +1077,10 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
             {/* Mode Selection */}
             <div>
               <label className="text-sm font-medium">Mode</label>
-              <div className="flex gap-4 mt-2">
-                <label className="flex items-center gap-2 cursor-pointer">
+              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:gap-4">
+                <label className="flex min-w-0 items-start gap-2 cursor-pointer">
                   <input
+                    className="mt-1"
                     type="radio"
                     name="active_mode"
                     value="assisted"
@@ -1081,15 +1089,16 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                   />
                   <span className="text-sm">Assisted (Manager-controlled)</span>
                 </label>
-                <label className="flex items-center gap-2 cursor-pointer">
+                <label className="flex min-w-0 items-start gap-2 cursor-pointer">
                   <input
+                    className="mt-1"
                     type="radio"
                     name="active_mode"
                     value="auto"
                     checked={formData.mode === 'auto'}
                     onChange={() => updateMode('auto')}
                   />
-                  <span className="text-sm">Auto (System-driven)</span>
+                  <span className="text-sm leading-snug">{CARLOS_AUTO_MODE_LABEL}</span>
                 </label>
               </div>
             </div>
@@ -1160,11 +1169,11 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                 onChange={(e) => setFormData({ ...formData, softConflictPolicy: e.target.value as any })}
                 className="w-full mt-1 px-2 py-1 border rounded text-sm bg-background"
               >
-                <option value="block">Block (Auto mode default)</option>
-                <option value="warn">Warn (Assisted mode)</option>
-                <option value="manager_approval">Manager approval</option>
-                <option value="ignore">Ignore</option>
-                <option value="allow">Allow (legacy escalation)</option>
+                <option value="block">Bloquear (predeterminado de {CARLOS_AGENT_NAME})</option>
+                <option value="warn">Avisar (modo asistido)</option>
+                <option value="manager_approval">Aprobación de responsable</option>
+                <option value="ignore">Ignorar</option>
+                <option value="allow">Permitir (escalado heredado)</option>
               </select>
             </div>
 
@@ -1180,7 +1189,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
               </select>
               {campaign.mode === 'assisted' && formData.mode === 'auto' && (
                 <p className="text-xs text-gray-600 mt-1">
-                  Auto mode will use existing assisted availability and offer responses before contacting new candidates.
+                  {CARLOS_AGENT_NAME} usará respuestas existentes de disponibilidad y oferta en modo asistido antes de contactar nuevos candidatos.
                 </p>
               )}
             </div>

--- a/src/features/staffing/carlos.ts
+++ b/src/features/staffing/carlos.ts
@@ -1,0 +1,4 @@
+export const CARLOS_AGENT_NAME = 'C.A.R.L.O.S.'
+export const CARLOS_AGENT_DESCRIPTION =
+  'Coordinador Automático de Recursos, Logística, Ofertas y Selección'
+export const CARLOS_AUTO_MODE_LABEL = `${CARLOS_AGENT_NAME} (${CARLOS_AGENT_DESCRIPTION})`

--- a/src/pages/__tests__/JobAssignmentMatrix.test.tsx
+++ b/src/pages/__tests__/JobAssignmentMatrix.test.tsx
@@ -598,10 +598,10 @@ describe('JobAssignmentMatrix', () => {
     await user.click(reminderButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Auto staffing/i)).toBeInTheDocument();
+      expect(screen.getByText(/C\.A\.R\.L\.O\.S\./i)).toBeInTheDocument();
     });
 
-    const autoStaffingButton = screen.getByText(/Auto staffing/i);
+    const autoStaffingButton = screen.getByText(/C\.A\.R\.L\.O\.S\./i);
     await user.click(autoStaffingButton);
 
     await waitFor(() => {

--- a/src/pages/job-assignment-matrix/StaffingReminderDialogs.tsx
+++ b/src/pages/job-assignment-matrix/StaffingReminderDialogs.tsx
@@ -1,6 +1,10 @@
 import { StaffingOrchestratorPanel } from '@/components/matrix/StaffingOrchestratorPanel';
 import { Button } from '@/components/ui/button';
 import {
+  CARLOS_AGENT_DESCRIPTION,
+  CARLOS_AGENT_NAME,
+} from '@/features/staffing/carlos';
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -72,7 +76,7 @@ export const StaffingReminderDialogs = ({
                           setShowStaffingReminder(false);
                         }}
                       >
-                        Auto staffing
+                        {CARLOS_AGENT_NAME}
                       </Button>
                     </div>
                     <ul className="ml-4 mt-1 list-disc space-y-1 text-sm text-muted-foreground">
@@ -105,11 +109,13 @@ export const StaffingReminderDialogs = ({
       <DialogContent className="max-w-5xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
-            Auto staffing{staffingOrchestratorTarget?.jobTitle ? ` — ${staffingOrchestratorTarget.jobTitle}` : ''}
+            {CARLOS_AGENT_NAME}
+            {staffingOrchestratorTarget?.jobTitle ? ` - ${staffingOrchestratorTarget.jobTitle}` : ''}
           </DialogTitle>
           <DialogDescription>
+            {CARLOS_AGENT_DESCRIPTION}
             {staffingOrchestratorTarget?.department
-              ? `Departamento: ${DEPARTMENT_LABELS[staffingOrchestratorTarget.department] || formatLabel(staffingOrchestratorTarget.department)}`
+              ? ` - Departamento: ${DEPARTMENT_LABELS[staffingOrchestratorTarget.department] || formatLabel(staffingOrchestratorTarget.department)}`
               : null}
           </DialogDescription>
         </DialogHeader>

--- a/supabase/functions/push/broadcast.ts
+++ b/supabase/functions/push/broadcast.ts
@@ -23,6 +23,11 @@ import {
 import { formatSpanishMediumDate, normalizeDateKey } from "./broadcast/date.ts";
 import { routeBroadcastEvent } from "./broadcast/eventRouter.ts";
 import { getScopedManagementIds as resolveScopedManagementIds } from "./broadcast/recipients.ts";
+import {
+  CARLOS_AGENT_DESCRIPTION,
+  CARLOS_AGENT_NAME,
+  isCarlosStaffingRequest,
+} from "./broadcast/staffingIdentity.ts";
 import type {
   BroadcastEventContext,
   BroadcastMessageState,
@@ -60,6 +65,7 @@ export async function handleBroadcast(
   const tourId = body.tour_id;
   const tourName = body.tour_name || (await getTourName(client, tourId)) || null;
   const routes = await getPushNotificationRoutes(client, type);
+  const sentByCarlos = isCarlosStaffingRequest(body.request_origin);
 
   const recipients = new Set<string>();
   const naturalRecipients = new Set<string>();
@@ -95,7 +101,9 @@ export async function handleBroadcast(
 
   const url = validateInternalUrl(body.url) || resolveNotificationUrl(type, jobId, tourId, jobType);
   const actorIdForLookup = body.actor_id || userId;
-  const actor = body.actor_name || (await getProfileDisplayName(client, actorIdForLookup)) || 'Alguien';
+  const actor = sentByCarlos
+    ? CARLOS_AGENT_NAME
+    : body.actor_name || (await getProfileDisplayName(client, actorIdForLookup)) || 'Alguien';
   const recipName = body.recipient_name || (await getProfileDisplayName(client, body.recipient_id)) || '';
   const channelLabel = channelEs(body.channel);
   const rawTargetDate = typeof body.target_date === 'string' ? body.target_date : undefined;
@@ -199,6 +207,7 @@ export async function handleBroadcast(
       tourId,
       tourName: tourName ?? undefined,
       actor,
+      ...(sentByCarlos ? { actorDescription: CARLOS_AGENT_DESCRIPTION } : {}),
       recipient: recipName,
       channel: channelLabel,
       ...(body.department ? { department: body.department } : {}),

--- a/supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
+++ b/supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
@@ -24,6 +24,76 @@ import {
   buildTourDateTypeChangedMessage,
 } from "../messages/tourMessages.ts";
 import type { BroadcastBody } from "../../types.ts";
+import type { BroadcastEventContext } from "../eventContext.ts";
+import { handleStaffingEvents } from "../families/staffingEvents.ts";
+import { CARLOS_AGENT_NAME } from "../staffingIdentity.ts";
+
+function createStaffingContext(overrides: Partial<BroadcastEventContext> = {}): BroadcastEventContext {
+  const state = { title: "", text: "", url: "/jobs/job-1", metaExtras: {} };
+  const recipients = new Set<string>();
+  const naturalRecipients = new Set<string>();
+  const management = new Set<string>();
+  const soundDept = new Set<string>();
+  const admin = new Set<string>();
+  const mgmt = new Set<string>();
+  const participants = new Set<string>();
+  const audience = {
+    recipients,
+    naturalRecipients,
+    management,
+    soundDept,
+    admin,
+    mgmt,
+    participants,
+    addRecipients: (ids: (string | null | undefined)[]) => {
+      ids.forEach((id) => {
+        if (id) recipients.add(id);
+      });
+    },
+    addNaturalRecipients: (ids: (string | null | undefined)[]) => {
+      ids.forEach((id) => {
+        if (id) naturalRecipients.add(id);
+      });
+    },
+    clearAllRecipients: () => {
+      recipients.clear();
+      naturalRecipients.clear();
+      management.clear();
+      soundDept.clear();
+      admin.clear();
+      mgmt.clear();
+      participants.clear();
+    },
+  };
+
+  return {
+    client: {} as BroadcastEventContext["client"],
+    userId: "manager-1",
+    body: {
+      action: "broadcast",
+      type: "staffing.offer.sent",
+      recipient_id: "tech-1",
+      request_origin: "auto_staffing",
+    },
+    type: "staffing.offer.sent",
+    jobId: "job-1",
+    jobTitle: "RBF",
+    jobDepartment: "sound",
+    jobType: null,
+    tourName: null,
+    routes: [],
+    actor: CARLOS_AGENT_NAME,
+    recipName: "Ana",
+    channelLabel: "email",
+    normalizedTargetDate: null,
+    formattedTargetDate: null,
+    singleDayFlag: false,
+    state,
+    audience,
+    getScopedManagementIds: async () => ["manager-2"],
+    ...overrides,
+  };
+}
 
 describe("push broadcast event message builders", () => {
   it("summarizes job update fields with Spanish labels", () => {
@@ -142,5 +212,32 @@ describe("push broadcast event message builders", () => {
       title: "Fecha cambiada a Viaje",
       text: 'Eva cambió "Madrid" a Viaje en "Gira Primavera".',
     });
+  });
+
+  it("brands auto-staffing offer sends as C.A.R.L.O.S.", async () => {
+    const context = createStaffingContext();
+
+    await expect(handleStaffingEvents(context)).resolves.toBe(true);
+
+    expect(context.state.title).toBe("Oferta enviada por C.A.R.L.O.S.");
+    expect(context.state.text).toBe("C.A.R.L.O.S. envió oferta a Ana (email).");
+    expect(context.audience.recipients.has("tech-1")).toBe(true);
+    expect(context.audience.naturalRecipients.has("manager-2")).toBe(true);
+  });
+
+  it("keeps manual staffing offer sends attributed to the user", async () => {
+    const context = createStaffingContext({
+      actor: "Laura",
+      body: {
+        action: "broadcast",
+        type: "staffing.offer.sent",
+        recipient_id: "tech-1",
+      },
+    });
+
+    await expect(handleStaffingEvents(context)).resolves.toBe(true);
+
+    expect(context.state.title).toBe("Oferta enviada");
+    expect(context.state.text).toBe("Laura envió oferta a Ana (email).");
   });
 });

--- a/supabase/functions/push/broadcast/families/staffingEvents.ts
+++ b/supabase/functions/push/broadcast/families/staffingEvents.ts
@@ -1,10 +1,15 @@
 import type { BroadcastEventContext, BroadcastHandlerResult } from "../eventContext.ts";
 import { setBroadcastMessage } from "../eventContext.ts";
+import {
+  CARLOS_AGENT_NAME,
+  isCarlosStaffingRequest,
+} from "../staffingIdentity.ts";
 
 export async function handleStaffingEvents(context: BroadcastEventContext): Promise<BroadcastHandlerResult> {
   const { type, body, actor, recipName, channelLabel, jobTitle, state, audience } = context;
   const isStaffingEvent = type.startsWith('staffing.');
   const recipientId = body.recipient_id?.trim();
+  const sentByCarlos = isCarlosStaffingRequest(body.request_origin);
 
   if (isStaffingEvent && !recipientId) {
     audience.clearAllRecipients();
@@ -12,14 +17,22 @@ export async function handleStaffingEvents(context: BroadcastEventContext): Prom
   }
 
   if (type === 'staffing.availability.sent') {
-    setBroadcastMessage(state, 'Solicitud de disponibilidad enviada', `${actor} envió solicitud a ${recipName || 'técnico'} (${channelLabel}).`);
+    setBroadcastMessage(
+      state,
+      sentByCarlos ? `Solicitud enviada por ${CARLOS_AGENT_NAME}` : 'Solicitud de disponibilidad enviada',
+      `${actor} envió solicitud a ${recipName || 'técnico'} (${channelLabel}).`,
+    );
     audience.addNaturalRecipients(await context.getScopedManagementIds(recipientId, 'staffing.availability.sent'));
     audience.addRecipients([recipientId]);
     return true;
   }
 
   if (type === 'staffing.offer.sent') {
-    setBroadcastMessage(state, 'Oferta enviada', `${actor} envió oferta a ${recipName || 'técnico'} (${channelLabel}).`);
+    setBroadcastMessage(
+      state,
+      sentByCarlos ? `Oferta enviada por ${CARLOS_AGENT_NAME}` : 'Oferta enviada',
+      `${actor} envió oferta a ${recipName || 'técnico'} (${channelLabel}).`,
+    );
     audience.addNaturalRecipients(await context.getScopedManagementIds(recipientId, 'staffing.offer.sent'));
     audience.addRecipients([recipientId]);
     return true;

--- a/supabase/functions/push/broadcast/staffingIdentity.ts
+++ b/supabase/functions/push/broadcast/staffingIdentity.ts
@@ -1,0 +1,8 @@
+export const CARLOS_AGENT_NAME = 'C.A.R.L.O.S.';
+export const CARLOS_AGENT_DESCRIPTION =
+  'Coordinador Automático de Recursos, Logística, Ofertas y Selección';
+export const CARLOS_REQUEST_ORIGIN = 'auto_staffing';
+
+export function isCarlosStaffingRequest(requestOrigin: string | null | undefined): boolean {
+  return requestOrigin === CARLOS_REQUEST_ORIGIN;
+}

--- a/tests/e2e/staffing-recommendations.spec.ts
+++ b/tests/e2e/staffing-recommendations.spec.ts
@@ -214,7 +214,7 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
   await page.goto("/job-assignment-matrix");
 
   await page.getByRole("button", { name: /ver recordatorio de staffing/i }).click();
-  await page.getByRole("button", { name: "Auto staffing" }).click();
+  await page.getByRole("button", { name: "C.A.R.L.O.S." }).click();
   await expect(page.getByText("Required 2")).toBeVisible();
   await expect(page.getByText("0/2 assigned")).toBeVisible();
 


### PR DESCRIPTION
## Summary
- Rename user-facing auto-staffing labels to C.A.R.L.O.S. and add the expanded Spanish description where there is room.
- Make auto-staffing availability/offer push notifications display C.A.R.L.O.S. as the sender when `request_origin` is `auto_staffing`.
- Keep manual staffing pushes attributed to the initiating user and add regression coverage for auto vs manual offer notifications.

## Validation
- npm install --legacy-peer-deps
- npm run lint:functions
- npm run test:run -- supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
- npm run lint
- PATH=/opt/homebrew/Cellar/node@22/22.22.0/bin:$PATH npm run test:run
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced C.A.R.L.O.S. (Coordinador Automático de Recursos, Logística, Ofertas y Selección) agent branding throughout staffing and job assignment features. UI labels, dialogs, and push notifications now reference the agent by name instead of generic auto-staffing terminology.

* **Tests**
  * Updated test cases to validate C.A.R.L.O.S. agent naming and branding in staffing operations and push notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->