### PR TITLE
[codex] Fix festival WhatsApp stage recipients

### DIFF
--- a/src/components/festival/scheduling/FestivalScheduling.tsx
+++ b/src/components/festival/scheduling/FestivalScheduling.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Plus, FileDown, RefreshCw } from "lucide-react";
+import { MessageCircle, Plus, RefreshCw } from "lucide-react";
 import { format } from "date-fns";
 import { SubscriptionIndicator } from "@/components/ui/subscription-indicator";
 import { useFestivalShifts } from "@/hooks/festival/useFestivalShifts";
@@ -19,9 +19,10 @@ interface FestivalSchedulingProps {
   jobId: string;
   jobDates: Date[];
   isViewOnly?: boolean;
+  onCreateWhatsappGroup?: () => void;
 }
 
-export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: FestivalSchedulingProps) => {
+export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false, onCreateWhatsappGroup }: FestivalSchedulingProps) => {
   const [selectedDate, setSelectedDate] = useState<string>("");
   const [isCreateShiftOpen, setIsCreateShiftOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"list" | "table">("table");
@@ -215,6 +216,17 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false }: Fest
         <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 sm:gap-4">
           <CardTitle className="text-base sm:text-lg">Programación del Festival</CardTitle>
           <div className="flex gap-2">
+            {!isViewOnly && onCreateWhatsappGroup && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={onCreateWhatsappGroup}
+                className="flex items-center gap-1"
+              >
+                <MessageCircle className="h-4 w-4" />
+                <span className="hidden sm:inline">WhatsApp</span>
+              </Button>
+            )}
             {!isViewOnly && (
               <Button
                 size="sm"

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -510,7 +510,7 @@ function JobCardNewFull({
   // WhatsApp group existence for this job + department (for management only)
   const { data: waGroup, refetch: refetchWaGroup } = useQuery({
     queryKey: queryKeys.scope('job-whatsapp-group', job.id, department, 0),
-    enabled: !!job?.id && !!department && isManagementUser,
+    enabled: !!job?.id && !!department && isManagementUser && !isFestivalLike,
     queryFn: async () => {
       const { data, error } = await dataLayerClient.from('job_whatsapp_groups')
         .select('id, wa_group_id')
@@ -525,7 +525,7 @@ function JobCardNewFull({
 
   const { data: waRequest, refetch: refetchWaRequest } = useQuery({
     queryKey: queryKeys.scope('job-whatsapp-group-request', job.id, department, 0),
-    enabled: !!job?.id && !!department && isManagementUser,
+    enabled: !!job?.id && !!department && isManagementUser && !isFestivalLike,
     queryFn: async () => {
       const { data, error } = await dataLayerClient.from('job_whatsapp_group_requests')
         .select('id, created_at')

--- a/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
+++ b/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
@@ -144,7 +144,14 @@ export const JobCardActionButtons = ({
         {transportButtonLabel}
       </Button>
     )}
-    {isProjectManagementPage && department !== "production" && isManagementUser && onCreateWhatsappGroup && job.job_type !== "dryhire" && (
+    {(
+      isProjectManagementPage &&
+      department !== "production" &&
+      isManagementUser &&
+      onCreateWhatsappGroup &&
+      job.job_type !== "dryhire" &&
+      !isFestivalLike
+    ) && (
       <>
         {whatsappRequest && !whatsappGroup && onRetryWhatsappGroup ? (
           <Button

--- a/src/hooks/__tests__/useTourRateSubscriptions.test.tsx
+++ b/src/hooks/__tests__/useTourRateSubscriptions.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  type MockChannel = {
+    topic: string;
+    state: string;
+    on: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
+  };
+
+  const channels: MockChannel[] = [];
+  const removeChannel = vi.fn(async (channel: MockChannel) => {
+    const index = channels.indexOf(channel);
+    if (index >= 0) channels.splice(index, 1);
+    channel.state = "closed";
+    return "ok";
+  });
+
+  const channel = vi.fn((name: string) => {
+    const mockChannel: MockChannel = {
+      topic: `realtime:${name}`,
+      state: "closed",
+      on: vi.fn(() => mockChannel),
+      subscribe: vi.fn(() => {
+        mockChannel.state = "joined";
+        return mockChannel;
+      }),
+    };
+    channels.push(mockChannel);
+    return mockChannel;
+  });
+
+  return {
+    channels,
+    channel,
+    removeChannel,
+    getChannels: vi.fn(() => channels),
+    reset: () => {
+      channels.splice(0, channels.length);
+      channel.mockClear();
+      removeChannel.mockClear();
+    },
+  };
+});
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    channel: mocks.channel,
+    getChannels: mocks.getChannels,
+    removeChannel: mocks.removeChannel,
+  },
+}));
+
+import { resetTourRateSubscriptionsForTests, useTourRateSubscriptions } from "@/hooks/useTourRateSubscriptions";
+
+function Harness(): React.JSX.Element {
+  useTourRateSubscriptions();
+  return null;
+}
+
+const renderHarness = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Harness />
+      <Harness />
+    </QueryClientProvider>,
+  );
+};
+
+describe("useTourRateSubscriptions", () => {
+  beforeEach(() => {
+    resetTourRateSubscriptionsForTests();
+    mocks.reset();
+  });
+
+  afterEach(() => {
+    resetTourRateSubscriptionsForTests();
+  });
+
+  it("shares one Supabase channel set across multiple mounted consumers", async () => {
+    const rendered = renderHarness();
+
+    await waitFor(() => {
+      expect(mocks.channel).toHaveBeenCalledTimes(4);
+    });
+
+    expect(mocks.channels.map((channel) => channel.topic)).toEqual([
+      "realtime:tour-jobs-changes",
+      "realtime:job-assignments-changes",
+      "realtime:house-tech-rates-changes",
+      "realtime:job-rate-extras-changes",
+    ]);
+    expect(mocks.channels.every((channel) => channel.on.mock.calls.length === 1)).toBe(true);
+
+    rendered.unmount();
+
+    await waitFor(() => {
+      expect(mocks.removeChannel).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/hooks/useTourRateSubscriptions.ts
+++ b/src/hooks/useTourRateSubscriptions.ts
@@ -1,9 +1,149 @@
 import { useEffect } from 'react';
+import type { QueryClient } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 
 
 import { queryKeys } from "@/lib/react-query";
+
+type TourRateChannel = ReturnType<typeof supabase.channel>;
+
+const channelNames = [
+  'tour-jobs-changes',
+  'job-assignments-changes',
+  'house-tech-rates-changes',
+  'job-rate-extras-changes',
+] as const;
+
+const queryClientRefCounts = new Map<QueryClient, number>();
+let channels: TourRateChannel[] = [];
+let setupPromise: Promise<void> | null = null;
+
+const invalidateTourRateQueries = () => {
+  for (const queryClient of queryClientRefCounts.keys()) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('technician-tour-rate-quotes') });
+  }
+};
+
+const invalidateExtrasQueries = () => {
+  for (const queryClient of queryClientRefCounts.keys()) {
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-extras') });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-tech-payout') });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('my-job-payout-totals') });
+  }
+};
+
+const removeExistingTourRateChannels = async () => {
+  const topics = new Set(channelNames.map((name) => `realtime:${name}`));
+  const existingChannels = typeof supabase.getChannels === 'function'
+    ? supabase.getChannels().filter((channel) => topics.has(channel.topic))
+    : [];
+
+  await Promise.all(existingChannels.map((channel) => supabase.removeChannel(channel)));
+};
+
+const setupTourRateSubscriptions = async () => {
+  if (channels.length > 0) return;
+  if (setupPromise) return setupPromise;
+
+  setupPromise = (async () => {
+    await removeExistingTourRateChannels();
+    if (queryClientRefCounts.size === 0 || channels.length > 0) return;
+
+    console.log('Setting up tour rates realtime subscriptions');
+
+    const jobsChannel = supabase
+      .channel('tour-jobs-changes')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'jobs',
+          filter: 'job_type=eq.tourdate'
+        },
+        (payload) => {
+          console.log('Tour job change detected:', payload);
+          invalidateTourRateQueries();
+        }
+      )
+      .subscribe();
+
+    const assignmentsChannel = supabase
+      .channel('job-assignments-changes')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'job_assignments'
+        },
+        (payload) => {
+          console.log('Job assignment change detected:', payload);
+          invalidateTourRateQueries();
+        }
+      )
+      .subscribe();
+
+    const houseRatesChannel = supabase
+      .channel('house-tech-rates-changes')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'custom_tech_rates'
+        },
+        (payload) => {
+          console.log('House tech rates change detected:', payload);
+          invalidateTourRateQueries();
+        }
+      )
+      .subscribe();
+
+    const extrasChannel = supabase
+      .channel('job-rate-extras-changes')
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'job_rate_extras'
+        },
+        (payload) => {
+          console.log('Job rate extras change detected:', payload);
+          invalidateTourRateQueries();
+          invalidateExtrasQueries();
+        }
+      )
+      .subscribe();
+
+    channels = [jobsChannel, assignmentsChannel, houseRatesChannel, extrasChannel];
+  })().finally(() => {
+    setupPromise = null;
+  });
+
+  return setupPromise;
+};
+
+const teardownTourRateSubscriptions = () => {
+  if (queryClientRefCounts.size > 0 || channels.length === 0) return;
+
+  console.log('Cleaning up tour rates subscriptions');
+  const channelsToRemove = channels;
+  channels = [];
+  void Promise.all(channelsToRemove.map((channel) => supabase.removeChannel(channel))).catch((error) => {
+    console.warn('Failed to clean up tour rates subscriptions', error);
+  });
+};
+
+export const resetTourRateSubscriptionsForTests = () => {
+  queryClientRefCounts.clear();
+  channels = [];
+  setupPromise = null;
+};
+
 /**
  * Hook for managing realtime subscriptions to tour rate related tables
  */
