### PR TITLE
[codex] Add multi-stage technical power allocation

### DIFF
--- a/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
+++ b/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
@@ -43,6 +43,25 @@ describe("technical power persistence payloads", () => {
     });
   });
 
+  it("builds stage-aware job inserts for multi-stage jobs", () => {
+    expect(
+      buildPowerRequirementInsert({
+        department: "sound",
+        jobId: "job-1",
+        settings,
+        stage: { number: 2, name: "Club Stage" },
+        table,
+      })
+    ).toMatchObject({
+      stage_name: "Club Stage",
+      stage_number: 2,
+      table_data: {
+        stageName: "Club Stage",
+        stageNumber: 2,
+      },
+    });
+  });
+
   it("builds tour default payloads with table data and metadata in one shape", () => {
     expect(buildTourPowerDefaultTable({ setId: "set-1", settings, table })).toMatchObject({
       set_id: "set-1",

--- a/src/features/technical-tools/power/__tests__/powerUploadPersistence.test.ts
+++ b/src/features/technical-tools/power/__tests__/powerUploadPersistence.test.ts
@@ -41,6 +41,29 @@ describe("technical power report persistence", () => {
     expect(mocks.autoCompleteConsumosTasks).toHaveBeenCalledWith("job-1", "lights");
   });
 
+  it("scopes Consumos PDF cleanup to the selected stage", async () => {
+    mocks.uploadJobPdfWithCleanup.mockResolvedValue(undefined);
+    mocks.autoCompleteConsumosTasks.mockResolvedValue({ completedCount: 1 });
+    const pdfBlob = new Blob(["pdf"]);
+
+    await uploadPowerReportAndCompleteTask({
+      department: "sound",
+      fileName: "Sound - Main Stage.pdf",
+      jobId: "job-1",
+      pdfBlob,
+      stage: { number: 1, name: "Main Stage" },
+    });
+
+    expect(mocks.uploadJobPdfWithCleanup).toHaveBeenCalledWith(
+      "job-1",
+      pdfBlob,
+      "Sound - Main Stage.pdf",
+      "calculators/consumos",
+      { cleanupScope: "stage-1-main-stage" },
+    );
+  });
+
+
   it("keeps successful power uploads non-fatal when auto-completion fails", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     mocks.uploadJobPdfWithCleanup.mockResolvedValue(undefined);

--- a/src/features/technical-tools/power/powerPersistence.ts
+++ b/src/features/technical-tools/power/powerPersistence.ts
@@ -5,6 +5,8 @@ import type {
   PowerTable,
   TechnicalDepartment,
 } from "@/features/technical-tools/power/types";
+import type { TechnicalStage } from "@/features/technical-tools/stage/stageUtils";
+import { getTechnicalStageStorageScope } from "@/features/technical-tools/stage/stageUtils";
 
 type PowerPersistenceClient = Pick<typeof typedSupabase, "from">;
 
@@ -15,6 +17,8 @@ export const buildPowerTableData = (table: PowerTable, settings: PowerElectrical
   const payload = {
     rows: table.rows,
     ...(table.id !== undefined ? { sourceTableId: String(table.id) } : {}),
+    ...(table.stageNumber ? { stageNumber: table.stageNumber } : {}),
+    ...(table.stageName ? { stageName: table.stageName } : {}),
     safetyMargin: settings.safetyMargin,
     phaseMode: settings.phaseMode,
     voltage: settings.voltage,
@@ -42,47 +46,78 @@ export const buildPowerTableMetadata = (
     ...(settings.orderIndex !== undefined ? { order_index: settings.orderIndex } : {}),
   }) as unknown as Json;
 
+const getPowerTableStage = (
+  table: PowerTable,
+  stage?: TechnicalStage | null
+): TechnicalStage | null => {
+  if (stage) return stage;
+  if (!table.stageNumber) return null;
+
+  return {
+    number: table.stageNumber,
+    name: table.stageName || `Stage ${table.stageNumber}`,
+  };
+};
+
 export const buildPowerRequirementInsert = ({
   department,
   jobId,
   settings,
+  stage,
   table,
 }: {
   department: TechnicalDepartment;
   jobId: string;
   settings?: PowerElectricalSettings & { powerFactor?: number };
+  stage?: TechnicalStage | null;
   table: PowerTable;
-}) => ({
-  job_id: jobId,
-  department,
-  table_name: table.name,
-  total_watts: table.totalWatts || 0,
-  current_per_phase: table.currentPerPhase || 0,
-  pdu_type: table.customPduType || table.pduType || "",
-  custom_pdu_type: table.customPduType,
-  position: table.position || null,
-  custom_position: table.customPosition || null,
-  table_data: (settings ? buildPowerTableData(table, settings) : ({ rows: table.rows } as unknown as Json)),
-  includes_hoist: table.includesHoist || false,
-});
+}) => {
+  const tableStage = getPowerTableStage(table, stage);
+
+  return {
+    job_id: jobId,
+    department,
+    stage_number: tableStage?.number ?? null,
+    stage_name: tableStage?.name ?? null,
+    table_name: table.name,
+    total_watts: table.totalWatts || 0,
+    current_per_phase: table.currentPerPhase || 0,
+    pdu_type: table.customPduType || table.pduType || "",
+    custom_pdu_type: table.customPduType,
+    position: table.position || null,
+    custom_position: table.customPosition || null,
+    table_data: (settings ? buildPowerTableData({
+      ...table,
+      stageName: tableStage?.name ?? table.stageName,
+      stageNumber: tableStage?.number ?? table.stageNumber,
+    }, settings) : ({
+      rows: table.rows,
+      ...(tableStage ? { stageNumber: tableStage.number, stageName: tableStage.name } : {}),
+    } as unknown as Json)),
+    includes_hoist: table.includesHoist || false,
+  };
+};
 
 export const saveJobPowerRequirementTable = async ({
   client,
   department,
   jobId,
   settings,
+  stage,
   table,
 }: {
   client: PowerPersistenceClient;
   department: TechnicalDepartment;
   jobId: string;
   settings?: PowerElectricalSettings & { powerFactor?: number };
+  stage?: TechnicalStage | null;
   table: PowerTable;
 }): Promise<string> => {
   const payload = buildPowerRequirementInsert({
     department,
     jobId,
     settings,
+    stage,
     table,
   });
 
@@ -195,14 +230,23 @@ export const uploadPowerReportAndCompleteTask = async ({
   fileName,
   jobId,
   pdfBlob,
+  stage,
 }: {
   department: TechnicalDepartment;
   fileName: string;
   jobId: string;
   pdfBlob: Blob;
+  stage?: TechnicalStage | null;
 }) => {
   const { uploadJobPdfWithCleanup } = await import("@/utils/jobDocumentsUpload");
-  await uploadJobPdfWithCleanup(jobId, pdfBlob, fileName, getPowerReportUploadCategory(department));
+  const cleanupScope = getTechnicalStageStorageScope(stage);
+  const category = getPowerReportUploadCategory(department);
+
+  if (cleanupScope) {
+    await uploadJobPdfWithCleanup(jobId, pdfBlob, fileName, category, { cleanupScope });
+  } else {
+    await uploadJobPdfWithCleanup(jobId, pdfBlob, fileName, category);
+  }
 
   try {
     const { autoCompleteConsumosTasks } = await import("@/utils/taskAutoCompletion");

--- a/src/features/technical-tools/power/types.ts
+++ b/src/features/technical-tools/power/types.ts
@@ -22,6 +22,8 @@ export type PowerTableRow = {
 export type PowerTable = {
   id?: number | string;
   powerRequirementId?: string;
+  stageNumber?: number | null;
+  stageName?: string | null;
   name: string;
   rows: PowerTableRow[];
   totalWatts?: number;

--- a/src/features/technical-tools/stage/__tests__/stageUtils.test.ts
+++ b/src/features/technical-tools/stage/__tests__/stageUtils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { appendTechnicalStageToFilename } from "@/features/technical-tools/stage/stageUtils";
+
+describe("technical stage utilities", () => {
+  it("sanitizes stage labels appended to filenames", () => {
+    expect(
+      appendTechnicalStageToFilename("Power Report.pdf", {
+        number: 2,
+        name: "Main/Alt\\Deck:Night",
+      })
+    ).toBe("Power Report - Main - Alt - Deck Night.pdf");
+  });
+});

--- a/src/features/technical-tools/stage/stageAllocation.tsx
+++ b/src/features/technical-tools/stage/stageAllocation.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import {
+  buildFallbackStageOptions,
+  buildFestivalStageOptions,
+} from "@/features/festival-management/selectors";
+import { queryKeys } from "@/lib/react-query";
+import { dataLayerClient } from "@/services/dataLayerClient";
+import type { TechnicalStage } from "@/features/technical-tools/stage/stageUtils";
+export {
+  appendTechnicalStageToFilename,
+  formatTechnicalStageLabel,
+  getTechnicalStageKey,
+  getTechnicalStageStorageScope,
+  isSameTechnicalStage,
+  type TechnicalStage,
+} from "@/features/technical-tools/stage/stageUtils";
+
+type FestivalStageRow = {
+  number?: number | null;
+  name?: string | null;
+};
+
+export const useJobTechnicalStages = ({
+  enabled = true,
+  jobId,
+}: {
+  enabled?: boolean;
+  jobId: string;
+}) =>
+  useQuery<TechnicalStage[]>({
+    queryKey: queryKeys.scope("technical-tool-stages", jobId),
+    enabled: enabled && Boolean(jobId),
+    staleTime: 60 * 1000,
+    queryFn: async () => {
+      const { data: gearSetups, error: gearError } = await dataLayerClient
+        .from("festival_gear_setups")
+        .select("max_stages")
+        .eq("job_id", jobId)
+        .order("created_at", { ascending: false })
+        .limit(1);
+
+      if (gearError) throw gearError;
+
+      const fallbackMaxStages = Math.max(
+        Number(gearSetups?.[0]?.max_stages || 1),
+        1
+      );
+
+      const { data: stageRows, error: stageError } = await dataLayerClient
+        .from("festival_stages")
+        .select("number, name")
+        .eq("job_id", jobId)
+        .order("number", { ascending: true });
+
+      if (stageError) throw stageError;
+
+      const hasConfiguredStages = (stageRows || []).length > 0;
+      const { maxStages, options } = hasConfiguredStages
+        ? buildFestivalStageOptions(stageRows as FestivalStageRow[], fallbackMaxStages)
+        : {
+            maxStages: fallbackMaxStages,
+            options: buildFallbackStageOptions(fallbackMaxStages),
+          };
+
+      return maxStages > 1 ? options : [];
+    },
+  });
+
+export const useSelectedTechnicalStage = ({
+  enabled = true,
+  jobId,
+}: {
+  enabled?: boolean;
+  jobId: string;
+}) => {
+  const { data: stages = [], isLoading } = useJobTechnicalStages({ enabled, jobId });
+  const [selectedStageNumber, setSelectedStageNumber] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (stages.length === 0) {
+      setSelectedStageNumber(null);
+      return;
+    }
+
+    setSelectedStageNumber((current) =>
+      current && stages.some((stage) => stage.number === current)
+        ? current
+        : stages[0].number
+    );
+  }, [stages]);
+
+  const selectedStage = useMemo(
+    () => stages.find((stage) => stage.number === selectedStageNumber) || null,
+    [selectedStageNumber, stages]
+  );
+
+  return {
+    hasMultipleStages: stages.length > 1,
+    isLoadingStages: isLoading,
+    selectedStage,
+    selectedStageNumber,
+    setSelectedStageNumber,
+    stages,
+  };
+};
+
+export const TechnicalStageSelector = ({
+  disabled = false,
+  label = "Stage",
+  onChange,
+  selectedStageNumber,
+  stages,
+}: {
+  disabled?: boolean;
+  label?: string;
+  onChange: (stageNumber: number) => void;
+  selectedStageNumber: number | null;
+  stages: TechnicalStage[];
+}) => {
+  if (stages.length <= 1) return null;
+
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      <Select
+        disabled={disabled}
+        value={selectedStageNumber ? String(selectedStageNumber) : undefined}
+        onValueChange={(value) => onChange(Number(value))}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="Select stage" />
+        </SelectTrigger>
+        <SelectContent>
+          {stages.map((stage) => (
+            <SelectItem key={stage.number} value={String(stage.number)}>
+              {stage.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/src/features/technical-tools/stage/stageUtils.ts
+++ b/src/features/technical-tools/stage/stageUtils.ts
@@ -14,6 +14,14 @@ const normalizePathSegment = (value: string) =>
     .replace(/^-+|-+$/g, "")
     .slice(0, 80);
 
+const sanitizeFilenameLabel = (value: string) =>
+  value
+    .normalize("NFC")
+    .replace(/[\\/]+/g, " - ")
+    .replace(/[\x00-\x1F\x7F<>:"|?*]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
 export const getTechnicalStageKey = (stage?: TechnicalStage | null) =>
   stage ? `stage-${stage.number}` : NO_STAGE_KEY;
 
@@ -40,8 +48,9 @@ export const appendTechnicalStageToFilename = (
   const extensionMatch = fileName.match(/(\.[^.]+)$/);
   const extension = extensionMatch?.[1] || "";
   const baseName = extension ? fileName.slice(0, -extension.length) : fileName;
+  const stageLabel = sanitizeFilenameLabel(stage.name) || `Stage ${stage.number}`;
 
-  return `${baseName} - ${stage.name}${extension}`;
+  return `${baseName} - ${stageLabel}${extension}`;
 };
 
 export const formatTechnicalStageLabel = (stage?: TechnicalStage | null) =>

--- a/src/features/technical-tools/stage/stageUtils.ts
+++ b/src/features/technical-tools/stage/stageUtils.ts
@@ -1,0 +1,48 @@
+export type TechnicalStage = {
+  number: number;
+  name: string;
+};
+
+const NO_STAGE_KEY = "__no_stage__";
+
+const normalizePathSegment = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+
+export const getTechnicalStageKey = (stage?: TechnicalStage | null) =>
+  stage ? `stage-${stage.number}` : NO_STAGE_KEY;
+
+export const isSameTechnicalStage = (
+  stageNumber: number | null | undefined,
+  selectedStage?: TechnicalStage | null
+) => {
+  if (!selectedStage) return true;
+  return Number(stageNumber) === selectedStage.number;
+};
+
+export const getTechnicalStageStorageScope = (stage?: TechnicalStage | null) => {
+  if (!stage) return undefined;
+  const nameSlug = normalizePathSegment(stage.name);
+  return nameSlug ? `stage-${stage.number}-${nameSlug}` : `stage-${stage.number}`;
+};
+
+export const appendTechnicalStageToFilename = (
+  fileName: string,
+  stage?: TechnicalStage | null
+) => {
+  if (!stage) return fileName;
+
+  const extensionMatch = fileName.match(/(\.[^.]+)$/);
+  const extension = extensionMatch?.[1] || "";
+  const baseName = extension ? fileName.slice(0, -extension.length) : fileName;
+
+  return `${baseName} - ${stage.name}${extension}`;
+};
+
+export const formatTechnicalStageLabel = (stage?: TechnicalStage | null) =>
+  stage ? stage.name || `Stage ${stage.number}` : "";

--- a/src/features/technical-tools/weights/__tests__/weightPersistence.test.ts
+++ b/src/features/technical-tools/weights/__tests__/weightPersistence.test.ts
@@ -40,6 +40,28 @@ describe("technical weight report persistence", () => {
     expect(mocks.autoCompletePesosTasks).toHaveBeenCalledWith("job-1");
   });
 
+  it("scopes Pesos PDF cleanup to the selected stage", async () => {
+    mocks.uploadJobPdfWithCleanup.mockResolvedValue(undefined);
+    mocks.autoCompletePesosTasks.mockResolvedValue({ completedCount: 1 });
+    const pdfBlob = new Blob(["pdf"]);
+
+    await uploadWeightReportAndCompleteTasks({
+      fileName: "Pesos - Main Stage.pdf",
+      jobId: "job-1",
+      pdfBlob,
+      stage: { number: 1, name: "Main Stage" },
+    });
+
+    expect(mocks.uploadJobPdfWithCleanup).toHaveBeenCalledWith(
+      "job-1",
+      pdfBlob,
+      "Pesos - Main Stage.pdf",
+      "calculators/pesos",
+      { cleanupScope: "stage-1-main-stage" },
+    );
+  });
+
+
   it("keeps successful uploads non-fatal when Pesos auto-completion fails", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     mocks.uploadJobPdfWithCleanup.mockResolvedValue(undefined);

--- a/src/features/technical-tools/weights/weightPersistence.ts
+++ b/src/features/technical-tools/weights/weightPersistence.ts
@@ -1,14 +1,25 @@
+import type { TechnicalStage } from "@/features/technical-tools/stage/stageUtils";
+import { getTechnicalStageStorageScope } from "@/features/technical-tools/stage/stageUtils";
+
 export const uploadWeightReportAndCompleteTasks = async ({
   fileName,
   jobId,
   pdfBlob,
+  stage,
 }: {
   fileName: string;
   jobId: string;
   pdfBlob: Blob;
+  stage?: TechnicalStage | null;
 }) => {
   const { uploadJobPdfWithCleanup } = await import("@/utils/jobDocumentsUpload");
-  await uploadJobPdfWithCleanup(jobId, pdfBlob, fileName, "calculators/pesos");
+  const cleanupScope = getTechnicalStageStorageScope(stage);
+
+  if (cleanupScope) {
+    await uploadJobPdfWithCleanup(jobId, pdfBlob, fileName, "calculators/pesos", { cleanupScope });
+  } else {
+    await uploadJobPdfWithCleanup(jobId, pdfBlob, fileName, "calculators/pesos");
+  }
 
   try {
     const { autoCompletePesosTasks } = await import("@/utils/taskAutoCompletion");

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -5330,6 +5330,8 @@ export type Database = {
           job_id: string | null
           pdu_type: string
           position: string | null
+          stage_name: string | null
+          stage_number: number | null
           table_data: Json
           table_name: string
           total_watts: number
@@ -5345,6 +5347,8 @@ export type Database = {
           job_id?: string | null
           pdu_type: string
           position?: string | null
+          stage_name?: string | null
+          stage_number?: number | null
           table_data?: Json
           table_name: string
           total_watts: number
@@ -5360,6 +5364,8 @@ export type Database = {
           job_id?: string | null
           pdu_type?: string
           position?: string | null
+          stage_name?: string | null
+          stage_number?: number | null
           table_data?: Json
           table_name?: string
           total_watts?: number

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -14,7 +14,16 @@ const getAuthStorage = (): Storage | undefined => {
   // Avoid crashing at import-time; tests can mock auth explicitly when needed.
   if (typeof window === 'undefined') return undefined;
   try {
-    return window.localStorage ?? undefined;
+    const storage = window.localStorage;
+    if (
+      storage &&
+      typeof storage.getItem === 'function' &&
+      typeof storage.setItem === 'function' &&
+      typeof storage.removeItem === 'function'
+    ) {
+      return storage;
+    }
+    return undefined;
   } catch {
     return undefined;
   }

--- a/src/pages/ConsumosTool.tsx
+++ b/src/pages/ConsumosTool.tsx
@@ -32,6 +32,13 @@ import {
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
+  TechnicalStageSelector,
+  appendTechnicalStageToFilename,
+  formatTechnicalStageLabel,
+  isSameTechnicalStage,
+  useSelectedTechnicalStage,
+} from '@/features/technical-tools/stage/stageAllocation';
+import {
   CUSTOM_POWER_POSITION_VALUE,
   getPowerPositionCustomValue,
   getPowerPositionSelectValue,
@@ -85,6 +92,15 @@ const ConsumosTool: React.FC = () => {
   // Tour override detection
   const isJobOverrideMode = Boolean(selectedJob?.tour_date_id);
   const tourDateId = selectedJob?.tour_date_id;
+  const {
+    selectedStage,
+    selectedStageNumber,
+    setSelectedStageNumber,
+    stages: jobStages,
+  } = useSelectedTechnicalStage({
+    enabled: Boolean(selectedJobId) && !isTourDefaults && !isJobOverrideMode,
+    jobId: selectedJobId,
+  });
 
   // NEW: Get tour name for tour defaults mode
   const [tourName, setTourName] = useState<string>('');
@@ -195,6 +211,9 @@ const ConsumosTool: React.FC = () => {
 
   const getPowerSettings = () => ({ safetyMargin, powerFactor: pf, phaseMode, voltage });
   const PDU_TYPES = getPowerPduOptions('sound', phaseMode);
+  const activeTables = selectedStage
+    ? tables.filter((table) => isSameTechnicalStage(table.stageNumber, selectedStage))
+    : tables;
 
   const savePowerRequirementTable = async (
     table: Table,
@@ -206,6 +225,7 @@ const ConsumosTool: React.FC = () => {
         department: 'sound',
         jobId: selectedJobId,
         settings: getPowerSettings(),
+        stage: selectedStage,
         table,
       });
 
@@ -309,6 +329,8 @@ const ConsumosTool: React.FC = () => {
       tablePatch: {
         isDefault: false,
         defaultTableId: undefined,
+        stageName: selectedStage?.name ?? null,
+        stageNumber: selectedStage?.number ?? null,
       },
     }) as Table;
 
@@ -452,7 +474,7 @@ const ConsumosTool: React.FC = () => {
         ? tourOverrideTables
         : isTourDefaults
           ? tourDefaultTables
-          : tables;
+          : activeTables;
 
       const totalSystemWatts = allTables.reduce((sum, table) => sum + (table.totalWatts || 0), 0);
       const totalSystemAmps = allTables.reduce((sum, table) => sum + (table.currentPerPhase || 0), 0);
@@ -474,7 +496,9 @@ const ConsumosTool: React.FC = () => {
 
       const jobTitle = isTourDefaults ? `${tourName} - Sound Power Defaults` : (selectedJob?.title || 'Power Report');
       const jobLocation = selectedJob?.location?.name || '';
-      const headerTitle = jobLocation ? `${jobTitle} - ${jobLocation}` : jobTitle;
+      const baseHeaderTitle = jobLocation ? `${jobTitle} - ${jobLocation}` : jobTitle;
+      const stageLabel = formatTechnicalStageLabel(selectedStage);
+      const headerTitle = stageLabel ? `${baseHeaderTitle} - ${stageLabel}` : baseHeaderTitle;
 
       const pdfBlob = await exportToPDF(
         headerTitle,
@@ -491,7 +515,10 @@ const ConsumosTool: React.FC = () => {
 
       const fileName = isTourDefaults
         ? `${tourName} - Sound Power Defaults.pdf`
-        : `Sound Power Report - ${selectedJob?.title || 'Report'}.pdf`;
+        : appendTechnicalStageToFilename(
+            `Sound Power Report - ${selectedJob?.title || 'Report'}.pdf`,
+            selectedStage
+          );
 
       // Auto-complete sound Consumos tasks only after successful upload
       // This automation is department-specific: only sound department tasks are affected
@@ -502,6 +529,7 @@ const ConsumosTool: React.FC = () => {
           fileName,
           jobId: selectedJobId,
           pdfBlob,
+          stage: selectedStage,
         });
 
         if (completedTasksCount > 0) {
@@ -669,7 +697,7 @@ const ConsumosTool: React.FC = () => {
               )}
             </div>
           </div>
-          {tables.length > 0 && (
+          {activeTables.length > 0 && (
             <Button onClick={handleExportPDF} variant="outline" className="gap-2">
               <FileText className="h-4 w-4" />
               {isTourDefaults ? 'Export PDF' : 'Export & Upload PDF'}
@@ -780,6 +808,15 @@ const ConsumosTool: React.FC = () => {
                       </SelectContent>
                     </Select>
                   </div>
+                )}
+
+                {!isTourDefaults && !isJobOverrideMode && (
+                  <TechnicalStageSelector
+                    label="Stage"
+                    selectedStageNumber={selectedStageNumber}
+                    stages={jobStages}
+                    onChange={setSelectedStageNumber}
+                  />
                 )}
 
                 {(isJobOverrideMode || isTourDefaults) && tourDefaultTables.length > 0 && (
@@ -1016,7 +1053,7 @@ const ConsumosTool: React.FC = () => {
         <div className="lg:col-span-4">
           <div className="space-y-6">
             {/* First half of tables */}
-            {tables.slice(0, Math.ceil(tables.length / 2)).map((table) => (
+            {activeTables.slice(0, Math.ceil(activeTables.length / 2)).map((table) => (
               <PowerTableCard
                 key={table.id}
                 table={table}
@@ -1034,7 +1071,7 @@ const ConsumosTool: React.FC = () => {
         <div className="lg:col-span-4">
           <div className="space-y-6">
             {/* Second half of tables */}
-            {tables.slice(Math.ceil(tables.length / 2)).map((table) => (
+            {activeTables.slice(Math.ceil(activeTables.length / 2)).map((table) => (
               <PowerTableCard
                 key={table.id}
                 table={table}

--- a/src/pages/LightsConsumosTool.tsx
+++ b/src/pages/LightsConsumosTool.tsx
@@ -41,6 +41,13 @@ import {
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
+  TechnicalStageSelector,
+  appendTechnicalStageToFilename,
+  formatTechnicalStageLabel,
+  isSameTechnicalStage,
+  useSelectedTechnicalStage,
+} from '@/features/technical-tools/stage/stageAllocation';
+import {
   CUSTOM_POWER_POSITION_VALUE,
   getPowerPositionCustomValue,
   getPowerPositionSelectValue,
@@ -157,6 +164,8 @@ interface Table {
   name: string;
   rows: TableRow[];
   powerRequirementId?: string;
+  stageNumber?: number | null;
+  stageName?: string | null;
   totalWatts?: number;
   adjustedWatts?: number;
   totalVa?: number;
@@ -204,6 +213,15 @@ const LightsConsumosTool: React.FC = () => {
 
   const [selectedJobId, setSelectedJobId] = useState<string>('');
   const [selectedJob, setSelectedJob] = useState<JobSelection | null>(null);
+  const {
+    selectedStage,
+    selectedStageNumber,
+    setSelectedStageNumber,
+    stages: jobStages,
+  } = useSelectedTechnicalStage({
+    enabled: Boolean(selectedJobId) && !isTourDefaults && !isOverrideMode,
+    jobId: selectedJobId,
+  });
   const [tableName, setTableName] = useState('');
   const [tables, setTables] = useState<Table[]>([]);
   const [safetyMargin, setSafetyMargin] = useState(0);
@@ -234,6 +252,9 @@ const LightsConsumosTool: React.FC = () => {
   const pendingSetIdRef = React.useRef<Promise<string> | null>(null);
   const resolvedSetIdRef = React.useRef<string | null>(null);
   const pduOptions = getPowerPduOptions('lights', phaseMode);
+  const activeTables = selectedStage
+    ? tables.filter((table) => isSameTechnicalStage(table.stageNumber, selectedStage))
+    : tables;
   const getPowerSettings = (
     overrides: Partial<{ phaseMode: 'single' | 'three'; safetyMargin: number; voltage: number }> = {}
   ) => ({
@@ -575,6 +596,7 @@ const LightsConsumosTool: React.FC = () => {
           safetyMargin: table.snapshotSafetyMargin,
           voltage: table.snapshotVoltage,
         }),
+        stage: selectedStage,
         table,
       });
 
@@ -653,6 +675,8 @@ const LightsConsumosTool: React.FC = () => {
       customPosition: resolvedCustomPosition,
       includesHoist,
       id: Date.now(),
+      stageName: selectedStage?.name ?? null,
+      stageNumber: selectedStage?.number ?? null,
       snapshotSafetyMargin: safetyMargin,
       snapshotPhaseMode: phaseMode,
       snapshotVoltage: voltage,
@@ -783,7 +807,7 @@ const LightsConsumosTool: React.FC = () => {
       // Combine defaults and current tables for export
       const allTables = isOverrideMode
         ? [...defaultTables, ...tables]
-        : tables;
+        : activeTables;
 
       let logoUrl: string | undefined = undefined;
       try {
@@ -802,11 +826,14 @@ const LightsConsumosTool: React.FC = () => {
       const totalSystemAmps = allTables.reduce((sum, table) => sum + (table.currentPerPhase || 0), 0);
       const totalSystemKva = allTables.reduce((sum, table) => sum + (table.totalVa || table.totalWatts || 0), 0) / 1000;
 
+      const stageLabel = formatTechnicalStageLabel(selectedStage);
+      const reportTitle = stageLabel ? `${jobToUse.title} - ${stageLabel}` : jobToUse.title;
+
       const pdfBlob = await exportToPDF(
-        jobToUse.title,
+        reportTitle,
         allTables.map((table) => ({ ...table, toolType: 'consumos', phaseMode })),
         'power',
-        jobToUse.title,
+        reportTitle,
         ('start_time' in jobToUse ? jobToUse.start_time : null) || new Date().toISOString(),
         undefined,
         { totalSystemWatts, totalSystemAmps, totalSystemKva },
@@ -814,7 +841,10 @@ const LightsConsumosTool: React.FC = () => {
         logoUrl
       );
 
-      const fileName = `Informe de Potencia - ${jobToUse.title}.pdf`;
+      const fileName = appendTechnicalStageToFilename(
+        `Informe de Potencia - ${jobToUse.title}.pdf`,
+        selectedStage
+      );
 
       // Auto-complete lights Consumos tasks only after successful upload
       // This automation is department-specific: only lights department tasks are affected
@@ -825,6 +855,7 @@ const LightsConsumosTool: React.FC = () => {
           fileName,
           jobId: selectedJobId,
           pdfBlob,
+          stage: selectedStage,
         });
 
         if (completedTasksCount > 0) {
@@ -1025,6 +1056,15 @@ const LightsConsumosTool: React.FC = () => {
                 </SelectContent>
               </Select>
             </div>
+          )}
+
+          {!isOverrideMode && !isTourDefaults && (
+            <TechnicalStageSelector
+              label="Stage"
+              selectedStageNumber={selectedStageNumber}
+              stages={jobStages}
+              onChange={setSelectedStageNumber}
+            />
           )}
 
           <div className="space-y-2">
@@ -1249,7 +1289,7 @@ const LightsConsumosTool: React.FC = () => {
             <Button onClick={resetCurrentTable} variant="destructive">
               Reiniciar
             </Button>
-            {tables.length > 0 && !isTourDefaults && (
+            {activeTables.length > 0 && !isTourDefaults && (
               <Button onClick={handleExportPDF} variant="outline" className="ml-auto gap-2">
                 <FileText className="w-4 h-4" />
                 Exportar y Subir PDF
@@ -1257,11 +1297,14 @@ const LightsConsumosTool: React.FC = () => {
             )}
           </div>
 
-          {tables.map((table) => (
+          {activeTables.map((table) => (
             <div key={table.id} className="border rounded-lg overflow-x-auto mt-6">
               <div className="bg-muted px-4 py-3 flex justify-between items-center">
                 <div className="flex items-center gap-2">
                   <h3 className="font-semibold">{table.name}</h3>
+                  {table.stageName && (
+                    <Badge variant="outline">{table.stageName}</Badge>
+                  )}
                   {isOverrideMode && (
                     <Badge variant="outline" className="bg-orange-50 text-orange-700">Override</Badge>
                   )}

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -153,7 +153,7 @@ const PesosTool: React.FC = () => {
 
     return tablesToAssign.map((table) => {
       const baseName = table.baseName || deriveBaseName(table.name);
-      const stageKey = table.stageNumber ? `stage-${table.stageNumber}` : 'default';
+      const stageKey = table.stageNumber != null ? `stage-${table.stageNumber}` : 'default';
       const counter = countersByStage.get(stageKey) || 1;
 
       if (table.dualMotors) {

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -13,6 +13,12 @@ import {
   sumWeightRows,
 } from '@/features/technical-tools/weights/weightCalculations';
 import { uploadWeightReportAndCompleteTasks } from '@/features/technical-tools/weights/weightPersistence';
+import {
+  appendTechnicalStageToFilename,
+  formatTechnicalStageLabel,
+  isSameTechnicalStage,
+  useSelectedTechnicalStage,
+} from '@/features/technical-tools/stage/stageAllocation';
 
 // Database for sound components.
 const soundComponentDatabase = [
@@ -72,6 +78,8 @@ interface Table {
   rows: TableRow[];
   totalWeight?: number;
   id?: number;
+  stageNumber?: number | null;
+  stageName?: string | null;
   dualMotors?: boolean;
   riggingPoints?: string; // Stores the generated SX suffix(es)
   clusterId?: string;     // New property to group tables (e.g. mirrored pair)
@@ -118,6 +126,15 @@ const PesosTool: React.FC = () => {
   // Job-based override mode detection
   const [isJobOverrideMode, setIsJobOverrideMode] = useState(false);
   const [jobTourInfo, setJobTourInfo] = useState<{ tourName: string; date: string; location: string } | null>(null);
+  const {
+    selectedStage,
+    selectedStageNumber,
+    setSelectedStageNumber,
+    stages: jobStages,
+  } = useSelectedTechnicalStage({
+    enabled: Boolean(selectedJobId) && !isTourContext && !isTourDefaults && !isJobOverrideMode,
+    jobId: selectedJobId,
+  });
 
   const [currentTable, setCurrentTable] = useState<Table>({
     name: '',
@@ -132,14 +149,18 @@ const PesosTool: React.FC = () => {
   const formatSuffixNumber = (value: number) => formatRiggingPoint('SX', value);
 
   const assignSuffixes = (tablesToAssign: Table[]): Table[] => {
-    let counter = 1;
+    const countersByStage = new Map<string, number>();
+
     return tablesToAssign.map((table) => {
       const baseName = table.baseName || deriveBaseName(table.name);
+      const stageKey = table.stageNumber ? `stage-${table.stageNumber}` : 'default';
+      const counter = countersByStage.get(stageKey) || 1;
 
       if (table.dualMotors) {
-        const suffixOne = formatSuffixNumber(counter++);
-        const suffixTwo = formatSuffixNumber(counter++);
+        const suffixOne = formatSuffixNumber(counter);
+        const suffixTwo = formatSuffixNumber(counter + 1);
         const riggingPoints = `${suffixOne}, ${suffixTwo}`;
+        countersByStage.set(stageKey, counter + 2);
         return {
           ...table,
           baseName,
@@ -148,7 +169,8 @@ const PesosTool: React.FC = () => {
         };
       }
 
-      const suffix = formatSuffixNumber(counter++);
+      const suffix = formatSuffixNumber(counter);
+      countersByStage.set(stageKey, counter + 1);
       return {
         ...table,
         baseName,
@@ -188,6 +210,9 @@ const PesosTool: React.FC = () => {
   // Get tour name for display
   const [tourName, setTourName] = useState<string>('');
   const [tourDateInfo, setTourDateInfo] = useState<{ date: string; location: string } | null>(null);
+  const activeTables = selectedStage
+    ? tables.filter((table) => isSameTechnicalStage(table.stageNumber, selectedStage))
+    : tables;
 
   // Preselect job from query param and fetch details if not in the list
   useEffect(() => {
@@ -616,6 +641,8 @@ const PesosTool: React.FC = () => {
         rows: calculatedRows,
         totalWeight,
         id: Date.now(),
+        stageName: selectedStage?.name ?? null,
+        stageNumber: selectedStage?.number ?? null,
         dualMotors: useDualMotors,
         clusterId: newClusterId,
         cablePick,
@@ -629,6 +656,8 @@ const PesosTool: React.FC = () => {
         rows: calculatedRows,
         totalWeight,
         id: Date.now() + 1,
+        stageName: selectedStage?.name ?? null,
+        stageNumber: selectedStage?.number ?? null,
         dualMotors: useDualMotors,
         clusterId: newClusterId,
         cablePick,
@@ -645,6 +674,8 @@ const PesosTool: React.FC = () => {
         rows: calculatedRows,
         totalWeight,
         id: Date.now(),
+        stageName: selectedStage?.name ?? null,
+        stageNumber: selectedStage?.number ?? null,
         dualMotors: useDualMotors,
         clusterId: newClusterId,
         cablePick,
@@ -703,7 +734,7 @@ const PesosTool: React.FC = () => {
       return;
     }
 
-    const summaryRows: SummaryRow[] = tables.map((table) => {
+    const summaryRows: SummaryRow[] = activeTables.map((table) => {
       const cleanName = table.name.split('(')[0].trim();
       return {
         clusterName: cleanName,
@@ -713,7 +744,7 @@ const PesosTool: React.FC = () => {
     });
 
     // Group tables by clusterId to handle cable picks
-    const clusters = tables.reduce((acc, table) => {
+    const clusters = activeTables.reduce((acc, table) => {
       if (table.clusterId) {
         if (!acc[table.clusterId]) {
           acc[table.clusterId] = [];
@@ -746,12 +777,14 @@ const PesosTool: React.FC = () => {
         console.error("Error fetching logo:", logoError);
       }
 
-      // For now just use the job title - location will be added later when available
+      const stageLabel = formatTechnicalStageLabel(selectedStage);
+      const reportTitle = stageLabel ? `${selectedJob.title} - ${stageLabel}` : selectedJob.title;
+
       const pdfBlob = await exportToPDF(
-        selectedJob.title,
-        tables.map((table) => ({ ...table, toolType: 'pesos' })),
+        reportTitle,
+        activeTables.map((table) => ({ ...table, toolType: 'pesos' })),
         'weight',
-        selectedJob.title,
+        reportTitle,
         selectedJob?.start_time || new Date().toISOString(),
         summaryRows,
         undefined,
@@ -759,7 +792,10 @@ const PesosTool: React.FC = () => {
         logoUrl
       );
 
-      const fileName = `Pesos Report - ${selectedJob.title}.pdf`;
+      const fileName = appendTechnicalStageToFilename(
+        `Pesos Report - ${selectedJob.title}.pdf`,
+        selectedStage
+      );
       let completedTasksCount = 0;
 
       // Upload PDF first - only auto-complete tasks if upload succeeds
@@ -767,6 +803,7 @@ const PesosTool: React.FC = () => {
         fileName,
         jobId: selectedJobId,
         pdfBlob,
+        stage: selectedStage,
       });
 
       if (completedTasksCount > 0) {
@@ -810,13 +847,16 @@ const PesosTool: React.FC = () => {
       isTourContext={isTourContext}
       isJobOverrideMode={isJobOverrideMode}
       jobTourInfo={jobTourInfo}
-      tables={tables}
+      tables={activeTables}
       currentSetName={currentSetName}
       setCurrentSetName={setCurrentSetName}
       jobIdFromUrl={jobIdFromUrl}
       selectedJobId={selectedJobId}
       handleJobSelect={handleJobSelect}
       jobs={jobs}
+      selectedStageNumber={selectedStageNumber}
+      setSelectedStageNumber={setSelectedStageNumber}
+      jobStages={jobStages}
       tableName={tableName}
       setTableName={setTableName}
       useDualMotors={useDualMotors}

--- a/src/pages/VideoConsumosTool.tsx
+++ b/src/pages/VideoConsumosTool.tsx
@@ -28,6 +28,13 @@ import {
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
+  TechnicalStageSelector,
+  appendTechnicalStageToFilename,
+  formatTechnicalStageLabel,
+  isSameTechnicalStage,
+  useSelectedTechnicalStage,
+} from '@/features/technical-tools/stage/stageAllocation';
+import {
   CUSTOM_POWER_POSITION_VALUE,
   getPowerPositionCustomValue,
   getPowerPositionSelectValue,
@@ -57,6 +64,8 @@ interface Table {
   name: string;
   rows: TableRow[];
   powerRequirementId?: string;
+  stageNumber?: number | null;
+  stageName?: string | null;
   totalWatts?: number;
   adjustedWatts?: number;
   totalVa?: number;
@@ -99,6 +108,15 @@ const VideoConsumosTool: React.FC = () => {
 
   const [selectedJobId, setSelectedJobId] = useState<string>('');
   const [selectedJob, setSelectedJob] = useState<any>(null);
+  const {
+    selectedStage,
+    selectedStageNumber,
+    setSelectedStageNumber,
+    stages: jobStages,
+  } = useSelectedTechnicalStage({
+    enabled: Boolean(selectedJobId) && !isTourDefaults && !isOverrideMode,
+    jobId: selectedJobId,
+  });
   const [tableName, setTableName] = useState('');
   const [tables, setTables] = useState<Table[]>([]);
   const [fohSchukoRequired, setFohSchukoRequired] = useState<boolean>(true);
@@ -245,6 +263,9 @@ const VideoConsumosTool: React.FC = () => {
 
   const getPowerSettings = () => ({ safetyMargin, powerFactor: pf, phaseMode, voltage });
   const PDU_TYPES = getPowerPduOptions('video', phaseMode);
+  const activeTables = selectedStage
+    ? tables.filter((table) => isSameTechnicalStage(table.stageNumber, selectedStage))
+    : tables;
 
   const savePowerRequirementTable = async (
     table: Table,
@@ -276,6 +297,7 @@ const VideoConsumosTool: React.FC = () => {
         department: 'video',
         jobId: selectedJobId,
         settings: getPowerSettings(),
+        stage: selectedStage,
         table,
       });
 
@@ -317,6 +339,8 @@ const VideoConsumosTool: React.FC = () => {
       settings: getPowerSettings(),
       tablePatch: {
         customPduType: undefined,
+        stageName: selectedStage?.name ?? null,
+        stageNumber: selectedStage?.number ?? null,
       },
     }) as Table;
 
@@ -447,7 +471,7 @@ const VideoConsumosTool: React.FC = () => {
       // Combine defaults and current tables for export
       const allTables = isOverrideMode 
         ? [...defaultTables, ...tables]
-        : tables;
+        : activeTables;
 
       // Generate power summary for consumos reports
       const totalSystemWatts = allTables.reduce((sum, table) => sum + (table.totalWatts || 0), 0);
@@ -468,11 +492,14 @@ const VideoConsumosTool: React.FC = () => {
         console.error("Error fetching logo:", logoError);
       }
 
+      const stageLabel = formatTechnicalStageLabel(selectedStage);
+      const reportTitle = stageLabel ? `${jobToUse.title} - ${stageLabel}` : jobToUse.title;
+
       const pdfBlob = await exportToPDF(
-        jobToUse.title,
+        reportTitle,
         allTables.map((table) => ({ ...table, toolType: 'consumos' })),
         'power',
-        jobToUse.title,
+        reportTitle,
         jobToUse?.start_time || new Date().toISOString(),
         undefined,
         powerSummary,
@@ -481,7 +508,10 @@ const VideoConsumosTool: React.FC = () => {
         fohSchukoRequired
       );
 
-      const fileName = `Video Power Report - ${jobToUse.title}.pdf`;
+      const fileName = appendTechnicalStageToFilename(
+        `Video Power Report - ${jobToUse.title}.pdf`,
+        selectedStage
+      );
       
       // Auto-complete video Consumos tasks only after successful upload
       // This automation is department-specific: only video department tasks are affected
@@ -492,6 +522,7 @@ const VideoConsumosTool: React.FC = () => {
           fileName,
           jobId: selectedJobId,
           pdfBlob,
+          stage: selectedStage,
         });
 
         if (completedTasksCount > 0) {
@@ -746,6 +777,15 @@ const VideoConsumosTool: React.FC = () => {
             </div>
           )}
 
+          {!isOverrideMode && !isTourDefaults && (
+            <TechnicalStageSelector
+              label="Stage"
+              selectedStageNumber={selectedStageNumber}
+              stages={jobStages}
+              onChange={setSelectedStageNumber}
+            />
+          )}
+
           <div className="flex items-center space-x-2">
             <Checkbox id="foh-schuko" checked={fohSchukoRequired} onCheckedChange={(c) => setFohSchukoRequired(!!c)} />
             <Label htmlFor="foh-schuko">Se requiere potencia de 16A en formato schuko hembra en posicion FoH</Label>
@@ -891,7 +931,7 @@ const VideoConsumosTool: React.FC = () => {
             <Button onClick={resetCurrentTable} variant="destructive">
               Reset
             </Button>
-            {tables.length > 0 && !isTourDefaults && (
+            {activeTables.length > 0 && !isTourDefaults && (
               <Button onClick={handleExportPDF} variant="outline" className="ml-auto gap-2">
                 <FileText className="h-4 w-4" />
                 Export & Upload PDF
@@ -900,11 +940,14 @@ const VideoConsumosTool: React.FC = () => {
           </div>
 
           {/* Updated tables section to show safety margin adjusted watts */}
-          {tables.map((table) => (
+          {activeTables.map((table) => (
             <div key={table.id} className="border rounded-lg overflow-x-auto mt-6">
               <div className="bg-muted px-4 py-3 flex justify-between items-center">
                 <div className="flex items-center gap-2">
                   <h3 className="font-semibold">{table.name}</h3>
+                  {table.stageName && (
+                    <Badge variant="outline">{table.stageName}</Badge>
+                  )}
                   {isOverrideMode && (
                     <Badge variant="outline" className="bg-orange-50 text-orange-700">Override</Badge>
                   )}

--- a/src/pages/consumos-tool/components/PowerTableCard.tsx
+++ b/src/pages/consumos-tool/components/PowerTableCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import type { Table } from "../types";
 import { PowerTableControls } from "@/features/technical-tools/power/PowerTableControls";
 import {
@@ -19,7 +20,10 @@ export const PowerTableCard: React.FC<{
   return (
     <div className="border rounded-lg overflow-hidden mt-6">
       <div className="bg-muted px-4 py-3 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
-        <h3 className="font-semibold">{table.name}</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="font-semibold">{table.name}</h3>
+          {table.stageName && <Badge variant="outline">{table.stageName}</Badge>}
+        </div>
         <Button variant="destructive" size="sm" onClick={onRemove}>
           Remove Table
         </Button>

--- a/src/pages/consumos-tool/types.ts
+++ b/src/pages/consumos-tool/types.ts
@@ -11,6 +11,8 @@ export interface Table {
   name: string;
   rows: TableRow[];
   powerRequirementId?: string;
+  stageNumber?: number | null;
+  stageName?: string | null;
   totalWatts?: number;
   adjustedWatts?: number;
   totalVa?: number; // apparent power (VA) — used for kVA display and generator sizing

--- a/src/pages/pesos-tool/PesosToolView.tsx
+++ b/src/pages/pesos-tool/PesosToolView.tsx
@@ -464,7 +464,7 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                 </div>
 
                 {/* Advanced Options Display */}
-                {(table.dualMotors || table.clusterId || cablePick) && (
+                {(table.dualMotors || table.clusterId || table.cablePick) && (
                   <div className="p-4 bg-muted/50 space-y-2">
                     <h4 className="font-medium text-sm">Configuration:</h4>
                     <div className="flex flex-wrap gap-4 text-sm">
@@ -472,9 +472,9 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                       {table.clusterId && (
                         <span className="bg-green-100 text-green-800 px-2 py-1 rounded">Mirrored Cluster</span>
                       )}
-                      {cablePick && (
+                      {table.cablePick && (
                         <span className="bg-purple-100 text-purple-800 px-2 py-1 rounded">
-                          Cable Pick ({cablePickWeight} kg)
+                          Cable Pick ({table.cablePickWeight} kg)
                         </span>
                       )}
                     </div>
@@ -552,7 +552,7 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                 </div>
 
                 {/* Advanced Options Display */}
-                {(table.dualMotors || table.clusterId || cablePick) && (
+                {(table.dualMotors || table.clusterId || table.cablePick) && (
                   <div className="p-4 bg-muted/50 space-y-2">
                     <h4 className="font-medium text-sm">Configuration:</h4>
                     <div className="flex flex-wrap gap-4 text-sm">
@@ -560,9 +560,9 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                       {table.clusterId && (
                         <span className="bg-green-100 text-green-800 px-2 py-1 rounded">Mirrored Cluster</span>
                       )}
-                      {cablePick && (
+                      {table.cablePick && (
                         <span className="bg-purple-100 text-purple-800 px-2 py-1 rounded">
-                          Cable Pick ({cablePickWeight} kg)
+                          Cable Pick ({table.cablePickWeight} kg)
                         </span>
                       )}
                     </div>

--- a/src/pages/pesos-tool/PesosToolView.tsx
+++ b/src/pages/pesos-tool/PesosToolView.tsx
@@ -8,6 +8,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  TechnicalStageSelector,
+  type TechnicalStage,
+} from "@/features/technical-tools/stage/stageAllocation";
 
 export interface PesosToolViewProps {
   handleBackNavigation: () => void;
@@ -27,6 +31,9 @@ export interface PesosToolViewProps {
   selectedJobId: string;
   handleJobSelect: (jobId: string) => void;
   jobs?: any[];
+  selectedStageNumber: number | null;
+  setSelectedStageNumber: (stageNumber: number) => void;
+  jobStages: TechnicalStage[];
   tableName: string;
   setTableName: (value: string) => void;
   useDualMotors: boolean;
@@ -71,6 +78,9 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
   selectedJobId,
   handleJobSelect,
   jobs,
+  selectedStageNumber,
+  setSelectedStageNumber,
+  jobStages,
   tableName,
   setTableName,
   useDualMotors,
@@ -232,6 +242,15 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                       </SelectContent>
                     </Select>
                   </div>
+                )}
+
+                {!isTourContext && !isTourDefaults && !isJobOverrideMode && (
+                  <TechnicalStageSelector
+                    label="Stage"
+                    selectedStageNumber={selectedStageNumber}
+                    stages={jobStages}
+                    onChange={setSelectedStageNumber}
+                  />
                 )}
 
                 <div className="space-y-2">
@@ -424,6 +443,7 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                 <div className="bg-muted px-4 py-3 flex justify-between items-center">
                   <div className="flex items-center gap-2">
                     <h3 className="font-semibold">{table.name}</h3>
+                    {table.stageName && <Badge variant="outline">{table.stageName}</Badge>}
                     {isTourDefaults && (
                       <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
                         Default
@@ -511,6 +531,7 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                 <div className="bg-muted px-4 py-3 flex justify-between items-center">
                   <div className="flex items-center gap-2">
                     <h3 className="font-semibold">{table.name}</h3>
+                    {table.stageName && <Badge variant="outline">{table.stageName}</Badge>}
                     {isTourDefaults && (
                       <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
                         Default
@@ -592,4 +613,3 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
     </div>
   );
 };
-

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -42,7 +42,64 @@ const createUnexpectedFetchError = (input?: RequestInfo | URL) => {
   );
 };
 
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+};
+
+const hasStorageMethods = (value: unknown): value is Storage =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as Storage).clear === "function" &&
+  typeof (value as Storage).getItem === "function" &&
+  typeof (value as Storage).removeItem === "function" &&
+  typeof (value as Storage).setItem === "function";
+
+const ensureTestLocalStorage = () => {
+  if (typeof window === "undefined") return;
+
+  let currentStorage: unknown;
+  try {
+    currentStorage = window.localStorage;
+  } catch {
+    currentStorage = undefined;
+  }
+
+  const storage = hasStorageMethods(currentStorage)
+    ? currentStorage
+    : createMemoryStorage();
+
+  if (storage !== currentStorage) {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+  }
+
+  if (!hasStorageMethods(globalThis.localStorage)) {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+  }
+};
+
 beforeEach(() => {
+  ensureTestLocalStorage();
   resetMockSupabase();
   toast.mockClear();
   toast.error.mockClear();

--- a/src/utils/__tests__/powerSummaryData.test.ts
+++ b/src/utils/__tests__/powerSummaryData.test.ts
@@ -316,6 +316,30 @@ describe('powerSummaryData', () => {
     ).toContain('SOUND - Main Stage - Main PA:');
   });
 
+  it('keeps numeric stage zero when formatting hoja de ruta power text', () => {
+    expect(
+      formatPowerRequirementsText([
+        {
+          id: 'sound-stage-0',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          stage_number: 0,
+          stage_name: null,
+          table_name: 'Main PA',
+          total_watts: 1000,
+          current_per_phase: 4,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          custom_position: null,
+          position: null,
+          includes_hoist: false,
+          table_data: { rows: [] },
+        } as any,
+      ])
+    ).toContain('SOUND - Stage 0 - Main PA:');
+  });
+
   it('uses saved job table electrical settings when calculating apparent power', async () => {
     const supabase = createMockSupabase({
       power_requirement_tables: [

--- a/src/utils/__tests__/powerSummaryData.test.ts
+++ b/src/utils/__tests__/powerSummaryData.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatPowerRequirementsText,
   getTechnicalPowerSummaryAvailability,
   loadTechnicalPowerSummaryData,
 } from '@/utils/powerSummaryData';
@@ -235,6 +236,84 @@ describe('powerSummaryData', () => {
       'Stage 1',
       'Stage 2',
     ]);
+  });
+
+  it('keeps same saved table identity separate per festival stage', async () => {
+    const supabase = createMockSupabase({
+      power_requirement_tables: [
+        {
+          id: 'sound-stage-1',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          stage_number: 1,
+          stage_name: 'Main Stage',
+          table_name: 'Main PA',
+          total_watts: 1000,
+          current_per_phase: 4,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: {
+            sourceTableId: 'same-local-table-id',
+            rows: [{ quantity: '1', componentId: '1', watts: '1000' }],
+          },
+        },
+        {
+          id: 'sound-stage-2',
+          created_at: '2026-04-07T08:05:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          stage_number: 2,
+          stage_name: 'Club Stage',
+          table_name: 'Main PA',
+          total_watts: 1200,
+          current_per_phase: 5,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: {
+            sourceTableId: 'same-local-table-id',
+            rows: [{ quantity: '1', componentId: '1', watts: '1000' }],
+          },
+        },
+      ],
+    });
+
+    const summary = await loadTechnicalPowerSummaryData({
+      job: { id: 'job-1', job_type: 'single' },
+      supabase,
+    });
+
+    expect(summary.departments.sound.rows).toHaveLength(2);
+    expect(summary.departments.sound.rows.map((row) => row.stageName)).toEqual([
+      'Main Stage',
+      'Club Stage',
+    ]);
+  });
+
+  it('includes stage labels in hoja de ruta power text', () => {
+    expect(
+      formatPowerRequirementsText([
+        {
+          id: 'sound-stage-1',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          stage_number: 1,
+          stage_name: 'Main Stage',
+          table_name: 'Main PA',
+          total_watts: 1000,
+          current_per_phase: 4,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          custom_position: null,
+          position: null,
+          includes_hoist: false,
+          table_data: { rows: [] },
+        } as any,
+      ])
+    ).toContain('SOUND - Main Stage - Main PA:');
   });
 
   it('uses saved job table electrical settings when calculating apparent power', async () => {

--- a/src/utils/__tests__/technicalPowerSummaryPack.test.ts
+++ b/src/utils/__tests__/technicalPowerSummaryPack.test.ts
@@ -136,7 +136,7 @@ describe('technicalPowerSummaryPack', () => {
     expect(autoTableMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        head: [['Nombre Cuadro', 'PDU', 'Posición', 'Potencia', 'Corriente', 'Notas']],
+        head: [['Stage', 'Nombre Cuadro', 'PDU', 'Posición', 'Potencia', 'Corriente', 'Notas']],
       })
     );
   });

--- a/src/utils/__tests__/technicalPowerSummaryPack.test.ts
+++ b/src/utils/__tests__/technicalPowerSummaryPack.test.ts
@@ -87,6 +87,7 @@ describe('technicalPowerSummaryPack', () => {
             rows: [
               {
                 name: 'FoH',
+                stageNumber: 0,
                 pduLabel: '32A',
                 positionLabel: 'FOH',
                 totalWatts: 1000,
@@ -137,6 +138,12 @@ describe('technicalPowerSummaryPack', () => {
       expect.anything(),
       expect.objectContaining({
         head: [['Stage', 'Nombre Cuadro', 'PDU', 'Posición', 'Potencia', 'Corriente', 'Notas']],
+      })
+    );
+    expect(autoTableMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        body: expect.arrayContaining([expect.arrayContaining(['Stage 0'])]),
       })
     );
   });

--- a/src/utils/jobDocumentsUpload.ts
+++ b/src/utils/jobDocumentsUpload.ts
@@ -1,5 +1,20 @@
 import { supabase } from "@/lib/supabase";
 
+export type JobPdfUploadOptions = {
+  cleanupScope?: string;
+};
+
+const sanitizeFileName = (fileName: string) =>
+  fileName
+    .replace(/[^a-zA-Z0-9._-]/g, "_")
+    .replace(/_{2,}/g, "_")
+    .replace(/^_|_$/g, "");
+
+const sanitizePathSegment = (value: string) =>
+  sanitizeFileName(value)
+    .replace(/\.+/g, ".")
+    .replace(/^\.+|\.+$/g, "") || "scope";
+
 /**
  * Upload a job-related PDF to the job-documents bucket under a category folder,
  * first cleaning up any previous versions for that job and category.
@@ -10,15 +25,16 @@ export const uploadJobPdfWithCleanup = async (
   jobId: string,
   pdfBlob: Blob,
   fileName: string,
-  category: string
+  category: string,
+  options: JobPdfUploadOptions = {}
 ): Promise<void> => {
   // Sanitize filename for storage
-  const sanitizedFileName = fileName
-    .replace(/[^a-zA-Z0-9._-]/g, "_")
-    .replace(/_{2,}/g, "_")
-    .replace(/^_|_$/g, "");
+  const sanitizedFileName = sanitizeFileName(fileName);
 
-  const baseFolder = `${category}/${jobId}`; // e.g. calculators/pesos/<jobId>
+  const scopeFolder = options.cleanupScope
+    ? `/${sanitizePathSegment(options.cleanupScope)}`
+    : "";
+  const baseFolder = `${category}/${jobId}${scopeFolder}`; // e.g. calculators/pesos/<jobId>/<stage>
   const objectPath = `${baseFolder}/${sanitizedFileName}`;
 
   try {

--- a/src/utils/pdf/technicalPowerSummaryPack.ts
+++ b/src/utils/pdf/technicalPowerSummaryPack.ts
@@ -153,6 +153,7 @@ const drawFooter = ({
 const departmentTableBody = (department: DepartmentPowerSummaryData) =>
   department.rows.length > 0
     ? department.rows.map((row) => [
+        row.stageName || (row.stageNumber ? `Stage ${row.stageNumber}` : '-'),
         row.name,
         row.pduLabel || 'N/A',
         row.positionLabel || 'N/A',
@@ -160,7 +161,7 @@ const departmentTableBody = (department: DepartmentPowerSummaryData) =>
         formatAmps(row.currentPerPhase),
         row.notes || '',
       ])
-    : [['Sin datos guardados', '-', '-', formatWatts(0), formatAmps(0), '']];
+    : [['-', 'Sin datos guardados', '-', '-', formatWatts(0), formatAmps(0), '']];
 
 const drawTotalsBox = ({
   doc,
@@ -315,7 +316,7 @@ export const generateTechnicalPowerSummaryPack = async ({
 
     autoTable(doc, {
       startY: CONTENT_START_Y,
-      head: [['Nombre Cuadro', 'PDU', 'Posición', 'Potencia', 'Corriente', 'Notas']],
+      head: [['Stage', 'Nombre Cuadro', 'PDU', 'Posición', 'Potencia', 'Corriente', 'Notas']],
       body: departmentTableBody(department),
       theme: 'grid',
       styles: {

--- a/src/utils/pdf/technicalPowerSummaryPack.ts
+++ b/src/utils/pdf/technicalPowerSummaryPack.ts
@@ -153,7 +153,7 @@ const drawFooter = ({
 const departmentTableBody = (department: DepartmentPowerSummaryData) =>
   department.rows.length > 0
     ? department.rows.map((row) => [
-        row.stageName || (row.stageNumber ? `Stage ${row.stageNumber}` : '-'),
+        row.stageName || (row.stageNumber != null ? `Stage ${row.stageNumber}` : '-'),
         row.name,
         row.pduLabel || 'N/A',
         row.positionLabel || 'N/A',

--- a/src/utils/powerSummaryData.ts
+++ b/src/utils/powerSummaryData.ts
@@ -74,6 +74,8 @@ const mapPowerRequirementTable = (
   department: TechnicalPowerDepartment
 ): DepartmentPowerSummaryRow => ({
   name: row.table_name || 'Unnamed',
+  stageName: getPowerRequirementStageName(row),
+  stageNumber: getPowerRequirementStageNumber(row),
   pduLabel: row.custom_pdu_type || row.pdu_type || 'N/A',
   positionLabel: getResolvedPowerPosition(row.position, row.custom_position) || 'N/A',
   totalWatts: row.total_watts || 0,
@@ -106,6 +108,42 @@ const getPowerRequirementSourceTableId = (row: PowerRequirementTableRow) => {
     : null;
 };
 
+const getPowerRequirementStageNumber = (row: PowerRequirementTableRow) => {
+  if (typeof row.stage_number === 'number') return row.stage_number;
+  if (!isRecord(row.table_data)) return null;
+
+  const stageNumber = row.table_data.stageNumber;
+  return typeof stageNumber === 'number' && Number.isFinite(stageNumber)
+    ? stageNumber
+    : null;
+};
+
+const getPowerRequirementStageName = (row: PowerRequirementTableRow) => {
+  if (row.stage_name?.trim()) return row.stage_name.trim();
+  if (!isRecord(row.table_data)) return null;
+
+  const stageName = row.table_data.stageName;
+  return typeof stageName === 'string' && stageName.trim()
+    ? stageName.trim()
+    : null;
+};
+
+const getPowerRequirementStageLabel = (row: PowerRequirementTableRow) => {
+  const stageName = getPowerRequirementStageName(row);
+  if (stageName) return stageName;
+
+  const stageNumber = getPowerRequirementStageNumber(row);
+  return stageNumber ? `Stage ${stageNumber}` : null;
+};
+
+const getPowerRequirementStageKey = (row: PowerRequirementTableRow) => {
+  const stageNumber = getPowerRequirementStageNumber(row);
+  if (stageNumber) return `stage-${stageNumber}`;
+
+  const stageName = getPowerRequirementStageName(row);
+  return stageName ? `stage-name-${stageName.toLowerCase()}` : 'no-stage';
+};
+
 const comparePowerRequirementTablesByFreshness = (
   left: IndexedPowerRequirementTableRow,
   right: IndexedPowerRequirementTableRow
@@ -130,16 +168,17 @@ const getPowerRequirementTableCurrentKey = (
   row: PowerRequirementTableRow,
   department: TechnicalPowerDepartment
 ) => {
+  const stageKey = getPowerRequirementStageKey(row);
   const sourceTableId = getPowerRequirementSourceTableId(row);
   if (sourceTableId) {
-    return `${department}:source:${sourceTableId}`;
+    return `${department}:${stageKey}:source:${sourceTableId}`;
   }
 
   const normalizedName = row.table_name?.trim().toLowerCase();
   const rowSignature = getPowerRequirementRowsSignature(row);
 
   if (normalizedName && rowSignature) {
-    return `${department}:legacy:${normalizedName}:${rowSignature}`;
+    return `${department}:${stageKey}:legacy:${normalizedName}:${rowSignature}`;
   }
 
   return `${department}:row:${row.id}`;
@@ -182,10 +221,11 @@ export const formatPowerRequirementsText = (
   getCurrentPowerRequirementTables(rows)
     .map((req) => {
       const department = (req.department || 'general').toUpperCase();
+      const stageLabel = getPowerRequirementStageLabel(req);
       const pduType = req.custom_pdu_type || req.pdu_type || 'N/D';
       const position = getResolvedPowerPosition(req.position, req.custom_position);
       const lines = [
-        `${department} - ${req.table_name || 'tabla'}:`,
+        `${[department, stageLabel, req.table_name || 'tabla'].filter(Boolean).join(' - ')}:`,
         `Potencia Total: ${formatPowerRequirementNumber(req.total_watts)}W`,
         `Corriente por Fase: ${formatPowerRequirementNumber(req.current_per_phase)}A`,
         `PDU Recomendado: ${pduType}`,

--- a/src/utils/powerSummaryData.ts
+++ b/src/utils/powerSummaryData.ts
@@ -133,12 +133,12 @@ const getPowerRequirementStageLabel = (row: PowerRequirementTableRow) => {
   if (stageName) return stageName;
 
   const stageNumber = getPowerRequirementStageNumber(row);
-  return stageNumber ? `Stage ${stageNumber}` : null;
+  return stageNumber !== null ? `Stage ${stageNumber}` : null;
 };
 
 const getPowerRequirementStageKey = (row: PowerRequirementTableRow) => {
   const stageNumber = getPowerRequirementStageNumber(row);
-  if (stageNumber) return `stage-${stageNumber}`;
+  if (stageNumber !== null) return `stage-${stageNumber}`;
 
   const stageName = getPowerRequirementStageName(row);
   return stageName ? `stage-name-${stageName.toLowerCase()}` : 'no-stage';

--- a/src/utils/technicalPowerTypes.ts
+++ b/src/utils/technicalPowerTypes.ts
@@ -40,6 +40,8 @@ export type DepartmentPowerSummarySource =
 
 export interface DepartmentPowerSummaryRow {
   name: string;
+  stageName?: string | null;
+  stageNumber?: number | null;
   pduLabel: string;
   positionLabel: string;
   totalWatts: number;

--- a/supabase/migrations/00000000000000_production_schema.sql
+++ b/supabase/migrations/00000000000000_production_schema.sql
@@ -6457,10 +6457,14 @@ CREATE TABLE IF NOT EXISTS "public"."power_requirement_tables" (
     "created_at" timestamp with time zone DEFAULT "now"(),
     "includes_hoist" boolean DEFAULT false,
     "custom_pdu_type" "text",
-    "department" "text"
+    "department" "text",
+    "stage_number" integer,
+    "stage_name" "text"
 );
 ALTER TABLE "public"."power_requirement_tables" OWNER TO "postgres";
 COMMENT ON COLUMN "public"."power_requirement_tables"."department" IS 'Department that created the power requirement (sound, lights, video)';
+COMMENT ON COLUMN "public"."power_requirement_tables"."stage_number" IS 'Festival stage number for multi-stage job power requirements.';
+COMMENT ON COLUMN "public"."power_requirement_tables"."stage_name" IS 'Festival stage display name captured when the power requirement was generated.';
 CREATE TABLE IF NOT EXISTS "public"."preset_items" (
     "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
     "preset_id" "uuid" NOT NULL,
@@ -8077,6 +8081,7 @@ CREATE INDEX "idx_messages_unread_sender" ON "public"."messages" USING "btree" (
 CREATE INDEX "idx_morning_subscriptions_user_id" ON "public"."morning_summary_subscriptions" USING "btree" ("user_id");
 CREATE INDEX "idx_notification_preferences_staffing_scope" ON "public"."notification_preferences" USING "btree" ("staffing_scope") WHERE ("staffing_scope" IS NOT NULL);
 CREATE INDEX "idx_notification_preferences_user_id_fk_066900" ON "public"."notification_preferences" USING "btree" ("user_id");
+CREATE INDEX "idx_power_requirement_tables_job_department_stage" ON "public"."power_requirement_tables" USING "btree" ("job_id", "department", "stage_number");
 CREATE INDEX "idx_power_requirement_tables_job_id_fk_209c8a" ON "public"."power_requirement_tables" USING "btree" ("job_id");
 CREATE INDEX "idx_preset_items_equipment_id_fk_754df4" ON "public"."preset_items" USING "btree" ("equipment_id");
 CREATE INDEX "idx_preset_items_preset_id_fk_3efc66" ON "public"."preset_items" USING "btree" ("preset_id");

--- a/supabase/migrations/20260603201000_add_stage_to_power_requirement_tables.sql
+++ b/supabase/migrations/20260603201000_add_stage_to_power_requirement_tables.sql
@@ -1,0 +1,12 @@
+alter table public.power_requirement_tables
+  add column if not exists stage_number integer,
+  add column if not exists stage_name text;
+
+create index if not exists idx_power_requirement_tables_job_department_stage
+  on public.power_requirement_tables (job_id, department, stage_number);
+
+comment on column public.power_requirement_tables.stage_number is
+  'Festival stage number for multi-stage job power requirements.';
+
+comment on column public.power_requirement_tables.stage_name is
+  'Festival stage display name captured when the power requirement was generated.';


### PR DESCRIPTION
## Summary
- Adds stage selection to Pesos and Consumos tools for sound, lights, and video jobs with configured festival stages.
- Persists `stage_number` and `stage_name` on `power_requirement_tables` and includes stage metadata in saved table data.
- Scopes generated Pesos/Consumos PDF cleanup by stage so one stage upload no longer replaces another stage's report.
- Includes stage labels in generated filenames, report titles, hoja de ruta power text, and the dedicated technical power summary PDF.
- Hardens Supabase auth storage detection for test/runtime safety.

## Why
Multi-stage jobs were sharing one set of saved power rows and one upload cleanup folder per department, so later stage calculations and PDFs could overwrite earlier stage outputs. This keeps single-stage behavior unchanged while isolating multi-stage requirements by selected stage.

## Validation
- `npm run test:run`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run build`
- Browser smoke: local app starts and protected tool route redirects to `/auth` as expected without an authenticated in-app browser session.

## Database
Adds nullable `stage_number` and `stage_name` columns plus an index on `(job_id, department, stage_number)` for `power_requirement_tables`. Existing rows remain compatible as unscoped single-stage rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-stage support to power management tools with stage selection controls.
  * Power tables now display stage information as badges and filter by selected stage automatically.
  * PDF exports now include stage labels in titles and filenames for better organization.

* **Bug Fixes**
  * Improved localStorage detection for more robust session persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->