### PR TITLE
Fix mobile navbar bottom anchoring

### DIFF
--- a/src/components/layout/MobileNavBar.test.tsx
+++ b/src/components/layout/MobileNavBar.test.tsx
@@ -3,8 +3,8 @@ import { ClipboardList, MapPin } from "lucide-react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { MemoryRouter } from "react-router-dom"
 
-import { MobileNavBar } from "./MobileNavBar"
-import type { NavigationItem } from "./SidebarNavigation"
+import { MobileNavBar } from "@/components/layout/MobileNavBar"
+import type { NavigationItem } from "@/components/layout/SidebarNavigation"
 
 const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight")
 const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")

--- a/src/components/layout/MobileNavBar.test.tsx
+++ b/src/components/layout/MobileNavBar.test.tsx
@@ -1,0 +1,139 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { ClipboardList, MapPin } from "lucide-react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
+
+import { MobileNavBar } from "./MobileNavBar"
+import type { NavigationItem } from "./SidebarNavigation"
+
+const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight")
+const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+
+afterEach(() => {
+  if (originalInnerHeight) {
+    Object.defineProperty(window, "innerHeight", originalInnerHeight)
+  }
+
+  if (originalVisualViewport) {
+    Object.defineProperty(window, "visualViewport", originalVisualViewport)
+  } else {
+    delete (window as { visualViewport?: VisualViewport }).visualViewport
+  }
+})
+
+function createNavigationItem(overrides: Partial<NavigationItem> = {}): NavigationItem {
+  return {
+    id: "projects",
+    label: "Proyectos",
+    mobileLabel: "Proyectos",
+    to: "/projects",
+    icon: ClipboardList,
+    mobileSlot: "primary",
+    isActive: (pathname) => pathname === "/projects",
+    ...overrides,
+  }
+}
+
+function renderMobileNav() {
+  return render(
+    <MemoryRouter initialEntries={["/tours"]}>
+      <MobileNavBar
+        primaryItems={[
+          createNavigationItem(),
+          createNavigationItem({
+            id: "tours",
+            label: "Giras",
+            mobileLabel: "Giras",
+            to: "/tours",
+            icon: MapPin,
+            isActive: (pathname) => pathname === "/tours",
+          }),
+        ]}
+        trayItems={[]}
+        onSignOut={vi.fn()}
+        isLoggingOut={false}
+      />
+    </MemoryRouter>,
+  )
+}
+
+function mockVisualViewport({
+  height,
+  innerHeight,
+  offsetTop,
+}: {
+  height: number
+  innerHeight: number
+  offsetTop: number
+}) {
+  const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>()
+  const visualViewport = {
+    width: 390,
+    height,
+    offsetTop,
+    addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      const typeListeners = listeners.get(type) ?? new Set<EventListenerOrEventListenerObject>()
+      typeListeners.add(listener)
+      listeners.set(type, typeListeners)
+    }),
+    removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      listeners.get(type)?.delete(listener)
+    }),
+  } as unknown as VisualViewport
+
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: innerHeight,
+  })
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: visualViewport,
+  })
+
+  return {
+    dispatch(type: string) {
+      for (const listener of listeners.get(type) ?? []) {
+        const event = new Event(type)
+        if (typeof listener === "function") {
+          listener(event)
+        } else {
+          listener.handleEvent(event)
+        }
+      }
+    },
+  }
+}
+
+describe("MobileNavBar", () => {
+  it("renders the fixed nav in a body portal", () => {
+    const { container } = renderMobileNav()
+
+    const nav = screen.getByRole("navigation", { name: /navegación principal/i })
+
+    expect(nav.parentElement).toBe(document.body)
+    expect(container).not.toContainElement(nav)
+    expect(nav).toHaveClass("fixed", "bottom-0")
+  })
+
+  it("offsets the nav to the visual viewport bottom when browser chrome changes visible height", async () => {
+    const visualViewport = mockVisualViewport({
+      height: 700,
+      innerHeight: 760,
+      offsetTop: 0,
+    })
+
+    renderMobileNav()
+
+    const nav = screen.getByRole("navigation", { name: /navegación principal/i })
+
+    await waitFor(() => expect(nav.style.bottom).toBe("60px"))
+
+    ;(window.visualViewport as unknown as { height: number }).height = 760
+
+    act(() => {
+      visualViewport.dispatch("resize")
+    })
+
+    await waitFor(() => expect(nav.style.bottom).toBe(""))
+  })
+})

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState, type CSSProperties } from "react"
+import { createPortal } from "react-dom"
 import { Link, useLocation } from "react-router-dom"
 import { MoreHorizontal } from "lucide-react"
 
@@ -20,6 +22,49 @@ interface MobileNavBarProps {
   userEmail?: string
 }
 
