### PR TITLE
[codex] Add hoja de ruta PDF preview modal

### DIFF
--- a/src/components/hoja-de-ruta/HojaDeRutaPdfPreviewDialog.tsx
+++ b/src/components/hoja-de-ruta/HojaDeRutaPdfPreviewDialog.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Download, ExternalLink } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export type HojaDeRutaPdfPreview = {
+  url: string;
+  filename: string;
+  title: string;
+};
+
+type HojaDeRutaPdfPreviewDialogProps = {
+  open: boolean;
+  preview: HojaDeRutaPdfPreview | null;
+  onOpenChange: (open: boolean) => void;
+  onDownload: () => void;
+  onOpenInNewTab: () => void;
+};
+
+export const HojaDeRutaPdfPreviewDialog: React.FC<HojaDeRutaPdfPreviewDialogProps> = ({
+  open,
+  preview,
+  onOpenChange,
+  onDownload,
+  onOpenInNewTab,
+}) => {
+  const iframeSrc = preview ? `${preview.url}#toolbar=1&navpanes=0` : undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[min(88vh,900px)] max-w-[calc(100vw-1rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-5xl">
+        <DialogHeader className="border-b px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <DialogTitle className="truncate text-base md:text-lg">
+                {preview?.title ?? "Vista previa PDF"}
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                Vista previa del PDF generado sin subirlo a documentos.
+              </DialogDescription>
+              {preview && (
+                <p className="mt-1 truncate text-xs text-muted-foreground">
+                  {preview.filename}
+                </p>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onOpenInNewTab}
+                disabled={!preview}
+                aria-label="Abrir PDF en una pestana"
+              >
+                <ExternalLink className="h-4 w-4 sm:mr-2" />
+                <span className="hidden sm:inline">Abrir</span>
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={onDownload}
+                disabled={!preview}
+                aria-label="Descargar PDF"
+              >
+                <Download className="h-4 w-4 sm:mr-2" />
+                <span className="hidden sm:inline">Descargar</span>
+              </Button>
+            </div>
+          </div>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 bg-muted">
+          {iframeSrc && (
+            <iframe
+              src={iframeSrc}
+              title={preview?.title ?? "Vista previa PDF"}
+              className="h-full w-full border-0 bg-background"
+            />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/hoja-de-ruta/HojaDeRutaPdfPreviewDialog.tsx
+++ b/src/components/hoja-de-ruta/HojaDeRutaPdfPreviewDialog.tsx
@@ -31,7 +31,7 @@ export const HojaDeRutaPdfPreviewDialog: React.FC<HojaDeRutaPdfPreviewDialogProp
   onDownload,
   onOpenInNewTab,
 }) => {
-  const iframeSrc = preview ? `${preview.url}#toolbar=1&navpanes=0` : undefined;
+  const pdfSrc = preview ? `${preview.url}#toolbar=1&navpanes=0&scrollbar=1&view=FitH` : undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -76,13 +76,21 @@ export const HojaDeRutaPdfPreviewDialog: React.FC<HojaDeRutaPdfPreviewDialogProp
             </div>
           </div>
         </DialogHeader>
-        <div className="min-h-0 flex-1 bg-muted">
-          {iframeSrc && (
-            <iframe
-              src={iframeSrc}
-              title={preview?.title ?? "Vista previa PDF"}
-              className="h-full w-full border-0 bg-background"
-            />
+        <div className="min-h-0 flex-1 overflow-auto bg-muted">
+          {pdfSrc && (
+            <object
+              data={pdfSrc}
+              type="application/pdf"
+              className="block h-full min-h-[72vh] w-full bg-background"
+              aria-label={preview?.title ?? "Vista previa PDF"}
+            >
+              <iframe
+                src={pdfSrc}
+                title={preview?.title ?? "Vista previa PDF"}
+                className="block h-[72vh] w-full border-0 bg-background"
+                scrolling="yes"
+              />
+            </object>
           )}
         </div>
       </DialogContent>

--- a/src/components/hoja-de-ruta/HojaDeRutaPdfPreviewDialog.tsx
+++ b/src/components/hoja-de-ruta/HojaDeRutaPdfPreviewDialog.tsx
@@ -58,7 +58,7 @@ export const HojaDeRutaPdfPreviewDialog: React.FC<HojaDeRutaPdfPreviewDialogProp
                 size="sm"
                 onClick={onOpenInNewTab}
                 disabled={!preview}
-                aria-label="Abrir PDF en una pestana"
+                aria-label="Abrir PDF en una pestaña"
               >
                 <ExternalLink className="h-4 w-4 sm:mr-2" />
                 <span className="hidden sm:inline">Abrir</span>

--- a/src/components/hoja-de-ruta/HojaDeRutaPrintDialog.tsx
+++ b/src/components/hoja-de-ruta/HojaDeRutaPrintDialog.tsx
@@ -2,11 +2,18 @@ import React from "react";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Loader2, Table, Printer } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Eye, Loader2, Table, Printer } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { HojaDeRutaPdfSectionId } from "@/utils/hoja-de-ruta/pdf";
 
@@ -16,16 +23,23 @@ export interface HojaDeRutaPrintSection {
   icon: LucideIcon;
 }
 
+export type HojaDeRutaPrintPreviewTarget = HojaDeRutaPdfSectionId | "full" | "driver-certificate" | null;
+
 interface HojaDeRutaPrintDialogProps {
   showDialog: boolean;
   setShowDialog: (open: boolean) => void;
   onGeneratePDF: () => void;
   onGenerateDriverCertificatePDF: () => void;
   onGenerateSectionPDF: (sectionId: HojaDeRutaPdfSectionId) => void;
+  onPreviewPDF: () => void;
+  onPreviewDriverCertificatePDF: () => void;
+  onPreviewSectionPDF: (sectionId: HojaDeRutaPdfSectionId) => void;
   onGenerateXLS: () => void;
   sections: HojaDeRutaPrintSection[];
   isGenerating?: boolean;
   generatingSectionId?: HojaDeRutaPdfSectionId | null;
+  isPreviewing?: boolean;
+  previewingTarget?: HojaDeRutaPrintPreviewTarget;
 }
 
 export const HojaDeRutaPrintDialog: React.FC<HojaDeRutaPrintDialogProps> = ({
@@ -34,63 +48,122 @@ export const HojaDeRutaPrintDialog: React.FC<HojaDeRutaPrintDialogProps> = ({
   onGeneratePDF,
   onGenerateDriverCertificatePDF,
   onGenerateSectionPDF,
+  onPreviewPDF,
+  onPreviewDriverCertificatePDF,
+  onPreviewSectionPDF,
   onGenerateXLS,
   sections,
   isGenerating = false,
   generatingSectionId = null,
+  isPreviewing = false,
+  previewingTarget = null,
 }) => {
+  const isBusy = isGenerating || isPreviewing;
+
+  const renderPreviewButton = (
+    label: string,
+    target: Exclude<HojaDeRutaPrintPreviewTarget, null>,
+    onClick: () => void
+  ) => {
+    const isTargetPreviewing = isPreviewing && previewingTarget === target;
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-10 w-11 shrink-0"
+            onClick={() => { void onClick(); }}
+            disabled={isBusy}
+            aria-label={label}
+          >
+            {isTargetPreviewing ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    );
+  };
+
   return (
     <Dialog open={showDialog} onOpenChange={setShowDialog}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Exportar Hoja de Ruta</DialogTitle>
+          <DialogDescription className="sr-only">
+            Genera, previsualiza o exporta la hoja de ruta.
+          </DialogDescription>
         </DialogHeader>
-        <div className="space-y-4">
-          <div className="flex flex-col gap-2">
-            <h3 className="font-semibold text-base">Imprimir a PDF</h3>
-            <Button onClick={() => { void onGeneratePDF(); }} disabled={isGenerating}>
-              <Printer className="h-4 w-4 mr-2" />
-              Documento Completo PDF
-            </Button>
-            <Button onClick={() => { void onGenerateDriverCertificatePDF(); }} disabled={isGenerating} variant="outline">
-              <Printer className="h-4 w-4 mr-2" />
-              Hoja de Transportes PDF
-            </Button>
-          </div>
-          <div className="flex flex-col gap-2">
-            <h3 className="font-semibold text-base">Imprimir sección a PDF</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-72 overflow-y-auto pr-1">
-              {sections.map((section) => {
-                const Icon = section.icon;
-                const isSectionGenerating = generatingSectionId === section.id;
+        <TooltipProvider>
+          <div className="space-y-4">
+            <div className="flex flex-col gap-2">
+              <h3 className="font-semibold text-base">Imprimir a PDF</h3>
+              <div className="grid grid-cols-[minmax(0,1fr)_44px] gap-2">
+                <Button onClick={() => { void onGeneratePDF(); }} disabled={isBusy}>
+                  <Printer className="h-4 w-4 mr-2" />
+                  Documento Completo PDF
+                </Button>
+                {renderPreviewButton("Vista previa documento completo PDF", "full", onPreviewPDF)}
+              </div>
+              <div className="grid grid-cols-[minmax(0,1fr)_44px] gap-2">
+                <Button onClick={() => { void onGenerateDriverCertificatePDF(); }} disabled={isBusy} variant="outline">
+                  <Printer className="h-4 w-4 mr-2" />
+                  Hoja de Transportes PDF
+                </Button>
+                {renderPreviewButton(
+                  "Vista previa hoja de transportes PDF",
+                  "driver-certificate",
+                  onPreviewDriverCertificatePDF
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col gap-2">
+              <h3 className="font-semibold text-base">Imprimir sección a PDF</h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-h-72 overflow-y-auto pr-1">
+                {sections.map((section) => {
+                  const Icon = section.icon;
+                  const isSectionGenerating = generatingSectionId === section.id;
 
-                return (
-                  <Button
-                    key={section.id}
-                    onClick={() => { void onGenerateSectionPDF(section.id); }}
-                    disabled={isGenerating}
-                    variant="outline"
-                    className="justify-start"
-                  >
-                    {isSectionGenerating ? (
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    ) : (
-                      <Icon className="h-4 w-4 mr-2" />
-                    )}
-                    {section.label}
-                  </Button>
-                );
-              })}
+                  return (
+                    <div key={section.id} className="grid grid-cols-[minmax(0,1fr)_44px] gap-2">
+                      <Button
+                        onClick={() => { void onGenerateSectionPDF(section.id); }}
+                        disabled={isBusy}
+                        variant="outline"
+                        className="justify-start"
+                      >
+                        {isSectionGenerating ? (
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        ) : (
+                          <Icon className="h-4 w-4 mr-2" />
+                        )}
+                        {section.label}
+                      </Button>
+                      {renderPreviewButton(
+                        `Vista previa ${section.label}`,
+                        section.id,
+                        () => onPreviewSectionPDF(section.id)
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="flex flex-col gap-2">
+              <h3 className="font-semibold text-base">Exportar a Excel</h3>
+              <Button onClick={() => { void onGenerateXLS(); }} disabled={isBusy}>
+                <Table className="h-4 w-4 mr-2" />
+                Hoja de Ruta Excel (Una pestaña por sección)
+              </Button>
             </div>
           </div>
-          <div className="flex flex-col gap-2">
-            <h3 className="font-semibold text-base">Exportar a Excel</h3>
-            <Button onClick={() => { void onGenerateXLS(); }} disabled={isGenerating}>
-              <Table className="h-4 w-4 mr-2" />
-              Hoja de Ruta Excel (Una pestaña por sección)
-            </Button>
-          </div>
-        </div>
+        </TooltipProvider>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -63,12 +63,21 @@ import { ModernStatusIndicator } from "./components/ModernStatusIndicator";
 import { ModernProgressTracker } from "./components/ModernProgressTracker";
 import { ModernWeatherSection } from "./sections/ModernWeatherSection";
 import { ModernRestaurantSection } from "./sections/ModernRestaurantSection";
-import { HojaDeRutaPrintDialog } from "./HojaDeRutaPrintDialog";
+import {
+  HojaDeRutaPrintDialog,
+  type HojaDeRutaPrintPreviewTarget,
+} from "./HojaDeRutaPrintDialog";
+import {
+  HojaDeRutaPdfPreviewDialog,
+  type HojaDeRutaPdfPreview,
+} from "./HojaDeRutaPdfPreviewDialog";
 import { generateHojaDeRutaXLS } from "@/utils/hojaDeRutaExport";
 import {
   getHojaDeRutaPdfSectionLabel,
+  type GeneratedHojaDeRutaPdf,
   type HojaDeRutaPdfSectionId,
 } from "@/utils/hoja-de-ruta/pdf";
+import type { EventData, HojaDeRutaMetadata } from "@/types/hoja-de-ruta";
 import type { LucideIcon } from "lucide-react";
 
 type ModernHojaDeRutaProps = {
@@ -84,6 +93,10 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [showPrintDialog, setShowPrintDialog] = useState(false);
   const [generatingSectionId, setGeneratingSectionId] = useState<HojaDeRutaPdfSectionId | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [previewingTarget, setPreviewingTarget] = useState<HojaDeRutaPrintPreviewTarget>(null);
+  const [showPdfPreviewDialog, setShowPdfPreviewDialog] = useState(false);
+  const [pdfPreview, setPdfPreview] = useState<HojaDeRutaPdfPreview | null>(null);
 
   // Get image management functions first (needed for form hook)
   const {
@@ -172,6 +185,14 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     }
   }, [routedJobId, selectedJobId, setSelectedJobId]);
 
+  useEffect(() => {
+    return () => {
+      if (pdfPreview?.url) {
+        URL.revokeObjectURL(pdfPreview.url);
+      }
+    };
+  }, [pdfPreview?.url]);
+
   // Calculate completion progress including weather and restaurants
   useEffect(() => {
     const calculateProgress = () => {
@@ -196,41 +217,89 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     calculateProgress();
   }, [eventData, travelArrangements, accommodations]);
 
-  const buildPdfEventData = () => ({
+  const normalizeHojaStatus = (status?: string | null): HojaDeRutaMetadata["status"] => {
+    if (status === "draft" || status === "review" || status === "approved" || status === "final") {
+      return status;
+    }
+    return "draft";
+  };
+
+  const buildPdfEventData = (): EventData => ({
     ...eventData,
     metadata: hojaDeRuta ? {
       id: hojaDeRuta.id,
       document_version: hojaDeRuta.document_version || 1,
-      status: hojaDeRuta.status || 'draft',
+      status: normalizeHojaStatus(hojaDeRuta.status),
       created_at: hojaDeRuta.created_at || new Date().toISOString(),
       updated_at: hojaDeRuta.updated_at || new Date().toISOString(),
       last_modified: hojaDeRuta.last_modified || new Date().toISOString(),
     } : undefined
   });
 
+  const getRequiredSelectedJobId = () => {
+    if (selectedJobId) return selectedJobId;
+
+    toast({
+      title: "Error",
+      description: "Por favor, seleccione un trabajo antes de generar el documento.",
+      variant: "destructive",
+    });
+    return null;
+  };
+
+  const getSelectedJobDetails = (jobIdToFind = selectedJobId) => jobs?.find(job => job.id === jobIdToFind);
+
+  const saveBeforePdfGeneration = async () => {
+    if (isDirty || hasSavedData) {
+      await handleSaveAll();
+    }
+  };
+
+  const openGeneratedPdfPreview = (generatedPdf: GeneratedHojaDeRutaPdf) => {
+    setPdfPreview({
+      url: URL.createObjectURL(generatedPdf.blob),
+      filename: generatedPdf.filename,
+      title: generatedPdf.title,
+    });
+    setShowPrintDialog(false);
+    setShowPdfPreviewDialog(true);
+  };
+
+  const handlePdfPreviewOpenChange = (open: boolean) => {
+    setShowPdfPreviewDialog(open);
+  };
+
+  const handleDownloadPdfPreview = () => {
+    if (!pdfPreview) return;
+
+    const link = document.createElement("a");
+    link.href = pdfPreview.url;
+    link.download = pdfPreview.filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  };
+
+  const handleOpenPdfPreviewInNewTab = () => {
+    if (!pdfPreview) return;
+    window.open(pdfPreview.url, "_blank", "noopener,noreferrer");
+  };
+
   // Enhanced PDF generation using the working functionality
   const handleGeneratePDF = async () => {
-    if (!selectedJobId) {
-      toast({
-        title: "Error",
-        description: "Por favor, seleccione un trabajo antes de generar el documento.",
-        variant: "destructive",
-      });
-      return;
-    }
+    const currentJobId = getRequiredSelectedJobId();
+    if (!currentJobId) return;
 
     setGeneratingSectionId(null);
     setIsGenerating(true);
     try {
       // Save data first if there are changes
-      if (isDirty || hasSavedData) {
-        await handleSaveAll();
-      }
+      await saveBeforePdfGeneration();
 
       const { generatePDF } = await import("@/utils/hoja-de-ruta/pdf");
       const enhancedEventData = buildPdfEventData();
 
-      const jobDetails = jobs?.find(job => job.id === selectedJobId);
+      const jobDetails = getSelectedJobDetails(currentJobId);
       // Convert accommodations to legacy room assignments for PDF generation
       const legacyRoomAssignments = accommodations.flatMap(acc => acc.rooms);
       
@@ -240,7 +309,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
         legacyRoomAssignments,
         imagePreviews,
         venueMapPreview,
-        selectedJobId,
+        currentJobId,
         jobDetails?.title || "",
         jobDetails?.start_time || undefined,
         toast,
@@ -266,24 +335,16 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
   };
 
   const handleGenerateSectionPDF = async (sectionId: HojaDeRutaPdfSectionId) => {
-    if (!selectedJobId) {
-      toast({
-        title: "Error",
-        description: "Por favor, seleccione un trabajo antes de generar el documento.",
-        variant: "destructive",
-      });
-      return;
-    }
+    const currentJobId = getRequiredSelectedJobId();
+    if (!currentJobId) return;
 
     setGeneratingSectionId(sectionId);
     setIsGenerating(true);
     try {
-      if (isDirty || hasSavedData) {
-        await handleSaveAll();
-      }
+      await saveBeforePdfGeneration();
 
       const { generatePDF } = await import("@/utils/hoja-de-ruta/pdf");
-      const jobDetails = jobs?.find(job => job.id === selectedJobId);
+      const jobDetails = getSelectedJobDetails(currentJobId);
       const legacyRoomAssignments = accommodations.flatMap(acc => acc.rooms);
 
       await generatePDF(
@@ -292,7 +353,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
         legacyRoomAssignments,
         imagePreviews,
         venueMapPreview,
-        selectedJobId,
+        currentJobId,
         jobDetails?.title || "",
         jobDetails?.start_time || undefined,
         toast,
@@ -312,30 +373,65 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     }
   };
 
-  const handleGenerateDriverCertificatePDF = async () => {
-    if (!selectedJobId) {
+  const handlePreviewPDF = async (sectionId?: HojaDeRutaPdfSectionId) => {
+    const currentJobId = getRequiredSelectedJobId();
+    if (!currentJobId) return;
+
+    const target = sectionId ?? "full";
+    setPdfPreview(null);
+    setPreviewingTarget(target);
+    setIsPreviewing(true);
+    try {
+      await saveBeforePdfGeneration();
+
+      const { generatePDFPreview } = await import("@/utils/hoja-de-ruta/pdf");
+      const jobDetails = getSelectedJobDetails(currentJobId);
+      const legacyRoomAssignments = accommodations.flatMap(acc => acc.rooms);
+
+      const generatedPdf = await generatePDFPreview(
+        buildPdfEventData(),
+        travelArrangements,
+        legacyRoomAssignments,
+        imagePreviews,
+        venueMapPreview,
+        currentJobId,
+        jobDetails?.title || "",
+        jobDetails?.start_time || undefined,
+        undefined,
+        accommodations,
+        sectionId ? { sections: [sectionId] } : undefined
+      );
+
+      openGeneratedPdfPreview(generatedPdf);
+    } catch (error) {
+      console.error("Error previewing PDF:", error);
       toast({
-        title: "Error",
-        description: "Por favor, seleccione un trabajo antes de generar la hoja de transportes.",
+        title: "❌ Error",
+        description: "Hubo un problema al preparar la vista previa.",
         variant: "destructive",
       });
-      return;
+    } finally {
+      setIsPreviewing(false);
+      setPreviewingTarget(null);
     }
+  };
+
+  const handleGenerateDriverCertificatePDF = async () => {
+    const currentJobId = getRequiredSelectedJobId();
+    if (!currentJobId) return;
 
     setGeneratingSectionId(null);
     setIsGenerating(true);
     try {
-      if (isDirty || hasSavedData) {
-        await handleSaveAll();
-      }
+      await saveBeforePdfGeneration();
 
       const { generateDriverCertificatePDF } = await import("@/utils/hoja-de-ruta/pdf");
 
-      const jobDetails = jobs?.find(job => job.id === selectedJobId);
+      const jobDetails = getSelectedJobDetails(currentJobId);
 
       await generateDriverCertificatePDF({
         eventData,
-        selectedJobId,
+        selectedJobId: currentJobId,
         jobTitle: jobDetails?.title || "",
         jobDate: jobDetails?.start_time || undefined,
         venueMapPreview,
@@ -350,6 +446,41 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
       });
     } finally {
       setIsGenerating(false);
+    }
+  };
+
+  const handlePreviewDriverCertificatePDF = async () => {
+    const currentJobId = getRequiredSelectedJobId();
+    if (!currentJobId) return;
+
+    setPdfPreview(null);
+    setPreviewingTarget("driver-certificate");
+    setIsPreviewing(true);
+    try {
+      await saveBeforePdfGeneration();
+
+      const { generateDriverCertificatePDFPreview } = await import("@/utils/hoja-de-ruta/pdf");
+      const jobDetails = getSelectedJobDetails(currentJobId);
+
+      const generatedPdf = await generateDriverCertificatePDFPreview({
+        eventData,
+        selectedJobId: currentJobId,
+        jobTitle: jobDetails?.title || "",
+        jobDate: jobDetails?.start_time || undefined,
+        venueMapPreview,
+      });
+
+      openGeneratedPdfPreview(generatedPdf);
+    } catch (error) {
+      console.error("Error previewing driver certificate PDF:", error);
+      toast({
+        title: "❌ Error",
+        description: "Hubo un problema al preparar la vista previa de transportes.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsPreviewing(false);
+      setPreviewingTarget(null);
     }
   };
 
@@ -835,10 +966,22 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
         onGeneratePDF={handleGeneratePDF}
         onGenerateDriverCertificatePDF={handleGenerateDriverCertificatePDF}
         onGenerateSectionPDF={handleGenerateSectionPDF}
+        onPreviewPDF={() => { void handlePreviewPDF(); }}
+        onPreviewDriverCertificatePDF={handlePreviewDriverCertificatePDF}
+        onPreviewSectionPDF={handlePreviewPDF}
         onGenerateXLS={handleGenerateXLS}
         sections={tabConfig}
         isGenerating={isGenerating}
         generatingSectionId={generatingSectionId}
+        isPreviewing={isPreviewing}
+        previewingTarget={previewingTarget}
+      />
+      <HojaDeRutaPdfPreviewDialog
+        open={showPdfPreviewDialog}
+        preview={pdfPreview}
+        onOpenChange={handlePdfPreviewOpenChange}
+        onDownload={handleDownloadPdfPreview}
+        onOpenInNewTab={handleOpenPdfPreviewInNewTab}
       />
     </div>
   );

--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -714,6 +714,22 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
               </Button>
 
               <Button
+                onClick={() => { void handlePreviewPDF(); }}
+                disabled={!selectedJobId || !isInitialized || isSaving || isGenerating || isPreviewing}
+                variant="outline"
+                size="sm"
+                aria-label="Vista previa PDF"
+                className="h-11 min-w-[44px] border-2 border-blue-500 text-blue-600 hover:bg-blue-50"
+              >
+                {isPreviewing && previewingTarget === "full" ? (
+                  <Loader2 className="w-4 h-4 sm:mr-2 animate-spin" />
+                ) : (
+                  <Eye className="w-4 h-4 sm:mr-2" />
+                )}
+                <span className="hidden sm:inline">Vista previa</span>
+              </Button>
+
+              <Button
                 onClick={() => setShowPrintDialog(true)}
                 disabled={!selectedJobId}
                 aria-label="Exportar"

--- a/src/components/hoja-de-ruta/__tests__/HojaDeRutaPrintDialog.test.tsx
+++ b/src/components/hoja-de-ruta/__tests__/HojaDeRutaPrintDialog.test.tsx
@@ -27,6 +27,9 @@ describe("HojaDeRutaPrintDialog", () => {
         onGeneratePDF={vi.fn()}
         onGenerateDriverCertificatePDF={vi.fn()}
         onGenerateSectionPDF={onGenerateSectionPDF}
+        onPreviewPDF={vi.fn()}
+        onPreviewDriverCertificatePDF={vi.fn()}
+        onPreviewSectionPDF={vi.fn()}
         onGenerateXLS={vi.fn()}
         sections={sections}
       />
@@ -39,5 +42,34 @@ describe("HojaDeRutaPrintDialog", () => {
 
     expect(onGenerateSectionPDF).toHaveBeenCalledTimes(1);
     expect(onGenerateSectionPDF).toHaveBeenCalledWith("event");
+  });
+
+  it("calls preview handlers without using generate actions", async () => {
+    const user = userEvent.setup();
+    const onGeneratePDF = vi.fn();
+    const onPreviewPDF = vi.fn();
+    const onPreviewSectionPDF = vi.fn();
+
+    render(
+      <HojaDeRutaPrintDialog
+        showDialog
+        setShowDialog={vi.fn()}
+        onGeneratePDF={onGeneratePDF}
+        onGenerateDriverCertificatePDF={vi.fn()}
+        onGenerateSectionPDF={vi.fn()}
+        onPreviewPDF={onPreviewPDF}
+        onPreviewDriverCertificatePDF={vi.fn()}
+        onPreviewSectionPDF={onPreviewSectionPDF}
+        onGenerateXLS={vi.fn()}
+        sections={sections}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Vista previa documento completo PDF" }));
+    await user.click(screen.getByRole("button", { name: "Vista previa Evento" }));
+
+    expect(onPreviewPDF).toHaveBeenCalledTimes(1);
+    expect(onPreviewSectionPDF).toHaveBeenCalledWith("event");
+    expect(onGeneratePDF).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/hoja-de-ruta/pdf/core/pdf-types.ts
+++ b/src/utils/hoja-de-ruta/pdf/core/pdf-types.ts
@@ -18,6 +18,18 @@ export type {
   ImagePreviews
 };
 
+export interface GeneratedHojaDeRutaPdf {
+  blob: Blob;
+  filename: string;
+  title: string;
+}
+
+export type HojaDeRutaPdfToast = (props: {
+  title: string;
+  description?: string;
+  variant?: string;
+}) => void;
+
 // PDF-specific types
 export interface PDFGenerationOptions {
   eventData: EventData;
@@ -28,7 +40,7 @@ export interface PDFGenerationOptions {
   selectedJobId: string;
   jobTitle: string;
   jobDate?: string;
-  toast?: any;
+  toast?: HojaDeRutaPdfToast;
   accommodations?: Accommodation[];
   // Rendering options (defaults applied in engine)
   includeAccommodationRooming?: boolean;
@@ -45,5 +57,5 @@ export interface DriverCertificatePDFGenerationOptions {
   jobTitle: string;
   jobDate?: string;
   venueMapPreview?: string | null;
-  toast?: any;
+  toast?: HojaDeRutaPdfToast;
 }

--- a/src/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine.ts
+++ b/src/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine.ts
@@ -5,7 +5,7 @@ import { supabase } from '@/lib/supabase';
 
 import { uploadPdfToJob } from '../pdf-upload';
 import { PDFDocument } from './core/pdf-document';
-import { DriverCertificatePDFGenerationOptions } from './core/pdf-types';
+import type { DriverCertificatePDFGenerationOptions, GeneratedHojaDeRutaPdf } from './core/pdf-types';
 import { FooterService } from './services/footer-service';
 import { HeaderService } from './services/header-service';
 import { LogoService } from './services/logo-service';
@@ -32,6 +32,23 @@ type CertificateJobContext = {
   jobLocation?: string | null;
 };
 
+type WarehouseFallbackJobRow = {
+  id: string;
+  title: string | null;
+  start_time: string | null;
+};
+
+type DeliveryCertificateJobRow = {
+  invoicing_company: string | null;
+  location: {
+    name: string | null;
+    formatted_address: string | null;
+  } | Array<{
+    name: string | null;
+    formatted_address: string | null;
+  }> | null;
+};
+
 export class DriverCertificatePDFEngine {
   private pdfDoc: PDFDocument;
   private deliveryCertificateSection: DeliveryCertificateSection;
@@ -42,51 +59,13 @@ export class DriverCertificatePDFEngine {
   }
 
   async generate(): Promise<void> {
-    const {
-      eventData,
-      selectedJobId,
-      jobTitle,
-      jobDate,
-      venueMapPreview = null,
-      toast,
-    } = this.options;
+    const { selectedJobId, toast } = this.options;
 
     try {
-      const [logoData, logisticsEvents, certificateJobContext, sectorProStamp] = await Promise.all([
-        LogoService.loadJobLogo(selectedJobId),
-        this.fetchWarehouseLogisticsEvents(selectedJobId, eventData),
-        this.fetchDeliveryCertificateJobContext(selectedJobId),
-        StampService.loadExactSectorProStamp(),
-      ]);
+      const generatedPdf = await this.renderPDF();
 
-      const headerLogoDims = await this.getHeaderLogoDims(logoData);
-      HeaderService.addHeaderToCurrentPage(
-        this.pdfDoc,
-        'Hoja de Transportes',
-        jobTitle,
-        jobDate,
-        logoData || undefined,
-        headerLogoDims
-      );
-
-      let yPosition = 54;
-
-      yPosition = await this.addVenueSection(eventData, yPosition, venueMapPreview);
-      yPosition = this.addContactsSection(eventData, yPosition);
-      yPosition = this.addWarehouseScheduleSection(logisticsEvents, yPosition);
-
-      const logisticsTypeBySourceId = new Map<string, string>(
-        logisticsEvents.map((event) => [event.id, event.event_type])
-      );
-      yPosition = this.addVenueScheduleSection(eventData, yPosition, logisticsTypeBySourceId);
-      yPosition = this.addLegalCertificateSection(eventData, yPosition, {
-        ...certificateJobContext,
-        issueDate: new Date(),
-        stamp: sectorProStamp,
-      });
-
-      await FooterService.addFooterToAllPages(this.pdfDoc, jobTitle);
-      await this.saveAndUploadPDF();
+      this.pdfDoc.save(generatedPdf.filename);
+      await this.uploadPDF(selectedJobId, generatedPdf.blob, generatedPdf.filename);
 
       toast?.({
         title: '✅ Documento generado',
@@ -101,6 +80,57 @@ export class DriverCertificatePDFEngine {
       });
       throw error;
     }
+  }
+
+  async generatePreview(): Promise<GeneratedHojaDeRutaPdf> {
+    return this.renderPDF();
+  }
+
+  private async renderPDF(): Promise<GeneratedHojaDeRutaPdf> {
+    const {
+      eventData,
+      selectedJobId,
+      jobTitle,
+      jobDate,
+      venueMapPreview = null,
+    } = this.options;
+
+    const [logoData, logisticsEvents, certificateJobContext, sectorProStamp] = await Promise.all([
+      LogoService.loadJobLogo(selectedJobId),
+      this.fetchWarehouseLogisticsEvents(selectedJobId, eventData),
+      this.fetchDeliveryCertificateJobContext(selectedJobId),
+      StampService.loadExactSectorProStamp(),
+    ]);
+
+    const headerLogoDims = await this.getHeaderLogoDims(logoData);
+    HeaderService.addHeaderToCurrentPage(
+      this.pdfDoc,
+      'Hoja de Transportes',
+      jobTitle,
+      jobDate,
+      logoData || undefined,
+      headerLogoDims
+    );
+
+    let yPosition = 54;
+
+    yPosition = await this.addVenueSection(eventData, yPosition, venueMapPreview);
+    yPosition = this.addContactsSection(eventData, yPosition);
+    yPosition = this.addWarehouseScheduleSection(logisticsEvents, yPosition);
+
+    const logisticsTypeBySourceId = new Map<string, string>(
+      logisticsEvents.map((event) => [event.id, event.event_type])
+    );
+    yPosition = this.addVenueScheduleSection(eventData, yPosition, logisticsTypeBySourceId);
+    yPosition = this.addLegalCertificateSection(eventData, yPosition, {
+      ...certificateJobContext,
+      issueDate: new Date(),
+      stamp: sectorProStamp,
+    });
+
+    await FooterService.addFooterToAllPages(this.pdfDoc, jobTitle);
+
+    return this.createGeneratedPDF();
   }
 
   private async addVenueSection(eventData: EventData, yPosition: number, venueMapPreview: string | null): Promise<number> {
@@ -376,7 +406,8 @@ export class DriverCertificatePDFEngine {
 
       if (currentJobError) throw currentJobError;
 
-      const currentTitle = (currentJob as any)?.title || '';
+      const currentJobRow = currentJob as WarehouseFallbackJobRow | null;
+      const currentTitle = currentJobRow?.title || '';
       const titlePrefix = this.extractJobTitlePrefix(currentTitle);
       if (!titlePrefix) return [];
 
@@ -389,7 +420,7 @@ export class DriverCertificatePDFEngine {
 
       if (relatedJobsError) throw relatedJobsError;
 
-      const currentStartTime = (currentJob as any)?.start_time ? new Date((currentJob as any).start_time) : null;
+      const currentStartTime = currentJobRow?.start_time ? new Date(currentJobRow.start_time) : null;
 
       const candidates = ((relatedJobs || []) as Array<{ id: string; title: string | null; start_time: string | null }>)
         .map((job) => {
@@ -438,11 +469,13 @@ export class DriverCertificatePDFEngine {
 
       if (error) throw error;
 
-      const location = (data as any)?.location;
+      const jobData = data as unknown as DeliveryCertificateJobRow | null;
+      const rawLocation = jobData?.location;
+      const location = Array.isArray(rawLocation) ? rawLocation[0] : rawLocation;
       const jobLocation = (location?.formatted_address || location?.name || null) as string | null;
 
       return {
-        invoicingCompany: (data as any)?.invoicing_company || null,
+        invoicingCompany: jobData?.invoicing_company || null,
         jobLocation,
       };
     } catch (error) {
@@ -454,8 +487,8 @@ export class DriverCertificatePDFEngine {
     }
   }
 
-  private async saveAndUploadPDF(): Promise<void> {
-    const { eventData, selectedJobId, jobTitle } = this.options;
+  private createGeneratedPDF(): GeneratedHojaDeRutaPdf {
+    const { eventData, jobTitle } = this.options;
 
     const eventName = eventData.eventName || jobTitle || 'Evento';
     const safeEventName = eventName.replace(/_/g, ' ').replace(/\s+/g, ' ').trim() || 'Evento';
@@ -464,10 +497,15 @@ export class DriverCertificatePDFEngine {
     const timePart = nowIso.slice(11, 19).replace(/:/g, '-');
     const filename = `Hoja de Transportes - ${safeEventName} - ${datePart} ${timePart}.pdf`;
 
-    this.pdfDoc.save(filename);
+    return {
+      blob: this.pdfDoc.outputBlob(),
+      filename,
+      title: 'Hoja de Transportes',
+    };
+  }
 
+  private async uploadPDF(selectedJobId: string, pdfBlob: Blob, filename: string): Promise<void> {
     try {
-      const pdfBlob = this.pdfDoc.outputBlob();
       await uploadPdfToJob(selectedJobId, pdfBlob, filename, { kind: 'certificado_entrega' });
       console.log('✅ Driver certificate PDF uploaded to job storage successfully');
     } catch (uploadError) {

--- a/src/utils/hoja-de-ruta/pdf/index.ts
+++ b/src/utils/hoja-de-ruta/pdf/index.ts
@@ -4,28 +4,62 @@ export {
   getHojaDeRutaPdfSelectionLabel,
   HOJA_DE_RUTA_PDF_SECTIONS
 } from '@/utils/hoja-de-ruta/pdf/section-options';
-export type { DriverCertificatePDFGenerationOptions, PDFGenerationOptions } from '@/utils/hoja-de-ruta/pdf/core/pdf-types';
+export type {
+  DriverCertificatePDFGenerationOptions,
+  GeneratedHojaDeRutaPdf,
+  PDFGenerationOptions,
+} from '@/utils/hoja-de-ruta/pdf/core/pdf-types';
 export type { HojaDeRutaPdfSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
 import { PDFEngine } from '@/utils/hoja-de-ruta/pdf/pdf-engine';
 import { DriverCertificatePDFEngine } from '@/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine';
-import type { DriverCertificatePDFGenerationOptions, PDFGenerationOptions } from '@/utils/hoja-de-ruta/pdf/core/pdf-types';
+import type {
+  DriverCertificatePDFGenerationOptions,
+  GeneratedHojaDeRutaPdf,
+  PDFGenerationOptions,
+} from '@/utils/hoja-de-ruta/pdf/core/pdf-types';
+
+const createPDFEngine = (
+  eventData: PDFGenerationOptions['eventData'],
+  travelArrangements: PDFGenerationOptions['travelArrangements'],
+  roomAssignments: PDFGenerationOptions['roomAssignments'],
+  imagePreviews: PDFGenerationOptions['imagePreviews'],
+  venueMapPreview: string | null,
+  selectedJobId: string,
+  jobTitle: string,
+  jobDate?: string,
+  toast?: PDFGenerationOptions['toast'],
+  accommodations?: PDFGenerationOptions['accommodations'],
+  pdfOptions?: Pick<PDFGenerationOptions, 'sections'>
+) => new PDFEngine({
+  eventData,
+  travelArrangements,
+  roomAssignments,
+  imagePreviews,
+  venueMapPreview,
+  selectedJobId,
+  jobTitle,
+  jobDate,
+  toast,
+  accommodations,
+  ...pdfOptions
+});
 
 // Main export function for backward compatibility
 export const generatePDF = async (
-  eventData: any,
-  travelArrangements: any[],
-  roomAssignments: any[],
-  imagePreviews: any,
+  eventData: PDFGenerationOptions['eventData'],
+  travelArrangements: PDFGenerationOptions['travelArrangements'],
+  roomAssignments: PDFGenerationOptions['roomAssignments'],
+  imagePreviews: PDFGenerationOptions['imagePreviews'],
   venueMapPreview: string | null,
   selectedJobId: string,
   jobTitle: string,
   // Optional parameters to enhance headers without breaking callers
   jobDate?: string,
-  toast?: any,
-  accommodations?: any[],
+  toast?: PDFGenerationOptions['toast'],
+  accommodations?: PDFGenerationOptions['accommodations'],
   pdfOptions?: Pick<PDFGenerationOptions, 'sections'>
 ): Promise<void> => {
-  const engine = new PDFEngine({
+  const engine = createPDFEngine(
     eventData,
     travelArrangements,
     roomAssignments,
@@ -36,10 +70,40 @@ export const generatePDF = async (
     jobDate,
     toast,
     accommodations,
-    ...pdfOptions
-  });
+    pdfOptions
+  );
   
   return engine.generate();
+};
+
+export const generatePDFPreview = async (
+  eventData: PDFGenerationOptions['eventData'],
+  travelArrangements: PDFGenerationOptions['travelArrangements'],
+  roomAssignments: PDFGenerationOptions['roomAssignments'],
+  imagePreviews: PDFGenerationOptions['imagePreviews'],
+  venueMapPreview: string | null,
+  selectedJobId: string,
+  jobTitle: string,
+  jobDate?: string,
+  toast?: PDFGenerationOptions['toast'],
+  accommodations?: PDFGenerationOptions['accommodations'],
+  pdfOptions?: Pick<PDFGenerationOptions, 'sections'>
+): Promise<GeneratedHojaDeRutaPdf> => {
+  const engine = createPDFEngine(
+    eventData,
+    travelArrangements,
+    roomAssignments,
+    imagePreviews,
+    venueMapPreview,
+    selectedJobId,
+    jobTitle,
+    jobDate,
+    toast,
+    accommodations,
+    pdfOptions
+  );
+
+  return engine.generatePreview();
 };
 
 export const generateDriverCertificatePDF = async (
@@ -47,4 +111,11 @@ export const generateDriverCertificatePDF = async (
 ): Promise<void> => {
   const engine = new DriverCertificatePDFEngine(options);
   return engine.generate();
+};
+
+export const generateDriverCertificatePDFPreview = async (
+  options: DriverCertificatePDFGenerationOptions
+): Promise<GeneratedHojaDeRutaPdf> => {
+  const engine = new DriverCertificatePDFEngine(options);
+  return engine.generatePreview();
 };

--- a/src/utils/hoja-de-ruta/pdf/pdf-engine.ts
+++ b/src/utils/hoja-de-ruta/pdf/pdf-engine.ts
@@ -1,5 +1,5 @@
 import { PDFDocument } from './core/pdf-document';
-import { PDFGenerationOptions } from './core/pdf-types';
+import type { GeneratedHojaDeRutaPdf, PDFGenerationOptions } from './core/pdf-types';
 import { LogoService } from './services/logo-service';
 import { uploadPdfToJob } from '../pdf-upload';
 import { HeaderSection } from './sections/header-section';
@@ -27,81 +27,18 @@ export class PDFEngine {
   }
 
   async generate(): Promise<void> {
-    const {
-      selectedJobId,
-      jobTitle,
-      toast,
-    } = this.options;
-    const selectedSections = this.options.sections?.length ? this.options.sections : undefined;
-    const sectionSelection = selectedSections ? new Set(selectedSections) : undefined;
-    const selectedSectionLabel = selectedSections
-      ? getHojaDeRutaPdfSelectionLabel(selectedSections) ?? "Secciones seleccionadas"
-      : undefined;
-    this.hasCoverPage = !sectionSelection;
-    this.renderedSectionCount = 0;
+    const { selectedJobId, toast } = this.options;
 
     try {
-      // Load logo first (used on cover and in page header)
-      this.logoData = await LogoService.loadJobLogo(selectedJobId);
+      const generatedPdf = await this.renderPDF();
 
-      // Compute header logo scaled dimensions to keep aspect ratio
-      let headerLogoDims: { width: number; height: number } | undefined = undefined;
-      if (this.logoData) {
-        headerLogoDims = await new Promise((resolve) => {
-          const img = new Image();
-          img.onload = () => {
-            const MAX_H = 28;
-            const MAX_W = 160;
-            const w = img.naturalWidth || img.width;
-            const h = img.naturalHeight || img.height;
-            if (w > 0 && h > 0) {
-              const scale = Math.min(MAX_H / h, MAX_W / w);
-              resolve({ width: Math.round(w * scale), height: Math.round(h * scale) });
-            } else {
-              resolve({ width: 84, height: 28 });
-            }
-          };
-          img.onerror = () => resolve({ width: 84, height: 28 });
-          img.src = this.logoData!;
-        });
-      }
-
-      // Initialize header section now that we have job info and logo
-      this.headerSection = new HeaderSection(
-        this.pdfDoc,
-        jobTitle,
-        this.options.jobDate,
-        selectedSections
-          ? `Hoja de Ruta - ${selectedSectionLabel}`
-          : 'Hoja de Ruta',
-        this.logoData || undefined,
-        headerLogoDims
-      );
-      
-      if (this.hasCoverPage) {
-        const coverSection = new CoverSection(this.pdfDoc, this.options.eventData, this.options.jobTitle, this.logoData);
-        await coverSection.generateCoverPage();
-      }
-
-      if (sectionSelection) {
-        await this.generateSelectedSections(sectionSelection);
-        if (this.renderedSectionCount === 0) {
-          this.addEmptySectionPage(selectedSections);
-        }
-      } else {
-        await this.generateFullDocument();
-      }
-
-      // Add Sector-Pro footer to all pages with page numbers and job name
-      await FooterService.addFooterToAllPages(this.pdfDoc, jobTitle, { hasCoverPage: this.hasCoverPage });
-
-      // Save and upload PDF
-      await this.saveAndUploadPDF();
+      this.pdfDoc.save(generatedPdf.filename);
+      await this.uploadPDF(selectedJobId, generatedPdf.blob, generatedPdf.filename);
 
       toast?.({
         title: "✅ Documento generado",
-        description: selectedSectionLabel
-          ? `${selectedSectionLabel} se ha generado y descargado correctamente.`
+        description: generatedPdf.sectionLabel
+          ? `${generatedPdf.sectionLabel} se ha generado y descargado correctamente.`
           : "La hoja de ruta ha sido generada y descargada correctamente.",
       });
 
@@ -114,6 +51,83 @@ export class PDFEngine {
       });
       throw error;
     }
+  }
+
+  async generatePreview(): Promise<GeneratedHojaDeRutaPdf> {
+    return this.renderPDF();
+  }
+
+  private async renderPDF(): Promise<GeneratedHojaDeRutaPdf & { sectionLabel?: string }> {
+    const {
+      selectedJobId,
+      jobTitle,
+    } = this.options;
+    const selectedSections = this.options.sections?.length ? this.options.sections : undefined;
+    const sectionSelection = selectedSections ? new Set(selectedSections) : undefined;
+    const selectedSectionLabel = selectedSections
+      ? getHojaDeRutaPdfSelectionLabel(selectedSections) ?? "Secciones seleccionadas"
+      : undefined;
+    this.hasCoverPage = !sectionSelection;
+    this.renderedSectionCount = 0;
+
+    // Load logo first (used on cover and in page header)
+    this.logoData = await LogoService.loadJobLogo(selectedJobId);
+
+    // Compute header logo scaled dimensions to keep aspect ratio
+    let headerLogoDims: { width: number; height: number } | undefined = undefined;
+    if (this.logoData) {
+      headerLogoDims = await new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => {
+          const MAX_H = 28;
+          const MAX_W = 160;
+          const w = img.naturalWidth || img.width;
+          const h = img.naturalHeight || img.height;
+          if (w > 0 && h > 0) {
+            const scale = Math.min(MAX_H / h, MAX_W / w);
+            resolve({ width: Math.round(w * scale), height: Math.round(h * scale) });
+          } else {
+            resolve({ width: 84, height: 28 });
+          }
+        };
+        img.onerror = () => resolve({ width: 84, height: 28 });
+        img.src = this.logoData!;
+      });
+    }
+
+    // Initialize header section now that we have job info and logo
+    this.headerSection = new HeaderSection(
+      this.pdfDoc,
+      jobTitle,
+      this.options.jobDate,
+      selectedSections
+        ? `Hoja de Ruta - ${selectedSectionLabel}`
+        : 'Hoja de Ruta',
+      this.logoData || undefined,
+      headerLogoDims
+    );
+    
+    if (this.hasCoverPage) {
+      const coverSection = new CoverSection(this.pdfDoc, this.options.eventData, this.options.jobTitle, this.logoData);
+      await coverSection.generateCoverPage();
+    }
+
+    if (sectionSelection) {
+      await this.generateSelectedSections(sectionSelection);
+      if (this.renderedSectionCount === 0) {
+        this.addEmptySectionPage(selectedSections);
+      }
+    } else {
+      await this.generateFullDocument();
+    }
+
+    // Add Sector-Pro footer to all pages with page numbers and job name
+    await FooterService.addFooterToAllPages(this.pdfDoc, jobTitle, { hasCoverPage: this.hasCoverPage });
+
+    return {
+      ...this.createGeneratedPDF(),
+      sectionLabel: selectedSectionLabel,
+    };
   }
 
   private async generateFullDocument(): Promise<void> {
@@ -333,10 +347,13 @@ export class PDFEngine {
       Boolean(this.options.imagePreviews?.venue?.length);
   }
 
-  private async saveAndUploadPDF(): Promise<void> {
-    const { eventData, selectedJobId, jobTitle } = this.options;
+  private createGeneratedPDF(): GeneratedHojaDeRutaPdf {
+    const { eventData, jobTitle } = this.options;
     const sectionFilenameLabel = this.options.sections?.length === 1
       ? getHojaDeRutaPdfSectionFilenameLabel(this.options.sections[0])
+      : undefined;
+    const sectionTitleLabel = this.options.sections?.length
+      ? getHojaDeRutaPdfSelectionLabel(this.options.sections)
       : undefined;
     
     // Generate filename
@@ -348,12 +365,15 @@ export class PDFEngine {
     const sectionPart = sectionFilenameLabel ? ` - ${sectionFilenameLabel}` : "";
     const filename = `Hoja de Ruta${sectionPart} - ${safeEventName} - ${datePart} ${timePart}.pdf`;
 
-    // Save locally
-    this.pdfDoc.save(filename);
+    return {
+      blob: this.pdfDoc.outputBlob(),
+      filename,
+      title: sectionTitleLabel ? `Hoja de Ruta - ${sectionTitleLabel}` : 'Hoja de Ruta',
+    };
+  }
 
-    // Upload to job storage
+  private async uploadPDF(selectedJobId: string, pdfBlob: Blob, filename: string): Promise<void> {
     try {
-      const pdfBlob = this.pdfDoc.outputBlob();
       await uploadPdfToJob(selectedJobId, pdfBlob, filename);
       console.log('✅ PDF uploaded to job storage successfully');
     } catch (uploadError) {


### PR DESCRIPTION
## What changed
- Adds a non-uploading PDF preview path for Hoja de Ruta exports.
- Adds preview buttons for the full Hoja de Ruta PDF, Hoja de Transportes PDF, and individual section PDFs.
- Adds a main ModernHojaDeRuta header preview button next to `Guardar`.
- Adds a preview modal with embedded scrollable PDF display plus open and download actions.

## Why
Production users need a way to inspect generated Hoja de Ruta PDFs before committing them to job documents/storage.

## Risk Assessment
Risk level: low to medium. The change is UI and PDF-generation-path focused, with no schema or storage policy changes.

Main risks: browser-native PDF embed behavior can vary by platform, object URL cleanup must avoid stale previews, and preview buttons must not accidentally call upload/generate paths.

## Test Evidence
- `npm install --legacy-peer-deps`
- `npm run test:run -- src/components/hoja-de-ruta/__tests__/HojaDeRutaPrintDialog.test.tsx src/utils/hoja-de-ruta/pdf/__tests__/section-options.test.ts`
- `npx eslint src/components/hoja-de-ruta/HojaDeRutaPrintDialog.tsx src/components/hoja-de-ruta/HojaDeRutaPdfPreviewDialog.tsx src/components/hoja-de-ruta/ModernHojaDeRuta.tsx src/components/hoja-de-ruta/__tests__/HojaDeRutaPrintDialog.test.tsx src/utils/hoja-de-ruta/pdf/core/pdf-types.ts src/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine.ts src/utils/hoja-de-ruta/pdf/index.ts src/utils/hoja-de-ruta/pdf/pdf-engine.ts`
- `npm run lint` (passes with existing repo-wide warnings)
- `npm run build`

## Known local validation notes
- `npm run typecheck` still fails on existing unrelated Supabase typing issues in festival/sound/video/task/tour power files.
- Full `npm run test:run` still fails on existing local test-environment `localStorage` issues in `JobAssignmentMatrix` and `TechnicianSuperApp`; those failing files reproduce when run alone.

## Rollback Plan
Revert this PR. No data migration or storage cleanup is required because preview generation creates temporary local object URLs and does not upload preview PDFs.

## Migration Impact
No Supabase migrations, database changes, or production `supabase db push` required. Merging `main` is the production deploy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF preview for roadmap documents, driver certificates, and individual sections
  * Preview dialog with open-in-new-tab and download actions
  * Preview buttons added alongside all generation/export options and a header “Vista previa” action

* **Improvements**
  * Unified busy state for previewing and generation for consistent UX
  * Automatic cleanup of temporary preview resources (object URLs)
  * Stronger typing for PDF payloads and preview flows

* **Tests**
  * Added tests verifying preview button behavior and handlers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
