### PR TITLE
Fix power requirement sync and department saves

### DIFF
--- a/src/components/jobs/EditJobDialog.tsx
+++ b/src/components/jobs/EditJobDialog.tsx
@@ -85,7 +85,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
   const [invoicingCompany, setInvoicingCompany] = useState<InvoicingCompany | null>(job.invoicing_company || null);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedDepartments, setSelectedDepartments] = useState<Department[]>(() => getDepartmentsFromJob(job));
-  const [departmentsLoaded, setDepartmentsLoaded] = useState(() => getDepartmentsFromJob(job).length > 0);
+  const [departmentsLoaded, setDepartmentsLoaded] = useState(false);
   const [departmentsLoadError, setDepartmentsLoadError] = useState<string | null>(null);
   const [isVenueBusy, setIsVenueBusy] = useState(false);
   const [requirementsOpen, setRequirementsOpen] = useState(false);
@@ -122,7 +122,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
         setInvoicingCompany(currentJob.invoicing_company || null);
         const jobDepartments = getDepartmentsFromJob(currentJob);
         setSelectedDepartments(jobDepartments);
-        setDepartmentsLoaded(jobDepartments.length > 0);
+        setDepartmentsLoaded(false);
         setDepartmentsLoadError(null);
 
         // Convert UTC times to local input format using job's timezone
