### PR TITLE
[codex] Scope assignment push notifications by department

### DIFF
--- a/src/components/matrix/AssignJobDialog.tsx
+++ b/src/components/matrix/AssignJobDialog.tsx
@@ -42,6 +42,7 @@ import { dataLayerClient } from '@/services/dataLayerClient';
 import { toast } from 'sonner';
 import { roleOptionsForDiscipline, codeForLabel, isRoleCode, labelForCode } from '@/utils/roles';
 import { determineFlexDepartmentsForAssignment } from '@/utils/flexCrewAssignments';
+import { getAssignmentNotificationDepartments } from '@/utils/assignmentNotificationDepartments';
 import { checkTimeConflictEnhanced, ConflictCheckResult } from '@/utils/technicianAvailability';
 import { toggleTimesheetDay } from '@/services/toggleTimesheetDay';
 import { removeTimesheetAssignment } from '@/services/removeTimesheetAssignment';
@@ -608,6 +609,7 @@ export const AssignJobDialog = ({
       );
 
       const recipientName = `${technician.first_name ?? ''} ${technician.last_name ?? ''}`.trim();
+      const assignmentDepartments = getAssignmentNotificationDepartments(basePayload, technician.department);
       try {
         void dataLayerClient.functions.invoke('push', {
           body: {
@@ -618,7 +620,9 @@ export const AssignJobDialog = ({
             recipient_name: recipientName || undefined,
             assignment_status: assignAsConfirmed ? 'confirmed' : 'invited',
             target_date: coverageMode === 'single' ? `${assignmentDate}T00:00:00Z` : undefined,
-            single_day: coverageMode !== 'full'
+            single_day: coverageMode !== 'full',
+            department: assignmentDepartments[0],
+            departments: assignmentDepartments,
           }
         });
       } catch (_) {

--- a/src/components/matrix/optimized-matrix-cell/useMatrixCellAssignmentRemoval.ts
+++ b/src/components/matrix/optimized-matrix-cell/useMatrixCellAssignmentRemoval.ts
@@ -3,6 +3,7 @@ import { format } from 'date-fns';
 import { toast } from 'sonner';
 
 import { dataLayerClient } from '@/services/dataLayerClient';
+import { getAssignmentNotificationDepartments } from '@/utils/assignmentNotificationDepartments';
 import { determineFlexDepartmentsForAssignment } from '@/utils/flexCrewAssignments';
 import { readAssignmentLifecycleResult } from '@/components/matrix/optimized-matrix-cell/helpers';
 import type { MultiDateRemovalState, TimesheetDateRow } from '@/components/matrix/optimized-matrix-cell/types';
@@ -114,6 +115,7 @@ export const useMatrixCellAssignmentRemoval = ({
         }
 
         try {
+          const assignmentDepartments = getAssignmentNotificationDepartments(assignment, technician.department);
           const { error: pushError } = await dataLayerClient.functions.invoke('push', {
             body: {
               action: 'broadcast',
@@ -121,6 +123,8 @@ export const useMatrixCellAssignmentRemoval = ({
               job_id: assignment.job_id,
               recipient_id: technician.id,
               technician_id: technician.id,
+              department: assignmentDepartments[0],
+              departments: assignmentDepartments,
             },
           });
           if (pushError) throw pushError;

--- a/src/hooks/useJobAssignmentsRealtime.ts
+++ b/src/hooks/useJobAssignmentsRealtime.ts
@@ -6,6 +6,7 @@ import { Assignment } from "@/types/assignment";
 import { toast } from "sonner";
 import { useRealtimeQuery } from "./useRealtimeQuery";
 import { useFlexCrewAssignments } from "@/hooks/useFlexCrewAssignments";
+import { getAssignmentNotificationDepartments } from "@/utils/assignmentNotificationDepartments";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -319,6 +320,7 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
         const recipientName = techProfile
           ? `${techProfile.first_name ?? ''} ${techProfile.last_name ?? ''}`.trim()
           : undefined;
+        const assignmentDepartments = getAssignmentNotificationDepartments(payload);
 
         void supabase.functions.invoke('push', {
           body: {
@@ -329,7 +331,9 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
             recipient_name: recipientName || undefined,
             assignment_status: options?.addAsConfirmed ? 'confirmed' : 'invited',
             target_date: options?.singleDayDate ? `${options.singleDayDate}T00:00:00Z` : undefined,
-            single_day: options?.singleDay || false
+            single_day: options?.singleDay || false,
+            department: assignmentDepartments[0],
+            departments: assignmentDepartments,
           }
         });
       } catch (pushError) {

--- a/src/hooks/useJobAssignmentsRealtime.ts
+++ b/src/hooks/useJobAssignmentsRealtime.ts
@@ -331,7 +331,7 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
             recipient_name: recipientName || undefined,
             assignment_status: options?.addAsConfirmed ? 'confirmed' : 'invited',
             target_date: options?.singleDayDate ? `${options.singleDayDate}T00:00:00Z` : undefined,
-            single_day: options?.singleDay || false,
+            single_day: payload.single_day,
             department: assignmentDepartments[0],
             departments: assignmentDepartments,
           }

--- a/src/utils/__tests__/assignmentNotificationDepartments.test.ts
+++ b/src/utils/__tests__/assignmentNotificationDepartments.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { getAssignmentNotificationDepartments } from "../assignmentNotificationDepartments";
+
+describe("getAssignmentNotificationDepartments", () => {
+  it("derives departments from active assignment role columns", () => {
+    expect(getAssignmentNotificationDepartments({
+      sound_role: "foh",
+      lights_role: "none",
+      video_role: null,
+      production_role: "pm",
+    })).toEqual(["sound", "production"]);
+  });
+
+  it("falls back to explicit or technician department when role columns are unavailable", () => {
+    expect(getAssignmentNotificationDepartments({ department: " lights " }, "sound")).toEqual(["lights"]);
+    expect(getAssignmentNotificationDepartments({}, "sound")).toEqual(["sound"]);
+  });
+});

--- a/src/utils/__tests__/assignmentNotificationDepartments.test.ts
+++ b/src/utils/__tests__/assignmentNotificationDepartments.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getAssignmentNotificationDepartments } from "../assignmentNotificationDepartments";
+import { getAssignmentNotificationDepartments } from "@/utils/assignmentNotificationDepartments";
 
 describe("getAssignmentNotificationDepartments", () => {
   it("derives departments from active assignment role columns", () => {

--- a/src/utils/assignmentNotificationDepartments.ts
+++ b/src/utils/assignmentNotificationDepartments.ts
@@ -1,0 +1,56 @@
+type AssignmentDepartmentSource = {
+  sound_role?: unknown;
+  lights_role?: unknown;
+  video_role?: unknown;
+  production_role?: unknown;
+  department?: unknown;
+  job?: { department?: unknown } | null;
+  jobs?: { department?: unknown } | null;
+} | null | undefined;
+
+const KNOWN_ASSIGNMENT_DEPARTMENTS = new Set([
+  'sound',
+  'lights',
+  'video',
+  'production',
+  'logistics',
+  'personnel',
+  'comercial',
+  'administrative',
+]);
+
+const normalizeDepartment = (department: unknown): string | null => {
+  if (typeof department !== 'string') return null;
+  const normalized = department.trim().toLowerCase();
+  return KNOWN_ASSIGNMENT_DEPARTMENTS.has(normalized) ? normalized : null;
+};
+
+const hasActiveRole = (role: unknown): boolean => {
+  if (typeof role !== 'string') return false;
+  const normalized = role.trim().toLowerCase();
+  return normalized.length > 0 && normalized !== 'none';
+};
+
+export const getAssignmentNotificationDepartments = (
+  assignment: AssignmentDepartmentSource,
+  fallbackDepartment?: unknown,
+): string[] => {
+  const departments = new Set<string>();
+
+  if (hasActiveRole(assignment?.sound_role)) departments.add('sound');
+  if (hasActiveRole(assignment?.lights_role)) departments.add('lights');
+  if (hasActiveRole(assignment?.video_role)) departments.add('video');
+  if (hasActiveRole(assignment?.production_role)) departments.add('production');
+
+  const explicitDepartment = normalizeDepartment(assignment?.department)
+    ?? normalizeDepartment(assignment?.job?.department)
+    ?? normalizeDepartment(assignment?.jobs?.department);
+  if (explicitDepartment) departments.add(explicitDepartment);
+
+  if (departments.size === 0) {
+    const fallback = normalizeDepartment(fallbackDepartment);
+    if (fallback) departments.add(fallback);
+  }
+
+  return Array.from(departments);
+};

--- a/supabase/functions/push/broadcast.ts
+++ b/supabase/functions/push/broadcast.ts
@@ -158,8 +158,8 @@ export async function handleBroadcast(
     singleDayFlag,
     state,
     audience,
-    getScopedManagementIds: (technicianId, scopeContext, departmentHint) =>
-      resolveScopedManagementIds(client, technicianId, scopeContext, departmentHint),
+    getScopedManagementIds: (technicianId, scopeContext, departmentHint, options) =>
+      resolveScopedManagementIds(client, technicianId, scopeContext, departmentHint, options),
   };
 
   const routeResult = await routeBroadcastEvent(context);

--- a/supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
+++ b/supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
@@ -1,4 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../delivery.ts", () => ({
+  sendPayloadToUsers: vi.fn(async (_client, userIds: string[]) =>
+    userIds.map((id) => ({ endpoint: `mock:${id}`, ok: true })),
+  ),
+}));
+
+vi.mock("../../config.ts", () => ({
+  EVENT_TYPES: {
+    ASSIGNMENT_REMOVED: "assignment.removed",
+  },
+}));
 
 import {
   buildJobDateTypeChangedMessage,
@@ -25,9 +37,14 @@ import {
 } from "../messages/tourMessages.ts";
 import type { BroadcastBody } from "../../types.ts";
 import type { BroadcastEventContext } from "../eventContext.ts";
+import { sendPayloadToUsers } from "../delivery.ts";
+import { handleAssignmentEvents } from "../families/assignmentEvents.ts";
 import { handleStaffingEvents } from "../families/staffingEvents.ts";
 import { CARLOS_AGENT_NAME } from "../staffingIdentity.ts";
-import { getJobDepartment } from "../../data.ts";
+import {
+  getActiveAssignmentDepartmentsFromRow,
+  getJobDepartment,
+} from "../../data.ts";
 
 function createStaffingContext(overrides: Partial<BroadcastEventContext> = {}): BroadcastEventContext {
   const state = { title: "", text: "", url: "/jobs/job-1", metaExtras: {} };
@@ -95,6 +112,83 @@ function createStaffingContext(overrides: Partial<BroadcastEventContext> = {}): 
     ...overrides,
   };
 }
+
+function createAssignmentContext(overrides: Partial<BroadcastEventContext> = {}): BroadcastEventContext {
+  const state = { title: "", text: "", url: "/jobs/job-1", metaExtras: {} };
+  const recipients = new Set<string>();
+  const naturalRecipients = new Set<string>();
+  const management = new Set<string>();
+  const soundDept = new Set<string>();
+  const admin = new Set<string>();
+  const mgmt = new Set<string>();
+  const participants = new Set<string>();
+  const audience = {
+    recipients,
+    naturalRecipients,
+    management,
+    soundDept,
+    admin,
+    mgmt,
+    participants,
+    addRecipients: (ids: (string | null | undefined)[]) => {
+      ids.forEach((id) => {
+        if (id) recipients.add(id);
+      });
+    },
+    addNaturalRecipients: (ids: (string | null | undefined)[]) => {
+      ids.forEach((id) => {
+        if (id) {
+          recipients.add(id);
+          naturalRecipients.add(id);
+        }
+      });
+    },
+    clearAllRecipients: () => {
+      recipients.clear();
+      naturalRecipients.clear();
+      management.clear();
+      soundDept.clear();
+      admin.clear();
+      mgmt.clear();
+      participants.clear();
+    },
+  };
+
+  return {
+    client: {} as BroadcastEventContext["client"],
+    userId: "manager-1",
+    body: {
+      action: "broadcast",
+      type: "job.assignment.direct",
+      job_id: "job-1",
+      recipient_id: "tech-1",
+      recipient_name: "Ana",
+      department: "lights",
+      departments: ["lights"],
+    },
+    type: "job.assignment.direct",
+    jobId: "job-1",
+    jobTitle: "RBF",
+    jobDepartment: null,
+    jobType: null,
+    tourName: null,
+    routes: [],
+    actor: "Laura",
+    recipName: "Ana",
+    channelLabel: "push",
+    normalizedTargetDate: null,
+    formattedTargetDate: null,
+    singleDayFlag: false,
+    state,
+    audience,
+    getScopedManagementIds: async () => ["lights-admin"],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(sendPayloadToUsers).mockClear();
+});
 
 describe("push broadcast event message builders", () => {
   it("summarizes job update fields with Spanish labels", () => {
@@ -242,6 +336,59 @@ describe("push broadcast event message builders", () => {
     expect(context.state.text).toBe("Laura envió oferta a Ana (email).");
   });
 
+  it("strictly scopes direct assignment management pushes to the assignment department", async () => {
+    const scopedCalls: Array<{ departmentHint: string | null | undefined; strict: boolean | undefined }> = [];
+    const context = createAssignmentContext({
+      getScopedManagementIds: async (_technicianId, _eventContext, departmentHint, options) => {
+        scopedCalls.push({ departmentHint, strict: options?.includeCrossDepartmentAdmins === false });
+        return departmentHint === "lights" ? ["lights-admin"] : ["sound-admin"];
+      },
+    });
+
+    await expect(handleAssignmentEvents(context)).resolves.not.toBe(false);
+
+    expect(scopedCalls).toEqual([{ departmentHint: "lights", strict: true }]);
+    expect(sendPayloadToUsers).toHaveBeenCalledWith(
+      context.client,
+      ["tech-1"],
+      expect.objectContaining({ title: "Nueva asignación" }),
+    );
+    expect(sendPayloadToUsers).toHaveBeenCalledWith(
+      context.client,
+      ["lights-admin"],
+      expect.objectContaining({ title: "Asignación directa" }),
+    );
+  });
+
+  it("strictly scopes assignment removal management pushes to the removed assignment department", async () => {
+    const scopedCalls: Array<{ departmentHint: string | null | undefined; strict: boolean | undefined }> = [];
+    const context = createAssignmentContext({
+      type: "assignment.removed",
+      body: {
+        action: "broadcast",
+        type: "assignment.removed",
+        job_id: "job-1",
+        recipient_id: "tech-1",
+        technician_id: "tech-1",
+        department: "lights",
+        departments: ["lights"],
+      },
+      getScopedManagementIds: async (_technicianId, _eventContext, departmentHint, options) => {
+        scopedCalls.push({ departmentHint, strict: options?.includeCrossDepartmentAdmins === false });
+        return departmentHint === "lights" ? ["lights-admin"] : ["sound-admin"];
+      },
+    });
+
+    await expect(handleAssignmentEvents(context)).resolves.not.toBe(false);
+
+    expect(scopedCalls).toEqual([{ departmentHint: "lights", strict: true }]);
+    expect(sendPayloadToUsers).toHaveBeenCalledWith(
+      context.client,
+      ["lights-admin"],
+      expect.objectContaining({ title: "Asignación eliminada" }),
+    );
+  });
+
   it("uses the staffing department instead of the technician department for management recipients", async () => {
     let scopedDepartment: string | null | undefined;
     const context = createStaffingContext({
@@ -262,6 +409,15 @@ describe("push broadcast event message builders", () => {
 
     expect(scopedDepartment).toBe("sound");
     expect(context.audience.naturalRecipients.has("sound-manager")).toBe(true);
+  });
+
+  it("derives assignment departments from active role columns", () => {
+    expect(getActiveAssignmentDepartmentsFromRow({
+      sound_role: "none",
+      lights_role: "lighting_designer",
+      video_role: null,
+      production_role: "pm",
+    })).toEqual(["lights", "production"]);
   });
 
   it("resolves unambiguous job departments from job_departments", async () => {

--- a/supabase/functions/push/broadcast/eventContext.ts
+++ b/supabase/functions/push/broadcast/eventContext.ts
@@ -35,6 +35,10 @@ export type BroadcastRecipients = {
   clearAllRecipients: () => void;
 };
 
+export type ScopedManagementOptions = {
+  includeCrossDepartmentAdmins?: boolean;
+};
+
 export type BroadcastEventContext = {
   client: BroadcastClient;
   userId: string;
@@ -56,7 +60,12 @@ export type BroadcastEventContext = {
   singleDayFlag: boolean;
   state: BroadcastMessageState;
   audience: BroadcastRecipients;
-  getScopedManagementIds: (technicianId: string | undefined, context?: string, departmentHint?: string | null) => Promise<string[]>;
+  getScopedManagementIds: (
+    technicianId: string | undefined,
+    context?: string,
+    departmentHint?: string | null,
+    options?: ScopedManagementOptions,
+  ) => Promise<string[]>;
 };
 
 export type BroadcastHandlerResult = false | true | Response;

--- a/supabase/functions/push/broadcast/families/assignmentEvents.ts
+++ b/supabase/functions/push/broadcast/families/assignmentEvents.ts
@@ -1,5 +1,5 @@
 import { EVENT_TYPES } from "../../config.ts";
-import { getProfileDisplayName } from "../../data.ts";
+import { getAssignmentRoleDepartments, getProfileDisplayName } from "../../data.ts";
 import { jsonResponse } from "../../http.ts";
 import type { PushPayload } from "../../types.ts";
 import { sendPayloadToUsers } from "../delivery.ts";
@@ -19,6 +19,74 @@ const baseAssignmentMeta = (context: BroadcastEventContext, recipient?: string) 
   recipient,
   ...context.state.metaExtras,
 });
+
+const normalizeDepartment = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+};
+
+const bodyAssignmentDepartments = (context: BroadcastEventContext): string[] => {
+  const departments = new Set<string>();
+  const bodyDepartment = normalizeDepartment(context.body.department);
+  if (bodyDepartment) departments.add(bodyDepartment);
+
+  if (Array.isArray(context.body.departments)) {
+    for (const department of context.body.departments) {
+      const normalized = normalizeDepartment(department);
+      if (normalized) departments.add(normalized);
+    }
+  }
+
+  return Array.from(departments);
+};
+
+const resolveAssignmentDepartments = async (
+  context: BroadcastEventContext,
+  technicianId: string | undefined,
+  allowAssignmentLookup: boolean,
+): Promise<string[]> => {
+  const fromBody = bodyAssignmentDepartments(context);
+  if (fromBody.length > 0) return fromBody;
+
+  if (allowAssignmentLookup && context.jobId && technicianId) {
+    const fromAssignment = await getAssignmentRoleDepartments(context.client, context.jobId, technicianId);
+    if (fromAssignment.length > 0) return fromAssignment;
+  }
+
+  return [];
+};
+
+const getStrictAssignmentManagementIds = async (
+  context: BroadcastEventContext,
+  technicianId: string | undefined,
+  departments: string[],
+  scopeContext: string,
+): Promise<string[]> => {
+  const ids = new Set<string>();
+
+  for (const department of departments) {
+    const scopedIds = await context.getScopedManagementIds(
+      technicianId,
+      scopeContext,
+      department,
+      { includeCrossDepartmentAdmins: false },
+    );
+    for (const id of scopedIds) ids.add(id);
+  }
+
+  if (ids.size > 0 || departments.length > 0) {
+    return Array.from(ids);
+  }
+
+  const fallbackIds = await context.getScopedManagementIds(
+    technicianId,
+    scopeContext,
+    undefined,
+    { includeCrossDepartmentAdmins: false },
+  );
+  return Array.from(new Set(fallbackIds));
+};
 
 export async function handleAssignmentEvents(context: BroadcastEventContext): Promise<BroadcastHandlerResult> {
   const { type, body, state, audience, jobTitle, recipName } = context;
@@ -71,7 +139,13 @@ export async function handleAssignmentEvents(context: BroadcastEventContext): Pr
       deliveredCount += (await sendPayloadToUsers(context.client, [assignedTechId], techPayload)).length;
     }
 
-    const scopedMgmtIds = await context.getScopedManagementIds(assignedTechId, `job.assignment.direct job=${context.jobId}`);
+    const assignmentDepartments = await resolveAssignmentDepartments(context, assignedTechId, true);
+    const scopedMgmtIds = await getStrictAssignmentManagementIds(
+      context,
+      assignedTechId,
+      assignmentDepartments,
+      `job.assignment.direct job=${context.jobId}`,
+    );
     if (scopedMgmtIds.length > 0) {
       const mgmtPayload: PushPayload = {
         title: 'Asignación directa',
@@ -113,7 +187,13 @@ export async function handleAssignmentEvents(context: BroadcastEventContext): Pr
       deliveredCount += (await sendPayloadToUsers(context.client, [removedTechId], techPayload)).length;
     }
 
-    const scopedMgmtIds = await context.getScopedManagementIds(removedTechId, `assignment.removed job=${context.jobId}`);
+    const assignmentDepartments = await resolveAssignmentDepartments(context, removedTechId, false);
+    const scopedMgmtIds = await getStrictAssignmentManagementIds(
+      context,
+      removedTechId,
+      assignmentDepartments,
+      `assignment.removed job=${context.jobId}`,
+    );
     if (scopedMgmtIds.length > 0) {
       const mgmtPayload: PushPayload = {
         title: 'Asignación eliminada',

--- a/supabase/functions/push/broadcast/recipients.ts
+++ b/supabase/functions/push/broadcast/recipients.ts
@@ -1,11 +1,15 @@
 import type { createClient } from "../deps.ts";
 import {
   getAdminUserIdsForStaffingNotifications,
+  getManagementAndAdminByDepartmentUserIds,
   getManagementByDepartmentUserIds,
   lookupTechnicianDepartment,
 } from "../data.ts";
 
 type BroadcastClient = ReturnType<typeof createClient>;
+type ScopedManagementOptions = {
+  includeCrossDepartmentAdmins?: boolean;
+};
 
 /**
  * Resolve department-scoped management + admin IDs for a technician.
@@ -17,6 +21,7 @@ export async function getScopedManagementIds(
   technicianId: string | undefined,
   context?: string,
   departmentHint?: string | null,
+  options: ScopedManagementOptions = {},
 ): Promise<string[]> {
   let techDepartment: string | null =
     typeof departmentHint === 'string' && departmentHint.trim().length > 0
@@ -34,6 +39,12 @@ export async function getScopedManagementIds(
           ' - department-scoped management recipients will be empty',
       );
     }
+  }
+
+  if (options.includeCrossDepartmentAdmins === false) {
+    return techDepartment
+      ? await getManagementAndAdminByDepartmentUserIds(client, techDepartment)
+      : [];
   }
 
   const deptMgmt = techDepartment

--- a/supabase/functions/push/data.ts
+++ b/supabase/functions/push/data.ts
@@ -112,6 +112,20 @@ export async function getManagementByDepartmentUserIds(client: ReturnType<typeof
   return data.map((r: any) => r.id).filter(Boolean);
 }
 
+export async function getManagementAndAdminByDepartmentUserIds(
+  client: ReturnType<typeof createClient>,
+  department: string,
+): Promise<string[]> {
+  if (!department) return [];
+  const { data, error } = await client
+    .from('profiles')
+    .select('id')
+    .in('role', ['admin', 'management'])
+    .eq('department', department);
+  if (error || !data) return [];
+  return data.map((r: any) => r.id).filter(Boolean);
+}
+
 /**
  * Retrieve the department name for a technician identified by user ID.
  *
@@ -274,6 +288,53 @@ export function normalizeDepartmentRolesPayload(value: unknown): DepartmentRoleS
   return value
     .map(parseDepartmentRoleSummary)
     .filter((item): item is DepartmentRoleSummary => Boolean(item));
+}
+
+function hasActiveAssignmentRole(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 && normalized !== 'none';
+}
+
+export function getActiveAssignmentDepartmentsFromRow(
+  row: {
+    sound_role?: unknown;
+    lights_role?: unknown;
+    video_role?: unknown;
+    production_role?: unknown;
+  } | null | undefined,
+): string[] {
+  if (!row) return [];
+  const departments = new Set<string>();
+  if (hasActiveAssignmentRole(row.sound_role)) departments.add('sound');
+  if (hasActiveAssignmentRole(row.lights_role)) departments.add('lights');
+  if (hasActiveAssignmentRole(row.video_role)) departments.add('video');
+  if (hasActiveAssignmentRole(row.production_role)) departments.add('production');
+  return Array.from(departments);
+}
+
+export async function getAssignmentRoleDepartments(
+  client: ReturnType<typeof createClient>,
+  jobId?: string | null,
+  technicianId?: string | null,
+): Promise<string[]> {
+  if (!jobId || !technicianId) return [];
+  try {
+    const { data, error } = await client
+      .from('job_assignments')
+      .select('sound_role, lights_role, video_role, production_role')
+      .eq('job_id', jobId)
+      .eq('technician_id', technicianId)
+      .maybeSingle();
+    if (error) {
+      console.error('⚠️ Failed to fetch assignment role departments:', { jobId, technicianId, error });
+      return [];
+    }
+    return getActiveAssignmentDepartmentsFromRow(data);
+  } catch (err) {
+    console.error('⚠️ Exception fetching assignment role departments:', { jobId, technicianId, err });
+    return [];
+  }
 }
 
 export function formatDepartmentRolesSummary(summary: DepartmentRoleSummary[]): string {


### PR DESCRIPTION
## Summary
- Scope direct assignment and assignment removal management push notifications to the assignment department.
- Include assignment department metadata in direct assignment/removal push payloads from the matrix and job assignment flows.
- Add regression coverage for strict same-department assignment routing and frontend department derivation.

## Root Cause
Direct assignment/removal push handling bypassed the configurable routing matrix and reused the staffing management recipient helper. That helper could include admins outside the assignment department, so a sound department admin could receive lights assignment/removal pushes.

## Validation
- `npm install --legacy-peer-deps`
- `npm run test:run -- supabase/functions/push/broadcast/__tests__/eventMessages.test.ts src/utils/__tests__/assignmentNotificationDepartments.test.ts`
- `npm run lint:functions`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assignment notifications now include department information for improved recipient targeting.
  * Management and administrative notifications for assignment events are now scoped by department.

* **Tests**
  * Added test coverage for department-based notification routing and assignment event handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->