@@ -11,129 +151,17 @@ export const useTourRateSubscriptions = () => {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    console.log('Setting up tour rates realtime subscriptions');
-
-    let isUnmounted = false;
-    let jobsChannel: ReturnType<typeof supabase.channel> | null = null;
-    let assignmentsChannel: ReturnType<typeof supabase.channel> | null = null;
-    let houseRatesChannel: ReturnType<typeof supabase.channel> | null = null;
-    let extrasChannel: ReturnType<typeof supabase.channel> | null = null;
-
-    const removeStaleChannel = async (channelName: string) => {
-      const topic = `realtime:${channelName}`;
-      const staleChannels = supabase
-        .getChannels()
-        .filter((channel) => {
-          const isMatchingTopic = channel.topic === topic;
-          const isActiveChannel = channel.state === 'joined' || channel.state === 'joining';
-          return isMatchingTopic && !isActiveChannel;
-        });
-
-      await Promise.all(staleChannels.map((channel) => supabase.removeChannel(channel)));
-    };
-
-    const setupSubscriptions = async () => {
-      await removeStaleChannel('tour-jobs-changes');
-      await removeStaleChannel('job-assignments-changes');
-      await removeStaleChannel('house-tech-rates-changes');
-      await removeStaleChannel('job-rate-extras-changes');
-
-      if (isUnmounted) return;
-      
-      // Subscribe to job changes (start_time changes affect weekly calculations)
-      jobsChannel = supabase
-        .channel('tour-jobs-changes')
-        .on(
-          'postgres_changes',
-          {
-            event: '*',
-            schema: 'public',
-            table: 'jobs',
-            filter: 'job_type=eq.tourdate'
-          },
-          (payload) => {
-            console.log('Tour job change detected:', payload);
-            
-            // Invalidate all tour rate queries
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('technician-tour-rate-quotes') });
-          }
-        )
-        .subscribe();
-
-      // Subscribe to job assignment changes
-      assignmentsChannel = supabase
-        .channel('job-assignments-changes')
-        .on(
-          'postgres_changes',
-          {
-            event: '*',
-            schema: 'public',
-            table: 'job_assignments'
-          },
-          (payload) => {
-            console.log('Job assignment change detected:', payload);
-            
-            // Invalidate tour rate queries
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('technician-tour-rate-quotes') });
-          }
-        )
-        .subscribe();
-
-      // Subscribe to house tech rates changes
-      houseRatesChannel = supabase
-        .channel('house-tech-rates-changes')
-        .on(
-          'postgres_changes',
-          {
-            event: '*',
-            schema: 'public',
-            table: 'custom_tech_rates'
-          },
-          (payload) => {
-            console.log('House tech rates change detected:', payload);
-            
-            // Invalidate tour rate queries
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('technician-tour-rate-quotes') });
-          }
-        )
-        .subscribe();
-
-      // Subscribe to job rate extras changes
-      extrasChannel = supabase
-        .channel('job-rate-extras-changes')
-        .on(
-          'postgres_changes',
-          {
-            event: '*',
-            schema: 'public',
-            table: 'job_rate_extras'
-          },
-          (payload) => {
-            console.log('Job rate extras change detected:', payload);
-            
-            // Invalidate tour rate and payout queries
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('technician-tour-rate-quotes') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-extras') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-tech-payout') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.scope('my-job-payout-totals') });
-          }
-        )
-        .subscribe();
-    };
-
-    void setupSubscriptions();
+    queryClientRefCounts.set(queryClient, (queryClientRefCounts.get(queryClient) ?? 0) + 1);
+    void setupTourRateSubscriptions();
 
     return () => {
-      isUnmounted = true;
-      console.log('Cleaning up tour rates subscriptions');
-      if (jobsChannel) supabase.removeChannel(jobsChannel);
-      if (assignmentsChannel) supabase.removeChannel(assignmentsChannel);
-      if (houseRatesChannel) supabase.removeChannel(houseRatesChannel);
-      if (extrasChannel) supabase.removeChannel(extrasChannel);
+      const refCount = queryClientRefCounts.get(queryClient) ?? 0;
+      if (refCount <= 1) {
+        queryClientRefCounts.delete(queryClient);
+      } else {
+        queryClientRefCounts.set(queryClient, refCount - 1);
+      }
+      teardownTourRateSubscriptions();
     };
   }, [queryClient]);
 };