@@ -249,12 +249,12 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
 
     try {
       if (!departmentsLoaded) {
-        throw new Error("Departments are still loading. Please wait before saving.");
+        throw new Error("Los departamentos aún se están cargando. Espera antes de guardar.");
       }
 
       const departmentsToSave = Array.from(new Set(selectedDepartments));
       if (departmentsToSave.length === 0) {
-        throw new Error("Select at least one department before saving.");
+        throw new Error("Selecciona al menos un departamento antes de guardar.");
       }
 
       // Convert local datetime-local input values to UTC using the job's timezone

--- a/src/components/jobs/EditJobDialog.tsx
+++ b/src/components/jobs/EditJobDialog.tsx
@@ -38,6 +38,24 @@ interface EditJobDialogProps {
   job: any;
 }
 
+const EDITABLE_JOB_DEPARTMENTS = new Set<string>(TECHNICAL_DEPARTMENTS);
+
+function isEditableJobDepartment(department: string | null | undefined): department is Department {
+  return Boolean(department) && EDITABLE_JOB_DEPARTMENTS.has(department);
+}
+
+function getDepartmentsFromJob(job: any): Department[] {
+  if (!Array.isArray(job?.job_departments)) return [];
+
+  return Array.from(
+    new Set(
+      job.job_departments
+        .map((row: { department?: string | null }) => row.department)
+        .filter(isEditableJobDepartment)
+    )
+  );
+}
+
 function isPrepDayEligibleJobType(jobType: JobType): boolean {
   return jobType !== "dryhire";
 }
@@ -66,7 +84,9 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
   const [timezone, setTimezone] = useState(job.timezone || "Europe/Madrid");
   const [invoicingCompany, setInvoicingCompany] = useState<InvoicingCompany | null>(job.invoicing_company || null);
   const [isLoading, setIsLoading] = useState(false);
-  const [selectedDepartments, setSelectedDepartments] = useState<Department[]>([]);
+  const [selectedDepartments, setSelectedDepartments] = useState<Department[]>(() => getDepartmentsFromJob(job));
+  const [departmentsLoaded, setDepartmentsLoaded] = useState(() => getDepartmentsFromJob(job).length > 0);
+  const [departmentsLoadError, setDepartmentsLoadError] = useState<string | null>(null);
   const [isVenueBusy, setIsVenueBusy] = useState(false);
   const [requirementsOpen, setRequirementsOpen] = useState(false);
   const [prepDayDates, setPrepDayDates] = useState<string[]>([]);
@@ -100,6 +120,10 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
         setJobType(currentJob.job_type || "single");
         setTimezone(currentJob.timezone || "Europe/Madrid");
         setInvoicingCompany(currentJob.invoicing_company || null);
+        const jobDepartments = getDepartmentsFromJob(currentJob);
+        setSelectedDepartments(jobDepartments);
+        setDepartmentsLoaded(jobDepartments.length > 0);
+        setDepartmentsLoadError(null);
 
         // Convert UTC times to local input format using job's timezone
         if (currentJob.start_time && currentJob.end_time) {
@@ -156,23 +180,38 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
 
   // Fetch current departments when dialog opens
   useEffect(() => {
+    let cancelled = false;
+
     const fetchDepartments = async () => {
+      setDepartmentsLoaded(false);
+      setDepartmentsLoadError(null);
+
       const { data, error } = await dataLayerClient.from("job_departments")
         .select("department")
         .eq("job_id", job.id);
 
+      if (cancelled) return;
+
       if (error) {
         console.error("Error fetching departments:", error);
+        setDepartmentsLoadError("No se pudieron cargar los departamentos. Vuelve a intentarlo antes de guardar.");
         return;
       }
 
-      const departments = data.map(d => d.department as Department);
+      const departments = Array.from(
+        new Set((data || []).map((d) => d.department).filter(isEditableJobDepartment))
+      );
       setSelectedDepartments(departments);
+      setDepartmentsLoaded(true);
     };
 
     if (open && job.id) {
       fetchDepartments();
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [open, job.id]);
 
   const handleDepartmentToggle = (department: Department) => {
@@ -209,6 +248,15 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
     setIsLoading(true);
 
     try {
+      if (!departmentsLoaded) {
+        throw new Error("Departments are still loading. Please wait before saving.");
+      }
+
+      const departmentsToSave = Array.from(new Set(selectedDepartments));
+      if (departmentsToSave.length === 0) {
+        throw new Error("Select at least one department before saving.");
+      }
+
       // Convert local datetime-local input values to UTC using the job's timezone
       const startTimeUTC = localInputToUTC(startTime, timezone);
       const endTimeUTC = localInputToUTC(endTime, timezone);
@@ -282,11 +330,25 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
 
       if (currentDeptsError) throw currentDeptsError;
 
-      const currentDepartments = currentDepts?.map((d) => d.department) || [];
+      const currentDepartments = Array.from(
+        new Set((currentDepts || []).map((d) => d.department).filter(isEditableJobDepartment))
+      );
 
-      // Remove deselected departments
+      // Add new departments before removing old ones. If the save is interrupted,
+      // the job remains visible in inner-join job queries.
+      const toAdd = departmentsToSave.filter((dept) => !currentDepartments.includes(dept));
+      if (toAdd.length > 0) {
+        const { error: insertDeptError } = await dataLayerClient.from("job_departments")
+          .upsert(
+            toAdd.map((department) => ({ job_id: job.id, department })),
+            { onConflict: "job_id,department", ignoreDuplicates: true }
+          );
+        if (insertDeptError) throw insertDeptError;
+      }
+
+      // Remove deselected departments after additions have been persisted.
       const toRemove = currentDepartments.filter(
-        (dept) => !selectedDepartments.includes(dept as Department)
+        (dept) => !departmentsToSave.includes(dept)
       );
       if (toRemove.length > 0) {
         const { error: deleteDeptError } = await dataLayerClient.from("job_departments")
@@ -294,14 +356,6 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
           .eq("job_id", job.id)
           .in("department", toRemove);
         if (deleteDeptError) throw deleteDeptError;
-      }
-
-      // Add new departments
-      const toAdd = selectedDepartments.filter((dept) => !currentDepartments.includes(dept));
-      if (toAdd.length > 0) {
-        const { error: insertDeptError } = await dataLayerClient.from("job_departments")
-          .insert(toAdd.map((department) => ({ job_id: job.id, department })));
-        if (insertDeptError) throw insertDeptError;
       }
 
       // Broadcast push notification about update (summarized changes)
@@ -599,6 +653,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
                     <Checkbox
                       id={`department-${department}`}
                       checked={selectedDepartments.includes(department)}
+                      disabled={!departmentsLoaded || isLoading}
                       onCheckedChange={() => handleDepartmentToggle(department)}
                     />
                     <Label htmlFor={`department-${department}`}>
@@ -607,6 +662,15 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
                   </div>
                 ))}
               </div>
+              {departmentsLoadError && (
+                <p className="text-sm text-destructive">{departmentsLoadError}</p>
+              )}
+              {!departmentsLoaded && !departmentsLoadError && (
+                <p className="text-sm text-muted-foreground">Cargando departamentos...</p>
+              )}
+              {departmentsLoaded && selectedDepartments.length === 0 && (
+                <p className="text-sm text-destructive">Selecciona al menos un departamento.</p>
+              )}
               {jobType !== 'dryhire' && (
                 <div className="pt-2">
                   <Button
@@ -629,7 +693,11 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={isLoading || isVenueBusy} className="bg-blue-600 hover:bg-blue-500 text-white">
+              <Button
+                type="submit"
+                disabled={isLoading || isVenueBusy || !departmentsLoaded || selectedDepartments.length === 0}
+                className="bg-blue-600 hover:bg-blue-500 text-white"
+              >
                 {isLoading ? "Saving..." : "Save Changes"}
               </Button>
             </div>

--- a/src/features/technical-tools/power/powerPersistence.ts
+++ b/src/features/technical-tools/power/powerPersistence.ts
@@ -1,9 +1,12 @@
 import type { Json } from "@/integrations/supabase/types";
+import type { supabase as typedSupabase } from "@/integrations/supabase/client";
 import type {
   PowerElectricalSettings,
   PowerTable,
   TechnicalDepartment,
 } from "@/features/technical-tools/power/types";
+
+type PowerPersistenceClient = Pick<typeof typedSupabase, "from">;
 
 export const getPowerReportUploadCategory = (department: TechnicalDepartment) =>
   department === "lights" ? "calculators/lights-consumos" : "calculators/consumos";
@@ -11,6 +14,7 @@ export const getPowerReportUploadCategory = (department: TechnicalDepartment) =>
 export const buildPowerTableData = (table: PowerTable, settings: PowerElectricalSettings & { powerFactor?: number }) => {
   const payload = {
     rows: table.rows,
+    ...(table.id !== undefined ? { sourceTableId: String(table.id) } : {}),
     safetyMargin: settings.safetyMargin,
     phaseMode: settings.phaseMode,
     voltage: settings.voltage,
@@ -61,6 +65,69 @@ export const buildPowerRequirementInsert = ({
   table_data: (settings ? buildPowerTableData(table, settings) : ({ rows: table.rows } as unknown as Json)),
   includes_hoist: table.includesHoist || false,
 });
+
+export const saveJobPowerRequirementTable = async ({
+  client,
+  department,
+  jobId,
+  settings,
+  table,
+}: {
+  client: PowerPersistenceClient;
+  department: TechnicalDepartment;
+  jobId: string;
+  settings?: PowerElectricalSettings & { powerFactor?: number };
+  table: PowerTable;
+}): Promise<string> => {
+  const payload = buildPowerRequirementInsert({
+    department,
+    jobId,
+    settings,
+    table,
+  });
+
+  if (table.powerRequirementId) {
+    const { data, error } = await client
+      .from("power_requirement_tables")
+      .update(payload)
+      .eq("id", table.powerRequirementId)
+      .eq("job_id", jobId)
+      .select("id")
+      .maybeSingle();
+
+    if (error) throw error;
+    if (data?.id) return data.id;
+  }
+
+  const { data, error } = await client
+    .from("power_requirement_tables")
+    .insert(payload)
+    .select("id")
+    .single();
+
+  if (error) throw error;
+  return data.id as string;
+};
+
+export const deleteJobPowerRequirementTable = async ({
+  client,
+  jobId,
+  table,
+}: {
+  client: PowerPersistenceClient;
+  jobId: string;
+  table: Pick<PowerTable, "powerRequirementId">;
+}) => {
+  if (!table.powerRequirementId) return;
+
+  const { error } = await client
+    .from("power_requirement_tables")
+    .delete()
+    .eq("id", table.powerRequirementId)
+    .eq("job_id", jobId);
+
+  if (error) throw error;
+};
 
 export const buildTourPowerDefaultTable = ({
   orderIndex,

--- a/src/features/technical-tools/power/types.ts
+++ b/src/features/technical-tools/power/types.ts
@@ -21,6 +21,7 @@ export type PowerTableRow = {
 
 export type PowerTable = {
   id?: number | string;
+  powerRequirementId?: string;
   name: string;
   rows: PowerTableRow[];
   totalWatts?: number;

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react';
 import { EventData } from '@/types/hoja-de-ruta';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { formatPowerRequirementsText } from '@/utils/powerSummaryData';
 
 export const useHojaDeRutaInitialization = (
   selectedJobId: string,
@@ -61,7 +62,8 @@ export const useHojaDeRutaInitialization = (
       const { data: powerRequirements, error } = await supabase
         .from("power_requirement_tables")
         .select("*")
-        .eq("job_id", jobId);
+        .eq("job_id", jobId)
+        .order("created_at", { ascending: true });
 
       if (error) {
         console.error("❌ INITIALIZATION: Error fetching power requirements:", error);
@@ -73,36 +75,7 @@ export const useHojaDeRutaInitialization = (
         return "";
       }
 
-      // Deduplicate requirements based on table_name and department
-      const uniqueRequirements = powerRequirements.reduce((acc: any[], current: any) => {
-        const x = acc.find(item => item.table_name === current.table_name && item.department === current.department);
-        if (!x) {
-          return acc.concat([current]);
-        } else {
-          return acc;
-        }
-      }, []);
-
-      const powerText = uniqueRequirements
-        .map((req: any) => {
-          const current = typeof req.current_per_phase === 'number' 
-            ? req.current_per_phase.toFixed(2) 
-            : req.current_per_phase;
-            
-          const pduType = req.custom_pdu_type || req.pdu_type;
-          
-          let text = `${req.department.toUpperCase()} - ${req.table_name}:\n` +
-            `Potencia Total: ${req.total_watts}W\n` +
-            `Corriente por Fase: ${current}A\n` +
-            `PDU Recomendado: ${pduType}\n`;
-
-          if (req.includes_hoist) {
-            text += `Requiere potencia adicional de motores (CEE32A 3P+N+G)\n`;
-          }
-
-          return text;
-        })
-        .join("\n");
+      const powerText = formatPowerRequirementsText(powerRequirements);
 
       console.log("✅ INITIALIZATION: Power requirements fetched successfully");
       return powerText;

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaSave.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaSave.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { EventData, TravelArrangement, Accommodation } from '@/types/hoja-de-ruta';
 import { supabase } from '@/lib/supabase';
 import { useToast } from '@/hooks/use-toast';
+import { formatPowerRequirementsText } from '@/utils/powerSummaryData';
 
 type SaveHojaDeRutaFn = (args: { eventData: EventData; userId: string }) => Promise<unknown>;
 type SaveTravelArrangementsFn = (travel: TravelArrangement[]) => Promise<unknown>;
@@ -63,28 +64,15 @@ export const useHojaDeRutaSave = (
       const { data: powerRequirements, error: powerError } = await supabase
         .from("power_requirement_tables")
         .select("*")
-        .eq("job_id", selectedJobId);
+        .eq("job_id", selectedJobId)
+        .order("created_at", { ascending: true });
 
       if (powerError) throw powerError;
 
       // Always update power requirements if available
       if (powerRequirements && powerRequirements.length > 0) {
         console.log("⚡ SAVE: Updating power requirements");
-        const powerText = powerRequirements
-          .map((req: {
-            department?: string | null;
-            table_name?: string | null;
-            total_watts?: number | string | null;
-            current_per_phase?: number | string | null;
-            pdu_type?: string | null;
-          }) => {
-            const department = (req.department || 'general').toUpperCase();
-            return `${department} - ${req.table_name || 'tabla'}:\n` +
-              `Potencia Total: ${req.total_watts ?? 'N/D'}W\n` +
-              `Corriente por Fase: ${req.current_per_phase ?? 'N/D'}A\n` +
-              `PDU Recomendado: ${req.pdu_type ?? 'N/D'}\n`;
-          })
-          .join("\n");
+        const powerText = formatPowerRequirementsText(powerRequirements);
 
         return { powerRequirements: powerText };
       }

--- a/src/pages/ConsumosTool.tsx
+++ b/src/pages/ConsumosTool.tsx
@@ -342,9 +342,13 @@ const ConsumosTool: React.FC = () => {
 
   const removeTable = async (tableId: number | string) => {
     const tableToRemove = tables.find((table) => table.id === tableId);
-    setTables((prev) => prev.filter((table) => table.id !== tableId));
+    if (!tableToRemove) {
+      toast({ title: "Error", description: "Power requirement table not found", variant: "destructive" });
+      return;
+    }
 
     if (!selectedJobId || isTourDefaults || isJobOverrideMode || !tableToRemove?.powerRequirementId) {
+      setTables((prev) => prev.filter((table) => table.id !== tableId));
       return;
     }
 
@@ -354,6 +358,7 @@ const ConsumosTool: React.FC = () => {
         jobId: selectedJobId,
         table: tableToRemove,
       });
+      setTables((prev) => prev.filter((table) => table.id !== tableId));
     } catch (error) {
       console.error('Error deleting power requirement table:', error);
       toast({ title: "Error", description: "Failed to delete power requirement table", variant: "destructive" });

--- a/src/pages/ConsumosTool.tsx
+++ b/src/pages/ConsumosTool.tsx
@@ -24,10 +24,11 @@ import {
 } from '@/features/technical-tools/power/powerCalculations';
 import {
   buildPowerOverridePayload,
-  buildPowerRequirementInsert,
   buildPowerTableData,
   buildPowerTableMetadata,
   buildTourPowerDefaultTable,
+  deleteJobPowerRequirementTable,
+  saveJobPowerRequirementTable,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
@@ -195,22 +196,28 @@ const ConsumosTool: React.FC = () => {
   const getPowerSettings = () => ({ safetyMargin, powerFactor: pf, phaseMode, voltage });
   const PDU_TYPES = getPowerPduOptions('sound', phaseMode);
 
-  const savePowerRequirementTable = async (table: Table) => {
+  const savePowerRequirementTable = async (
+    table: Table,
+    { showToast = true }: { showToast?: boolean } = {},
+  ) => {
     try {
-      const { error } = await dataLayerClient.from('power_requirement_tables')
-        .insert(buildPowerRequirementInsert({
-          department: 'sound',
-          jobId: selectedJobId,
-          settings: getPowerSettings(),
-          table,
-        }));
+      const powerRequirementId = await saveJobPowerRequirementTable({
+        client: dataLayerClient,
+        department: 'sound',
+        jobId: selectedJobId,
+        settings: getPowerSettings(),
+        table,
+      });
 
-      if (error) throw error;
+      if (showToast) {
+        toast({ title: "Success", description: "Power requirement table saved successfully" });
+      }
 
-      toast({ title: "Success", description: "Power requirement table saved successfully" });
+      return powerRequirementId;
     } catch (error: any) {
       console.error('Error saving power requirement table:', error);
       toast({ title: "Error", description: "Failed to save power requirement table", variant: "destructive" });
+      return table.powerRequirementId;
     }
   };
 
@@ -305,16 +312,20 @@ const ConsumosTool: React.FC = () => {
       },
     }) as Table;
 
-    setTables((prev) => [...prev, newTable]);
+    let tableToAdd = newTable;
 
     if (isTourDefaults) {
       // user can tweak before saving defaults
     } else if (isJobOverrideMode) {
       await saveTourOverride(newTable);
     } else if (selectedJobId) {
-      await savePowerRequirementTable(newTable);
+      const powerRequirementId = await savePowerRequirementTable(newTable);
+      if (powerRequirementId) {
+        tableToAdd = { ...newTable, powerRequirementId };
+      }
     }
 
+    setTables((prev) => [...prev, tableToAdd]);
     resetCurrentTable();
   };
 
@@ -329,8 +340,24 @@ const ConsumosTool: React.FC = () => {
     setEditingOverride(null);
   };
 
-  const removeTable = (tableId: number | string) => {
+  const removeTable = async (tableId: number | string) => {
+    const tableToRemove = tables.find((table) => table.id === tableId);
     setTables((prev) => prev.filter((table) => table.id !== tableId));
+
+    if (!selectedJobId || isTourDefaults || isJobOverrideMode || !tableToRemove?.powerRequirementId) {
+      return;
+    }
+
+    try {
+      await deleteJobPowerRequirementTable({
+        client: dataLayerClient,
+        jobId: selectedJobId,
+        table: tableToRemove,
+      });
+    } catch (error) {
+      console.error('Error deleting power requirement table:', error);
+      toast({ title: "Error", description: "Failed to delete power requirement table", variant: "destructive" });
+    }
   };
 
   // Save unsaved default tables
@@ -363,41 +390,47 @@ const ConsumosTool: React.FC = () => {
   };
 
   const updateTableSettings = async (tableId: number | string, updates: Partial<Table>) => {
+    const existingTable = tables.find((table) => table.id === tableId);
+    if (!existingTable) return;
+
+    const updatedTable = { ...existingTable, ...updates };
     setTables((prev) =>
-      prev.map((table) => {
-        if (table.id === tableId) {
-          const updatedTable = { ...table, ...updates };
-          if (isTourDefaults && table.isDefault && table.defaultTableId && updateTourDefaultTable) {
-            updateTourDefaultTable({
-              tableId: table.defaultTableId,
-              updates: {
-                table_data: buildPowerTableData(updatedTable, getPowerSettings()),
-                total_value: updatedTable.totalWatts || 0,
-                metadata: buildPowerTableMetadata(updatedTable, getPowerSettings()),
-              }
-            });
-          } else if (isJobOverrideMode && table.isOverride && table.overrideId && updatePowerOverride) {
-            updatePowerOverride({
-              id: table.overrideId,
-              data: {
-                total_watts: updatedTable.totalWatts || 0,
-                current_per_phase: updatedTable.currentPerPhase || 0,
-                pdu_type: updatedTable.customPduType || updatedTable.pduType || '',
-                custom_pdu_type: updatedTable.customPduType,
-                position: updatedTable.position || null,
-                custom_position: updatedTable.customPosition || null,
-                includes_hoist: updatedTable.includesHoist || false,
-                override_data: buildPowerTableData(updatedTable, getPowerSettings()),
-              }
-            });
-          } else if (selectedJobId) {
-            savePowerRequirementTable(updatedTable);
-          }
-          return updatedTable;
-        }
-        return table;
-      })
+      prev.map((table) => (table.id === tableId ? updatedTable : table))
     );
+
+    if (isTourDefaults && existingTable.isDefault && existingTable.defaultTableId && updateTourDefaultTable) {
+      updateTourDefaultTable({
+        tableId: existingTable.defaultTableId,
+        updates: {
+          table_data: buildPowerTableData(updatedTable, getPowerSettings()),
+          total_value: updatedTable.totalWatts || 0,
+          metadata: buildPowerTableMetadata(updatedTable, getPowerSettings()),
+        }
+      });
+    } else if (isJobOverrideMode && existingTable.isOverride && existingTable.overrideId && updatePowerOverride) {
+      updatePowerOverride({
+        id: existingTable.overrideId,
+        data: {
+          total_watts: updatedTable.totalWatts || 0,
+          current_per_phase: updatedTable.currentPerPhase || 0,
+          pdu_type: updatedTable.customPduType || updatedTable.pduType || '',
+          custom_pdu_type: updatedTable.customPduType,
+          position: updatedTable.position || null,
+          custom_position: updatedTable.customPosition || null,
+          includes_hoist: updatedTable.includesHoist || false,
+          override_data: buildPowerTableData(updatedTable, getPowerSettings()),
+        }
+      });
+    } else if (selectedJobId) {
+      const powerRequirementId = await savePowerRequirementTable(updatedTable, { showToast: false });
+      if (powerRequirementId && powerRequirementId !== updatedTable.powerRequirementId) {
+        setTables((prev) =>
+          prev.map((table) =>
+            table.id === tableId ? { ...table, powerRequirementId } : table
+          )
+        );
+      }
+    }
   };
 
   const handleExportPDF = async () => {

--- a/src/pages/LightsConsumosTool.tsx
+++ b/src/pages/LightsConsumosTool.tsx
@@ -33,10 +33,11 @@ import {
 } from '@/features/technical-tools/power/PowerTableControls';
 import {
   buildLegacyPowerOverridePayload,
-  buildPowerRequirementInsert,
   buildPowerTableData,
   buildPowerTableMetadata,
   buildTourPowerDefaultTable,
+  deleteJobPowerRequirementTable,
+  saveJobPowerRequirementTable,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
@@ -155,6 +156,7 @@ interface TableRow {
 interface Table {
   name: string;
   rows: TableRow[];
+  powerRequirementId?: string;
   totalWatts?: number;
   adjustedWatts?: number;
   totalVa?: number;
@@ -540,7 +542,10 @@ const LightsConsumosTool: React.FC = () => {
 
   const recommendPDU = (currentLine: number) => recommendPowerPdu(currentLine, pduOptions);
 
-  const savePowerRequirementTable = async (table: Table) => {
+  const savePowerRequirementTable = async (
+    table: Table,
+    { showToast = true }: { showToast?: boolean } = {},
+  ) => {
     if (isOverrideMode && overrideData) {
       // Save as override for tour date
       const overrideSuccess = await saveOverride('power', buildLegacyPowerOverridePayload({
@@ -554,31 +559,33 @@ const LightsConsumosTool: React.FC = () => {
           description: "Override saved for tour date",
         });
       }
-      return;
+      return table.powerRequirementId;
     }
 
     // Original job-based save logic
     if (!selectedJobId) return;
 
     try {
-      const { error } = await dataLayerClient.from('power_requirement_tables')
-        .insert(buildPowerRequirementInsert({
-          department: 'lights',
-          jobId: selectedJobId,
-          settings: getPowerSettings({
-            phaseMode: table.snapshotPhaseMode,
-            safetyMargin: table.snapshotSafetyMargin,
-            voltage: table.snapshotVoltage,
-          }),
-          table,
-        }));
-
-      if (error) throw error;
-
-      toast({
-        title: "Éxito",
-        description: "La tabla de requerimientos de potencia se ha guardado exitosamente",
+      const powerRequirementId = await saveJobPowerRequirementTable({
+        client: dataLayerClient,
+        department: 'lights',
+        jobId: selectedJobId,
+        settings: getPowerSettings({
+          phaseMode: table.snapshotPhaseMode,
+          safetyMargin: table.snapshotSafetyMargin,
+          voltage: table.snapshotVoltage,
+        }),
+        table,
       });
+
+      if (showToast) {
+        toast({
+          title: "Éxito",
+          description: "La tabla de requerimientos de potencia se ha guardado exitosamente",
+        });
+      }
+
+      return powerRequirementId;
     } catch (error: unknown) {
       console.error('Error saving power requirement table:', error);
       toast({
@@ -586,10 +593,11 @@ const LightsConsumosTool: React.FC = () => {
         description: "Error al guardar la tabla de requerimientos de potencia",
         variant: "destructive",
       });
+      return table.powerRequirementId;
     }
   };
 
-  const generateTable = () => {
+  const generateTable = async () => {
     if (!tableName) {
       toast({
         title: 'Falta el nombre de la tabla',
@@ -650,14 +658,18 @@ const LightsConsumosTool: React.FC = () => {
       snapshotVoltage: voltage,
     };
 
-    setTables((prev) => [...prev, newTable]);
+    let tableToAdd = newTable;
 
     if (isTourDefaults) {
       // user can review before saving defaults
     } else if (selectedJobId) {
-      savePowerRequirementTable(newTable);
+      const powerRequirementId = await savePowerRequirementTable(newTable);
+      if (powerRequirementId) {
+        tableToAdd = { ...newTable, powerRequirementId };
+      }
     }
 
+    setTables((prev) => [...prev, tableToAdd]);
     resetCurrentTable();
   };
 
@@ -677,10 +689,30 @@ const LightsConsumosTool: React.FC = () => {
     setCustomPosition('');
   };
 
-  const removeTable = (tableId: number | string) => {
+  const removeTable = async (tableId: number | string) => {
     // Only allow removal of regular tables (numeric IDs), not default tables
     if (typeof tableId === 'number') {
+      const tableToRemove = tables.find((table) => table.id === tableId);
       setTables((prev) => prev.filter((table) => table.id !== tableId));
+
+      if (!selectedJobId || isTourDefaults || isOverrideMode || !tableToRemove?.powerRequirementId) {
+        return;
+      }
+
+      try {
+        await deleteJobPowerRequirementTable({
+          client: dataLayerClient,
+          jobId: selectedJobId,
+          table: tableToRemove,
+        });
+      } catch (error) {
+        console.error('Error deleting power requirement table:', error);
+        toast({
+          title: "Error",
+          description: "Error al eliminar la tabla de requerimientos de potencia",
+          variant: "destructive",
+        });
+      }
     }
   };
 
@@ -703,7 +735,19 @@ const LightsConsumosTool: React.FC = () => {
               },
             });
           } else if (!isTourDefaults && selectedJobId) {
-            savePowerRequirementTable(updatedTable);
+            void savePowerRequirementTable(updatedTable, { showToast: false })
+              .then((powerRequirementId) => {
+                if (powerRequirementId && powerRequirementId !== updatedTable.powerRequirementId) {
+                  setTables((storedTables) =>
+                    storedTables.map((storedTable) =>
+                      storedTable.id === tableId ? { ...storedTable, powerRequirementId } : storedTable
+                    )
+                  );
+                }
+              })
+              .catch((error) => {
+                console.error('Error saving table settings:', error);
+              });
           }
           return updatedTable;
         }

--- a/src/pages/LightsConsumosTool.tsx
+++ b/src/pages/LightsConsumosTool.tsx
@@ -662,7 +662,7 @@ const LightsConsumosTool: React.FC = () => {
 
     if (isTourDefaults) {
       // user can review before saving defaults
-    } else if (selectedJobId) {
+    } else if (isOverrideMode || selectedJobId) {
       const powerRequirementId = await savePowerRequirementTable(newTable);
       if (powerRequirementId) {
         tableToAdd = { ...newTable, powerRequirementId };
@@ -693,9 +693,17 @@ const LightsConsumosTool: React.FC = () => {
     // Only allow removal of regular tables (numeric IDs), not default tables
     if (typeof tableId === 'number') {
       const tableToRemove = tables.find((table) => table.id === tableId);
-      setTables((prev) => prev.filter((table) => table.id !== tableId));
+      if (!tableToRemove) {
+        toast({
+          title: "Error",
+          description: "No se encontró la tabla de requerimientos de potencia",
+          variant: "destructive",
+        });
+        return;
+      }
 
       if (!selectedJobId || isTourDefaults || isOverrideMode || !tableToRemove?.powerRequirementId) {
+        setTables((prev) => prev.filter((table) => table.id !== tableId));
         return;
       }
 
@@ -705,6 +713,7 @@ const LightsConsumosTool: React.FC = () => {
           jobId: selectedJobId,
           table: tableToRemove,
         });
+        setTables((prev) => prev.filter((table) => table.id !== tableId));
       } catch (error) {
         console.error('Error deleting power requirement table:', error);
         toast({
@@ -734,7 +743,7 @@ const LightsConsumosTool: React.FC = () => {
                 metadata: buildPowerTableMetadata(updatedTable, settings),
               },
             });
-          } else if (!isTourDefaults && selectedJobId) {
+          } else if (!isTourDefaults && (isOverrideMode || selectedJobId)) {
             void savePowerRequirementTable(updatedTable, { showToast: false })
               .then((powerRequirementId) => {
                 if (powerRequirementId && powerRequirementId !== updatedTable.powerRequirementId) {

--- a/src/pages/VideoConsumosTool.tsx
+++ b/src/pages/VideoConsumosTool.tsx
@@ -22,8 +22,9 @@ import {
 import { PowerTableControls } from '@/features/technical-tools/power/PowerTableControls';
 import {
   buildLegacyPowerOverridePayload,
-  buildPowerRequirementInsert,
   buildTourPowerDefaultTable,
+  deleteJobPowerRequirementTable,
+  saveJobPowerRequirementTable,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
@@ -55,6 +56,7 @@ interface TableRow {
 interface Table {
   name: string;
   rows: TableRow[];
+  powerRequirementId?: string;
   totalWatts?: number;
   adjustedWatts?: number;
   totalVa?: number;
@@ -244,7 +246,10 @@ const VideoConsumosTool: React.FC = () => {
   const getPowerSettings = () => ({ safetyMargin, powerFactor: pf, phaseMode, voltage });
   const PDU_TYPES = getPowerPduOptions('video', phaseMode);
 
-  const savePowerRequirementTable = async (table: Table) => {
+  const savePowerRequirementTable = async (
+    table: Table,
+    { showToast = true }: { showToast?: boolean } = {},
+  ) => {
     if (isOverrideMode && overrideData) {
       // Save as override for tour date
       const overrideSuccess = await saveOverride('power', buildLegacyPowerOverridePayload({
@@ -258,24 +263,26 @@ const VideoConsumosTool: React.FC = () => {
           description: "Override saved for tour date",
         });
       }
-      return;
+      return table.powerRequirementId;
     }
 
     try {
-      const { error } = await dataLayerClient.from('power_requirement_tables')
-        .insert(buildPowerRequirementInsert({
-          department: 'video',
-          jobId: selectedJobId,
-          settings: getPowerSettings(),
-          table,
-        }));
-
-      if (error) throw error;
-
-      toast({
-        title: "Success",
-        description: "Power requirement table saved successfully",
+      const powerRequirementId = await saveJobPowerRequirementTable({
+        client: dataLayerClient,
+        department: 'video',
+        jobId: selectedJobId,
+        settings: getPowerSettings(),
+        table,
       });
+
+      if (showToast) {
+        toast({
+          title: "Success",
+          description: "Power requirement table saved successfully",
+        });
+      }
+
+      return powerRequirementId;
     } catch (error: any) {
       console.error('Error saving power requirement table:', error);
       toast({
@@ -283,6 +290,7 @@ const VideoConsumosTool: React.FC = () => {
         description: "Failed to save power requirement table",
         variant: "destructive"
       });
+      return table.powerRequirementId;
     }
   };
 
@@ -308,15 +316,19 @@ const VideoConsumosTool: React.FC = () => {
       },
     }) as Table;
 
-    setTables((prev) => [...prev, newTable]);
+    let tableToAdd = newTable;
     
     // Save based on mode
     if (isTourDefaults) {
       await saveTourDefault(newTable);
     } else if (selectedJobId) {
-      await savePowerRequirementTable(newTable);
+      const powerRequirementId = await savePowerRequirementTable(newTable);
+      if (powerRequirementId) {
+        tableToAdd = { ...newTable, powerRequirementId };
+      }
     }
     
+    setTables((prev) => [...prev, tableToAdd]);
     resetCurrentTable();
   };
 
@@ -330,10 +342,30 @@ const VideoConsumosTool: React.FC = () => {
     setTableName('');
   };
 
-  const removeTable = (tableId: number | string) => {
+  const removeTable = async (tableId: number | string) => {
     // Only allow removal of regular tables (numeric IDs), not default tables
     if (typeof tableId === 'number') {
+      const tableToRemove = tables.find((table) => table.id === tableId);
       setTables((prev) => prev.filter((table) => table.id !== tableId));
+
+      if (!selectedJobId || isTourDefaults || isOverrideMode || !tableToRemove?.powerRequirementId) {
+        return;
+      }
+
+      try {
+        await deleteJobPowerRequirementTable({
+          client: dataLayerClient,
+          jobId: selectedJobId,
+          table: tableToRemove,
+        });
+      } catch (error) {
+        console.error('Error deleting power requirement table:', error);
+        toast({
+          title: "Error",
+          description: "Failed to delete power requirement table",
+          variant: "destructive",
+        });
+      }
     }
   };
 
@@ -351,7 +383,15 @@ const VideoConsumosTool: React.FC = () => {
     pendingTableSaveTimeoutsRef.current[timeoutKey] = window.setTimeout(() => {
       delete pendingTableSaveTimeoutsRef.current[timeoutKey];
 
-      void savePowerRequirementTable(table).catch((error) => {
+      void savePowerRequirementTable(table, { showToast: false }).then((powerRequirementId) => {
+        if (powerRequirementId && powerRequirementId !== table.powerRequirementId) {
+          setTables((prev) =>
+            prev.map((storedTable) =>
+              storedTable.id === table.id ? { ...storedTable, powerRequirementId } : storedTable
+            )
+          );
+        }
+      }).catch((error) => {
         console.error('Error saving table settings:', error);
       });
     }, TABLE_SETTINGS_SAVE_DEBOUNCE_MS);

--- a/src/pages/VideoConsumosTool.tsx
+++ b/src/pages/VideoConsumosTool.tsx
@@ -266,6 +266,10 @@ const VideoConsumosTool: React.FC = () => {
       return table.powerRequirementId;
     }
 
+    if (!selectedJobId) {
+      return table.powerRequirementId;
+    }
+
     try {
       const powerRequirementId = await saveJobPowerRequirementTable({
         client: dataLayerClient,
@@ -321,7 +325,7 @@ const VideoConsumosTool: React.FC = () => {
     // Save based on mode
     if (isTourDefaults) {
       await saveTourDefault(newTable);
-    } else if (selectedJobId) {
+    } else if (isOverrideMode || selectedJobId) {
       const powerRequirementId = await savePowerRequirementTable(newTable);
       if (powerRequirementId) {
         tableToAdd = { ...newTable, powerRequirementId };
@@ -346,9 +350,17 @@ const VideoConsumosTool: React.FC = () => {
     // Only allow removal of regular tables (numeric IDs), not default tables
     if (typeof tableId === 'number') {
       const tableToRemove = tables.find((table) => table.id === tableId);
-      setTables((prev) => prev.filter((table) => table.id !== tableId));
+      if (!tableToRemove) {
+        toast({
+          title: "Error",
+          description: "Power requirement table not found",
+          variant: "destructive",
+        });
+        return;
+      }
 
       if (!selectedJobId || isTourDefaults || isOverrideMode || !tableToRemove?.powerRequirementId) {
+        setTables((prev) => prev.filter((table) => table.id !== tableId));
         return;
       }
 
@@ -358,6 +370,7 @@ const VideoConsumosTool: React.FC = () => {
           jobId: selectedJobId,
           table: tableToRemove,
         });
+        setTables((prev) => prev.filter((table) => table.id !== tableId));
       } catch (error) {
         console.error('Error deleting power requirement table:', error);
         toast({
@@ -370,7 +383,11 @@ const VideoConsumosTool: React.FC = () => {
   };
 
   const scheduleTableSettingsSave = (table: Table) => {
-    if (isTourDefaults || !selectedJobId || table.id === undefined) {
+    if (isTourDefaults || table.id === undefined) {
+      return;
+    }
+
+    if (!isOverrideMode && !selectedJobId) {
       return;
     }
 

--- a/src/pages/consumos-tool/types.ts
+++ b/src/pages/consumos-tool/types.ts
@@ -10,6 +10,7 @@ export interface TableRow {
 export interface Table {
   name: string;
   rows: TableRow[];
+  powerRequirementId?: string;
   totalWatts?: number;
   adjustedWatts?: number;
   totalVa?: number; // apparent power (VA) — used for kVA display and generator sizing

--- a/src/utils/__tests__/powerSummaryData.test.ts
+++ b/src/utils/__tests__/powerSummaryData.test.ts
@@ -114,6 +114,7 @@ describe('powerSummaryData', () => {
           pdu_type: 'CEE125A 3P+N+G',
           custom_pdu_type: null,
           includes_hoist: false,
+          table_data: { rows: [{ quantity: '1', componentId: '1', watts: '31500' }] },
         },
         {
           id: 'sound-new',
@@ -126,6 +127,7 @@ describe('powerSummaryData', () => {
           pdu_type: 'CEE125A 3P+N+G',
           custom_pdu_type: null,
           includes_hoist: true,
+          table_data: { rows: [{ quantity: '1', componentId: '1', watts: '31500' }] },
         },
       ],
     });
@@ -138,6 +140,92 @@ describe('powerSummaryData', () => {
     expect(summary.departments.sound.rows).toHaveLength(1);
     expect(summary.departments.sound.rows[0].name).toBe('MAIN L');
     expect(summary.departments.sound.rows[0].notes).toContain('CEE32A');
+  });
+
+  it('keeps multiple current tables for the same department when they have distinct saved identities', async () => {
+    const supabase = createMockSupabase({
+      power_requirement_tables: [
+        {
+          id: 'sound-stage-1',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'Main PA',
+          total_watts: 1000,
+          current_per_phase: 4,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          position: 'Stage 1',
+          custom_position: null,
+          includes_hoist: false,
+          table_data: {
+            sourceTableId: 'stage-1-table',
+            rows: [{ quantity: '1', componentId: '1', watts: '1000' }],
+          },
+        },
+        {
+          id: 'sound-stage-2',
+          created_at: '2026-04-07T08:05:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'Main PA',
+          total_watts: 1200,
+          current_per_phase: 5,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          position: 'Stage 2',
+          custom_position: null,
+          includes_hoist: false,
+          table_data: {
+            sourceTableId: 'stage-2-table',
+            rows: [{ quantity: '1', componentId: '1', watts: '1000' }],
+          },
+        },
+      ],
+    });
+
+    const summary = await loadTechnicalPowerSummaryData({
+      job: { id: 'job-1', job_type: 'single' },
+      supabase,
+    });
+
+    expect(summary.departments.sound.rows).toHaveLength(2);
+    expect(summary.departments.sound.rows.map((row) => row.positionLabel)).toEqual([
+      'Stage 1',
+      'Stage 2',
+    ]);
+  });
+
+  it('uses saved job table electrical settings when calculating apparent power', async () => {
+    const supabase = createMockSupabase({
+      power_requirement_tables: [
+        {
+          id: 'sound-1',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'FoH',
+          total_watts: 950,
+          current_per_phase: 5,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: {
+            pf: 0.95,
+            safetyMargin: 20,
+            rows: [{ quantity: '1', componentId: '1', watts: '950' }],
+          },
+        },
+      ],
+    });
+
+    const summary = await loadTechnicalPowerSummaryData({
+      job: { id: 'job-1', job_type: 'single' },
+      supabase,
+    });
+
+    expect(summary.departments.sound.rows[0].totalVa).toBe(1200);
+    expect(summary.departments.sound.totalKva).toBe(1.2);
   });
 
   it('prefers tour date overrides over defaults for tourdate jobs', async () => {

--- a/src/utils/__tests__/powerSummaryData.test.ts
+++ b/src/utils/__tests__/powerSummaryData.test.ts
@@ -142,6 +142,47 @@ describe('powerSummaryData', () => {
     expect(summary.departments.sound.rows[0].notes).toContain('CEE32A');
   });
 
+  it('uses input order instead of lexicographic ids to break duplicate save freshness ties', async () => {
+    const supabase = createMockSupabase({
+      power_requirement_tables: [
+        {
+          id: 'z-old-id',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'MAIN L',
+          total_watts: 31500,
+          current_per_phase: 57.43,
+          pdu_type: 'CEE125A 3P+N+G',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: { rows: [{ quantity: '1', componentId: '1', watts: '31500' }] },
+        },
+        {
+          id: 'a-new-id',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'MAIN L',
+          total_watts: 31500,
+          current_per_phase: 57.43,
+          pdu_type: 'CEE125A 3P+N+G',
+          custom_pdu_type: null,
+          includes_hoist: true,
+          table_data: { rows: [{ quantity: '1', componentId: '1', watts: '31500' }] },
+        },
+      ],
+    });
+
+    const summary = await loadTechnicalPowerSummaryData({
+      job: { id: 'job-1', job_type: 'single' },
+      supabase,
+    });
+
+    expect(summary.departments.sound.rows).toHaveLength(1);
+    expect(summary.departments.sound.rows[0].notes).toContain('CEE32A');
+  });
+
   it('keeps multiple current tables for the same department when they have distinct saved identities', async () => {
     const supabase = createMockSupabase({
       power_requirement_tables: [

--- a/src/utils/__tests__/tourPowerTables.test.ts
+++ b/src/utils/__tests__/tourPowerTables.test.ts
@@ -26,6 +26,11 @@ describe('tourPowerTables', () => {
     expect(computePowerTotalVa(0, { pf: 0.5 }, 'sound')).toBe(0);
   });
 
+  it('clamps stored safety margin before calculating apparent power', () => {
+    expect(computePowerTotalVa(1000, { pf: 1, safetyMargin: -100 }, 'sound')).toBe(1000);
+    expect(computePowerTotalVa(1000, { pf: 1, safetyMargin: 150 }, 'sound')).toBe(2000);
+  });
+
   it('uses department defaults when metadata is null or undefined', () => {
     expect(computePowerTotalVa(950, null, 'sound')).toBe(1000);
     expect(computePowerTotalVa(900, undefined, 'video')).toBe(1000);
@@ -54,6 +59,29 @@ describe('tourPowerTables', () => {
 
     expect(normalized.position).toBe('USL');
     expect(normalized.customPosition).toBeUndefined();
+  });
+
+  it('uses table data safety margin when default metadata is missing it', () => {
+    const normalized = normalizeTourDefaultPowerTable(
+      {
+        id: 'default-1',
+        set_id: 'set-1',
+        table_name: 'FoH',
+        table_type: 'power',
+        total_value: 950,
+        metadata: {
+          current_per_phase: 5,
+          pdu_type: '32A',
+          pf: 0.95,
+        },
+        table_data: { rows: [], safetyMargin: 20 },
+        created_at: '2026-04-08T10:00:00.000Z',
+        updated_at: '2026-04-08T10:00:00.000Z',
+      } as any,
+      'sound'
+    );
+
+    expect(normalized.totalVa).toBe(1200);
   });
 
   it('normalizes custom positions from legacy defaults and overrides', () => {

--- a/src/utils/powerSummaryData.ts
+++ b/src/utils/powerSummaryData.ts
@@ -23,6 +23,10 @@ type TourDefaultSetRow = Database['public']['Tables']['tour_default_sets']['Row'
 type TourDefaultTableRow = Database['public']['Tables']['tour_default_tables']['Row'];
 type TourPowerDefaultRow = Database['public']['Tables']['tour_power_defaults']['Row'];
 type TourDatePowerOverrideRow = Database['public']['Tables']['tour_date_power_overrides']['Row'];
+type IndexedPowerRequirementTableRow = {
+  row: PowerRequirementTableRow;
+  inputIndex: number;
+};
 
 export interface TechnicalPowerSummaryJob {
   id: string;
@@ -103,23 +107,23 @@ const getPowerRequirementSourceTableId = (row: PowerRequirementTableRow) => {
 };
 
 const comparePowerRequirementTablesByFreshness = (
-  left: PowerRequirementTableRow,
-  right: PowerRequirementTableRow
+  left: IndexedPowerRequirementTableRow,
+  right: IndexedPowerRequirementTableRow
 ) => {
-  const leftTimestamp = left.created_at ? Date.parse(left.created_at) : 0;
-  const rightTimestamp = right.created_at ? Date.parse(right.created_at) : 0;
+  const leftTimestamp = left.row.created_at ? Date.parse(left.row.created_at) : 0;
+  const rightTimestamp = right.row.created_at ? Date.parse(right.row.created_at) : 0;
 
   if (leftTimestamp !== rightTimestamp) {
     return leftTimestamp - rightTimestamp;
   }
 
-  const leftCreatedAt = left.created_at || '';
-  const rightCreatedAt = right.created_at || '';
+  const leftCreatedAt = left.row.created_at || '';
+  const rightCreatedAt = right.row.created_at || '';
   if (leftCreatedAt !== rightCreatedAt) {
     return leftCreatedAt.localeCompare(rightCreatedAt);
   }
 
-  return left.id.localeCompare(right.id);
+  return left.inputIndex - right.inputIndex;
 };
 
 const getPowerRequirementTableCurrentKey = (
@@ -144,24 +148,27 @@ const getPowerRequirementTableCurrentKey = (
 export const getCurrentPowerRequirementTables = (
   rows: PowerRequirementTableRow[]
 ): PowerRequirementTableRow[] => {
-  const latestRows = new Map<string, PowerRequirementTableRow>();
+  const latestRows = new Map<string, IndexedPowerRequirementTableRow>();
 
-  for (const row of rows) {
+  rows.forEach((row, inputIndex) => {
     const department = row.department as TechnicalPowerDepartment | null;
-    if (!department) continue;
+    if (!department) return;
 
     const dedupKey = getPowerRequirementTableCurrentKey(row, department);
     const current = latestRows.get(dedupKey);
+    const indexedRow = { row, inputIndex };
 
     if (
       !current ||
-      comparePowerRequirementTablesByFreshness(row, current) >= 0
+      comparePowerRequirementTablesByFreshness(indexedRow, current) >= 0
     ) {
-      latestRows.set(dedupKey, row);
+      latestRows.set(dedupKey, indexedRow);
     }
-  }
+  });
 
-  return [...latestRows.values()].sort(comparePowerRequirementTablesByFreshness);
+  return [...latestRows.values()]
+    .sort(comparePowerRequirementTablesByFreshness)
+    .map((value) => value.row);
 };
 
 const formatPowerRequirementNumber = (value: number | string | null | undefined) => {

--- a/src/utils/powerSummaryData.ts
+++ b/src/utils/powerSummaryData.ts
@@ -74,22 +74,74 @@ const mapPowerRequirementTable = (
   positionLabel: getResolvedPowerPosition(row.position, row.custom_position) || 'N/A',
   totalWatts: row.total_watts || 0,
   currentPerPhase: row.current_per_phase || 0,
-  totalVa: computePowerTotalVa(row.total_watts || 0, null, department),
+  totalVa: computePowerTotalVa(row.total_watts || 0, row.table_data, department),
   notes: row.includes_hoist ? 'Motor adicional CEE32A 3P+N+G' : '',
   source: 'job',
 });
 
-const getPowerRequirementTableDedupKey = (
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getPowerRequirementRowsSignature = (row: PowerRequirementTableRow) => {
+  if (!isRecord(row.table_data) || !Array.isArray(row.table_data.rows)) {
+    return null;
+  }
+
+  try {
+    return JSON.stringify(row.table_data.rows);
+  } catch {
+    return null;
+  }
+};
+
+const getPowerRequirementSourceTableId = (row: PowerRequirementTableRow) => {
+  if (!isRecord(row.table_data)) return null;
+  const sourceTableId = row.table_data.sourceTableId;
+  return typeof sourceTableId === 'string' && sourceTableId.trim()
+    ? sourceTableId.trim()
+    : null;
+};
+
+const comparePowerRequirementTablesByFreshness = (
+  left: PowerRequirementTableRow,
+  right: PowerRequirementTableRow
+) => {
+  const leftTimestamp = left.created_at ? Date.parse(left.created_at) : 0;
+  const rightTimestamp = right.created_at ? Date.parse(right.created_at) : 0;
+
+  if (leftTimestamp !== rightTimestamp) {
+    return leftTimestamp - rightTimestamp;
+  }
+
+  const leftCreatedAt = left.created_at || '';
+  const rightCreatedAt = right.created_at || '';
+  if (leftCreatedAt !== rightCreatedAt) {
+    return leftCreatedAt.localeCompare(rightCreatedAt);
+  }
+
+  return left.id.localeCompare(right.id);
+};
+
+const getPowerRequirementTableCurrentKey = (
   row: PowerRequirementTableRow,
   department: TechnicalPowerDepartment
 ) => {
+  const sourceTableId = getPowerRequirementSourceTableId(row);
+  if (sourceTableId) {
+    return `${department}:source:${sourceTableId}`;
+  }
+
   const normalizedName = row.table_name?.trim().toLowerCase();
-  return normalizedName
-    ? `${department}:${normalizedName}`
-    : `${department}:${row.id}`;
+  const rowSignature = getPowerRequirementRowsSignature(row);
+
+  if (normalizedName && rowSignature) {
+    return `${department}:legacy:${normalizedName}:${rowSignature}`;
+  }
+
+  return `${department}:row:${row.id}`;
 };
 
-const dedupePowerRequirementTables = (
+export const getCurrentPowerRequirementTables = (
   rows: PowerRequirementTableRow[]
 ): PowerRequirementTableRow[] => {
   const latestRows = new Map<string, PowerRequirementTableRow>();
@@ -98,18 +150,51 @@ const dedupePowerRequirementTables = (
     const department = row.department as TechnicalPowerDepartment | null;
     if (!department) continue;
 
-    const dedupKey = getPowerRequirementTableDedupKey(row, department);
+    const dedupKey = getPowerRequirementTableCurrentKey(row, department);
     const current = latestRows.get(dedupKey);
-    const currentTimestamp = current?.created_at ? Date.parse(current.created_at) : 0;
-    const nextTimestamp = row.created_at ? Date.parse(row.created_at) : 0;
 
-    if (!current || nextTimestamp >= currentTimestamp) {
+    if (
+      !current ||
+      comparePowerRequirementTablesByFreshness(row, current) >= 0
+    ) {
       latestRows.set(dedupKey, row);
     }
   }
 
-  return [...latestRows.values()];
+  return [...latestRows.values()].sort(comparePowerRequirementTablesByFreshness);
 };
+
+const formatPowerRequirementNumber = (value: number | string | null | undefined) => {
+  if (typeof value === 'number') return value.toFixed(2);
+  return value ?? 'N/D';
+};
+
+export const formatPowerRequirementsText = (
+  rows: PowerRequirementTableRow[]
+) =>
+  getCurrentPowerRequirementTables(rows)
+    .map((req) => {
+      const department = (req.department || 'general').toUpperCase();
+      const pduType = req.custom_pdu_type || req.pdu_type || 'N/D';
+      const position = getResolvedPowerPosition(req.position, req.custom_position);
+      const lines = [
+        `${department} - ${req.table_name || 'tabla'}:`,
+        `Potencia Total: ${formatPowerRequirementNumber(req.total_watts)}W`,
+        `Corriente por Fase: ${formatPowerRequirementNumber(req.current_per_phase)}A`,
+        `PDU Recomendado: ${pduType}`,
+      ];
+
+      if (position) {
+        lines.push(`Posición: ${position}`);
+      }
+
+      if (req.includes_hoist) {
+        lines.push('Requiere potencia adicional de motores (CEE32A 3P+N+G)');
+      }
+
+      return `${lines.join('\n')}\n`;
+    })
+    .join('\n');
 
 const mapNormalizedTourPowerTable = (
   table: ReturnType<typeof buildNormalizedTourPowerTables>['tables'][number]
@@ -140,7 +225,8 @@ const loadStandardJobPowerData = async ({
     .from('power_requirement_tables')
     .select('*')
     .eq('job_id', jobId)
-    .in('department', [...TECHNICAL_POWER_DEPARTMENTS]);
+    .in('department', [...TECHNICAL_POWER_DEPARTMENTS])
+    .order('created_at', { ascending: true });
 
   if (error) {
     throw error;
@@ -150,7 +236,7 @@ const loadStandardJobPowerData = async ({
     TECHNICAL_POWER_DEPARTMENTS.map((department) => [department, [] as PowerRequirementTableRow[]])
   ) as Record<TechnicalPowerDepartment, PowerRequirementTableRow[]>;
 
-  for (const row of dedupePowerRequirementTables(data || [])) {
+  for (const row of getCurrentPowerRequirementTables(data || [])) {
     const department = row.department as TechnicalPowerDepartment | null;
     if (!department || !(department in rowsByDepartment)) continue;
     rowsByDepartment[department].push(row);

--- a/src/utils/tourPowerTables.ts
+++ b/src/utils/tourPowerTables.ts
@@ -68,8 +68,10 @@ export const computePowerTotalVa = (
     candidatePf <= 1
       ? candidatePf
       : DEFAULT_POWER_FACTOR[department];
+  const safetyMargin = getNumber(isRecord(metadata) ? metadata.safetyMargin : undefined) ?? 0;
+  const adjustedWatts = watts * (1 + safetyMargin / 100);
 
-  return watts / storedPf;
+  return adjustedWatts / storedPf;
 };
 
 export const sortTourPowerDefaultTables = (tables: TourDefaultTableRow[]) =>

--- a/src/utils/tourPowerTables.ts
+++ b/src/utils/tourPowerTables.ts
@@ -35,6 +35,9 @@ const isRecord = (value: unknown): value is JsonRecord =>
 const getNumber = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 
+const clampSafetyMargin = (value: number): number =>
+  Math.min(Math.max(value, 0), 100);
+
 const getBoolean = (value: unknown): boolean | undefined =>
   typeof value === 'boolean' ? value : undefined;
 
@@ -68,7 +71,9 @@ export const computePowerTotalVa = (
     candidatePf <= 1
       ? candidatePf
       : DEFAULT_POWER_FACTOR[department];
-  const safetyMargin = getNumber(isRecord(metadata) ? metadata.safetyMargin : undefined) ?? 0;
+  const safetyMargin = clampSafetyMargin(
+    getNumber(isRecord(metadata) ? metadata.safetyMargin : undefined) ?? 0
+  );
   const adjustedWatts = watts * (1 + safetyMargin / 100);
 
   return adjustedWatts / storedPf;
@@ -111,7 +116,13 @@ export const normalizeTourDefaultPowerTable = (
   table: TourDefaultTableRow,
   department: TechnicalPowerDepartment
 ): NormalizedTourPowerTable => {
-  const metadata = isRecord(table.metadata) ? table.metadata : {};
+  const tableData = isRecord(table.table_data) ? table.table_data : {};
+  const metadata = {
+    ...(isRecord(table.metadata) ? table.metadata : {}),
+    safetyMargin: isRecord(table.metadata) && table.metadata.safetyMargin !== undefined
+      ? table.metadata.safetyMargin
+      : tableData.safetyMargin,
+  };
   const pduType = String(getMetadataValue(metadata, 'pdu_type', ''));
   const customPduType = String(getMetadataValue(metadata, 'custom_pdu_type', ''));
   const position = String(getMetadataValue(metadata, 'position', ''));

--- a/src/utils/weather/__tests__/weatherApi.test.ts
+++ b/src/utils/weather/__tests__/weatherApi.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getWeatherForJob, parseEventDates } from "@/utils/weather/weatherApi";
+
+const dateKey = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const weatherResponse = {
+  daily: {
+    time: ["2026-06-03"],
+    temperature_2m_max: [28],
+    temperature_2m_min: [17],
+    precipitation_sum: [0],
+    weathercode: [0],
+  },
+  timezone: "Europe/Madrid",
+};
+
+describe("parseEventDates", () => {
+  it("parses es-ES numeric dates as day-month-year", () => {
+    const range = parseEventDates("3/6/2026");
+
+    expect(range).not.toBeNull();
+    expect(dateKey(range!.startDate)).toBe("2026-06-03");
+    expect(dateKey(range!.endDate)).toBe("2026-06-03");
+  });
+
+  it("parses explicit ISO date ranges", () => {
+    const range = parseEventDates("2026-06-03 - 2026-06-05");
+
+    expect(range).not.toBeNull();
+    expect(dateKey(range!.startDate)).toBe("2026-06-03");
+    expect(dateKey(range!.endDate)).toBe("2026-06-05");
+  });
+
+  it("parses Spanish month day ranges from the event placeholder format", () => {
+    const range = parseEventDates("15-17 Junio 2026");
+
+    expect(range).not.toBeNull();
+    expect(dateKey(range!.startDate)).toBe("2026-06-15");
+    expect(dateKey(range!.endDate)).toBe("2026-06-17");
+  });
+
+  it("rejects invalid calendar dates instead of normalizing them", () => {
+    expect(parseEventDates("31/2/2026")).toBeNull();
+  });
+});
+
+describe("getWeatherForJob", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 2, 12));
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("requests Open-Meteo with local calendar dates", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(weatherResponse), { status: 200 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getWeatherForJob(
+      { coordinates: { lat: 40.3448304, lng: -3.5147915 } },
+      "3/6/2026"
+    );
+
+    expect(result).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("start_date=2026-06-03");
+    expect(url).toContain("end_date=2026-06-03");
+  });
+
+  it("does not call the forecast API for past event dates", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getWeatherForJob(
+      { coordinates: { lat: 40.3448304, lng: -3.5147915 } },
+      "3/6/2006"
+    );
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/weather/weatherApi.ts
+++ b/src/utils/weather/weatherApi.ts
@@ -20,6 +20,7 @@ interface WeatherApiResponse {
     temperature_2m_max: number[];
     temperature_2m_min: number[];
     precipitation_probability_mean: number[];
+    precipitation_sum?: number[];
     weathercode: number[];
   };
   timezone: string;
@@ -110,7 +111,12 @@ export const geocodeAddress = async (address: string): Promise<GeocodeResult | n
  * Fetch weather data from Open-Meteo API
  */
 const fetchWeatherFromApi = async (lat: number, lng: number, startDate: Date, endDate: Date): Promise<WeatherData[]> => {
-  const formatDate = (date: Date) => date.toISOString().split('T')[0];
+  const formatDate = (date: Date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
   const start = formatDate(startDate);
   const end = formatDate(endDate);
 
@@ -121,7 +127,11 @@ const fetchWeatherFromApi = async (lat: number, lng: number, startDate: Date, en
   
   if (!response.ok) {
     let detail = '';
-    try { detail = await response.text(); } catch {}
+    try {
+      detail = await response.text();
+    } catch {
+      detail = '';
+    }
     throw new Error(`Weather API failed: ${response.status}${detail ? ` - ${detail}` : ''}`);
   }
 
@@ -138,10 +148,123 @@ const fetchWeatherFromApi = async (lat: number, lng: number, startDate: Date, en
       maxTemp: Math.round(data.daily.temperature_2m_max[index]),
       minTemp: Math.round(data.daily.temperature_2m_min[index]),
       // Approximate precipitation chance: 100% if any precipitation expected, otherwise 0%
-      precipitationProbability: ((data as any).daily?.precipitation_sum?.[index] || 0) > 0 ? 100 : 0,
+      precipitationProbability: (data.daily.precipitation_sum?.[index] || 0) > 0 ? 100 : 0,
       icon: weatherInfo.icon
     };
   });
+};
+
+const SPANISH_MONTHS: Record<string, number> = {
+  enero: 0,
+  ene: 0,
+  febrero: 1,
+  feb: 1,
+  marzo: 2,
+  mar: 2,
+  abril: 3,
+  abr: 3,
+  mayo: 4,
+  may: 4,
+  junio: 5,
+  jun: 5,
+  julio: 6,
+  jul: 6,
+  agosto: 7,
+  ago: 7,
+  septiembre: 8,
+  setiembre: 8,
+  sep: 8,
+  set: 8,
+  octubre: 9,
+  oct: 9,
+  noviembre: 10,
+  nov: 10,
+  diciembre: 11,
+  dic: 11,
+};
+
+const normalizeMonthName = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+const parseYear = (value: string): number => {
+  const year = Number(value);
+  return value.length === 2 ? 2000 + year : year;
+};
+
+const createLocalDate = (year: number, monthIndex: number, day: number): Date | null => {
+  const date = new Date(year, monthIndex, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== monthIndex ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+};
+
+const startOfLocalDay = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+const buildDateRange = (startDate: Date | null, endDate: Date | null) => {
+  if (!startDate || !endDate) return null;
+
+  const start = startOfLocalDay(startDate);
+  const end = startOfLocalDay(endDate);
+  if (end < start) return null;
+
+  return { startDate: start, endDate: end };
+};
+
+const parseIsoDates = (value: string) => {
+  const matches = Array.from(value.matchAll(/(?:^|[^\d])(\d{4})-(\d{1,2})-(\d{1,2})(?!\d)/g));
+  if (matches.length === 0) return null;
+
+  const dates = matches
+    .slice(0, 2)
+    .map((match) => createLocalDate(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+
+  return buildDateRange(dates[0], dates[1] ?? dates[0]);
+};
+
+const parseNumericDates = (value: string) => {
+  const matches = Array.from(value.matchAll(/(?:^|[^\d])(\d{1,2})[./-](\d{1,2})[./-](\d{2}|\d{4})(?!\d)/g));
+  if (matches.length === 0) return null;
+
+  const dates = matches
+    .slice(0, 2)
+    .map((match) => createLocalDate(parseYear(match[3]), Number(match[2]) - 1, Number(match[1])));
+
+  return buildDateRange(dates[0], dates[1] ?? dates[0]);
+};
+
+const parseSpanishMonthDates = (value: string) => {
+  const dayRangeMatch = value.match(
+    /(?:^|[^\d])(\d{1,2})\s*[-–—]\s*(\d{1,2})\s+(?:de\s+)?([a-záéíóúüñ]+)\s+(?:de\s+)?(\d{2}|\d{4})(?!\d)/i
+  );
+  if (dayRangeMatch) {
+    const monthIndex = SPANISH_MONTHS[normalizeMonthName(dayRangeMatch[3])];
+    if (monthIndex == null) return null;
+
+    return buildDateRange(
+      createLocalDate(parseYear(dayRangeMatch[4]), monthIndex, Number(dayRangeMatch[1])),
+      createLocalDate(parseYear(dayRangeMatch[4]), monthIndex, Number(dayRangeMatch[2]))
+    );
+  }
+
+  const singleDateMatch = value.match(
+    /(?:^|[^\d])(\d{1,2})\s+(?:de\s+)?([a-záéíóúüñ]+)\s+(?:de\s+)?(\d{2}|\d{4})(?!\d)/i
+  );
+  if (!singleDateMatch) return null;
+
+  const monthIndex = SPANISH_MONTHS[normalizeMonthName(singleDateMatch[2])];
+  if (monthIndex == null) return null;
+
+  const date = createLocalDate(parseYear(singleDateMatch[3]), monthIndex, Number(singleDateMatch[1]));
+  return buildDateRange(date, date);
 };
 
 /**
@@ -151,43 +274,10 @@ export const parseEventDates = (eventDates: string): { startDate: Date; endDate:
   if (!eventDates?.trim()) return null;
 
   try {
-    // Handle various date formats
     const cleanDates = eventDates.trim();
-    
-    // Try to match different date patterns
-    const singleDateMatch = cleanDates.match(/(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})/);
-    const dateRangeMatch = cleanDates.match(/(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4}).*?(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})/);
-    
-    if (dateRangeMatch) {
-      // Date range found
-      const startDate = new Date(
-        parseInt(dateRangeMatch[3]), 
-        parseInt(dateRangeMatch[2]) - 1, 
-        parseInt(dateRangeMatch[1])
-      );
-      const endDate = new Date(
-        parseInt(dateRangeMatch[6]), 
-        parseInt(dateRangeMatch[5]) - 1, 
-        parseInt(dateRangeMatch[4])
-      );
-      return { startDate, endDate };
-    } else if (singleDateMatch) {
-      // Single date found
-      const date = new Date(
-        parseInt(singleDateMatch[3]), 
-        parseInt(singleDateMatch[2]) - 1, 
-        parseInt(singleDateMatch[1])
-      );
-      return { startDate: date, endDate: date };
-    }
-    
-    // Try ISO format
-    const isoDate = new Date(cleanDates);
-    if (!isNaN(isoDate.getTime())) {
-      return { startDate: isoDate, endDate: isoDate };
-    }
-    
-    return null;
+    return parseIsoDates(cleanDates) ??
+      parseNumericDates(cleanDates) ??
+      parseSpanishMonthDates(cleanDates);
   } catch (error) {
     console.error('Error parsing event dates:', error);
     return null;
@@ -209,10 +299,20 @@ export const getWeatherForJob = async (
       return null;
     }
 
-    // Respect forecast horizon (~16 days). If range starts beyond horizon, skip request.
-    const today = new Date();
+    // Respect forecast horizon (~16 days). Open-Meteo forecast does not serve old event dates.
+    const today = startOfLocalDay(new Date());
     const horizon = new Date(today);
     horizon.setDate(horizon.getDate() + 16);
+
+    if (dateRange.endDate < today) {
+      console.warn('Requested weather ends before available forecast window:', eventDates);
+      return null;
+    }
+
+    if (dateRange.startDate < today) {
+      dateRange.startDate = today;
+    }
+
     if (dateRange.startDate > horizon) {
       console.warn('Requested weather starts beyond available forecast horizon:', eventDates);
       return null;


### PR DESCRIPTION
## Summary
- persist power requirement table updates/deletes against the exact saved row so combined reports, technicalPowerSummaryPack, and Hoja de Ruta stay in sync
- preserve multiple same-department power reports for multi-stage situations while conservatively collapsing only legacy duplicate saves
- prevent job edit saves from wiping all job_departments by waiting for department load, requiring at least one department, and inserting additions before removals

## Operations
- Restored Subsonico (`93745439-702a-45b4-adc2-fc5668c411ec`) job_departments for sound, lights, video, and production via an idempotent linked Supabase insert. Verified the UI inner-join query returns the job again.

## Validation
- npm install --legacy-peer-deps
- npm run test:run -- powerSummaryData powerPersistence tourPowerTables
- npm run lint (0 errors; existing warnings remain)
- npm run test:run
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added department selection and validation to job editing—users must select at least one department to save changes
  * Introduced safety margin feature for power calculations to improve accuracy
  * Enhanced power requirement table persistence with better tracking and management

* **Bug Fixes**
  * Improved deduplication logic for power requirement tables to prevent duplicate entries
  * Better error handling and loading state feedback in power tools

* **Refactor**
  * Consolidated power requirements text formatting across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->