### PR TITLE
Allow restarting C.A.R.L.O.S. staffing campaigns

### DIFF
--- a/src/components/matrix/StaffingAutoModePanel.tsx
+++ b/src/components/matrix/StaffingAutoModePanel.tsx
@@ -84,7 +84,11 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
       return payload
     },
     onSuccess: () => {
-      toast({ title: `${CARLOS_AGENT_NAME} reanudado` })
+      toast({
+        title: campaign.status === 'stopped'
+          ? `${CARLOS_AGENT_NAME} reiniciado`
+          : `${CARLOS_AGENT_NAME} reanudado`,
+      })
       invalidateAll()
     },
     onError: (error: any) => {
@@ -200,6 +204,9 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
   }
 
   const progress = calculateProgress()
+  const canResumeCampaign = campaign.status === 'paused' || campaign.status === 'stopped'
+  const canStopCampaign = campaign.status === 'active' || campaign.status === 'paused'
+  const resumeActionLabel = campaign.status === 'stopped' ? 'Restart' : 'Resume'
 
   return (
     <div className="space-y-4">
@@ -371,7 +378,7 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
               </>
             )}
 
-            {campaign.status === 'paused' && (
+            {canResumeCampaign && (
               <Button
                 size="sm"
                 onClick={() => {
@@ -381,22 +388,24 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
                 className="gap-2"
               >
                 <Play size={16} />
-                Resume
+                {resumeActionLabel}
               </Button>
             )}
 
-            <Button
-              size="sm"
-              variant="destructive"
-              onClick={() => {
-                stopMutation.mutate()
-              }}
-              disabled={stopMutation.isPending}
-              className="gap-2 ml-auto"
-            >
-              <Square size={16} />
-              Stop
-            </Button>
+            {canStopCampaign && (
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => {
+                  stopMutation.mutate()
+                }}
+                disabled={stopMutation.isPending}
+                className="gap-2 ml-auto"
+              >
+                <Square size={16} />
+                Stop
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/matrix/StaffingAutoModePanel.tsx
+++ b/src/components/matrix/StaffingAutoModePanel.tsx
@@ -206,7 +206,7 @@ export const StaffingAutoModePanel: React.FC<StaffingAutoModePanelProps> = ({
   const progress = calculateProgress()
   const canResumeCampaign = campaign.status === 'paused' || campaign.status === 'stopped'
   const canStopCampaign = campaign.status === 'active' || campaign.status === 'paused'
-  const resumeActionLabel = campaign.status === 'stopped' ? 'Restart' : 'Resume'
+  const resumeActionLabel = campaign.status === 'stopped' ? 'Reiniciar' : 'Reanudar'
 
   return (
     <div className="space-y-4">

--- a/src/components/matrix/StaffingCampaignPanel.tsx
+++ b/src/components/matrix/StaffingCampaignPanel.tsx
@@ -515,11 +515,12 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
           body: JSON.stringify({ campaign_id: campaign?.id })
         }
       )
-      if (!response.ok) throw new Error('Failed to resume campaign')
-      return response.json()
+      const payload = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(payload?.error || 'Failed to resume campaign')
+      return payload
     },
     onSuccess: () => {
-      toast({ title: 'Campaign resumed' })
+      toast({ title: campaign?.status === 'stopped' ? 'Campaign restarted' : 'Campaign resumed' })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_campaign', jobId, department) })
     }
   })
@@ -1280,6 +1281,14 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
                 Stop
               </Button>
             </>
+          ) : campaign.status === 'stopped' ? (
+            <Button
+              size="sm"
+              onClick={() => resumeMutation.mutate()}
+              disabled={resumeMutation.isPending}
+            >
+              Restart
+            </Button>
           ) : null}
         </div>
       </CardContent>

--- a/src/components/matrix/StaffingCampaignPanel.tsx
+++ b/src/components/matrix/StaffingCampaignPanel.tsx
@@ -520,7 +520,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
       return payload
     },
     onSuccess: () => {
-      toast({ title: campaign?.status === 'stopped' ? 'Campaign restarted' : 'Campaign resumed' })
+      toast({ title: campaign?.status === 'stopped' ? 'Campaña reiniciada' : 'Campaña reanudada' })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_campaign', jobId, department) })
     }
   })
@@ -1287,7 +1287,7 @@ export const StaffingCampaignPanel: React.FC<StaffingCampaignPanelProps> = ({
               onClick={() => resumeMutation.mutate()}
               disabled={resumeMutation.isPending}
             >
-              Restart
+              Reiniciar
             </Button>
           ) : null}
         </div>

