### PR TITLE
[codex] Preserve manual Hoja power requirements

### DIFF
--- a/src/hooks/hoja-de-ruta/__tests__/useHojaDeRutaInitialization.test.ts
+++ b/src/hooks/hoja-de-ruta/__tests__/useHojaDeRutaInitialization.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePowerRequirementsForHojaInitialization } from "@/hooks/hoja-de-ruta/useHojaDeRutaInitialization";
+
+describe("resolvePowerRequirementsForHojaInitialization", () => {
+  it("keeps saved manual Hoja power requirements over generated table text", () => {
+    expect(
+      resolvePowerRequirementsForHojaInitialization({
+        savedPowerRequirements: "Manual override\nCEE63A",
+        generatedPowerRequirements: "Generated power table",
+      })
+    ).toBe("Manual override\nCEE63A");
+  });
+
+  it("uses generated power requirements when the saved Hoja field is empty", () => {
+    expect(
+      resolvePowerRequirementsForHojaInitialization({
+        savedPowerRequirements: "  ",
+        generatedPowerRequirements: "Generated power table",
+      })
+    ).toBe("Generated power table");
+  });
+});

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
@@ -4,6 +4,19 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { formatPowerRequirementsText } from '@/utils/powerSummaryData';
 
+export const resolvePowerRequirementsForHojaInitialization = ({
+  savedPowerRequirements,
+  generatedPowerRequirements,
+}: {
+  savedPowerRequirements?: string | null;
+  generatedPowerRequirements?: string | null;
+}) => {
+  const saved = savedPowerRequirements ?? "";
+  if (saved.trim().length > 0) return saved;
+
+  return generatedPowerRequirements ?? "";
+};
+
 export const useHojaDeRutaInitialization = (
   selectedJobId: string,
   hojaDeRuta: any,
@@ -378,8 +391,10 @@ export const useHojaDeRutaInitialization = (
           // Structured program schedules
           programSchedule: savedEventData?.programSchedule || undefined,
           programScheduleDays: savedEventData?.programScheduleDays || undefined,
-          // Use fresh power requirements from database, fallback to saved if none found
-          powerRequirements: powerRequirementsText || savedEventData?.powerRequirements || "",
+          powerRequirements: resolvePowerRequirementsForHojaInitialization({
+            savedPowerRequirements: savedEventData?.powerRequirements,
+            generatedPowerRequirements: powerRequirementsText,
+          }),
           auxiliaryNeeds: savedEventData?.auxiliaryNeeds || "",
           auxiliaryStaffSetupQty: savedEventData?.auxiliaryStaffSetupQty ?? 0,
           auxiliaryStaffDismantleQty: savedEventData?.auxiliaryStaffDismantleQty ?? 0,

--- a/src/utils/hoja-de-ruta/pdf/core/__tests__/pdf-document.test.ts
+++ b/src/utils/hoja-de-ruta/pdf/core/__tests__/pdf-document.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PDFDocument } from '../pdf-document';
+
+describe('PDFDocument', () => {
+  it('wraps text lines and advances vertical position for each wrapped segment', () => {
+    const pdfDoc = new PDFDocument();
+    const splitSpy = vi
+      .spyOn(pdfDoc, 'splitText')
+      .mockReturnValueOnce(['first segment', 'second segment']);
+    const addTextSpy = vi.spyOn(pdfDoc, 'addText').mockImplementation(() => undefined);
+
+    const nextY = pdfDoc.addWrappedLines(['long text'], 30, 100, { lineHeight: 6 });
+
+    expect(splitSpy.mock.calls[0][0]).toBe('long text');
+    expect(splitSpy.mock.calls[0][1]).toBeCloseTo(160, 2);
+    expect(addTextSpy).toHaveBeenNthCalledWith(1, 'first segment', 30, 100, undefined);
+    expect(addTextSpy).toHaveBeenNthCalledWith(2, 'second segment', 30, 106, undefined);
+    expect(nextY).toBe(112);
+  });
+});

--- a/src/utils/hoja-de-ruta/pdf/core/pdf-document.ts
+++ b/src/utils/hoja-de-ruta/pdf/core/pdf-document.ts
@@ -5,6 +5,17 @@ export interface AutoTableJsPDF extends jsPDF {
   lastAutoTable: { finalY: number };
 }
 
+type PdfTextOptions = Parameters<jsPDF['text']>[3];
+
+interface WrappedLinesOptions {
+  maxWidth?: number;
+  rightMargin?: number;
+  lineHeight?: number;
+  trim?: boolean;
+  skipEmpty?: boolean;
+  textOptions?: PdfTextOptions;
+}
+
 export class PDFDocument {
   private doc: AutoTableJsPDF;
   private pageWidth: number;
@@ -76,6 +87,38 @@ export class PDFDocument {
       this.doc.text(line, centerX, y, { align });
     });
     return lines.length;
+  }
+
+  addWrappedLines(
+    text: string | string[],
+    x: number,
+    yPosition: number,
+    options: WrappedLinesOptions = {}
+  ): number {
+    const lineHeight = options.lineHeight ?? 6;
+    const maxWidth = options.maxWidth ?? this.pageWidth - x - (options.rightMargin ?? 20);
+    const lines = Array.isArray(text) ? text : text.split(/\r?\n/);
+    const shouldTrim = options.trim ?? true;
+    const skipEmpty = options.skipEmpty ?? true;
+
+    for (const rawLine of lines) {
+      const line = shouldTrim ? rawLine.trim() : rawLine.trimEnd();
+      if (!line) {
+        if (!skipEmpty) {
+          yPosition = this.checkPageBreak(yPosition, lineHeight + 2);
+          yPosition += lineHeight;
+        }
+        continue;
+      }
+
+      for (const wrappedLine of this.splitText(line, maxWidth)) {
+        yPosition = this.checkPageBreak(yPosition, lineHeight + 2);
+        this.addText(wrappedLine, x, yPosition, options.textOptions);
+        yPosition += lineHeight;
+      }
+    }
+
+    return yPosition;
   }
 
   addTable(options: any): void {

--- a/src/utils/hoja-de-ruta/pdf/sections/aux-needs.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/aux-needs.ts
@@ -72,11 +72,7 @@ export class AuxNeedsSection {
     this.pdfDoc.addText("Notas:", 30, yPosition);
     yPosition += lineHeight;
 
-    for (const line of auxLines) {
-      yPosition = this.pdfDoc.checkPageBreak(yPosition, lineHeight + 2);
-      this.pdfDoc.addText(line, 30, yPosition);
-      yPosition += lineHeight;
-    }
+    yPosition = this.pdfDoc.addWrappedLines(auxLines, 30, yPosition, { lineHeight });
 
     return yPosition + 4;
   }

--- a/src/utils/hoja-de-ruta/pdf/sections/logistics.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/logistics.ts
@@ -67,11 +67,7 @@ export class LogisticsSection {
         .map((line) => line.trim())
         .filter(Boolean);
 
-      for (const line of loadingLines) {
-        yPosition = this.pdfDoc.checkPageBreak(yPosition, lineHeight + 2);
-        this.pdfDoc.addText(line, 30, yPosition);
-        yPosition += lineHeight;
-      }
+      yPosition = this.pdfDoc.addWrappedLines(loadingLines, 30, yPosition, { lineHeight });
       yPosition += 6;
     }
 
@@ -89,11 +85,7 @@ export class LogisticsSection {
         .map((line) => line.trim())
         .filter(Boolean);
 
-      for (const line of unloadingLines) {
-        yPosition = this.pdfDoc.checkPageBreak(yPosition, lineHeight + 2);
-        this.pdfDoc.addText(line, 30, yPosition);
-        yPosition += lineHeight;
-      }
+      yPosition = this.pdfDoc.addWrappedLines(unloadingLines, 30, yPosition, { lineHeight });
       yPosition += 6;
     }
 
@@ -111,11 +103,7 @@ export class LogisticsSection {
         .map((line) => line.trim())
         .filter(Boolean);
 
-      for (const line of equipmentLines) {
-        yPosition = this.pdfDoc.checkPageBreak(yPosition, lineHeight + 2);
-        this.pdfDoc.addText(line, 30, yPosition);
-        yPosition += lineHeight;
-      }
+      yPosition = this.pdfDoc.addWrappedLines(equipmentLines, 30, yPosition, { lineHeight });
       yPosition += 6;
     }
 

--- a/src/utils/hoja-de-ruta/pdf/sections/power.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/power.ts
@@ -15,14 +15,8 @@ export class PowerSection {
       return yPosition;
     }
 
-    const powerLines = eventData.powerRequirements!.split('\n');
-    for (const line of powerLines) {
-      if (line.trim()) {
-        this.pdfDoc.addText(line.trim(), 30, yPosition);
-        yPosition += 5;
-      }
-    }
-
-    return yPosition + 10;
+    return this.pdfDoc.addWrappedLines(eventData.powerRequirements!, 30, yPosition, {
+      lineHeight: 5,
+    }) + 10;
   }
 }