--- a/src/pages/festival-management/FestivalManagementDialogs.tsx
+++ b/src/pages/festival-management/FestivalManagementDialogs.tsx
@@ -26,6 +26,7 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
     isSchedulingRoute,
     jobDates,
     isViewOnly,
+    isManagementUser,
 
     isAssignmentDialogOpen,
     setIsAssignmentDialogOpen,
@@ -156,7 +157,12 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
           </div>
 
           {jobDates.length > 0 ? (
-            <FestivalScheduling jobId={jobId} jobDates={jobDates} isViewOnly={isViewOnly} />
+            <FestivalScheduling
+              jobId={jobId}
+              jobDates={jobDates}
+              isViewOnly={isViewOnly}
+              onCreateWhatsappGroup={isManagementUser ? () => setIsWhatsappDialogOpen(true) : undefined}
+            />
           ) : (
             <Card>
               <CardContent className="p-8 text-center">

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -105,7 +105,6 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
     isBackfilling,
 
     userRole,
-    setIsWhatsappDialogOpen,
     setWaMessage,
     setIsAlmacenDialogOpen,
 
@@ -619,22 +618,6 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                       variant="outline"
                     >
                       {isBackfilling ? "Rellenando..." : "Abrir Relleno"}
-                    </Button>
-                  </div>
-                )}
-
-                {/* WhatsApp Group */}
-                {isManagementUser && (
-                  <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-green-500/5">
-                    <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
-                      <MessageCircle className="h-4 w-4 flex-shrink-0 text-green-500" />
-                      Grupo de WhatsApp
-                    </div>
-                    <p className="text-xs md:text-sm text-muted-foreground">
-                      Crea grupo de WhatsApp para coordinación del trabajo.
-                    </p>
-                    <Button onClick={() => setIsWhatsappDialogOpen(true)} size="sm" className="w-full" variant="outline">
-                      Crear Grupo
                     </Button>
                   </div>
                 )}

--- a/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
+++ b/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
@@ -2,53 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildWahaGroupParticipants,
-  inferDepartmentFromFestivalAssignmentRole,
   phoneToWahaJid,
-  resolveFestivalWhatsappStageTechnicianIds,
-  type StageAssignmentRecipientRow,
-  type StageProfileRecipientRow,
-  type StageShiftRecipientRow,
 } from "../recipientUtils.ts";
 
