### PR TITLE
[codex] Show festival artists on calendars

### DIFF
--- a/src/components/dashboard/CalendarSection.tsx
+++ b/src/components/dashboard/CalendarSection.tsx
@@ -29,6 +29,7 @@ import { toZonedTime } from "date-fns-tz";
 import { useOptimizedDateTypes } from "@/hooks/useOptimizedDateTypes";
 import { useToast } from "@/hooks/use-toast";
 import { isJobOnDate } from "@/utils/timezoneUtils";
+import { getCalendarJobDisplayTitle } from "@/utils/calendarArtists";
 import { DateType, DATE_TYPE_META, DATE_TYPE_ORDER, getDateTypeMeta } from "@/constants/dateTypes";
 
 type PrintableJobType = keyof PrintSettings["jobTypes"];
@@ -490,7 +491,7 @@ export const CalendarSection: React.FC<CalendarSectionProps> = ({
             const maxTitleWidth = cellWidth - (titleX - x) - 2;
             const maxTitleLength = Math.floor(maxTitleWidth / 1.2);
 
-            let displayTitle = job.title;
+            let displayTitle = getCalendarJobDisplayTitle(job, day);
             if (displayTitle.length > maxTitleLength) {
               displayTitle = displayTitle.substring(0, maxTitleLength - 3) + "...";
             }
@@ -730,7 +731,7 @@ export const CalendarSection: React.FC<CalendarSectionProps> = ({
 
               const cell = ws.getRow(startExcelRow + i + 1).getCell(col);
               const label = dtInfo ? `${dtInfo.label} ` : "";
-              cell.value = `${label}${job.title}`;
+              cell.value = `${label}${getCalendarJobDisplayTitle(job, day)}`;
 
               // Use job color as tinted background (20% opacity equivalent)
               const bgHex = dtInfo ? dtInfo.bg : tintColor(jobColor, 0.2);

--- a/src/components/dashboard/DashboardMobileHub.tsx
+++ b/src/components/dashboard/DashboardMobileHub.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { getOptimizedProfilePictureUrl } from "@/utils/imageOptimization";
 import { isManagementRole } from "@/utils/permissions";
+import { getCalendarJobDisplayTitle } from "@/utils/calendarArtists";
 
 interface DashboardMobileHubProps {
   jobs: any[];
@@ -452,7 +453,9 @@ export const DashboardMobileHub: React.FC<DashboardMobileHubProps> = ({
                 >
                   <div className="flex justify-between items-start mb-2">
                     <div className="flex-1">
-                      <h3 className={cn("font-bold text-lg", themeTokens.textMain)}>{job.title}</h3>
+                      <h3 className={cn("font-bold text-lg", themeTokens.textMain)}>
+                        {getCalendarJobDisplayTitle(job, selectedDate)}
+                      </h3>
                       <div className={cn("text-xs mt-1", themeTokens.textMuted)}>
                         {job.location_data?.name || "Sin ubicación"}
                       </div>

--- a/src/components/dashboard/MobileJobCard.tsx
+++ b/src/components/dashboard/MobileJobCard.tsx
@@ -41,6 +41,7 @@ import { useFlexUuidLazy } from "@/hooks/useFlexUuidLazy";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useQueryClient } from "@tanstack/react-query";
 import { openFlexElement } from "@/utils/flex-folders";
+import { getCalendarJobDisplayTitle } from "@/utils/calendarArtists";
 import { isFestivalLikeJobType } from "@/utils/jobType";
 import { DateType, DATE_TYPE_OPTIONS, getDateTypeMeta } from "@/constants/dateTypes";
 
@@ -130,9 +131,10 @@ export function MobileJobCard({
 
   const currentDateTypeEmoji = getDateTypeMeta(currentTypeValue)?.emoji || '🎭';
 
-  const jobTitle = (job.title || job.job_name || 'Untitled Job').length > 26 
-    ? (job.title || job.job_name || 'Untitled Job').substring(0, 26) + '...'
-    : (job.title || job.job_name || 'Untitled Job');
+  const fullJobTitle = getCalendarJobDisplayTitle(job, currentDate);
+  const jobTitle = fullJobTitle.length > 26
+    ? fullJobTitle.substring(0, 26) + '...'
+    : fullJobTitle;
   const jobVenue = (job.location?.name || job.venue || 'No venue').length > 26
     ? (job.location?.name || job.venue || 'No venue').substring(0, 26) + '...'
     : (job.location?.name || job.venue || 'No venue');

--- a/src/components/dashboard/MobileJobCard.tsx
+++ b/src/components/dashboard/MobileJobCard.tsx
@@ -135,9 +135,9 @@ export function MobileJobCard({
   const jobTitle = fullJobTitle.length > 26
     ? fullJobTitle.substring(0, 26) + '...'
     : fullJobTitle;
-  const jobVenue = (job.location?.name || job.venue || 'No venue').length > 26
-    ? (job.location?.name || job.venue || 'No venue').substring(0, 26) + '...'
-    : (job.location?.name || job.venue || 'No venue');
+  const jobVenue = (job.location?.name || job.venue || 'Sin ubicación').length > 26
+    ? (job.location?.name || job.venue || 'Sin ubicación').substring(0, 26) + '...'
+    : (job.location?.name || job.venue || 'Sin ubicación');
   const startTime = job.start_time ? format(new Date(job.start_time), 'HH:mm') : '';
   const endTime = job.end_time ? format(new Date(job.end_time), 'HH:mm') : '';
   const timeRange = startTime && endTime ? `${startTime} - ${endTime}` : startTime;
@@ -182,8 +182,8 @@ export function MobileJobCard({
       if (error) throw error;
 
       toast({
-        title: "Date type updated",
-        description: `Set to ${DATE_TYPE_OPTIONS.find(opt => opt.value === newType)?.label}`
+        title: "Tipo de fecha actualizado",
+        description: `Cambiado a ${DATE_TYPE_OPTIONS.find(opt => opt.value === newType)?.label}`
       });
 
       // Ensure both mobile and desktop calendars refresh their caches
@@ -199,7 +199,7 @@ export function MobileJobCard({
       console.error('Error updating date type:', error);
       toast({
         title: "Error",
-        description: "Failed to update date type",
+        description: "No se pudo actualizar el tipo de fecha",
         variant: "destructive"
       });
     }
@@ -220,7 +220,7 @@ export function MobileJobCard({
       }
 
       if (isLoadingFlexUuid) {
-        toast({ title: "Loading", description: "Please wait while we load the Flex folder..." });
+        toast({ title: "Cargando", description: "Espera mientras cargamos la carpeta de Flex..." });
         return;
       }
 
@@ -233,13 +233,13 @@ export function MobileJobCard({
           onError: (error) => {
             toast({
               title: "Error",
-              description: error.message || "Failed to open Flex",
+              description: error.message || "No se pudo abrir Flex",
               variant: "destructive",
             });
           },
           onWarning: (message) => {
             toast({
-              title: "Warning",
+              title: "Aviso",
               description: message,
             });
           },
@@ -247,7 +247,7 @@ export function MobileJobCard({
       } else if (flexError) {
         toast({ title: "Error", description: String(flexError), variant: "destructive" });
       } else {
-        toast({ title: "Info", description: "Flex folder not available for this job" });
+        toast({ title: "Información", description: "La carpeta de Flex no está disponible para este trabajo" });
       }
     } catch (err: any) {
       console.error('Flex navigation error', err);
@@ -255,9 +255,9 @@ export function MobileJobCard({
   };
 
   const getFlexMenuText = () => {
-    if (!hasChecked) return 'Check Flex';
-    if (isLoadingFlexUuid) return 'Loading Flex...';
-    if (flexUuid) return 'Open Flex';
+    if (!hasChecked) return 'Comprobar Flex';
+    if (isLoadingFlexUuid) return 'Cargando Flex...';
+    if (flexUuid) return 'Abrir Flex';
     return 'Flex';
   };
 
@@ -284,7 +284,7 @@ export function MobileJobCard({
         {isJobBeingDeleted && (
           <div className="absolute inset-0 bg-black bg-opacity-20 flex items-center justify-center z-10 rounded">
             <div className="bg-background px-3 py-2 rounded shadow-lg">
-              <span className="text-sm font-medium">Deleting job...</span>
+              <span className="text-sm font-medium">Eliminando trabajo...</span>
             </div>
           </div>
         )}
@@ -314,7 +314,7 @@ export function MobileJobCard({
                 >
                   <DropdownMenuItem onClick={handleDateTypeBadgeClick}>
                     <Calendar className="mr-2 h-4 w-4" />
-                    Change Date Type
+                    Cambiar tipo de fecha
                   </DropdownMenuItem>
 
                   <DropdownMenuItem 
@@ -327,7 +327,7 @@ export function MobileJobCard({
                   
                   <DropdownMenuSeparator />
                   
-                  {/* View Details */}
+                  {/* View details */}
                   {canViewJobDetails && (
                     <DropdownMenuItem 
                       onClick={(e) => {
@@ -336,7 +336,7 @@ export function MobileJobCard({
                       }}
                     >
                       <FileText className="mr-2 h-4 w-4" />
-                      View Details
+                      Ver detalles
                     </DropdownMenuItem>
                   )}
                   
@@ -347,18 +347,18 @@ export function MobileJobCard({
                     }}
                   >
                     <Users className="mr-2 h-4 w-4" />
-                    Assign Users
+                    Asignar usuarios
                   </DropdownMenuItem>
                   
                   <DropdownMenuItem onClick={handleTimesheetClick}>
                     <Clock className="mr-2 h-4 w-4" />
-                    Timesheets
+                    Partes de horas
                   </DropdownMenuItem>
                   
                   {isFestival && canManageArtists && (
                     <DropdownMenuItem onClick={handleFestivalArtistsClick}>
                       <Star className="mr-2 h-4 w-4" />
-                      Manage Artists
+                      Gestionar artistas
                     </DropdownMenuItem>
                   )}
                   
@@ -368,7 +368,7 @@ export function MobileJobCard({
                     <DropdownMenuItem asChild>
                       <label className="cursor-pointer">
                         <FileUp className="mr-2 h-4 w-4" />
-                        Upload Document
+                        Subir documento
                         <input
                           type="file"
                           className="hidden"
@@ -399,7 +399,7 @@ export function MobileJobCard({
                       ) : (
                         <FolderPlus className="mr-2 h-4 w-4" />
                       )}
-                      {isCreatingFolders ? 'Creating...' : foldersAreCreated ? 'Flex Folders Created' : 'Create Flex Folders'}
+                      {isCreatingFolders ? 'Creando...' : foldersAreCreated ? 'Carpetas Flex creadas' : 'Crear carpetas Flex'}
                     </DropdownMenuItem>
                   )}
                   
@@ -412,14 +412,14 @@ export function MobileJobCard({
                       disabled={isCreatingLocalFolders}
                     >
                       <HardDrive className="mr-2 h-4 w-4" />
-                      {isCreatingLocalFolders ? 'Creating...' : 'Create Local Folders'}
+                      {isCreatingLocalFolders ? 'Creando...' : 'Crear carpetas locales'}
                     </DropdownMenuItem>
                   )}
                   
                   {canEditJobs && (
                     <DropdownMenuItem onClick={handleEditButtonClick}>
                       <Edit className="mr-2 h-4 w-4" />
-                      Edit Job
+                      Editar trabajo
                     </DropdownMenuItem>
                   )}
                   
@@ -429,7 +429,7 @@ export function MobileJobCard({
                       className="text-destructive focus:text-destructive"
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
-                      Delete Job
+                      Eliminar trabajo
                     </DropdownMenuItem>
                   )}
                 </DropdownMenuContent>
@@ -477,7 +477,7 @@ export function MobileJobCard({
       <Dialog open={dateTypeDialogOpen} onOpenChange={setDateTypeDialogOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Change Date Type</DialogTitle>
+            <DialogTitle>Cambiar tipo de fecha</DialogTitle>
           </DialogHeader>
           <div className="grid gap-2">
             {DATE_TYPE_OPTIONS.map((option) => (

--- a/src/components/dashboard/PrintDialog.tsx
+++ b/src/components/dashboard/PrintDialog.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Printer, FileSpreadsheet } from "lucide-react";
 import { format } from "date-fns";
+import { usePrintJobTypeInitialization } from "@/hooks/usePrintJobTypeInitialization";
 
 interface PrintSettings {
   jobTypes: {
@@ -37,20 +38,7 @@ export const PrintDialog: React.FC<PrintDialogProps> = ({
   currentMonth,
   selectedJobTypes,
 }) => {
-  useEffect(() => {
-    if (showDialog) {
-      // Initialize print settings job types based on current selected filters
-      const includeAllJobTypes = selectedJobTypes.length === 0;
-      const newJobTypes = {
-        tourdate: includeAllJobTypes || selectedJobTypes.includes("tourdate"),
-        tour: includeAllJobTypes || selectedJobTypes.includes("tour"),
-        single: includeAllJobTypes || selectedJobTypes.includes("single"),
-        dryhire: includeAllJobTypes || selectedJobTypes.includes("dryhire"),
-        festival: includeAllJobTypes || selectedJobTypes.includes("festival"),
-      };
-      setPrintSettings((prev) => ({ ...prev, jobTypes: newJobTypes }));
-    }
-  }, [showDialog, selectedJobTypes, setPrintSettings]);
+  usePrintJobTypeInitialization(showDialog, selectedJobTypes, setPrintSettings);
 
   return (
     <Dialog open={showDialog} onOpenChange={setShowDialog}>

--- a/src/components/dashboard/PrintDialog.tsx
+++ b/src/components/dashboard/PrintDialog.tsx
@@ -40,12 +40,13 @@ export const PrintDialog: React.FC<PrintDialogProps> = ({
   useEffect(() => {
     if (showDialog) {
       // Initialize print settings job types based on current selected filters
+      const includeAllJobTypes = selectedJobTypes.length === 0;
       const newJobTypes = {
-        tourdate: selectedJobTypes.includes("tourdate"),
-        tour: selectedJobTypes.includes("tour"),
-        single: selectedJobTypes.includes("single"),
-        dryhire: selectedJobTypes.includes("dryhire"),
-        festival: selectedJobTypes.includes("festival"),
+        tourdate: includeAllJobTypes || selectedJobTypes.includes("tourdate"),
+        tour: includeAllJobTypes || selectedJobTypes.includes("tour"),
+        single: includeAllJobTypes || selectedJobTypes.includes("single"),
+        dryhire: includeAllJobTypes || selectedJobTypes.includes("dryhire"),
+        festival: includeAllJobTypes || selectedJobTypes.includes("festival"),
       };
       setPrintSettings((prev) => ({ ...prev, jobTypes: newJobTypes }));
     }

--- a/src/components/dashboard/TodaySchedule.tsx
+++ b/src/components/dashboard/TodaySchedule.tsx
@@ -44,7 +44,7 @@ export const TodaySchedule = ({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Agenda del Dia</CardTitle>
+          <CardTitle>Agenda del Día</CardTitle>
         </CardHeader>
         <CardContent className="p-1">
           <div className="flex items-center justify-center p-4">
@@ -66,7 +66,7 @@ export const TodaySchedule = ({
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Agenda del Dia</CardTitle>
+          <CardTitle>Agenda del Día</CardTitle>
         </CardHeader>
         <CardContent className="p-1">
           <div className="flex items-center justify-center p-4">
@@ -114,7 +114,7 @@ export const TodaySchedule = ({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Agenda del Dia</CardTitle>
+        <CardTitle>Agenda del Día</CardTitle>
       </CardHeader>
       <CardContent className="p-1">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/components/dashboard/TodaySchedule.tsx
+++ b/src/components/dashboard/TodaySchedule.tsx
@@ -103,6 +103,7 @@ export const TodaySchedule = ({
               hideTasks={hideTasks}
               showManageArtists={isFestivalJob}
               detailsOnlyMode={detailsOnlyMode}
+              selectedDate={selectedDate}
             />
           );
         })}
@@ -160,6 +161,7 @@ export const TodaySchedule = ({
                 hideTasks={hideTasks}
                 showManageArtists={isFestivalJob}
                 detailsOnlyMode={detailsOnlyMode}
+                selectedDate={selectedDate}
               />
             );
           })}

--- a/src/components/dashboard/calendar-section/CalendarJobCard.tsx
+++ b/src/components/dashboard/calendar-section/CalendarJobCard.tsx
@@ -126,7 +126,7 @@ export const CalendarJobCard: React.FC<CalendarJobCardProps> = ({ job, date, dat
               )}
               {artistsForDate.length > 0 && (
                 <div className="space-y-1">
-                  <div className="text-sm font-medium">Artists:</div>
+                  <div className="text-sm font-medium">Artistas:</div>
                   <div className="flex flex-wrap gap-1">
                     {artistsForDate.map((artist) => (
                       <Badge

--- a/src/components/dashboard/calendar-section/CalendarJobCard.tsx
+++ b/src/components/dashboard/calendar-section/CalendarJobCard.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { getCalendarArtistsForDate, getCalendarJobDisplayTitle } from "@/utils/calendarArtists";
 import { formatInJobTimezone } from "@/utils/timezoneUtils";
 import { getDateTypeMeta } from "@/constants/dateTypes";
 
@@ -79,6 +80,8 @@ export const CalendarJobCard: React.FC<CalendarJobCardProps> = ({ job, date, dat
   const currentlyAssigned = job.job_assignments?.length || 0;
   const jobTimezone = job.timezone || "Europe/Madrid";
   const dateTypeIcon = getDateTypeIcon(job.id, date);
+  const artistsForDate = getCalendarArtistsForDate(job, date);
+  const displayTitle = getCalendarJobDisplayTitle(job, date);
 
   return (
     <DateTypeContextMenu
@@ -94,14 +97,14 @@ export const CalendarJobCard: React.FC<CalendarJobCardProps> = ({ job, date, dat
         <Tooltip>
           <TooltipTrigger asChild>
             <div
-              className="px-1.5 py-0.5 rounded text-xs truncate hover:bg-accent/50 transition-colors flex items-center gap-1 cursor-pointer"
+              className="px-1.5 py-0.5 rounded text-xs hover:bg-accent/50 transition-colors flex items-center gap-1 cursor-pointer min-w-0"
               style={{
                 backgroundColor: `${job.color}20`,
                 color: job.color,
               }}
             >
               {dateTypeIcon}
-              <span>{job.title}</span>
+              <span className="min-w-0 truncate">{displayTitle}</span>
             </div>
           </TooltipTrigger>
           <TooltipContent className="w-64 p-2">
@@ -119,6 +122,22 @@ export const CalendarJobCard: React.FC<CalendarJobCardProps> = ({ job, date, dat
                 <div className="flex items-center gap-2 text-sm">
                   <MapPin className="h-4 w-4" />
                   <span>{job.location.name}</span>
+                </div>
+              )}
+              {artistsForDate.length > 0 && (
+                <div className="space-y-1">
+                  <div className="text-sm font-medium">Artists:</div>
+                  <div className="flex flex-wrap gap-1">
+                    {artistsForDate.map((artist) => (
+                      <Badge
+                        key={artist.id || `${artist.name}-${artist.stage}-${artist.show_start}`}
+                        variant="outline"
+                        className="max-w-full"
+                      >
+                        <span className="truncate">{artist.name}</span>
+                      </Badge>
+                    ))}
+                  </div>
                 </div>
               )}
               <div className="space-y-1">

--- a/src/components/dashboard/calendar-section/PrintDialog.tsx
+++ b/src/components/dashboard/calendar-section/PrintDialog.tsx
@@ -32,12 +32,13 @@ export const PrintDialog: React.FC<PrintDialogProps> = ({
 }) => {
   useEffect(() => {
     if (showDialog) {
+      const includeAllJobTypes = selectedJobTypes.length === 0;
       const newJobTypes = {
-        tourdate: selectedJobTypes.includes("tourdate"),
-        tour: selectedJobTypes.includes("tour"),
-        single: selectedJobTypes.includes("single"),
-        dryhire: selectedJobTypes.includes("dryhire"),
-        festival: selectedJobTypes.includes("festival"),
+        tourdate: includeAllJobTypes || selectedJobTypes.includes("tourdate"),
+        tour: includeAllJobTypes || selectedJobTypes.includes("tour"),
+        single: includeAllJobTypes || selectedJobTypes.includes("single"),
+        dryhire: includeAllJobTypes || selectedJobTypes.includes("dryhire"),
+        festival: includeAllJobTypes || selectedJobTypes.includes("festival"),
       };
       setPrintSettings((prev) => ({ ...prev, jobTypes: newJobTypes }));
     }

--- a/src/components/dashboard/calendar-section/PrintDialog.tsx
+++ b/src/components/dashboard/calendar-section/PrintDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { format } from "date-fns";
 import { Printer, Table } from "lucide-react";
 
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { usePrintJobTypeInitialization } from "@/hooks/usePrintJobTypeInitialization";
 
 import type { CalendarExportRange, PrintSettings } from "./types";
 
@@ -30,19 +31,7 @@ export const PrintDialog: React.FC<PrintDialogProps> = ({
   currentMonth,
   selectedJobTypes,
 }) => {
-  useEffect(() => {
-    if (showDialog) {
-      const includeAllJobTypes = selectedJobTypes.length === 0;
-      const newJobTypes = {
-        tourdate: includeAllJobTypes || selectedJobTypes.includes("tourdate"),
-        tour: includeAllJobTypes || selectedJobTypes.includes("tour"),
-        single: includeAllJobTypes || selectedJobTypes.includes("single"),
-        dryhire: includeAllJobTypes || selectedJobTypes.includes("dryhire"),
-        festival: includeAllJobTypes || selectedJobTypes.includes("festival"),
-      };
-      setPrintSettings((prev) => ({ ...prev, jobTypes: newJobTypes }));
-    }
-  }, [showDialog, selectedJobTypes, setPrintSettings]);
+  usePrintJobTypeInitialization(showDialog, selectedJobTypes, setPrintSettings);
 
   return (
     <Dialog open={showDialog} onOpenChange={setShowDialog}>

--- a/src/components/department/DepartmentMobileHub.tsx
+++ b/src/components/department/DepartmentMobileHub.tsx
@@ -21,6 +21,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { Badge } from "@/components/ui/badge";
 import { isManagementRole } from "@/utils/permissions";
+import { getCalendarJobDisplayTitle } from "@/utils/calendarArtists";
 
 interface ToolDefinition {
   label: string;
@@ -495,7 +496,9 @@ export const DepartmentMobileHub: React.FC<DepartmentMobileHubProps> = ({
                 >
                   <div className="flex justify-between items-start mb-2">
                     <div className="flex-1">
-                      <h3 className={cn("font-bold text-lg", t.textMain)}>{job.title}</h3>
+                      <h3 className={cn("font-bold text-lg", t.textMain)}>
+                        {getCalendarJobDisplayTitle(job, selectedDate)}
+                      </h3>
                       <div className={cn("text-xs flex items-center gap-1 mt-0.5", t.textMuted)}>
                         <MapPin size={12} />
                         {job.location?.name || "Sin ubicación"}

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -154,6 +154,7 @@ export interface JobCardNewProps {
   isProjectManagementPage?: boolean;
   hideTasks?: boolean;
   detailsOnlyMode?: boolean;
+  selectedDate?: Date;
   openHojaDeRuta?: boolean;
   onHojaDeRutaOpened?: () => void;
 }
@@ -161,6 +162,7 @@ export interface JobCardNewProps {
 function JobCardNewDetailsOnlyCard({
   job,
   department = "sound",
+  selectedDate,
 }: JobCardNewProps) {
   const { theme } = useTheme();
   const isJobBeingDeleted = useDeletionState((state) => state.deletingJobs.has(job.id));
@@ -183,6 +185,7 @@ function JobCardNewDetailsOnlyCard({
       isJobBeingDeleted={isJobBeingDeleted}
       cardOpacity={cardOpacity}
       pointerEvents={pointerEvents}
+      selectedDate={selectedDate}
       jobDetailsDialogOpen={jobDetailsDialogOpen}
       setJobDetailsDialogOpen={setJobDetailsDialogOpen}
     />

--- a/src/components/jobs/cards/job-card-new/JobCardNewDetailsOnly.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewDetailsOnly.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { format } from "date-fns";
+import { format, isValid } from "date-fns";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { JobDetailsDialog } from "@/components/jobs/JobDetailsDialog";
 import type { Department } from "@/types/department";
+import { getCalendarArtistNamesForDate } from "@/utils/calendarArtists";
 
 export interface JobCardNewDetailsOnlyProps {
   job: any;
@@ -14,6 +16,7 @@ export interface JobCardNewDetailsOnlyProps {
   isJobBeingDeleted: boolean;
   cardOpacity: string;
   pointerEvents: string;
+  selectedDate?: Date;
   jobDetailsDialogOpen: boolean;
   setJobDetailsDialogOpen: (open: boolean) => void;
 }
@@ -25,12 +28,17 @@ export function JobCardNewDetailsOnly({
   isJobBeingDeleted,
   cardOpacity,
   pointerEvents,
+  selectedDate,
   jobDetailsDialogOpen,
   setJobDetailsDialogOpen,
 }: JobCardNewDetailsOnlyProps) {
   const jobName = job.title || job.name || job.job_name || "Unnamed Job";
   const startDate = job.start_time ? format(new Date(job.start_time), "dd/MM/yyyy HH:mm") : "";
   const endDate = job.end_time ? format(new Date(job.end_time), "dd/MM/yyyy HH:mm") : "";
+  const artistDate = selectedDate || (job.start_time ? new Date(job.start_time) : null);
+  const artistNames = artistDate && isValid(artistDate) ? getCalendarArtistNamesForDate(job, artistDate) : [];
+  const visibleArtistNames = artistNames.slice(0, 4);
+  const hiddenArtistCount = artistNames.length - visibleArtistNames.length;
 
   let location = "No location";
   if (typeof job.location === "string") {
@@ -64,6 +72,30 @@ export function JobCardNewDetailsOnly({
           <h3 className="font-semibold text-lg truncate" title={jobName}>
             {jobName}
           </h3>
+
+          {visibleArtistNames.length > 0 && (
+            <div className="flex flex-wrap gap-1.5" aria-label="Artists scheduled for this date">
+              {visibleArtistNames.map((artistName) => (
+                <Badge
+                  key={artistName}
+                  variant="secondary"
+                  className="max-w-full truncate border border-primary/15 bg-primary/10 px-2 py-0 text-[11px] font-medium text-primary"
+                  title={artistName}
+                >
+                  {artistName}
+                </Badge>
+              ))}
+              {hiddenArtistCount > 0 && (
+                <Badge
+                  variant="outline"
+                  className="border-primary/20 px-2 py-0 text-[11px] font-medium text-primary"
+                  title={artistNames.slice(visibleArtistNames.length).join(", ")}
+                >
+                  +{hiddenArtistCount}
+                </Badge>
+              )}
+            </div>
+          )}
 
           <div className="text-sm text-muted-foreground">
             <div className="flex flex-col gap-1">
@@ -103,4 +135,3 @@ export function JobCardNewDetailsOnly({
     </div>
   );
 }
-

--- a/src/components/jobs/cards/job-card-new/JobCardNewDetailsOnly.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewDetailsOnly.tsx
@@ -32,7 +32,7 @@ export function JobCardNewDetailsOnly({
   jobDetailsDialogOpen,
   setJobDetailsDialogOpen,
 }: JobCardNewDetailsOnlyProps) {
-  const jobName = job.title || job.name || job.job_name || "Unnamed Job";
+  const jobName = job.title || job.name || job.job_name || "Trabajo sin nombre";
   const startDate = job.start_time ? format(new Date(job.start_time), "dd/MM/yyyy HH:mm") : "";
   const endDate = job.end_time ? format(new Date(job.end_time), "dd/MM/yyyy HH:mm") : "";
   const artistDate = selectedDate || (job.start_time ? new Date(job.start_time) : null);
@@ -40,13 +40,13 @@ export function JobCardNewDetailsOnly({
   const visibleArtistNames = artistNames.slice(0, 4);
   const hiddenArtistCount = artistNames.length - visibleArtistNames.length;
 
-  let location = "No location";
+  let location = "Sin ubicación";
   if (typeof job.location === "string") {
     location = job.location;
   } else if (job.location && typeof job.location === "object") {
-    location = job.location.name || job.location.formatted_address || "No location";
+    location = job.location.name || job.location.formatted_address || "Sin ubicación";
   } else if (job.location_data) {
-    location = job.location_data.name || job.location_data.formatted_address || "No location";
+    location = job.location_data.name || job.location_data.formatted_address || "Sin ubicación";
   } else if (job.venue_name) {
     location = job.venue_name;
   }
@@ -63,7 +63,7 @@ export function JobCardNewDetailsOnly({
         {isJobBeingDeleted && (
           <div className="absolute inset-0 bg-black bg-opacity-20 flex items-center justify-center z-10 rounded">
             <div className="bg-white dark:bg-gray-800 px-4 py-2 rounded-md shadow-lg">
-              <span className="text-sm font-medium">Deleting job...</span>
+              <span className="text-sm font-medium">Eliminando trabajo...</span>
             </div>
           </div>
         )}
@@ -74,7 +74,7 @@ export function JobCardNewDetailsOnly({
           </h3>
 
           {visibleArtistNames.length > 0 && (
-            <div className="flex flex-wrap gap-1.5" aria-label="Artists scheduled for this date">
+            <div className="flex flex-wrap gap-1.5" aria-label="Artistas programados para esta fecha">
               {visibleArtistNames.map((artistName) => (
                 <Badge
                   key={artistName}
@@ -101,19 +101,19 @@ export function JobCardNewDetailsOnly({
             <div className="flex flex-col gap-1">
               {startDate && (
                 <div>
-                  <span className="font-medium">Start:</span> {startDate}
+                  <span className="font-medium">Inicio:</span> {startDate}
                 </div>
               )}
               {endDate && (
                 <div>
-                  <span className="font-medium">End:</span> {endDate}
+                  <span className="font-medium">Fin:</span> {endDate}
                 </div>
               )}
             </div>
           </div>
 
           <div className="text-sm">
-            <span className="font-medium">Location:</span>{" "}
+            <span className="font-medium">Ubicación:</span>{" "}
             <span className="text-muted-foreground">{location}</span>
           </div>
 
@@ -126,7 +126,7 @@ export function JobCardNewDetailsOnly({
               setJobDetailsDialogOpen(true);
             }}
           >
-            View Details
+            Ver detalles
           </Button>
         </div>
       </Card>

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -14,6 +14,7 @@ export const useJobs = () => {
     { table: 'job_assignments', queryKey: queryKeys.scope('jobs'), priority: 'medium' },
     { table: 'job_departments', queryKey: queryKeys.scope('jobs'), priority: 'medium' },
     { table: 'job_date_types', queryKey: queryKeys.scope('jobs'), priority: 'medium' },
+    { table: 'festival_artists', queryKey: queryKeys.scope('jobs'), priority: 'medium' },
     // Documents and tour dates change less frequently; keep lower priority
     { table: 'job_documents', queryKey: queryKeys.scope('jobs'), priority: 'low' },
     { table: 'tour_dates', queryKey: queryKeys.scope('jobs'), priority: 'low' },
@@ -55,6 +56,14 @@ export const useJobs = () => {
               job_date_types(
                 date,
                 type
+              ),
+              festival_artists(
+                id,
+                name,
+                date,
+                show_start,
+                stage,
+                isaftermidnight
               ),
               job_documents(
                 id,

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -28,6 +28,7 @@ export const useOptimizedJobs = (
     { table: 'job_assignments', queryKey: queryKeys.scope('optimized-jobs'), priority: 'high' },
     { table: 'job_departments', queryKey: queryKeys.scope('optimized-jobs'), priority: 'medium' },
     { table: 'job_date_types', queryKey: queryKeys.scope('optimized-jobs'), priority: 'medium' },
+    { table: 'festival_artists', queryKey: queryKeys.scope('optimized-jobs'), priority: 'medium' },
     { table: 'job_documents', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'flex_folders', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'locations', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
@@ -93,6 +94,14 @@ export const useOptimizedJobs = (
           date,
           type
         ),
+        festival_artists(
+          id,
+          name,
+          date,
+          show_start,
+          stage,
+          isaftermidnight
+        ),
         tour_date:tour_dates(
           date,
           start_date,
@@ -136,6 +145,7 @@ export const useOptimizedJobs = (
     const processedJobs = jobs.map(job => ({
       ...job,
       job_documents: job.job_documents || [],
+      festival_artists: job.festival_artists || [],
       flex_folders_exist: (job.flex_folders?.length || 0) > 0,
     }));
 

--- a/src/hooks/usePrintJobTypeInitialization.ts
+++ b/src/hooks/usePrintJobTypeInitialization.ts
@@ -1,0 +1,34 @@
+import { Dispatch, SetStateAction, useEffect } from "react";
+
+type PrintJobTypes = {
+  tourdate: boolean;
+  tour: boolean;
+  single: boolean;
+  dryhire: boolean;
+  festival: boolean;
+};
+
+type PrintSettingsWithJobTypes = {
+  jobTypes: PrintJobTypes;
+};
+
+export const usePrintJobTypeInitialization = <TPrintSettings extends PrintSettingsWithJobTypes>(
+  showDialog: boolean,
+  selectedJobTypes: string[],
+  setPrintSettings: Dispatch<SetStateAction<TPrintSettings>>,
+) => {
+  useEffect(() => {
+    if (!showDialog) return;
+
+    const includeAllJobTypes = selectedJobTypes.length === 0;
+    const newJobTypes = {
+      tourdate: includeAllJobTypes || selectedJobTypes.includes("tourdate"),
+      tour: includeAllJobTypes || selectedJobTypes.includes("tour"),
+      single: includeAllJobTypes || selectedJobTypes.includes("single"),
+      dryhire: includeAllJobTypes || selectedJobTypes.includes("dryhire"),
+      festival: includeAllJobTypes || selectedJobTypes.includes("festival"),
+    };
+
+    setPrintSettings((prev) => ({ ...prev, jobTypes: newJobTypes }));
+  }, [showDialog, selectedJobTypes, setPrintSettings]);
+};

--- a/src/utils/__tests__/calendarArtists.test.ts
+++ b/src/utils/__tests__/calendarArtists.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatCalendarArtistSummary,
+  getCalendarArtistNamesForDate,
+  getCalendarJobDisplayTitle,
+} from "@/utils/calendarArtists";
+
+describe("calendar artist helpers", () => {
+  const job = {
+    title: "Fiestas Populares Torrejon",
+    festival_artists: [
+      {
+        id: "artist-1",
+        name: "Alpha",
+        date: "2026-06-19",
+        show_start: "21:00",
+        stage: 2,
+      },
+      {
+        id: "artist-2",
+        name: "Beta",
+        date: "2026-06-18",
+        show_start: "20:00",
+        stage: 1,
+      },
+      {
+        id: "artist-3",
+        name: "Gamma",
+        date: "2026-06-19",
+        show_start: "23:30",
+        stage: 1,
+      },
+      {
+        id: "artist-4",
+        name: "After Midnight",
+        date: "2026-06-19",
+        show_start: "01:00",
+        stage: 1,
+        isaftermidnight: true,
+      },
+    ],
+  };
+
+  it("returns artist names for the selected calendar day only", () => {
+    expect(getCalendarArtistNamesForDate(job, new Date(2026, 5, 19))).toEqual([
+      "Alpha",
+      "Gamma",
+      "After Midnight",
+    ]);
+  });
+
+  it("adds a compact artist suffix to calendar job titles", () => {
+    expect(getCalendarJobDisplayTitle(job, new Date(2026, 5, 19))).toBe(
+      "Fiestas Populares Torrejon - Alpha, Gamma +1",
+    );
+  });
+
+  it("omits the artist suffix when no artist is configured for the date", () => {
+    expect(getCalendarJobDisplayTitle(job, new Date(2026, 5, 20))).toBe("Fiestas Populares Torrejon");
+  });
+
+  it("formats all artists when the summary fits inside the visible limit", () => {
+    expect(formatCalendarArtistSummary(["Alpha", "Beta"], 2)).toBe("Alpha, Beta");
+  });
+});

--- a/src/utils/__tests__/calendarArtists.test.ts
+++ b/src/utils/__tests__/calendarArtists.test.ts
@@ -60,6 +60,10 @@ describe("calendar artist helpers", () => {
     expect(getCalendarJobDisplayTitle(job, new Date(2026, 5, 20))).toBe("Fiestas Populares Torrejon");
   });
 
+  it("uses a Spanish fallback title when a job title is missing", () => {
+    expect(getCalendarJobDisplayTitle({ festival_artists: [] }, new Date(2026, 5, 20))).toBe("Trabajo sin título");
+  });
+
   it("formats all artists when the summary fits inside the visible limit", () => {
     expect(formatCalendarArtistSummary(["Alpha", "Beta"], 2)).toBe("Alpha, Beta");
   });

--- a/src/utils/calendarArtists.ts
+++ b/src/utils/calendarArtists.ts
@@ -1,0 +1,91 @@
+import { format } from "date-fns";
+
+export interface CalendarArtist {
+  id?: string | null;
+  name?: string | null;
+  date?: string | null;
+  show_start?: string | null;
+  stage?: number | null;
+  isaftermidnight?: boolean | null;
+}
+
+interface CalendarJobWithArtists {
+  title?: string | null;
+  job_name?: string | null;
+  festival_artists?: CalendarArtist[] | null;
+}
+
+const normalizeArtistDate = (value: string | null | undefined) => {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  return trimmed.split("T")[0].slice(0, 10);
+};
+
+const getArtistSortMinutes = (artist: CalendarArtist) => {
+  const match = artist.show_start?.match(/^(\d{1,2}):(\d{2})/);
+  if (!match) return Number.POSITIVE_INFINITY;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return hours * 60 + minutes + (artist.isaftermidnight ? 24 * 60 : 0);
+};
+
+export const getCalendarArtistsForDate = (job: CalendarJobWithArtists, date: Date): CalendarArtist[] => {
+  const targetDate = format(date, "yyyy-MM-dd");
+  const artists = Array.isArray(job.festival_artists) ? job.festival_artists : [];
+
+  return artists
+    .filter((artist) => normalizeArtistDate(artist.date) === targetDate && Boolean(artist.name?.trim()))
+    .slice()
+    .sort((a, b) => {
+      const timeDiff = getArtistSortMinutes(a) - getArtistSortMinutes(b);
+      if (timeDiff !== 0) return timeDiff;
+
+      const stageDiff = (a.stage ?? Number.MAX_SAFE_INTEGER) - (b.stage ?? Number.MAX_SAFE_INTEGER);
+      if (stageDiff !== 0) return stageDiff;
+
+      return (a.name || "").localeCompare(b.name || "");
+    });
+};
+
+export const getCalendarArtistNamesForDate = (job: CalendarJobWithArtists, date: Date): string[] => {
+  const seen = new Set<string>();
+
+  return getCalendarArtistsForDate(job, date).reduce<string[]>((names, artist) => {
+    const name = artist.name?.trim();
+    if (!name) return names;
+
+    const key = name.toLocaleLowerCase();
+    if (seen.has(key)) return names;
+
+    seen.add(key);
+    names.push(name);
+    return names;
+  }, []);
+};
+
+export const formatCalendarArtistSummary = (artistNames: string[], maxVisible = 2) => {
+  if (artistNames.length === 0) return "";
+  if (artistNames.length <= maxVisible) return artistNames.join(", ");
+
+  return `${artistNames.slice(0, maxVisible).join(", ")} +${artistNames.length - maxVisible}`;
+};
+
+export const getCalendarJobDisplayTitle = (
+  job: CalendarJobWithArtists,
+  date: Date,
+  maxVisibleArtists = 2,
+) => {
+  const title = (job.title || job.job_name || "Untitled Job").trim();
+  const artistSummary = formatCalendarArtistSummary(
+    getCalendarArtistNamesForDate(job, date),
+    maxVisibleArtists,
+  );
+
+  return artistSummary ? `${title} - ${artistSummary}` : title;
+};

--- a/src/utils/calendarArtists.ts
+++ b/src/utils/calendarArtists.ts
@@ -81,7 +81,7 @@ export const getCalendarJobDisplayTitle = (
   date: Date,
   maxVisibleArtists = 2,
 ) => {
-  const title = (job.title || job.job_name || "Untitled Job").trim();
+  const title = (job.title || job.job_name || "Trabajo sin título").trim();
   const artistSummary = formatCalendarArtistSummary(
     getCalendarArtistNamesForDate(job, date),
     maxVisibleArtists,


### PR DESCRIPTION
## Summary

- Loads festival artist rows with dashboard and department job queries so calendar views can render day-specific artist names.
- Shows configured artists in calendar pills, hover tooltips, mobile/department calendar job titles, and today's scheduled cards as compact badges.
- Includes artist names in calendar PDF/XLS print/export output and fixes empty job-type filters so unfiltered prints include all job types.

## Validation

- `npm install --legacy-peer-deps`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run test:run -- src/utils/__tests__/calendarArtists.test.ts`
- `npm run test:run`
- `npm run build` (passes with existing chunk-size warnings)

No database migration required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Job cards now display artists scheduled for specific dates as interactive badges
  * Job titles now include relevant artist information contextually on the calendar

* **Improvements**
  * Enhanced job card layouts to show comprehensive scheduling details across mobile and desktop views
  * Updated print and export functionality to include artist scheduling information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->