### PR DESCRIPTION
## What changed
- Preserves saved/manual Hoja de Ruta power requirements when loading an existing Hoja.
- Falls back to generated power requirement text only when the saved field is blank.
- Wraps long Hoja PDF free-text lines in logistics, power requirements, and auxiliary notes so content stays inside page margins.
- Runs wrapped free-text through the shared page-break check so long sections do not overlap the footer/logo.
- Adds focused coverage for saved-manual/generated-fallback initialization and PDF wrapped-line behavior.

## Why
PR #657 added synced generated power tables, but the Hoja initialization path preferred generated text over a previously saved `hoja_de_ruta.power_requirements` value. That made manual edits appear to be lost on reload and prevented amending older unsynced Hoja data.

The generated Hoja PDF also drew several long text fields directly with `doc.text`, bypassing wrapping and footer-aware page breaks. Long logistics notes and power requirements could run past the right margin or into the footer.

## Validation
- `npm run test:run -- src/utils/hoja-de-ruta/pdf/core/__tests__/pdf-document.test.ts src/hooks/hoja-de-ruta/__tests__/useHojaDeRutaInitialization.test.ts`
- `npx eslint src/utils/hoja-de-ruta/pdf/core/pdf-document.ts src/utils/hoja-de-ruta/pdf/sections/aux-needs.ts src/utils/hoja-de-ruta/pdf/sections/logistics.ts src/utils/hoja-de-ruta/pdf/sections/power.ts src/utils/hoja-de-ruta/pdf/core/__tests__/pdf-document.test.ts` (0 errors; existing PDF wrapper `any` warnings remain)
- `npm run build`
- `npm run typecheck` was run and still fails on pre-existing current-main issues outside this change: mobile artist config/task dialog mutation payload typing and tour power table metadata fields.

Visual rerendering with Poppler/PyMuPDF was not available in this environment; the fix targets the exact direct-text code paths shown in the supplied PDF screenshots.