-describe("festival WhatsApp stage recipient resolution", () => {
-  it("infers departments from scheduling role codes", () => {
-    expect(inferDepartmentFromFestivalAssignmentRole("SND-FOH-R")).toBe("sound");
-    expect(inferDepartmentFromFestivalAssignmentRole("LGT-BRD-R")).toBe("lights");
-    expect(inferDepartmentFromFestivalAssignmentRole("VID-SW-R")).toBe("video");
-    expect(inferDepartmentFromFestivalAssignmentRole("FOH")).toBeNull();
-  });
-
-  it("uses scheduling shifts and assignments to resolve department recipients for a stage", () => {
-    const shifts = new Map<string, StageShiftRecipientRow>([
-      ["shift-sound", { id: "shift-sound", department: "sound" }],
-      ["shift-open-role", { id: "shift-open-role", department: null }],
-      ["shift-open-profile", { id: "shift-open-profile", department: null }],
-      ["shift-video", { id: "shift-video", department: "video" }],
-    ]);
-
-    const profiles = new Map<string, StageProfileRecipientRow>([
-      ["tech-1", { id: "tech-1", department: "sound" }],
-      ["tech-2", { id: "tech-2", department: "video" }],
-      ["tech-3", { id: "tech-3", department: "sound" }],
-      ["tech-4", { id: "tech-4", department: "video" }],
-    ]);
-
-    const assignments: StageAssignmentRecipientRow[] = [
-      { shift_id: "shift-sound", technician_id: "tech-1", role: "SND-FOH-R" },
-      { shift_id: "shift-open-role", technician_id: "tech-3", role: "SND-MON-R" },
-      { shift_id: "shift-open-profile", technician_id: "tech-1", role: "legacy-role" },
-      { shift_id: "shift-open-role", technician_id: "tech-2", role: "VID-SW-R" },
-      { shift_id: "shift-video", technician_id: "tech-4", role: "SND-FOH-R" },
-    ];
-
-    expect(
-      resolveFestivalWhatsappStageTechnicianIds({
-        assignments,
-        department: "sound",
-        profilesById: profiles,
-        shiftsById: shifts,
-      }),
-    ).toEqual(["tech-1", "tech-3"]);
+describe("WAHA participant helpers", () => {
+  it("converts phone numbers to WAHA JIDs", () => {
+    expect(phoneToWahaJid("+34 611 111 111")).toBe("34611111111@c.us");
   });
 
   it("excludes the actor/session JID from WAHA group creation participants", () => {

--- a/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
+++ b/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildWahaGroupParticipants,
   inferDepartmentFromFestivalAssignmentRole,
+  phoneToWahaJid,
   resolveFestivalWhatsappStageTechnicianIds,
   type StageAssignmentRecipientRow,
   type StageProfileRecipientRow,
@@ -47,5 +49,19 @@ describe("festival WhatsApp stage recipient resolution", () => {
         shiftsById: shifts,
       }),
     ).toEqual(["tech-1", "tech-3"]);
+  });
+
+  it("excludes the actor/session JID from WAHA group creation participants", () => {
+    const actorJid = phoneToWahaJid("+34611111111");
+
+    expect(
+      buildWahaGroupParticipants({
+        actorJid,
+        participants: ["+34611111111", "+34622222222", "+34633333333"],
+      }),
+    ).toEqual({
+      allParticipants: [{ id: actorJid }, { id: "34622222222@c.us" }, { id: "34633333333@c.us" }],
+      groupParticipants: [{ id: "34622222222@c.us" }, { id: "34633333333@c.us" }],
+    });
   });
 });

--- a/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
+++ b/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  inferDepartmentFromFestivalAssignmentRole,
+  resolveFestivalWhatsappStageTechnicianIds,
+  type StageAssignmentRecipientRow,
+  type StageProfileRecipientRow,
+  type StageShiftRecipientRow,
+} from "../recipientUtils.ts";
+
+describe("festival WhatsApp stage recipient resolution", () => {
+  it("infers departments from scheduling role codes", () => {
+    expect(inferDepartmentFromFestivalAssignmentRole("SND-FOH-R")).toBe("sound");
+    expect(inferDepartmentFromFestivalAssignmentRole("LGT-BRD-R")).toBe("lights");
+    expect(inferDepartmentFromFestivalAssignmentRole("VID-SW-R")).toBe("video");
+    expect(inferDepartmentFromFestivalAssignmentRole("FOH")).toBeNull();
+  });
+
+  it("uses scheduling shifts and assignments to resolve department recipients for a stage", () => {
+    const shifts = new Map<string, StageShiftRecipientRow>([
+      ["shift-sound", { id: "shift-sound", department: "sound" }],
+      ["shift-open-role", { id: "shift-open-role", department: null }],
+      ["shift-open-profile", { id: "shift-open-profile", department: null }],
+      ["shift-video", { id: "shift-video", department: "video" }],
+    ]);
+
+    const profiles = new Map<string, StageProfileRecipientRow>([
+      ["tech-1", { id: "tech-1", department: "sound" }],
+      ["tech-2", { id: "tech-2", department: "video" }],
+      ["tech-3", { id: "tech-3", department: "sound" }],
+      ["tech-4", { id: "tech-4", department: "video" }],
+    ]);
+
+    const assignments: StageAssignmentRecipientRow[] = [
+      { shift_id: "shift-sound", technician_id: "tech-1", role: "SND-FOH-R" },
+      { shift_id: "shift-open-role", technician_id: "tech-3", role: "SND-MON-R" },
+      { shift_id: "shift-open-profile", technician_id: "tech-1", role: "legacy-role" },
+      { shift_id: "shift-open-role", technician_id: "tech-2", role: "VID-SW-R" },
+      { shift_id: "shift-video", technician_id: "tech-4", role: "SND-FOH-R" },
+    ];
+
+    expect(
+      resolveFestivalWhatsappStageTechnicianIds({
+        assignments,
+        department: "sound",
+        profilesById: profiles,
+        shiftsById: shifts,
+      }),
+    ).toEqual(["tech-1", "tech-3"]);
+  });
+});

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -1,6 +1,8 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import {
+  buildWahaGroupParticipants,
+  phoneToWahaJid,
   resolveFestivalWhatsappStageTechnicianIds,
 } from "./recipientUtils.ts";
 import type {
@@ -407,19 +409,24 @@ serve(async (req: Request) => {
 
     // WAHA expects JIDs like 34900111222@c.us and an object list
     const session = (cfg?.[0] as any)?.session || Deno.env.get('WAHA_SESSION') || 'default';
-    const participantObjects = uniqueParticipants.map((p) => {
-      const jid = p.replace(/^\+/, '').replace(/\D/g, '') + '@c.us';
-      return { id: jid };
-    });
     const actorJidCandidate = (() => {
       if (actor?.phone && actor.department === department) {
         const norm = normalizePhone(actor.phone, defaultCC);
-        if (norm.ok) return norm.value.replace(/^\+/, '') + '@c.us';
+        if (norm.ok) return phoneToWahaJid(norm.value);
       }
       return null;
     })();
+    const { allParticipants: participantObjects, groupParticipants } = buildWahaGroupParticipants({
+      actorJid: actorJidCandidate,
+      participants: uniqueParticipants,
+    });
+
+    if (groupParticipants.length === 0) {
+      return new Response(JSON.stringify({ error: 'No valid non-actor phone numbers found', warnings: { missing, invalid } }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
 
     let usedFallback = false;
+    let fallbackSeedParticipant: { id: string } | null = null;
     let wa_group_id = '';
     let groupText = '';
     if (!finalizeOnly) {
@@ -430,30 +437,43 @@ serve(async (req: Request) => {
         groupRes = await fetch(groupUrl, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ name: subject, participants: participantObjects })
+          body: JSON.stringify({ name: subject, participants: groupParticipants })
         });
       } catch (fe) {
         return new Response(JSON.stringify({ error: 'WAHA request failed', step: 'create-group', url: groupUrl, message: (fe as Error)?.message || String(fe) }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
       }
       if (!groupRes.ok) {
         const txt = await groupRes.text().catch(() => '');
-        if (groupRes.status >= 500 && groupRes.status < 600 && participantObjects.length > 1) {
-          // Fallback: try create group with a single participant when WAHA rejects bulk creation.
-          const first = actorJidCandidate ? { id: actorJidCandidate } : participantObjects[0];
-          try {
+        if (groupRes.status >= 500 && groupRes.status < 600 && groupParticipants.length > 1) {
+          // Fallback: try real assigned participants one by one when WAHA rejects bulk creation.
+          const fallbackErrors: Array<{ id: string; status?: number; body?: string; message?: string }> = [];
+          for (const candidate of groupParticipants) {
             const fallbackRes = await fetch(groupUrl, {
               method: 'POST',
               headers,
-              body: JSON.stringify({ name: subject, participants: [first] })
+              body: JSON.stringify({ name: subject, participants: [candidate] })
+            }).catch((err) => {
+              fallbackErrors.push({ id: candidate.id, message: (err as Error)?.message || String(err) });
+              return null;
             });
-            if (!fallbackRes.ok) {
-              const fbTxt = await fallbackRes.text().catch(() => '');
-              return new Response(JSON.stringify({ error: 'WAHA group creation failed', status: fallbackRes.status, url: groupUrl, response: fbTxt, firstAttempt: { status: groupRes.status, body: txt } }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+
+            if (!fallbackRes) {
+              continue;
             }
-            usedFallback = true;
-            groupRes = fallbackRes;
-          } catch (fe2) {
-            return new Response(JSON.stringify({ error: 'WAHA request failed', step: 'create-group-fallback', url: groupUrl, message: (fe2 as Error)?.message || String(fe2), firstAttempt: { status: groupRes.status, body: txt } }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+
+            if (fallbackRes.ok) {
+              usedFallback = true;
+              fallbackSeedParticipant = candidate;
+              groupRes = fallbackRes;
+              break;
+            }
+
+            const fbTxt = await fallbackRes.text().catch(() => '');
+            fallbackErrors.push({ id: candidate.id, status: fallbackRes.status, body: fbTxt });
+          }
+
+          if (!usedFallback) {
+            return new Response(JSON.stringify({ error: 'WAHA group creation failed', status: groupRes.status, url: groupUrl, response: txt, fallbackAttempts: fallbackErrors, firstAttempt: { status: groupRes.status, body: txt } }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
           }
         } else {
           return new Response(JSON.stringify({ error: 'WAHA group creation failed', status: groupRes.status, url: groupUrl, response: txt }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
@@ -568,10 +588,10 @@ serve(async (req: Request) => {
     }
 
     // If fallback creation used with only 1 participant, add the rest now (best effort)
-    if (participantObjects.length > 1) {
+    if (groupParticipants.length > 1) {
       try {
-        const first = actorJidCandidate ? { id: actorJidCandidate } : participantObjects[0];
-        const toAdd = participantObjects.filter((p) => p.id !== first.id);
+        const first = fallbackSeedParticipant || groupParticipants[0];
+        const toAdd = groupParticipants.filter((p) => p.id !== first.id);
         if (toAdd.length) {
           const addUrl = `${base}/api/${encodeURIComponent(session)}/groups/${encodeURIComponent(wa_group_id)}/participants/add`;
           const tryAdd = async () => {

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -437,8 +437,8 @@ serve(async (req: Request) => {
       }
       if (!groupRes.ok) {
         const txt = await groupRes.text().catch(() => '');
-        if (groupRes.status === 500 && participantObjects.length > 1) {
-          // Fallback: try create group with a single participant (WAHA bug workaround)
+        if (groupRes.status >= 500 && groupRes.status < 600 && participantObjects.length > 1) {
+          // Fallback: try create group with a single participant when WAHA rejects bulk creation.
           const first = actorJidCandidate ? { id: actorJidCandidate } : participantObjects[0];
           try {
             const fallbackRes = await fetch(groupUrl, {

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -3,14 +3,8 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import {
   buildWahaGroupParticipants,
   phoneToWahaJid,
-  resolveFestivalWhatsappStageTechnicianIds,
 } from "./recipientUtils.ts";
-import type {
-  Dept,
-  StageAssignmentRecipientRow,
-  StageProfileRecipientRow,
-  StageShiftRecipientRow,
-} from "./recipientUtils.ts";
+import type { Dept } from "./recipientUtils.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -183,164 +177,38 @@ serve(async (req: Request) => {
     const participants: string[] = [];
     const missing: string[] = [];
     const invalid: string[] = [];
-    if (effectiveStageNumber > 0) {
-      const { data: stageShifts, error: stageShiftsErr } = await supabaseAdmin
-        .from('festival_shifts')
-        .select('id, department')
-        .eq('job_id', job_id)
-        .eq('stage', effectiveStageNumber);
 
-      if (stageShiftsErr) {
-        console.warn('festival_shifts fetch error', stageShiftsErr);
-        return new Response(
-          JSON.stringify({
-            error: 'Failed to fetch scheduled shifts for selected stage',
-            details: stageShiftsErr.message,
-            source: 'festival_shifts',
-          }),
-          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
+    // Recipients intentionally come from job assignments for every job type.
+    // Festival stage selection only scopes the group name and persistence key.
+    const { data: assigns, error: assignsErr } = await supabaseAdmin
+      .from('job_assignments')
+      .select(`
+        technician_id,
+        sound_role, lights_role, video_role,
+        profiles!job_assignments_technician_id_fkey ( first_name, last_name, phone )
+      `)
+      .eq('job_id', job_id);
+    if (assignsErr) {
+      console.warn('job_assignments fetch error', assignsErr);
+    }
+
+    const rows = (assigns ?? []).filter((r: any) => {
+      if (department === 'sound') return !!r.sound_role;
+      if (department === 'lights') return !!r.lights_role;
+      if (department === 'video') return !!r.video_role;
+      return false;
+    });
+
+    for (const r of rows) {
+      const fullName = `${r.profiles?.first_name ?? ''} ${r.profiles?.last_name ?? ''}`.trim() || 'Tecnico';
+      const rawPhone = (r.profiles?.phone || '').trim();
+      if (!rawPhone) {
+        missing.push(fullName);
+        continue;
       }
-
-      const shiftsById = new Map<string, StageShiftRecipientRow>(
-        ((stageShifts || []) as StageShiftRecipientRow[])
-          .filter((shift) => !!shift.id)
-          .map((shift) => [shift.id, shift]),
-      );
-
-      const shiftIds = Array.from(shiftsById.keys());
-      if (shiftIds.length === 0) {
-        return new Response(
-          JSON.stringify({
-            error: 'No scheduled shifts found for selected stage',
-            stage_number: effectiveStageNumber,
-            department,
-            source: 'festival_shifts',
-          }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-
-      const { data: stageAssignments, error: stageAssignmentsErr } = await supabaseAdmin
-        .from('festival_shift_assignments')
-        .select('shift_id, technician_id, role')
-        .in('shift_id', shiftIds)
-        .not('technician_id', 'is', null);
-
-      if (stageAssignmentsErr) {
-        console.warn('festival_shift_assignments fetch error', stageAssignmentsErr);
-        return new Response(
-          JSON.stringify({
-            error: 'Failed to fetch scheduled assignments for selected stage',
-            details: stageAssignmentsErr.message,
-            source: 'festival_shift_assignments',
-          }),
-          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-
-      const stageAssignmentRows = (stageAssignments || []) as StageAssignmentRecipientRow[];
-      const scheduledTechnicianIds = Array.from(
-        new Set(
-          stageAssignmentRows
-            .map((row) => row.technician_id)
-            .filter((id): id is string => !!id)
-        )
-      );
-
-      if (scheduledTechnicianIds.length === 0) {
-        return new Response(
-          JSON.stringify({
-            error: 'No technicians assigned to selected stage',
-            stage_number: effectiveStageNumber,
-            department,
-            source: 'festival_shift_assignments',
-          }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-
-      const { data: stageProfiles, error: stageProfilesErr } = await supabaseAdmin
-        .from('profiles')
-        .select('id, first_name, last_name, department, phone')
-        .in('id', scheduledTechnicianIds);
-
-      if (stageProfilesErr) {
-        console.warn('profiles fetch error for stage participants', stageProfilesErr);
-      }
-
-      type StageProfileWithContact = StageProfileRecipientRow & {
-        first_name?: string | null;
-        last_name?: string | null;
-        phone?: string | null;
-      };
-      const stageProfileRows = (stageProfiles || []) as StageProfileWithContact[];
-      const profileById = new Map<string, StageProfileWithContact>(
-        stageProfileRows.map((p) => [p.id, p]),
-      );
-      const technicianIds = resolveFestivalWhatsappStageTechnicianIds({
-        assignments: stageAssignmentRows,
-        department,
-        profilesById,
-        shiftsById,
-      });
-
-      if (technicianIds.length === 0) {
-        return new Response(
-          JSON.stringify({
-            error: 'No technicians assigned to selected stage and department',
-            stage_number: effectiveStageNumber,
-            department,
-            source: 'festival_shifts/festival_shift_assignments',
-          }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-
-      for (const technicianId of technicianIds) {
-        const profile = profileById.get(technicianId);
-        const fullName = `${profile?.first_name ?? ''} ${profile?.last_name ?? ''}`.trim() || 'Tecnico';
-        const rawPhone = (profile?.phone || '').trim();
-        if (!rawPhone) {
-          missing.push(fullName);
-          continue;
-        }
-        const norm = normalizePhone(rawPhone, defaultCC);
-        if (norm.ok) participants.push(norm.value);
-        else invalid.push(`${fullName} (${rawPhone})`);
-      }
-    } else {
-      // Default behavior: recipients come from job assignments by department.
-      const { data: assigns, error: assignsErr } = await supabaseAdmin
-        .from('job_assignments')
-        .select(`
-          technician_id,
-          sound_role, lights_role, video_role,
-          profiles!job_assignments_technician_id_fkey ( first_name, last_name, phone )
-        `)
-        .eq('job_id', job_id);
-      if (assignsErr) {
-        console.warn('job_assignments fetch error', assignsErr);
-      }
-
-      const rows = (assigns ?? []).filter((r: any) => {
-        if (department === 'sound') return !!r.sound_role;
-        if (department === 'lights') return !!r.lights_role;
-        if (department === 'video') return !!r.video_role;
-        return false;
-      });
-
-      for (const r of rows) {
-        const fullName = `${r.profiles?.first_name ?? ''} ${r.profiles?.last_name ?? ''}`.trim() || 'Tecnico';
-        const rawPhone = (r.profiles?.phone || '').trim();
-        if (!rawPhone) {
-          missing.push(fullName);
-          continue;
-        }
-        const norm = normalizePhone(rawPhone, defaultCC);
-        if (norm.ok) participants.push(norm.value);
-        else invalid.push(`${fullName} (${rawPhone})`);
-      }
+      const norm = normalizePhone(rawPhone, defaultCC);
+      if (norm.ok) participants.push(norm.value);
+      else invalid.push(`${fullName} (${rawPhone})`);
     }
 
     // Always include management user for the department (if phone exists and matches department)

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -1,7 +1,14 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
-
-type Dept = 'sound' | 'lights' | 'video';
+import {
+  resolveFestivalWhatsappStageTechnicianIds,
+} from "./recipientUtils.ts";
+import type {
+  Dept,
+  StageAssignmentRecipientRow,
+  StageProfileRecipientRow,
+  StageShiftRecipientRow,
+} from "./recipientUtils.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -143,17 +150,6 @@ serve(async (req: Request) => {
       return new Response(JSON.stringify({ success: true, wa_group_id: null, note: 'Group request already recorded (locked)' }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    // Record request to lock further attempts
-    if (!priorReq) {
-      const { error: lockErr } = await supabaseAdmin
-        .from('job_whatsapp_group_requests')
-        .insert({ job_id, department, stage_number: effectiveStageNumber });
-      if (lockErr && !(lockErr as any)?.code?.includes?.('23505')) {
-        // Not a unique violation; fail explicitly
-        return new Response(JSON.stringify({ error: 'Failed to record group request', details: lockErr.message }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-      }
-    }
-
     // Fetch job details
     const { data: job, error: jobErr } = await supabaseAdmin
       .from('jobs')
@@ -186,39 +182,77 @@ serve(async (req: Request) => {
     const missing: string[] = [];
     const invalid: string[] = [];
     if (effectiveStageNumber > 0) {
+      const { data: stageShifts, error: stageShiftsErr } = await supabaseAdmin
+        .from('festival_shifts')
+        .select('id, department')
+        .eq('job_id', job_id)
+        .eq('stage', effectiveStageNumber);
+
+      if (stageShiftsErr) {
+        console.warn('festival_shifts fetch error', stageShiftsErr);
+        return new Response(
+          JSON.stringify({
+            error: 'Failed to fetch scheduled shifts for selected stage',
+            details: stageShiftsErr.message,
+            source: 'festival_shifts',
+          }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const shiftsById = new Map<string, StageShiftRecipientRow>(
+        ((stageShifts || []) as StageShiftRecipientRow[])
+          .filter((shift) => !!shift.id)
+          .map((shift) => [shift.id, shift]),
+      );
+
+      const shiftIds = Array.from(shiftsById.keys());
+      if (shiftIds.length === 0) {
+        return new Response(
+          JSON.stringify({
+            error: 'No scheduled shifts found for selected stage',
+            stage_number: effectiveStageNumber,
+            department,
+            source: 'festival_shifts',
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
       const { data: stageAssignments, error: stageAssignmentsErr } = await supabaseAdmin
         .from('festival_shift_assignments')
-        .select(`
-          technician_id,
-          festival_shifts!inner (
-            job_id,
-            department,
-            stage
-          )
-        `)
-        .eq('festival_shifts.job_id', job_id)
-        .eq('festival_shifts.department', department)
-        .eq('festival_shifts.stage', effectiveStageNumber)
+        .select('shift_id, technician_id, role')
+        .in('shift_id', shiftIds)
         .not('technician_id', 'is', null);
 
       if (stageAssignmentsErr) {
         console.warn('festival_shift_assignments fetch error', stageAssignmentsErr);
+        return new Response(
+          JSON.stringify({
+            error: 'Failed to fetch scheduled assignments for selected stage',
+            details: stageAssignmentsErr.message,
+            source: 'festival_shift_assignments',
+          }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
       }
 
-      const technicianIds = Array.from(
+      const stageAssignmentRows = (stageAssignments || []) as StageAssignmentRecipientRow[];
+      const scheduledTechnicianIds = Array.from(
         new Set(
-          (stageAssignments || [])
-            .map((row: any) => row.technician_id)
-            .filter((id: string | null) => !!id)
+          stageAssignmentRows
+            .map((row) => row.technician_id)
+            .filter((id): id is string => !!id)
         )
       );
 
-      if (technicianIds.length === 0) {
+      if (scheduledTechnicianIds.length === 0) {
         return new Response(
           JSON.stringify({
             error: 'No technicians assigned to selected stage',
             stage_number: effectiveStageNumber,
             department,
+            source: 'festival_shift_assignments',
           }),
           { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
@@ -226,14 +260,41 @@ serve(async (req: Request) => {
 
       const { data: stageProfiles, error: stageProfilesErr } = await supabaseAdmin
         .from('profiles')
-        .select('id, first_name, last_name, phone')
-        .in('id', technicianIds);
+        .select('id, first_name, last_name, department, phone')
+        .in('id', scheduledTechnicianIds);
 
       if (stageProfilesErr) {
         console.warn('profiles fetch error for stage participants', stageProfilesErr);
       }
 
-      const profileById = new Map((stageProfiles || []).map((p: any) => [p.id, p]));
+      type StageProfileWithContact = StageProfileRecipientRow & {
+        first_name?: string | null;
+        last_name?: string | null;
+        phone?: string | null;
+      };
+      const stageProfileRows = (stageProfiles || []) as StageProfileWithContact[];
+      const profileById = new Map<string, StageProfileWithContact>(
+        stageProfileRows.map((p) => [p.id, p]),
+      );
+      const technicianIds = resolveFestivalWhatsappStageTechnicianIds({
+        assignments: stageAssignmentRows,
+        department,
+        profilesById,
+        shiftsById,
+      });
+
+      if (technicianIds.length === 0) {
+        return new Response(
+          JSON.stringify({
+            error: 'No technicians assigned to selected stage and department',
+            stage_number: effectiveStageNumber,
+            department,
+            source: 'festival_shifts/festival_shift_assignments',
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
       for (const technicianId of technicianIds) {
         const profile = profileById.get(technicianId);
         const fullName = `${profile?.first_name ?? ''} ${profile?.last_name ?? ''}`.trim() || 'Tecnico';
@@ -312,6 +373,20 @@ serve(async (req: Request) => {
     const uniqueParticipants = Array.from(new Set(participants));
     if (uniqueParticipants.length === 0) {
       return new Response(JSON.stringify({ error: 'No valid phone numbers found', warnings: { missing, invalid } }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+
+    // Record request to lock further attempts only after recipient validation succeeds.
+    if (!priorReq) {
+      const { error: lockErr } = await supabaseAdmin
+        .from('job_whatsapp_group_requests')
+        .insert({ job_id, department, stage_number: effectiveStageNumber });
+      if (lockErr) {
+        const isDuplicateLock = lockErr.code === '23505';
+        if (isDuplicateLock && !finalizeOnly) {
+          return new Response(JSON.stringify({ success: true, wa_group_id: null, note: 'Group request already recorded (locked)' }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+        }
+        return new Response(JSON.stringify({ error: 'Failed to record group request', details: lockErr.message }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
     }
 
     // WAHA config - use actor's endpoint

--- a/supabase/functions/create-whatsapp-group/recipientUtils.ts
+++ b/supabase/functions/create-whatsapp-group/recipientUtils.ts
@@ -1,0 +1,85 @@
+export type Dept = 'sound' | 'lights' | 'video';
+
+export type StageShiftRecipientRow = {
+  id: string;
+  department?: string | null;
+};
+
+export type StageAssignmentRecipientRow = {
+  shift_id?: string | null;
+  technician_id?: string | null;
+  role?: string | null;
+};
+
+export type StageProfileRecipientRow = {
+  id: string;
+  department?: string | null;
+};
+
+const normalizeDepartment = (value?: string | null): Dept | null => {
+  const normalized = (value || '').trim().toLowerCase();
+  return normalized === 'sound' || normalized === 'lights' || normalized === 'video' ? normalized : null;
+};
+
+export const inferDepartmentFromFestivalAssignmentRole = (role?: string | null): Dept | null => {
+  const normalized = (role || '').trim().toUpperCase();
+  if (!normalized) return null;
+
+  if (normalized.startsWith('SND-')) return 'sound';
+  if (normalized.startsWith('LGT-')) return 'lights';
+  if (normalized.startsWith('VID-')) return 'video';
+
+  return null;
+};
+
+export const assignmentMatchesFestivalWhatsappDepartment = ({
+  assignment,
+  department,
+  profile,
+  shift,
+}: {
+  assignment: StageAssignmentRecipientRow;
+  department: Dept;
+  profile?: StageProfileRecipientRow | null;
+  shift?: StageShiftRecipientRow | null;
+}) => {
+  const shiftDepartment = normalizeDepartment(shift?.department);
+  if (shiftDepartment) return shiftDepartment === department;
+
+  const roleDepartment = inferDepartmentFromFestivalAssignmentRole(assignment.role);
+  if (roleDepartment) return roleDepartment === department;
+
+  return normalizeDepartment(profile?.department) === department;
+};
+
+export const resolveFestivalWhatsappStageTechnicianIds = ({
+  assignments,
+  department,
+  profilesById,
+  shiftsById,
+}: {
+  assignments: StageAssignmentRecipientRow[];
+  department: Dept;
+  profilesById: ReadonlyMap<string, StageProfileRecipientRow>;
+  shiftsById: ReadonlyMap<string, StageShiftRecipientRow>;
+}) => {
+  const ids = new Set<string>();
+
+  for (const assignment of assignments) {
+    const technicianId = assignment.technician_id;
+    if (!technicianId) continue;
+
+    const matchesDepartment = assignmentMatchesFestivalWhatsappDepartment({
+      assignment,
+      department,
+      profile: profilesById.get(technicianId),
+      shift: assignment.shift_id ? shiftsById.get(assignment.shift_id) : null,
+    });
+
+    if (matchesDepartment) {
+      ids.add(technicianId);
+    }
+  }
+
+  return Array.from(ids);
+};

--- a/supabase/functions/create-whatsapp-group/recipientUtils.ts
+++ b/supabase/functions/create-whatsapp-group/recipientUtils.ts
@@ -16,10 +16,16 @@ export type StageProfileRecipientRow = {
   department?: string | null;
 };
 
+export type WahaParticipantObject = {
+  id: string;
+};
+
 const normalizeDepartment = (value?: string | null): Dept | null => {
   const normalized = (value || '').trim().toLowerCase();
   return normalized === 'sound' || normalized === 'lights' || normalized === 'video' ? normalized : null;
 };
+
+export const phoneToWahaJid = (phone: string) => `${phone.replace(/^\+/, '').replace(/\D/g, '')}@c.us`;
 
 export const inferDepartmentFromFestivalAssignmentRole = (role?: string | null): Dept | null => {
   const normalized = (role || '').trim().toUpperCase();
@@ -82,4 +88,22 @@ export const resolveFestivalWhatsappStageTechnicianIds = ({
   }
 
   return Array.from(ids);
+};
+
+export const buildWahaGroupParticipants = ({
+  actorJid,
+  participants,
+}: {
+  actorJid?: string | null;
+  participants: string[];
+}) => {
+  const allParticipants = participants.map<WahaParticipantObject>((phone) => ({ id: phoneToWahaJid(phone) }));
+  const groupParticipants = actorJid
+    ? allParticipants.filter((participant) => participant.id !== actorJid)
+    : allParticipants;
+
+  return {
+    allParticipants,
+    groupParticipants,
+  };
 };

--- a/supabase/functions/create-whatsapp-group/recipientUtils.ts
+++ b/supabase/functions/create-whatsapp-group/recipientUtils.ts
@@ -1,94 +1,10 @@
 export type Dept = 'sound' | 'lights' | 'video';
 
-export type StageShiftRecipientRow = {
-  id: string;
-  department?: string | null;
-};
-
-export type StageAssignmentRecipientRow = {
-  shift_id?: string | null;
-  technician_id?: string | null;
-  role?: string | null;
-};
-
-export type StageProfileRecipientRow = {
-  id: string;
-  department?: string | null;
-};
-
 export type WahaParticipantObject = {
   id: string;
 };
 
-const normalizeDepartment = (value?: string | null): Dept | null => {
-  const normalized = (value || '').trim().toLowerCase();
-  return normalized === 'sound' || normalized === 'lights' || normalized === 'video' ? normalized : null;
-};
-
 export const phoneToWahaJid = (phone: string) => `${phone.replace(/^\+/, '').replace(/\D/g, '')}@c.us`;
-
-export const inferDepartmentFromFestivalAssignmentRole = (role?: string | null): Dept | null => {
-  const normalized = (role || '').trim().toUpperCase();
-  if (!normalized) return null;
-
-  if (normalized.startsWith('SND-')) return 'sound';
-  if (normalized.startsWith('LGT-')) return 'lights';
-  if (normalized.startsWith('VID-')) return 'video';
-
-  return null;
-};
-
-export const assignmentMatchesFestivalWhatsappDepartment = ({
-  assignment,
-  department,
-  profile,
-  shift,
-}: {
-  assignment: StageAssignmentRecipientRow;
-  department: Dept;
-  profile?: StageProfileRecipientRow | null;
-  shift?: StageShiftRecipientRow | null;
-}) => {
-  const shiftDepartment = normalizeDepartment(shift?.department);
-  if (shiftDepartment) return shiftDepartment === department;
-
-  const roleDepartment = inferDepartmentFromFestivalAssignmentRole(assignment.role);
-  if (roleDepartment) return roleDepartment === department;
-
-  return normalizeDepartment(profile?.department) === department;
-};
-
-export const resolveFestivalWhatsappStageTechnicianIds = ({
-  assignments,
-  department,
-  profilesById,
-  shiftsById,
-}: {
-  assignments: StageAssignmentRecipientRow[];
-  department: Dept;
-  profilesById: ReadonlyMap<string, StageProfileRecipientRow>;
-  shiftsById: ReadonlyMap<string, StageShiftRecipientRow>;
-}) => {
-  const ids = new Set<string>();
-
-  for (const assignment of assignments) {
-    const technicianId = assignment.technician_id;
-    if (!technicianId) continue;
-
-    const matchesDepartment = assignmentMatchesFestivalWhatsappDepartment({
-      assignment,
-      department,
-      profile: profilesById.get(technicianId),
-      shift: assignment.shift_id ? shiftsById.get(assignment.shift_id) : null,
-    });
-
-    if (matchesDepartment) {
-      ids.add(technicianId);
-    }
-  }
-
-  return Array.from(ids);
-};
 
 export const buildWahaGroupParticipants = ({
   actorJid,

--- a/tests/e2e/festival-management.spec.ts
+++ b/tests/e2e/festival-management.spec.ts
@@ -14,7 +14,7 @@ const festivalJob = {
 };
 
 test.describe("festival management smoke", () => {
-  test("loads the overview and opens the WhatsApp dialog", async ({ page }) => {
+  test("loads scheduling and opens the WhatsApp dialog", async ({ page }) => {
     await bootstrapApp(page, {
       auth: {
         role: "management",
@@ -62,11 +62,11 @@ test.describe("festival management smoke", () => {
       },
     });
 
-    await page.goto("/festival-management/festival-job-1");
+    await page.goto("/festival-management/festival-job-1/scheduling");
 
     await expect(page.getByRole("heading", { name: "Festival Smoke" })).toBeVisible();
-    await expect(page.getByText("Acciones Rápidas")).toBeVisible();
-    await page.getByRole("button", { name: "Crear Grupo" }).click();
+    await expect(page.getByRole("heading", { name: "Programación del Festival" })).toBeVisible();
+    await page.getByRole("button", { name: "WhatsApp" }).click();
     await expect(page.getByRole("heading", { name: "Crear Grupo de WhatsApp" })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
- Remove the festival scheduling-recipient fork from `create-whatsapp-group`; all job types now source WhatsApp recipients from the proven `job_assignments` department-role path.
- Keep festival `stage_number` only for group naming and persistence scoping, so stage-specific creation still creates per-stage records without changing recipient resolution.
- Hide the create-group action and related WhatsApp group/request queries from festival job cards.
- Move the festival WhatsApp entry point to the festival management scheduling header, using the existing stage-aware dialog.
- Keep the WAHA actor/session JID exclusion and one-by-one seed fallback from the previous commit.
- Fix the `tour-jobs-changes` realtime channel callback flood by sharing one channel set across mounted consumers.

## Root Cause
The production failure log supplied after the previous deploy was still running Edge Function version `422`, not the claimed `423`. Independently, the festival-only recipient branch was the risky path: it depended on festival shift/stage scheduling rows and then hit WAHA fallback behavior that does not match the reliable non-festival group flow. This update removes that branch and makes festival stage creation reuse the same assignment-based recipient workflow as regular jobs.

## Deployment
- Deployed Supabase Edge Function `create-whatsapp-group` to linked project `syldobdcdsgfgjtbuwxm` (`Agenda Tecnica V3`).
- Latest deployed function version after this update: `424` at `2026-05-22 11:27:54 UTC`.
- Frontend changes are on this PR branch and will reach production through the normal `main` deploy path when the PR is merged.

## Validation
- `npm run test:run -- supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts src/hooks/__tests__/useTourRateSubscriptions.test.tsx`
- `npm run lint:functions`
- `npm run lint:app`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npx playwright test tests/e2e/festival-management.spec.ts --project=chromium`
- GitHub CI on PR #650 latest commit `6170c6ca`: `npm run lint`, `npm run test:critical`, `npm run test:run`, `npm run build`, `npm run test:e2e (smoke)`, Cloudflare Pages all passed; CodeRabbit passed/skipped review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WhatsApp group creation button to festival scheduling interface
  * Implemented fallback mechanism for improved WhatsApp group creation reliability

* **Bug Fixes**
  * Disabled WhatsApp features for festival-type jobs to prevent conflicts

* **Tests**
  * Added comprehensive test coverage for WhatsApp utilities and tour rate subscriptions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->