### PR TITLE
[codex] Add recurso preventivo job role

### DIFF
--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -68,6 +68,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
           timesheets(technician_id, date, is_active, is_schedule_only),
           job_date_types(date, type),
           tour_date:tour_dates(date, start_date, end_date, tour_date_type),
+          preventive_resource:profiles!jobs_preventive_resource_technician_id_fkey(id, first_name, last_name, department, role, profile_picture_url),
           job_documents(id, file_name, file_path, uploaded_at, file_size, visible_to_tech, read_only, template_type),
           logistics_events(id, event_type, transport_type, event_date, event_time, license_plate)
         `
@@ -294,7 +295,12 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
               )}
 
               {!isDryhire && (
-                <JobDetailsPersonnelTab jobDetails={jobDetails} isJobLoading={isJobLoading} department={department} />
+                <JobDetailsPersonnelTab
+                  jobDetails={jobDetails}
+                  isJobLoading={isJobLoading}
+                  department={department}
+                  canManagePreventiveResource={canSeeAutoStaffing}
+                />
               )}
 
               {!isDryhire && canSeeAutoStaffing && (

--- a/src/components/jobs/job-details-dialog/PreventiveResourceSelector.tsx
+++ b/src/components/jobs/job-details-dialog/PreventiveResourceSelector.tsx
@@ -1,0 +1,102 @@
+import React, { useMemo } from 'react';
+import { ShieldCheck } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useSetPreventiveResource } from '@/hooks/usePreventiveResource';
+import {
+  getPreventiveResourceOptions,
+  getTechnicianDisplayName,
+  PREVENTIVE_RESOURCE_EXTRA_EUR,
+} from '@/utils/preventiveResource';
+
+const UNASSIGNED_VALUE = '__unassigned__';
+
+interface PreventiveResourceSelectorProps {
+  jobId: string;
+  assignments: any[];
+  selectedTechnicianId?: string | null;
+  selectedProfile?: {
+    first_name?: string | null;
+    last_name?: string | null;
+    department?: string | null;
+  } | null;
+  canManage: boolean;
+}
+
+export const PreventiveResourceSelector: React.FC<PreventiveResourceSelectorProps> = ({
+  jobId,
+  assignments,
+  selectedTechnicianId,
+  selectedProfile,
+  canManage,
+}) => {
+  const options = useMemo(() => getPreventiveResourceOptions(assignments), [assignments]);
+  const mutation = useSetPreventiveResource(jobId);
+  const selectedOption = options.find((option) => option.id === selectedTechnicianId);
+  const selectedName = selectedOption?.name || getTechnicianDisplayName(selectedProfile);
+  const selectedDepartment = selectedOption?.department || selectedProfile?.department || null;
+  const hasSelectedTechnician = Boolean(selectedTechnicianId);
+  const selectOptions = selectedOption || !selectedTechnicianId
+    ? options
+    : [
+        {
+          id: selectedTechnicianId,
+          name: selectedName,
+          department: selectedDepartment,
+          role: null,
+        },
+        ...options,
+      ];
+
+  const handleChange = (value: string) => {
+    mutation.mutate(value === UNASSIGNED_VALUE ? null : value);
+  };
+
+  return (
+    <Card className="p-3 border-dashed bg-amber-500/5 border-amber-500/30">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-amber-600" />
+            <span className="font-medium">Recurso preventivo</span>
+            <Badge variant="outline" className="border-amber-500/40 text-amber-700 dark:text-amber-200">
+              +{PREVENTIVE_RESOURCE_EXTRA_EUR}€ por trabajo
+            </Badge>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {hasSelectedTechnician
+              ? `${selectedName}${selectedDepartment ? ` · ${selectedDepartment}` : ''}`
+              : 'Sin recurso preventivo asignado'}
+          </p>
+        </div>
+
+        {canManage && (
+          <Select
+            value={selectedTechnicianId || UNASSIGNED_VALUE}
+            onValueChange={handleChange}
+            disabled={mutation.isPending || (options.length === 0 && !hasSelectedTechnician)}
+          >
+            <SelectTrigger className="w-full md:w-[300px] bg-background">
+              <SelectValue placeholder="Seleccionar técnico" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={UNASSIGNED_VALUE}>Sin recurso preventivo</SelectItem>
+              {selectOptions.map((option) => (
+                <SelectItem key={option.id} value={option.id}>
+                  {option.name}{option.department ? ` · ${option.department}` : ''}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+      {canManage && options.length === 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Solo se puede designar a técnicos confirmados en este trabajo.
+        </p>
+      )}
+    </Card>
+  );
+};

--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsPersonnelTab.tsx
@@ -7,7 +7,9 @@ import { TabsContent } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { PreventiveResourceSelector } from "@/components/jobs/job-details-dialog/PreventiveResourceSelector";
 import { labelForCode } from "@/utils/roles";
+import { isPreventiveResourceForJob } from "@/utils/preventiveResource";
 import { getScheduledWorkDateKeys, resolveAssignmentWorkDateKeys } from "@/utils/assignmentWorkDates";
 
 const MADRID_TIME_ZONE = "Europe/Madrid";
@@ -16,9 +18,15 @@ interface JobDetailsPersonnelTabProps {
   jobDetails: any;
   isJobLoading: boolean;
   department?: string;
+  canManagePreventiveResource?: boolean;
 }
 
-export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ jobDetails, isJobLoading, department }) => {
+export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({
+  jobDetails,
+  isJobLoading,
+  department,
+  canManagePreventiveResource = false,
+}) => {
   const normalizedDepartment = department?.toLowerCase?.() ?? null;
 
   const filteredAssignments = useMemo(() => {
@@ -83,6 +91,16 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
 
   return (
     <TabsContent value="personnel" className="space-y-4 min-w-0 overflow-x-hidden">
+      {jobDetails?.id && (
+        <PreventiveResourceSelector
+          jobId={jobDetails.id}
+          assignments={jobDetails.job_assignments ?? []}
+          selectedTechnicianId={jobDetails.preventive_resource_technician_id}
+          selectedProfile={jobDetails.preventive_resource}
+          canManage={canManagePreventiveResource}
+        />
+      )}
+
       <Card className="p-4 w-full min-w-0 overflow-hidden">
         <h3 className="font-semibold mb-4 flex items-center gap-2">
           <Users className="h-4 w-4" />
@@ -146,6 +164,11 @@ export const JobDetailsPersonnelTab: React.FC<JobDetailsPersonnelTabProps> = ({ 
                   {assignment.video_role && (
                     <Badge variant="outline" className="text-xs">
                       Vídeo: {labelForCode(assignment.video_role)}
+                    </Badge>
+                  )}
+                  {isPreventiveResourceForJob(jobDetails, assignment.technician_id) && (
+                    <Badge variant="outline" className="text-xs border-amber-500/40 text-amber-700 dark:text-amber-200">
+                      Recurso preventivo
                     </Badge>
                   )}
                   {workDateKeys.length > 0 && (

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -13,7 +13,7 @@ import { cn, formatCurrency } from '@/lib/utils';
 import { getAutonomoBadgeLabel } from '@/utils/autonomo';
 import { JobPayoutOverrideSection, type JobPayoutOverride } from '@/components/jobs/JobPayoutOverrideSection';
 import type { TechnicianDateRateMode } from '@/hooks/useTechnicianRateModeDates';
-import type { JobPayoutTotals } from '@/types/jobExtras';
+import { labelForJobExtraType, type JobPayoutTotals } from '@/types/jobExtras';
 import type { TourJobRateQuote } from '@/types/tourRates';
 import type { TechnicianProfileWithEmail } from '@/lib/job-payout-email';
 import { surface, controlButton, NON_AUTONOMO_DEDUCTION_EUR } from './types';
@@ -397,7 +397,7 @@ export function TechnicianPayoutCard({
                 {payout.extras_breakdown.items.map((item, idx) => (
                   <div key={idx} className="flex justify-between text-xs text-muted-foreground">
                     <span>
-                      {item.extra_type.replace(/_/g, ' ')} x {item.quantity}
+                      {labelForJobExtraType(item.extra_type)} x {item.quantity}
                     </span>
                     <span>{formatCurrency(item.amount_eur)}</span>
                   </div>

--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -6,7 +6,7 @@ import { format } from "date-fns";
 import { formatInJobTimezone } from "@/utils/timezoneUtils";
 import { formatInTimeZone } from "date-fns-tz";
 import { es } from "date-fns/locale";
-import { RefreshCw, Clock, Eye, Download, FileText, ChevronDown, ChevronRight, Info, Dice5, Receipt } from "lucide-react";
+import { RefreshCw, Clock, Eye, Download, FileText, ChevronDown, ChevronRight, Info, Dice5, Receipt, ShieldCheck } from "lucide-react";
 import { TechnicianIncidentReportDialog } from "@/components/incident-reports/TechnicianIncidentReportDialog";
 import { JobDetailsDialog } from "@/components/jobs/JobDetailsDialog";
 import { useExpensePermissions, isPermissionActive } from "@/hooks/useExpensePermissions";
@@ -20,6 +20,7 @@ import { createSignedUrl } from '@/utils/jobDocuments';
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { OBLIQUE_STRATEGIES } from "./obliqueStrategies";
 import { getCategoryFromAssignment } from '@/utils/roleCategory';
+import { isPreventiveResourceForJob } from '@/utils/preventiveResource';
 
 type Assignment = any;
 
@@ -87,6 +88,7 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
 
   const jobData = assignment.jobs || assignment.festival_jobs;
   if (!jobData) return null;
+  const isPreventiveResource = isPreventiveResourceForJob(jobData, assignment.technician_id);
 
   const jobTimezone = jobData.timezone || 'Europe/Madrid';
   let formattedDate = "Fecha desconocida";
@@ -168,6 +170,12 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
             <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
               {role}
             </span>
+            {isPreventiveResource && (
+              <Badge variant="outline" className="ml-2 border-amber-500/40 text-amber-700 dark:text-amber-200">
+                <ShieldCheck className="mr-1 h-3 w-3" />
+                Recurso preventivo
+              </Badge>
+            )}
           </div>
         </div>
 

--- a/src/components/technician/TechJobCard.tsx
+++ b/src/components/technician/TechJobCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { formatInTimeZone } from 'date-fns-tz';
-import { MapPin, Clock, User, FileText, Lightbulb, Receipt, Users, Radio } from 'lucide-react';
+import { MapPin, Clock, User, FileText, Lightbulb, Receipt, Users, Radio, ShieldCheck } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { labelForCode } from '@/utils/roles';
 import { TechnicianIncidentReportDialog } from '@/components/incident-reports/TechnicianIncidentReportDialog';
@@ -11,6 +11,7 @@ import { useJobExpenses } from '@/hooks/useJobExpenses';
 import { ExpenseForm, ExpenseList, ExpenseSummaryCard } from '@/components/expenses';
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { JobCardProps } from './types';
+import { isPreventiveResourceForJob } from '@/utils/preventiveResource';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -48,6 +49,7 @@ export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techNam
     else if (job.role) roleLabel = job.role;
 
     const location = jobData?.location?.name || 'Sin ubicación';
+    const isPreventiveResource = isPreventiveResourceForJob(jobData, job.technician_id);
 
     // Status color
     const statusColors: Record<string, string> = {
@@ -125,6 +127,11 @@ export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techNam
                 <div className={`flex items-center gap-1.5 px-2 py-1 rounded ${isDark ? 'bg-white/5 border border-white/5' : 'bg-slate-100 border border-slate-200'}`}>
                     <User size={12} /> {roleLabel}
                 </div>
+                {isPreventiveResource && (
+                    <div className={`flex items-center gap-1.5 px-2 py-1 rounded font-semibold ${isDark ? 'bg-amber-500/10 border border-amber-500/20 text-amber-300' : 'bg-amber-50 border border-amber-200 text-amber-800'}`}>
+                        <ShieldCheck size={12} /> Recurso preventivo
+                    </div>
+                )}
             </div>
 
             {/* Action Grid */}

--- a/src/components/technician/types.ts
+++ b/src/components/technician/types.ts
@@ -27,6 +27,7 @@ export interface TechnicianJobData {
   status?: string;
   created_at?: string;
   artist_count?: number;
+  preventive_resource_technician_id?: string | null;
   location?: { name: string } | null;
   job_documents?: Array<{
     id: string;

--- a/src/components/tours/TourRatesPanel.tsx
+++ b/src/components/tours/TourRatesPanel.tsx
@@ -20,6 +20,7 @@ import { sendTourJobEmails } from "@/lib/tour-payout-email";
 import { getAutonomoBadgeLabel } from "@/utils/autonomo";
 import { isJobPastClosureWindow } from "@/utils/jobClosureUtils";
 import type { TechnicianProfile } from "@/utils/rates-pdf-export";
+import { labelForJobExtraType } from "@/types/jobExtras";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -503,7 +504,7 @@ export const TourRatesPanel: React.FC<TourRatesPanelProps> = ({
                           {quote.extras.items.map((item, idx) => (
                             <div key={idx} className="flex justify-between text-sm text-green-700">
                               <span>
-                                {item.extra_type.replace('_', ' ')} × {item.quantity}
+                                {labelForJobExtraType(item.extra_type)} × {item.quantity}
                                 {item.is_house_tech_rate && (
                                   <span className="ml-1 text-xs text-blue-600">(plantilla)</span>
                                 )}

--- a/src/hooks/usePreventiveResource.ts
+++ b/src/hooks/usePreventiveResource.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
+import { queryKeys } from '@/lib/react-query';
+import { setJobPreventiveResource } from '@/services/preventiveResourceService';
+
+export function useSetPreventiveResource(jobId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (technicianId: string | null) => setJobPreventiveResource(jobId, technicianId),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-details', jobId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-extras', jobId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-tech-payout', jobId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-job-rate-quotes') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('technician-tour-rate-quotes') });
+      queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.approvals });
+
+      if (!result.technician_id) {
+        toast.success('Recurso preventivo eliminado');
+        return;
+      }
+
+      if (result.email_sent) {
+        toast.success('Recurso preventivo asignado y email enviado');
+        return;
+      }
+
+      toast.warning('Recurso preventivo asignado, pero el email no se pudo enviar');
+    },
+    onError: (error) => {
+      console.error('Failed to update preventive resource', error);
+      toast.error(error instanceof Error ? error.message : 'No se pudo actualizar el recurso preventivo');
+    },
+  });
+}

--- a/src/hooks/useRateExtrasCatalog.ts
+++ b/src/hooks/useRateExtrasCatalog.ts
@@ -2,9 +2,10 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
+import type { JobExtraType } from '@/types/jobExtras';
 
 export interface RateExtraRow {
-  extra_type: 'travel_half' | 'travel_full' | 'day_off';
+  extra_type: JobExtraType;
   amount_eur: number;
 }
 
@@ -45,4 +46,3 @@ export function useSaveRateExtra() {
     }
   });
 }
-

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4510,6 +4510,9 @@ export type Database = {
             | null
           job_type: Database["public"]["Enums"]["job_type"]
           location_id: string | null
+          preventive_resource_assigned_at: string | null
+          preventive_resource_assigned_by: string | null
+          preventive_resource_technician_id: string | null
           rates_approved: boolean
           rates_approved_at: string | null
           rates_approved_by: string | null
@@ -4534,6 +4537,9 @@ export type Database = {
             | null
           job_type?: Database["public"]["Enums"]["job_type"]
           location_id?: string | null
+          preventive_resource_assigned_at?: string | null
+          preventive_resource_assigned_by?: string | null
+          preventive_resource_technician_id?: string | null
           rates_approved?: boolean
           rates_approved_at?: string | null
           rates_approved_by?: string | null
@@ -4558,6 +4564,9 @@ export type Database = {
             | null
           job_type?: Database["public"]["Enums"]["job_type"]
           location_id?: string | null
+          preventive_resource_assigned_at?: string | null
+          preventive_resource_assigned_by?: string | null
+          preventive_resource_technician_id?: string | null
           rates_approved?: boolean
           rates_approved_at?: string | null
           rates_approved_by?: string | null
@@ -4575,6 +4584,34 @@ export type Database = {
             columns: ["location_id"]
             isOneToOne: false
             referencedRelation: "locations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobs_preventive_resource_assigned_by_fkey"
+            columns: ["preventive_resource_assigned_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobs_preventive_resource_assigned_by_fkey"
+            columns: ["preventive_resource_assigned_by"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobs_preventive_resource_technician_id_fkey"
+            columns: ["preventive_resource_technician_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobs_preventive_resource_technician_id_fkey"
+            columns: ["preventive_resource_technician_id"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
             referencedColumns: ["id"]
           },
           {

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -44,6 +44,7 @@ interface TechnicianJobData {
   status?: string;
   created_at?: string;
   artist_count?: number;
+  preventive_resource_technician_id?: string | null;
   location?: { name: string } | null;
   job_documents?: Array<{
     id: string;
@@ -193,6 +194,7 @@ const TechnicianDashboard = () => {
             job_type,
             color,
             status,
+            preventive_resource_technician_id,
             location:locations(name),
             job_documents(
               id,

--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -212,6 +212,7 @@ export default function TechnicianSuperApp() {
             job_type,
             color,
             status,
+            preventive_resource_technician_id,
             location:locations(name),
             job_documents(
               id,

--- a/src/services/preventiveResourceService.ts
+++ b/src/services/preventiveResourceService.ts
@@ -1,0 +1,35 @@
+import { dataLayerClient } from '@/services/dataLayerClient';
+
+export interface SetPreventiveResourceResult {
+  success: boolean;
+  job_id: string;
+  technician_id: string | null;
+  previous_technician_id: string | null;
+  email_sent: boolean;
+  email_error?: string;
+}
+
+export async function setJobPreventiveResource(
+  jobId: string,
+  technicianId: string | null,
+): Promise<SetPreventiveResourceResult> {
+  const { data, error } = await dataLayerClient.functions.invoke<SetPreventiveResourceResult>(
+    'set-job-preventive-resource',
+    {
+      body: {
+        jobId,
+        technicianId,
+      },
+    },
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data?.success) {
+    throw new Error('No se pudo actualizar el recurso preventivo');
+  }
+
+  return data;
+}

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -51,6 +51,9 @@ export interface Job {
   job_type: JobType;
   flex_folders_created?: boolean;
   invoicing_company?: InvoicingCompany | null;
+  preventive_resource_technician_id?: string | null;
+  preventive_resource_assigned_at?: string | null;
+  preventive_resource_assigned_by?: string | null;
 }
 
 export interface JobWithLocationAndDocs extends Job {

--- a/src/types/jobExtras.ts
+++ b/src/types/jobExtras.ts
@@ -1,4 +1,7 @@
+import { PREVENTIVE_RESOURCE_EXTRA_TYPE } from '@/utils/preventiveResource';
+
 export type JobExtraType = 'travel_half' | 'travel_full' | 'day_off' | 'conduccion';
+export type JobExtraBreakdownType = JobExtraType | typeof PREVENTIVE_RESOURCE_EXTRA_TYPE;
 
 export interface JobExtra {
   job_id: string;
@@ -12,7 +15,7 @@ export interface JobExtra {
 }
 
 export interface JobExtraItem {
-  extra_type: JobExtraType;
+  extra_type: JobExtraBreakdownType;
   quantity: number;
   unit_eur: number;
   amount_eur: number;
@@ -65,6 +68,19 @@ export const EXTRA_TYPE_LABELS: Record<JobExtraType, string> = {
   day_off: 'Day Off',
   conduccion: 'Conducción'
 };
+
+export const JOB_EXTRA_BREAKDOWN_LABELS: Record<JobExtraBreakdownType, string> = {
+  ...EXTRA_TYPE_LABELS,
+  [PREVENTIVE_RESOURCE_EXTRA_TYPE]: 'Recurso preventivo',
+};
+
+export function labelForJobExtraType(extraType: string): string {
+  if (extraType === PREVENTIVE_RESOURCE_EXTRA_TYPE) {
+    return JOB_EXTRA_BREAKDOWN_LABELS[PREVENTIVE_RESOURCE_EXTRA_TYPE];
+  }
+
+  return extraType.replace(/_/g, ' ');
+}
 
 export const EXTRA_TYPE_LIMITS: Record<JobExtraType, number> = {
   travel_half: 2,

--- a/src/utils/__tests__/preventiveResource.test.ts
+++ b/src/utils/__tests__/preventiveResource.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getPreventiveResourceOptions,
+  isPreventiveResourceForJob,
+} from '@/utils/preventiveResource';
+
+describe('preventiveResource', () => {
+  it('keeps only confirmed assigned technicians across departments', () => {
+    const options = getPreventiveResourceOptions([
+      {
+        technician_id: 'sound-tech',
+        status: 'confirmed',
+        profiles: { first_name: 'Ana', last_name: 'Sonido', department: 'sound', role: 'technician' },
+      },
+      {
+        technician_id: 'lights-tech',
+        status: 'confirmed',
+        profiles: { first_name: 'Luis', last_name: 'Luces', department: 'lights', role: 'house_tech' },
+      },
+      {
+        technician_id: 'pending-tech',
+        status: 'invited',
+        profiles: { first_name: 'Pendiente', last_name: 'Uno', department: 'video', role: 'technician' },
+      },
+      {
+        technician_id: 'sound-tech',
+        status: 'confirmed',
+        profiles: { first_name: 'Ana', last_name: 'Sonido', department: 'sound', role: 'technician' },
+      },
+    ]);
+
+    expect(options).toEqual([
+      { id: 'sound-tech', name: 'Ana Sonido', department: 'sound', role: 'technician' },
+      { id: 'lights-tech', name: 'Luis Luces', department: 'lights', role: 'house_tech' },
+    ]);
+  });
+
+  it('detects when a technician is the job preventive resource', () => {
+    expect(isPreventiveResourceForJob({ preventive_resource_technician_id: 'tech-1' }, 'tech-1')).toBe(true);
+    expect(isPreventiveResourceForJob({ preventive_resource_technician_id: 'tech-1' }, 'tech-2')).toBe(false);
+    expect(isPreventiveResourceForJob({ preventive_resource_technician_id: null }, 'tech-1')).toBe(false);
+  });
+});

--- a/src/utils/preventiveResource.ts
+++ b/src/utils/preventiveResource.ts
@@ -1,0 +1,53 @@
+export const PREVENTIVE_RESOURCE_EXTRA_EUR = 10;
+export const PREVENTIVE_RESOURCE_EXTRA_TYPE = 'recurso_preventivo';
+
+interface JobLike {
+  preventive_resource_technician_id?: string | null;
+}
+
+interface AssignmentLike {
+  technician_id?: string | null;
+  status?: string | null;
+  profiles?: {
+    first_name?: string | null;
+    last_name?: string | null;
+    department?: string | null;
+    role?: string | null;
+  } | null;
+}
+
+export interface PreventiveResourceOption {
+  id: string;
+  name: string;
+  department: string | null;
+  role: string | null;
+}
+
+export function isPreventiveResourceForJob(job: JobLike | null | undefined, technicianId?: string | null): boolean {
+  return Boolean(job?.preventive_resource_technician_id && technicianId && job.preventive_resource_technician_id === technicianId);
+}
+
+export function getTechnicianDisplayName(profile?: AssignmentLike['profiles']): string {
+  const name = [profile?.first_name, profile?.last_name].filter(Boolean).join(' ').trim();
+  return name || 'Técnico sin nombre';
+}
+
+export function getPreventiveResourceOptions(assignments: AssignmentLike[] = []): PreventiveResourceOption[] {
+  const optionsById = new Map<string, PreventiveResourceOption>();
+
+  assignments.forEach((assignment) => {
+    const technicianId = assignment.technician_id;
+    if (!technicianId || assignment.status !== 'confirmed' || optionsById.has(technicianId)) {
+      return;
+    }
+
+    optionsById.set(technicianId, {
+      id: technicianId,
+      name: getTechnicianDisplayName(assignment.profiles),
+      department: assignment.profiles?.department ?? null,
+      role: assignment.profiles?.role ?? null,
+    });
+  });
+
+  return Array.from(optionsById.values()).sort((left, right) => left.name.localeCompare(right.name, 'es'));
+}

--- a/src/utils/rates-pdf-export.ts
+++ b/src/utils/rates-pdf-export.ts
@@ -11,6 +11,7 @@ import { fetchJobLogo, fetchTourLogo, getCompanyLogo } from '@/utils/pdf/logoUti
 import { appendAutonomoLabel } from '@/utils/autonomo';
 import { loadPdfLibs } from '@/utils/pdf/lazyPdf';
 import { getInvoicingCompanyDetails } from '@/utils/invoicing-company-data';
+import { labelForJobExtraType } from '@/types/jobExtras';
 import type jsPDF from 'jspdf';
 
 const NON_AUTONOMO_DEDUCTION_EUR = 30;
@@ -1221,7 +1222,7 @@ export async function generateJobPayoutPDF(
 
       payout.extras_breakdown!.items!.forEach((item: any) => {
         const houseTechLabel = item.is_house_tech_rate ? ' (plantilla)' : '';
-        const itemText = `• ${item.extra_type.replace('_', ' ')}${houseTechLabel} × ${item.quantity} = ${formatCurrency(item.amount_eur)}`;
+        const itemText = `• ${labelForJobExtraType(item.extra_type)}${houseTechLabel} × ${item.quantity} = ${formatCurrency(item.amount_eur)}`;
         doc.text(itemText, 18, currentY);
         currentY += 5;
 

--- a/supabase/functions/set-job-preventive-resource/index.ts
+++ b/supabase/functions/set-job-preventive-resource/index.ts
@@ -1,0 +1,299 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import { escapeHtml, wrapInCorporateTemplate } from "../_shared/corporateEmailTemplate.ts";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const BREVO_KEY = Deno.env.get("BREVO_API_KEY") ?? "";
+const FROM_EMAIL = Deno.env.get("CREW_EMAIL_FROM") || "crew@sector-pro.com";
+const FROM_NAME = Deno.env.get("CREW_EMAIL_FROM_NAME") || "Crew | Sector Pro";
+const ALLOWED_ROLES = new Set(["admin", "management", "logistics"]);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface RequestBody {
+  jobId?: unknown;
+  technicianId?: unknown;
+}
+
+interface JobRow {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+  timezone: string | null;
+  job_type: string;
+  preventive_resource_technician_id: string | null;
+}
+
+interface TechnicianProfile {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  department: string | null;
+}
+
+function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_RE.test(value);
+}
+
+function normalizeNullableUuid(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return null;
+  if (isUuid(value)) return value;
+  return undefined;
+}
+
+function fullName(profile: Pick<TechnicianProfile, "first_name" | "last_name" | "email">): string {
+  return [profile.first_name, profile.last_name].filter(Boolean).join(" ").trim() || profile.email || "Técnico";
+}
+
+function safeDateRange(job: JobRow): string {
+  const timezone = job.timezone || "Europe/Madrid";
+  const start = new Date(job.start_time);
+  const end = new Date(job.end_time);
+
+  if (Number.isNaN(start.getTime())) {
+    return "fecha pendiente";
+  }
+
+  try {
+    const dateText = new Intl.DateTimeFormat("es-ES", {
+      timeZone: timezone,
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }).format(start);
+    const timeFormat = new Intl.DateTimeFormat("es-ES", {
+      timeZone: timezone,
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    const startTime = timeFormat.format(start);
+    const endTime = Number.isNaN(end.getTime()) ? null : timeFormat.format(end);
+    return endTime ? `${dateText} · ${startTime}-${endTime}` : `${dateText} · ${startTime}`;
+  } catch {
+    return start.toISOString();
+  }
+}
+
+async function sendPreventiveResourceEmail(params: {
+  technician: TechnicianProfile;
+  job: JobRow;
+}): Promise<{ sent: boolean; error?: string }> {
+  const email = params.technician.email?.trim();
+  if (!email) {
+    return { sent: false, error: "missing_email" };
+  }
+  if (!BREVO_KEY) {
+    return { sent: false, error: "missing_brevo_api_key" };
+  }
+
+  const technicianName = fullName(params.technician);
+  const escapedJobTitle = escapeHtml(params.job.title);
+  const escapedDateRange = escapeHtml(safeDateRange(params.job));
+  const subject = `Recurso preventivo · ${params.job.title}`;
+
+  const bodyHtml = `
+    <p style="margin:0 0 12px 0;color:#374151;line-height:1.55;">
+      Has sido designado como <b>recurso preventivo</b> para el trabajo <b>${escapedJobTitle}</b>.
+    </p>
+    <div style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:8px;padding:12px 14px;color:#374151;font-size:14px;line-height:1.55;margin-bottom:12px;">
+      <b>Trabajo:</b> ${escapedJobTitle}<br/>
+      <b>Fecha y hora:</b> ${escapedDateRange}<br/>
+      <b>Compensación:</b> extra de 10€ en el payout de este trabajo.
+    </div>
+    <p style="margin:0 0 8px 0;color:#374151;line-height:1.55;">
+      Como recurso preventivo, tus responsabilidades asociadas son:
+    </p>
+    <ul style="margin:0 0 12px 18px;padding:0;color:#374151;line-height:1.55;">
+      <li>Vigilar que se respeten las medidas preventivas durante la actividad.</li>
+      <li>Coordinar la comunicación de cualquier riesgo con el responsable del trabajo y producción.</li>
+      <li>Parar o escalar cualquier tarea si detectas una situación insegura.</li>
+      <li>Comunicar incidentes, desviaciones o necesidades preventivas antes de continuar.</li>
+    </ul>
+    <p style="margin:0;color:#374151;line-height:1.55;">
+      Si no puedes asumir esta función, contacta con coordinación antes del inicio del trabajo.
+    </p>
+  `;
+
+  const htmlContent = wrapInCorporateTemplate({
+    subject,
+    greeting: technicianName,
+    bodyHtml,
+  });
+
+  const response = await fetch("https://api.brevo.com/v3/smtp/email", {
+    method: "POST",
+    headers: {
+      "api-key": BREVO_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sender: { email: FROM_EMAIL, name: FROM_NAME },
+      to: [{ email, name: technicianName }],
+      subject,
+      htmlContent,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => response.statusText);
+    return { sent: false, error: errorText || response.statusText };
+  }
+
+  return { sent: true };
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return jsonResponse({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE);
+    const token = authHeader.replace("Bearer ", "").trim();
+    const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(token);
+
+    if (userError || !userData.user?.id) {
+      return jsonResponse({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data: callerProfile, error: callerError } = await supabaseAdmin
+      .from("profiles")
+      .select("role")
+      .eq("id", userData.user.id)
+      .maybeSingle();
+
+    if (callerError) {
+      console.error("[set-job-preventive-resource] caller lookup failed", callerError);
+      return jsonResponse({ error: "Failed to verify permissions" }, { status: 500 });
+    }
+
+    if (!callerProfile?.role || !ALLOWED_ROLES.has(callerProfile.role)) {
+      return jsonResponse({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const body = (await req.json()) as RequestBody;
+    if (!isUuid(body.jobId)) {
+      return jsonResponse({ error: "Invalid jobId" }, { status: 400 });
+    }
+
+    const technicianId = normalizeNullableUuid(body.technicianId);
+    if (technicianId === undefined) {
+      return jsonResponse({ error: "Invalid technicianId" }, { status: 400 });
+    }
+
+    const { data: job, error: jobError } = await supabaseAdmin
+      .from("jobs")
+      .select("id, title, start_time, end_time, timezone, job_type, preventive_resource_technician_id")
+      .eq("id", body.jobId)
+      .maybeSingle<JobRow>();
+
+    if (jobError) {
+      console.error("[set-job-preventive-resource] job lookup failed", jobError);
+      return jsonResponse({ error: "Failed to load job" }, { status: 500 });
+    }
+    if (!job) {
+      return jsonResponse({ error: "Job not found" }, { status: 404 });
+    }
+    if (job.job_type === "dryhire" && technicianId) {
+      return jsonResponse({ error: "Dry hires cannot have a recurso preventivo" }, { status: 400 });
+    }
+
+    const previousTechnicianId = job.preventive_resource_technician_id;
+    if (previousTechnicianId === technicianId) {
+      return jsonResponse({
+        success: true,
+        job_id: job.id,
+        technician_id: technicianId,
+        previous_technician_id: previousTechnicianId,
+        email_sent: false,
+      });
+    }
+
+    let technician: TechnicianProfile | null = null;
+    if (technicianId) {
+      const [{ data: assignment, error: assignmentError }, { data: profile, error: profileError }] = await Promise.all([
+        supabaseAdmin
+          .from("job_assignments")
+          .select("technician_id, status")
+          .eq("job_id", job.id)
+          .eq("technician_id", technicianId)
+          .eq("status", "confirmed")
+          .maybeSingle(),
+        supabaseAdmin
+          .from("profiles")
+          .select("id, first_name, last_name, email, department")
+          .eq("id", technicianId)
+          .maybeSingle<TechnicianProfile>(),
+      ]);
+
+      if (assignmentError) {
+        console.error("[set-job-preventive-resource] assignment lookup failed", assignmentError);
+        return jsonResponse({ error: "Failed to verify assignment" }, { status: 500 });
+      }
+      if (!assignment) {
+        return jsonResponse({ error: "Technician must be confirmed on this job" }, { status: 400 });
+      }
+      if (profileError) {
+        console.error("[set-job-preventive-resource] technician lookup failed", profileError);
+        return jsonResponse({ error: "Failed to load technician" }, { status: 500 });
+      }
+      if (!profile) {
+        return jsonResponse({ error: "Technician not found" }, { status: 404 });
+      }
+      if (!profile.email?.trim()) {
+        return jsonResponse({ error: "Selected technician has no email" }, { status: 400 });
+      }
+      technician = profile;
+    }
+
+    const now = new Date().toISOString();
+    const { error: updateError } = await supabaseAdmin
+      .from("jobs")
+      .update({
+        preventive_resource_technician_id: technicianId,
+        preventive_resource_assigned_at: technicianId ? now : null,
+        preventive_resource_assigned_by: technicianId ? userData.user.id : null,
+      })
+      .eq("id", job.id);
+
+    if (updateError) {
+      console.error("[set-job-preventive-resource] update failed", updateError);
+      return jsonResponse({ error: "Failed to update job" }, { status: 500 });
+    }
+
+    let emailResult: { sent: boolean; error?: string } = { sent: false };
+    if (technician) {
+      emailResult = await sendPreventiveResourceEmail({ technician, job });
+      if (!emailResult.sent) {
+        console.error("[set-job-preventive-resource] email failed", emailResult.error);
+      }
+    }
+
+    return jsonResponse({
+      success: true,
+      job_id: job.id,
+      technician_id: technicianId,
+      previous_technician_id: previousTechnicianId,
+      email_sent: emailResult.sent,
+      email_error: emailResult.error,
+    });
+  } catch (error) {
+    console.error("[set-job-preventive-resource] unexpected error", error);
+    return jsonResponse({ error: error instanceof Error ? error.message : "Unexpected error" }, { status: 500 });
+  }
+});

--- a/supabase/migrations/20260529120000_add_job_preventive_resource.sql
+++ b/supabase/migrations/20260529120000_add_job_preventive_resource.sql
@@ -1,0 +1,215 @@
+-- Add a nullable per-job "recurso preventivo" designation.
+-- The payout impact is additive through extras_total_for_job_tech so existing payout views keep working.
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS preventive_resource_technician_id uuid,
+  ADD COLUMN IF NOT EXISTS preventive_resource_assigned_at timestamptz,
+  ADD COLUMN IF NOT EXISTS preventive_resource_assigned_by uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'jobs_preventive_resource_technician_id_fkey'
+  ) THEN
+    ALTER TABLE public.jobs
+      ADD CONSTRAINT jobs_preventive_resource_technician_id_fkey
+      FOREIGN KEY (preventive_resource_technician_id)
+      REFERENCES public.profiles(id)
+      ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'jobs_preventive_resource_assigned_by_fkey'
+  ) THEN
+    ALTER TABLE public.jobs
+      ADD CONSTRAINT jobs_preventive_resource_assigned_by_fkey
+      FOREIGN KEY (preventive_resource_assigned_by)
+      REFERENCES public.profiles(id)
+      ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'jobs_preventive_resource_not_dryhire'
+  ) THEN
+    ALTER TABLE public.jobs
+      ADD CONSTRAINT jobs_preventive_resource_not_dryhire
+      CHECK (
+        preventive_resource_technician_id IS NULL
+        OR job_type <> 'dryhire'::public.job_type
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_jobs_preventive_resource_technician_id
+  ON public.jobs(preventive_resource_technician_id)
+  WHERE preventive_resource_technician_id IS NOT NULL;
+
+COMMENT ON COLUMN public.jobs.preventive_resource_technician_id IS
+  'Confirmed assigned technician designated as recurso preventivo for this job. Nullable and not allowed for dry hires.';
+COMMENT ON COLUMN public.jobs.preventive_resource_assigned_at IS
+  'Timestamp when the recurso preventivo designation was last set.';
+COMMENT ON COLUMN public.jobs.preventive_resource_assigned_by IS
+  'Profile ID of the user who last set the recurso preventivo designation.';
+
+CREATE OR REPLACE FUNCTION public.clear_job_preventive_resource_when_assignment_inactive()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    UPDATE public.jobs
+    SET
+      preventive_resource_technician_id = NULL,
+      preventive_resource_assigned_at = NULL,
+      preventive_resource_assigned_by = NULL
+    WHERE id = OLD.job_id
+      AND preventive_resource_technician_id = OLD.technician_id;
+
+    RETURN OLD;
+  END IF;
+
+  IF NEW.status IS DISTINCT FROM 'confirmed'::public.assignment_status
+    OR NEW.job_id IS DISTINCT FROM OLD.job_id
+    OR NEW.technician_id IS DISTINCT FROM OLD.technician_id
+  THEN
+    UPDATE public.jobs
+    SET
+      preventive_resource_technician_id = NULL,
+      preventive_resource_assigned_at = NULL,
+      preventive_resource_assigned_by = NULL
+    WHERE id = OLD.job_id
+      AND preventive_resource_technician_id = OLD.technician_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_clear_job_preventive_resource_assignment_inactive ON public.job_assignments;
+CREATE TRIGGER trg_clear_job_preventive_resource_assignment_inactive
+  AFTER DELETE OR UPDATE OF status, job_id, technician_id
+  ON public.job_assignments
+  FOR EACH ROW
+  EXECUTE FUNCTION public.clear_job_preventive_resource_when_assignment_inactive();
+
+CREATE OR REPLACE FUNCTION public.extras_total_for_job_tech(_job_id uuid, _technician_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_result jsonb;
+  v_qualifies_for_fixed_travel_rate boolean := false;
+  v_fixed_travel_rate numeric := 20.00;
+  v_custom_travel_half numeric := NULL;
+  v_custom_travel_full numeric := NULL;
+  v_preventive_resource_extra numeric := 10.00;
+BEGIN
+  -- Check if technician qualifies for fixed travel rate:
+  -- 1. House techs (role = 'house_tech')
+  -- 2. Management users assignable as techs (role IN ('admin', 'management') AND assignable_as_tech = true)
+  SELECT (
+    role = 'house_tech' OR
+    (role IN ('admin', 'management') AND COALESCE(assignable_as_tech, false) = true)
+  ) INTO v_qualifies_for_fixed_travel_rate
+  FROM public.profiles
+  WHERE id = _technician_id;
+
+  -- Fetch per-technician custom travel rates (highest priority)
+  SELECT travel_half_day_eur, travel_full_day_eur
+  INTO v_custom_travel_half, v_custom_travel_full
+  FROM public.custom_tech_rates
+  WHERE profile_id = _technician_id;
+
+  -- Calculate extras from job_rate_extras joined with rate_extras_2025 for unit prices.
+  -- Resolve the travel rate once per row so the priority logic stays centralized.
+  WITH resolved_extras AS (
+    SELECT
+      jre.extra_type::text AS extra_type,
+      jre.quantity,
+      jre.amount_override_eur,
+      jre.updated_at,
+      CASE
+        WHEN jre.extra_type = 'travel_half' AND v_custom_travel_half IS NOT NULL
+        THEN v_custom_travel_half
+        WHEN jre.extra_type = 'travel_full' AND v_custom_travel_full IS NOT NULL
+        THEN v_custom_travel_full
+        WHEN v_qualifies_for_fixed_travel_rate AND jre.extra_type IN ('travel_half', 'travel_full')
+        THEN v_fixed_travel_rate
+        ELSE re.amount_eur
+      END AS unit_eur,
+      jre.amount_override_eur IS NULL
+        AND v_qualifies_for_fixed_travel_rate
+        AND jre.extra_type IN ('travel_half', 'travel_full')
+        AND ((jre.extra_type = 'travel_half' AND v_custom_travel_half IS NULL)
+          OR (jre.extra_type = 'travel_full' AND v_custom_travel_full IS NULL)) AS is_house_tech_rate,
+      jre.amount_override_eur IS NULL
+        AND ((jre.extra_type = 'travel_half' AND v_custom_travel_half IS NOT NULL)
+          OR (jre.extra_type = 'travel_full' AND v_custom_travel_full IS NOT NULL)) AS is_custom_travel_rate,
+      false AS is_preventive_resource,
+      10 AS sort_order
+    FROM job_rate_extras jre
+    LEFT JOIN rate_extras_2025 re ON re.extra_type = jre.extra_type
+    WHERE jre.job_id = _job_id
+      AND jre.technician_id = _technician_id
+      AND jre.status = 'approved'
+  ),
+  preventive_extra AS (
+    SELECT
+      'recurso_preventivo'::text AS extra_type,
+      1 AS quantity,
+      NULL::numeric AS amount_override_eur,
+      jobs.preventive_resource_assigned_at AS updated_at,
+      v_preventive_resource_extra AS unit_eur,
+      false AS is_house_tech_rate,
+      false AS is_custom_travel_rate,
+      true AS is_preventive_resource,
+      20 AS sort_order
+    FROM public.jobs
+    WHERE jobs.id = _job_id
+      AND jobs.preventive_resource_technician_id = _technician_id
+      AND jobs.job_type <> 'dryhire'::public.job_type
+  ),
+  all_extras AS (
+    SELECT * FROM resolved_extras
+    UNION ALL
+    SELECT * FROM preventive_extra
+  )
+  SELECT jsonb_build_object(
+    'total_eur', COALESCE(SUM(
+      COALESCE(
+        all_extras.amount_override_eur,
+        all_extras.quantity * all_extras.unit_eur
+      )
+    ), 0),
+    'items', COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'extra_type', all_extras.extra_type,
+        'quantity', all_extras.quantity,
+        'unit_eur', all_extras.unit_eur,
+        'amount_eur', COALESCE(
+          all_extras.amount_override_eur,
+          all_extras.quantity * all_extras.unit_eur
+        ),
+        'is_house_tech_rate', all_extras.is_house_tech_rate,
+        'is_custom_travel_rate', all_extras.is_custom_travel_rate,
+        'is_preventive_resource', all_extras.is_preventive_resource
+      )
+      ORDER BY all_extras.sort_order, all_extras.updated_at NULLS LAST
+    ), '[]'::jsonb)
+  )
+  INTO v_result
+  FROM all_extras;
+
+  RETURN COALESCE(v_result, '{"total_eur": 0, "items": []}'::jsonb);
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.extras_total_for_job_tech(uuid, uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.extras_total_for_job_tech(uuid, uuid) TO authenticated, service_role;
+COMMENT ON FUNCTION public.extras_total_for_job_tech(uuid, uuid) IS
+  'Calculates total rate extras for a specific job and technician. Priority: per-technician custom travel rates > house tech/assignable management fixed €20 rate > catalog rates. Adds the fixed recurso preventivo extra when designated.';


### PR DESCRIPTION
## What changed

- Adds a nullable per-job `recurso preventivo` technician designation for non-dry-hire jobs.
- Adds a management selector in the job personnel tab using confirmed job assignments across departments.
- Shows a `Recurso preventivo` badge in management personnel lists and technician job cards.
- Adds an additive 10 EUR payout item through the existing job extras payout function, preserving the existing payment views and quote flows.
- Adds a Supabase Edge Function that validates permissions and assignment status, updates the job, and sends the Spanish corporate-template email from the configured crew sender.

## Impact

Designated technicians are notified by email and see the badge on their job card. Their payout gains a synthetic `Recurso preventivo` extra for that job without changing existing rate-extra records.

## Validation

- `npm install --legacy-peer-deps`
- `npm run typecheck`
- `npm run lint:app`
- `npm run lint:functions`
- `npm run test:run -- src/utils/__tests__/preventiveResource.test.ts`
- `npm run test:run -- src/components/jobs/__tests__/JobPayoutTotalsPanel.tourdate.test.tsx src/utils/__tests__/preventiveResource.test.ts`
- `npm run test:run`
- `npm run build`

## Notes

- No `package-lock.json` changes were made.
- The migration is additive except for replacing `extras_total_for_job_tech` to add the synthetic payout item via the existing payout hook.
- Existing unrelated local flex-folder changes were left out of this branch commit.