### PR TITLE
Fix festival stage WhatsApp recipients

### DIFF
--- a/src/features/festival-management/hooks/useFestivalWhatsappActions.ts
+++ b/src/features/festival-management/hooks/useFestivalWhatsappActions.ts
@@ -90,7 +90,9 @@ export const useFestivalWhatsappActions = ({
       await createWhatsappGroup({ department: waDepartment, jobId, stageNumber: waStageNumber });
       toast({
         title: "Éxito",
-        description: "Grupo de WhatsApp creado exitosamente",
+        description: waGroup
+          ? "Participantes de WhatsApp actualizados"
+          : "Grupo de WhatsApp creado exitosamente",
       });
       setIsWhatsappDialogOpen(false);
       await refreshWhatsappState();
@@ -105,7 +107,7 @@ export const useFestivalWhatsappActions = ({
     } finally {
       setIsSendingWa(false);
     }
-  }, [jobId, refreshWhatsappState, toast, waDepartment, waStageNumber]);
+  }, [jobId, refreshWhatsappState, toast, waDepartment, waGroup, waStageNumber]);
 
   const handleRetryWhatsappGroup = useCallback(async () => {
     if (!jobId) {

--- a/src/pages/festival-management/FestivalManagementDialogs.tsx
+++ b/src/pages/festival-management/FestivalManagementDialogs.tsx
@@ -116,6 +116,7 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
   } = vm;
   const festivalWhatsappStageOptions = buildFestivalWhatsappStageOptions(festivalStageOptions, maxStages);
   const requiresStageScopedWhatsapp = requiresFestivalWhatsappStage(maxStages, waDepartment);
+  const canUpdateExistingWaGroup = !!waGroup && requiresStageScopedWhatsapp;
 
   return (
     <>
@@ -429,9 +430,13 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
             ) : (
               <Button
                 onClick={handleCreateWhatsappGroup}
-                disabled={isSendingWa || !!waGroup || (requiresStageScopedWhatsapp && waStageNumber < 1)}
+                disabled={isSendingWa || (!!waGroup && !canUpdateExistingWaGroup) || (requiresStageScopedWhatsapp && waStageNumber < 1)}
               >
-                {isSendingWa ? "Creando..." : waGroup ? "Grupo Creado" : "Crear Grupo"}
+                {isSendingWa
+                  ? (waGroup ? "Actualizando..." : "Creando...")
+                  : waGroup
+                    ? (canUpdateExistingWaGroup ? "Actualizar Participantes" : "Grupo Creado")
+                    : "Crear Grupo"}
               </Button>
             )}
           </DialogFooter>

--- a/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
+++ b/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildWahaGroupParticipants,
+  collectFestivalStageRecipients,
   phoneToWahaJid,
 } from "../recipientUtils.ts";
 