+function getVisualViewportBottomOffset() {
+  if (typeof window === "undefined" || !window.visualViewport) {
+    return 0
+  }
+
+  const visualViewport = window.visualViewport
+  const layoutViewportHeight = window.innerHeight
+  const visualViewportBottom = visualViewport.offsetTop + visualViewport.height
+
+  return Math.max(0, Math.round(layoutViewportHeight - visualViewportBottom))
+}
+
+function useVisualViewportBottomOffset() {
+  const [bottomOffset, setBottomOffset] = useState(0)
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined
+    }
+
+    const updateBottomOffset = () => {
+      setBottomOffset(getVisualViewportBottomOffset())
+    }
+
+    updateBottomOffset()
+
+    const visualViewport = window.visualViewport
+    window.addEventListener("resize", updateBottomOffset)
+    window.addEventListener("orientationchange", updateBottomOffset)
+    visualViewport?.addEventListener("resize", updateBottomOffset)
+    visualViewport?.addEventListener("scroll", updateBottomOffset)
+
+    return () => {
+      window.removeEventListener("resize", updateBottomOffset)
+      window.removeEventListener("orientationchange", updateBottomOffset)
+      visualViewport?.removeEventListener("resize", updateBottomOffset)
+      visualViewport?.removeEventListener("scroll", updateBottomOffset)
+    }
+  }, [])
+
+  return bottomOffset
+}
+
 export const MobileNavBar = ({
   primaryItems,
   trayItems,
@@ -30,6 +75,7 @@ export const MobileNavBar = ({
   userEmail,
 }: MobileNavBarProps) => {
   const { pathname } = useLocation()
+  const visualViewportBottomOffset = useVisualViewportBottomOffset()
   const hasNavigation = primaryItems.length > 0 || trayItems.length > 0
   // Always render the tray trigger so persistent actions like Sign Out and About
   // remain accessible for all roles, even when there are no additional tray items.
@@ -40,12 +86,17 @@ export const MobileNavBar = ({
   }
 
   const activeInTray = trayItems.some((item) => item.isActive(pathname))
+  const navStyle: CSSProperties | undefined = visualViewportBottomOffset > 0
+    ? { bottom: `${visualViewportBottomOffset}px` }
+    : undefined
 
-  return (
+  const nav = (
     <nav
       role="navigation"
       aria-label="Navegación principal"
+      data-mobile-navbar
       className="fixed inset-x-0 bottom-0 z-40 bg-background/95 backdrop-blur-xl border-t border-border px-2 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-2 shadow-lg md:hidden"
+      style={navStyle}
     >
       <div className="mx-auto flex w-full max-w-3xl items-stretch justify-evenly gap-1">
         {primaryItems.map((item) => {
@@ -96,4 +147,6 @@ export const MobileNavBar = ({
       </div>
     </nav>
   )
+
+  return typeof document === "undefined" ? nav : createPortal(nav, document.body)
 }

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -22,6 +22,9 @@ interface MobileNavBarProps {
   userEmail?: string
 }
 
+/**
+ * Returns the inset between the layout viewport bottom and the visible viewport bottom.
+ */
 function getVisualViewportBottomOffset() {
   if (typeof window === "undefined" || !window.visualViewport) {
     return 0
@@ -34,6 +37,9 @@ function getVisualViewportBottomOffset() {
   return Math.max(0, Math.round(layoutViewportHeight - visualViewportBottom))
 }
 
+/**
+ * Tracks browser UI and keyboard viewport changes that can move fixed mobile chrome.
+ */
 function useVisualViewportBottomOffset() {
   const [bottomOffset, setBottomOffset] = useState(0)
 

--- a/tests/e2e/tour-management.spec.ts
+++ b/tests/e2e/tour-management.spec.ts
@@ -108,4 +108,51 @@ test.describe("tour management smoke", () => {
     await page.getByRole("heading", { name: "World Tour" }).click();
     await expect(page).toHaveURL(/\/tours$/);
   });
+
+  test("anchors the mobile navbar to the viewport bottom", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await bootstrapApp(page, {
+      auth: {
+        role: "management",
+        department: "sound",
+      },
+      tables: {
+        profiles: [
+          {
+            role: "management",
+            department: "sound",
+            soundvision_access_enabled: false,
+            assignable_as_tech: false,
+          },
+        ],
+        tours: [smokeTour],
+      },
+    });
+
+    await page.goto("/tours");
+
+    await expect(page.getByText(new RegExp(`tours ${smokeTourYear}`, "i"))).toBeVisible();
+
+    const navbar = page.locator("[data-mobile-navbar]");
+    await expect(navbar).toHaveCount(1);
+    await expect(navbar).toBeVisible();
+
+    const assertPinnedToBottom = async () => {
+      const metrics = await navbar.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+
+        return {
+          bottomGap: window.innerHeight - rect.bottom,
+          parentTagName: element.parentElement?.tagName,
+        };
+      });
+
+      expect(metrics.parentTagName).toBe("BODY");
+      expect(Math.abs(metrics.bottomGap)).toBeLessThanOrEqual(1);
+    };
+
+    await assertPinnedToBottom();
+    await page.mouse.wheel(0, 900);
+    await assertPinnedToBottom();
+  });
 });


### PR DESCRIPTION
## Summary
- Render the global mobile navbar through a body portal to avoid ancestor/layout containment pulling fixed positioning away from the viewport.
- Track visual viewport bottom changes so mobile browser chrome or keyboard viewport changes keep the nav anchored correctly.
- Add component and e2e regression coverage for portal rendering and viewport-bottom positioning.

## Risk Assessment
- Level: Low.
- Functional risk: the navbar now renders under document.body, so routing and theme context must continue to work through React portal behavior.
- Data risk: none; no persistence or Supabase schema behavior changed.
- Deployment risk: low; frontend-only change with CI, e2e smoke, and Cloudflare preview coverage.

## Test Evidence
- npm run lint: passed with existing repo warnings only.
- npm run test:run: passed, 137 files / 877 tests.
- npm run build: passed with existing chunk-size warnings.
- npm run typecheck: passed.
- npm run cap:sync: passed; generated iOS Package.swift drift was excluded from the PR.
- npx playwright test tests/e2e/tour-management.spec.ts --project=chromium: passed, 3 tests.
- npx vitest run src/components/layout/MobileNavBar.test.tsx src/components/layout/Layout.test.ts: passed, 14 tests.

## Rollback Plan
- Revert this PR from main if the navbar shows a regression in production.
- No data cleanup or migration rollback is required.

## Migration Impact
- No database migrations.
- No Supabase Edge Function changes.
- No dependency or lockfile changes.