### PR TITLE
[codex] Complete UI data/theme/safe-area audit roadmap

### DIFF
--- a/docs/plans/ui-data-theme-safe-area-audit-roadmap.md
+++ b/docs/plans/ui-data-theme-safe-area-audit-roadmap.md
@@ -1,0 +1,420 @@
+# UI Data, Theme, And Safe-Area Audit Roadmap
+
+Date: 2026-05-21  
+Branch synced for audit: `main` at `origin/main` commit `f246c830`  
+Production note: no `origin/prod` or `origin/production` branch exists in this checkout. The closest canonical branch found was `origin/main`; prod-like feature/hotfix branches exist but are not a deploy branch.
+
+## Scope
+
+This audit covers desktop and mobile UI across routed pages, job cards, dialogs, forms, sheets, drawers, layout chrome, and the data hooks that feed job surfaces. It focuses on:
+
+- Data inconsistencies and missing data caused by divergent Supabase query shapes.
+- Job card and dialog mismatches for assignments, location, documents, folders, tour metadata, and staff roles.
+- Theme, color, typography, and hard-coded palette drift.
+- Mobile and desktop responsive behavior, especially safe-area clipping in forms, modals, sheets, floating actions, and bottom navigation.
+
+Inventory from the current codebase:
+
+- 61 routed page-like files.
+- 109 dialog/form-like component files.
+- 170 job/task/assignment-related surfaces.
+- 1,742 Supabase `.from(...)` calls and 888 `.select(...)` calls.
+- 469 `DialogContent` usages, 44 `SheetContent` usages, and 4 `DrawerContent` usages.
+- 3,659 hard-coded color utility/hex references.
+- 84 safe-area references, mostly in layout/global utilities rather than modal primitives.
+
+## Surface Map
+
+Primary route groups audited:
+
+- App shell and route guards: `src/App.tsx`, `src/routes/AuthenticatedShell.tsx`, `src/components/layout/Layout.tsx`, `src/components/layout/MobileNavBar.tsx`.
+- Department pages: `src/pages/Sound.tsx`, `src/pages/Lights.tsx`, `src/pages/Video.tsx`, `src/pages/Operaciones.tsx`, legacy department pages.
+- Job dashboards: `src/pages/Dashboard.tsx`, `src/pages/ProjectManagement.tsx`, `src/pages/JobAssignmentMatrix.tsx`, `src/pages/TechnicianDashboard.tsx`, `src/pages/TechnicianSuperApp.tsx`.
+- Tour/festival pages: `src/pages/Tours.tsx`, `src/pages/TourManagement.tsx`, `src/features/tour-ops/TourOpsManagementHub.tsx`, festival management and artist forms.
+- Operations/admin pages: expenses, personal/vacation, equipment, logistics, settings, rates, feedback, announcements, incident reports, stage plot, payouts, timesheets, wallboards.
+
+Core job data sources currently diverge:
+
+- General dashboard list: `src/hooks/useJobs.ts`.
+- Optimized department/project lists: `src/hooks/useOptimizedJobs.ts`.
+- Card-level enrichment: `src/hooks/useOptimizedJobCard.ts`.
+- Assignment dialog data: `src/hooks/useJobAssignmentsRealtime.ts`.
+- Job details dialog data: `src/components/jobs/JobDetailsDialog.tsx`.
+- Matrix data: `src/pages/job-assignment-matrix/utils.ts` and `src/hooks/useOptimizedMatrixData.ts`.
+- Technician views: `src/pages/TechnicianDashboard.tsx`, `src/pages/TechnicianSuperApp.tsx`, technician detail modal hooks.
+
+## Critical Findings
+
+### P0: Assignment role mutations are incomplete
+
+`src/components/jobs/JobAssignmentDialog.tsx` can display and update existing `video_role` rows, but its add path only builds sound/lights insert payloads. `src/hooks/useJobAssignmentsRealtime.ts` `buildAssignmentInsertPayload` accepts `soundRole` and `lightsRole` only, and Flex sync only checks sound/lights.
+
+Impact:
+
+- Video assignments added through the dialog can be inserted with no role.
+- Production roles are supported by matrix utilities but absent from job card/dialog hooks.
+- Counts and role badges can disagree between `JobAssignmentMatrix`, job cards, job details, and technician views.
+
+Roadmap action:
+
+- Introduce a single assignment role model that includes `sound_role`, `lights_role`, `video_role`, and `production_role`.
+- Update dialog add/edit/remove flows, Flex sync integration, notifications, card summaries, detail tabs, matrix, and technician views to consume the same role map.
+
+### P0: Job cards omit fields that downstream UI already expects
+
+`src/components/jobs/cards/JobCardAssignments.tsx` and `src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx` handle `external_technician_name`, but `src/hooks/useJobs.ts`, `src/hooks/useOptimizedJobs.ts`, and `src/components/jobs/JobDetailsDialog.tsx` do not consistently select it. `production_role` is also missing from card/detail query shapes while matrix and notification utilities already understand it.
+
+Impact:
+
+- External technicians can render as `Unknown` / `Desconocido`.
+- Production staffing is invisible in job cards and details while present in matrix data.
+- Role totals undercount staffed people for production and can undercount external staff.
+
+Roadmap action:
+
+- Define a shared `JobCardQueryShape` and `JobAssignmentRow` contract.
+- Select `id`, `technician_id`, all role columns, `status`, source/date fields, `external_technician_name`, and profile display fields everywhere a job card or dialog consumes assignments.
+- Add regression tests for internal staff, external staff, video roles, production roles, single-day assignments, and tour-sourced assignments.
+
+### P0: Different job list hooks return different location and tour data
+
+`src/hooks/useJobs.ts` selects `location:locations(name)` while `src/hooks/useOptimizedJobs.ts` selects id, formatted address, latitude, and longitude. Job detail and department modals expect formatted address and coordinates for weather/maps. Tour metadata is also shaped differently between list hooks.
+
+Impact:
+
+- The same job can show only a venue name in one card and full address/map/weather data in another.
+- Mobile department modals can fall back to incomplete location data if opened from a surface using the leaner query.
+- Tour cancellation/deletion filtering is implemented differently across list hooks.
+
+Roadmap action:
+
+- Promote location and tour metadata to a shared job summary select.
+- Keep lightweight and heavyweight views separate only after a typed transform normalizes the public shape.
+
+### P1: Job selectors can miss active jobs and misread tour-date shape
+
+`src/hooks/useJobSelection.ts` filters with `.gte('start_time', today)`, which excludes ongoing multi-day jobs that started before today. It also excludes `Completado` but not `Cancelado`, and treats `tour_date` / `tour` as arrays (`job.tour_date[0]`) even though the named one-to-one relation can arrive as an object.
+
+Impact:
+
+- Linkers/selectors can hide jobs that are active today.
+- Canceled jobs can still appear in selectors.
+- Tour labels can become undefined depending on PostgREST relationship shape.
+
+Roadmap action:
+
+- Filter selectors with `end_time >= startOfToday` and exclude canceled/deleted jobs/tours.
+- Normalize relation payloads with a `oneOrFirst` helper or explicit generated type.
+
+### P1: Assignment dialog display is timesheet-first, not assignment-first
+
+`src/hooks/useJobAssignmentsRealtime.ts` uses timesheets as the display source of truth, then fetches `job_assignments` only for technician IDs found in timesheets. Invited or scheduled assignment rows without timesheets can be invisible in the dialog.
+
+Impact:
+
+- A freshly invited assignment may not show until schedule/timesheet rows exist.
+- The card and matrix can show a different assignment state from the assignment dialog.
+- Remove operations can delete timesheets and assignments while the UI still relies on stale caches.
+
+Roadmap action:
+
+- Build assignment display from `job_assignments` first, then decorate with timesheet date metadata.
+- Add a visible state for invited, confirmed, schedule-only, and timesheet-backed assignments.
+
+### P1: Realtime and optimistic cache keys are inconsistent
+
+`src/hooks/useJobAssignmentsRealtime.ts` uses `queryClient.setQueryData(['jobs'], ...)`, while the actual jobs hook uses `queryKeys.scope('jobs')`. `src/hooks/useAvailableTechnicians.ts` subscribes to availability changes but invalidates a key that omits `assignmentDate`.
+
+Impact:
+
+- Optimistic assignment updates do not reliably update job cards.
+- Single-day availability dialogs can stay stale after assignments change.
+- Users may see a technician as available after a relevant assignment mutation.
+
+Roadmap action:
+
+- Replace raw query keys with `queryKeys.scope(...)` everywhere.
+- Add cache-key guard tests for assignment, availability, optimized jobs, and job details.
+
+### P1: Availability date logic has timezone and empty-filter risks
+
+`src/utils/technicianAvailability.ts` derives date keys with `new Date(...).toISOString().split('T')[0]`, which can shift local date boundaries. It also calls `.in('id', conflictingJobIds)` without guarding empty arrays.
+
+Impact:
+
+- Madrid-local single-day assignments can drift by a day in edge timezones.
+- Empty conflict sets can produce fragile Supabase behavior.
+- Availability in dialogs can disagree with the matrix for overnight or multi-day jobs.
+
+Roadmap action:
+
+- Use date-only helpers that preserve event timezone/local calendar date.
+- Short-circuit empty conflict arrays before Supabase `.in(...)`.
+- Test overnight jobs, rehearsal/prep/off/travel days, and single-day assignments.
+
+## Theme And Color Findings
+
+### P1: Hard-coded colors are widespread
+
+The scan found 3,659 hard-coded color utility/hex references. High-density files include:
+
+- `src/components/technician/TechnicianRfTableModal.tsx`
+- `src/components/personal/VacationRequestsTabs.tsx`
+- `src/components/technician/details-modal/DetailsModalTabs.tsx`
+- `src/components/personal/MobilePersonalCalendar.tsx`
+- `src/components/department/EnhancedJobDetailsModal.tsx`
+- `src/components/dashboard/TechnicianTourRates.tsx`
+- `src/components/jobs/JobPayoutOverrideSection.tsx`
+- `src/components/incident-reports/TechnicianIncidentReportDialog.tsx`
+- `src/pages/TechnicianSuperApp.tsx`
+
+Impact:
+
+- Department, technician, admin, and dashboard surfaces do not share a consistent semantic palette.
+- Dark-mode and light-mode behavior depends on individual component choices.
+- Mobile technician surfaces feel like a separate app from desktop operations pages.
+
+Roadmap action:
+
+- Introduce semantic role tokens for status, discipline, warning, success, destructive, transport, finance, and staffing.
+- Build a department color adapter that maps sound/lights/video/production to tokens instead of inline blue/amber/purple classes.
+- Add lint guidance or a small color-token audit script to keep new hard-coded colors out of shared UI.
+
+### P2: Global typography scales with viewport width
+
+`src/index.css` uses viewport-based `clamp(...)` for base typography. That makes text sizing vary by viewport instead of component context.
+
+Impact:
+
+- Compact cards, dialogs, sheets, and dense operational tables can inflate unexpectedly on wide or narrow viewports.
+- Button text and card labels are harder to guarantee against overflow.
+
+Roadmap action:
+
+- Replace viewport-scaled base text with fixed semantic text sizes.
+- Keep responsive typography only for true page heroes or explicitly designed large display surfaces.
+
+### P2: Wallboard/alien tokens are globally declared
+
+`src/index.css` defines wallboard-specific ALIEN palette variables globally. This is not immediately breaking, but it increases theme vocabulary outside the wallboard domain.
+
+Roadmap action:
+
+- Scope wallboard-specific variables under a wallboard class or route root.
+
+## Safe-Area And Responsive Findings
+
+### P0: Modal and sheet primitives do not include safe-area defaults
+
+`src/components/ui/dialog.tsx`, `src/components/ui/sheet.tsx`, and `src/components/ui/drawer.tsx` place content centered or fixed to viewport edges, but do not provide mobile safe-area padding by default. Many callers use `max-h-[90vh]`, `h-[96vh]`, or bottom sheets with scroll content and footers.
+
+High-risk examples:
+
+- `src/components/jobs/JobAssignmentDialog.tsx`
+- `src/components/jobs/CreateJobDialog.tsx`
+- `src/components/jobs/EditJobDialog.tsx`
+- `src/components/jobs/JobDetailsDialog.tsx`
+- `src/components/jobs/cards/job-card-new/JobCardNewView.tsx`
+- `src/components/tours/TourDateManagementDialog.tsx`
+- `src/components/tours/TourRatesManagerDialog.tsx`
+- `src/features/tour-ops/TourOpsManagementHub.tsx`
+- `src/pages/festival-management/FestivalManagementDialogs.tsx`
+- `src/components/feedback/AdminPanel.tsx`
+- `src/pages/Expenses.tsx`
+- `src/pages/TourManagement.tsx`
+
+Impact:
+
+- Mobile submit/cancel footers can sit behind the home indicator.
+- Close buttons can sit too close to notches or browser UI.
+- Long forms can trap users between inner scroll containers and page scroll.
+
+Roadmap action:
+
+- Add `MobileDialogContent`, `MobileSheetContent`, or variant props to primitives.
+- Standardize modal shells with safe top/bottom padding, footer safe padding, fixed header/footer, and one scroll owner.
+- Audit every form modal after the primitive migration.
+
+### P1: Mobile full-screen department behavior is inconsistent
+
+`src/components/layout/Layout.tsx` only treats `/sound` as a mobile full-screen route. `/lights` and `/video` still render inside normal mobile layout while also using fixed bottom create buttons.
+
+Impact:
+
+- Sound mobile hub suppresses chrome; lights/video can overlap mobile nav and fixed actions.
+- Department UIs behave differently on mobile despite sharing the same hub pattern.
+
+Roadmap action:
+
+- Decide whether all department hubs are full-screen on mobile.
+- If not full-screen, move FABs above `MobileNavBar` with `bottom-[calc(...env(safe-area-inset-bottom))]`.
+
+### P1: Fixed bottom actions and sheets need safe-area review
+
+Risk files include:
+
+- `src/pages/ProjectManagement.tsx` fixed create button at `bottom-20`.
+- `src/pages/Lights.tsx` and `src/pages/Video.tsx` mobile fixed create buttons at `bottom-6`.
+- `src/pages/TechnicianUnavailability.tsx` fixed bottom action and bottom sheet.
+- `src/components/ui/drawer.tsx` fixed bottom drawer.
+- `src/components/ui/sheet.tsx` bottom sheet variant.
+- `src/components/ui/toast.tsx` and connection/status overlays.
+
+Roadmap action:
+
+- Add a shared `safe-bottom-action` utility and use it for all mobile fixed actions.
+- Add bottom padding to bottom sheets/drawers with `max(env(safe-area-inset-bottom), spacing)`.
+
+### P2: Desktop modal heights are inconsistent
+
+Desktop uses a mix of `max-h-[80vh]`, `85vh`, `90vh`, `92vh`, `95vh`, `96vh`, and `md:max-h-none`. Some forms scroll the whole dialog; others scroll an inner area.
+
+Impact:
+
+- Repeated workflows feel different depending on which module owns the dialog.
+- Keyboard focus and sticky action behavior varies.
+
+Roadmap action:
+
+- Define modal sizes: compact, form, wide, full-workflow.
+- Use one scroll strategy per size.
+
+## Forms And Modals Checklist
+
+Every item below needs desktop and mobile verification after the primitive/data fixes:
+
+- Global create/edit job forms: `GlobalCreateJobDialog`, `CreateJobDialog`, `EditJobDialog`, `JobRequirementsEditor`.
+- Job card modals: details, assignments, route sheet, transport requests, logistics, expenses, payout overrides, Flex sync log, document actions.
+- Department tools: sound report generator, amplifier, memoria técnica, incident report, sound task dialog, video task dialog, lights task dialogs.
+- Project management filters, mobile sheets, and create FAB.
+- Matrix dialogs: optimized cell dialogs, assign job, staffing campaigns, reminders, job selectors.
+- Tour dialogs: create/edit tour, tour date management, tour assignments, tour defaults, tour rates, documents, logistics, availability requests.
+- Festival dialogs: artist management, shift create/edit/copy, gear setup, print options, push to Flex.
+- Technician app dialogs/sheets: assignment cards, RF table modal, availability sheet, messages, details modal, unavailability form.
+- Admin/operations dialogs: user create/edit/import, feedback admin, expenses, personal/vacation, equipment/subrental/stock movement, milestones, rates approvals.
+- Public routes: auth, privacy, artist forms, tour share, wallboards.
+
+## Phased Roadmap
+
+### Phase 0: Verification Harness
+
+Goal: make the audit repeatable.
+
+- Add environment-backed local run instructions for authenticated UI QA.
+- Add a small route/modal inventory script that reports routed pages, `DialogContent`, `SheetContent`, hard-coded colors, fixed-bottom elements, and safe-area usage.
+- Create desktop and mobile viewport smoke flows for auth, dashboard, department hub, project management, job details, assignment dialog, technician app, tour management, and festival management.
+- Acceptance: anyone can run the audit and get a stable report without manually searching the whole codebase.
+
+### Phase 1: Critical Data Contract Fixes
+
+Goal: stop job cards/dialogs from disagreeing.
+
+- Create shared assignment/job summary types and query fragments.
+- Include `external_technician_name`, `production_role`, all role columns, status/source/date fields, profile display fields, complete location metadata, and tour status/deleted metadata where relevant.
+- Fix `JobAssignmentDialog` and `useJobAssignmentsRealtime` for video and production roles.
+- Fix `useJobSelection` active/canceled/tour relation shape.
+- Fix availability invalidation keys and timezone-safe date logic.
+- Acceptance: job card, job details, assignment dialog, matrix, and technician view show the same staff/location/tour status for a seeded set of jobs.
+
+### Phase 2: Job Card And Dialog Source Unification
+
+Goal: one enriched job state per job, not per surface.
+
+- Move assignment/date/timesheet enrichment to a shared service/hook.
+- Standardize folder state, logistics events, transport requests, documents, tasks, and tour date chips.
+- Remove per-card query duplication where list-level batching is possible.
+- Acceptance: expanding a card, opening details, and opening assignment dialogs does not cause visible data shape changes or stale badges.
+
+### Phase 3: Safe-Area Primitive Migration
+
+Goal: fix mobile clipping at the component-system layer.
+
+- Add safe-area-aware dialog, sheet, drawer, and alert-dialog variants.
+- Define modal size variants and a single scroll-owner convention.
+- Migrate high-risk forms first: job assignment, create/edit job, job details, tour dates, tour rates, festival management, technician RF modal, feedback admin.
+- Acceptance: iPhone-style portrait and landscape viewports can submit/cancel/close every critical form without controls behind notches, browser chrome, or home indicators.
+
+### Phase 4: Department Mobile Shell Consistency
+
+Goal: make sound/lights/video/production behave consistently on mobile.
+
+- Decide full-screen route policy for `/sound`, `/lights`, `/video`, and production/ops equivalents.
+- Fix department FAB offsets and bottom-nav interaction.
+- Validate `DepartmentMobileHub`, `MobileJobCard`, `EnhancedJobDetailsModal`, technician app, and project management mobile filters.
+- Acceptance: no department mobile page has overlapping FAB/nav/content, and shared interactions appear in the same location.
+
+### Phase 5: Theme Token Migration
+
+Goal: reduce palette drift without redesigning the product.
+
+- Build a semantic token map for departments, statuses, finance, transport, warnings, and assignments.
+- Replace hard-coded blue/amber/purple/slate clusters in shared surfaces first.
+- Scope wallboard-specific tokens.
+- Replace viewport-scaled base typography with fixed semantic sizes.
+- Acceptance: shared job surfaces look coherent in light/dark mode and new color usage goes through tokens.
+
+### Phase 6: Page-By-Page QA Pass
+
+Goal: finish the in-depth manual audit after data/primitives are stable.
+
+- Desktop viewports: 1440x900 and 1920x1080.
+- Mobile viewports: 390x844, 430x932, and landscape 844x390.
+- Walk all forms/modals listed in the checklist.
+- Record screenshots only for regressions or before/after fixes.
+- Acceptance: every routed page and modal has a checked status for data completeness, safe-area behavior, theme consistency, keyboard/focus behavior, empty/loading/error states, and submit/cancel ergonomics.
+
+### Phase 7: Rollout And Monitoring
+
+Goal: ship without breaking live operations.
+
+- Release data-contract fixes first behind focused regression tests.
+- Release safe-area primitive changes in batches by workflow.
+- Add production monitoring notes for assignment mutations, job card query errors, and Supabase relationship errors.
+- Acceptance: no new assignment/job-card data drift reports for one release cycle, and mobile critical workflows remain passable.
+
+## Verification Results
+
+Completed:
+
+- Synced local `main` to `origin/main` at `f246c830`.
+- Preserved pre-sync local work in stashes:
+  - `pre-sync-main-audit-preserve-tracked-work`
+  - `pre-sync-main-audit-preserve-local-work`
+- Ran static inventory over routes, dialogs/forms, job surfaces, query usage, color usage, and safe-area usage.
+- Installed missing local dependencies with `npm install --package-lock=false` so the current workspace can run Vite without import-resolution failures.
+- Implemented the Phase 1 data-contract fixes across job cards, job details, assignment dialogs, matrix, technician views, and selection/availability hooks.
+- Implemented the Phase 3/4 safe-area fixes for shared dialog/sheet/drawer primitives plus high-risk job, tour, festival, technician, and department mobile surfaces.
+- Reduced hard-coded CTA/FAB palette drift in shared create/edit/availability flows by moving them back to app semantic tokens.
+- Fixed dynamic Supabase payload typing issues that blocked strict typecheck.
+- Fixed a real task-document data bug where the video task upload path inserted `task_id` instead of `video_task_id`.
+- Ran `npm run typecheck`: passed.
+- Ran focused regression tests:
+  - `src/hooks/__tests__/useJobAssignmentsRealtime.test.ts`
+  - `src/utils/__tests__/assignmentNotificationDepartments.test.ts`
+  - `src/hooks/__tests__/useOptimizedMatrixData.test.ts`
+  - `src/pages/__tests__/jobAssignmentMatrixUtils.test.ts`
+  - `src/pages/__tests__/TechnicianSuperApp.test.tsx`
+  - `src/pages/__tests__/ProjectManagement.test.tsx`
+  - `src/pages/__tests__/TechnicianUnavailability.test.tsx`
+- Ran `npm run build`: passed, with existing chunk-size warnings.
+- Started built preview on `http://127.0.0.1:4175/` and attempted browser smoke.
+- Confirmed browser runtime still blocks before UI render on missing `VITE_SUPABASE_URL`, so authenticated desktop/mobile visual walkthrough still needs an environment-backed run.
+
+Current verification blockers:
+
+- No `.env` exists in the workspace; only `.env.example` and `.env.staging.example` are present.
+- Browser boot error: missing `VITE_SUPABASE_URL`.
+- `npm install` reported 19 dependency audit findings and a Node engine warning for `eslint-visitor-keys`.
+
+## Acceptance Checklist For Completion
+
+- [x] All job-card and job-dialog queries use the same assignment/location/tour contract.
+- [x] External technicians and production roles render correctly in the audited job-card/detail/personnel paths.
+- [x] Video and production assignment role mutations are represented in dialog payloads and role helpers.
+- [x] Ongoing multi-day jobs appear in selectors; canceled jobs/tours are excluded.
+- [x] Availability dialogs refresh correctly for single-day and multi-day assignment changes.
+- [x] Dialog/sheet/drawer primitives support mobile safe areas by default.
+- [x] High-risk custom p-0/full-height modals use `dvh` and safe-area padding.
+- [x] Sound/lights/video mobile route chrome and fixed-action behavior are aligned.
+- [x] Hard-coded color usage in shared create/edit/FAB flows is reduced to app semantic tokens.
+- [ ] Desktop and mobile visual QA is completed against an environment with Supabase variables.

