### PR TITLE
[codex] Fix mobile project filters and dashboard locations

### DIFF
--- a/src/components/dashboard/DashboardMobileHub.tsx
+++ b/src/components/dashboard/DashboardMobileHub.tsx
@@ -47,6 +47,9 @@ const themeTokens = {
   hover: "hover:bg-accent",
 };
 
+const getJobLocationName = (job: any) =>
+  job.location?.name || job.location_data?.name || job.locations?.name || job.venue || "Sin ubicación";
+
 export const DashboardMobileHub: React.FC<DashboardMobileHubProps> = ({
   jobs,
   date,
@@ -457,7 +460,7 @@ export const DashboardMobileHub: React.FC<DashboardMobileHubProps> = ({
                         {getCalendarJobDisplayTitle(job, selectedDate)}
                       </h3>
                       <div className={cn("text-xs mt-1", themeTokens.textMuted)}>
-                        {job.location_data?.name || "Sin ubicación"}
+                        {getJobLocationName(job)}
                       </div>
                       {departments.length > 0 && (
                         <div className="flex flex-wrap gap-1 mt-1">

--- a/src/components/dashboard/DashboardMobileHub.tsx
+++ b/src/components/dashboard/DashboardMobileHub.tsx
@@ -48,7 +48,15 @@ const themeTokens = {
 };
 
 const getJobLocationName = (job: any) =>
-  job.location?.name || job.location_data?.name || job.locations?.name || job.venue || "Sin ubicación";
+  (typeof job.location === "string" && job.location) ||
+  job.location?.name ||
+  job.location?.formatted_address ||
+  job.location_data?.name ||
+  job.location_data?.formatted_address ||
+  job.locations?.name ||
+  job.venue_name ||
+  job.venue ||
+  "Sin ubicación";
 
 export const DashboardMobileHub: React.FC<DashboardMobileHubProps> = ({
   jobs,

--- a/src/components/dashboard/__tests__/DashboardMobileHub.test.tsx
+++ b/src/components/dashboard/__tests__/DashboardMobileHub.test.tsx
@@ -2,7 +2,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { DashboardMobileHub } from "../DashboardMobileHub";
+import { DashboardMobileHub } from "@/components/dashboard/DashboardMobileHub";
 
 vi.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => true,
@@ -49,6 +49,36 @@ describe("DashboardMobileHub", () => {
     );
 
     expect(await screen.findByText("Madrid Arena")).toBeInTheDocument();
+    expect(screen.queryByText("Sin ubicación")).not.toBeInTheDocument();
+  });
+
+  it("preserves legacy string location values", async () => {
+    render(
+      <DashboardMobileHub
+        jobs={[
+          {
+            id: "job-legacy-location",
+            title: "Legacy Location Job",
+            job_type: "single",
+            status: "Confirmado",
+            start_time: "2026-06-03T08:00:00.000Z",
+            end_time: "2026-06-03T23:59:00.000Z",
+            timezone: "Europe/Madrid",
+            location: "WiZink Center",
+            job_departments: [{ department: "sound" }],
+            job_assignments: [],
+          },
+        ]}
+        date={new Date("2026-06-03T12:00:00.000Z")}
+        onDateSelect={vi.fn()}
+        userRole="management"
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+        onJobClick={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText("WiZink Center")).toBeInTheDocument();
     expect(screen.queryByText("Sin ubicación")).not.toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/__tests__/DashboardMobileHub.test.tsx
+++ b/src/components/dashboard/__tests__/DashboardMobileHub.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DashboardMobileHub } from "../DashboardMobileHub";
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => true,
+}));
+
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    },
+    from: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/imageOptimization", () => ({
+  getOptimizedProfilePictureUrl: (url: string) => url,
+}));
+
+describe("DashboardMobileHub", () => {
+  it("shows the job location from the optimized jobs location relation", async () => {
+    render(
+      <DashboardMobileHub
+        jobs={[
+          {
+            id: "job-1",
+            title: "WOW 31",
+            job_type: "single",
+            status: "Confirmado",
+            start_time: "2026-06-03T08:00:00.000Z",
+            end_time: "2026-06-03T23:59:00.000Z",
+            timezone: "Europe/Madrid",
+            location: { name: "Madrid Arena" },
+            job_departments: [{ department: "sound" }],
+            job_assignments: [],
+          },
+        ]}
+        date={new Date("2026-06-03T12:00:00.000Z")}
+        onDateSelect={vi.fn()}
+        userRole="management"
+        onEditClick={vi.fn()}
+        onDeleteClick={vi.fn()}
+        onJobClick={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText("Madrid Arena")).toBeInTheDocument();
+    expect(screen.queryByText("Sin ubicación")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -37,20 +37,20 @@ const normalizeSearchText = (value: string) =>
 const buildSearchTokens = (query: string) => normalizeSearchText(query).split(/\s+/).filter(Boolean);
 
 const TYPE_LABELS: Record<string, string> = {
-  single: "Single",
+  single: "Sencillo",
   festival: "Festival",
   ciclo: "Ciclo",
-  tour: "Tour",
-  tourdate: "Tour Date",
+  tour: "Gira",
+  tourdate: "Fecha de gira",
   dryhire: "Dry Hire",
   evento: "Evento",
 };
 
 const STATUS_LABELS: Record<string, string> = {
-  Tentativa: "Tentative",
-  Confirmado: "Confirmed",
-  Completado: "Completed",
-  Cancelado: "Cancelled",
+  Tentativa: "Tentativa",
+  Confirmado: "Confirmado",
+  Completado: "Completado",
+  Cancelado: "Cancelado",
 };
 
 const getTypeLabel = (type: string) => TYPE_LABELS[type?.toLowerCase()] || type;
@@ -361,14 +361,9 @@ const ProjectManagement = () => {
   };
 
   const toggleAllJobStatuses = () => {
-    if (allJobStatusesSelected) {
-      selectedJobStatuses.forEach(status => handleJobStatusSelection(status));
-      return;
-    }
-
-    allJobStatuses.forEach(status => {
-      if (!selectedJobStatuses.includes(status)) handleJobStatusSelection(status);
-    });
+    const nextStatuses = allJobStatusesSelected ? [] : allJobStatuses;
+    setSelectedJobStatuses(nextStatuses);
+    saveUserPreferences(nextStatuses);
   };
 
   const MobileFilterOption = ({
@@ -406,7 +401,7 @@ const ProjectManagement = () => {
           <AccordionTrigger className="py-3 text-sm hover:no-underline">
             <span className="flex items-center gap-2">
               <Filter className="h-4 w-4" />
-              Types
+              Tipos
               {selectedJobTypes.length > 0 && (
                 <span className="rounded-full bg-primary px-2 py-0.5 text-xs text-primary-foreground">
                   {selectedJobTypes.length}
@@ -422,7 +417,7 @@ const ProjectManagement = () => {
               onClick={toggleAllJobTypes}
               className="w-full justify-start"
             >
-              {allJobTypesSelected ? "Clear All" : "Select All"}
+              {allJobTypesSelected ? "Limpiar todo" : "Seleccionar todo"}
             </Button>
             <div className="max-h-52 space-y-1 overflow-y-auto pr-1">
               {allJobTypes.length > 0 ? (
@@ -435,7 +430,7 @@ const ProjectManagement = () => {
                   />
                 ))
               ) : (
-                <div className="px-2 py-3 text-sm text-muted-foreground">No types available</div>
+                <div className="px-2 py-3 text-sm text-muted-foreground">No hay tipos disponibles</div>
               )}
             </div>
           </AccordionContent>
@@ -445,7 +440,7 @@ const ProjectManagement = () => {
           <AccordionTrigger className="py-3 text-sm hover:no-underline">
             <span className="flex items-center gap-2">
               <Filter className="h-4 w-4" />
-              Status
+              Estado
               {selectedJobStatuses.length > 0 && (
                 <span className="rounded-full bg-primary px-2 py-0.5 text-xs text-primary-foreground">
                   {selectedJobStatuses.length}
@@ -461,7 +456,7 @@ const ProjectManagement = () => {
               onClick={toggleAllJobStatuses}
               className="w-full justify-start"
             >
-              {allJobStatusesSelected ? "Clear All" : "Select All"}
+              {allJobStatusesSelected ? "Limpiar todo" : "Seleccionar todo"}
             </Button>
             <div className="max-h-52 space-y-1 overflow-y-auto pr-1">
               {allJobStatuses.length > 0 ? (
@@ -474,7 +469,7 @@ const ProjectManagement = () => {
                   />
                 ))
               ) : (
-                <div className="px-2 py-3 text-sm text-muted-foreground">No statuses available</div>
+                <div className="px-2 py-3 text-sm text-muted-foreground">No hay estados disponibles</div>
               )}
             </div>
           </AccordionContent>
@@ -494,7 +489,7 @@ const ProjectManagement = () => {
           ) : (
             <CheckCircle className="mr-2 h-4 w-4" />
           )}
-          Auto-Complete Past Jobs
+          Autocompletar trabajos pasados
         </Button>
       )}
     </div>
@@ -551,7 +546,7 @@ const ProjectManagement = () => {
                 <SheetTrigger asChild>
                   <Button variant="outline" size="sm" className="gap-2">
                     <Filter className="h-4 w-4" />
-                    Filters
+                    Filtros
                     {(selectedJobTypes.length > 0 || selectedJobStatuses.length > 0) && (
                       <span className="ml-1 rounded-full bg-primary text-primary-foreground text-xs px-2 py-0.5">
                         {selectedJobTypes.length + selectedJobStatuses.length}
@@ -564,9 +559,9 @@ const ProjectManagement = () => {
                   className="h-auto max-h-[85dvh] overflow-y-auto px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-5"
                 >
                   <SheetHeader className="mb-4">
-                    <SheetTitle>Filters</SheetTitle>
+                    <SheetTitle>Filtros</SheetTitle>
                     <SheetDescription className="sr-only">
-                      Choose project types and statuses to filter the project list.
+                      Selecciona tipos y estados para filtrar la lista de proyectos.
                     </SheetDescription>
                   </SheetHeader>
                   <FilterContent />

--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Loader2, CheckCircle, Search, Filter, X, Plus } from "lucide-react";
+import { Loader2, CheckCircle, Search, Filter, Plus, Check } from "lucide-react";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { Department } from "@/types/department";
 import { startOfMonth, endOfMonth, addMonths } from "date-fns";
@@ -18,7 +18,8 @@ import { useSubscriptionContext } from "@/providers/SubscriptionProvider";
 import { autoCompleteJobs } from "@/utils/jobStatusUtils";
 import { useToast } from "@/hooks/use-toast";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { cn } from "@/lib/utils";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useCreateJobDialogStore } from "@/stores/useCreateJobDialogStore";
@@ -34,6 +35,26 @@ const normalizeSearchText = (value: string) =>
     .trim();
 
 const buildSearchTokens = (query: string) => normalizeSearchText(query).split(/\s+/).filter(Boolean);
+
+const TYPE_LABELS: Record<string, string> = {
+  single: "Single",
+  festival: "Festival",
+  ciclo: "Ciclo",
+  tour: "Tour",
+  tourdate: "Tour Date",
+  dryhire: "Dry Hire",
+  evento: "Evento",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  Tentativa: "Tentative",
+  Confirmado: "Confirmed",
+  Completado: "Completed",
+  Cancelado: "Cancelled",
+};
+
+const getTypeLabel = (type: string) => TYPE_LABELS[type?.toLowerCase()] || type;
+const getStatusLabel = (status: string) => STATUS_LABELS[status] || status;
 
 const ProjectManagement = () => {
   const navigate = useNavigate();
@@ -325,35 +346,195 @@ const ProjectManagement = () => {
     ));
   };
 
-  const FilterContent = () => (
-    <div className={cn("flex flex-col gap-4", isMobile ? "w-full" : "")}>
-      <div className={cn("flex", isMobile ? "flex-col gap-3" : "items-center gap-4")}>
-        <JobTypeFilter
-          allJobTypes={allJobTypes}
-          selectedJobTypes={selectedJobTypes}
-          onTypeToggle={toggleJobType}
-        />
-        <StatusFilter
-          allJobStatuses={allJobStatuses}
-          selectedJobStatuses={selectedJobStatuses}
-          onStatusSelection={handleJobStatusSelection}
-        />
-      </div>
+  const allJobTypesSelected = allJobTypes.length > 0 && selectedJobTypes.length === allJobTypes.length;
+  const allJobStatusesSelected = allJobStatuses.length > 0 && selectedJobStatuses.length === allJobStatuses.length;
+
+  const toggleAllJobTypes = () => {
+    if (allJobTypesSelected) {
+      selectedJobTypes.forEach(type => toggleJobType(type));
+      return;
+    }
+
+    allJobTypes.forEach(type => {
+      if (!selectedJobTypes.includes(type)) toggleJobType(type);
+    });
+  };
+
+  const toggleAllJobStatuses = () => {
+    if (allJobStatusesSelected) {
+      selectedJobStatuses.forEach(status => handleJobStatusSelection(status));
+      return;
+    }
+
+    allJobStatuses.forEach(status => {
+      if (!selectedJobStatuses.includes(status)) handleJobStatusSelection(status);
+    });
+  };
+
+  const MobileFilterOption = ({
+    checked,
+    label,
+    onClick,
+  }: {
+    checked: boolean;
+    label: string;
+    onClick: () => void;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={checked}
+      className="flex min-h-10 w-full items-center gap-3 rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted"
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded border",
+          checked ? "border-primary bg-primary text-primary-foreground" : "border-input"
+        )}
+      >
+        {checked && <Check className="h-3 w-3" />}
+      </span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+    </button>
+  );
+
+  const MobileFilterContent = () => (
+    <div className="w-full space-y-4">
+      <Accordion type="multiple" defaultValue={["types", "status"]} className="w-full space-y-3">
+        <AccordionItem value="types" className="rounded-md border px-3">
+          <AccordionTrigger className="py-3 text-sm hover:no-underline">
+            <span className="flex items-center gap-2">
+              <Filter className="h-4 w-4" />
+              Types
+              {selectedJobTypes.length > 0 && (
+                <span className="rounded-full bg-primary px-2 py-0.5 text-xs text-primary-foreground">
+                  {selectedJobTypes.length}
+                </span>
+              )}
+            </span>
+          </AccordionTrigger>
+          <AccordionContent className="space-y-2 pb-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={toggleAllJobTypes}
+              className="w-full justify-start"
+            >
+              {allJobTypesSelected ? "Clear All" : "Select All"}
+            </Button>
+            <div className="max-h-52 space-y-1 overflow-y-auto pr-1">
+              {allJobTypes.length > 0 ? (
+                allJobTypes.map((type) => (
+                  <MobileFilterOption
+                    key={type}
+                    checked={selectedJobTypes.includes(type)}
+                    label={getTypeLabel(type)}
+                    onClick={() => toggleJobType(type)}
+                  />
+                ))
+              ) : (
+                <div className="px-2 py-3 text-sm text-muted-foreground">No types available</div>
+              )}
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem value="status" className="rounded-md border px-3">
+          <AccordionTrigger className="py-3 text-sm hover:no-underline">
+            <span className="flex items-center gap-2">
+              <Filter className="h-4 w-4" />
+              Status
+              {selectedJobStatuses.length > 0 && (
+                <span className="rounded-full bg-primary px-2 py-0.5 text-xs text-primary-foreground">
+                  {selectedJobStatuses.length}
+                </span>
+              )}
+            </span>
+          </AccordionTrigger>
+          <AccordionContent className="space-y-2 pb-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={toggleAllJobStatuses}
+              className="w-full justify-start"
+            >
+              {allJobStatusesSelected ? "Clear All" : "Select All"}
+            </Button>
+            <div className="max-h-52 space-y-1 overflow-y-auto pr-1">
+              {allJobStatuses.length > 0 ? (
+                allJobStatuses.map((status) => (
+                  <MobileFilterOption
+                    key={status}
+                    checked={selectedJobStatuses.includes(status)}
+                    label={getStatusLabel(status)}
+                    onClick={() => handleJobStatusSelection(status)}
+                  />
+                ))
+              ) : (
+                <div className="px-2 py-3 text-sm text-muted-foreground">No statuses available</div>
+              )}
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+
       {canCreateItems && (
         <Button 
           onClick={handleAutoCompleteAll}
           disabled={isAutoCompleting || jobsLoading}
           variant="outline"
           size="sm"
-          className={cn("flex items-center gap-2", isMobile && "w-full")}
+          className="w-full"
         >
           {isAutoCompleting ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           ) : (
-            <CheckCircle className="h-4 w-4" />
+            <CheckCircle className="mr-2 h-4 w-4" />
           )}
           Auto-Complete Past Jobs
         </Button>
+      )}
+    </div>
+  );
+
+  const FilterContent = () => (
+    <div className={cn("flex flex-col gap-4", isMobile ? "w-full" : "")}>
+      {isMobile ? (
+        <MobileFilterContent />
+      ) : (
+        <>
+          <div className="flex items-center gap-4">
+            <JobTypeFilter
+              allJobTypes={allJobTypes}
+              selectedJobTypes={selectedJobTypes}
+              onTypeToggle={toggleJobType}
+            />
+            <StatusFilter
+              allJobStatuses={allJobStatuses}
+              selectedJobStatuses={selectedJobStatuses}
+              onStatusSelection={handleJobStatusSelection}
+            />
+          </div>
+          {canCreateItems && (
+            <Button 
+              onClick={handleAutoCompleteAll}
+              disabled={isAutoCompleting || jobsLoading}
+              variant="outline"
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              {isAutoCompleting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCircle className="h-4 w-4" />
+              )}
+              Auto-Complete Past Jobs
+            </Button>
+          )}
+        </>
       )}
     </div>
   );
@@ -378,9 +559,15 @@ const ProjectManagement = () => {
                     )}
                   </Button>
                 </SheetTrigger>
-                <SheetContent side="bottom" className="h-auto max-h-[85vh] overflow-y-auto">
+                <SheetContent
+                  side="bottom"
+                  className="h-auto max-h-[85dvh] overflow-y-auto px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-5"
+                >
                   <SheetHeader className="mb-4">
                     <SheetTitle>Filters</SheetTitle>
+                    <SheetDescription className="sr-only">
+                      Choose project types and statuses to filter the project list.
+                    </SheetDescription>
                   </SheetHeader>
                   <FilterContent />
                 </SheetContent>

--- a/src/pages/__tests__/ProjectManagement.test.tsx
+++ b/src/pages/__tests__/ProjectManagement.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import ProjectManagement from "../ProjectManagement";
@@ -39,8 +40,9 @@ vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
+let mockIsMobile = false;
 vi.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => false,
+  useIsMobile: () => mockIsMobile,
 }));
 
 vi.mock("@/components/project-management/MonthNavigation", () => ({
@@ -85,6 +87,7 @@ describe("ProjectManagement department tabs", () => {
     mockUseOptimizedAuth.mockReset();
     mockUseOptimizedJobs.mockReset();
     mockAutoCompleteJobs.mockClear();
+    mockIsMobile = false;
     mockGetSession.mockResolvedValue({
       data: { session: { user: { id: "user-1" } } },
     });
@@ -163,5 +166,40 @@ describe("ProjectManagement department tabs", () => {
 
     const videoTab = await screen.findByRole("tab", { name: /video/i });
     await waitFor(() => expect(videoTab).toHaveAttribute("data-state", "active"));
+  });
+
+  it("renders mobile filters inline inside the sheet", async () => {
+    mockIsMobile = true;
+    mockUseOptimizedAuth.mockReturnValue({
+      userDepartment: "sound",
+      isLoading: false,
+    });
+    mockUseOptimizedJobs.mockReturnValue({
+      data: [
+        {
+          id: "job-1",
+          title: "Mobile Filter Job",
+          job_type: "single",
+          status: "Confirmado",
+          start_time: "2026-06-03T08:00:00.000Z",
+          end_time: "2026-06-03T23:00:00.000Z",
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <ProjectManagement />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: /filters/i }));
+
+    expect(screen.queryByTestId("job-type-filter")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("status-filter")).not.toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /single/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirmed/i })).toBeInTheDocument();
   });
 });

--- a/src/pages/__tests__/ProjectManagement.test.tsx
+++ b/src/pages/__tests__/ProjectManagement.test.tsx
@@ -184,6 +184,14 @@ describe("ProjectManagement department tabs", () => {
           start_time: "2026-06-03T08:00:00.000Z",
           end_time: "2026-06-03T23:00:00.000Z",
         },
+        {
+          id: "job-2",
+          title: "Mobile Tentative Job",
+          job_type: "dryhire",
+          status: "Tentativa",
+          start_time: "2026-06-04T08:00:00.000Z",
+          end_time: "2026-06-04T23:00:00.000Z",
+        },
       ],
       isLoading: false,
       error: null,
@@ -195,11 +203,55 @@ describe("ProjectManagement department tabs", () => {
       </MemoryRouter>
     );
 
-    await userEvent.click(await screen.findByRole("button", { name: /filters/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /filtros/i }));
 
     expect(screen.queryByTestId("job-type-filter")).not.toBeInTheDocument();
     expect(screen.queryByTestId("status-filter")).not.toBeInTheDocument();
-    expect(await screen.findByRole("button", { name: /single/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /confirmed/i })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /sencillo/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirmado/i })).toBeInTheDocument();
+  });
+
+  it("clears all selected mobile statuses in one state update", async () => {
+    mockIsMobile = true;
+    mockUseOptimizedAuth.mockReturnValue({
+      userDepartment: "sound",
+      isLoading: false,
+    });
+    mockUseOptimizedJobs.mockReturnValue({
+      data: [
+        {
+          id: "job-1",
+          title: "Confirmed Job",
+          job_type: "single",
+          status: "Confirmado",
+          start_time: "2026-06-03T08:00:00.000Z",
+          end_time: "2026-06-03T23:00:00.000Z",
+        },
+        {
+          id: "job-2",
+          title: "Tentative Job",
+          job_type: "single",
+          status: "Tentativa",
+          start_time: "2026-06-04T08:00:00.000Z",
+          end_time: "2026-06-04T23:00:00.000Z",
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <ProjectManagement />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: /filtros/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /limpiar todo/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /confirmado/i })).toHaveAttribute("aria-pressed", "false");
+      expect(screen.getByRole("button", { name: /tentativa/i })).toHaveAttribute("aria-pressed", "false");
+    });
   });
 });


### PR DESCRIPTION
## What changed
- Replaced nested dropdown filters inside the mobile Project Management bottom sheet with inline accordion filter sections.
- Kept the existing desktop Project Management filter dropdowns unchanged.
- Fixed the mobile dashboard job-card location label to read the same `location` relation used by department mobile cards, with fallbacks for legacy shapes.
- Added regression tests for mobile project filters and dashboard location rendering.

## Why
On mobile, Project Management filter dropdowns could render outside the visible sheet/viewport. Mobile dashboard cards also showed `Sin ubicación` even when the optimized jobs query returned a valid `location` relation.

## Risk Assessment
Risk level: low. The change is limited to mobile UI rendering and label resolution; no data writes, schema changes, or permissions behavior changed.

Main risks: the mobile filter sheet uses a different layout than desktop, and dashboard job-card location display now accepts multiple existing job data shapes.

## Test Evidence
- `npm install --legacy-peer-deps`
- `npm run test:run -- src/pages/__tests__/ProjectManagement.test.tsx src/components/dashboard/__tests__/DashboardMobileHub.test.tsx` passes.
- `npx eslint src/pages/ProjectManagement.tsx src/pages/__tests__/ProjectManagement.test.tsx src/components/dashboard/DashboardMobileHub.tsx src/components/dashboard/__tests__/DashboardMobileHub.test.tsx` passes with existing warnings only.
- `npm run lint` passes with existing repo-wide warnings.
- `npm run build` passes; Vite chunk-size warnings only.
- Browser smoke: local dev server at `http://127.0.0.1:4179/project-management` with mobile viewport reached the protected login screen with no console errors. Auth prevented deeper route verification.

## Known local validation notes
- Full local `npm run test:run` still fails on existing local test-environment `localStorage` issues in `src/pages/__tests__/JobAssignmentMatrix.test.tsx` and `src/pages/__tests__/TechnicianSuperApp.test.tsx`; the affected files reproduce the same storage-method failures independent of this change.

## Rollback Plan
Revert this PR. No data cleanup is needed because the change is frontend-only.

## Migration Impact
No Supabase migrations, database changes, or production `supabase db push` required. Merging `main` is the production deploy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile filters now include "select all/clear all" functionality for job types and statuses.
  * Improved job location display to reliably handle multiple location field formats for better accuracy.
  * Enhanced mobile filter UI with optimized layout and accessibility improvements.

* **Tests**
  * Added test coverage for mobile dashboard and mobile filter UI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->