### PR TITLE
Add WAHA endpoint pairing settings

### DIFF
--- a/src/components/settings/WahaEndpointSettings.tsx
+++ b/src/components/settings/WahaEndpointSettings.tsx
@@ -1,0 +1,352 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, QrCode, RefreshCw, Save, Smartphone, Unplug } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  getWahaEndpointLabel,
+  normalizeWahaEndpoint,
+  NO_WAHA_ENDPOINT,
+  WAHA_ENDPOINTS,
+} from "@/constants/wahaEndpoints";
+import { toast } from "@/hooks/use-toast";
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
+import { queryKeys } from "@/lib/react-query";
+import { dataLayerClient } from "@/services/dataLayerClient";
+
+type WahaSessionStatus = "NOT_CONFIGURED" | "NOT_CREATED" | "STOPPED" | "STARTING" | "SCAN_QR_CODE" | "WORKING" | "FAILED" | "UNKNOWN";
+
+type WahaSessionResponse = {
+  endpoint: string | null;
+  session?: string | null;
+  status?: WahaSessionStatus | string | null;
+  me?: { id?: string; pushName?: string } | null;
+  qr?: {
+    dataUrl: string;
+    mimetype: string;
+  };
+};
+
+async function invokeWahaSession(body: Record<string, unknown>) {
+  const { data, error } = await dataLayerClient.functions.invoke("waha-session", { body });
+
+  if (error) throw error;
+
+  return data as WahaSessionResponse;
+}
+
+function statusLabel(status: string | null | undefined) {
+  switch (status) {
+    case "WORKING":
+      return "Working";
+    case "SCAN_QR_CODE":
+      return "Scan QR";
+    case "STARTING":
+      return "Starting";
+    case "STOPPED":
+      return "Stopped";
+    case "FAILED":
+      return "Failed";
+    case "NOT_CREATED":
+      return "Not started";
+    case "NOT_CONFIGURED":
+      return "Not configured";
+    default:
+      return "Unknown";
+  }
+}
+
+function statusVariant(status: string | null | undefined): "default" | "secondary" | "destructive" | "outline" {
+  if (status === "WORKING") return "default";
+  if (status === "FAILED") return "destructive";
+  if (status === "SCAN_QR_CODE" || status === "STARTING") return "secondary";
+  return "outline";
+}
+
+export function WahaEndpointSettings() {
+  const queryClient = useQueryClient();
+  const { user } = useOptimizedAuth();
+  const userId = user?.id ?? null;
+  const [selectedEndpoint, setSelectedEndpoint] = useState(NO_WAHA_ENDPOINT);
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+
+  const queryKey = queryKeys.scope("waha-session", userId || "anonymous");
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
+    queryKey,
+    enabled: Boolean(userId),
+    queryFn: () => invokeWahaSession({ action: "get" }),
+    staleTime: 1000 * 30,
+  });
+
+  const savedEndpoint = normalizeWahaEndpoint(data?.endpoint);
+  const selectedNormalized = selectedEndpoint === NO_WAHA_ENDPOINT
+    ? null
+    : normalizeWahaEndpoint(selectedEndpoint);
+  const hasUnsavedChange = savedEndpoint !== selectedNormalized;
+
+  useEffect(() => {
+    setSelectedEndpoint(savedEndpoint || NO_WAHA_ENDPOINT);
+    setQrDataUrl(null);
+  }, [savedEndpoint]);
+
+  const endpointOptions = useMemo(() => {
+    if (!savedEndpoint || WAHA_ENDPOINTS.some((option) => option.value === savedEndpoint)) {
+      return WAHA_ENDPOINTS;
+    }
+
+    return [
+      ...WAHA_ENDPOINTS,
+      { label: "Configured endpoint", value: savedEndpoint },
+    ];
+  }, [savedEndpoint]);
+
+  const saveMutation = useMutation({
+    mutationFn: () => invokeWahaSession({ action: "save", endpoint: selectedNormalized }),
+    onSuccess: async (result) => {
+      setQrDataUrl(null);
+      await queryClient.setQueryData(queryKey, result);
+      toast({
+        title: result.endpoint ? "WAHA endpoint saved" : "WAHA endpoint cleared",
+        description: result.endpoint ? getWahaEndpointLabel(result.endpoint) : "WhatsApp sending is disabled for this account.",
+      });
+    },
+    onError: (err) => {
+      toast({
+        title: "Failed to save WAHA endpoint",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: () => invokeWahaSession({ action: "status" }),
+    onSuccess: async (result) => {
+      setQrDataUrl(null);
+      await queryClient.setQueryData(queryKey, result);
+    },
+    onError: (err) => {
+      toast({
+        title: "Failed to read WAHA status",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const startMutation = useMutation({
+    mutationFn: () => invokeWahaSession({ action: "start" }),
+    onSuccess: async (result) => {
+      setQrDataUrl(null);
+      await queryClient.setQueryData(queryKey, result);
+      toast({
+        title: "WAHA session started",
+        description: `Session ${result.session || "default"} is ${statusLabel(result.status).toLowerCase()}.`,
+      });
+    },
+    onError: (err) => {
+      toast({
+        title: "Failed to start WAHA session",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const qrMutation = useMutation({
+    mutationFn: () => invokeWahaSession({ action: "qr" }),
+    onSuccess: async (result) => {
+      if (result.qr?.dataUrl) {
+        setQrDataUrl(result.qr.dataUrl);
+      }
+      await queryClient.setQueryData(queryKey, {
+        ...result,
+        qr: undefined,
+      });
+    },
+    onError: (err) => {
+      setQrDataUrl(null);
+      toast({
+        title: "Failed to load WAHA QR",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const isBusy =
+    saveMutation.isPending ||
+    statusMutation.isPending ||
+    startMutation.isPending ||
+    qrMutation.isPending;
+  const canUseSessionControls = Boolean(savedEndpoint) && !hasUnsavedChange && !isBusy;
+
+  if (!userId) {
+    return (
+      <Alert>
+        <AlertDescription>Sign in again to manage WhatsApp pairing.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading WAHA settings...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>WAHA settings unavailable</AlertTitle>
+        <AlertDescription>{error instanceof Error ? error.message : "Unknown error"}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-medium">Endpoint</span>
+            <Badge variant={statusVariant(data?.status)}>
+              {statusLabel(data?.status)}
+            </Badge>
+          </div>
+          <Select value={selectedEndpoint} onValueChange={setSelectedEndpoint} disabled={saveMutation.isPending}>
+            <SelectTrigger aria-label="WAHA endpoint">
+              <SelectValue placeholder="Select WAHA endpoint" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_WAHA_ENDPOINT}>
+                No WAHA endpoint
+              </SelectItem>
+              {endpointOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label} - {option.value.replace(/^https?:\/\//, "")}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button
+          type="button"
+          onClick={() => saveMutation.mutate()}
+          disabled={!hasUnsavedChange || saveMutation.isPending}
+          size="sm"
+          className="w-full md:w-auto"
+        >
+          {saveMutation.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="mr-2 h-4 w-4" />
+          )}
+          Save
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            if (savedEndpoint && !hasUnsavedChange) {
+              statusMutation.mutate();
+              return;
+            }
+
+            void refetch();
+          }}
+          disabled={isFetching || isBusy}
+          className="w-full"
+        >
+          <RefreshCw className={`mr-2 h-4 w-4 ${isFetching || statusMutation.isPending ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => startMutation.mutate()}
+          disabled={!canUseSessionControls}
+          className="w-full"
+        >
+          {startMutation.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Smartphone className="mr-2 h-4 w-4" />
+          )}
+          Start
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={() => qrMutation.mutate()}
+          disabled={!canUseSessionControls}
+          className="col-span-2 w-full md:col-span-1"
+        >
+          {qrMutation.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <QrCode className="mr-2 h-4 w-4" />
+          )}
+          QR
+        </Button>
+      </div>
+
+      {hasUnsavedChange && (
+        <Alert variant="info">
+          <AlertDescription>Save the endpoint before starting or pairing the WAHA session.</AlertDescription>
+        </Alert>
+      )}
+
+      {!savedEndpoint && (
+        <div className="flex items-start gap-2 rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+          <Unplug className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>No WAHA endpoint is assigned to your account.</span>
+        </div>
+      )}
+
+      {savedEndpoint && (
+        <div className="rounded-md border p-3 text-sm">
+          <div className="grid gap-1 sm:grid-cols-2">
+            <span>
+              <span className="font-medium">Host:</span> {savedEndpoint.replace(/^https?:\/\//, "")}
+            </span>
+            <span>
+              <span className="font-medium">Session:</span> {data?.session || "default"}
+            </span>
+            {data?.me?.pushName && (
+              <span className="sm:col-span-2">
+                <span className="font-medium">Linked account:</span> {data.me.pushName}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {qrDataUrl && (
+        <div className="flex flex-col items-center gap-3 rounded-md border bg-muted/20 p-4">
+          <img
+            src={qrDataUrl}
+            alt="WAHA pairing QR code"
+            className="h-56 w-56 rounded bg-white p-2 shadow-sm"
+          />
+          <p className="text-center text-xs text-muted-foreground">
+            Refresh the QR if the session remains in scan mode.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/WahaEndpointSettings.tsx
+++ b/src/components/settings/WahaEndpointSettings.tsx
@@ -41,21 +41,21 @@ async function invokeWahaSession(body: Record<string, unknown>) {
 function statusLabel(status: string | null | undefined) {
   switch (status) {
     case "WORKING":
-      return "Working";
+      return "En funcionamiento";
     case "SCAN_QR_CODE":
-      return "Scan QR";
+      return "Escanear QR";
     case "STARTING":
-      return "Starting";
+      return "Iniciando";
     case "STOPPED":
-      return "Stopped";
+      return "Detenida";
     case "FAILED":
-      return "Failed";
+      return "Error";
     case "NOT_CREATED":
-      return "Not started";
+      return "Sin iniciar";
     case "NOT_CONFIGURED":
-      return "Not configured";
+      return "Sin configurar";
     default:
-      return "Unknown";
+      return "Desconocido";
   }
 }
 
@@ -99,7 +99,7 @@ export function WahaEndpointSettings() {
 
     return [
       ...WAHA_ENDPOINTS,
-      { label: "Configured endpoint", value: savedEndpoint },
+      { label: "Endpoint configurado", value: savedEndpoint },
     ];
   }, [savedEndpoint]);
 
@@ -109,14 +109,14 @@ export function WahaEndpointSettings() {
       setQrDataUrl(null);
       await queryClient.setQueryData(queryKey, result);
       toast({
-        title: result.endpoint ? "WAHA endpoint saved" : "WAHA endpoint cleared",
-        description: result.endpoint ? getWahaEndpointLabel(result.endpoint) : "WhatsApp sending is disabled for this account.",
+        title: result.endpoint ? "Endpoint WAHA guardado" : "Endpoint WAHA eliminado",
+        description: result.endpoint ? getWahaEndpointLabel(result.endpoint) : "El envio por WhatsApp queda desactivado para esta cuenta.",
       });
     },
     onError: (err) => {
       toast({
-        title: "Failed to save WAHA endpoint",
-        description: err instanceof Error ? err.message : "Unknown error",
+        title: "No se pudo guardar el endpoint WAHA",
+        description: err instanceof Error ? err.message : "Error desconocido",
         variant: "destructive",
       });
     },
@@ -130,8 +130,8 @@ export function WahaEndpointSettings() {
     },
     onError: (err) => {
       toast({
-        title: "Failed to read WAHA status",
-        description: err instanceof Error ? err.message : "Unknown error",
+        title: "No se pudo leer el estado WAHA",
+        description: err instanceof Error ? err.message : "Error desconocido",
         variant: "destructive",
       });
     },
@@ -143,14 +143,14 @@ export function WahaEndpointSettings() {
       setQrDataUrl(null);
       await queryClient.setQueryData(queryKey, result);
       toast({
-        title: "WAHA session started",
-        description: `Session ${result.session || "default"} is ${statusLabel(result.status).toLowerCase()}.`,
+        title: "Sesion WAHA iniciada",
+        description: `La sesion ${result.session || "default"} esta ${statusLabel(result.status).toLowerCase()}.`,
       });
     },
     onError: (err) => {
       toast({
-        title: "Failed to start WAHA session",
-        description: err instanceof Error ? err.message : "Unknown error",
+        title: "No se pudo iniciar la sesion WAHA",
+        description: err instanceof Error ? err.message : "Error desconocido",
         variant: "destructive",
       });
     },
@@ -161,6 +161,8 @@ export function WahaEndpointSettings() {
     onSuccess: async (result) => {
       if (result.qr?.dataUrl) {
         setQrDataUrl(result.qr.dataUrl);
+      } else {
+        setQrDataUrl(null);
       }
       await queryClient.setQueryData(queryKey, {
         ...result,
@@ -170,8 +172,8 @@ export function WahaEndpointSettings() {
     onError: (err) => {
       setQrDataUrl(null);
       toast({
-        title: "Failed to load WAHA QR",
-        description: err instanceof Error ? err.message : "Unknown error",
+        title: "No se pudo cargar el QR de WAHA",
+        description: err instanceof Error ? err.message : "Error desconocido",
         variant: "destructive",
       });
     },
@@ -187,7 +189,7 @@ export function WahaEndpointSettings() {
   if (!userId) {
     return (
       <Alert>
-        <AlertDescription>Sign in again to manage WhatsApp pairing.</AlertDescription>
+        <AlertDescription>Inicia sesion de nuevo para gestionar el emparejamiento de WhatsApp.</AlertDescription>
       </Alert>
     );
   }
@@ -196,7 +198,7 @@ export function WahaEndpointSettings() {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin" />
-        Loading WAHA settings...
+        Cargando configuracion WAHA...
       </div>
     );
   }
@@ -204,8 +206,8 @@ export function WahaEndpointSettings() {
   if (error) {
     return (
       <Alert variant="destructive">
-        <AlertTitle>WAHA settings unavailable</AlertTitle>
-        <AlertDescription>{error instanceof Error ? error.message : "Unknown error"}</AlertDescription>
+        <AlertTitle>Configuracion WAHA no disponible</AlertTitle>
+        <AlertDescription>{error instanceof Error ? error.message : "Error desconocido"}</AlertDescription>
       </Alert>
     );
   }
@@ -221,12 +223,12 @@ export function WahaEndpointSettings() {
             </Badge>
           </div>
           <Select value={selectedEndpoint} onValueChange={setSelectedEndpoint} disabled={saveMutation.isPending}>
-            <SelectTrigger aria-label="WAHA endpoint">
-              <SelectValue placeholder="Select WAHA endpoint" />
+            <SelectTrigger aria-label="Endpoint WAHA">
+              <SelectValue placeholder="Selecciona endpoint WAHA" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={NO_WAHA_ENDPOINT}>
-                No WAHA endpoint
+                Sin endpoint WAHA
               </SelectItem>
               {endpointOptions.map((option) => (
                 <SelectItem key={option.value} value={option.value}>
@@ -249,7 +251,7 @@ export function WahaEndpointSettings() {
           ) : (
             <Save className="mr-2 h-4 w-4" />
           )}
-          Save
+          Guardar
         </Button>
       </div>
 
@@ -270,7 +272,7 @@ export function WahaEndpointSettings() {
           className="w-full"
         >
           <RefreshCw className={`mr-2 h-4 w-4 ${isFetching || statusMutation.isPending ? "animate-spin" : ""}`} />
-          Refresh
+          Actualizar
         </Button>
         <Button
           type="button"
@@ -285,7 +287,7 @@ export function WahaEndpointSettings() {
           ) : (
             <Smartphone className="mr-2 h-4 w-4" />
           )}
-          Start
+          Iniciar
         </Button>
         <Button
           type="button"
@@ -306,14 +308,14 @@ export function WahaEndpointSettings() {
 
       {hasUnsavedChange && (
         <Alert variant="info">
-          <AlertDescription>Save the endpoint before starting or pairing the WAHA session.</AlertDescription>
+          <AlertDescription>Guarda el endpoint antes de iniciar o emparejar la sesion WAHA.</AlertDescription>
         </Alert>
       )}
 
       {!savedEndpoint && (
         <div className="flex items-start gap-2 rounded-md border border-dashed p-3 text-sm text-muted-foreground">
           <Unplug className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>No WAHA endpoint is assigned to your account.</span>
+          <span>No hay un endpoint WAHA asignado a tu cuenta.</span>
         </div>
       )}
 
@@ -321,14 +323,14 @@ export function WahaEndpointSettings() {
         <div className="rounded-md border p-3 text-sm">
           <div className="grid gap-1 sm:grid-cols-2">
             <span>
-              <span className="font-medium">Host:</span> {savedEndpoint.replace(/^https?:\/\//, "")}
+              <span className="font-medium">Servidor:</span> {savedEndpoint.replace(/^https?:\/\//, "")}
             </span>
             <span>
-              <span className="font-medium">Session:</span> {data?.session || "default"}
+              <span className="font-medium">Sesion:</span> {data?.session || "default"}
             </span>
             {data?.me?.pushName && (
               <span className="sm:col-span-2">
-                <span className="font-medium">Linked account:</span> {data.me.pushName}
+                <span className="font-medium">Cuenta vinculada:</span> {data.me.pushName}
               </span>
             )}
           </div>
@@ -339,11 +341,11 @@ export function WahaEndpointSettings() {
         <div className="flex flex-col items-center gap-3 rounded-md border bg-muted/20 p-4">
           <img
             src={qrDataUrl}
-            alt="WAHA pairing QR code"
+            alt="Codigo QR de emparejamiento WAHA"
             className="h-56 w-56 rounded bg-white p-2 shadow-sm"
           />
           <p className="text-center text-xs text-muted-foreground">
-            Refresh the QR if the session remains in scan mode.
+            Actualiza el QR si la sesion sigue en modo escaneo.
           </p>
         </div>
       )}

--- a/src/components/settings/__tests__/WahaEndpointSettings.test.tsx
+++ b/src/components/settings/__tests__/WahaEndpointSettings.test.tsx
@@ -72,7 +72,7 @@ describe("WahaEndpointSettings", () => {
 
     expect(await screen.findByText(/WAHA 2 - waha2\.sector-pro\.work/i)).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /refresh/i }));
+    await user.click(screen.getByRole("button", { name: /actualizar/i }));
 
     await waitFor(() => {
       expect(mockSupabase.functions.invoke).toHaveBeenCalledWith("waha-session", {
@@ -80,8 +80,8 @@ describe("WahaEndpointSettings", () => {
       });
     });
 
-    expect(await screen.findByText("Working")).toBeInTheDocument();
-    expect(screen.getByText((_, element) => element?.textContent === "Linked account: Sector Pro")).toBeInTheDocument();
+    expect(await screen.findByText("En funcionamiento")).toBeInTheDocument();
+    expect(screen.getByText((_, element) => element?.textContent === "Cuenta vinculada: Sector Pro")).toBeInTheDocument();
   });
 
   it("saves a selected WAHA endpoint", async () => {
@@ -115,11 +115,11 @@ describe("WahaEndpointSettings", () => {
 
     renderWithProviders(<WahaEndpointSettings />);
 
-    await screen.findByText(/No WAHA endpoint is assigned/i);
+    await screen.findByText(/No hay un endpoint WAHA asignado/i);
 
-    await user.click(screen.getByRole("combobox", { name: /waha endpoint/i }));
+    await user.click(screen.getByRole("combobox", { name: /endpoint waha/i }));
     await user.click(await screen.findByRole("option", { name: /WAHA 3 - waha3\.sector-pro\.work/i }));
-    await user.click(screen.getByRole("button", { name: /save/i }));
+    await user.click(screen.getByRole("button", { name: /guardar/i }));
 
     await waitFor(() => {
       expect(mockSupabase.functions.invoke).toHaveBeenCalledWith("waha-session", {
@@ -132,7 +132,7 @@ describe("WahaEndpointSettings", () => {
 
     expect(toastMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        title: "WAHA endpoint saved",
+        title: "Endpoint WAHA guardado",
       }),
     );
   });
@@ -176,7 +176,7 @@ describe("WahaEndpointSettings", () => {
     await screen.findByText(/WAHA 1 - waha\.sector-pro\.work/i);
     await user.click(screen.getByRole("button", { name: "QR" }));
 
-    const qr = await screen.findByRole("img", { name: /waha pairing qr code/i });
+    const qr = await screen.findByRole("img", { name: /codigo qr de emparejamiento waha/i });
     expect(qr).toHaveAttribute("src", dataUrl);
   });
 });

--- a/src/components/settings/__tests__/WahaEndpointSettings.test.tsx
+++ b/src/components/settings/__tests__/WahaEndpointSettings.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+import { renderWithProviders } from "@/test/renderWithProviders";
+
+const {
+  toastMock,
+  useOptimizedAuthMock,
+} = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  useOptimizedAuthMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/useOptimizedAuth", () => ({
+  useOptimizedAuth: (...args: unknown[]) => useOptimizedAuthMock(...args),
+}));
+
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: mockSupabase,
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  toast: (...args: unknown[]) => toastMock(...args),
+}));
+
+import { WahaEndpointSettings } from "@/components/settings/WahaEndpointSettings";
+
+describe("WahaEndpointSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    useOptimizedAuthMock.mockReturnValue({
+      user: { id: "user-1" },
+      userRole: "management",
+    });
+  });
+
+  it("refreshes WAHA status for the saved endpoint", async () => {
+    const user = userEvent.setup();
+
+    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
+      const action = options?.body?.action;
+
+      if (action === "status") {
+        return {
+          data: {
+            endpoint: "https://waha2.sector-pro.work",
+            session: "default",
+            status: "WORKING",
+            me: { pushName: "Sector Pro" },
+          },
+          error: null,
+        };
+      }
+
+      return {
+        data: {
+          endpoint: "https://waha2.sector-pro.work",
+          session: "default",
+          status: "UNKNOWN",
+          me: null,
+        },
+        error: null,
+      };
+    });
+
+    renderWithProviders(<WahaEndpointSettings />);
+
+    expect(await screen.findByText(/WAHA 2 - waha2\.sector-pro\.work/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /refresh/i }));
+
+    await waitFor(() => {
+      expect(mockSupabase.functions.invoke).toHaveBeenCalledWith("waha-session", {
+        body: { action: "status" },
+      });
+    });
+
+    expect(await screen.findByText("Working")).toBeInTheDocument();
+    expect(screen.getByText((_, element) => element?.textContent === "Linked account: Sector Pro")).toBeInTheDocument();
+  });
+
+  it("saves a selected WAHA endpoint", async () => {
+    const user = userEvent.setup();
+
+    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
+      const action = options?.body?.action;
+
+      if (action === "save") {
+        return {
+          data: {
+            endpoint: options.body.endpoint,
+            session: "default",
+            status: "UNKNOWN",
+            me: null,
+          },
+          error: null,
+        };
+      }
+
+      return {
+        data: {
+          endpoint: null,
+          session: "default",
+          status: "NOT_CONFIGURED",
+          me: null,
+        },
+        error: null,
+      };
+    });
+
+    renderWithProviders(<WahaEndpointSettings />);
+
+    await screen.findByText(/No WAHA endpoint is assigned/i);
+
+    await user.click(screen.getByRole("combobox", { name: /waha endpoint/i }));
+    await user.click(await screen.findByRole("option", { name: /WAHA 3 - waha3\.sector-pro\.work/i }));
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mockSupabase.functions.invoke).toHaveBeenCalledWith("waha-session", {
+        body: {
+          action: "save",
+          endpoint: "https://waha3.sector-pro.work",
+        },
+      });
+    });
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "WAHA endpoint saved",
+      }),
+    );
+  });
+
+  it("renders the pairing QR returned by the proxy", async () => {
+    const user = userEvent.setup();
+    const dataUrl = "data:image/png;base64,abc123";
+
+    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
+      const action = options?.body?.action;
+
+      if (action === "qr") {
+        return {
+          data: {
+            endpoint: "https://waha.sector-pro.work",
+            session: "default",
+            status: "SCAN_QR_CODE",
+            me: null,
+            qr: {
+              dataUrl,
+              mimetype: "image/png",
+            },
+          },
+          error: null,
+        };
+      }
+
+      return {
+        data: {
+          endpoint: "https://waha.sector-pro.work",
+          session: "default",
+          status: "SCAN_QR_CODE",
+          me: null,
+        },
+        error: null,
+      };
+    });
+
+    renderWithProviders(<WahaEndpointSettings />);
+
+    await screen.findByText(/WAHA 1 - waha\.sector-pro\.work/i);
+    await user.click(screen.getByRole("button", { name: "QR" }));
+
+    const qr = await screen.findByRole("img", { name: /waha pairing qr code/i });
+    expect(qr).toHaveAttribute("src", dataUrl);
+  });
+});

--- a/src/constants/wahaEndpoints.ts
+++ b/src/constants/wahaEndpoints.ts
@@ -1,0 +1,22 @@
+export const WAHA_ENDPOINTS = [
+  { label: "WAHA 1", value: "https://waha.sector-pro.work" },
+  { label: "WAHA 2", value: "https://waha2.sector-pro.work" },
+  { label: "WAHA 3", value: "https://waha3.sector-pro.work" },
+  { label: "WAHA 4", value: "https://waha4.sector-pro.work" },
+  { label: "WAHA 5", value: "https://waha5.sector-pro.work" },
+] as const;
+
+export const NO_WAHA_ENDPOINT = "__none__";
+
+export function normalizeWahaEndpoint(value: string | null | undefined) {
+  const trimmed = (value || "").trim();
+  if (!trimmed) return null;
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  return withScheme.replace(/\/+$/, "");
+}
+
+export function getWahaEndpointLabel(endpoint: string | null | undefined) {
+  const normalized = normalizeWahaEndpoint(endpoint);
+  const match = WAHA_ENDPOINTS.find((option) => option.value === normalized);
+  return match?.label || normalized || "No endpoint";
+}

--- a/src/constants/wahaEndpoints.ts
+++ b/src/constants/wahaEndpoints.ts
@@ -18,5 +18,5 @@ export function normalizeWahaEndpoint(value: string | null | undefined) {
 export function getWahaEndpointLabel(endpoint: string | null | undefined) {
   const normalized = normalizeWahaEndpoint(endpoint);
   const match = WAHA_ENDPOINTS.find((option) => option.value === normalized);
-  return match?.label || normalized || "No endpoint";
+  return match?.label || normalized || "Sin endpoint";
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -478,8 +478,8 @@ const Settings = () => {
             {isManagementUser && (
               <CollapsibleCard
                 id="waha-endpoint"
-                title="WAHA WhatsApp"
-                description="Configure the WhatsApp endpoint assigned to your account and pair its WAHA session."
+                title="WAHA de WhatsApp"
+                description="Configura el endpoint de WhatsApp asignado a tu cuenta y empareja su sesion WAHA."
                 isOpen={collapsibleStates['waha-endpoint']}
                 onOpenChange={(open) => setCollapsibleStates(prev => ({ ...prev, 'waha-endpoint': open }))}
               >

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -31,6 +31,7 @@ import { MorningSummarySubscription } from '@/components/settings/MorningSummary
 import { ShortcutsSettings } from '@/components/settings/ShortcutsSettings'
 import { DryHireFolderManager } from '@/components/settings/DryHireFolderManager'
 import { SkillRoleMappingManager } from '@/components/settings/SkillRoleMappingManager'
+import { WahaEndpointSettings } from '@/components/settings/WahaEndpointSettings'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { ChevronDown } from "lucide-react"
 import { VersionDisplay } from "@/components/VersionDisplay"
@@ -222,6 +223,7 @@ const Settings = () => {
     'push-diagnostics': false,
     'push-matrix': false,
     'push-schedule': false,
+    'waha-endpoint': false,
     'morning-summary': false,
     'shortcuts': false,
     'users': false,
@@ -415,6 +417,18 @@ const Settings = () => {
                 onOpenChange={(open) => setCollapsibleStates(prev => ({ ...prev, 'push-matrix': open }))}
               >
                 <PushNotificationMatrix />
+              </CollapsibleCard>
+            )}
+
+            {isManagementUser && (
+              <CollapsibleCard
+                id="waha-endpoint"
+                title="WAHA WhatsApp"
+                description="Configure the WhatsApp endpoint assigned to your account and pair its WAHA session."
+                isOpen={collapsibleStates['waha-endpoint']}
+                onOpenChange={(open) => setCollapsibleStates(prev => ({ ...prev, 'waha-endpoint': open }))}
+              >
+                <WahaEndpointSettings />
               </CollapsibleCard>
             )}
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -422,18 +422,6 @@ const Settings = () => {
 
             {isManagementUser && (
               <CollapsibleCard
-                id="waha-endpoint"
-                title="WAHA WhatsApp"
-                description="Configure the WhatsApp endpoint assigned to your account and pair its WAHA session."
-                isOpen={collapsibleStates['waha-endpoint']}
-                onOpenChange={(open) => setCollapsibleStates(prev => ({ ...prev, 'waha-endpoint': open }))}
-              >
-                <WahaEndpointSettings />
-              </CollapsibleCard>
-            )}
-
-            {isManagementUser && (
-              <CollapsibleCard
                 id="push-schedule"
                 title="Push notification schedule"
                 isOpen={collapsibleStates['push-schedule']}
@@ -486,6 +474,18 @@ const Settings = () => {
                 isManagementUser={isManagementUser}
               />
             </CollapsibleCard>
+
+            {isManagementUser && (
+              <CollapsibleCard
+                id="waha-endpoint"
+                title="WAHA WhatsApp"
+                description="Configure the WhatsApp endpoint assigned to your account and pair its WAHA session."
+                isOpen={collapsibleStates['waha-endpoint']}
+                onOpenChange={(open) => setCollapsibleStates(prev => ({ ...prev, 'waha-endpoint': open }))}
+              >
+                <WahaEndpointSettings />
+              </CollapsibleCard>
+            )}
 
             <CollapsibleCard
               id="company-settings"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -49,6 +49,9 @@ verify_jwt = false
 [functions.wallboard-feed]
 verify_jwt = true
 
+[functions.waha-session]
+verify_jwt = true
+
 [functions.tech-calendar-ics]
 verify_jwt = false
 

--- a/supabase/functions/waha-session/index.ts
+++ b/supabase/functions/waha-session/index.ts
@@ -1,0 +1,427 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readJsonObject,
+  requireBearerToken,
+  requireEnvValues,
+} from "../_shared/http.ts";
+import { normalizeBaseUrl } from "../_shared/waha.ts";
+
+type Action = "get" | "save" | "status" | "start" | "qr";
+
+type RequestBody = Record<string, unknown> & {
+  action?: unknown;
+  endpoint?: unknown;
+};
+
+type ProfileRow = {
+  id: string;
+  role: string | null;
+  waha_endpoint: string | null;
+};
+
+type WahaConfigRow = {
+  api_key?: string | null;
+  session?: string | null;
+};
+
+type WahaSessionInfo = {
+  name?: string;
+  status?: string;
+  me?: {
+    id?: string;
+    pushName?: string;
+  } | null;
+};
+
+const DEFAULT_ENDPOINTS = [
+  "https://waha.sector-pro.work",
+  "https://waha2.sector-pro.work",
+  "https://waha3.sector-pro.work",
+  "https://waha4.sector-pro.work",
+  "https://waha5.sector-pro.work",
+];
+
+const ACTIONS = ["get", "save", "status", "start", "qr"] as const;
+
+function isAction(value: string): value is Action {
+  return (ACTIONS as readonly string[]).includes(value);
+}
+
+function getAllowedEndpointHosts() {
+  const configured = (Deno.env.get("WAHA_ALLOWED_ENDPOINTS") || "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return new Set(
+    [...DEFAULT_ENDPOINTS, ...configured]
+      .map((endpoint) => {
+        try {
+          return new URL(normalizeBaseUrl(endpoint)).host.toLowerCase();
+        } catch {
+          return null;
+        }
+      })
+      .filter((host): host is string => Boolean(host)),
+  );
+}
+
+function normalizeEndpointForStorage(endpoint: unknown) {
+  if (endpoint == null) return null;
+
+  if (typeof endpoint !== "string") {
+    throw new HttpError(400, "Invalid WAHA endpoint", { code: "invalid_endpoint" });
+  }
+
+  const trimmed = endpoint.trim();
+  if (!trimmed) return null;
+
+  const base = normalizeBaseUrl(trimmed);
+  let parsed: URL;
+
+  try {
+    parsed = new URL(base);
+  } catch {
+    throw new HttpError(400, "Invalid WAHA endpoint", { code: "invalid_endpoint" });
+  }
+
+  parsed.pathname = "";
+  parsed.search = "";
+  parsed.hash = "";
+
+  if (parsed.protocol === "http:") {
+    parsed.protocol = "https:";
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new HttpError(400, "WAHA endpoint must use HTTPS", { code: "invalid_endpoint_scheme" });
+  }
+
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+function assertAllowedEndpoint(endpoint: string) {
+  const host = new URL(endpoint).host.toLowerCase();
+  const allowedHosts = getAllowedEndpointHosts();
+
+  if (allowedHosts.has(host) || /^waha\d*\.sector-pro\.work$/i.test(host)) {
+    return;
+  }
+
+  throw new HttpError(400, "WAHA endpoint is not allowed", {
+    code: "endpoint_not_allowed",
+  });
+}
+
+function headersFor(apiKey: string) {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+
+  if (apiKey) {
+    headers["X-Api-Key"] = apiKey;
+  }
+
+  return headers;
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(new DOMException("timeout", "AbortError")), timeoutMs);
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function readWahaJson<T>(res: Response) {
+  const contentType = res.headers.get("content-type") || "";
+  if (/application\/json/i.test(contentType)) {
+    return await res.json().catch(() => null) as T | null;
+  }
+
+  return null;
+}
+
+async function readWahaError(res: Response) {
+  const contentType = res.headers.get("content-type") || "";
+  if (/application\/json/i.test(contentType)) {
+    const payload = await res.json().catch(() => null) as Record<string, unknown> | null;
+    const message = typeof payload?.message === "string" ? payload.message : typeof payload?.error === "string" ? payload.error : null;
+    return message || JSON.stringify(payload || {});
+  }
+
+  return (await res.text().catch(() => "")).slice(0, 500);
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+
+  return btoa(binary);
+}
+
+function parseQrJson(payload: Record<string, unknown>) {
+  const mimetype = typeof payload.mimetype === "string" ? payload.mimetype : "image/png";
+  const data = typeof payload.data === "string"
+    ? payload.data
+    : typeof payload.qrCode === "string"
+      ? payload.qrCode
+      : null;
+
+  if (!data) return null;
+
+  return data.startsWith("data:")
+    ? { dataUrl: data, mimetype }
+    : { dataUrl: `data:${mimetype};base64,${data}`, mimetype };
+}
+
+async function getWahaConfig(supabaseAdmin: ReturnType<typeof createClient>, endpoint: string) {
+  const { data, error } = await supabaseAdmin.rpc("get_waha_config", { base_url: endpoint });
+  if (error) {
+    console.warn("get_waha_config RPC failed, falling back to env vars:", error.message);
+  }
+
+  const row = (data as WahaConfigRow[] | null)?.[0];
+
+  return {
+    apiKey: row?.api_key || Deno.env.get("WAHA_API_KEY") || "",
+    session: row?.session || Deno.env.get("WAHA_SESSION") || "default",
+  };
+}
+
+async function getSessionStatus(endpoint: string, session: string, apiKey: string) {
+  const url = `${endpoint}/api/sessions/${encodeURIComponent(session)}`;
+  const res = await fetchWithTimeout(url, {
+    method: "GET",
+    headers: headersFor(apiKey),
+  }, Number(Deno.env.get("WAHA_FETCH_TIMEOUT_MS") || 9000));
+
+  if (res.status === 404) {
+    return {
+      endpoint,
+      session,
+      status: "NOT_CREATED",
+      me: null,
+    };
+  }
+
+  if (!res.ok) {
+    throw new HttpError(502, "WAHA status request failed", {
+      code: "waha_status_failed",
+      details: { status: res.status, body: await readWahaError(res) },
+      exposeDetails: true,
+    });
+  }
+
+  const payload = await readWahaJson<WahaSessionInfo>(res);
+
+  return {
+    endpoint,
+    session,
+    status: payload?.status || "UNKNOWN",
+    me: payload?.me || null,
+  };
+}
+
+async function ensureSessionStarted(endpoint: string, session: string, apiKey: string) {
+  const current = await getSessionStatus(endpoint, session, apiKey);
+  const timeoutMs = Number(Deno.env.get("WAHA_FETCH_TIMEOUT_MS") || 9000);
+
+  if (current.status === "NOT_CREATED") {
+    const createRes = await fetchWithTimeout(`${endpoint}/api/sessions`, {
+      method: "POST",
+      headers: headersFor(apiKey),
+      body: JSON.stringify({ name: session }),
+    }, timeoutMs);
+
+    if (!createRes.ok && createRes.status !== 409) {
+      throw new HttpError(502, "WAHA session create request failed", {
+        code: "waha_session_create_failed",
+        details: { status: createRes.status, body: await readWahaError(createRes) },
+        exposeDetails: true,
+      });
+    }
+  } else if (current.status === "STOPPED" || current.status === "FAILED") {
+    const startRes = await fetchWithTimeout(`${endpoint}/api/sessions/${encodeURIComponent(session)}/start`, {
+      method: "POST",
+      headers: headersFor(apiKey),
+      body: JSON.stringify({}),
+    }, timeoutMs);
+
+    if (!startRes.ok) {
+      throw new HttpError(502, "WAHA session start request failed", {
+        code: "waha_session_start_failed",
+        details: { status: startRes.status, body: await readWahaError(startRes) },
+        exposeDetails: true,
+      });
+    }
+  }
+
+  return getSessionStatus(endpoint, session, apiKey);
+}
+
+async function getQr(endpoint: string, session: string, apiKey: string) {
+  const res = await fetchWithTimeout(`${endpoint}/api/${encodeURIComponent(session)}/auth/qr`, {
+    method: "GET",
+    headers: {
+      ...headersFor(apiKey),
+      Accept: "image/png",
+    },
+  }, Number(Deno.env.get("WAHA_FETCH_TIMEOUT_MS") || 9000));
+
+  if (!res.ok) {
+    throw new HttpError(502, "WAHA QR request failed", {
+      code: "waha_qr_failed",
+      details: { status: res.status, body: await readWahaError(res) },
+      exposeDetails: true,
+    });
+  }
+
+  const contentType = res.headers.get("content-type") || "";
+
+  if (/application\/json/i.test(contentType)) {
+    const payload = await res.json().catch(() => null) as Record<string, unknown> | null;
+    const parsed = payload ? parseQrJson(payload) : null;
+    if (parsed) return parsed;
+  }
+
+  const mimetype = /image\/[a-z0-9.+-]+/i.test(contentType) ? contentType : "image/png";
+  const data = arrayBufferToBase64(await res.arrayBuffer());
+
+  return {
+    dataUrl: `data:${mimetype};base64,${data}`,
+    mimetype,
+  };
+}
+
+async function loadActorProfile(supabaseAdmin: ReturnType<typeof createClient>, token: string) {
+  const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(token);
+  const actorId = userData?.user?.id || null;
+
+  if (userError || !actorId) {
+    throw new HttpError(401, "Unauthorized", { code: "unauthorized" });
+  }
+
+  const { data: profile, error } = await supabaseAdmin
+    .from("profiles")
+    .select("id, role, waha_endpoint")
+    .eq("id", actorId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!profile) throw new HttpError(403, "Profile not found", { code: "profile_not_found" });
+
+  const actorProfile = profile as ProfileRow;
+  if (!["admin", "management"].includes((actorProfile.role || "").toLowerCase())) {
+    throw new HttpError(403, "Forbidden", { code: "forbidden" });
+  }
+
+  return actorProfile;
+}
+
+async function loadEndpointContext(supabaseAdmin: ReturnType<typeof createClient>, profile: ProfileRow) {
+  const endpoint = normalizeEndpointForStorage(profile.waha_endpoint);
+  if (!endpoint) {
+    return {
+      endpoint: null,
+      session: "default",
+      apiKey: "",
+    };
+  }
+
+  const config = await getWahaConfig(supabaseAdmin, endpoint);
+
+  return {
+    endpoint,
+    ...config,
+  };
+}
+
+async function handler(req: Request) {
+  const env = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, Deno.env.get);
+  const supabaseAdmin = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+  const token = requireBearerToken(req);
+  const profile = await loadActorProfile(supabaseAdmin, token);
+  const body = await readJsonObject<RequestBody>(req);
+  const action = typeof body.action === "string" ? body.action : "get";
+
+  if (!isAction(action)) {
+    throw new HttpError(400, "Invalid WAHA action", { code: "invalid_action" });
+  }
+
+  if (action === "save") {
+    const endpoint = normalizeEndpointForStorage(body.endpoint);
+    if (endpoint) assertAllowedEndpoint(endpoint);
+
+    const { error } = await supabaseAdmin
+      .from("profiles")
+      .update({ waha_endpoint: endpoint })
+      .eq("id", profile.id);
+
+    if (error) throw error;
+
+    return jsonResponse({
+      endpoint,
+      session: endpoint ? (await getWahaConfig(supabaseAdmin, endpoint)).session : "default",
+      status: endpoint ? "UNKNOWN" : "NOT_CONFIGURED",
+      me: null,
+    });
+  }
+
+  const context = await loadEndpointContext(supabaseAdmin, profile);
+
+  if (!context.endpoint) {
+    return jsonResponse({
+      endpoint: null,
+      session: context.session,
+      status: "NOT_CONFIGURED",
+      me: null,
+    });
+  }
+
+  if (action === "get") {
+    return jsonResponse({
+      endpoint: context.endpoint,
+      session: context.session,
+      status: "UNKNOWN",
+      me: null,
+    });
+  }
+
+  if (action === "status") {
+    return jsonResponse(await getSessionStatus(context.endpoint, context.session, context.apiKey));
+  }
+
+  if (action === "start") {
+    return jsonResponse(await ensureSessionStarted(context.endpoint, context.session, context.apiKey));
+  }
+
+  const status = await ensureSessionStarted(context.endpoint, context.session, context.apiKey);
+  const qr = await getQr(context.endpoint, context.session, context.apiKey);
+
+  return jsonResponse({
+    ...status,
+    qr,
+  });
+}
+
+serve(createHttpHandler(handler, {
+  allowedMethods: ["POST"],
+  onError: (error) => {
+    console.error("waha-session failed", error);
+  },
+}));

--- a/supabase/functions/waha-session/index.ts
+++ b/supabase/functions/waha-session/index.ts
@@ -38,6 +38,8 @@ type WahaSessionInfo = {
   } | null;
 };
 
+// Keep in sync with src/constants/wahaEndpoints.ts. Edge Functions cannot import
+// the frontend module directly, so the server keeps its own allow-list copy.
 const DEFAULT_ENDPOINTS = [
   "https://waha.sector-pro.work",
   "https://waha2.sector-pro.work",


### PR DESCRIPTION
## Summary
- add a management Settings panel for selecting/clearing the WAHA endpoint assigned to the current account
- add a server-side `waha-session` Supabase function to save endpoint assignments, read/start WAHA sessions, and return pairing QR images without exposing WAHA API keys in the browser
- preserve existing `profiles.waha_endpoint` behavior for already configured send flows; stored endpoints remain usable, while new saves are limited to the known WAHA hosts

## WAHA docs checked
- https://waha.devlike.pro/docs/how-to/sessions/

## Validation
- `npm install --legacy-peer-deps`
- `npm run lint` (passes with existing warning backlog)
- `npm run test:run`
- `npm run build`
- browser smoke: local `/settings` route renders the expected auth redirect with placeholder Supabase env

## Deployment notes
- no database migration in this PR
- new Supabase Edge Function: `waha-session`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WAHA WhatsApp integration settings panel enabling users to configure and manage endpoints, check session status, start sessions, and generate pairing QR codes.
  * New "WAHA WhatsApp" settings section accessible to management users for endpoint configuration and session lifecycle control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->