### PR TITLE
Add Hoja de Ruta section PDF export

### DIFF
--- a/src/components/hoja-de-ruta/HojaDeRutaPrintDialog.tsx
+++ b/src/components/hoja-de-ruta/HojaDeRutaPrintDialog.tsx
@@ -6,15 +6,26 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Table, Printer } from "lucide-react";
+import { Loader2, Table, Printer } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { HojaDeRutaPdfSectionId } from "@/utils/hoja-de-ruta/pdf";
+
+export interface HojaDeRutaPrintSection {
+  id: HojaDeRutaPdfSectionId;
+  label: string;
+  icon: LucideIcon;
+}
 
 interface HojaDeRutaPrintDialogProps {
   showDialog: boolean;
   setShowDialog: (open: boolean) => void;
   onGeneratePDF: () => void;
   onGenerateDriverCertificatePDF: () => void;
+  onGenerateSectionPDF: (sectionId: HojaDeRutaPdfSectionId) => void;
   onGenerateXLS: () => void;
+  sections: HojaDeRutaPrintSection[];
   isGenerating?: boolean;
+  generatingSectionId?: HojaDeRutaPdfSectionId | null;
 }
 
 export const HojaDeRutaPrintDialog: React.FC<HojaDeRutaPrintDialogProps> = ({
@@ -22,12 +33,15 @@ export const HojaDeRutaPrintDialog: React.FC<HojaDeRutaPrintDialogProps> = ({
   setShowDialog,
   onGeneratePDF,
   onGenerateDriverCertificatePDF,
+  onGenerateSectionPDF,
   onGenerateXLS,
+  sections,
   isGenerating = false,
+  generatingSectionId = null,
 }) => {
   return (
     <Dialog open={showDialog} onOpenChange={setShowDialog}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Exportar Hoja de Ruta</DialogTitle>
         </DialogHeader>
@@ -42,6 +56,32 @@ export const HojaDeRutaPrintDialog: React.FC<HojaDeRutaPrintDialogProps> = ({
               <Printer className="h-4 w-4 mr-2" />
               Hoja de Transportes PDF
             </Button>
+          </div>
+          <div className="flex flex-col gap-2">
+            <h3 className="font-semibold text-base">Imprimir sección a PDF</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-72 overflow-y-auto pr-1">
+              {sections.map((section) => {
+                const Icon = section.icon;
+                const isSectionGenerating = generatingSectionId === section.id;
+
+                return (
+                  <Button
+                    key={section.id}
+                    onClick={() => { void onGenerateSectionPDF(section.id); }}
+                    disabled={isGenerating}
+                    variant="outline"
+                    className="justify-start"
+                  >
+                    {isSectionGenerating ? (
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    ) : (
+                      <Icon className="h-4 w-4 mr-2" />
+                    )}
+                    {section.label}
+                  </Button>
+                );
+              })}
+            </div>
           </div>
           <div className="flex flex-col gap-2">
             <h3 className="font-semibold text-base">Exportar a Excel</h3>

--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -65,6 +65,8 @@ import { ModernWeatherSection } from "./sections/ModernWeatherSection";
 import { ModernRestaurantSection } from "./sections/ModernRestaurantSection";
 import { HojaDeRutaPrintDialog } from "./HojaDeRutaPrintDialog";
 import { generateHojaDeRutaXLS } from "@/utils/hojaDeRutaExport";
+import type { HojaDeRutaPdfSectionId } from "@/utils/hoja-de-ruta/pdf";
+import type { LucideIcon } from "lucide-react";
 
 type ModernHojaDeRutaProps = {
   jobId?: string;
@@ -78,6 +80,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
   const [completionProgress, setCompletionProgress] = useState(0);
   const [isGenerating, setIsGenerating] = useState(false);
   const [showPrintDialog, setShowPrintDialog] = useState(false);
+  const [generatingSectionId, setGeneratingSectionId] = useState<HojaDeRutaPdfSectionId | null>(null);
 
   // Get image management functions first (needed for form hook)
   const {
@@ -190,6 +193,18 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     calculateProgress();
   }, [eventData, travelArrangements, accommodations]);
 
+  const buildPdfEventData = () => ({
+    ...eventData,
+    metadata: hojaDeRuta ? {
+      id: hojaDeRuta.id,
+      document_version: hojaDeRuta.document_version || 1,
+      status: hojaDeRuta.status || 'draft',
+      created_at: hojaDeRuta.created_at || new Date().toISOString(),
+      updated_at: hojaDeRuta.updated_at || new Date().toISOString(),
+      last_modified: hojaDeRuta.last_modified || new Date().toISOString(),
+    } : undefined
+  });
+
   // Enhanced PDF generation using the working functionality
   const handleGeneratePDF = async () => {
     if (!selectedJobId) {
@@ -201,6 +216,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
       return;
     }
 
+    setGeneratingSectionId(null);
     setIsGenerating(true);
     try {
       // Save data first if there are changes
@@ -209,18 +225,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
       }
 
       const { generatePDF } = await import("@/utils/hoja-de-ruta/pdf");
-      
-      const enhancedEventData = {
-        ...eventData,
-        metadata: hojaDeRuta ? {
-          id: hojaDeRuta.id,
-          document_version: hojaDeRuta.document_version || 1,
-          status: hojaDeRuta.status || 'draft',
-          created_at: hojaDeRuta.created_at || new Date().toISOString(),
-          updated_at: hojaDeRuta.updated_at || new Date().toISOString(),
-          last_modified: hojaDeRuta.last_modified || new Date().toISOString(),
-        } : undefined
-      };
+      const enhancedEventData = buildPdfEventData();
 
       const jobDetails = jobs?.find(job => job.id === selectedJobId);
       // Convert accommodations to legacy room assignments for PDF generation
@@ -257,6 +262,53 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     }
   };
 
+  const handleGenerateSectionPDF = async (sectionId: HojaDeRutaPdfSectionId) => {
+    if (!selectedJobId) {
+      toast({
+        title: "Error",
+        description: "Por favor, seleccione un trabajo antes de generar el documento.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setGeneratingSectionId(sectionId);
+    setIsGenerating(true);
+    try {
+      if (isDirty || hasSavedData) {
+        await handleSaveAll();
+      }
+
+      const { generatePDF } = await import("@/utils/hoja-de-ruta/pdf");
+      const jobDetails = jobs?.find(job => job.id === selectedJobId);
+      const legacyRoomAssignments = accommodations.flatMap(acc => acc.rooms);
+
+      await generatePDF(
+        buildPdfEventData(),
+        travelArrangements,
+        legacyRoomAssignments,
+        imagePreviews,
+        venueMapPreview,
+        selectedJobId,
+        jobDetails?.title || "",
+        jobDetails?.start_time || undefined,
+        toast,
+        accommodations,
+        { sections: [sectionId] }
+      );
+    } catch (error) {
+      console.error("Error generating section PDF:", error);
+      toast({
+        title: "❌ Error",
+        description: "Hubo un problema al generar la sección seleccionada.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsGenerating(false);
+      setGeneratingSectionId(null);
+    }
+  };
+
   const handleGenerateDriverCertificatePDF = async () => {
     if (!selectedJobId) {
       toast({
@@ -267,6 +319,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
       return;
     }
 
+    setGeneratingSectionId(null);
     setIsGenerating(true);
     try {
       if (isDirty || hasSavedData) {
@@ -308,6 +361,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
       return;
     }
 
+    setGeneratingSectionId(null);
     try {
       const jobDetails = jobs?.find(job => job.id === selectedJobId);
 
@@ -411,7 +465,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     }
   };
 
-  const tabConfig = [
+  const tabConfig: Array<{ id: HojaDeRutaPdfSectionId; label: string; icon: LucideIcon; color: string }> = [
     { id: "event", label: "Evento", icon: Calendar, color: "text-blue-600" },
     { id: "venue", label: "Venue", icon: MapPin, color: "text-green-600" },
     { id: "weather", label: "Clima", icon: CloudSun, color: "text-sky-600" },
@@ -772,8 +826,11 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
         setShowDialog={setShowPrintDialog}
         onGeneratePDF={handleGeneratePDF}
         onGenerateDriverCertificatePDF={handleGenerateDriverCertificatePDF}
+        onGenerateSectionPDF={handleGenerateSectionPDF}
         onGenerateXLS={handleGenerateXLS}
+        sections={tabConfig}
         isGenerating={isGenerating}
+        generatingSectionId={generatingSectionId}
       />
     </div>
   );

--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -65,7 +65,10 @@ import { ModernWeatherSection } from "./sections/ModernWeatherSection";
 import { ModernRestaurantSection } from "./sections/ModernRestaurantSection";
 import { HojaDeRutaPrintDialog } from "./HojaDeRutaPrintDialog";
 import { generateHojaDeRutaXLS } from "@/utils/hojaDeRutaExport";
-import type { HojaDeRutaPdfSectionId } from "@/utils/hoja-de-ruta/pdf";
+import {
+  getHojaDeRutaPdfSectionLabel,
+  type HojaDeRutaPdfSectionId,
+} from "@/utils/hoja-de-ruta/pdf";
 import type { LucideIcon } from "lucide-react";
 
 type ModernHojaDeRutaProps = {
@@ -465,18 +468,23 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     }
   };
 
-  const tabConfig: Array<{ id: HojaDeRutaPdfSectionId; label: string; icon: LucideIcon; color: string }> = [
-    { id: "event", label: "Evento", icon: Calendar, color: "text-blue-600" },
-    { id: "venue", label: "Venue", icon: MapPin, color: "text-green-600" },
-    { id: "weather", label: "Clima", icon: CloudSun, color: "text-sky-600" },
-    { id: "contacts", label: "Contactos", icon: Phone, color: "text-purple-600" },
-    { id: "staff", label: "Personal", icon: Users, color: "text-orange-600" },
-    { id: "travel", label: "Viajes", icon: Car, color: "text-cyan-600" },
-    { id: "accommodation", label: "Alojamiento", icon: Bed, color: "text-pink-600" },
-    { id: "logistics", label: "Logística", icon: Building2, color: "text-indigo-600" },
-    { id: "schedule", label: "Programa", icon: Activity, color: "text-red-600" },
-    { id: "restaurants", label: "Restaurantes", icon: UtensilsCrossed, color: "text-emerald-600" },
+  const tabPresentationConfig: Array<{ id: HojaDeRutaPdfSectionId; icon: LucideIcon; color: string }> = [
+    { id: "event", icon: Calendar, color: "text-blue-600" },
+    { id: "venue", icon: MapPin, color: "text-green-600" },
+    { id: "weather", icon: CloudSun, color: "text-sky-600" },
+    { id: "contacts", icon: Phone, color: "text-purple-600" },
+    { id: "staff", icon: Users, color: "text-orange-600" },
+    { id: "travel", icon: Car, color: "text-cyan-600" },
+    { id: "accommodation", icon: Bed, color: "text-pink-600" },
+    { id: "logistics", icon: Building2, color: "text-indigo-600" },
+    { id: "schedule", icon: Activity, color: "text-red-600" },
+    { id: "restaurants", icon: UtensilsCrossed, color: "text-emerald-600" },
   ];
+
+  const tabConfig: Array<{ id: HojaDeRutaPdfSectionId; label: string; icon: LucideIcon; color: string }> = tabPresentationConfig.map((section) => ({
+    ...section,
+    label: getHojaDeRutaPdfSectionLabel(section.id),
+  }));
 
   if (isLoadingHojaDeRuta) {
     return (

--- a/src/components/hoja-de-ruta/__tests__/HojaDeRutaPrintDialog.test.tsx
+++ b/src/components/hoja-de-ruta/__tests__/HojaDeRutaPrintDialog.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Calendar, MapPin } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  HojaDeRutaPrintDialog,
+  type HojaDeRutaPrintSection,
+} from "../HojaDeRutaPrintDialog";
+
+const sections: HojaDeRutaPrintSection[] = [
+  { id: "event", label: "Evento", icon: Calendar },
+  { id: "venue", label: "Venue", icon: MapPin },
+];
+
+describe("HojaDeRutaPrintDialog", () => {
+  it("renders section PDF actions and calls the selected section handler", async () => {
+    const user = userEvent.setup();
+    const onGenerateSectionPDF = vi.fn();
+
+    render(
+      <HojaDeRutaPrintDialog
+        showDialog
+        setShowDialog={vi.fn()}
+        onGeneratePDF={vi.fn()}
+        onGenerateDriverCertificatePDF={vi.fn()}
+        onGenerateSectionPDF={onGenerateSectionPDF}
+        onGenerateXLS={vi.fn()}
+        sections={sections}
+      />
+    );
+
+    expect(screen.getByText("Imprimir sección a PDF")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Documento Completo PDF" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Evento" }));
+
+    expect(onGenerateSectionPDF).toHaveBeenCalledTimes(1);
+    expect(onGenerateSectionPDF).toHaveBeenCalledWith("event");
+  });
+});

--- a/src/components/hoja-de-ruta/__tests__/HojaDeRutaPrintDialog.test.tsx
+++ b/src/components/hoja-de-ruta/__tests__/HojaDeRutaPrintDialog.test.tsx
@@ -8,11 +8,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   HojaDeRutaPrintDialog,
   type HojaDeRutaPrintSection,
-} from "../HojaDeRutaPrintDialog";
+} from "@/components/hoja-de-ruta/HojaDeRutaPrintDialog";
 
 const sections: HojaDeRutaPrintSection[] = [
   { id: "event", label: "Evento", icon: Calendar },
-  { id: "venue", label: "Venue", icon: MapPin },
+  { id: "venue", label: "Lugar", icon: MapPin },
 ];
 
 describe("HojaDeRutaPrintDialog", () => {

--- a/src/utils/hoja-de-ruta/pdf/__tests__/section-options.test.ts
+++ b/src/utils/hoja-de-ruta/pdf/__tests__/section-options.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getHojaDeRutaPdfSectionFilenameLabel,
+  getHojaDeRutaPdfSectionLabel,
+  getHojaDeRutaPdfSelectionLabel,
+  HOJA_DE_RUTA_PDF_SECTIONS,
+  isHojaDeRutaPdfSectionId,
+} from "../section-options";
+
+describe("hoja de ruta PDF section options", () => {
+  it("matches the quick navigation sections", () => {
+    expect(HOJA_DE_RUTA_PDF_SECTIONS.map((section) => section.id)).toEqual([
+      "event",
+      "venue",
+      "weather",
+      "contacts",
+      "staff",
+      "travel",
+      "accommodation",
+      "logistics",
+      "schedule",
+      "restaurants",
+    ]);
+  });
+
+  it("labels single and multi-section exports", () => {
+    expect(getHojaDeRutaPdfSectionLabel("logistics")).toBe("Logística");
+    expect(getHojaDeRutaPdfSectionFilenameLabel("logistics")).toBe("Logistica");
+    expect(getHojaDeRutaPdfSelectionLabel(["contacts"])).toBe("Contactos");
+    expect(getHojaDeRutaPdfSelectionLabel(["contacts", "staff"])).toBe("Secciones seleccionadas");
+    expect(getHojaDeRutaPdfSelectionLabel()).toBeUndefined();
+  });
+
+  it("guards section ids", () => {
+    expect(isHojaDeRutaPdfSectionId("event")).toBe(true);
+    expect(isHojaDeRutaPdfSectionId("not-a-section")).toBe(false);
+  });
+});

--- a/src/utils/hoja-de-ruta/pdf/__tests__/section-options.test.ts
+++ b/src/utils/hoja-de-ruta/pdf/__tests__/section-options.test.ts
@@ -6,7 +6,7 @@ import {
   getHojaDeRutaPdfSelectionLabel,
   HOJA_DE_RUTA_PDF_SECTIONS,
   isHojaDeRutaPdfSectionId,
-} from "../section-options";
+} from "@/utils/hoja-de-ruta/pdf/section-options";
 
 describe("hoja de ruta PDF section options", () => {
   it("matches the quick navigation sections", () => {
@@ -27,6 +27,8 @@ describe("hoja de ruta PDF section options", () => {
   it("labels single and multi-section exports", () => {
     expect(getHojaDeRutaPdfSectionLabel("logistics")).toBe("Logística");
     expect(getHojaDeRutaPdfSectionFilenameLabel("logistics")).toBe("Logistica");
+    expect(getHojaDeRutaPdfSectionLabel("venue")).toBe("Lugar");
+    expect(getHojaDeRutaPdfSectionFilenameLabel("venue")).toBe("Lugar");
     expect(getHojaDeRutaPdfSelectionLabel(["contacts"])).toBe("Contactos");
     expect(getHojaDeRutaPdfSelectionLabel(["contacts", "staff"])).toBe("Secciones seleccionadas");
     expect(getHojaDeRutaPdfSelectionLabel()).toBeUndefined();

--- a/src/utils/hoja-de-ruta/pdf/core/pdf-types.ts
+++ b/src/utils/hoja-de-ruta/pdf/core/pdf-types.ts
@@ -7,7 +7,7 @@ import type {
   WeatherData,
   ImagePreviews
 } from '@/types/hoja-de-ruta';
-import type { HojaDeRutaPdfSectionId } from '../section-options';
+import type { HojaDeRutaPdfSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
 
 export type {
   EventData,

--- a/src/utils/hoja-de-ruta/pdf/core/pdf-types.ts
+++ b/src/utils/hoja-de-ruta/pdf/core/pdf-types.ts
@@ -7,6 +7,7 @@ import type {
   WeatherData,
   ImagePreviews
 } from '@/types/hoja-de-ruta';
+import type { HojaDeRutaPdfSectionId } from '../section-options';
 
 export type {
   EventData,
@@ -35,6 +36,7 @@ export interface PDFGenerationOptions {
   includeTravelArrangements?: boolean;
   includeLogisticsTransport?: boolean;
   dedupeTransportAcrossSections?: boolean;
+  sections?: HojaDeRutaPdfSectionId[];
 }
 
 export interface DriverCertificatePDFGenerationOptions {

--- a/src/utils/hoja-de-ruta/pdf/index.ts
+++ b/src/utils/hoja-de-ruta/pdf/index.ts
@@ -1,8 +1,14 @@
 export { PDFEngine } from './pdf-engine';
+export {
+  getHojaDeRutaPdfSectionLabel,
+  getHojaDeRutaPdfSelectionLabel,
+  HOJA_DE_RUTA_PDF_SECTIONS
+} from './section-options';
 export type { DriverCertificatePDFGenerationOptions, PDFGenerationOptions } from './core/pdf-types';
+export type { HojaDeRutaPdfSectionId } from './section-options';
 import { PDFEngine } from './pdf-engine';
 import { DriverCertificatePDFEngine } from './driver-certificate-pdf-engine';
-import type { DriverCertificatePDFGenerationOptions } from './core/pdf-types';
+import type { DriverCertificatePDFGenerationOptions, PDFGenerationOptions } from './core/pdf-types';
 
 // Main export function for backward compatibility
 export const generatePDF = async (
@@ -16,7 +22,8 @@ export const generatePDF = async (
   // Optional parameters to enhance headers without breaking callers
   jobDate?: string,
   toast?: any,
-  accommodations?: any[]
+  accommodations?: any[],
+  pdfOptions?: Pick<PDFGenerationOptions, 'sections'>
 ): Promise<void> => {
   const engine = new PDFEngine({
     eventData,
@@ -28,7 +35,8 @@ export const generatePDF = async (
     jobTitle,
     jobDate,
     toast,
-    accommodations
+    accommodations,
+    ...pdfOptions
   });
   
   return engine.generate();

--- a/src/utils/hoja-de-ruta/pdf/index.ts
+++ b/src/utils/hoja-de-ruta/pdf/index.ts
@@ -1,14 +1,14 @@
-export { PDFEngine } from './pdf-engine';
+export { PDFEngine } from '@/utils/hoja-de-ruta/pdf/pdf-engine';
 export {
   getHojaDeRutaPdfSectionLabel,
   getHojaDeRutaPdfSelectionLabel,
   HOJA_DE_RUTA_PDF_SECTIONS
-} from './section-options';
-export type { DriverCertificatePDFGenerationOptions, PDFGenerationOptions } from './core/pdf-types';
-export type { HojaDeRutaPdfSectionId } from './section-options';
-import { PDFEngine } from './pdf-engine';
-import { DriverCertificatePDFEngine } from './driver-certificate-pdf-engine';
-import type { DriverCertificatePDFGenerationOptions, PDFGenerationOptions } from './core/pdf-types';
+} from '@/utils/hoja-de-ruta/pdf/section-options';
+export type { DriverCertificatePDFGenerationOptions, PDFGenerationOptions } from '@/utils/hoja-de-ruta/pdf/core/pdf-types';
+export type { HojaDeRutaPdfSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
+import { PDFEngine } from '@/utils/hoja-de-ruta/pdf/pdf-engine';
+import { DriverCertificatePDFEngine } from '@/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine';
+import type { DriverCertificatePDFGenerationOptions, PDFGenerationOptions } from '@/utils/hoja-de-ruta/pdf/core/pdf-types';
 
 // Main export function for backward compatibility
 export const generatePDF = async (

--- a/src/utils/hoja-de-ruta/pdf/pdf-engine.ts
+++ b/src/utils/hoja-de-ruta/pdf/pdf-engine.ts
@@ -6,13 +6,19 @@ import { HeaderSection } from './sections/header-section';
 import { CoverSection } from './sections/cover-section';
 import { ContentSections } from './sections/content-sections';
 import { FooterService } from './services/footer-service';
+import {
+  getHojaDeRutaPdfSectionFilenameLabel,
+  getHojaDeRutaPdfSelectionLabel,
+} from './section-options';
+import type { HojaDeRutaPdfSectionId } from './section-options';
 
 export class PDFEngine {
   private pdfDoc: PDFDocument;
   private headerSection: HeaderSection;
-  private coverSection: CoverSection;
   private contentSections: ContentSections;
   private logoData?: string;
+  private hasCoverPage = true;
+  private renderedSectionCount = 0;
 
   constructor(private options: PDFGenerationOptions) {
     this.pdfDoc = new PDFDocument();
@@ -22,14 +28,17 @@ export class PDFEngine {
 
   async generate(): Promise<void> {
     const {
-      eventData,
       selectedJobId,
       jobTitle,
       toast,
-      travelArrangements,
-      accommodations = [],
-      venueMapPreview
     } = this.options;
+    const selectedSections = this.options.sections?.length ? this.options.sections : undefined;
+    const sectionSelection = selectedSections ? new Set(selectedSections) : undefined;
+    const selectedSectionLabel = selectedSections
+      ? getHojaDeRutaPdfSelectionLabel(selectedSections) ?? "Secciones seleccionadas"
+      : undefined;
+    this.hasCoverPage = !sectionSelection;
+    this.renderedSectionCount = 0;
 
     try {
       // Load logo first (used on cover and in page header)
@@ -62,146 +71,38 @@ export class PDFEngine {
         this.pdfDoc,
         jobTitle,
         this.options.jobDate,
-        'Hoja de Ruta',
+        selectedSections
+          ? `Hoja de Ruta - ${selectedSectionLabel}`
+          : 'Hoja de Ruta',
         this.logoData || undefined,
         headerLogoDims
       );
       
-      // Generate cover page
-      const coverSection = new CoverSection(this.pdfDoc, this.options.eventData, this.options.jobTitle, this.logoData);
-      await coverSection.generateCoverPage();
-
-      // Each major section starts on a new page as per requirements
-      // 2. Job Details and Venue (combined on same page)
-      if (this.contentSections.hasEventDetailsData(this.options.eventData) || this.contentSections.hasVenueData(this.options.eventData)) {
-        let currentY = this.headerSection.addSectionHeader("Detalles y Venue");
-        
-        if (this.contentSections.hasEventDetailsData(this.options.eventData)) {
-          currentY = this.contentSections.addEventDetailsSection(this.options.eventData, currentY);
-        }
-        
-        if (this.contentSections.hasVenueData(this.options.eventData)) {
-          currentY = await this.contentSections.addVenueSection(
-            this.options.eventData, 
-            this.options.venueMapPreview, 
-            currentY,
-            this.options.imagePreviews?.venue
-          );
-        }
+      if (this.hasCoverPage) {
+        const coverSection = new CoverSection(this.pdfDoc, this.options.eventData, this.options.jobTitle, this.logoData);
+        await coverSection.generateCoverPage();
       }
 
-      // 3. Weather section
-      if (this.contentSections.hasWeatherData(this.options.eventData)) {
-        const currentY = this.headerSection.addSectionHeader("Clima");
-        this.contentSections.addWeatherSection(this.options.eventData, currentY);
+      if (sectionSelection) {
+        await this.generateSelectedSections(sectionSelection);
+        if (this.renderedSectionCount === 0) {
+          this.addEmptySectionPage(selectedSections);
+        }
       } else {
-        // Attempt to fetch weather on-the-fly if missing
-        try {
-          const { getWeatherForJob } = await import('@/utils/weather/weatherApi');
-          if (this.options.eventData?.venue && this.options.eventData?.eventDates) {
-            const weather = await getWeatherForJob(
-              this.options.eventData.venue,
-              this.options.eventData.eventDates
-            );
-            if (weather && weather.length > 0) {
-              (this.options.eventData as any).weather = weather;
-              const currentY = this.headerSection.addSectionHeader("Clima");
-              this.contentSections.addWeatherSection(this.options.eventData, currentY);
-            }
-          }
-        } catch (e) {
-          console.warn('Weather fetch during PDF generation failed:', e);
-        }
-      }
-
-      // 4. Contactos
-      if (this.contentSections.hasContactsData(this.options.eventData)) {
-        const currentY = this.headerSection.addSectionHeader("Contactos");
-        this.contentSections.addContactsSection(this.options.eventData, currentY);
-      }
-
-      // 5. Personal
-      if (this.contentSections.hasStaffData(this.options.eventData)) {
-        const currentY = this.headerSection.addSectionHeader("Personal");
-        this.contentSections.addStaffSection(this.options.eventData, currentY);
-      }
-
-      // Defaults for rendering options
-      const includeAccommodationRooming = this.options.includeAccommodationRooming ?? true;
-      const includeAggregatedRooming = this.options.includeAggregatedRooming ?? false;
-      const includeTravelArrangements = this.options.includeTravelArrangements ?? true;
-      const includeLogisticsTransport = this.options.includeLogisticsTransport ?? true;
-
-      // 6. Viajes
-      if (includeTravelArrangements && this.contentSections.hasTravelData(this.options.travelArrangements)) {
-        const currentY = this.headerSection.addSectionHeader("Viajes");
-        await this.contentSections.addTravelSection(
-          this.options.travelArrangements, 
-          this.options.eventData?.venue?.address,
-          currentY
-        );
-      }
-
-      // 7. Alojamientos
-      if (this.contentSections.hasAccommodationData(this.options.accommodations)) {
-        const currentY = this.headerSection.addSectionHeader("Alojamientos");
-        await this.contentSections.addAccommodationSection(
-          this.options.accommodations || [], 
-          this.options.eventData, 
-          currentY,
-          includeAccommodationRooming === false && includeAggregatedRooming === true // suppress per-hotel rooms when we show aggregated
-        );
-      }
-
-      // 8. Rooming (aggregated)
-      if (includeAggregatedRooming && this.contentSections.hasRoomingData(this.options.accommodations)) {
-        const currentY = this.headerSection.addSectionHeader("Rooming");
-        this.contentSections.addRoomingSection(
-          this.options.accommodations || [], 
-          this.options.eventData, 
-          currentY
-        );
-      }
-
-      // 9. Transportes
-      if (includeLogisticsTransport && this.contentSections.hasLogisticsData(this.options.eventData)) {
-        const currentY = this.headerSection.addSectionHeader("Transportes");
-        this.contentSections.addLogisticsSection(this.options.eventData, currentY);
-      }
-
-      // 10. Power Requirements
-      if (this.contentSections.hasPowerData(this.options.eventData)) {
-        const currentY = this.headerSection.addSectionHeader("Requerimientos eléctricos");
-        this.contentSections.addPowerSection(this.options.eventData, currentY);
-      }
-
-      // 11. Necesidades Auxiliares
-      if (this.contentSections.hasAuxNeedsData(this.options.eventData)) {
-        const currentY = this.headerSection.addSectionHeader("Necesidades auxiliares");
-        this.contentSections.addAuxNeedsSection(this.options.eventData, currentY);
-      }
-
-      // 12. Programa
-      if (this.contentSections.hasProgramData(this.options.eventData)) {
-        const currentY = this.headerSection.addSectionHeader("Programa");
-        this.contentSections.addProgramSection(this.options.eventData, currentY);
-      }
-
-      // 13. Restaurantes
-      if (this.contentSections.hasRestaurantsData(this.options.eventData)) {
-        const currentY = this.headerSection.addSectionHeader("Restaurantes");
-        await this.contentSections.addRestaurantsSection(this.options.eventData, currentY);
+        await this.generateFullDocument();
       }
 
       // Add Sector-Pro footer to all pages with page numbers and job name
-      await FooterService.addFooterToAllPages(this.pdfDoc, jobTitle);
+      await FooterService.addFooterToAllPages(this.pdfDoc, jobTitle, { hasCoverPage: this.hasCoverPage });
 
       // Save and upload PDF
       await this.saveAndUploadPDF();
-      
+
       toast?.({
         title: "✅ Documento generado",
-        description: "La hoja de ruta ha sido generada y descargada correctamente.",
+        description: selectedSectionLabel
+          ? `${selectedSectionLabel} se ha generado y descargado correctamente.`
+          : "La hoja de ruta ha sido generada y descargada correctamente.",
       });
 
     } catch (error) {
@@ -215,8 +116,225 @@ export class PDFEngine {
     }
   }
 
+  private async generateFullDocument(): Promise<void> {
+    // Each major section starts on a new page as per requirements.
+    if (this.contentSections.hasEventDetailsData(this.options.eventData) || this.contentSections.hasVenueData(this.options.eventData)) {
+      let currentY = this.addSectionHeader("Detalles y Venue");
+
+      if (this.contentSections.hasEventDetailsData(this.options.eventData)) {
+        currentY = this.contentSections.addEventDetailsSection(this.options.eventData, currentY);
+      }
+
+      if (this.contentSections.hasVenueData(this.options.eventData)) {
+        await this.contentSections.addVenueSection(
+          this.options.eventData,
+          this.options.venueMapPreview,
+          currentY,
+          this.options.imagePreviews?.venue
+        );
+      }
+    }
+
+    await this.addWeatherSectionIfAvailable();
+
+    if (this.contentSections.hasContactsData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Contactos");
+      this.contentSections.addContactsSection(this.options.eventData, currentY);
+    }
+
+    if (this.contentSections.hasStaffData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Personal");
+      this.contentSections.addStaffSection(this.options.eventData, currentY);
+    }
+
+    const includeAccommodationRooming = this.options.includeAccommodationRooming ?? true;
+    const includeAggregatedRooming = this.options.includeAggregatedRooming ?? false;
+    const includeTravelArrangements = this.options.includeTravelArrangements ?? true;
+    const includeLogisticsTransport = this.options.includeLogisticsTransport ?? true;
+
+    if (includeTravelArrangements && this.contentSections.hasTravelData(this.options.travelArrangements)) {
+      const currentY = this.addSectionHeader("Viajes");
+      await this.contentSections.addTravelSection(
+        this.options.travelArrangements,
+        this.options.eventData?.venue?.address,
+        currentY
+      );
+    }
+
+    if (this.contentSections.hasAccommodationData(this.options.accommodations)) {
+      const currentY = this.addSectionHeader("Alojamientos");
+      await this.contentSections.addAccommodationSection(
+        this.options.accommodations || [],
+        this.options.eventData,
+        currentY,
+        includeAccommodationRooming === false && includeAggregatedRooming === true
+      );
+    }
+
+    if (includeAggregatedRooming && this.contentSections.hasRoomingData(this.options.accommodations)) {
+      const currentY = this.addSectionHeader("Rooming");
+      this.contentSections.addRoomingSection(
+        this.options.accommodations || [],
+        this.options.eventData,
+        currentY
+      );
+    }
+
+    if (includeLogisticsTransport && this.contentSections.hasLogisticsData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Transportes");
+      this.contentSections.addLogisticsSection(this.options.eventData, currentY);
+    }
+
+    if (this.contentSections.hasPowerData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Requerimientos eléctricos");
+      this.contentSections.addPowerSection(this.options.eventData, currentY);
+    }
+
+    if (this.contentSections.hasAuxNeedsData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Necesidades auxiliares");
+      this.contentSections.addAuxNeedsSection(this.options.eventData, currentY);
+    }
+
+    if (this.contentSections.hasProgramData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Programa");
+      this.contentSections.addProgramSection(this.options.eventData, currentY);
+    }
+
+    if (this.contentSections.hasRestaurantsData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Restaurantes");
+      await this.contentSections.addRestaurantsSection(this.options.eventData, currentY);
+    }
+  }
+
+  private async generateSelectedSections(sectionSelection: Set<HojaDeRutaPdfSectionId>): Promise<void> {
+    if (sectionSelection.has("event")) {
+      if (this.contentSections.hasEventDetailsData(this.options.eventData)) {
+        const currentY = this.addSectionHeader("Evento");
+        this.contentSections.addEventDetailsSection(this.options.eventData, currentY);
+      }
+
+      if (this.contentSections.hasAuxNeedsData(this.options.eventData)) {
+        const currentY = this.addSectionHeader("Necesidades auxiliares");
+        this.contentSections.addAuxNeedsSection(this.options.eventData, currentY);
+      }
+    }
+
+    if (sectionSelection.has("venue") && this.hasVenueExportData()) {
+      const currentY = this.addSectionHeader("Venue");
+      await this.contentSections.addVenueSection(
+        this.options.eventData,
+        this.options.venueMapPreview,
+        currentY,
+        this.options.imagePreviews?.venue
+      );
+    }
+
+    if (sectionSelection.has("weather")) {
+      await this.addWeatherSectionIfAvailable();
+    }
+
+    if (sectionSelection.has("contacts") && this.contentSections.hasContactsData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Contactos");
+      this.contentSections.addContactsSection(this.options.eventData, currentY);
+    }
+
+    if (sectionSelection.has("staff") && this.contentSections.hasStaffData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Personal");
+      this.contentSections.addStaffSection(this.options.eventData, currentY);
+    }
+
+    if (sectionSelection.has("travel") && this.contentSections.hasTravelData(this.options.travelArrangements)) {
+      const currentY = this.addSectionHeader("Viajes");
+      await this.contentSections.addTravelSection(
+        this.options.travelArrangements,
+        this.options.eventData?.venue?.address,
+        currentY
+      );
+    }
+
+    if (sectionSelection.has("accommodation") && this.contentSections.hasAccommodationData(this.options.accommodations)) {
+      const currentY = this.addSectionHeader("Alojamiento");
+      await this.contentSections.addAccommodationSection(
+        this.options.accommodations || [],
+        this.options.eventData,
+        currentY
+      );
+    }
+
+    if (sectionSelection.has("logistics") && this.contentSections.hasLogisticsData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Logística");
+      this.contentSections.addLogisticsSection(this.options.eventData, currentY);
+    }
+
+    if (sectionSelection.has("schedule")) {
+      if (this.contentSections.hasProgramData(this.options.eventData)) {
+        const currentY = this.addSectionHeader("Programa");
+        this.contentSections.addProgramSection(this.options.eventData, currentY);
+      }
+
+      if (this.contentSections.hasPowerData(this.options.eventData)) {
+        const currentY = this.addSectionHeader("Requerimientos eléctricos");
+        this.contentSections.addPowerSection(this.options.eventData, currentY);
+      }
+    }
+
+    if (sectionSelection.has("restaurants") && this.contentSections.hasRestaurantsData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Restaurantes");
+      await this.contentSections.addRestaurantsSection(this.options.eventData, currentY);
+    }
+  }
+
+  private async addWeatherSectionIfAvailable(): Promise<void> {
+    if (this.contentSections.hasWeatherData(this.options.eventData)) {
+      const currentY = this.addSectionHeader("Clima");
+      this.contentSections.addWeatherSection(this.options.eventData, currentY);
+      return;
+    }
+
+    try {
+      const { getWeatherForJob } = await import('@/utils/weather/weatherApi');
+      if (this.options.eventData?.venue && this.options.eventData?.eventDates) {
+        const weather = await getWeatherForJob(
+          this.options.eventData.venue,
+          this.options.eventData.eventDates
+        );
+        if (weather && weather.length > 0) {
+          (this.options.eventData as any).weather = weather;
+          const currentY = this.addSectionHeader("Clima");
+          this.contentSections.addWeatherSection(this.options.eventData, currentY);
+        }
+      }
+    } catch (e) {
+      console.warn('Weather fetch during PDF generation failed:', e);
+    }
+  }
+
+  private addSectionHeader(title: string): number {
+    const currentY = this.headerSection.addSectionHeader(title, 55, {
+      startOnNewPage: this.hasCoverPage || this.renderedSectionCount > 0,
+    });
+    this.renderedSectionCount += 1;
+    return currentY;
+  }
+
+  private addEmptySectionPage(sectionIds: readonly HojaDeRutaPdfSectionId[] | undefined): void {
+    const title = getHojaDeRutaPdfSelectionLabel(sectionIds) ?? "Hoja de Ruta";
+    const currentY = this.addSectionHeader(title);
+    this.pdfDoc.setText(11, [80, 80, 80]);
+    this.pdfDoc.addText("No hay datos disponibles para esta sección.", 20, currentY);
+  }
+
+  private hasVenueExportData(): boolean {
+    return this.contentSections.hasVenueData(this.options.eventData) ||
+      Boolean(this.options.venueMapPreview) ||
+      Boolean(this.options.imagePreviews?.venue?.length);
+  }
+
   private async saveAndUploadPDF(): Promise<void> {
     const { eventData, selectedJobId, jobTitle } = this.options;
+    const sectionFilenameLabel = this.options.sections?.length === 1
+      ? getHojaDeRutaPdfSectionFilenameLabel(this.options.sections[0])
+      : undefined;
     
     // Generate filename
     const eventName = eventData.eventName || jobTitle || 'Evento';
@@ -224,7 +342,8 @@ export class PDFEngine {
     const nowIso = new Date().toISOString();
     const datePart = nowIso.slice(0, 10); // YYYY-MM-DD (UTC)
     const timePart = nowIso.slice(11, 19).replace(/:/g, '-'); // HH-MM-SS (UTC)
-    const filename = `Hoja de Ruta - ${safeEventName} - ${datePart} ${timePart}.pdf`;
+    const sectionPart = sectionFilenameLabel ? ` - ${sectionFilenameLabel}` : "";
+    const filename = `Hoja de Ruta${sectionPart} - ${safeEventName} - ${datePart} ${timePart}.pdf`;
 
     // Save locally
     this.pdfDoc.save(filename);

--- a/src/utils/hoja-de-ruta/pdf/pdf-engine.ts
+++ b/src/utils/hoja-de-ruta/pdf/pdf-engine.ts
@@ -9,8 +9,8 @@ import { FooterService } from './services/footer-service';
 import {
   getHojaDeRutaPdfSectionFilenameLabel,
   getHojaDeRutaPdfSelectionLabel,
-} from './section-options';
-import type { HojaDeRutaPdfSectionId } from './section-options';
+} from '@/utils/hoja-de-ruta/pdf/section-options';
+import type { HojaDeRutaPdfSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
 
 export class PDFEngine {
   private pdfDoc: PDFDocument;
@@ -299,9 +299,12 @@ export class PDFEngine {
           this.options.eventData.eventDates
         );
         if (weather && weather.length > 0) {
-          (this.options.eventData as any).weather = weather;
+          const eventDataWithWeather = {
+            ...this.options.eventData,
+            weather,
+          };
           const currentY = this.addSectionHeader("Clima");
-          this.contentSections.addWeatherSection(this.options.eventData, currentY);
+          this.contentSections.addWeatherSection(eventDataWithWeather, currentY);
         }
       }
     } catch (e) {

--- a/src/utils/hoja-de-ruta/pdf/section-options.ts
+++ b/src/utils/hoja-de-ruta/pdf/section-options.ts
@@ -1,0 +1,37 @@
+export const HOJA_DE_RUTA_PDF_SECTIONS = [
+  { id: "event", label: "Evento", filenameLabel: "Evento" },
+  { id: "venue", label: "Venue", filenameLabel: "Venue" },
+  { id: "weather", label: "Clima", filenameLabel: "Clima" },
+  { id: "contacts", label: "Contactos", filenameLabel: "Contactos" },
+  { id: "staff", label: "Personal", filenameLabel: "Personal" },
+  { id: "travel", label: "Viajes", filenameLabel: "Viajes" },
+  { id: "accommodation", label: "Alojamiento", filenameLabel: "Alojamiento" },
+  { id: "logistics", label: "Logística", filenameLabel: "Logistica" },
+  { id: "schedule", label: "Programa", filenameLabel: "Programa" },
+  { id: "restaurants", label: "Restaurantes", filenameLabel: "Restaurantes" },
+] as const;
+
+export type HojaDeRutaPdfSectionId = (typeof HOJA_DE_RUTA_PDF_SECTIONS)[number]["id"];
+
+const SECTION_BY_ID = new Map<HojaDeRutaPdfSectionId, (typeof HOJA_DE_RUTA_PDF_SECTIONS)[number]>(
+  HOJA_DE_RUTA_PDF_SECTIONS.map((section) => [section.id, section])
+);
+
+const SECTION_ID_SET = new Set<string>(HOJA_DE_RUTA_PDF_SECTIONS.map((section) => section.id));
+
+export const isHojaDeRutaPdfSectionId = (value: string): value is HojaDeRutaPdfSectionId =>
+  SECTION_ID_SET.has(value);
+
+export const getHojaDeRutaPdfSectionLabel = (sectionId: HojaDeRutaPdfSectionId): string =>
+  SECTION_BY_ID.get(sectionId)?.label ?? sectionId;
+
+export const getHojaDeRutaPdfSectionFilenameLabel = (sectionId: HojaDeRutaPdfSectionId): string =>
+  SECTION_BY_ID.get(sectionId)?.filenameLabel ?? sectionId;
+
+export const getHojaDeRutaPdfSelectionLabel = (
+  sectionIds?: readonly HojaDeRutaPdfSectionId[]
+): string | undefined => {
+  if (!sectionIds || sectionIds.length === 0) return undefined;
+  if (sectionIds.length === 1) return getHojaDeRutaPdfSectionLabel(sectionIds[0]);
+  return "Secciones seleccionadas";
+};

--- a/src/utils/hoja-de-ruta/pdf/section-options.ts
+++ b/src/utils/hoja-de-ruta/pdf/section-options.ts
@@ -1,6 +1,6 @@
 export const HOJA_DE_RUTA_PDF_SECTIONS = [
   { id: "event", label: "Evento", filenameLabel: "Evento" },
-  { id: "venue", label: "Venue", filenameLabel: "Venue" },
+  { id: "venue", label: "Lugar", filenameLabel: "Lugar" },
   { id: "weather", label: "Clima", filenameLabel: "Clima" },
   { id: "contacts", label: "Contactos", filenameLabel: "Contactos" },
   { id: "staff", label: "Personal", filenameLabel: "Personal" },

--- a/src/utils/hoja-de-ruta/pdf/sections/header-section.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/header-section.ts
@@ -11,9 +11,15 @@ export class HeaderSection {
     private smallLogoDims?: { width: number; height: number }
   ) {}
 
-  addSectionHeader(title: string, yPosition: number = 55): number {
-    // New page per section
-    this.pdfDoc.addPage();
+  addSectionHeader(
+    title: string,
+    yPosition: number = 55,
+    options: { startOnNewPage?: boolean } = {}
+  ): number {
+    // New page per section unless this is the first page of a section-only PDF.
+    if (options.startOnNewPage ?? true) {
+      this.pdfDoc.addPage();
+    }
 
     // Draw a consistent header at the very top (matches PesosTool styling)
     HeaderService.addHeaderToCurrentPage(

--- a/src/utils/hoja-de-ruta/pdf/services/footer-service.ts
+++ b/src/utils/hoja-de-ruta/pdf/services/footer-service.ts
@@ -8,11 +8,17 @@ export class FooterService {
   private static cachedLogoData: string | null = null;
   private static cachedLogoDims: { width: number; height: number } | null = null;
 
-  static async addFooterToAllPages(pdfDoc: PDFDocument, jobName?: string): Promise<void> {
+  static async addFooterToAllPages(
+    pdfDoc: PDFDocument,
+    jobName?: string,
+    options: { hasCoverPage?: boolean } = {}
+  ): Promise<void> {
     try {
+      const hasCoverPage = options.hasCoverPage ?? true;
       // Load Sector Pro logo from public assets
       const logoData = await this.loadSectorProLogo();
       const totalPages = pdfDoc.document.getNumberOfPages();
+      const totalContentPages = hasCoverPage ? Math.max(totalPages - 1, 0) : totalPages;
       const { width: pageWidth, height: pageHeight } = pdfDoc.dimensions;
       const bottomMargin = 12;
 
@@ -32,8 +38,8 @@ export class FooterService {
       for (let i = 1; i <= totalPages; i++) {
         pdfDoc.document.setPage(i);
 
-        // Skip cover page (page 1) for page numbers and footer
-        const isContentPage = i > 1;
+        // Skip cover page for full PDFs; section-only PDFs start content on page 1.
+        const isContentPage = hasCoverPage ? i > 1 : true;
 
         // Only add footer elements to content pages (skip cover page)
         if (isContentPage) {
@@ -57,7 +63,8 @@ export class FooterService {
         if (isContentPage) {
           pdfDoc.setText(8, [120, 120, 120]);
           // Page number on left
-          pdfDoc.addText(`Pág. ${i - 1} de ${totalPages - 1}`, 20, pageHeight - bottomMargin);
+          const pageNumber = hasCoverPage ? i - 1 : i;
+          pdfDoc.addText(`Pág. ${pageNumber} de ${totalContentPages}`, 20, pageHeight - bottomMargin);
           
           // Job name on right (if provided)
           if (jobName) {
@@ -69,7 +76,9 @@ export class FooterService {
     } catch (error) {
       console.error('Error adding footer to pages:', error);
       // Add fallback text footer
+      const hasCoverPage = options.hasCoverPage ?? true;
       const totalPages = pdfDoc.document.getNumberOfPages();
+      const totalContentPages = hasCoverPage ? Math.max(totalPages - 1, 0) : totalPages;
       const { width: pageWidth, height: pageHeight } = pdfDoc.dimensions;
       const bottomMargin = 12;
 
@@ -78,9 +87,10 @@ export class FooterService {
         pdfDoc.setText(8, [125, 1, 1]);
         pdfDoc.addText('Sector-Pro', pageWidth / 2, pageHeight - bottomMargin, { align: 'center' });
         
-        if (i > 1) {
+        if (hasCoverPage ? i > 1 : true) {
           pdfDoc.setText(8, [120, 120, 120]);
-          pdfDoc.addText(`Pág. ${i - 1} de ${totalPages - 1}`, 20, pageHeight - bottomMargin);
+          const pageNumber = hasCoverPage ? i - 1 : i;
+          pdfDoc.addText(`Pág. ${pageNumber} de ${totalContentPages}`, 20, pageHeight - bottomMargin);
         }
       }
     }


### PR DESCRIPTION
## Summary
- add per-section PDF export actions to the Hoja de Ruta print dialog
- allow the PDF engine to render isolated Hoja sections while preserving the existing full export
- add section metadata and tests for the quick-nav-aligned export options

## Validation
- npm install --legacy-peer-deps
- npm run lint
- npm run test:run
- npm run build

## Deploy notes
- No Supabase migrations included; no production database push required before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added section-level PDF export—users can now select and export individual sections of the Hoja de Ruta instead of the full document.
  * New grid-based UI displays buttons for each section with loading indicators during generation.

* **Tests**
  * Added test coverage for section export dialog and PDF generation helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->