--- a/src/components/department/EnhancedJobDetailsModal.tsx
+++ b/src/components/department/EnhancedJobDetailsModal.tsx
@@ -51,6 +51,8 @@ interface StaffAssignment {
     sound_role?: string | null;
     lights_role?: string | null;
     video_role?: string | null;
+    production_role?: string | null;
+    external_technician_name?: string | null;
     technician: {
         id: string;
         first_name: string;
@@ -110,6 +112,8 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
           sound_role,
           lights_role,
           video_role,
+          production_role,
+          external_technician_name,
           technician:profiles(id, first_name, last_name, email, department)
         `)
                 .eq('job_id', job.id)
@@ -370,11 +374,12 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
         if (assignment.sound_role) return 'sound';
         if (assignment.lights_role) return 'lights';
         if (assignment.video_role) return 'video';
+        if (assignment.production_role) return 'production';
         return 'unknown';
     };
 
     const getRoleFromAssignment = (assignment: StaffAssignment): string => {
-        const role = assignment.sound_role || assignment.lights_role || assignment.video_role;
+        const role = assignment.sound_role || assignment.lights_role || assignment.video_role || assignment.production_role;
         return role ? (labelForCode(role) || role) : 'Técnico';
     };
 
@@ -397,8 +402,8 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
     };
 
     return (
-        <div className={`fixed inset-0 z-50 flex items-center justify-center ${theme.modalOverlay} p-4 animate-in fade-in duration-200`}>
-            <div className={`w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] h-[90vh] ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${theme.divider} shadow-2xl flex flex-col overflow-hidden overflow-x-hidden animate-in zoom-in-95 duration-200`}>
+        <div className={`fixed inset-0 z-50 flex items-center justify-center ${theme.modalOverlay} px-4 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200`}>
+            <div className={`w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] h-[calc(100dvh-2rem)] md:h-[90dvh] ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${theme.divider} shadow-2xl flex flex-col overflow-hidden overflow-x-hidden animate-in zoom-in-95 duration-200`}>
 
                 {/* Header */}
                 <div className={`p-4 border-b ${theme.divider} flex justify-between items-center shrink-0`}>
@@ -429,7 +434,7 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
                     ))}
                 </div>
 
-                <ScrollArea className="flex-1 p-5 overflow-x-hidden min-w-0">
+                <ScrollArea className="flex-1 px-5 pt-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] overflow-x-hidden min-w-0">
 
                     {/* TAB: INFO */}
                     {activeTab === 'Info' && (
@@ -615,11 +620,12 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
                                             sound: 'text-blue-400 bg-blue-900/30 border-blue-900/50',
                                             lights: 'text-amber-400 bg-amber-900/30 border-amber-900/50',
                                             video: 'text-purple-400 bg-purple-900/30 border-purple-900/50',
+                                            production: 'text-emerald-400 bg-emerald-900/30 border-emerald-900/50',
                                         };
                                         return (
                                             <div key={idx} className={`${isDark ? 'bg-[#0f1219] border-[#1f232e]' : 'bg-slate-50 border-slate-200'} border rounded-lg p-4 min-w-0 overflow-hidden`}>
                                                 <div className={`font-bold text-sm ${theme.textMain} mb-1 break-words`}>
-                                                    {tech?.first_name} {tech?.last_name}
+                                                    {tech ? `${tech.first_name} ${tech.last_name}` : assignment.external_technician_name || 'Técnico externo'}
                                                 </div>
                                                 <div className={`text-xs ${theme.textMuted} break-words`}>{role}</div>
                                                 <div className={`mt-2 inline-block px-2 py-0.5 rounded text-[10px] font-bold uppercase border ${deptColors[dept] || theme.textMuted}`}>

--- a/src/components/department/MobileAssignmentsDialog.tsx
+++ b/src/components/department/MobileAssignmentsDialog.tsx
@@ -15,6 +15,10 @@ import { useQuery } from '@tanstack/react-query';
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useTechnicianTheme } from '@/hooks/useTechnicianTheme';
 import { canManageJobAssignments } from '@/utils/permissions';
+import {
+  buildAssignmentRoleInputForDepartment,
+  getAssignmentRoleForDepartment,
+} from '@/utils/assignmentRoles';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -153,10 +157,7 @@ export const MobileAssignmentsDialog: React.FC<MobileAssignmentsDialogProps> = (
 
     setIsSaving(true);
     try {
-      const soundRole = department === 'sound' ? selectedRole : 'none';
-      const lightsRole = department === 'lights' ? selectedRole : 'none';
-
-      await addAssignment(selectedTech, soundRole, lightsRole, {
+      await addAssignment(selectedTech, buildAssignmentRoleInputForDepartment(department, selectedRole), {
         singleDay,
         singleDayDate: singleDay && selectedJobDate ? format(selectedJobDate, 'yyyy-MM-dd') : null,
       });
@@ -176,7 +177,7 @@ export const MobileAssignmentsDialog: React.FC<MobileAssignmentsDialogProps> = (
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="p-0 border-none bg-transparent shadow-none">
-        <div className={`${theme.bg} ${theme.textMain} rounded-2xl border ${theme.card} w-[95vw] max-w-xl max-h-[85vh] overflow-hidden flex flex-col`}>
+        <div className={`${theme.bg} ${theme.textMain} rounded-2xl border ${theme.card} w-[95vw] max-w-xl max-h-[calc(100dvh-1rem)] overflow-hidden flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]`}>
           <div className={`flex items-center justify-between p-4 border-b ${theme.divider}`}>
             <div>
               <p className={`text-xs ${theme.textMuted} uppercase tracking-[0.08em]`}>Asignaciones</p>
@@ -230,8 +231,11 @@ export const MobileAssignmentsDialog: React.FC<MobileAssignmentsDialogProps> = (
               ) : (
                 <div className="space-y-2">
                   {assignments.map((assignment: any) => {
-                    const name = `${assignment.profiles?.first_name ?? ''} ${assignment.profiles?.last_name ?? ''}`.trim() || 'Técnico';
-                    const roleCode = department === 'sound' ? assignment.sound_role : assignment.lights_role || assignment.video_role;
+                    const name = `${assignment.profiles?.first_name ?? ''} ${assignment.profiles?.last_name ?? ''}`.trim()
+                      || assignment.external_technician_name
+                      || 'Técnico';
+                    const roleCode = getAssignmentRoleForDepartment(assignment, department);
+                    if (!roleCode) return null;
                     const roleLabel = labelForCode(roleCode) || 'Asignado';
                     const singleDayLabel = assignment.single_day && assignment.assignment_date
                       ? format(new Date(`${assignment.assignment_date}T00:00:00`), "d 'de' MMM", { locale: es })

--- a/src/components/disponibilidad/MobileAvailabilityView.tsx
+++ b/src/components/disponibilidad/MobileAvailabilityView.tsx
@@ -302,19 +302,19 @@ export function MobileAvailabilityView({
             </div>
 
             {/* Floating Action Button / Bottom Sheet */}
-            <div className="fixed bottom-6 right-6 z-50">
+            <div className="fixed bottom-[max(1.5rem,env(safe-area-inset-bottom))] right-[max(1.5rem,env(safe-area-inset-right))] z-50">
                 <Sheet>
                     <SheetTrigger asChild>
                         <Button
                             size="icon"
-                            className="h-14 w-14 rounded-full shadow-xl bg-blue-600 hover:bg-blue-500 text-white border-0"
+                            className="h-14 w-14 rounded-full shadow-xl bg-primary hover:bg-primary/90 text-primary-foreground border-0"
                         >
                             <Plus className="h-6 w-6" />
                         </Button>
                     </SheetTrigger>
-                    <SheetContent side="bottom" className="h-[80vh] bg-[#0f1219] border-t border-[#1f232e] rounded-t-2xl">
+                    <SheetContent side="bottom" className="h-[min(80dvh,calc(100dvh-1rem))] bg-card border-t border-border rounded-t-2xl">
                         <SheetHeader className="mb-4">
-                            <SheetTitle className="text-white">Asignar Preset Rápido</SheetTitle>
+                            <SheetTitle>Asignar Preset Rápido</SheetTitle>
                         </SheetHeader>
                         <QuickPresetAssignment
                             selectedDate={selectedDate}
@@ -335,7 +335,7 @@ export function MobileAvailabilityView({
             <Sheet open={showWeeklySummary} onOpenChange={setShowWeeklySummary}>
                 <SheetContent
                     side="bottom"
-                    className="h-[90vh] bg-[#0f1219] border-t border-[#1f232e] rounded-t-2xl overflow-y-auto"
+                    className="h-[calc(100dvh-1rem)] md:h-[90dvh] bg-card border-t border-border rounded-t-2xl overflow-y-auto"
                 >
                     <SheetHeader className="mb-4 flex flex-row items-center justify-between">
                         <div className="flex items-center gap-2">
@@ -347,7 +347,7 @@ export function MobileAvailabilityView({
                             >
                                 <ChevronLeft className="h-5 w-5" />
                             </Button>
-                            <SheetTitle className="text-white">Resumen Semanal</SheetTitle>
+                            <SheetTitle>Resumen Semanal</SheetTitle>
                         </div>
                         <Button
                             variant="ghost"
@@ -358,7 +358,7 @@ export function MobileAvailabilityView({
                             <X className="h-5 w-5" />
                         </Button>
                     </SheetHeader>
-                    <div className="pb-6">
+                    <div className="pb-[max(1.5rem,env(safe-area-inset-bottom))]">
                         <WeeklySummary
                             selectedDate={selectedDate}
                             onDateChange={onDateSelect}

--- a/src/components/festival/ArtistManagementDialog.tsx
+++ b/src/components/festival/ArtistManagementDialog.tsx
@@ -67,8 +67,8 @@ export const ArtistManagementDialog = ({
   // Desktop: standard dialog
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="flex h-[100vh] max-h-[100vh] md:max-h-[100vh] w-[100vw] max-w-[100vw] flex-col gap-0 overflow-hidden rounded-none sm:rounded-none p-0">
-        <DialogHeader className="border-b px-4 py-3 sm:px-6">
+      <DialogContent className="flex h-[100dvh] max-h-[100dvh] md:max-h-[100dvh] w-[100vw] max-w-[100vw] flex-col gap-0 overflow-hidden rounded-none sm:rounded-none p-0">
+        <DialogHeader className="border-b px-4 pb-3 pt-[max(0.75rem,env(safe-area-inset-top))] sm:px-6 sm:pt-3">
           <DialogTitle>
             {artist ? "Editar Artista" : "Agregar Artista"}
           </DialogTitle>
@@ -83,7 +83,7 @@ export const ArtistManagementDialog = ({
             formId={formId}
           />
         </div>
-        <div className="border-t bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:px-6">
+        <div className="border-t bg-background/95 px-4 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:px-6 sm:pb-3">
           <div className="flex justify-end">
             <Button
               type="submit"

--- a/src/components/festival/mobile/MobileArtistConfigEditor.tsx
+++ b/src/components/festival/mobile/MobileArtistConfigEditor.tsx
@@ -13,6 +13,10 @@ import { dataLayerClient } from "@/services/dataLayerClient";
 import { toast } from "sonner";
 import { formatBandOptionLabel, getBandOptionsEU, isFrequencyBandSelection } from "@/lib/frequencyBands";
 import type { MobileArtistRiderFile, MobileConfigCategory } from "./MobileArtistCard";
+import type { Database } from "@/integrations/supabase/types";
+
+type FestivalArtistUpdate = Database["public"]["Tables"]["festival_artists"]["Update"];
+type ProviderType = Database["public"]["Enums"]["provider_type"];
 
 interface Artist {
   id: string;
@@ -451,15 +455,15 @@ export const MobileArtistConfigEditor = ({
     setIsSaving(true);
     try {
       // Build the update payload based on category
-      let updatePayload: Record<string, any> = {};
+      let updatePayload: FestivalArtistUpdate = {};
 
       switch (category) {
         case 'consoles':
           updatePayload = {
             foh_console: formData.foh_console,
-            foh_console_provided_by: formData.foh_console_provided_by,
+            foh_console_provided_by: formData.foh_console_provided_by as ProviderType,
             mon_console: formData.mon_console,
-            mon_console_provided_by: formData.mon_console_provided_by,
+            mon_console_provided_by: formData.mon_console_provided_by as ProviderType,
             monitors_from_foh: formData.monitors_from_foh,
             foh_waves_outboard: formData.foh_waves_outboard || null,
             mon_waves_outboard: formData.mon_waves_outboard || null,
@@ -470,9 +474,9 @@ export const MobileArtistConfigEditor = ({
         case 'wireless':
           updatePayload = {
             wireless_systems: formData.wireless_systems,
-            wireless_provided_by: formData.wireless_provided_by,
+            wireless_provided_by: formData.wireless_provided_by as ProviderType,
             iem_systems: formData.iem_systems,
-            iem_provided_by: formData.iem_provided_by,
+            iem_provided_by: formData.iem_provided_by as ProviderType,
           };
           break;
         case 'microphones':
@@ -502,7 +506,7 @@ export const MobileArtistConfigEditor = ({
             infra_opticalcon_duo: formData.infra_opticalcon_duo,
             infra_opticalcon_duo_quantity: formData.infra_opticalcon_duo_quantity,
             infra_analog: formData.infra_analog,
-            infrastructure_provided_by: formData.infrastructure_provided_by,
+            infrastructure_provided_by: formData.infrastructure_provided_by as ProviderType,
             other_infrastructure: formData.other_infrastructure || null,
           };
           break;

--- a/src/components/jobs/CreateJobDialog.tsx
+++ b/src/components/jobs/CreateJobDialog.tsx
@@ -302,7 +302,7 @@ export const CreateJobDialog = ({ open, onOpenChange, currentDepartment, initial
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-h-[calc(100dvh-1rem)] md:max-h-[90dvh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Crear Nuevo Trabajo</DialogTitle>
         </DialogHeader>
@@ -452,7 +452,7 @@ export const CreateJobDialog = ({ open, onOpenChange, currentDepartment, initial
                   onClick={() => toggleDepartment(department)}
                   className={
                     selectedDepartments.includes(department)
-                      ? "bg-blue-600 hover:bg-blue-500 text-white"
+                      ? "bg-primary hover:bg-primary/90 text-primary-foreground"
                       : "border-border"
                   }
                 >
@@ -551,8 +551,8 @@ export const CreateJobDialog = ({ open, onOpenChange, currentDepartment, initial
             </div>
           )}
 
-          <div className="w-full flex justify-end">
-            <Button type="submit" disabled={isSubmitting} className="gap-2 bg-blue-600 hover:bg-blue-500 text-white">
+          <div className="w-full flex justify-end pb-[max(0px,env(safe-area-inset-bottom))]">
+            <Button type="submit" disabled={isSubmitting} className="gap-2">
               {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" />}
               {isSubmitting ? "Creando..." : "Crear Trabajo"}
             </Button>

--- a/src/components/jobs/EditJobDialog.tsx
+++ b/src/components/jobs/EditJobDialog.tsx
@@ -412,7 +412,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-h-[90vh] md:max-h-none md:h-auto overflow-y-auto md:overflow-visible">
+        <DialogContent className="max-h-[calc(100dvh-1rem)] md:max-h-none md:h-auto overflow-y-auto md:overflow-visible">
           <DialogHeader>
             <DialogTitle>Edit Job</DialogTitle>
           </DialogHeader>
@@ -620,7 +620,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
                 </div>
               )}
             </div>
-            <div className="flex justify-end gap-2">
+            <div className="flex justify-end gap-2 pb-[max(0px,env(safe-area-inset-bottom))]">
               <Button
                 type="button"
                 variant="outline"
@@ -629,7 +629,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={isLoading || isVenueBusy} className="bg-blue-600 hover:bg-blue-500 text-white">
+              <Button type="submit" disabled={isLoading || isVenueBusy}>
                 {isLoading ? "Saving..." : "Save Changes"}
               </Button>
             </div>

--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -51,6 +51,11 @@ import { fromZonedTime, formatInTimeZone } from "date-fns-tz";
 import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 import { syncTimesheetCategoriesForAssignment } from '@/services/syncTimesheetCategories';
 import { isDepartmentManagementRole, isManagementRole } from '@/utils/permissions';
+import {
+  buildAssignmentRoleInputForDepartment,
+  getAssignmentRoleForDepartment,
+  hasAssignmentRoleForDepartment,
+} from '@/utils/assignmentRoles';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -84,6 +89,8 @@ interface Assignment {
   technician_id: string;
   sound_role: string;
   lights_role: string;
+  video_role?: string | null;
+  production_role?: string | null;
 }
 
 // Role options from centralized registry (codes with labels)
@@ -130,7 +137,7 @@ const formatAssignmentTechnicianName = (assignment: any) => {
     const fullName = `${firstName} ${lastName}`.trim();
     return fullName || 'Unnamed Technician';
   }
-  return 'Unknown Technician';
+  return assignment.external_technician_name || 'Unknown Technician';
 };
 
 // Helper function to format available technician name
@@ -162,7 +169,8 @@ const formatDepartmentName = (department: string) => {
   const names: Record<string, string> = {
     'sound': 'Sonido',
     'lights': 'Luces',
-    'video': 'Video'
+    'video': 'Video',
+    'production': 'Producción'
   };
   return names[department.toLowerCase()] || department;
 };
@@ -173,6 +181,8 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
   const [selectedTechnician, setSelectedTechnician] = useState<string | null>(null);
   const [soundRole, setSoundRole] = useState<string>("none");
   const [lightsRole, setLightsRole] = useState<string>("none");
+  const [videoRole, setVideoRole] = useState<string>("none");
+  const [productionRole, setProductionRole] = useState<string>("none");
   const [singleDay, setSingleDay] = useState(false);
   const [addAsConfirmed, setAddAsConfirmed] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
@@ -188,14 +198,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
   // Filter assignments to only show those for the current department
   const departmentAssignments = useMemo(() => {
     return (assignments || []).filter((assignment: any) => {
-      if (currentDepartment === 'sound') {
-        return assignment.sound_role && assignment.sound_role !== 'none';
-      } else if (currentDepartment === 'lights') {
-        return assignment.lights_role && assignment.lights_role !== 'none';
-      } else if (currentDepartment === 'video') {
-        return assignment.video_role && assignment.video_role !== 'none';
-      }
-      return false;
+      return hasAssignmentRoleForDepartment(assignment, currentDepartment);
     });
   }, [assignments, currentDepartment]);
 
@@ -308,7 +311,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
   const assignedByRole = useMemo(() => {
     const m = new Map<string, number>();
     (assignments || []).forEach((a: any) => {
-      const code = currentDepartment === 'sound' ? a.sound_role : currentDepartment === 'lights' ? a.lights_role : a.video_role;
+      const code = getAssignmentRoleForDepartment(a, currentDepartment);
       if (code) m.set(code, (m.get(code) || 0) + 1);
     });
     return m;
@@ -355,7 +358,12 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
 
     try {
       // Guard against over-assignment when requirements exist and no override
-      const selectedCode = currentDepartment === 'sound' ? soundRole : currentDepartment === 'lights' ? lightsRole : 'none';
+      const selectedCode = getAssignmentRoleForDepartment({
+        sound_role: soundRole,
+        lights_role: lightsRole,
+        video_role: videoRole,
+        production_role: productionRole,
+      }, currentDepartment);
       if (reqForDept && selectedCode && selectedCode !== 'none' && !isManagementRole(userRole)) {
         const left = remainingByRole.get(selectedCode) ?? 0;
         if (left <= 0) {
@@ -366,8 +374,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
       }
       await addAssignment(
         selectedTechnician,
-        soundRole,
-        lightsRole,
+        buildAssignmentRoleInputForDepartment(currentDepartment, selectedCode),
         singleDay
           ? {
             singleDay: true,
@@ -387,6 +394,8 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
       setSelectedTechnician(null);
       setSoundRole("none");
       setLightsRole("none");
+      setVideoRole("none");
+      setProductionRole("none");
       setSingleDay(false);
       setAddAsConfirmed(false);
       setSelectedJobDate(null);
@@ -412,6 +421,8 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
         technician_id: assignment.technician_id,
         sound_role: assignment.sound_role,
         lights_role: assignment.lights_role,
+        video_role: assignment.video_role,
+        production_role: assignment.production_role,
       });
     });
 
@@ -431,13 +442,17 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
       for (const assignment of assignmentsToProcess) {
         const technicianId = assignment.technician_id;
 
-        // Add to Flex crew calls for sound and lights departments
+        // Add to Flex crew calls for supported technical departments
         if (assignment.sound_role && assignment.sound_role !== 'none') {
           await manageFlexCrewAssignment(jobId, technicianId, 'sound', 'add');
         }
 
         if (assignment.lights_role && assignment.lights_role !== 'none') {
           await manageFlexCrewAssignment(jobId, technicianId, 'lights', 'add');
+        }
+
+        if (assignment.video_role && assignment.video_role !== 'none') {
+          await manageFlexCrewAssignment(jobId, technicianId, 'video', 'add');
         }
       }
 
@@ -522,7 +537,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="w-[95vw] max-w-[625px] max-h-[90vh] flex flex-col overflow-hidden">
+      <DialogContent className="w-[95vw] max-w-[625px] max-h-[calc(100dvh-1rem)] md:max-h-[90dvh] flex flex-col overflow-hidden">
         {isClosureLocked && (
           <Alert className="border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-50">
             <AlertCircle className="h-4 w-4" />
@@ -576,7 +591,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex-1 overflow-y-auto px-1">
+        <div className="flex-1 overflow-y-auto px-1 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
           <div className="py-3 md:py-4">
             <h3 className="text-base md:text-lg font-semibold mb-2">Asignaciones Actuales de {formatDepartmentName(currentDepartment)}</h3>
             {departmentAssignments.length === 0 ? (
@@ -784,6 +799,53 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
                             <SelectContent>
                               <SelectItem value="none">Ninguno</SelectItem>
                               {roleOptionsForDiscipline('video').map((opt) => (
+                                <SelectItem key={opt.code} value={opt.code}>
+                                  {opt.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      )}
+
+                      {currentDepartment === "production" && (
+                        <div>
+                          <Label htmlFor={`production-role-${assignment.technician_id}`} className="text-xs md:text-sm mb-1">
+                            Rol de Producción
+                          </Label>
+                          <Select
+                            value={assignment.production_role || "none"}
+                            disabled={isClosureLocked}
+                            onValueChange={async (newRole) => {
+                              try {
+                                const { error } = await dataLayerClient.from('job_assignments')
+                                  .update({ production_role: newRole === 'none' ? null : newRole })
+                                  .eq('job_id', jobId)
+                                  .eq('technician_id', assignment.technician_id);
+
+                                if (error) throw error;
+
+                                toast({
+                                  title: "Rol actualizado",
+                                  description: "El rol de producción se ha actualizado exitosamente",
+                                });
+                                onAssignmentChange();
+                              } catch (error: any) {
+                                console.error("Error updating role:", error);
+                                toast({
+                                  title: "Error",
+                                  description: error.message || "No se pudo actualizar el rol",
+                                  variant: "destructive",
+                                });
+                              }
+                            }}
+                          >
+                            <SelectTrigger id={`production-role-${assignment.technician_id}`}>
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="none">Ninguno</SelectItem>
+                              {roleOptionsForDiscipline('production').map((opt) => (
                                 <SelectItem key={opt.code} value={opt.code}>
                                   {opt.label}
                                 </SelectItem>

--- a/src/components/jobs/JobAssignments.tsx
+++ b/src/components/jobs/JobAssignments.tsx
@@ -11,6 +11,7 @@ import { useJobAssignmentsRealtime } from "@/hooks/useJobAssignmentsRealtime";
 import { useEffect, useState } from "react";
 import { labelForCode } from '@/utils/roles';
 import { format } from "date-fns";
+import { getAssignmentRoleForDepartment, hasAssignmentRoleForDepartment } from "@/utils/assignmentRoles";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -134,8 +135,8 @@ export const JobAssignments = ({ jobId, department, userRole }: JobAssignmentsPr
   // Filter assignments based on department if specified
   const filteredAssignments = department
     ? assignments.filter(assignment => {
-        // Add null check for profiles
-        return assignment.profiles && assignment.profiles.department === department;
+        const profileDepartment = assignment.profiles?.department;
+        return profileDepartment === department || hasAssignmentRoleForDepartment(assignment, department);
       })
     : assignments;
 
@@ -144,13 +145,12 @@ export const JobAssignments = ({ jobId, department, userRole }: JobAssignmentsPr
   const getRoleForDepartment = (assignment: Assignment) => {
     switch (department) {
       case "sound":
-        return assignment.sound_role;
       case "lights":
-        return assignment.lights_role;
       case "video":
-        return assignment.video_role;
+      case "production":
+        return getAssignmentRoleForDepartment(assignment, department);
       default:
-        return assignment.sound_role || assignment.lights_role || assignment.video_role;
+        return assignment.sound_role || assignment.lights_role || assignment.video_role || assignment.production_role;
     }
   };
 
@@ -190,11 +190,9 @@ export const JobAssignments = ({ jobId, department, userRole }: JobAssignmentsPr
         const displayRole = role ? labelForCode(role) : null;
         if (!displayRole) return null;
         
-        // Add null check for profiles before rendering
-        if (!assignment.profiles) {
-          console.warn("Assignment missing profiles data:", assignment);
-          return null;
-        }
+        const technicianName = assignment.profiles
+          ? `${assignment.profiles.first_name} ${assignment.profiles.last_name}`.trim()
+          : (assignment as any).external_technician_name || "External technician";
         
         return (
           <div
@@ -206,7 +204,7 @@ export const JobAssignments = ({ jobId, department, userRole }: JobAssignmentsPr
               <div className="flex flex-col">
                 <div className="flex items-center gap-2">
                   <span className="font-medium">
-                    {assignment.profiles.first_name} {assignment.profiles.last_name}
+                    {technicianName}
                   </span>
                   <span className="text-xs">({displayRole})</span>
                 </div>

--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -60,8 +60,9 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
           *,
           locations(id, name, formatted_address, latitude, longitude),
           job_assignments(
-            job_id, technician_id, assigned_by, assigned_at,
-            sound_role, lights_role, video_role, status,
+            id, job_id, technician_id, assigned_by, assigned_at,
+            sound_role, lights_role, video_role, production_role, status,
+            external_technician_name,
             single_day, assignment_date, assignment_source,
             profiles!job_assignments_technician_id_fkey(id, first_name, last_name, department, role, profile_picture_url)
           ),
@@ -199,7 +200,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
   if (isJobLoading) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[90vh] flex flex-col overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(100dvh-1rem)] md:max-h-[90dvh] flex flex-col overflow-y-auto">
           <div className="flex items-center justify-center h-32">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
           </div>
@@ -212,7 +213,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] max-h-[92vh] flex flex-col overflow-y-auto overflow-x-hidden px-3 sm:px-6">
+      <DialogContent className="w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] max-h-[calc(100dvh-1rem)] md:max-h-[92dvh] flex flex-col overflow-y-auto overflow-x-hidden px-3 sm:px-6">
         <DialogHeader className="flex-shrink-0">
           <DialogTitle className="flex items-center gap-2 text-base md:text-lg">
             <Calendar className="h-4 w-4 md:h-5 md:w-5" />
@@ -220,7 +221,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
           </DialogTitle>
         </DialogHeader>
 
-        <div className="min-h-0 overflow-y-auto overflow-x-hidden max-h-[75vh]">
+        <div className="min-h-0 overflow-y-auto overflow-x-hidden max-h-[calc(100dvh-12rem)] md:max-h-[75dvh] pb-[max(0.5rem,env(safe-area-inset-bottom))]">
           <Tabs value={selectedTab} onValueChange={setSelectedTab} className="flex flex-col min-w-0">
             <TabsList className={`grid w-full ${gridColsClass} flex-shrink-0 h-auto text-xs md:text-sm overflow-x-auto no-scrollbar`}>
               <TabsTrigger value="info" className="py-2">

--- a/src/components/jobs/cards/JobCardAssignments.tsx
+++ b/src/components/jobs/cards/JobCardAssignments.tsx
@@ -107,8 +107,10 @@ export const JobCardAssignments: React.FC<JobCardAssignmentsProps> = ({
         roleCode = assignment.lights_role; break;
       case 'video':
         roleCode = assignment.video_role; break;
+      case 'production':
+        roleCode = assignment.production_role; break;
       default:
-        roleCode = assignment.sound_role || assignment.lights_role || assignment.video_role;
+        roleCode = assignment.sound_role || assignment.lights_role || assignment.video_role || assignment.production_role;
     }
     if (!roleCode) continue;
 

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -48,17 +48,20 @@ type AssignmentWithProfile = {
   profiles?: ProfileContact | ProfileContact[] | null;
 };
 
-type AssignmentRoleKey = "sound_role" | "lights_role" | "video_role";
+type AssignmentRoleKey = "sound_role" | "lights_role" | "video_role" | "production_role";
 const ASSIGNMENT_ROLE_BY_DEPARTMENT: Partial<Record<Department, AssignmentRoleKey>> = {
   sound: "sound_role",
   lights: "lights_role",
   video: "video_role",
+  production: "production_role",
 };
 
 type JobAssignmentContactRow = {
   sound_role?: string | null;
   lights_role?: string | null;
   video_role?: string | null;
+  production_role?: string | null;
+  external_technician_name?: string | null;
   profiles?: ProfileContact | ProfileContact[] | null;
 };
 
@@ -581,10 +584,10 @@ function JobCardNewFull({
     try {
       // Pre-check: warn for missing phones
       const { data: rows } = await dataLayerClient.from('job_assignments')
-        .select('sound_role, lights_role, video_role, profiles!job_assignments_technician_id_fkey(first_name,last_name,phone)')
+        .select('sound_role, lights_role, video_role, production_role, external_technician_name, profiles!job_assignments_technician_id_fkey(first_name,last_name,phone)')
         .eq('job_id', job.id);
       const deptKey = ASSIGNMENT_ROLE_BY_DEPARTMENT[department];
-      if (!deptKey) {
+      if (!deptKey || deptKey === "production_role") {
         toast({ title: 'Departamento no soportado', description: 'Solo sonido, luces o vídeo pueden crear grupos de WhatsApp.', variant: 'destructive' });
         return;
       }

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -591,8 +591,8 @@ export function JobCardNewView({
 
           {isProjectManagementPage && (
             <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
-              <DialogContent className="max-w-[96vw] w-[96vw] h-[96vh] p-0 overflow-hidden">
-                <div className="h-full overflow-auto">
+              <DialogContent className="max-w-[96vw] w-[96vw] h-[calc(100dvh-1rem)] max-h-[calc(100dvh-1rem)] p-0 overflow-hidden">
+                <div className="h-full overflow-auto pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
                   <ModernHojaDeRuta jobId={job.id} />
                 </div>
               </DialogContent>

--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
@@ -9,6 +9,7 @@ import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { labelForCode } from "@/utils/roles";
 import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from "@/utils/assignmentWorkDates";
+import { hasAssignmentRoleForDepartment } from "@/utils/assignmentRoles";
 
 const MADRID_TIME_ZONE = "Europe/Madrid";
 
@@ -31,16 +32,7 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
       if (profileDept === normalizedDepartment) {
         return true;
       }
-      if (normalizedDepartment === "sound" && assignment.sound_role) {
-        return true;
-      }
-      if (normalizedDepartment === "lights" && assignment.lights_role) {
-        return true;
-      }
-      if (normalizedDepartment === "video" && assignment.video_role) {
-        return true;
-      }
-      return false;
+      return hasAssignmentRoleForDepartment(assignment, normalizedDepartment);
     });
   }, [jobDetails?.job_assignments, normalizedDepartment]);
 
@@ -146,6 +138,11 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
                   {assignment.video_role && (
                     <Badge variant="outline" className="text-xs">
                       Vídeo: {labelForCode(assignment.video_role)}
+                    </Badge>
+                  )}
+                  {assignment.production_role && (
+                    <Badge variant="outline" className="text-xs">
+                      Producción: {labelForCode(assignment.production_role)}
                     </Badge>
                   )}
                   {workDateKeys.length > 0 && (

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -396,7 +396,7 @@ const Layout = () => {
 
   // Routes that should be full-screen on mobile but have Layout on desktop
   const mobileFullscreenRoutes = useMemo(() => {
-    const routes = ["/sound"]
+    const routes = ["/sound", "/lights", "/video"]
     return isMobile && routes.some((route) => location.pathname.startsWith(route))
   }, [isMobile, location.pathname])
 

--- a/src/components/matrix/DateHeader.tsx
+++ b/src/components/matrix/DateHeader.tsx
@@ -172,7 +172,7 @@ const DateHeaderComp = ({ date, width, jobs = [], technicianIds, onJobClick }: D
       const [{ data: req }, { data: assignments }] = await Promise.all([
         dataLayerClient.from('job_required_roles_summary').select('total_required, job_id').in('job_id', jobIds),
         dataLayerClient.from('job_assignments')
-          .select('job_id, technician_id, sound_role, lights_role, video_role')
+          .select('job_id, technician_id, sound_role, lights_role, video_role, production_role')
           .in('job_id', jobIds)
           .in('technician_id', Array.from(allScheduledTechs)),
       ]);
@@ -187,6 +187,7 @@ const DateHeaderComp = ({ date, width, jobs = [], technicianIds, onJobClick }: D
           if (a.sound_role != null) assigned++;
           if (a.lights_role != null) assigned++;
           if (a.video_role != null) assigned++;
+          if (a.production_role != null) assigned++;
         }
       });
 

--- a/src/components/milestones/ManageMilestonesDialog.tsx
+++ b/src/components/milestones/ManageMilestonesDialog.tsx
@@ -237,13 +237,13 @@ export const ManageMilestonesDialog = ({ open, onOpenChange, jobId }: ManageMile
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[800px] h-[80vh] flex flex-col p-0">
-        <DialogHeader className="p-6 pb-2">
+      <DialogContent className="max-w-[800px] h-[min(80dvh,calc(100dvh-1rem))] flex flex-col p-0">
+        <DialogHeader className="px-6 pb-2 pt-[max(1.5rem,env(safe-area-inset-top))]">
           <DialogTitle>Manage Milestone Definitions</DialogTitle>
         </DialogHeader>
 
         <ScrollArea className="flex-1 px-6">
-          <div className="space-y-4 pb-6">
+          <div className="space-y-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
             <div className="flex justify-between items-center">
               <Button
                 onClick={() => {

--- a/src/components/sound/SoundTaskDialog.tsx
+++ b/src/components/sound/SoundTaskDialog.tsx
@@ -31,9 +31,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import type { Database } from "@/integrations/supabase/types";
 
 
 import { queryKeys } from "@/lib/react-query";
+type SoundJobPersonnelUpdate = Database["public"]["Tables"]["sound_job_personnel"]["Update"];
+type SoundPersonnelField = "foh_engineers" | "mon_engineers" | "pa_techs" | "rf_techs";
+
 interface SoundTaskDialogProps {
   jobId: string;
   open: boolean;
@@ -281,14 +285,15 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
     }
   };
 
-  const updatePersonnel = (key: string, value: number) => {
+  const updatePersonnel = (key: SoundPersonnelField, value: number) => {
     setPersonnel((prev) => ({ ...prev, [key]: isNaN(value) ? 0 : value }));
   };
 
-  const updatePersonnelField = async (field: string, value: number) => {
+  const updatePersonnelField = async (field: SoundPersonnelField, value: number) => {
     try {
+      const payload = { [field]: value } as SoundJobPersonnelUpdate;
       const { error } = await dataLayerClient.from('sound_job_personnel')
-        .update({ [field]: value })
+        .update(payload)
         .eq('job_id', jobId);
       if (error) throw error;
       toast({
@@ -372,8 +377,8 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
 
    return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-full max-w-4xl h-[90vh] flex flex-col p-0">
-        <DialogHeader className="px-4 py-2 flex flex-row items-center justify-between border-b">
+      <DialogContent className="w-full max-w-4xl h-[calc(100dvh-1rem)] max-h-[calc(100dvh-1rem)] md:h-[90dvh] flex flex-col p-0">
+        <DialogHeader className="px-4 pb-2 pt-[max(0.5rem,env(safe-area-inset-top))] flex flex-row items-center justify-between border-b">
           <DialogTitle className="flex items-center gap-2">
             <Table className="h-5 w-5" />
             <span>Sound Department Tasks</span>
@@ -409,7 +414,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
           </div>
         </DialogHeader>
 
-        <div className="flex-1 overflow-y-auto p-4">
+        <div className="flex-1 overflow-y-auto px-4 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
           <div className="space-y-6">
             {/* Personnel Section */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/components/technician/TechnicianRfTableModal.tsx
+++ b/src/components/technician/TechnicianRfTableModal.tsx
@@ -582,7 +582,7 @@ export function TechnicianRfTableModal({
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
       <DialogContent
-        className={`w-[calc(100vw-1rem)] max-w-lg h-[92vh] rounded-2xl border shadow-2xl p-0 gap-0 overflow-hidden [&>button]:hidden ${
+        className={`w-[calc(100vw-1rem)] max-w-lg h-[calc(100dvh-1rem)] max-h-[calc(100dvh-1rem)] rounded-2xl border shadow-2xl p-0 gap-0 overflow-hidden [&>button]:hidden ${
           isDark
             ? "bg-black border-zinc-800"
             : "bg-slate-50 border-slate-200"
@@ -594,7 +594,7 @@ export function TechnicianRfTableModal({
         <div className="flex h-full flex-col">
         {/* Header */}
         <div
-          className={`p-4 pb-3 flex justify-between items-center shrink-0 border-b ${
+          className={`px-4 pb-3 pt-[max(1rem,env(safe-area-inset-top))] flex justify-between items-center shrink-0 border-b ${
             isDark ? "border-zinc-800 bg-black/80" : "border-slate-200 bg-white"
           }`}
         >
@@ -749,7 +749,7 @@ export function TechnicianRfTableModal({
 
         {/* Card list */}
         <ScrollArea className="flex-1">
-          <div className="p-4">
+          <div className="px-4 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
             {isLoading ? (
               <div className="flex items-center justify-center py-12">
                 <Loader2 className="h-6 w-6 animate-spin text-blue-500" />

--- a/src/components/tours/CreateTourDialog.tsx
+++ b/src/components/tours/CreateTourDialog.tsx
@@ -41,12 +41,12 @@ const CreateTourDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] md:max-h-[85vh] overflow-y-auto flex flex-col gap-0 p-0">
-        <DialogHeader className="px-4 pt-4 md:px-6 md:pt-6">
+      <DialogContent className="max-w-2xl max-h-[calc(100dvh-1rem)] md:max-h-[85dvh] overflow-y-auto flex flex-col gap-0 p-0">
+        <DialogHeader className="px-4 pt-[max(1rem,env(safe-area-inset-top))] md:px-6 md:pt-6">
           <DialogTitle className="text-base md:text-lg">Create New Tour</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto px-4 md:px-6 pb-4 md:pb-6">
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto px-4 md:px-6 pb-[max(1rem,env(safe-area-inset-bottom))] md:pb-6">
           <div className="space-y-4 md:space-y-6 pt-4">
             <TourFormFields
               title={title}

--- a/src/components/tours/TourDateManagementDialog.tsx
+++ b/src/components/tours/TourDateManagementDialog.tsx
@@ -752,15 +752,15 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-3xl w-[95vw] md:w-full max-h-[95vh] md:max-h-[90vh] flex flex-col gap-0 p-0">
-          <DialogHeader className="px-4 pt-4 pb-2 md:px-6 md:pt-6 md:pb-4 border-b">
+        <DialogContent className="max-w-3xl w-[95vw] md:w-full max-h-[calc(100dvh-1rem)] md:max-h-[90dvh] flex flex-col gap-0 p-0">
+          <DialogHeader className="px-4 pt-[max(1rem,env(safe-area-inset-top))] pb-2 md:px-6 md:pt-6 md:pb-4 border-b">
             <DialogTitle className="text-base md:text-lg">
               {readOnly ? 'Tour Dates' : 'Manage Tour Dates'}
             </DialogTitle>
           </DialogHeader>
 
           <ScrollArea className="flex-1 overflow-auto px-4 md:px-6">
-            <div className="space-y-3 md:space-y-4 py-4 pb-6">
+            <div className="space-y-3 md:space-y-4 pt-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
               {/* Bulk folders button removed; availability moved to Team Assignments */}
 
               <div className="space-y-4">

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,9 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:w-full sm:rounded-lg",
+        "max-h-[calc(100dvh-1rem)] overflow-y-auto",
+        "pt-[max(1.5rem,env(safe-area-inset-top))] pr-[max(1.5rem,env(safe-area-inset-right))] pb-[max(1.5rem,env(safe-area-inset-bottom))] pl-[max(1.5rem,env(safe-area-inset-left))] sm:p-6",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,14 +36,15 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        "max-h-[90vh] overflow-y-auto md:max-h-[85vh]",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:w-full sm:rounded-lg",
+        "max-h-[calc(100dvh-1rem)] overflow-y-auto md:max-h-[85vh]",
+        "pt-[max(1.5rem,env(safe-area-inset-top))] pr-[max(1.5rem,env(safe-area-inset-right))] pb-[max(1.5rem,env(safe-area-inset-bottom))] pl-[max(1.5rem,env(safe-area-inset-left))] sm:p-6",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground z-10">
+      <DialogPrimitive.Close className="absolute right-[max(1rem,env(safe-area-inset-right))] top-[max(1rem,env(safe-area-inset-top))] rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground z-10 sm:right-4 sm:top-4">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -41,7 +41,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto max-h-[calc(100dvh-env(safe-area-inset-top))] flex-col rounded-t-[10px] border bg-background pb-[max(1rem,env(safe-area-inset-bottom))]",
         className
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -29,16 +29,16 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 max-h-[100dvh] overflow-y-auto",
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 border-b pt-[max(1.5rem,env(safe-area-inset-top))] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          "inset-x-0 bottom-0 border-t pb-[max(1.5rem,env(safe-area-inset-bottom))] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r pl-[max(1.5rem,env(safe-area-inset-left))] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4 border-l pr-[max(1.5rem,env(safe-area-inset-right))] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {
@@ -63,7 +63,7 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-[max(1rem,env(safe-area-inset-right))] top-[max(1rem,env(safe-area-inset-top))] rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary sm:right-4 sm:top-4">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/src/components/video/VideoTaskDialog.tsx
+++ b/src/components/video/VideoTaskDialog.tsx
@@ -145,7 +145,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
 
       const { error: dbError } = await dataLayerClient.from('task_documents')
         .insert({
-          task_id: taskId,
+          video_task_id: taskId,
           file_name: file.name,
           file_path: filePath,
         });

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
@@ -142,7 +142,7 @@ export const useHojaDeRutaInitialization = (
         name: assignment.profiles?.first_name || "",
         surname1: assignment.profiles?.last_name || "",
         surname2: "",
-        position: assignment.sound_role || assignment.lights_role || assignment.video_role || "Técnico",
+        position: assignment.sound_role || assignment.lights_role || assignment.video_role || assignment.production_role || "Técnico",
         dni: assignment.profiles?.dni || "",
         phone: assignment.profiles?.phone || "",
         role: "house_tech",

--- a/src/hooks/useAvailableTechnicians.ts
+++ b/src/hooks/useAvailableTechnicians.ts
@@ -88,7 +88,7 @@ export function useAvailableTechnicians({
           console.log('Job assignment changed, refreshing available technicians:', payload);
           // Invalidate and refetch the available technicians query
           queryClient.invalidateQueries({
-            queryKey: queryKeys.scope("available-technicians", department, jobId, jobStartTime, jobEndTime)
+            queryKey: queryKeys.scope("available-technicians", department, jobId, jobStartTime, jobEndTime, assignmentDate ?? null)
           });
         }
       )

--- a/src/hooks/useFlexCrewAssignments.ts
+++ b/src/hooks/useFlexCrewAssignments.ts
@@ -11,7 +11,7 @@ export const useFlexCrewAssignments = () => {
   const manageFlexCrewAssignment = async (
     jobId: string,
     technicianId: string,
-    department: 'sound' | 'lights',
+    department: 'sound' | 'lights' | 'video',
     action: 'add' | 'remove'
   ) => {
     try {

--- a/src/hooks/useGlobalTaskMutations.ts
+++ b/src/hooks/useGlobalTaskMutations.ts
@@ -730,7 +730,7 @@ export function useGlobalTaskMutations(department: Dept) {
       .upload(taskKey, file, { upsert: false });
     if (upErr) throw upErr;
 
-    const { error: insErr } = await supabase.from('task_documents').insert({
+    const { error: insErr } = await fromDynamicTable('task_documents').insert({
       [docFk]: taskId,
       file_name: file.name,
       file_path: taskKey,

--- a/src/hooks/useJobAssignmentsRealtime.ts
+++ b/src/hooks/useJobAssignmentsRealtime.ts
@@ -7,6 +7,12 @@ import { toast } from "sonner";
 import { useRealtimeQuery } from "./useRealtimeQuery";
 import { useFlexCrewAssignments } from "@/hooks/useFlexCrewAssignments";
 import { getAssignmentNotificationDepartments } from "@/utils/assignmentNotificationDepartments";
+import {
+  ASSIGNMENT_DEPARTMENTS,
+  AssignmentRoleInput,
+  normalizeAssignmentRole,
+  normalizeAssignmentRoleInput,
+} from "@/utils/assignmentRoles";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -16,24 +22,93 @@ export interface AssignmentInsertOptions {
   addAsConfirmed?: boolean;
 }
 
-export const buildAssignmentInsertPayload = (
+type AssignmentInsertPayload = {
+  job_id: string;
+  technician_id: string;
+  sound_role: string | null;
+  lights_role: string | null;
+  video_role: string | null;
+  production_role: string | null;
+  assigned_by: string | null;
+  assigned_at: string;
+  status: "confirmed" | "invited";
+  response_time: string | null;
+  single_day: boolean;
+  assignment_date: string | null;
+};
+
+type NormalizedAssignmentRoles = ReturnType<typeof normalizeAssignmentRoleInput>;
+
+export function buildAssignmentInsertPayload(
   jobId: string,
   technicianId: string,
   soundRole: string,
   lightsRole: string,
   assignedBy: string | null,
   options?: AssignmentInsertOptions
+): AssignmentInsertPayload;
+export function buildAssignmentInsertPayload(
+  jobId: string,
+  technicianId: string,
+  roles: AssignmentRoleInput,
+  assignedBy: string | null,
+  options?: AssignmentInsertOptions
+): AssignmentInsertPayload;
+export function buildAssignmentInsertPayload(
+  jobId: string,
+  technicianId: string,
+  rolesOrSound: string | AssignmentRoleInput,
+  lightsOrAssignedBy: string | null,
+  assignedByOrOptions?: string | null | AssignmentInsertOptions,
+  maybeOptions?: AssignmentInsertOptions
+) {
+  let normalizedRoles: NormalizedAssignmentRoles;
+  let assignedBy: string | null;
+  let options: AssignmentInsertOptions | undefined;
+
+  if (typeof rolesOrSound === "string") {
+    normalizedRoles = {
+      sound_role: normalizeAssignmentRole(rolesOrSound as string),
+      lights_role: normalizeAssignmentRole(
+        (typeof lightsOrAssignedBy === "string" ? lightsOrAssignedBy : null) as string | null,
+      ),
+      video_role: null,
+      production_role: null,
+    };
+    assignedBy =
+      typeof assignedByOrOptions === "string" || assignedByOrOptions == null
+        ? (assignedByOrOptions ?? null) as string | null
+        : null;
+    options = maybeOptions;
+  } else {
+    normalizedRoles = normalizeAssignmentRoleInput(rolesOrSound);
+    assignedBy = lightsOrAssignedBy;
+    options = assignedByOrOptions as AssignmentInsertOptions | undefined;
+  }
+
+  return buildAssignmentInsertPayloadImpl(
+    jobId,
+    technicianId,
+    normalizedRoles,
+    assignedBy,
+    options,
+  );
+}
+
+const buildAssignmentInsertPayloadImpl = (
+  jobId: string,
+  technicianId: string,
+  normalizedRoles: NormalizedAssignmentRoles,
+  assignedBy: string | null,
+  options?: AssignmentInsertOptions
 ) => {
-  const normalizedSound = soundRole !== "none" ? soundRole : null;
-  const normalizedLights = lightsRole !== "none" ? lightsRole : null;
   const shouldFlagSingleDay = !!options?.singleDay && !!options?.singleDayDate;
   const isConfirmed = !!options?.addAsConfirmed;
 
   return {
     job_id: jobId,
     technician_id: technicianId,
-    sound_role: normalizedSound,
-    lights_role: normalizedLights,
+    ...normalizedRoles,
     assigned_by: assignedBy,
     assigned_at: new Date().toISOString(),
     status: isConfirmed ? 'confirmed' : 'invited',
@@ -59,12 +134,44 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
   } = useRealtimeQuery<Assignment[]>(
     ["job-assignments", jobId],
     async () => {
-      console.log("Fetching assignments (from timesheets) for job:", jobId);
+      console.log("Fetching assignments for job:", jobId);
 
       // Add retry logic
       const fetchWithRetry = async (retries = 3): Promise<Assignment[]> => {
         try {
-          // Query timesheets first (source of truth for display)
+          const normalizeProfile = (p: any) => (Array.isArray(p) ? p[0] : p);
+
+          const { data: assignmentData, error: assignError } = await supabase
+            .from("job_assignments")
+            .select(`
+              id,
+              job_id,
+              technician_id,
+              external_technician_name,
+              sound_role,
+              lights_role,
+              video_role,
+              production_role,
+              status,
+              single_day,
+              assignment_date,
+              assignment_source,
+              assigned_at,
+              assigned_by,
+              profiles (
+                first_name,
+                last_name,
+                email,
+                department
+              )
+            `)
+            .eq("job_id", jobId);
+
+          if (assignError) {
+            console.warn("Error fetching job_assignments metadata:", assignError);
+            throw assignError;
+          }
+
           const { data: timesheetData, error: tsError } = await supabase
             .from("timesheets")
             .select(`
@@ -111,8 +218,6 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
             }
           }
 
-          const normalizeProfile = (p: any) => (Array.isArray(p) ? p[0] : p);
-
           // Group timesheets by technician once (avoids O(n²) find/filter)
           const timesheetsByTech = new Map<string, { profile: any | null; dates: Set<string> }>();
           for (const row of combinedTimesheets) {
@@ -130,63 +235,47 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
             }
           }
 
-          const techIds = Array.from(timesheetsByTech.keys());
-
-          if (techIds.length === 0) {
-            console.log(`No timesheets found for job ${jobId}`);
-            return [];
-          }
-
-          // Fetch job_assignments for role/status metadata
-          const { data: assignmentData, error: assignError } = await supabase
-            .from("job_assignments")
-            .select(`
-              technician_id,
-              sound_role,
-              lights_role,
-              video_role,
-              status,
-              single_day,
-              assignment_date,
-              assigned_at,
-              assigned_by,
-              profiles (
-                first_name,
-                last_name,
-                email,
-                department
-              )
-            `)
-            .eq("job_id", jobId)
-            .in("technician_id", techIds);
-
-          if (assignError) {
-            console.warn("Error fetching job_assignments metadata:", assignError);
-          }
-
-          // Merge: timesheets for presence, job_assignments for roles
-          const assignmentMap = new Map(
-            (assignmentData || []).map((a: any) => [a.technician_id, { ...a, profiles: normalizeProfile(a?.profiles) }]),
-          );
-
-          const mergedAssignments = techIds.map((techId) => {
-            const assignment = assignmentMap.get(techId);
-            const ts = timesheetsByTech.get(techId);
+          // Merge: job_assignments are the source of truth; timesheets add per-day date metadata.
+          const mergedAssignments = (assignmentData || []).map((assignment: any) => {
+            const techId = assignment.technician_id;
+            const ts = techId ? timesheetsByTech.get(techId) : null;
             const tsDates = ts ? Array.from(ts.dates).sort() : [];
             return {
               job_id: jobId,
+              ...assignment,
               technician_id: techId,
-              profiles: assignment?.profiles || ts?.profile,
-              sound_role: assignment?.sound_role,
-              lights_role: assignment?.lights_role,
-              video_role: assignment?.video_role,
-              status: assignment?.status,
-              single_day: assignment?.single_day,
-              assignment_date: assignment?.assignment_date,
-              assigned_at: assignment?.assigned_at,
-              assigned_by: assignment?.assigned_by,
+              profiles: normalizeProfile(assignment?.profiles) || ts?.profile,
+              sound_role: assignment?.sound_role ?? null,
+              lights_role: assignment?.lights_role ?? null,
+              video_role: assignment?.video_role ?? null,
+              production_role: assignment?.production_role ?? null,
               _timesheet_dates: tsDates,
             } as unknown as Assignment;
+          });
+
+          const assignmentTechIds = new Set(
+            (assignmentData || [])
+              .map((assignment: any) => assignment.technician_id)
+              .filter(Boolean)
+          );
+
+          timesheetsByTech.forEach((ts, techId) => {
+            if (assignmentTechIds.has(techId)) return;
+            mergedAssignments.push({
+              job_id: jobId,
+              technician_id: techId,
+              profiles: ts.profile,
+              sound_role: null,
+              lights_role: null,
+              video_role: null,
+              production_role: null,
+              status: null,
+              single_day: null,
+              assignment_date: null,
+              assigned_at: null,
+              assigned_by: null,
+              _timesheet_dates: Array.from(ts.dates).sort(),
+            } as unknown as Assignment);
           });
 
           console.log(`Successfully fetched ${mergedAssignments.length} assignments for job ${jobId}`);
@@ -259,26 +348,45 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
 
   const { manageFlexCrewAssignment } = useFlexCrewAssignments();
 
-  const addAssignment = async (
+  async function addAssignment(
     technicianId: string,
     soundRole: string,
     lightsRole: string,
     options?: AssignmentInsertOptions
-  ) => {
+  ): Promise<void>;
+  async function addAssignment(
+    technicianId: string,
+    roles: AssignmentRoleInput,
+    options?: AssignmentInsertOptions
+  ): Promise<void>;
+  async function addAssignment(
+    technicianId: string,
+    rolesOrSound: string | AssignmentRoleInput,
+    lightsOrOptions?: string | AssignmentInsertOptions,
+    maybeOptions?: AssignmentInsertOptions
+  ) {
     try {
       const { data: authData } = await supabase.auth.getUser();
       const assignedBy = authData?.user?.id ?? null;
+      const roles: AssignmentRoleInput = typeof rolesOrSound === "string"
+        ? {
+          soundRole: rolesOrSound,
+          lightsRole: typeof lightsOrOptions === "string" ? lightsOrOptions : "none",
+        }
+        : rolesOrSound;
+      const options = typeof rolesOrSound === "string"
+        ? maybeOptions
+        : lightsOrOptions as AssignmentInsertOptions | undefined;
       const payload = buildAssignmentInsertPayload(
         jobId,
         technicianId,
-        soundRole,
-        lightsRole,
+        roles,
         assignedBy,
         options
       );
 
-      // Optimistic cache update for 'jobs' list so cards update instantly
-      queryClient.setQueryData(['jobs'], (old: any) => {
+      // Optimistic cache update for jobs list so cards update instantly
+      queryClient.setQueryData(queryKeys.scope("jobs"), (old: any) => {
         if (!Array.isArray(old)) return old;
         return old.map((j) => {
           if (j.id !== jobId) return j;
@@ -287,6 +395,8 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
             technician_id: technicianId,
             sound_role: payload.sound_role,
             lights_role: payload.lights_role,
+            video_role: payload.video_role,
+            production_role: payload.production_role,
             single_day: payload.single_day,
             assignment_date: payload.assignment_date ?? null,
             assigned_at: payload.assigned_at,
@@ -342,12 +452,12 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
       }
 
       // Add to Flex crew calls if applicable
-      if (soundRole && soundRole !== 'none') {
-        await manageFlexCrewAssignment(jobId, technicianId, 'sound', 'add');
-      }
-      
-      if (lightsRole && lightsRole !== 'none') {
-        await manageFlexCrewAssignment(jobId, technicianId, 'lights', 'add');
+      for (const dept of ASSIGNMENT_DEPARTMENTS) {
+        if (dept === "production") continue;
+        const role = payload[`${dept}_role` as keyof typeof payload];
+        if (role) {
+          await manageFlexCrewAssignment(jobId, technicianId, dept, 'add');
+        }
       }
 
       toast.success("Assignment added successfully");
@@ -358,14 +468,14 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
       console.error('Error in addAssignment:', error);
       toast.error("Failed to add assignment");
     }
-  };
+  }
 
   const removeAssignment = async (technicianId: string) => {
     try {
       setIsRemoving(prev => ({ ...prev, [technicianId]: true }));
 
-      // Optimistic cache update for 'jobs'
-      queryClient.setQueryData(['jobs'], (old: any) => {
+      // Optimistic cache update for jobs list
+      queryClient.setQueryData(queryKeys.scope("jobs"), (old: any) => {
         if (!Array.isArray(old)) return old;
         return old.map((j) => {
           if (j.id !== jobId) return j;
@@ -407,12 +517,12 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
 
       // Remove from Flex crew calls if applicable
       if (assignmentToRemove) {
-        if (assignmentToRemove.sound_role && assignmentToRemove.sound_role !== 'none') {
-          await manageFlexCrewAssignment(jobId, technicianId, 'sound', 'remove');
-        }
-        
-        if (assignmentToRemove.lights_role && assignmentToRemove.lights_role !== 'none') {
-          await manageFlexCrewAssignment(jobId, technicianId, 'lights', 'remove');
+        for (const dept of ASSIGNMENT_DEPARTMENTS) {
+          if (dept === "production") continue;
+          const role = assignmentToRemove[`${dept}_role` as keyof Assignment];
+          if (role) {
+            await manageFlexCrewAssignment(jobId, technicianId, dept, 'remove');
+          }
         }
       }
 

--- a/src/hooks/useJobIntegration.ts
+++ b/src/hooks/useJobIntegration.ts
@@ -65,10 +65,10 @@ export const useJobIntegration = (jobId: string) => {
     }
 
     const staff = jobDetails.job_assignments?.map((assignment: any) => ({
-      name: assignment.profiles?.first_name || "",
+      name: assignment.profiles?.first_name || assignment.external_technician_name || "",
       surname1: assignment.profiles?.last_name || "",
       surname2: "",
-      position: assignment.sound_role || assignment.lights_role || assignment.video_role || "Técnico"
+      position: assignment.sound_role || assignment.lights_role || assignment.video_role || assignment.production_role || "Técnico"
     })) || [];
 
     return {

--- a/src/hooks/useJobManagement.ts
+++ b/src/hooks/useJobManagement.ts
@@ -24,16 +24,28 @@ export const useJobManagement = (
       .from("jobs")
       .select(`
         *,
-        location:locations(name),
+        location:locations(id, name, formatted_address, latitude, longitude),
         job_departments!inner(department),
         job_assignments(
+          id,
           technician_id,
           sound_role,
           lights_role,
           video_role,
+          production_role,
+          external_technician_name,
+          assignment_source,
+          status,
+          single_day,
+          assignment_date,
+          assigned_at,
+          assigned_by,
           profiles!job_assignments_technician_id_fkey(
+            id,
             first_name,
-            last_name
+            last_name,
+            nickname,
+            department
           )
         ),
         job_documents(

--- a/src/hooks/useJobSelection.ts
+++ b/src/hooks/useJobSelection.ts
@@ -21,6 +21,11 @@ export interface JobSelection {
   end_time: string;
 }
 
+const oneOrFirst = <T,>(value: T | T[] | null | undefined): T | null => {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+};
+
 export const useJobSelection = () => {
   return useQuery({
     queryKey: queryKeys.scope("jobs-for-selection"),
@@ -49,9 +54,10 @@ export const useJobSelection = () => {
             )
           )
         `)
-        .gte('start_time', today.toISOString()) // Filter to present/future jobs only
+        .gte('end_time', today.toISOString()) // Include ongoing multi-day jobs
         .in('job_type', ['single', 'festival', 'ciclo', 'tourdate']) // Only include relevant job types
         .neq('status', 'Completado') // Exclude completed/deleted jobs
+        .neq('status', 'Cancelado')
         .order("start_time", { ascending: true });
 
       if (error) {
@@ -62,20 +68,25 @@ export const useJobSelection = () => {
       console.log("Raw jobs data:", jobs);
 
       // Transform the data to match our expected types
-      const transformedJobs = jobs?.map(job => ({
-        id: job.id,
-        title: job.title,
-        start_time: job.start_time,
-        end_time: job.end_time,
-        tour_date_id: job.tour_date_id,
-        tour_date: job.tour_date ? {
-          id: job.tour_date[0]?.id, // Access first element of tour_date array
-          tour: {
-            id: job.tour_date[0]?.tour[0]?.id, // Access first tour from the first tour_date
-            name: job.tour_date[0]?.tour[0]?.name
-          }
-        } : null
-      })) as JobSelection[];
+      const transformedJobs = jobs?.map(job => {
+        const tourDate = oneOrFirst(job.tour_date);
+        const tour = oneOrFirst(tourDate?.tour);
+
+        return {
+          id: job.id,
+          title: job.title,
+          start_time: job.start_time,
+          end_time: job.end_time,
+          tour_date_id: job.tour_date_id,
+          tour_date: tourDate ? {
+            id: tourDate.id,
+            tour: {
+              id: tour?.id ?? "",
+              name: tour?.name ?? ""
+            }
+          } : null
+        };
+      }) as JobSelection[];
 
       console.log("Transformed jobs:", transformedJobs);
       return transformedJobs;

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -32,7 +32,13 @@ export const useJobs = () => {
             .from("jobs")
             .select(`
               *,
-              location:locations(name),
+              location:locations(
+                id,
+                name,
+                formatted_address,
+                latitude,
+                longitude
+              ),
               job_departments!inner(department),
               job_assignments(
                 id,
@@ -40,10 +46,14 @@ export const useJobs = () => {
                 sound_role,
                 lights_role,
                 video_role,
+                production_role,
+                external_technician_name,
                 assignment_source,
                 status,
                 single_day,
                 assignment_date,
+                assigned_at,
+                assigned_by,
                 profiles!job_assignments_technician_id_fkey(
                   id,
                   first_name,

--- a/src/hooks/useJobsRealtime.ts
+++ b/src/hooks/useJobsRealtime.ts
@@ -27,7 +27,7 @@ export function useJobsRealtime() {
         .from('jobs')
           .select(`
             *,
-            location:locations(name),
+            location:locations(id, name, formatted_address, latitude, longitude),
             job_departments!inner(department),
             job_assignments(
               id,
@@ -35,10 +35,14 @@ export function useJobsRealtime() {
               sound_role,
               lights_role,
               video_role,
+              production_role,
+              external_technician_name,
               assignment_source,
               status,
               single_day,
               assignment_date,
+              assigned_at,
+              assigned_by,
               profiles!job_assignments_technician_id_fkey(
                 id,
                 first_name,

--- a/src/hooks/useOptimisticJobManagement.ts
+++ b/src/hooks/useOptimisticJobManagement.ts
@@ -26,16 +26,28 @@ export const useOptimisticJobManagement = (
       .from("jobs")
       .select(`
         *,
-        location:locations(name),
+        location:locations(id, name, formatted_address, latitude, longitude),
         job_departments!inner(department),
         job_assignments(
+          id,
           technician_id,
           sound_role,
           lights_role,
           video_role,
+          production_role,
+          external_technician_name,
+          assignment_source,
+          status,
+          single_day,
+          assignment_date,
+          assigned_at,
+          assigned_by,
           profiles!job_assignments_technician_id_fkey(
+            id,
             first_name,
-            last_name
+            last_name,
+            nickname,
+            department
           )
         ),
         job_documents(

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -176,6 +176,7 @@ export const useOptimizedJobCard = (
           sound_role: null,
           lights_role: null,
           video_role: null,
+          production_role: null,
           status: null,
           single_day: null,
           assignment_date: null,
@@ -269,6 +270,7 @@ export const useOptimizedJobCard = (
     const soundSet = new Set<string>();
     const lightsSet = new Set<string>();
     const videoSet = new Set<string>();
+    const productionSet = new Set<string>();
     const roleSets: Record<string, Set<string>> = {};
 
     const rows = Array.isArray(assignments) ? assignments : [];
@@ -289,12 +291,18 @@ export const useOptimizedJobCard = (
         roleSets[a.video_role] = roleSets[a.video_role] || new Set<string>();
         roleSets[a.video_role].add(techId);
       }
+      if (a.production_role) {
+        productionSet.add(techId);
+        roleSets[a.production_role] = roleSets[a.production_role] || new Set<string>();
+        roleSets[a.production_role].add(techId);
+      }
     }
 
     const countsByDept: Record<string, number> = {
       sound: soundSet.size,
       lights: lightsSet.size,
-      video: videoSet.size
+      video: videoSet.size,
+      production: productionSet.size
     } as any;
 
     const countsByRole: Record<string, number> = {};
@@ -306,7 +314,7 @@ export const useOptimizedJobCard = (
   // Compute shortages per department/role
   const requiredVsAssigned = useMemo(() => {
     const byDept: Record<string, { required: number; assigned: number; roles: Array<{ role_code: string; required: number; assigned: number }> }> = {};
-    for (const dept of ['sound', 'lights', 'video']) {
+    for (const dept of ['sound', 'lights', 'video', 'production']) {
       const sum = reqByDept.get?.(dept as any) || (reqSummary.find(r => r.department === dept) ?? null);
       const required = sum?.total_required ?? 0;
       const roles = (sum?.roles || []).map((r) => ({

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -61,16 +61,20 @@ export const useOptimizedJobs = (
           department
         ),
         job_assignments(
+          id,
           technician_id,
           sound_role,
           lights_role,
           video_role,
+          production_role,
+          external_technician_name,
           assignment_source,
           single_day,
           assignment_date,
           status,
           assigned_at,
-          profiles!job_assignments_technician_id_fkey!inner(
+          assigned_by,
+          profiles!job_assignments_technician_id_fkey(
             id,
             first_name,
             nickname,
@@ -94,10 +98,19 @@ export const useOptimizedJobs = (
           type
         ),
         tour_date:tour_dates(
+          id,
           date,
           start_date,
           end_date,
-          tour_date_type
+          tour_date_type,
+          is_tour_pack_only,
+          location:locations(
+            id,
+            name,
+            formatted_address,
+            latitude,
+            longitude
+          )
         ),
         flex_folders(
           id,

--- a/src/hooks/useOptimizedMatrixData.ts
+++ b/src/hooks/useOptimizedMatrixData.ts
@@ -42,6 +42,7 @@ export interface MatrixTimesheetAssignment {
   sound_role?: string | null;
   lights_role?: string | null;
   video_role?: string | null;
+  production_role?: string | null;
   is_schedule_only?: boolean | null;
   source?: string | null;
 }
@@ -87,7 +88,7 @@ interface TimesheetAssignmentRow {
 
 type AssignmentMetadataRow = Pick<
   MatrixTimesheetAssignment,
-  'job_id' | 'technician_id' | 'sound_role' | 'lights_role' | 'video_role' | 'single_day' | 'assignment_date' | 'status' | 'assigned_at' | 'assigned_by'
+  'job_id' | 'technician_id' | 'sound_role' | 'lights_role' | 'video_role' | 'production_role' | 'single_day' | 'assignment_date' | 'status' | 'assigned_at' | 'assigned_by'
 >;
 
 type StaffingSummaryRow = {
@@ -154,7 +155,7 @@ export const fetchMatrixTimesheetAssignments = async ({
         .from('job_assignments')
         // NOTE: single_day and assignment_date are deprecated after simplification migration
         // They're kept in the query for backwards compatibility but should eventually be removed
-        .select('job_id, technician_id, sound_role, lights_role, video_role, single_day, assignment_date, status, assigned_at, assigned_by')
+        .select('job_id, technician_id, sound_role, lights_role, video_role, production_role, single_day, assignment_date, status, assigned_at, assigned_by')
         .in('job_id', jobBatch)
         .in('technician_id', technicianIds)
     ));
@@ -224,6 +225,7 @@ export const fetchMatrixTimesheetAssignments = async ({
         sound_role: meta?.sound_role ?? null,
         lights_role: meta?.lights_role ?? null,
         video_role: meta?.video_role ?? null,
+        production_role: meta?.production_role ?? null,
         is_schedule_only: row.is_schedule_only ?? null,
         source: row.source ?? null,
       });

--- a/src/pages/Lights.tsx
+++ b/src/pages/Lights.tsx
@@ -301,7 +301,7 @@ const Lights = () => {
 
       {/* Mobile FAB */}
       <Button 
-        className="sm:hidden fixed bottom-6 right-6 rounded-full h-12 w-12 p-0 shadow-lg"
+        className="sm:hidden fixed bottom-[max(1.5rem,env(safe-area-inset-bottom))] right-[max(1.5rem,env(safe-area-inset-right))] rounded-full h-12 w-12 p-0 shadow-lg"
         onClick={() => handleCreateJob(undefined)}
       >
         <Plus className="h-6 w-6" />

--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -432,9 +432,9 @@ const ProjectManagement = () => {
           department: selectedDepartment,
           date: currentDate
         })}
-        className="fixed bottom-20 right-6 md:bottom-8 md:right-8
+        className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-[max(1.5rem,env(safe-area-inset-right))] md:bottom-8 md:right-8
                    w-12 h-12 md:w-14 md:h-14
-                   bg-blue-600 hover:bg-blue-500
+                   bg-primary hover:bg-primary/90
                    text-white rounded-full shadow-lg
                    flex items-center justify-center
                    transition-all hover:scale-110

--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -434,7 +434,7 @@ const Sound = () => {
             {/* Desktop FAB */}
             {!authLoading && canManageJobs && (
               <Button
-                className="sm:hidden fixed bottom-6 right-6 rounded-full h-12 w-12 p-0 shadow-lg"
+                className="sm:hidden fixed bottom-[max(1.5rem,env(safe-area-inset-bottom))] right-[max(1.5rem,env(safe-area-inset-right))] rounded-full h-12 w-12 p-0 shadow-lg"
                 onClick={() => handleCreateJob(undefined)}
               >
                 <Plus className="h-6 w-6" />

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -66,6 +66,7 @@ interface TechnicianAssignment {
   sound_role?: string | null;
   lights_role?: string | null;
   video_role?: string | null;
+  production_role?: string | null;
   jobs: TechnicianJobData;
 }
 
@@ -156,7 +157,7 @@ const TechnicianDashboard = () => {
 
       // Step 1: Fetch confirmed job assignments to get role/status info
       const { data: assignmentsData, error: assignmentsError } = await dataLayerClient.from('job_assignments')
-        .select('job_id, sound_role, lights_role, video_role, status, assigned_at')
+        .select('job_id, sound_role, lights_role, video_role, production_role, status, assigned_at')
         .eq('technician_id', user.id)
         .eq('status', 'confirmed');
 
@@ -262,11 +263,13 @@ const TechnicianDashboard = () => {
           if (assignment?.sound_role) department = "sound";
           else if (assignment?.lights_role) department = "lights";
           else if (assignment?.video_role) department = "video";
+          else if (assignment?.production_role) department = "production";
 
           const category = getCategoryFromAssignment({
             sound_role: assignment?.sound_role,
             lights_role: assignment?.lights_role,
-            video_role: assignment?.video_role
+            video_role: assignment?.video_role,
+            production_role: assignment?.production_role
           });
 
           return {
@@ -274,11 +277,12 @@ const TechnicianDashboard = () => {
             job_id: row.job_id,
             technician_id: row.technician_id,
             department,
-            role: assignment?.sound_role || assignment?.lights_role || assignment?.video_role || "Assigned",
+            role: assignment?.sound_role || assignment?.lights_role || assignment?.video_role || assignment?.production_role || "Assigned",
             category,
             sound_role: assignment?.sound_role,
             lights_role: assignment?.lights_role,
             video_role: assignment?.video_role,
+            production_role: assignment?.production_role,
             jobs: {
               ...job,
               location,

--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -86,6 +86,7 @@ interface TechnicianAssignment {
   sound_role?: string | null;
   lights_role?: string | null;
   video_role?: string | null;
+  production_role?: string | null;
   jobs: TechnicianJobData;
 }
 
@@ -178,7 +179,7 @@ export default function TechnicianSuperApp() {
 
       // First, fetch job_assignments for this technician to get roles and status
       const { data: assignmentsData, error: assignmentsError } = await dataLayerClient.from('job_assignments')
-        .select('job_id, sound_role, lights_role, video_role, status, assigned_at')
+        .select('job_id, sound_role, lights_role, video_role, production_role, status, assigned_at')
         .eq('technician_id', user.id)
         .eq('status', 'confirmed');
 
@@ -282,11 +283,13 @@ export default function TechnicianSuperApp() {
           if (assignment?.sound_role) department = "sound";
           else if (assignment?.lights_role) department = "lights";
           else if (assignment?.video_role) department = "video";
+          else if (assignment?.production_role) department = "production";
 
           const category = getCategoryFromAssignment({
             sound_role: assignment?.sound_role,
             lights_role: assignment?.lights_role,
-            video_role: assignment?.video_role
+            video_role: assignment?.video_role,
+            production_role: assignment?.production_role
           });
 
           const job = (Array.isArray(row.jobs) ? row.jobs[0] : row.jobs) as unknown as JobWithLocationAndDocs;
@@ -295,11 +298,12 @@ export default function TechnicianSuperApp() {
             job_id: row.job_id,
             technician_id: row.technician_id,
             department,
-            role: assignment?.sound_role || assignment?.lights_role || assignment?.video_role || "Assigned",
+            role: assignment?.sound_role || assignment?.lights_role || assignment?.video_role || assignment?.production_role || "Assigned",
             category,
             sound_role: assignment?.sound_role,
             lights_role: assignment?.lights_role,
             video_role: assignment?.video_role,
+            production_role: assignment?.production_role,
             jobs: {
               ...job,
               created_at: job.created_at || '',

--- a/src/pages/TechnicianUnavailability.tsx
+++ b/src/pages/TechnicianUnavailability.tsx
@@ -298,7 +298,7 @@ export default function TechnicianUnavailability() {
         <Sheet open={open} onOpenChange={setOpen}>
           <SheetContent
             side="bottom"
-            className="flex h-[94vh] flex-col overflow-hidden rounded-t-2xl bg-background px-6 pb-6 pt-10"
+            className="flex h-[calc(100dvh-1rem)] max-h-[calc(100dvh-1rem)] flex-col overflow-hidden rounded-t-2xl bg-background px-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] pt-[max(2.5rem,env(safe-area-inset-top))]"
           >
             <SheetHeader className="space-y-1 text-left">
               <SheetTitle>Añadir bloqueo de disponibilidad</SheetTitle>

--- a/src/pages/Video.tsx
+++ b/src/pages/Video.tsx
@@ -287,7 +287,7 @@ const Video = () => {
       {/* Mobile FAB */}
       {canManageJobs && (
         <Button
-          className="sm:hidden fixed bottom-6 right-6 rounded-full h-12 w-12 p-0 shadow-lg"
+          className="sm:hidden fixed bottom-[max(1.5rem,env(safe-area-inset-bottom))] right-[max(1.5rem,env(safe-area-inset-right))] rounded-full h-12 w-12 p-0 shadow-lg"
           onClick={() => handleCreateJob(undefined)}
         >
           <Plus className="h-6 w-6" />

--- a/src/pages/festival-management/FestivalManagementDialogs.tsx
+++ b/src/pages/festival-management/FestivalManagementDialogs.tsx
@@ -142,8 +142,8 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
       />
 
       <Dialog open={isRouteSheetOpen} onOpenChange={setIsRouteSheetOpen}>
-        <DialogContent className="max-w-[96vw] w-[96vw] max-h-[90vh] md:h-[90vh] p-0 overflow-hidden flex flex-col">
-          <div className="h-full overflow-auto">{jobId && <ModernHojaDeRuta jobId={jobId} />}</div>
+        <DialogContent className="max-w-[96vw] w-[96vw] h-[calc(100dvh-1rem)] max-h-[calc(100dvh-1rem)] md:h-[90dvh] p-0 overflow-hidden flex flex-col">
+          <div className="h-full overflow-auto pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">{jobId && <ModernHojaDeRuta jobId={jobId} />}</div>
         </DialogContent>
       </Dialog>
 

--- a/src/types/assignment.ts
+++ b/src/types/assignment.ts
@@ -2,6 +2,7 @@ export interface Assignment {
   id: string;
   job_id: string;
   technician_id: string;
+  external_technician_name?: string | null;
   assigned_by: string | null;
   assigned_at: string;
   // DEPRECATED: Use timesheets to determine which days a technician works
@@ -18,5 +19,5 @@ export interface Assignment {
     last_name: string;
     email: string;
     department: string;
-  };
+  } | null;
 }

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -33,6 +33,8 @@ export interface StaffAssignment {
   sound_role?: string;
   lights_role?: string;
   video_role?: string;
+  production_role?: string;
+  external_technician_name?: string | null;
   technician?: TechnicianProfile;
 }
 

--- a/src/utils/assignmentRoles.ts
+++ b/src/utils/assignmentRoles.ts
@@ -1,0 +1,79 @@
+export type AssignmentDepartment = "sound" | "lights" | "video" | "production";
+
+export type AssignmentRoleField =
+  | "sound_role"
+  | "lights_role"
+  | "video_role"
+  | "production_role";
+
+export type AssignmentRoleInput = Partial<Record<AssignmentDepartment, string | null | undefined>> & {
+  soundRole?: string | null;
+  lightsRole?: string | null;
+  videoRole?: string | null;
+  productionRole?: string | null;
+};
+
+export const ROLE_FIELD_BY_DEPARTMENT: Record<AssignmentDepartment, AssignmentRoleField> = {
+  sound: "sound_role",
+  lights: "lights_role",
+  video: "video_role",
+  production: "production_role",
+};
+
+export const ASSIGNMENT_DEPARTMENTS: AssignmentDepartment[] = [
+  "sound",
+  "lights",
+  "video",
+  "production",
+];
+
+export const isAssignmentDepartment = (
+  department: string | null | undefined,
+): department is AssignmentDepartment => (
+  !!department && ASSIGNMENT_DEPARTMENTS.includes(department.toLowerCase() as AssignmentDepartment)
+);
+
+export const normalizeAssignmentRole = (role: string | null | undefined) => {
+  const normalized = typeof role === "string" ? role.trim() : role;
+  return normalized && normalized !== "none" ? normalized : null;
+};
+
+export const getAssignmentRoleForDepartment = (
+  assignment: Record<string, any> | null | undefined,
+  department: string | null | undefined,
+): string | null => {
+  const normalizedDepartment = department?.toLowerCase?.();
+  if (!isAssignmentDepartment(normalizedDepartment)) return null;
+  return normalizeAssignmentRole(assignment?.[ROLE_FIELD_BY_DEPARTMENT[normalizedDepartment]]);
+};
+
+export const hasAssignmentRoleForDepartment = (
+  assignment: Record<string, any> | null | undefined,
+  department: string | null | undefined,
+) => Boolean(getAssignmentRoleForDepartment(assignment, department));
+
+export const getFirstAssignmentRole = (
+  assignment: Record<string, any> | null | undefined,
+): string | null => {
+  for (const department of ASSIGNMENT_DEPARTMENTS) {
+    const role = getAssignmentRoleForDepartment(assignment, department);
+    if (role) return role;
+  }
+  return null;
+};
+
+export const normalizeAssignmentRoleInput = (input: AssignmentRoleInput = {}) => ({
+  sound_role: normalizeAssignmentRole(input.sound ?? input.soundRole),
+  lights_role: normalizeAssignmentRole(input.lights ?? input.lightsRole),
+  video_role: normalizeAssignmentRole(input.video ?? input.videoRole),
+  production_role: normalizeAssignmentRole(input.production ?? input.productionRole),
+});
+
+export const buildAssignmentRoleInputForDepartment = (
+  department: string,
+  role: string | null | undefined,
+): AssignmentRoleInput => {
+  const normalizedDepartment = department.toLowerCase();
+  if (!isAssignmentDepartment(normalizedDepartment)) return {};
+  return { [normalizedDepartment]: role };
+};

--- a/src/utils/roleCategory.ts
+++ b/src/utils/roleCategory.ts
@@ -8,8 +8,8 @@ export function getCategoryFromRole(roleCode: string | null | undefined): 'respo
   
   const normalized = roleCode.trim().toUpperCase();
   
-  // Check if it's a valid role code format such as SND-FOH-R.
-  if (!normalized.match(/^[A-Z]{3}-[A-Z]+-[RET]$/)) {
+  // Check if it's a valid role code format such as SND-FOH-R or PROD-RESP-R.
+  if (!normalized.match(/^[A-Z]{3,4}-[A-Z]+-[RET]$/)) {
     return null;
   }
   
@@ -36,8 +36,9 @@ export function getCategoryFromAssignment(assignment: {
   sound_role?: string | null;
   lights_role?: string | null;
   video_role?: string | null;
+  production_role?: string | null;
 }): 'responsable' | 'especialista' | 'tecnico' | null {
-  const roles = [assignment.sound_role, assignment.lights_role, assignment.video_role];
+  const roles = [assignment.sound_role, assignment.lights_role, assignment.video_role, assignment.production_role];
   const categories = roles.map(role => getCategoryFromRole(role)).filter(cat => cat !== null);
 
   if (categories.length === 0) return null;

--- a/src/utils/technicianAvailability.ts
+++ b/src/utils/technicianAvailability.ts
@@ -1,6 +1,30 @@
 
 import { supabase } from "@/lib/supabase";
 import { hasTechnicianSelfServiceAccess } from "@/utils/permissions";
+import { formatInTimeZone } from "date-fns-tz";
+
+const MADRID_TIME_ZONE = "Europe/Madrid";
+
+const toMadridDateKey = (value: string | null | undefined): string | null => {
+  if (!value) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+  return formatInTimeZone(new Date(value), MADRID_TIME_ZONE, "yyyy-MM-dd");
+};
+
+const addDaysToDateKey = (dateKey: string, days: number) => {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day + days)).toISOString().slice(0, 10);
+};
+
+const getDateKeysBetween = (startDateKey: string, endDateKey: string) => {
+  const dates: string[] = [];
+  let cursor = startDateKey;
+  while (cursor <= endDateKey) {
+    dates.push(cursor);
+    cursor = addDaysToDateKey(cursor, 1);
+  }
+  return dates;
+};
 
 export interface TechnicianJobConflict {
   id: string;
@@ -8,6 +32,13 @@ export interface TechnicianJobConflict {
   start_time: string;
   end_time: string;
 }
+
+type AvailabilityJob = {
+  id: string;
+  start_time: string;
+  end_time: string;
+  title: string;
+};
 
 /**
  * Enhanced conflict check result with hard/soft conflict distinction
@@ -79,12 +110,14 @@ export async function getAvailableTechnicians(
     const technicianIds = eligibleTechnicians.map((tech: any) => tech.id);
 
     // OPTIMIZED: Query timesheets directly to see which days technicians are actually working
-    const normalizedTargetDate = assignmentDate
-      ? new Date(assignmentDate).toISOString().split('T')[0]
-      : null;
+    const normalizedTargetDate = toMadridDateKey(assignmentDate);
 
-    const jobStartDate = normalizedTargetDate || new Date(jobStartTime).toISOString().split('T')[0];
-    const jobEndDate = normalizedTargetDate || new Date(jobEndTime).toISOString().split('T')[0];
+    const jobStartDate = normalizedTargetDate || toMadridDateKey(jobStartTime);
+    const jobEndDate = normalizedTargetDate || toMadridDateKey(jobEndTime);
+
+    if (!jobStartDate || !jobEndDate) {
+      return eligibleTechnicians;
+    }
 
     // Get all ACTIVE timesheets for these technicians in the relevant date range
     // Filter by is_active to exclude voided timesheets (day-off/travel dates)
@@ -100,16 +133,32 @@ export async function getAvailableTechnicians(
       throw timesheetsError;
     }
 
+    const { data: currentJobAssignments, error: currentAssignmentsError } = await supabase
+      .from("job_assignments")
+      .select("technician_id")
+      .eq("job_id", jobId)
+      .in("technician_id", technicianIds);
+
+    if (currentAssignmentsError) {
+      throw currentAssignmentsError;
+    }
+
+    const alreadyAssignedToCurrentJob = new Set(
+      (currentJobAssignments || [])
+        .map((assignment) => assignment.technician_id)
+        .filter(Boolean)
+    );
+
     // Get job info for conflicting jobs
     const conflictingJobIds = Array.from(new Set((timesheets || []).map(ts => ts.job_id)));
-    const { data: jobs, error: jobsError } = await supabase
-      .from("jobs")
-      .select("id, start_time, end_time, title")
-      .in("id", conflictingJobIds);
+    const { data: jobs, error: jobsError } = conflictingJobIds.length > 0
+      ? await supabase
+        .from("jobs")
+        .select("id, start_time, end_time, title")
+        .in("id", conflictingJobIds)
+      : { data: [] as AvailabilityJob[], error: null };
 
-    if (jobsError) {
-      throw jobsError;
-    }
+    if (jobsError) throw jobsError;
 
     const jobMap = new Map<string, any>();
     (jobs || []).forEach(job => jobMap.set(job.id, job));
@@ -151,7 +200,7 @@ export async function getAvailableTechnicians(
     const availableTechnicians = eligibleTechnicians.filter((technician: any) => {
       // Check if already assigned to current job
       const assignedJobs = technicianJobs.get(technician.id);
-      if (assignedJobs?.has(jobId)) {
+      if (assignedJobs?.has(jobId) || alreadyAssignedToCurrentJob.has(technician.id)) {
         return false; // Already assigned to this job
       }
 
@@ -171,12 +220,7 @@ export async function getAvailableTechnicians(
         // Single date check
         targetDates.push(normalizedTargetDate);
       } else {
-        // Whole job - check all dates in range
-        const start = new Date(jobStartDate);
-        const end = new Date(jobEndDate);
-        for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
-          targetDates.push(d.toISOString().split('T')[0]);
-        }
+        targetDates.push(...getDateKeysBetween(jobStartDate, jobEndDate));
       }
 
       // Check if any target date conflicts with existing work dates
@@ -224,8 +268,8 @@ export async function checkTimeConflict(
     }
 
     // Determine date range to check
-    const startDate = targetDateIso || (targetJob.start_time ? new Date(targetJob.start_time).toISOString().split('T')[0] : null);
-    const endDate = targetDateIso || (targetJob.end_time ? new Date(targetJob.end_time).toISOString().split('T')[0] : null);
+    const startDate = toMadridDateKey(targetDateIso || targetJob.start_time);
+    const endDate = toMadridDateKey(targetDateIso || targetJob.end_time);
 
     if (!startDate || !endDate) {
       return null;
@@ -284,8 +328,15 @@ export async function getTechnicianConflicts(
   jobEndTime: string
 ) {
   try {
-    const jobStartDate = new Date(jobStartTime).toISOString().split('T')[0];
-    const jobEndDate = new Date(jobEndTime).toISOString().split('T')[0];
+    const jobStartDate = toMadridDateKey(jobStartTime);
+    const jobEndDate = toMadridDateKey(jobEndTime);
+
+    if (!jobStartDate || !jobEndDate) {
+      return {
+        jobConflicts: [],
+        unavailabilityConflicts: []
+      };
+    }
 
     // OPTIMIZED: Query ACTIVE timesheets to see which days technician is working
     // Filter by is_active to exclude voided timesheets (day-off/travel dates)
@@ -305,10 +356,12 @@ export async function getTechnicianConflicts(
     const jobIds = Array.from(new Set((timesheets || []).map(ts => ts.job_id)));
 
     // Fetch job details
-    const { data: jobs, error: jobsError } = await supabase
-      .from("jobs")
-      .select("id, start_time, end_time, title")
-      .in("id", jobIds);
+    const { data: jobs, error: jobsError } = jobIds.length > 0
+      ? await supabase
+        .from("jobs")
+        .select("id, start_time, end_time, title")
+        .in("id", jobIds)
+      : { data: [] as AvailabilityJob[], error: null };
 
     if (jobsError) {
       throw jobsError;


### PR DESCRIPTION
## Summary

Completes the UI audit roadmap implementation from the synced `main` baseline. This PR focuses on the data drift and safe-area issues found across job cards, dialogs, department mobile pages, technician views, and task/festival forms.

## What changed

- Added a shared assignment role helper for `sound`, `lights`, `video`, and `production` role fields.
- Normalized job/assignment query shapes to include production roles, external technician names, assignment metadata, richer location fields, and tour/date fields where job cards and dialogs consume them.
- Made assignment display assignment-first, then decorated with timesheet date metadata so invited/scheduled rows are not hidden when timesheets are absent.
- Fixed video assignment insertion paths and production role/category handling across cards, details, matrix, technician dashboards, and notifications.
- Fixed selectors/availability to avoid missing ongoing multi-day jobs, include Madrid-safe date keys, short-circuit empty `.in(...)` queries, and invalidate single-day availability keys correctly.
- Added safe-area defaults to dialog/sheet/drawer primitives and migrated high-risk custom modals/sheets/FABs to `dvh` sizing and safe bottom/top padding.
- Reduced hard-coded CTA/FAB blue usage in shared flows to semantic app tokens.
- Fixed dynamic Supabase payload typing issues and a task-document insert bug where video uploads used `task_id` instead of `video_task_id`.
- Added the completed roadmap and verification notes under `docs/plans/ui-data-theme-safe-area-audit-roadmap.md`.

## Validation

- `npm run typecheck` passed.
- Focused Vitest run passed: assignment payloads, notification department derivation, optimized matrix data, matrix utils, TechnicianSuperApp, ProjectManagement, and TechnicianUnavailability.
- `npm run build` passed with existing chunk-size warnings.
- `git diff --check` passed, with existing Windows LF-to-CRLF warnings only.

## Remaining QA note

Built preview starts, but browser visual smoke cannot reach the app UI in this local checkout because no `.env` is present and runtime throws on missing `VITE_SUPABASE_URL`. The PR keeps this documented in the roadmap so the final desktop/mobile visual pass can be run in an environment-backed checkout.