### PR TITLE
[codex] Fix staffing job data fetch

### DIFF
--- a/supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
+++ b/supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildJobDateTypeChangedMessage,
@@ -27,6 +27,7 @@ import type { BroadcastBody } from "../../types.ts";
 import type { BroadcastEventContext } from "../eventContext.ts";
 import { handleStaffingEvents } from "../families/staffingEvents.ts";
 import { CARLOS_AGENT_NAME } from "../staffingIdentity.ts";
+import { getJobDepartment } from "../../data.ts";
 
 function createStaffingContext(overrides: Partial<BroadcastEventContext> = {}): BroadcastEventContext {
   const state = { title: "", text: "", url: "/jobs/job-1", metaExtras: {} };
@@ -261,5 +262,51 @@ describe("push broadcast event message builders", () => {
 
     expect(scopedDepartment).toBe("sound");
     expect(context.audience.naturalRecipients.has("sound-manager")).toBe(true);
+  });
+
+  it("resolves unambiguous job departments from job_departments", async () => {
+    const query = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      order: vi.fn(),
+    };
+    query.select.mockReturnValue(query);
+    query.eq.mockReturnValue(query);
+    query.order.mockResolvedValue({ data: [{ department: " sound " }], error: null });
+    const client = {
+      from: vi.fn(() => query),
+    };
+
+    await expect(
+      getJobDepartment(client as unknown as Parameters<typeof getJobDepartment>[0], "job-1"),
+    ).resolves.toBe("sound");
+
+    expect(client.from).toHaveBeenCalledWith("job_departments");
+    expect(query.select).toHaveBeenCalledWith("department");
+    expect(query.eq).toHaveBeenCalledWith("job_id", "job-1");
+  });
+
+  it("does not guess a job department when a job spans multiple departments", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const query = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      order: vi.fn(),
+    };
+    query.select.mockReturnValue(query);
+    query.eq.mockReturnValue(query);
+    query.order.mockResolvedValue({
+      data: [{ department: "sound" }, { department: "lights" }],
+      error: null,
+    });
+    const client = {
+      from: vi.fn(() => query),
+    };
+
+    await expect(
+      getJobDepartment(client as unknown as Parameters<typeof getJobDepartment>[0], "job-1"),
+    ).resolves.toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/supabase/functions/push/data.ts
+++ b/supabase/functions/push/data.ts
@@ -321,12 +321,28 @@ export async function getJobTitle(client: ReturnType<typeof createClient>, jobId
 export async function getJobDepartment(client: ReturnType<typeof createClient>, jobId?: string): Promise<string | null> {
   if (!jobId) return null;
   try {
-    const { data, error } = await client.from('jobs').select('department').eq('id', jobId).maybeSingle();
+    const { data, error } = await client
+      .from('job_departments')
+      .select('department')
+      .eq('job_id', jobId)
+      .order('department', { ascending: true });
     if (error) {
       console.error('⚠️ Failed to fetch job department:', { jobId, error });
       return null;
     }
-    return data?.department ?? null;
+    const departments = Array.from(new Set(
+      (data || [])
+        .map((row: { department?: unknown }) => typeof row.department === 'string' ? row.department.trim() : '')
+        .filter(Boolean)
+    ));
+    if (departments.length === 1) return departments[0];
+    if (departments.length > 1) {
+      console.warn('⚠️ Job has multiple departments; skipping ambiguous job department fallback:', {
+        jobId,
+        departments,
+      });
+    }
+    return null;
   } catch (err) {
     console.error('⚠️ Exception fetching job department:', { jobId, err });
     return null;
@@ -417,4 +433,3 @@ export async function resolveSoundVisionVenueName(
 
   return null;
 }
-

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -441,13 +441,18 @@ serve(async (req) => {
           return query;
         })()
         : Promise.resolve({ data: null, error: null });
+      const jobDepartmentsPromise = !departmentHint
+        ? supabase.from("job_departments")
+          .select("department")
+          .eq("job_id", job_id)
+          .order("department", { ascending: true })
+        : Promise.resolve({ data: null, error: null });
 
-      const [jobResult, techResult, actorResult, roleDepartmentResult] = await Promise.all([
+      const [jobResult, techResult, actorResult, roleDepartmentResult, jobDepartmentsResult] = await Promise.all([
         supabase.from("jobs")
           .select(`
             id,
             title,
-            department,
             start_time,
             end_time,
             locations(formatted_address)
@@ -457,6 +462,7 @@ serve(async (req) => {
         supabase.from("profiles").select("id,first_name,last_name,email,phone").eq("id", profile_id).maybeSingle(),
         actorId ? supabase.from("profiles").select("waha_endpoint, department").eq("id", actorId).maybeSingle() : Promise.resolve({ data: null, error: null }),
         roleDepartmentPromise,
+        jobDepartmentsPromise,
       ]);
       
       console.log('📋 JOB RESULT:', { data: jobResult.data, error: jobResult.error });
@@ -466,6 +472,9 @@ serve(async (req) => {
       });
       if (roleDepartmentResult.error) {
         console.warn('⚠️ ROLE DEPARTMENT LOOKUP FAILED (non-blocking):', roleDepartmentResult.error);
+      }
+      if (jobDepartmentsResult.error) {
+        console.warn('⚠️ JOB DEPARTMENTS LOOKUP FAILED (non-blocking):', jobDepartmentsResult.error);
       }
 
       if (jobResult.error) {
@@ -495,16 +504,27 @@ serve(async (req) => {
       const roleDepartmentRows = Array.isArray(roleDepartmentResult.data)
         ? roleDepartmentResult.data as Array<{ department?: string | null }>
         : [];
+      const jobDepartmentRows = Array.isArray(jobDepartmentsResult.data)
+        ? jobDepartmentsResult.data as Array<{ department?: string | null }>
+        : [];
       const uniqueRoleDepartments = Array.from(new Set(
         roleDepartmentRows
           .map((row) => typeof row.department === 'string' ? row.department.trim() : '')
           .filter(Boolean)
       ));
+      const uniqueJobDepartments = Array.from(new Set(
+        jobDepartmentRows
+          .map((row) => typeof row.department === 'string' ? row.department.trim() : '')
+          .filter(Boolean)
+      ));
       const roleDepartment = roleCode
-        ? roleDepartmentRows[0]?.department ?? null
+        ? (typeof roleDepartmentRows[0]?.department === 'string' ? roleDepartmentRows[0].department.trim() || null : null)
         : uniqueRoleDepartments.length === 1 ? uniqueRoleDepartments[0] : null;
-      const actorDepartment = (actorResult.data as any)?.department ?? null;
-      const jobDepartment = (job as any)?.department ?? null;
+      const actorRow = actorResult.data as { department?: unknown } | null;
+      const actorDepartment = typeof actorRow?.department === 'string'
+        ? actorRow.department.trim() || null
+        : null;
+      const jobDepartment = uniqueJobDepartments.length === 1 ? uniqueJobDepartments[0] : null;
       const staffingDepartment = departmentHint || roleDepartment || actorDepartment || jobDepartment || null;
       
       if (!job) {

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -163,6 +163,8 @@ describe("smarter staffing recommendation migration", () => {
 
   it("scopes staffing push notifications to the staffing department", () => {
     expect(sendStaffingEmailFunction).toContain("department: staffingDepartment");
+    expect(sendStaffingEmailFunction).toContain('supabase.from("job_departments")');
+    expect(sendStaffingEmailFunction).not.toContain("            department,\n            start_time");
     expect(staffingPushEvents).toContain("typeof body.department === 'string' ? body.department.trim() : ''");
     expect(staffingPushEvents).toContain("bodyDepartment || jobDepartment");
     expect(staffingPushFunction).toContain("resolveStaffingDepartment");


### PR DESCRIPTION
## Summary
- fix staffing availability/offer sends by removing the invalid `jobs.department` select from `send-staffing-email`
- resolve job department fallback from `job_departments` instead of the `jobs` table
- add regression tests for unambiguous and ambiguous job department fallback behavior

## Root Cause
`jobs` has no `department` column; departments are stored in `job_departments`. The previous PR added `department` to the job select in `send-staffing-email`, which caused all availability request sends to fail while fetching job data.

## Validation
- `npm run test:run -- supabase/functions/push/broadcast/__tests__/eventMessages.test.ts tests/assignments/staffing-recommendations.test.ts`
- `npm run lint:functions`
- `git diff --check`
- deployed Edge Functions to production project `syldobdcdsgfgjtbuwxm`: `push`, `send-staffing-email`
