### PR TITLE
[codex] Add management project notes

### DIFF
--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -217,6 +217,7 @@ function JobCardNewFull({
   const { selectJob, clearSelection, isJobSelected } = useSelectedJobStore();
   const isSelected = isJobSelected(job.id);
   const [routeSheetOpen, setRouteSheetOpen] = useState(false);
+  const [projectNotesOpen, setProjectNotesOpen] = useState(false);
   const [taskManagerOpen, setTaskManagerOpen] = useState(false);
   const [isGeneratingTransportPdf, setIsGeneratingTransportPdf] = useState(false);
   const [isGeneratingCrewReportPdf, setIsGeneratingCrewReportPdf] = useState(false);
@@ -314,6 +315,7 @@ function JobCardNewFull({
   const [logisticsInitialEventType, setLogisticsInitialEventType] = useState<'load' | 'unload' | undefined>(undefined);
   const { user, userDepartment: currentUserDepartment } = useOptimizedAuth();
   const isManagementUser = isManagementRole(userRole);
+  const canManageProjectNotes = isProjectManagementPage && isManagementUser;
 
   const canGenerateTransportPdf = React.useMemo(() => {
     const normalizedDepartment = (currentUserDepartment || '').trim().toLowerCase();
@@ -1250,6 +1252,9 @@ function JobCardNewFull({
       canGenerateCrewReportPdf={canGenerateCrewReportPdf}
       isGeneratingCrewReportPdf={isGeneratingCrewReportPdf}
       handleGenerateCrewReportPdf={handleGenerateCrewReportPdf}
+      canManageProjectNotes={canManageProjectNotes}
+      projectNotesOpen={projectNotesOpen}
+      setProjectNotesOpen={setProjectNotesOpen}
       foldersAreCreated={foldersAreCreated}
       isFoldersLoading={isFoldersLoading}
       showUpload={showUpload}

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -366,7 +366,7 @@ export function JobCardNewView({
                   setProjectNotesOpen(true);
                 }}
                 className="h-7 gap-1.5 px-3 text-xs"
-                title="Notas de produccion"
+                title="Notas de producción"
               >
                 <NotebookPen className="h-3.5 w-3.5" />
                 <span>Notas</span>

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { createPortal } from "react-dom";
 import { useReducedMotion } from "framer-motion";
-import { ChevronDown, ChevronRight, Download, Eye, FileText, Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Download, Eye, FileText, Loader2, NotebookPen } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,6 +15,7 @@ import { EditJobDialog } from "@/components/jobs/EditJobDialog";
 import { JobRequirementsEditor } from "@/components/jobs/JobRequirementsEditor";
 import { LightsTaskDialog } from "@/components/lights/LightsTaskDialog";
 import { LogisticsEventDialog } from "@/components/logistics/LogisticsEventDialog";
+import { ProjectNotesDialog } from "@/components/project-management/ProjectNotesDialog";
 import { TransportRequestDialog } from "@/components/logistics/TransportRequestDialog";
 import { SoundTaskDialog } from "@/components/sound/SoundTaskDialog";
 import { TaskManagerDialog } from "@/components/tasks/TaskManagerDialog";
@@ -59,6 +60,9 @@ export interface JobCardNewViewProps {
   canGenerateCrewReportPdf: boolean;
   isGeneratingCrewReportPdf: boolean;
   handleGenerateCrewReportPdf: (e: React.MouseEvent) => void;
+  canManageProjectNotes: boolean;
+  projectNotesOpen: boolean;
+  setProjectNotesOpen: (open: boolean) => void;
 
   foldersAreCreated: boolean;
   isFoldersLoading: boolean;
@@ -173,6 +177,9 @@ export function JobCardNewView({
   canGenerateCrewReportPdf,
   isGeneratingCrewReportPdf,
   handleGenerateCrewReportPdf,
+  canManageProjectNotes,
+  projectNotesOpen,
+  setProjectNotesOpen,
   foldersAreCreated,
   isFoldersLoading,
   showUpload,
@@ -348,6 +355,22 @@ export function JobCardNewView({
               >
                 Hoja de Ruta
               </button>
+            )}
+            {canManageProjectNotes && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setProjectNotesOpen(true);
+                }}
+                className="h-7 gap-1.5 px-3 text-xs"
+                title="Notas de produccion"
+              >
+                <NotebookPen className="h-3.5 w-3.5" />
+                <span>Notas</span>
+              </Button>
             )}
             {isProjectManagementPage && job.job_type !== "dryhire" && canGenerateTransportPdf && (
               <button
@@ -590,13 +613,22 @@ export function JobCardNewView({
           <FlexSyncLogDialog jobId={job.id} open={flexLogDialogOpen} onOpenChange={setFlexLogDialogOpen} />
 
           {isProjectManagementPage && (
-            <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
-              <DialogContent className="max-w-[96vw] w-[96vw] h-[96vh] p-0 overflow-hidden">
-                <div className="h-full overflow-auto">
-                  <ModernHojaDeRuta jobId={job.id} />
-                </div>
-              </DialogContent>
-            </Dialog>
+            <>
+              <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
+                <DialogContent className="max-w-[96vw] w-[96vw] h-[96vh] p-0 overflow-hidden">
+                  <div className="h-full overflow-auto">
+                    <ModernHojaDeRuta jobId={job.id} />
+                  </div>
+                </DialogContent>
+              </Dialog>
+              <ProjectNotesDialog
+                open={projectNotesOpen}
+                onOpenChange={setProjectNotesOpen}
+                jobId={job.id}
+                jobTitle={job.title}
+                canManageNotes={canManageProjectNotes}
+              />
+            </>
           )}
 
           {transportDialogOpen && !canManageTransportRequests && isTechDept && userDepartment && (

--- a/src/components/project-management/ProjectNotesDialog.test.tsx
+++ b/src/components/project-management/ProjectNotesDialog.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProjectNotesDialog } from "./ProjectNotesDialog";
+
+const mockToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockGetUser = vi.fn();
+const mockMaybeSingle = vi.fn();
+const mockUpsert = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: {
+    auth: {
+      getUser: (...args: unknown[]) => mockGetUser(...args),
+    },
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+const renderDialog = (props?: Partial<React.ComponentProps<typeof ProjectNotesDialog>>) => {
+  const queryClient = createQueryClient();
+  const onOpenChange = vi.fn();
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProjectNotesDialog
+        open
+        onOpenChange={onOpenChange}
+        jobId="job-1"
+        jobTitle="Test Job"
+        canManageNotes
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+
+  return { onOpenChange };
+};
+
+describe("ProjectNotesDialog", () => {
+  beforeEach(() => {
+    mockToast.mockReset();
+    mockGetUser.mockReset();
+    mockMaybeSingle.mockReset();
+    mockUpsert.mockReset();
+    mockFrom.mockReset();
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockMaybeSingle.mockResolvedValue({
+      data: {
+        job_id: "job-1",
+        notes: "Initial note",
+        updated_at: "2026-06-05T09:30:00.000Z",
+        updated_by: "user-1",
+      },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: mockMaybeSingle,
+        }),
+      }),
+      upsert: mockUpsert,
+    });
+  });
+
+  it("does not mount the notepad when the user lacks management permissions", () => {
+    renderDialog({ canManageNotes: false });
+
+    expect(screen.queryByText("Notas de produccion")).not.toBeInTheDocument();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("loads and saves the job project note", async () => {
+    const { onOpenChange } = renderDialog();
+
+    const textarea = await screen.findByRole("textbox", { name: "Notas de produccion" });
+    await waitFor(() => expect(textarea).toHaveValue("Initial note"));
+
+    await userEvent.clear(textarea);
+    await userEvent.type(textarea, "Updated production note");
+    await userEvent.click(screen.getByRole("button", { name: /guardar/i }));
+
+    await waitFor(() => {
+      expect(mockUpsert).toHaveBeenCalledWith(
+        {
+          job_id: "job-1",
+          notes: "Updated production note",
+          updated_by: "user-1",
+        },
+        { onConflict: "job_id" },
+      );
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/project-management/ProjectNotesDialog.test.tsx
+++ b/src/components/project-management/ProjectNotesDialog.test.tsx
@@ -6,25 +6,20 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ProjectNotesDialog } from "./ProjectNotesDialog";
+import { getJobProjectNote, saveJobProjectNote } from "@/services/projectNotesService";
 
 const mockToast = vi.fn();
 vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: mockToast }),
 }));
 
-const mockGetUser = vi.fn();
-const mockMaybeSingle = vi.fn();
-const mockUpsert = vi.fn();
-const mockFrom = vi.fn();
-
-vi.mock("@/services/dataLayerClient", () => ({
-  dataLayerClient: {
-    auth: {
-      getUser: (...args: unknown[]) => mockGetUser(...args),
-    },
-    from: (...args: unknown[]) => mockFrom(...args),
-  },
+vi.mock("@/services/projectNotesService", () => ({
+  getJobProjectNote: vi.fn(),
+  saveJobProjectNote: vi.fn(),
 }));
+
+const mockGetJobProjectNote = vi.mocked(getJobProjectNote);
+const mockSaveJobProjectNote = vi.mocked(saveJobProjectNote);
 
 const createQueryClient = () =>
   new QueryClient({
@@ -58,37 +53,23 @@ const renderDialog = (props?: Partial<React.ComponentProps<typeof ProjectNotesDi
 describe("ProjectNotesDialog", () => {
   beforeEach(() => {
     mockToast.mockReset();
-    mockGetUser.mockReset();
-    mockMaybeSingle.mockReset();
-    mockUpsert.mockReset();
-    mockFrom.mockReset();
+    mockGetJobProjectNote.mockReset();
+    mockSaveJobProjectNote.mockReset();
 
-    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
-    mockMaybeSingle.mockResolvedValue({
-      data: {
-        job_id: "job-1",
-        notes: "Initial note",
-        updated_at: "2026-06-05T09:30:00.000Z",
-        updated_by: "user-1",
-      },
-      error: null,
+    mockGetJobProjectNote.mockResolvedValue({
+      job_id: "job-1",
+      notes: "Initial note",
+      updated_at: "2026-06-05T09:30:00.000Z",
+      updated_by: "user-1",
     });
-    mockUpsert.mockResolvedValue({ error: null });
-    mockFrom.mockReturnValue({
-      select: () => ({
-        eq: () => ({
-          maybeSingle: mockMaybeSingle,
-        }),
-      }),
-      upsert: mockUpsert,
-    });
+    mockSaveJobProjectNote.mockResolvedValue(undefined);
   });
 
   it("does not mount the notepad when the user lacks management permissions", () => {
     renderDialog({ canManageNotes: false });
 
     expect(screen.queryByText("Notas de produccion")).not.toBeInTheDocument();
-    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockGetJobProjectNote).not.toHaveBeenCalled();
   });
 
   it("loads and saves the job project note", async () => {
@@ -102,14 +83,7 @@ describe("ProjectNotesDialog", () => {
     await userEvent.click(screen.getByRole("button", { name: /guardar/i }));
 
     await waitFor(() => {
-      expect(mockUpsert).toHaveBeenCalledWith(
-        {
-          job_id: "job-1",
-          notes: "Updated production note",
-          updated_by: "user-1",
-        },
-        { onConflict: "job_id" },
-      );
+      expect(mockSaveJobProjectNote).toHaveBeenCalledWith("job-1", "Updated production note");
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });

--- a/src/components/project-management/ProjectNotesDialog.test.tsx
+++ b/src/components/project-management/ProjectNotesDialog.test.tsx
@@ -68,14 +68,14 @@ describe("ProjectNotesDialog", () => {
   it("does not mount the notepad when the user lacks management permissions", () => {
     renderDialog({ canManageNotes: false });
 
-    expect(screen.queryByText("Notas de produccion")).not.toBeInTheDocument();
+    expect(screen.queryByText("Notas de producción")).not.toBeInTheDocument();
     expect(mockGetJobProjectNote).not.toHaveBeenCalled();
   });
 
   it("loads and saves the job project note", async () => {
     const { onOpenChange } = renderDialog();
 
-    const textarea = await screen.findByRole("textbox", { name: "Notas de produccion" });
+    const textarea = await screen.findByRole("textbox", { name: "Notas de producción" });
     await waitFor(() => expect(textarea).toHaveValue("Initial note"));
 
     await userEvent.clear(textarea);

--- a/src/components/project-management/ProjectNotesDialog.tsx
+++ b/src/components/project-management/ProjectNotesDialog.tsx
@@ -1,0 +1,182 @@
+import React from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, NotebookPen, Save } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { queryKeys } from "@/lib/react-query";
+import { dataLayerClient } from "@/services/dataLayerClient";
+
+type ProjectNotesDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  jobId: string;
+  jobTitle: string;
+  canManageNotes: boolean;
+};
+
+type JobProjectNoteRow = {
+  job_id: string;
+  notes: string;
+  updated_at: string;
+  updated_by: string | null;
+};
+
+const formatUpdatedAt = (value?: string | null) => {
+  if (!value) return null;
+
+  return new Intl.DateTimeFormat("es-ES", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+};
+
+export const ProjectNotesDialog = ({
+  open,
+  onOpenChange,
+  jobId,
+  jobTitle,
+  canManageNotes,
+}: ProjectNotesDialogProps) => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = React.useState("");
+
+  const notesQuery = useQuery({
+    queryKey: queryKeys.scope("job-project-notes", jobId),
+    enabled: open && canManageNotes && Boolean(jobId),
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient
+        .from("job_project_notes")
+        .select("job_id, notes, updated_at, updated_by")
+        .eq("job_id", jobId)
+        .maybeSingle();
+
+      if (error) throw error;
+      return data as JobProjectNoteRow | null;
+    },
+  });
+
+  React.useEffect(() => {
+    if (!open || notesQuery.isLoading) return;
+    setDraft(notesQuery.data?.notes ?? "");
+  }, [notesQuery.data?.notes, notesQuery.isLoading, open]);
+
+  const saveNotes = useMutation({
+    mutationFn: async (notes: string) => {
+      const { data: authData } = await dataLayerClient.auth.getUser();
+      const { error } = await dataLayerClient
+        .from("job_project_notes")
+        .upsert(
+          {
+            job_id: jobId,
+            notes,
+            updated_by: authData.user?.id ?? null,
+          },
+          { onConflict: "job_id" },
+        );
+
+      if (error) throw error;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.scope("job-project-notes", jobId),
+      });
+      toast({
+        title: "Notas guardadas",
+        description: "Las notas del proyecto se han actualizado.",
+      });
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      toast({
+        title: "No se pudieron guardar las notas",
+        description: error instanceof Error ? error.message : "Intentalo de nuevo.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  if (!canManageNotes) return null;
+
+  const updatedAt = formatUpdatedAt(notesQuery.data?.updated_at);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl gap-0 overflow-hidden border-slate-300 p-0 shadow-2xl dark:border-slate-700">
+        <DialogHeader className="border-b bg-slate-50 px-5 py-4 pr-12 dark:bg-slate-900">
+          <DialogTitle className="flex min-w-0 items-center gap-2">
+            <NotebookPen className="h-5 w-5 shrink-0 text-slate-600 dark:text-slate-300" />
+            <span className="truncate">Notas de produccion</span>
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Notas internas del proyecto para usuarios admin y management.
+          </DialogDescription>
+          <div className="min-w-0 text-sm text-muted-foreground">
+            <div className="truncate">{jobTitle}</div>
+            {updatedAt && <div className="mt-1 text-xs">Actualizado {updatedAt}</div>}
+          </div>
+        </DialogHeader>
+
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            saveNotes.mutate(draft);
+          }}
+        >
+          <div className="p-5">
+            {notesQuery.isLoading ? (
+              <div className="flex min-h-[45vh] items-center justify-center">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : notesQuery.isError ? (
+              <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+                No se pudieron cargar las notas.
+              </div>
+            ) : (
+              <Textarea
+                aria-label="Notas de produccion"
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                className="min-h-[45vh] resize-none whitespace-pre-wrap border-slate-300 bg-background text-base leading-7 shadow-inner dark:border-slate-700"
+                autoFocus
+              />
+            )}
+          </div>
+
+          <DialogFooter className="gap-2 border-t px-5 py-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={saveNotes.isPending}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={notesQuery.isLoading || notesQuery.isError || saveNotes.isPending}
+              className="gap-2"
+            >
+              {saveNotes.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="h-4 w-4" />
+              )}
+              Guardar
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/project-management/ProjectNotesDialog.tsx
+++ b/src/components/project-management/ProjectNotesDialog.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { queryKeys } from "@/lib/react-query";
-import { dataLayerClient } from "@/services/dataLayerClient";
+import { getJobProjectNote, saveJobProjectNote } from "@/services/projectNotesService";
 
 type ProjectNotesDialogProps = {
   open: boolean;
@@ -22,13 +22,6 @@ type ProjectNotesDialogProps = {
   jobId: string;
   jobTitle: string;
   canManageNotes: boolean;
-};
-
-type JobProjectNoteRow = {
-  job_id: string;
-  notes: string;
-  updated_at: string;
-  updated_by: string | null;
 };
 
 const formatUpdatedAt = (value?: string | null) => {
@@ -54,16 +47,7 @@ export const ProjectNotesDialog = ({
   const notesQuery = useQuery({
     queryKey: queryKeys.scope("job-project-notes", jobId),
     enabled: open && canManageNotes && Boolean(jobId),
-    queryFn: async () => {
-      const { data, error } = await dataLayerClient
-        .from("job_project_notes")
-        .select("job_id, notes, updated_at, updated_by")
-        .eq("job_id", jobId)
-        .maybeSingle();
-
-      if (error) throw error;
-      return data as JobProjectNoteRow | null;
-    },
+    queryFn: () => getJobProjectNote(jobId),
   });
 
   React.useEffect(() => {
@@ -72,21 +56,7 @@ export const ProjectNotesDialog = ({
   }, [notesQuery.data?.notes, notesQuery.isLoading, open]);
 
   const saveNotes = useMutation({
-    mutationFn: async (notes: string) => {
-      const { data: authData } = await dataLayerClient.auth.getUser();
-      const { error } = await dataLayerClient
-        .from("job_project_notes")
-        .upsert(
-          {
-            job_id: jobId,
-            notes,
-            updated_by: authData.user?.id ?? null,
-          },
-          { onConflict: "job_id" },
-        );
-
-      if (error) throw error;
-    },
+    mutationFn: (notes: string) => saveJobProjectNote(jobId, notes),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: queryKeys.scope("job-project-notes", jobId),

--- a/src/components/project-management/ProjectNotesDialog.tsx
+++ b/src/components/project-management/ProjectNotesDialog.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format, parseISO } from "date-fns";
+import { es } from "date-fns/locale";
+import { toZonedTime } from "date-fns-tz";
 import { Loader2, NotebookPen, Save } from "lucide-react";
 
 import {
@@ -27,10 +30,7 @@ type ProjectNotesDialogProps = {
 const formatUpdatedAt = (value?: string | null) => {
   if (!value) return null;
 
-  return new Intl.DateTimeFormat("es-ES", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(value));
+  return format(toZonedTime(parseISO(value), "Europe/Madrid"), "Pp", { locale: es });
 };
 
 export const ProjectNotesDialog = ({
@@ -86,7 +86,7 @@ export const ProjectNotesDialog = ({
         <DialogHeader className="border-b bg-slate-50 px-5 py-4 pr-12 dark:bg-slate-900">
           <DialogTitle className="flex min-w-0 items-center gap-2">
             <NotebookPen className="h-5 w-5 shrink-0 text-slate-600 dark:text-slate-300" />
-            <span className="truncate">Notas de produccion</span>
+            <span className="truncate">Notas de producción</span>
           </DialogTitle>
           <DialogDescription className="sr-only">
             Notas internas del proyecto para usuarios admin y management.
@@ -114,7 +114,7 @@ export const ProjectNotesDialog = ({
               </div>
             ) : (
               <Textarea
-                aria-label="Notas de produccion"
+                aria-label="Notas de producción"
                 value={draft}
                 onChange={(event) => setDraft(event.target.value)}
                 className="min-h-[45vh] resize-none whitespace-pre-wrap border-slate-300 bg-background text-base leading-7 shadow-inner dark:border-slate-700"

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4016,6 +4016,76 @@ export type Database = {
           },
         ]
       }
+      job_project_notes: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          job_id: string
+          notes: string
+          updated_at: string
+          updated_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          job_id: string
+          notes?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          job_id?: string
+          notes?: string
+          updated_at?: string
+          updated_by?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_project_notes_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_project_notes_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_project_notes_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: true
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_project_notes_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: true
+            referencedRelation: "v_job_staffing_summary"
+            referencedColumns: ["job_id"]
+          },
+          {
+            foreignKeyName: "job_project_notes_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_project_notes_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       job_rate_extras: {
         Row: {
           amount_override_eur: number | null

--- a/src/services/projectNotesService.ts
+++ b/src/services/projectNotesService.ts
@@ -18,7 +18,12 @@ export async function getJobProjectNote(jobId: string): Promise<JobProjectNoteRo
 }
 
 export async function saveJobProjectNote(jobId: string, notes: string): Promise<void> {
-  const { data: authData } = await dataLayerClient.auth.getUser();
+  const { data: authData, error: authError } = await dataLayerClient.auth.getUser();
+
+  if (authError) throw authError;
+  if (!authData.user) {
+    throw new Error("An authenticated user is required to save project notes.");
+  }
 
   const { error } = await dataLayerClient
     .from("job_project_notes")
@@ -26,7 +31,7 @@ export async function saveJobProjectNote(jobId: string, notes: string): Promise<
       {
         job_id: jobId,
         notes,
-        updated_by: authData.user?.id ?? null,
+        updated_by: authData.user.id,
       },
       { onConflict: "job_id" },
     );

--- a/src/services/projectNotesService.ts
+++ b/src/services/projectNotesService.ts
@@ -1,0 +1,35 @@
+import type { Database } from "@/integrations/supabase/types";
+import { dataLayerClient } from "@/services/dataLayerClient";
+
+export type JobProjectNoteRow = Pick<
+  Database["public"]["Tables"]["job_project_notes"]["Row"],
+  "job_id" | "notes" | "updated_at" | "updated_by"
+>;
+
+export async function getJobProjectNote(jobId: string): Promise<JobProjectNoteRow | null> {
+  const { data, error } = await dataLayerClient
+    .from("job_project_notes")
+    .select("job_id, notes, updated_at, updated_by")
+    .eq("job_id", jobId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function saveJobProjectNote(jobId: string, notes: string): Promise<void> {
+  const { data: authData } = await dataLayerClient.auth.getUser();
+
+  const { error } = await dataLayerClient
+    .from("job_project_notes")
+    .upsert(
+      {
+        job_id: jobId,
+        notes,
+        updated_by: authData.user?.id ?? null,
+      },
+      { onConflict: "job_id" },
+    );
+
+  if (error) throw error;
+}

--- a/supabase/migrations/20260605110000_create_job_project_notes.sql
+++ b/supabase/migrations/20260605110000_create_job_project_notes.sql
@@ -41,6 +41,30 @@ for delete
 to authenticated
 using (public.get_current_user_role() = any (array['admin'::text, 'management'::text]));
 
+create or replace function public.set_job_project_notes_user_audit()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if tg_op = 'INSERT' then
+    new.created_by = auth.uid();
+  else
+    new.created_by = old.created_by;
+  end if;
+
+  new.updated_by = auth.uid();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_set_job_project_notes_user_audit on public.job_project_notes;
+create trigger trg_set_job_project_notes_user_audit
+before insert or update on public.job_project_notes
+for each row
+execute function public.set_job_project_notes_user_audit();
+
 drop trigger if exists set_job_project_notes_updated_at on public.job_project_notes;
 create trigger set_job_project_notes_updated_at
 before update on public.job_project_notes

--- a/supabase/migrations/20260605110000_create_job_project_notes.sql
+++ b/supabase/migrations/20260605110000_create_job_project_notes.sql
@@ -1,0 +1,51 @@
+create table if not exists public.job_project_notes (
+  job_id uuid primary key references public.jobs(id) on delete cascade,
+  notes text not null default '',
+  created_at timestamp with time zone not null default timezone('utc'::text, now()),
+  updated_at timestamp with time zone not null default timezone('utc'::text, now()),
+  created_by uuid references public.profiles(id) on delete set null default auth.uid(),
+  updated_by uuid references public.profiles(id) on delete set null default auth.uid()
+);
+
+comment on table public.job_project_notes is 'Internal project notes for jobs, visible and editable only by admin and management users.';
+comment on column public.job_project_notes.notes is 'Free-text production/project notes for the job.';
+
+alter table public.job_project_notes enable row level security;
+
+drop policy if exists "job_project_notes_select_management" on public.job_project_notes;
+create policy "job_project_notes_select_management"
+on public.job_project_notes
+for select
+to authenticated
+using (public.get_current_user_role() = any (array['admin'::text, 'management'::text]));
+
+drop policy if exists "job_project_notes_insert_management" on public.job_project_notes;
+create policy "job_project_notes_insert_management"
+on public.job_project_notes
+for insert
+to authenticated
+with check (public.get_current_user_role() = any (array['admin'::text, 'management'::text]));
+
+drop policy if exists "job_project_notes_update_management" on public.job_project_notes;
+create policy "job_project_notes_update_management"
+on public.job_project_notes
+for update
+to authenticated
+using (public.get_current_user_role() = any (array['admin'::text, 'management'::text]))
+with check (public.get_current_user_role() = any (array['admin'::text, 'management'::text]));
+
+drop policy if exists "job_project_notes_delete_management" on public.job_project_notes;
+create policy "job_project_notes_delete_management"
+on public.job_project_notes
+for delete
+to authenticated
+using (public.get_current_user_role() = any (array['admin'::text, 'management'::text]));
+
+drop trigger if exists set_job_project_notes_updated_at on public.job_project_notes;
+create trigger set_job_project_notes_updated_at
+before update on public.job_project_notes
+for each row
+execute function public.set_updated_at();
+
+grant select, insert, update, delete on table public.job_project_notes to authenticated;
+grant all on table public.job_project_notes to service_role;


### PR DESCRIPTION
## What changed
- Added a management-only project notes notepad for each job in Project Management.
- Added a dedicated `job_project_notes` table with RLS limited to `admin` and `management` roles.
- Wired a `Notas` button into Project Management job cards and added focused dialog tests.

## Why
Production requested a per-job notes section that opens above Project Management like a notepad, with access restricted to admin/management users.

## Risk assessment
Risk level: Low to medium.

Main risks:
- New Supabase table/policies must be applied before the UI can save notes in production.
- Incorrect RLS/audit behavior could expose or misattribute note edits; this is mitigated by role-scoped policies and a server-side audit trigger.
- The feature is additive and isolated to Project Management job cards.

## Impact checklist
- Database: Adds `public.job_project_notes`, RLS policies, grants, and audit/update triggers.
- Security: Admin/management-only UI gate plus Supabase RLS enforcing admin/management CRUD access.
- Performance: Lazy React Query fetch only when the notepad dialog is opened.
- Mobile/PWA: No Capacitor runtime changes.
- Existing data: No existing tables are rewritten or deleted.

## Validation
- `npm install --legacy-peer-deps`
- `npm run typecheck`
- `npm run test:run -- src/components/project-management/ProjectNotesDialog.test.tsx`
- `npm run governance:source`
- `npm run lint` (passes with existing warnings)
- `npm run test:run` (141 files, 894 tests passed)
- `npm run build`

## Deployment notes
This PR includes a Supabase migration. Before merging to production, run the normal production `supabase db push --dry-run`, apply the migration to the linked production project, and confirm a follow-up dry run reports the remote DB is up to date.

## Rollback plan
- Revert the merged UI/service/types commit and redeploy `main` if the UI needs to be disabled.
- If the database object must also be removed, manually drop the `job_project_notes` triggers, table, and audit function after confirming production notes do not need to be retained.
- If notes should be retained during rollback, leave the table in place and only revert the UI path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Management users can now view and edit project notes for jobs via a new "Notas" button on job cards.
  * Project notes dialog supports inline editing and automatic saving of notes.

* **Tests**
  * Added comprehensive test coverage for project notes functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