--- a/src/components/matrix/StaffingOrchestratorPanel.tsx
+++ b/src/components/matrix/StaffingOrchestratorPanel.tsx
@@ -149,7 +149,7 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
                       : campaign.status === 'completed'
                         ? 'Campaign completed - all roles filled!'
                         : campaign.status === 'stopped'
-                          ? 'Campaign has been stopped.'
+                          ? 'Campaign has been stopped. Restart it from the Settings tab.'
                           : 'Campaign encountered an error.'}
                 </p>
               </div>

--- a/src/components/matrix/StaffingOrchestratorPanel.tsx
+++ b/src/components/matrix/StaffingOrchestratorPanel.tsx
@@ -149,7 +149,7 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
                       : campaign.status === 'completed'
                         ? 'Campaign completed - all roles filled!'
                         : campaign.status === 'stopped'
-                          ? 'Campaign has been stopped. Restart it from the Settings tab.'
+                          ? 'La campaña se ha detenido. Reiníciala desde la pestaña Configuración.'
                           : 'Campaign encountered an error.'}
                 </p>
               </div>

--- a/supabase/functions/staffing-orchestrator/index.ts
+++ b/supabase/functions/staffing-orchestrator/index.ts
@@ -620,7 +620,7 @@ async function pauseCampaign(
   }
 }
 
-// RESUME action: Resume paused campaign
+// RESUME action: Resume paused or stopped campaign
 async function resumeCampaign(
   supabase: ReturnType<typeof createClient>,
   user: any,
@@ -648,8 +648,8 @@ async function resumeCampaign(
       return { status: 403, body: { error: 'Not authorized' } };
     }
 
-    if (campaign.status !== 'paused') {
-      return { status: 400, body: { error: 'Campaign must be paused to resume' } };
+    if (!['paused', 'stopped'].includes(campaign.status)) {
+      return { status: 400, body: { error: 'Campaign must be paused or stopped to resume' } };
     }
 
     const { data: updated } = await supabase


### PR DESCRIPTION
### Motivation
- Teams need the ability to reactivate campaigns that were previously `stopped` in addition to `paused` so C.A.R.L.O.S. can be restarted without recreating the campaign.
- The UI should clearly distinguish restarting a stopped campaign from resuming a paused one and avoid showing destructive actions when inappropriate.

### Description
- Update the orchestrator `resume` action to accept campaigns in `paused` or `stopped` states and set them to `active` with `next_run_at` scheduled immediately in `supabase/functions/staffing-orchestrator/index.ts`.
- Surface API error payloads when resume requests fail by parsing the function response and throwing `payload?.error` when present in `src/components/matrix/StaffingCampaignPanel.tsx`.
- Add a `Restart` label for stopped campaigns and show `Resume` for paused ones while hiding the `Stop` button when a campaign is already stopped in `src/components/matrix/StaffingAutoModePanel.tsx` and `src/components/matrix/StaffingCampaignPanel.tsx`.
- Update assisted-mode wording to instruct users to restart stopped campaigns from Settings and adjust C.A.R.L.O.S. toast copy to indicate when a campaign was "restarted" vs "resumed" in `src/components/matrix/StaffingOrchestratorPanel.tsx` and `src/components/matrix/StaffingAutoModePanel.tsx`.

### Testing
- `npm run typecheck` was executed and failed due to existing unrelated TypeScript errors in other parts of the codebase (unrelated files), so typecheck did not pass for the repo as a whole.
- `npx eslint src/components/matrix/StaffingAutoModePanel.tsx src/components/matrix/StaffingCampaignPanel.tsx src/components/matrix/StaffingOrchestratorPanel.tsx supabase/functions/staffing-orchestrator/index.ts` was run and completed successfully while reporting existing `no-explicit-any` warnings only.
- `git diff --check` (local pre-commit checks) ran and reported no whitespace/merge-marker problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b12563250832f880b1adb5be2c912)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restart stopped campaigns from Settings; active controls show a single Restart action for stopped campaigns.

* **Bug Fixes**
  * Improved resume action error handling to surface server-provided error messages when available.

* **Improvements**
  * Resume button label and visibility now reflect campaign state (“Restart” vs “Resume”); Overview guidance updated to direct users to Settings for restarting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jvhtec/area-tecnica/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->