@@ -21,6 +22,73 @@ describe("WAHA participant helpers", () => {
     ).toEqual({
       allParticipants: [{ id: actorJid }, { id: "34622222222@c.us" }, { id: "34633333333@c.us" }],
       groupParticipants: [{ id: "34622222222@c.us" }, { id: "34633333333@c.us" }],
+    });
+  });
+});
+
+describe("festival stage recipient helpers", () => {
+  it("collects scheduled technicians from matching stage department shifts", () => {
+    expect(
+      collectFestivalStageRecipients({
+        department: "sound",
+        shifts: [
+          { id: "shift-sound", department: "sound" },
+          { id: "shift-lights", department: "lights" },
+        ],
+        assignments: [
+          {
+            external_technician_name: null,
+            role: "SND-FOH-R",
+            shift_id: "shift-sound",
+            technician_id: "tech-1",
+          },
+          {
+            external_technician_name: null,
+            role: "LGT-BRD-R",
+            shift_id: "shift-lights",
+            technician_id: "tech-2",
+          },
+          {
+            external_technician_name: "External Sound",
+            role: "SND-PA-T",
+            shift_id: "shift-sound",
+            technician_id: null,
+          },
+        ],
+      }),
+    ).toEqual({
+      assignmentCount: 3,
+      externalNames: ["External Sound"],
+      shiftCount: 2,
+      technicianIds: ["tech-1"],
+    });
+  });
+
+  it("uses role prefixes for stage shifts without a department", () => {
+    expect(
+      collectFestivalStageRecipients({
+        department: "video",
+        shifts: [{ id: "shift-open", department: null }],
+        assignments: [
+          {
+            external_technician_name: null,
+            role: "VID-CAM-E",
+            shift_id: "shift-open",
+            technician_id: "video-tech",
+          },
+          {
+            external_technician_name: null,
+            role: "SND-FOH-R",
+            shift_id: "shift-open",
+            technician_id: "sound-tech",
+          },
+        ],
+      }),
+    ).toEqual({
+      assignmentCount: 2,
+      externalNames: [],
+      shiftCount: 1,
+      technicianIds: ["video-tech"],
     });
   });
 });

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -566,7 +566,7 @@ serve(async (req: Request) => {
     };
 
     // Existing festival stage groups may have been created before stage recipients were enabled.
-    if (existingWaGroupId) {
+    if (shouldSyncExistingStageGroup) {
       await addParticipantsBestEffort(groupParticipants, 'existing-stage-group-sync');
     } else if (usedFallback && groupParticipants.length > 1) {
       const first = fallbackSeedParticipant || groupParticipants[0];
@@ -666,7 +666,7 @@ serve(async (req: Request) => {
       warnings: { missing, invalid },
       participants: uniqueParticipants
     };
-    if (existingWaGroupId) resp.note = 'Grupo ya existia; participantes programados sincronizados.';
+    if (shouldSyncExistingStageGroup) resp.note = 'Grupo ya existia; participantes programados sincronizados.';
     else if (usedFallback) resp.note = 'Grupo creado con 1 participante por fallback; añadiremos el resto en una futura sincronización.';
     return new Response(JSON.stringify(resp), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   } catch (err) {

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import {
   buildWahaGroupParticipants,
   phoneToWahaJid,
+  resolveFestivalStageTechnicianIds,
 } from "./recipientUtils.ts";
 import type { Dept } from "./recipientUtils.ts";
 
@@ -130,7 +131,9 @@ serve(async (req: Request) => {
     if (existingErr && existingErr.message) {
       console.warn('job_whatsapp_groups lookup error', existingErr);
     }
-    if (existing && !finalizeOnly) {
+    const existingWaGroupId = existing?.wa_group_id || null;
+    const shouldSyncExistingStageGroup = !!existingWaGroupId && effectiveStageNumber > 0 && !finalizeOnly;
+    if (existing && !shouldSyncExistingStageGroup && !finalizeOnly) {
       return new Response(JSON.stringify({ success: true, wa_group_id: existing.wa_group_id, note: 'Group already exists' }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
@@ -142,7 +145,7 @@ serve(async (req: Request) => {
       .eq('department', department)
       .eq('stage_number', effectiveStageNumber)
       .maybeSingle();
-    if (priorReq && !finalizeOnly) {
+    if (priorReq && !shouldSyncExistingStageGroup && !finalizeOnly) {
       return new Response(JSON.stringify({ success: true, wa_group_id: null, note: 'Group request already recorded (locked)' }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
@@ -178,37 +181,104 @@ serve(async (req: Request) => {
     const missing: string[] = [];
     const invalid: string[] = [];
 
-    // Recipients intentionally come from job assignments for every job type.
-    // Festival stage selection only scopes the group name and persistence key.
-    const { data: assigns, error: assignsErr } = await supabaseAdmin
-      .from('job_assignments')
-      .select(`
-        technician_id,
-        sound_role, lights_role, video_role,
-        profiles!job_assignments_technician_id_fkey ( first_name, last_name, phone )
-      `)
-      .eq('job_id', job_id);
-    if (assignsErr) {
-      console.warn('job_assignments fetch error', assignsErr);
-    }
-
-    const rows = (assigns ?? []).filter((r: any) => {
-      if (department === 'sound') return !!r.sound_role;
-      if (department === 'lights') return !!r.lights_role;
-      if (department === 'video') return !!r.video_role;
-      return false;
-    });
-
-    for (const r of rows) {
-      const fullName = `${r.profiles?.first_name ?? ''} ${r.profiles?.last_name ?? ''}`.trim() || 'Tecnico';
-      const rawPhone = (r.profiles?.phone || '').trim();
+    const addProfilePhoneRecipient = (
+      profile: { first_name?: string | null; last_name?: string | null; phone?: string | null } | null | undefined,
+      fallbackName = 'Tecnico',
+    ) => {
+      const fullName = `${profile?.first_name ?? ''} ${profile?.last_name ?? ''}`.trim() || fallbackName;
+      const rawPhone = (profile?.phone || '').trim();
       if (!rawPhone) {
         missing.push(fullName);
-        continue;
+        return false;
       }
       const norm = normalizePhone(rawPhone, defaultCC);
-      if (norm.ok) participants.push(norm.value);
-      else invalid.push(`${fullName} (${rawPhone})`);
+      if (norm.ok) {
+        participants.push(norm.value);
+        return true;
+      }
+
+      invalid.push(`${fullName} (${rawPhone})`);
+      return false;
+    };
+
+    let scheduledStageParticipantCount = 0;
+
+    if (effectiveStageNumber > 0) {
+      let stageRecipients;
+      try {
+        stageRecipients = await resolveFestivalStageTechnicianIds({
+          department,
+          jobId: job_id,
+          stageNumber: effectiveStageNumber,
+          supabase: supabaseAdmin,
+        });
+      } catch (stageRecipientError) {
+        console.warn('festival stage recipient lookup error', stageRecipientError);
+        return new Response(JSON.stringify({ error: 'Failed to fetch festival stage schedule', details: String(stageRecipientError) }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+
+      for (const externalName of stageRecipients.externalNames) {
+        missing.push(`${externalName} (external technician without profile phone)`);
+      }
+
+      console.info('Festival stage WhatsApp recipients resolved', {
+        assignmentCount: stageRecipients.assignmentCount,
+        department,
+        externalCount: stageRecipients.externalNames.length,
+        job_id,
+        shiftCount: stageRecipients.shiftCount,
+        stage_number: effectiveStageNumber,
+        technicianCount: stageRecipients.technicianIds.length,
+      });
+
+      if (stageRecipients.technicianIds.length === 0) {
+        return new Response(JSON.stringify({ error: 'No scheduled technicians found for this festival stage', warnings: { missing, invalid } }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+
+      const { data: scheduledProfiles, error: scheduledProfilesError } = await supabaseAdmin
+        .from('profiles')
+        .select('id, first_name, last_name, phone')
+        .in('id', stageRecipients.technicianIds);
+
+      if (scheduledProfilesError) {
+        console.warn('profiles fetch error for festival stage recipients', scheduledProfilesError);
+        return new Response(JSON.stringify({ error: 'Failed to fetch scheduled technician profiles', details: scheduledProfilesError.message }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+
+      const profilesById = new Map((scheduledProfiles ?? []).map((profile: any) => [profile.id, profile]));
+      for (const technicianId of stageRecipients.technicianIds) {
+        const profile = profilesById.get(technicianId);
+        if (addProfilePhoneRecipient(profile, 'Scheduled technician')) {
+          scheduledStageParticipantCount++;
+        }
+      }
+
+      if (scheduledStageParticipantCount === 0) {
+        return new Response(JSON.stringify({ error: 'No valid phone numbers found for scheduled technicians on this festival stage', warnings: { missing, invalid } }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+      }
+    } else {
+      const { data: assigns, error: assignsErr } = await supabaseAdmin
+        .from('job_assignments')
+        .select(`
+          technician_id,
+          sound_role, lights_role, video_role,
+          profiles!job_assignments_technician_id_fkey ( first_name, last_name, phone )
+        `)
+        .eq('job_id', job_id);
+      if (assignsErr) {
+        console.warn('job_assignments fetch error', assignsErr);
+      }
+
+      const rows = (assigns ?? []).filter((r: any) => {
+        if (department === 'sound') return !!r.sound_role;
+        if (department === 'lights') return !!r.lights_role;
+        if (department === 'video') return !!r.video_role;
+        return false;
+      });
+
+      for (const r of rows) {
+        addProfilePhoneRecipient(r.profiles);
+      }
     }
 
     // Always include management user for the department (if phone exists and matches department)
@@ -246,7 +316,7 @@ serve(async (req: Request) => {
     }
 
     // Record request to lock further attempts only after recipient validation succeeds.
-    if (!priorReq) {
+    if (!priorReq && !existingWaGroupId) {
       const { error: lockErr } = await supabaseAdmin
         .from('job_whatsapp_group_requests')
         .insert({ job_id, department, stage_number: effectiveStageNumber });
@@ -284,7 +354,7 @@ serve(async (req: Request) => {
       }
       return null;
     })();
-    const { allParticipants: participantObjects, groupParticipants } = buildWahaGroupParticipants({
+    const { groupParticipants } = buildWahaGroupParticipants({
       actorJid: actorJidCandidate,
       participants: uniqueParticipants,
     });
@@ -295,9 +365,9 @@ serve(async (req: Request) => {
 
     let usedFallback = false;
     let fallbackSeedParticipant: { id: string } | null = null;
-    let wa_group_id = '';
+    let wa_group_id = existingWaGroupId || '';
     let groupText = '';
-    if (!finalizeOnly) {
+    if (!finalizeOnly && !existingWaGroupId) {
       // Create the group per WAHA API: POST /api/{session}/groups { name, participants: [{id}] }
       const groupUrl = `${base}/api/${encodeURIComponent(session)}/groups`;
       let groupRes: Response;
@@ -423,12 +493,14 @@ serve(async (req: Request) => {
     }
 
     // Persist
-    const { error: insErr } = await supabaseAdmin
-      .from('job_whatsapp_groups')
-      .insert({ job_id, department, stage_number: effectiveStageNumber, wa_group_id });
-    if (insErr) {
-      // Best effort to not leave group untracked, still respond with success but include warning
-      console.warn('Failed to persist job_whatsapp_groups:', insErr);
+    if (!existingWaGroupId) {
+      const { error: insErr } = await supabaseAdmin
+        .from('job_whatsapp_groups')
+        .insert({ job_id, department, stage_number: effectiveStageNumber, wa_group_id });
+      if (insErr) {
+        // Best effort to not leave group untracked, still respond with success but include warning
+        console.warn('Failed to persist job_whatsapp_groups:', insErr);
+      }
     }
 
     // Turn OFF "admins-only" so all members can send (best effort)
@@ -455,123 +527,137 @@ serve(async (req: Request) => {
       console.warn('⚠️ Error toggling group send permissions:', err);
     }
 
-    // If fallback creation used with only 1 participant, add the rest now (best effort)
-    if (groupParticipants.length > 1) {
+    const addParticipantsBestEffort = async (participantsToAdd: Array<{ id: string }>, context: string) => {
+      if (!participantsToAdd.length) return;
+      const addUrl = `${base}/api/${encodeURIComponent(session)}/groups/${encodeURIComponent(wa_group_id)}/participants/add`;
+
+      const tryBulkAdd = async () => {
+        const res = await fetch(addUrl, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ participants: participantsToAdd })
+        });
+        if (!res.ok) {
+          const addTxt = await res.text().catch(() => '');
+          throw new Error(`add participants failed ${res.status}: ${addTxt}`);
+        }
+      };
+
       try {
-        const first = fallbackSeedParticipant || groupParticipants[0];
-        const toAdd = groupParticipants.filter((p) => p.id !== first.id);
-        if (toAdd.length) {
-          const addUrl = `${base}/api/${encodeURIComponent(session)}/groups/${encodeURIComponent(wa_group_id)}/participants/add`;
-          const tryAdd = async () => {
+        await tryBulkAdd();
+      } catch (bulkError) {
+        console.warn('⚠️ Bulk participant add failed; trying one by one', { context, error: String(bulkError) });
+        for (const participant of participantsToAdd) {
+          try {
             const res = await fetch(addUrl, {
               method: 'POST',
               headers,
-              body: JSON.stringify({ participants: toAdd })
+              body: JSON.stringify({ participants: [participant] })
             });
             if (!res.ok) {
               const addTxt = await res.text().catch(() => '');
               throw new Error(`add participants failed ${res.status}: ${addTxt}`);
             }
-          };
-          try {
-            await tryAdd();
-          } catch (e1) {
-            // small wait then retry once
-            await new Promise((r) => setTimeout(r, 1000));
-            try {
-              await tryAdd();
-            } catch (e2) {
-              console.warn('⚠️ Could not add remaining participants after fallback', { error: String(e2) });
-            }
+          } catch (singleError) {
+            console.warn('⚠️ Could not add participant to group', { context, participant: participant.id, error: String(singleError) });
           }
         }
-      } catch (e) {
-        console.warn('⚠️ Error adding remaining participants:', e);
       }
+    };
+
+    // Existing festival stage groups may have been created before stage recipients were enabled.
+    if (existingWaGroupId) {
+      await addParticipantsBestEffort(groupParticipants, 'existing-stage-group-sync');
+    } else if (usedFallback && groupParticipants.length > 1) {
+      const first = fallbackSeedParticipant || groupParticipants[0];
+      const toAdd = groupParticipants.filter((p) => p.id !== first.id);
+      await addParticipantsBestEffort(toAdd, 'fallback-create');
     }
 
-    // Try to set group picture from job or tour logo (best effort)
-    try {
-      // 1) Festival logo by job
-      let logoUrl: string | null = null;
+    if (!existingWaGroupId) {
+      // Try to set group picture from job or tour logo (best effort)
       try {
-        const { data: festLogo } = await supabaseAdmin
-          .from('festival_logos')
-          .select('file_path')
-          .eq('job_id', job_id)
-          .maybeSingle();
-        if (festLogo?.file_path) {
-          const { data: pub } = supabaseAdmin.storage
-            .from('festival-logos')
-            .getPublicUrl(festLogo.file_path);
-          if (pub?.publicUrl) logoUrl = pub.publicUrl;
-        }
-      } catch { /* ignore */ }
-
-      // 2) Fallback to tour logo
-      if (!logoUrl && job?.tour_id) {
+        // 1) Festival logo by job
+        let logoUrl: string | null = null;
         try {
-          const { data: tourLogo } = await supabaseAdmin
-            .from('tour_logos')
+          const { data: festLogo } = await supabaseAdmin
+            .from('festival_logos')
             .select('file_path')
-            .eq('tour_id', job.tour_id)
+            .eq('job_id', job_id)
             .maybeSingle();
-          if (tourLogo?.file_path) {
+          if (festLogo?.file_path) {
             const { data: pub } = supabaseAdmin.storage
-              .from('tour-logos')
-              .getPublicUrl(tourLogo.file_path);
+              .from('festival-logos')
+              .getPublicUrl(festLogo.file_path);
             if (pub?.publicUrl) logoUrl = pub.publicUrl;
           }
         } catch { /* ignore */ }
-      }
 
-      if (logoUrl) {
-        // Infer mimetype/filename from URL
-        const lower = logoUrl.toLowerCase();
-        const mimetype = lower.endsWith('.png') ? 'image/png' : 'image/jpeg';
-        const filename = (() => {
-          try { return new URL(logoUrl).pathname.split('/').pop() || 'logo'; } catch { return 'logo'; }
-        })();
-
-        const picUrl = `${base}/api/${encodeURIComponent(session)}/groups/${encodeURIComponent(wa_group_id)}/picture`;
-        const body = { file: { mimetype, filename, url: logoUrl } } as const;
-        const picRes = await fetch(picUrl, { method: 'PUT', headers, body: JSON.stringify(body) });
-        if (!picRes.ok) {
-          const txt = await picRes.text().catch(() => '');
-          console.warn('⚠️ Failed to set group picture', { status: picRes.status, url: picUrl, body: txt });
-        } else {
-          console.log(`🖼️ Group ${wa_group_id} picture set from ${filename}`);
+        // 2) Fallback to tour logo
+        if (!logoUrl && job?.tour_id) {
+          try {
+            const { data: tourLogo } = await supabaseAdmin
+              .from('tour_logos')
+              .select('file_path')
+              .eq('tour_id', job.tour_id)
+              .maybeSingle();
+            if (tourLogo?.file_path) {
+              const { data: pub } = supabaseAdmin.storage
+                .from('tour-logos')
+                .getPublicUrl(tourLogo.file_path);
+              if (pub?.publicUrl) logoUrl = pub.publicUrl;
+            }
+          } catch { /* ignore */ }
         }
-      } else {
-        console.log('No festival/tour logo found for group picture');
-      }
-    } catch (e) {
-      console.warn('⚠️ Error setting group picture:', e);
-    }
 
-    // Send welcome message (best effort) using WAHA /api/sendText
-    const message = `👋 Bienvenidos al grupo de ${job.title} - ${deptNameEs}${stageSuffix}.\nUsad este chat para la coordinación.`;
-    try {
-      const msgBody = { chatId: wa_group_id, text: message, session } as const;
-      const sendUrl = `${base}/api/sendText`;
-      const timeoutMs = Number(Deno.env.get('WAHA_FETCH_TIMEOUT_MS') || 15000);
-      const controller = new AbortController();
-      const to = setTimeout(() => controller.abort(new DOMException('timeout','AbortError')), timeoutMs);
-      try {
-        const sendRes = await fetch(sendUrl, { method: 'POST', headers, body: JSON.stringify(msgBody), signal: controller.signal });
-        if (!sendRes.ok) {
-          const errTxt = await sendRes.text().catch(() => '');
-          if (sendRes.status === 524) {
-            const ray = (errTxt.match(/Cloudflare Ray ID:\s*<strong[^>]*>([^<]+)/i)?.[1]) || null;
-            console.warn('WAHA sendText timeout via Cloudflare (524)', { status: sendRes.status, url: sendUrl, rayId: ray });
+        if (logoUrl) {
+          // Infer mimetype/filename from URL
+          const lower = logoUrl.toLowerCase();
+          const mimetype = lower.endsWith('.png') ? 'image/png' : 'image/jpeg';
+          const filename = (() => {
+            try { return new URL(logoUrl).pathname.split('/').pop() || 'logo'; } catch { return 'logo'; }
+          })();
+
+          const picUrl = `${base}/api/${encodeURIComponent(session)}/groups/${encodeURIComponent(wa_group_id)}/picture`;
+          const body = { file: { mimetype, filename, url: logoUrl } } as const;
+          const picRes = await fetch(picUrl, { method: 'PUT', headers, body: JSON.stringify(body) });
+          if (!picRes.ok) {
+            const txt = await picRes.text().catch(() => '');
+            console.warn('⚠️ Failed to set group picture', { status: picRes.status, url: picUrl, body: txt });
           } else {
-            console.warn('WAHA sendText failed', { status: sendRes.status, url: sendUrl, body: errTxt });
+            console.log(`🖼️ Group ${wa_group_id} picture set from ${filename}`);
           }
+        } else {
+          console.log('No festival/tour logo found for group picture');
         }
-      } finally {
-        clearTimeout(to);
+      } catch (e) {
+        console.warn('⚠️ Error setting group picture:', e);
       }
-    } catch (_) { /* ignore */ }
+
+      // Send welcome message (best effort) using WAHA /api/sendText
+      const message = `👋 Bienvenidos al grupo de ${job.title} - ${deptNameEs}${stageSuffix}.\nUsad este chat para la coordinación.`;
+      try {
+        const msgBody = { chatId: wa_group_id, text: message, session } as const;
+        const sendUrl = `${base}/api/sendText`;
+        const timeoutMs = Number(Deno.env.get('WAHA_FETCH_TIMEOUT_MS') || 15000);
+        const controller = new AbortController();
+        const to = setTimeout(() => controller.abort(new DOMException('timeout','AbortError')), timeoutMs);
+        try {
+          const sendRes = await fetch(sendUrl, { method: 'POST', headers, body: JSON.stringify(msgBody), signal: controller.signal });
+          if (!sendRes.ok) {
+            const errTxt = await sendRes.text().catch(() => '');
+            if (sendRes.status === 524) {
+              const ray = (errTxt.match(/Cloudflare Ray ID:\s*<strong[^>]*>([^<]+)/i)?.[1]) || null;
+              console.warn('WAHA sendText timeout via Cloudflare (524)', { status: sendRes.status, url: sendUrl, rayId: ray });
+            } else {
+              console.warn('WAHA sendText failed', { status: sendRes.status, url: sendUrl, body: errTxt });
+            }
+          }
+        } finally {
+          clearTimeout(to);
+        }
+      } catch (_) { /* ignore */ }
+    }
 
     const resp: any = {
       success: true,
@@ -580,7 +666,8 @@ serve(async (req: Request) => {
       warnings: { missing, invalid },
       participants: uniqueParticipants
     };
-    if (usedFallback) resp.note = 'Grupo creado con 1 participante por fallback; añadiremos el resto en una futura sincronización.';
+    if (existingWaGroupId) resp.note = 'Grupo ya existia; participantes programados sincronizados.';
+    else if (usedFallback) resp.note = 'Grupo creado con 1 participante por fallback; añadiremos el resto en una futura sincronización.';
     return new Response(JSON.stringify(resp), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   } catch (err) {
     console.error('create-whatsapp-group error:', err);

--- a/supabase/functions/create-whatsapp-group/recipientUtils.ts
+++ b/supabase/functions/create-whatsapp-group/recipientUtils.ts
@@ -4,6 +4,31 @@ export type WahaParticipantObject = {
   id: string;
 };
 
+export type FestivalStageShiftRow = {
+  id: string;
+  department: string | null;
+};
+
+export type FestivalStageAssignmentRow = {
+  external_technician_name: string | null;
+  role: string | null;
+  shift_id: string | null;
+  technician_id: string | null;
+};
+
+export type FestivalStageRecipientResolution = {
+  assignmentCount: number;
+  externalNames: string[];
+  shiftCount: number;
+  technicianIds: string[];
+};
+
+const ROLE_PREFIX_BY_DEPARTMENT: Record<Dept, string> = {
+  sound: 'SND-',
+  lights: 'LGT-',
+  video: 'VID-',
+};
+
 export const phoneToWahaJid = (phone: string) => `${phone.replace(/^\+/, '').replace(/\D/g, '')}@c.us`;
 
 export const buildWahaGroupParticipants = ({
@@ -22,4 +47,98 @@ export const buildWahaGroupParticipants = ({
     allParticipants,
     groupParticipants,
   };
+};
+
+const normalizeDepartment = (department: string | null | undefined) => {
+  const normalized = (department || '').trim().toLowerCase();
+  return normalized === 'none' ? '' : normalized;
+};
+
+export const festivalAssignmentMatchesDepartment = (
+  assignment: Pick<FestivalStageAssignmentRow, 'role'>,
+  shift: Pick<FestivalStageShiftRow, 'department'> | undefined,
+  department: Dept,
+) => {
+  const shiftDepartment = normalizeDepartment(shift?.department);
+  if (shiftDepartment) return shiftDepartment === department;
+
+  const role = (assignment.role || '').trim().toUpperCase();
+  return role.startsWith(ROLE_PREFIX_BY_DEPARTMENT[department]);
+};
+
+export const collectFestivalStageRecipients = ({
+  assignments,
+  department,
+  shifts,
+}: {
+  assignments: FestivalStageAssignmentRow[];
+  department: Dept;
+  shifts: FestivalStageShiftRow[];
+}): FestivalStageRecipientResolution => {
+  const shiftById = new Map(shifts.map((shift) => [shift.id, shift]));
+  const technicianIds: string[] = [];
+  const externalNames: string[] = [];
+
+  for (const assignment of assignments) {
+    const shift = assignment.shift_id ? shiftById.get(assignment.shift_id) : undefined;
+    if (!shift) continue;
+    if (!festivalAssignmentMatchesDepartment(assignment, shift, department)) continue;
+
+    if (assignment.technician_id) {
+      technicianIds.push(assignment.technician_id);
+    } else if (assignment.external_technician_name) {
+      externalNames.push(assignment.external_technician_name);
+    }
+  }
+
+  return {
+    assignmentCount: assignments.length,
+    externalNames: Array.from(new Set(externalNames)),
+    shiftCount: shifts.length,
+    technicianIds: Array.from(new Set(technicianIds)),
+  };
+};
+
+export const resolveFestivalStageTechnicianIds = async ({
+  department,
+  jobId,
+  stageNumber,
+  supabase,
+}: {
+  department: Dept;
+  jobId: string;
+  stageNumber: number;
+  supabase: any;
+}): Promise<FestivalStageRecipientResolution> => {
+  const { data: shifts, error: shiftsError } = await supabase
+    .from('festival_shifts')
+    .select('id, department')
+    .eq('job_id', jobId)
+    .eq('stage', stageNumber);
+
+  if (shiftsError) throw shiftsError;
+
+  const stageShifts = (shifts ?? []) as FestivalStageShiftRow[];
+  if (stageShifts.length === 0) {
+    return {
+      assignmentCount: 0,
+      externalNames: [],
+      shiftCount: 0,
+      technicianIds: [],
+    };
+  }
+
+  const shiftIds = stageShifts.map((shift) => shift.id);
+  const { data: assignments, error: assignmentsError } = await supabase
+    .from('festival_shift_assignments')
+    .select('shift_id, technician_id, role, external_technician_name')
+    .in('shift_id', shiftIds);
+
+  if (assignmentsError) throw assignmentsError;
+
+  return collectFestivalStageRecipients({
+    assignments: (assignments ?? []) as FestivalStageAssignmentRow[],
+    department,
+    shifts: stageShifts,
+  });
 };


### PR DESCRIPTION
## Summary
- Resolve festival stage WhatsApp recipients from festival_shifts and festival_shift_assignments, then fetch phones from profiles
- Prevent stage-scoped festival groups from being created with only default users when no scheduled tech phone is available
- Allow existing stage-scoped festival groups to sync scheduled participants from the WhatsApp dialog

## Validation
- npm run test:run -- supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
- npm run test:run -- src/features/festival-management/__tests__/selectors.test.ts
- npm run lint:functions
- npm run typecheck
- npm run lint:app
- npm run test:run
- npm run build
- npx playwright test tests/e2e/festival-management.spec.ts --project=chromium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp groups for festival stages now sync participants to existing groups instead of only creating new ones.
  * Improved button labels and states in WhatsApp group dialogs to distinguish between creating new groups and updating participants.

* **Bug Fixes**
  * Fixed success notification messaging to accurately reflect whether a WhatsApp group was created or participants were updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->