### PR TITLE
Fix prep day timesheet surfacing

### DIFF
--- a/src/components/jobs/PayoutEmailPreview.tsx
+++ b/src/components/jobs/PayoutEmailPreview.tsx
@@ -227,6 +227,14 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
     const deductionFormatted = formatCurrency(deductionAmount);
     const hasDeduction = deductionAmount > 0;
     const lpoNumber = selectedAttachment.lpo_number;
+    const prepServiceDates = timesheetLines
+      .filter((line) => line.is_prep_day === true)
+      .map((line) => line.date)
+      .filter((date): date is string => date != null)
+      .map((date) => parseServiceDate(date))
+      .filter((date): date is Date => date !== null)
+      .sort((a, b) => a.getTime() - b.getTime());
+    const prepDatesText = prepServiceDates.length > 0 ? formatWorkedDates(prepServiceDates) : '';
     const invoicingCompany = context.job.invoicing_company;
     const companyDetails = getInvoicingCompanyDetails(invoicingCompany);
     const safeJobTitle = escapeHtml(context.job.title || '');
@@ -277,6 +285,7 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
                   <li><b>Total general:</b> ${grand}</li>
                 </ul>
                 ${hasDeduction ? `<p style="margin:10px 0 0 0;font-size:12px;color:#b91c1c;">* Se ha aplicado una deducción de 30€/día por condición de no autónomo.</p>` : ''}
+                ${prepDatesText ? `<p style="margin:10px 0 0 0;font-size:12px;color:#2563eb;">* Incluye día(s) de preparación (${escapeHtml(prepDatesText)}), calculados a 15€/h sobre horas redondeadas.</p>` : ''}
               </div>
             </td>
           </tr>
@@ -408,9 +417,20 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
                     <div className="space-y-1">
                       {(() => {
                         const lines = context.timesheetMap.get(selectedAttachment.technician_id) || [];
+                        const prepDates = new Set(
+                          lines
+                            .filter((line) => line.is_prep_day === true)
+                            .map((line) => line.date)
+                            .filter(Boolean)
+                        );
                         const dates = Array.from(new Set(lines.map(l => l.date).filter(Boolean)));
                         return dates.length > 0
-                          ? dates.map(d => <div key={d}>{formatDateLong(d) ?? d}</div>)
+                          ? dates.map(d => (
+                              <div key={d}>
+                                {formatDateLong(d) ?? d}
+                                {prepDates.has(d) && <span className="ml-2 text-blue-600">(preparación)</span>}
+                              </div>
+                            ))
                           : <div className="text-muted-foreground">Sin partes registrados</div>;
                       })()}
                     </div>

--- a/src/components/jobs/__tests__/JobDetailsDialog.timesheet-pdf.test.ts
+++ b/src/components/jobs/__tests__/JobDetailsDialog.timesheet-pdf.test.ts
@@ -113,6 +113,7 @@ describe('JobDetailsDialog timesheet enrichment', () => {
 
     expect(autoTableCalls.length).toBeGreaterThan(0);
     const firstTable = autoTableCalls[0];
-    expect(firstTable.body[0][1]).toBe('Alice Doe');
+    expect(firstTable.body[0][1]).toBe('Work');
+    expect(firstTable.body[0][2]).toBe('Alice Doe');
   });
 });

--- a/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
+++ b/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
@@ -1080,5 +1080,21 @@ describe('JobCardActions', () => {
       const openFlexButton = screen.getByTitle('Abrir en Flex');
       expect(openFlexButton).not.toBeDisabled();
     });
+
+    it('should show prep-day timesheet approvals for tourdate jobs with prep dates', () => {
+      const props = {
+        ...defaultProps,
+        job: {
+          ...defaultProps.job,
+          job_type: 'tourdate',
+          start_time: '2024-01-15',
+          job_date_types: [{ date: '2024-01-14', type: 'prep_day' }],
+        },
+      };
+
+      render(<JobCardActions {...props} />);
+
+      expect(screen.getByTitle('Gestionar partes de preparación')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
+++ b/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
@@ -35,6 +35,7 @@ import type {
   TechnicalPowerPackState,
 } from "@/components/jobs/cards/job-card-actions/types";
 import { cn } from "@/lib/utils";
+import { hasPrepDayDateType } from "@/utils/timesheetPrepDays";
 import { canSubmitTechnicianIncidentReports } from "@/utils/permissions";
 
 type JobCardActionButtonsProps = JobCardActionsProps & {
@@ -119,7 +120,13 @@ export const JobCardActionButtons = ({
   whatsappDisabled,
   whatsappGroup,
   whatsappRequest,
-}: JobCardActionButtonsProps) => (
+}: JobCardActionButtonsProps) => {
+  const normalizedJobType = String(job.job_type || "").toLowerCase();
+  const canOpenTimesheets = !["dryhire", "dry_hire"].includes(normalizedJobType) && (
+    normalizedJobType !== "tourdate" || hasPrepDayDateType(job.job_date_types)
+  );
+
+  return (
   <div className={cn("flex flex-wrap", isMobile ? "gap-1" : "gap-1.5")} onClick={(e) => e.stopPropagation()}>
     {isProjectManagementPage && job.job_type !== "dryhire" && onOpenTasks && (
       <Button
@@ -270,12 +277,12 @@ export const JobCardActionButtons = ({
         <RefreshCw className="h-4 w-4" />
       </Button>
     )}
-    {job.job_type !== "dryhire" && job.job_type !== "tourdate" && (
+    {canOpenTimesheets && (
       <Button
         variant="ghost"
         size="icon"
         onClick={handleTimesheetClick}
-        title="Gestionar Hojas de Tiempo"
+        title={normalizedJobType === "tourdate" ? "Gestionar partes de preparación" : "Gestionar Hojas de Tiempo"}
         className="hover:bg-accent/50"
       >
         <Clock className="h-4 w-4" />
@@ -502,4 +509,5 @@ export const JobCardActionButtons = ({
       </Button>
     )}
   </div>
-);
+  );
+};

--- a/src/components/jobs/cards/job-card-actions/types.ts
+++ b/src/components/jobs/cards/job-card-actions/types.ts
@@ -32,6 +32,7 @@ export interface JobCardJob extends Job {
   flex_presupuesto_element_id?: string | null;
   flexPresupuestoElementId?: string | null;
   job_name?: string | null;
+  job_date_types?: Array<{ date?: string | null; type?: string | null }> | null;
   location?: JobCardLocation;
   location_data?: JobCardLocationObject | null;
   name?: string | null;

--- a/src/components/jobs/job-details-dialog/tabs/JobDetailsInfoTab.tsx
+++ b/src/components/jobs/job-details-dialog/tabs/JobDetailsInfoTab.tsx
@@ -521,6 +521,9 @@ export const JobDetailsInfoTab: React.FC<JobDetailsInfoTabProps> = ({
                         overtime_amount_eur:
                           b.overtime_amount_eur != null ? Number(b.overtime_amount_eur) : undefined,
                         total_eur: b.total_eur != null ? Number(b.total_eur) : undefined,
+                        is_prep_day: b.is_prep_day === true,
+                        prep_day_hourly_rate_eur:
+                          b.prep_day_hourly_rate_eur != null ? Number(b.prep_day_hourly_rate_eur) : undefined,
                       };
                       const arr = tsByTech.get(row.technician_id) || [];
                       arr.push(line);

--- a/src/components/jobs/payout-totals/usePayoutActions.ts
+++ b/src/components/jobs/payout-totals/usePayoutActions.ts
@@ -13,7 +13,7 @@ import {
   type TechnicianProfileWithEmail,
 } from '@/lib/job-payout-email';
 import { sendTourJobEmails, prepareTourJobEmailContext } from '@/lib/tour-payout-email';
-import { generateJobPayoutPDF, generateRateQuotePDF, type TechnicianProfile } from '@/utils/rates-pdf-export';
+import { generateJobPayoutPDF, generateRateQuotePDF, type TechnicianProfile, type TimesheetLine } from '@/utils/rates-pdf-export';
 import type { JobPayoutTotals } from '@/types/jobExtras';
 import type { TourJobRateQuote } from '@/types/tourRates';
 import type { JobMetadata, PayoutActions } from './types';
@@ -63,6 +63,28 @@ export function usePayoutActions({
   const setOverrideMutation = useSetTechnicianPayoutOverride();
   const removeOverrideMutation = useRemoveTechnicianPayoutOverride();
   const toggleApprovalMutation = useToggleTechnicianPayoutApproval();
+
+  const buildTourPreviewTimesheetMap = React.useCallback((
+    tourContext: Awaited<ReturnType<typeof prepareTourJobEmailContext>>
+  ) => {
+    const map = new Map<string, TimesheetLine[]>(
+      Array.from(tourContext.timesheetDateMap.entries()).map(([techId, dates]) => [
+        techId,
+        Array.from(dates).sort().map((date) => ({ date, hours_rounded: 0 })),
+      ])
+    );
+
+    tourContext.prepTimesheetMap.forEach((prepLines, techId) => {
+      const prepDates = new Set(prepLines.map((line) => line.date).filter(Boolean));
+      const existing = map.get(techId) || [];
+      map.set(techId, [
+        ...prepLines,
+        ...existing.filter((line) => !prepDates.has(line.date)),
+      ]);
+    });
+
+    return map;
+  }, []);
 
   /* ── Reset on job/type change ── */
   React.useEffect(() => {
@@ -134,6 +156,13 @@ export function usePayoutActions({
       if (visibleTourQuotes.length === 0 || !jobMeta) return;
       setIsExporting(true);
       try {
+        const tourContext = await prepareTourJobEmailContext({
+          jobId,
+          supabase: dataLayerClient,
+          quotes: visibleTourQuotes,
+          profiles: profilesWithEmail as (TechnicianProfile & { email?: string | null })[],
+        });
+
         await generateRateQuotePDF(
           visibleTourQuotes,
           {
@@ -144,7 +173,11 @@ export function usePayoutActions({
             job_type: jobMeta.job_type ?? undefined,
           },
           profilesWithEmail as TechnicianProfile[],
-          lpoMap
+          lpoMap,
+          {
+            timesheetMap: tourContext.timesheetDateMap,
+            prepTimesheetMap: tourContext.prepTimesheetMap,
+          }
         );
         toast.success('PDF de tarifas generado');
       } catch (err) {
@@ -317,17 +350,13 @@ export function usePayoutActions({
           payouts: [],
           profiles: profilesWithEmail,
           lpoMap: tourContext.lpoMap,
-          timesheetMap: new Map(
-            Array.from(tourContext.timesheetDateMap.entries()).map(([techId, dates]) => [
-              techId,
-              Array.from(dates).sort().map(d => ({
-                date: d,
-                hours_rounded: 0,
-              })),
-            ])
-          ),
+          timesheetMap: buildTourPreviewTimesheetMap(tourContext),
           attachments: tourContext.attachments.map((a) => {
             const baseTotal = Number(a.quote.total_eur ?? 0);
+            const prepTotal = (tourContext.prepTimesheetMap.get(a.technician_id) || []).reduce(
+              (sum, line) => sum + Number(line.total_eur ?? 0),
+              0
+            );
             const extrasTotal = Number(
               a.quote.extras_total_eur ?? (a.quote.extras?.total_eur != null ? a.quote.extras.total_eur : 0)
             );
@@ -337,8 +366,8 @@ export function usePayoutActions({
             const expensesBreakdown = techPayout?.expenses_breakdown ?? [];
             const totalWithExtras =
               a.quote.total_with_extras_eur != null
-                ? Number(a.quote.total_with_extras_eur) + expensesTotal
-                : baseTotal + extrasTotal + expensesTotal;
+                ? Number(a.quote.total_with_extras_eur) + prepTotal + expensesTotal
+                : baseTotal + prepTotal + extrasTotal + expensesTotal;
 
             return {
               technician_id: a.technician_id,
@@ -347,7 +376,7 @@ export function usePayoutActions({
               payout: {
                 job_id: jobId,
                 technician_id: a.technician_id,
-                timesheets_total_eur: baseTotal,
+                timesheets_total_eur: baseTotal + prepTotal,
                 extras_total_eur: extrasTotal,
                 total_eur: totalWithExtras,
                 extras_breakdown: { items: a.quote.extras?.items ?? [], total_eur: extrasTotal },
@@ -395,7 +424,7 @@ export function usePayoutActions({
     } finally {
       setIsLoadingPreview(false);
     }
-  }, [jobId, isTourDate, visibleTourQuotes, standardPayoutTotals, payoutTotals, profilesWithEmail, lpoMap, jobMeta]);
+  }, [jobId, isTourDate, visibleTourQuotes, standardPayoutTotals, payoutTotals, profilesWithEmail, lpoMap, jobMeta, buildTourPreviewTimesheetMap]);
 
   /* ── Single technician email ── */
   const handleSendEmailForTech = React.useCallback(

--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -21,6 +21,7 @@ import { dataLayerClient } from '@/services/dataLayerClient';
 import { OBLIQUE_STRATEGIES } from "./obliqueStrategies";
 import { getCategoryFromAssignment } from '@/utils/roleCategory';
 import { isPreventiveResourceForJob } from '@/utils/preventiveResource';
+import { hasPrepDayDateType } from '@/utils/timesheetPrepDays';
 
 type Assignment = any;
 
@@ -89,6 +90,13 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
   const jobData = assignment.jobs || assignment.festival_jobs;
   if (!jobData) return null;
   const isPreventiveResource = isPreventiveResourceForJob(jobData, assignment.technician_id);
+  const normalizedJobType = String(jobData.job_type || '').toLowerCase();
+  const hasPrepDayTimesheets =
+    jobData.has_prep_day_timesheet === true ||
+    hasPrepDayDateType(jobData.job_date_types);
+  const showTimesheetButton = !['dryhire', 'dry_hire'].includes(normalizedJobType) && (
+    normalizedJobType !== 'tourdate' || hasPrepDayTimesheets
+  );
 
   const jobTimezone = jobData.timezone || 'Europe/Madrid';
   let formattedDate = "Fecha desconocida";
@@ -198,7 +206,7 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
             </Button>
           )}
 
-          {jobData.job_type !== "dryhire" && jobData.job_type !== "tourdate" && (
+          {showTimesheetButton && (
             <Button onClick={() => handleTimesheetClick(jobData.id)} variant="outline" size="sm" className="gap-2">
               <Clock className="h-3 w-3" />
               Tiempos

--- a/src/components/technician/TechJobCard.tsx
+++ b/src/components/technician/TechJobCard.tsx
@@ -12,6 +12,7 @@ import { ExpenseForm, ExpenseList, ExpenseSummaryCard } from '@/components/expen
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { JobCardProps } from './types';
 import { isPreventiveResourceForJob } from '@/utils/preventiveResource';
+import { hasPrepDayDateType } from '@/utils/timesheetPrepDays';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -64,7 +65,10 @@ export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techNam
     const jobType = jobData?.job_type?.toLowerCase() || '';
     const isTourdate = jobType === 'tourdate';
     const isDryhire = jobType === 'dryhire' || jobType === 'dry_hire';
-    const showTimesheetButton = !isTourdate && !isDryhire;
+    const hasPrepDayTimesheets =
+        jobData?.has_prep_day_timesheet === true ||
+        hasPrepDayDateType(jobData?.job_date_types);
+    const showTimesheetButton = !isDryhire && (!isTourdate || hasPrepDayTimesheets);
     const showIncidentReport = !isDryhire;
     const artistCountFromJob = Number(jobData?.artist_count || 0);
     const shouldFetchArtistCountFallback = jobData?.artist_count == null && Boolean(jobData?.id);

--- a/src/components/technician/TimesheetView.tsx
+++ b/src/components/technician/TimesheetView.tsx
@@ -41,6 +41,7 @@ import { useJobRatesApproval } from '@/hooks/useJobRatesApproval';
 import { formatCurrency } from '@/lib/utils';
 import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 import { isTechnicianRole } from '@/utils/permissions';
+import { isPrepDayBreakdown, isPrepDayTimesheet, prepDayHourlyRate } from '@/utils/timesheetPrepDays';
 import { Timesheet, TimesheetFormData } from '@/types/timesheet';
 import SignatureCanvas from 'react-signature-canvas';
 import { Theme } from './types';
@@ -171,16 +172,17 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
     setEditingId(null);
   };
 
-  const saveTimesheet = async (timesheetId: string) => {
+  const saveTimesheet = async (timesheet: Timesheet) => {
+    const isPrepDay = isPrepDayTimesheet(timesheet);
     try {
-      await updateTimesheet(timesheetId, {
+      await updateTimesheet(timesheet.id, {
         start_time: formData.start_time,
         end_time: formData.end_time,
         break_minutes: formData.break_minutes,
-        overtime_hours: formData.overtime_hours,
+        overtime_hours: isPrepDay ? 0 : formData.overtime_hours,
         notes: formData.notes,
         ends_next_day: formData.ends_next_day,
-        category: formData.category,
+        category: isPrepDay ? undefined : formData.category,
       });
       setEditingId(null);
     } catch (err: unknown) {
@@ -343,6 +345,7 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                   </div>
 
                   {dayTimesheets.map((timesheet) => {
+                    const isPrepDay = isPrepDayTimesheet(timesheet);
                     const isEditing = editingId === timesheet.id;
                     const statusBadge = getStatusBadge(timesheet.status, isDark);
                     const editableStatuses: Array<Timesheet['status']> = ['draft', 'rejected'];
@@ -372,9 +375,16 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                       >
                         {/* Status badge */}
                         <div className="flex items-center justify-between mb-4">
-                          <span className={`px-2.5 py-1 rounded text-[10px] font-bold uppercase ${statusBadge.bg} ${statusBadge.text}`}>
-                            {statusBadge.label}
-                          </span>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className={`px-2.5 py-1 rounded text-[10px] font-bold uppercase ${statusBadge.bg} ${statusBadge.text}`}>
+                              {statusBadge.label}
+                            </span>
+                            {isPrepDay && (
+                              <span className="px-2.5 py-1 rounded text-[10px] font-bold uppercase bg-blue-500/20 text-blue-500">
+                                Día de preparación · 15 €/h
+                              </span>
+                            )}
+                          </div>
                           {timesheet.ends_next_day && (
                             <span className={`flex items-center gap-1 text-xs ${theme.textMuted}`}>
                               <Moon size={12} /> Noche
@@ -453,39 +463,48 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                               </div>
                             </div>
 
-                            {/* Category */}
-                            <div>
-                              <label className={`text-xs font-bold ${theme.textMuted} mb-1 block`}>Categoría</label>
-                              <Select
-                                value={formData.category || ''}
-                                onValueChange={(v) => {
-                                  const category = v === 'tecnico' || v === 'especialista' || v === 'responsable' ? v : undefined;
-                                  setFormData({ ...formData, category });
-                                }}
-                              >
-                                <SelectTrigger className={theme.input}>
-                                  <SelectValue placeholder="Seleccionar categoría" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  <SelectItem value="tecnico">Técnico</SelectItem>
-                                  <SelectItem value="especialista">Especialista</SelectItem>
-                                  <SelectItem value="responsable">Responsable</SelectItem>
-                                </SelectContent>
-                              </Select>
-                            </div>
+                            {isPrepDay ? (
+                              <div className={`p-3 rounded-xl ${isDark ? 'bg-blue-500/10 border border-blue-500/20' : 'bg-blue-50 border border-blue-100'}`}>
+                                <div className="text-xs font-bold text-blue-500 mb-1">Día de preparación</div>
+                                <div className={`text-xs ${theme.textMuted}`}>Se calcula a 15 €/h sobre horas redondeadas.</div>
+                              </div>
+                            ) : (
+                              <>
+                                {/* Category */}
+                                <div>
+                                  <label className={`text-xs font-bold ${theme.textMuted} mb-1 block`}>Categoría</label>
+                                  <Select
+                                    value={formData.category || ''}
+                                    onValueChange={(v) => {
+                                      const category = v === 'tecnico' || v === 'especialista' || v === 'responsable' ? v : undefined;
+                                      setFormData({ ...formData, category });
+                                    }}
+                                  >
+                                    <SelectTrigger className={theme.input}>
+                                      <SelectValue placeholder="Seleccionar categoría" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      <SelectItem value="tecnico">Técnico</SelectItem>
+                                      <SelectItem value="especialista">Especialista</SelectItem>
+                                      <SelectItem value="responsable">Responsable</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                </div>
 
-                            {/* Overtime */}
-                            <div>
-                              <label className={`text-xs font-bold ${theme.textMuted} mb-1 block`}>Horas extra</label>
-                              <Input
-                                type="number"
-                                value={formData.overtime_hours}
-                                onChange={(e) => setFormData({ ...formData, overtime_hours: parseFloat(e.target.value) || 0 })}
-                                className={`${theme.input} font-mono`}
-                                min={0}
-                                step={0.5}
-                              />
-                            </div>
+                                {/* Overtime */}
+                                <div>
+                                  <label className={`text-xs font-bold ${theme.textMuted} mb-1 block`}>Horas extra</label>
+                                  <Input
+                                    type="number"
+                                    value={formData.overtime_hours}
+                                    onChange={(e) => setFormData({ ...formData, overtime_hours: parseFloat(e.target.value) || 0 })}
+                                    className={`${theme.input} font-mono`}
+                                    min={0}
+                                    step={0.5}
+                                  />
+                                </div>
+                              </>
+                            )}
 
                             {/* Notes */}
                             <div>
@@ -525,7 +544,7 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   e.preventDefault();
-                                  saveTimesheet(timesheet.id);
+                                  saveTimesheet(timesheet);
                                 }}
                               >
                                 <Save size={16} className="mr-2" />
@@ -557,7 +576,7 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                               <div className="grid grid-cols-2 gap-3">
                                 <div>
                                   <div className={`text-[10px] font-bold uppercase ${theme.textMuted}`}>Categoría</div>
-                                  <div className={`font-medium ${theme.textMain}`}>{timesheet.category || 'Sin asignar'}</div>
+                                  <div className={`font-medium ${theme.textMain}`}>{isPrepDay ? 'Día de preparación' : (timesheet.category || 'Sin asignar')}</div>
                                 </div>
                                 <div>
                                   <div className={`text-[10px] font-bold uppercase ${theme.textMuted}`}>Horas totales</div>
@@ -584,7 +603,22 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                               {/* Rate breakdown (only if approved and visible) */}
                               {timesheet.amount_breakdown_visible && (
                                 <div className={`p-3 rounded-xl ${isDark ? 'bg-emerald-500/10' : 'bg-emerald-50'} border border-emerald-500/20`}>
-                                  <div className={`text-xs font-bold text-emerald-600 mb-2`}>Desglose de tarifa</div>
+                                  {(() => {
+                                    const breakdownIsPrepDay = isPrepDay || isPrepDayBreakdown(timesheet.amount_breakdown_visible);
+                                    const prepRate = prepDayHourlyRate(timesheet.amount_breakdown_visible) ?? 15;
+                                    return (
+                                      <>
+                                        <div className={`text-xs font-bold text-emerald-600 mb-2`}>
+                                          {breakdownIsPrepDay ? 'Desglose de preparación' : 'Desglose de tarifa'}
+                                        </div>
+                                        {breakdownIsPrepDay && (
+                                          <div className="mb-2 rounded-md bg-blue-500/10 px-2 py-1 text-xs text-blue-500">
+                                            Día de preparación: {formatCurrency(prepRate)}/h sobre horas redondeadas.
+                                          </div>
+                                        )}
+                                      </>
+                                    );
+                                  })()}
                                   <div className="grid grid-cols-2 gap-2 text-sm">
                                     <div>
                                       <span className={theme.textMuted}>Horas: </span>

--- a/src/components/technician/types.ts
+++ b/src/components/technician/types.ts
@@ -27,6 +27,8 @@ export interface TechnicianJobData {
   status?: string;
   created_at?: string;
   artist_count?: number;
+  has_prep_day_timesheet?: boolean;
+  job_date_types?: Array<{ date?: string | null; type?: string | null }> | null;
   preventive_resource_technician_id?: string | null;
   location?: { name: string } | null;
   job_documents?: Array<{

--- a/src/components/timesheet/TimesheetEditForm.tsx
+++ b/src/components/timesheet/TimesheetEditForm.tsx
@@ -12,8 +12,17 @@ export const TimesheetEditForm: React.FC<{
   setFormData: Dispatch<SetStateAction<TimesheetFormData>>;
   onSave: () => void;
   onCancel: () => void;
-}> = ({ formData, setFormData, onSave, onCancel }) => (
+  isPrepDay?: boolean;
+}> = ({ formData, setFormData, onSave, onCancel, isPrepDay = false }) => (
   <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    {isPrepDay && (
+      <div className="col-span-2 md:col-span-4 rounded-md border border-blue-500/30 bg-blue-50 p-3 text-sm text-blue-900 dark:bg-blue-950/30 dark:text-blue-100">
+        <Badge variant="secondary" className="mb-2 bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100">
+          Día de preparación · 15 €/h
+        </Badge>
+        <p>Este parte se calcula por horas redondeadas como día de preparación.</p>
+      </div>
+    )}
     <div>
       <Label htmlFor="start_time">Hora de Inicio</Label>
       <Input
@@ -59,29 +68,33 @@ export const TimesheetEditForm: React.FC<{
         </Badge>
       )}
     </div>
-    <div>
-      <Label htmlFor="category">Categoría</Label>
-      <Select value={formData.category} onValueChange={(v) => setFormData({ ...formData, category: v as any })}>
-        <SelectTrigger>
-          <SelectValue placeholder="Seleccionar categoría" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="tecnico">técnico</SelectItem>
-          <SelectItem value="especialista">especialista</SelectItem>
-          <SelectItem value="responsable">responsable</SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
-    <div>
-      <Label htmlFor="overtime_hours">Horas Extra</Label>
-      <Input
-        id="overtime_hours"
-        type="number"
-        step="0.5"
-        value={formData.overtime_hours}
-        onChange={(e) => setFormData({ ...formData, overtime_hours: parseFloat(e.target.value) || 0 })}
-      />
-    </div>
+    {!isPrepDay && (
+      <>
+        <div>
+          <Label htmlFor="category">Categoría</Label>
+          <Select value={formData.category} onValueChange={(v) => setFormData({ ...formData, category: v as any })}>
+            <SelectTrigger>
+              <SelectValue placeholder="Seleccionar categoría" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="tecnico">técnico</SelectItem>
+              <SelectItem value="especialista">especialista</SelectItem>
+              <SelectItem value="responsable">responsable</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label htmlFor="overtime_hours">Horas Extra</Label>
+          <Input
+            id="overtime_hours"
+            type="number"
+            step="0.5"
+            value={formData.overtime_hours}
+            onChange={(e) => setFormData({ ...formData, overtime_hours: parseFloat(e.target.value) || 0 })}
+          />
+        </div>
+      </>
+    )}
     <div className="col-span-2 md:col-span-4">
       <Label htmlFor="notes">Notas</Label>
       <Textarea
@@ -99,4 +112,3 @@ export const TimesheetEditForm: React.FC<{
     </div>
   </div>
 );
-

--- a/src/components/timesheet/TimesheetView.tsx
+++ b/src/components/timesheet/TimesheetView.tsx
@@ -326,14 +326,21 @@ export const TimesheetView = ({
 
     try {
       const promises = Array.from(selectedTimesheets).map(timesheetId => {
+        const timesheet = filteredTimesheets.find(t => t.id === timesheetId);
+        const isPrepDay = timesheet ? isPrepDayTimesheet(timesheet) : false;
         const updates: Partial<Timesheet> = {};
 
         if (bulkFormData.start_time) updates.start_time = bulkFormData.start_time;
         if (bulkFormData.end_time) updates.end_time = bulkFormData.end_time;
         if (bulkFormData.break_minutes !== undefined) updates.break_minutes = bulkFormData.break_minutes;
-        if (bulkFormData.overtime_hours !== undefined) updates.overtime_hours = bulkFormData.overtime_hours;
+        if (bulkFormData.overtime_hours !== undefined) {
+          updates.overtime_hours = isPrepDay ? 0 : bulkFormData.overtime_hours;
+        }
         if (bulkFormData.notes) updates.notes = bulkFormData.notes;
         if (bulkFormData.ends_next_day !== undefined) updates.ends_next_day = bulkFormData.ends_next_day;
+        if (!isPrepDay && bulkFormData.category !== undefined) {
+          updates.category = bulkFormData.category;
+        }
 
         console.log('Updating timesheet', timesheetId, 'with:', updates);
         // Skip refetch for bulk operations

--- a/src/components/timesheet/TimesheetView.tsx
+++ b/src/components/timesheet/TimesheetView.tsx
@@ -21,6 +21,7 @@ import { es } from "date-fns/locale";
 import { useToast } from "@/hooks/use-toast";
 import { sendTimesheetReminder } from "@/lib/timesheet-reminder-email";
 import { dataLayerClient } from "@/services/dataLayerClient";
+import { formatCurrency } from "@/lib/utils";
 import { isJobPastClosureWindow } from "@/utils/jobClosureUtils";
 import {
   AlertDialog,
@@ -41,6 +42,7 @@ import { isManagementRole, isTechnicianRole } from "@/utils/permissions";
 import { TimesheetEditForm } from "./TimesheetEditForm";
 import { TimesheetRejectDialog } from "./TimesheetRejectDialog";
 import { calculateHours } from "./utils";
+import { isPrepDayBreakdown, isPrepDayTimesheet, prepDayHourlyRate } from "@/utils/timesheetPrepDays";
 
 interface TimesheetViewProps {
   jobId: string;
@@ -180,15 +182,16 @@ export const TimesheetView = ({
 
   const handleUpdateTimesheet = async (timesheet: Timesheet) => {
     if (!editingTimesheet || isClosureLocked) return;
+    const isPrepDay = isPrepDayTimesheet(timesheet);
 
     await updateTimesheet(editingTimesheet, {
       start_time: formData.start_time,
       end_time: formData.end_time,
       break_minutes: formData.break_minutes,
-      overtime_hours: formData.overtime_hours,
+      overtime_hours: isPrepDay ? 0 : formData.overtime_hours,
       notes: formData.notes,
       ends_next_day: formData.ends_next_day,
-      category: formData.category
+      category: isPrepDay ? undefined : formData.category
     });
     setEditingTimesheet(null);
   };
@@ -684,6 +687,7 @@ export const TimesheetView = ({
           </CardHeader>
           <CardContent className="space-y-4">
             {dayTimesheets.map((timesheet) => {
+              const isPrepDay = isPrepDayTimesheet(timesheet);
               const editableStatuses: Array<Timesheet['status']> = ['draft', 'rejected'];
               const canEditTimesheet = isTechnician
                 ? (timesheet.technician_id === user?.id && editableStatuses.includes(timesheet.status) && !isClosureLocked)
@@ -728,6 +732,11 @@ export const TimesheetView = ({
                       <Badge variant={getStatusColor(timesheet.status)}>
                         {translateStatus(timesheet.status)}
                       </Badge>
+                      {isPrepDay && (
+                        <Badge variant="secondary" className="bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-100">
+                          Día de preparación · 15 €/h
+                        </Badge>
+                      )}
                     </div>
 
                     <div className="flex items-center gap-2">
@@ -858,6 +867,7 @@ export const TimesheetView = ({
                       setFormData={setFormData}
                       onSave={() => handleUpdateTimesheet(timesheet)}
                       onCancel={() => setEditingTimesheet(null)}
+                      isPrepDay={isPrepDay}
                     />
                   ) : (
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
@@ -893,7 +903,7 @@ export const TimesheetView = ({
                       )}
                       <div>
                         <p className="text-muted-foreground">Categoría</p>
-                        <p className="font-medium">{timesheet.category || 'No establecido'}</p>
+                        <p className="font-medium">{isPrepDay ? 'Día de preparación' : (timesheet.category || 'No establecido')}</p>
                       </div>
                       {timesheet.notes && (
                         <div className="col-span-2 md:col-span-4">
@@ -917,7 +927,7 @@ export const TimesheetView = ({
                     return (
                       <div className="mt-4 p-3 rounded-md border">
                         <div className="flex items-center justify-between mb-2">
-                          <p className="font-medium">Cálculo de Tarifa</p>
+                          <p className="font-medium">{isPrepDay ? 'Cálculo de Preparación' : 'Cálculo de Tarifa'}</p>
                           {isManagementUser && (
                             <div className="flex gap-2">
                               <Button
@@ -946,14 +956,21 @@ export const TimesheetView = ({
                               </p>
                             );
                           }
+                          const breakdownIsPrepDay = isPrepDay || isPrepDayBreakdown(breakdown);
+                          const prepRate = prepDayHourlyRate(breakdown) ?? 15;
                           return (
                             <div className="grid grid-cols-2 md:grid-cols-5 gap-3 text-sm">
+                              {breakdownIsPrepDay && (
+                                <div className="col-span-2 md:col-span-5 rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-900 dark:bg-blue-950/30 dark:text-blue-100">
+                                  Día de preparación: {formatCurrency(prepRate)}/h sobre horas redondeadas.
+                                </div>
+                              )}
                               <div>
-                                <p className="text-muted-foreground">Horas Redondeadas</p>
+                                <p className="text-muted-foreground">{breakdownIsPrepDay ? 'Horas Preparación' : 'Horas Redondeadas'}</p>
                                 <p className="font-medium">{breakdown.worked_hours_rounded || 0}h</p>
                               </div>
                               <div>
-                                <p className="text-muted-foreground">Cantidad Base</p>
+                                <p className="text-muted-foreground">{breakdownIsPrepDay ? 'Importe preparación' : 'Cantidad Base'}</p>
                                 <p className="font-medium">€{(breakdown.base_amount_eur ?? 0).toFixed(2)}</p>
                               </div>
                               {(breakdown.plus_10_12_amount_eur ?? 0) > 0 && (

--- a/src/hooks/useTimesheets.ts
+++ b/src/hooks/useTimesheets.ts
@@ -5,6 +5,7 @@ import { Timesheet } from "@/types/timesheet";
 import { toast } from "sonner";
 import { RATES_QUERY_KEYS } from "@/constants/ratesQueryKeys";
 import { isManagementRole } from "@/utils/permissions";
+import { isPrepDayBreakdown } from "@/utils/timesheetPrepDays";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -51,6 +52,16 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
         return;
       }
 
+      const { data: prepDayRows, error: prepDayError } = await supabase
+        .from("job_date_types")
+        .select("date")
+        .eq("job_id", jobId)
+        .eq("type", "prep_day");
+      if (prepDayError) {
+        console.warn("Error fetching prep day dates:", prepDayError);
+      }
+      const prepDayDates = new Set((prepDayRows || []).map((row) => row.date));
+
       const technicianIds = [...new Set(data.map(t => t.technician_id))];
       const { data: profiles } = await supabase
         .from("profiles")
@@ -80,6 +91,10 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
           amount_breakdown: visible?.amount_breakdown ?? undefined,
           amount_eur_visible: visible?.amount_eur_visible ?? null,
           amount_breakdown_visible: visible?.amount_breakdown_visible ?? null,
+          is_prep_day:
+            prepDayDates.has(t.date) ||
+            isPrepDayBreakdown(visible?.amount_breakdown) ||
+            isPrepDayBreakdown(visible?.amount_breakdown_visible),
           technician: profiles?.find(p => p.id === t.technician_id)
         } as unknown as Timesheet;
       });
@@ -103,7 +118,7 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
       // Get job assignments and job details
       const { data: assignments, error: assignmentsError } = await supabase
         .from("job_assignments")
-        .select("technician_id")
+        .select("technician_id, status")
         .eq("job_id", jobId);
 
       console.log("Assignments fetched:", assignments, "Error:", assignmentsError);
@@ -133,10 +148,22 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
         return;
       }
 
+      const prepDayDates = Array.from(new Set(
+        (job.job_date_types || [])
+          .filter((dateType: any) => dateType?.type === 'prep_day' && dateType.date)
+          .map((dateType: any) => dateType.date)
+      )).sort();
+
       // Skip if this job type should not create timesheets automatically
       const jtype = String(job.job_type || '').toLowerCase();
-      if (jtype === 'dryhire' || jtype === 'dry_hire' || jtype === 'tourdate') {
+      if (jtype === 'dryhire' || jtype === 'dry_hire') {
         console.log('Job type excludes auto timesheets:', jtype);
+        setIsLoading(false);
+        return;
+      }
+
+      if (jtype === 'tourdate' && prepDayDates.length === 0) {
+        console.log('Tourdate has no prep days; skipping auto timesheets');
         setIsLoading(false);
         return;
       }
@@ -153,11 +180,18 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
       }
 
       // Filter out dates that are marked as "off" or "travel"
-      const dates = allDates.filter(date => {
+      const regularDates = allDates.filter(date => {
         const dateType = job.job_date_types?.find((dt: any) => dt.date === date);
-        // If no date type is defined, or if it's not "off" or "travel", include it
-        return !dateType || (dateType.type !== 'off' && dateType.type !== 'travel');
+        // If no date type is defined, or if it's not "off", "travel", or "prep_day", include it.
+        // Prep days live before the job start date and are added explicitly below.
+        return !dateType || !['off', 'travel', 'prep_day'].includes(dateType.type);
       });
+
+      const dates = Array.from(new Set(
+        jtype === 'tourdate'
+          ? prepDayDates
+          : [...prepDayDates, ...regularDates]
+      )).sort();
 
       console.log("Generated dates (filtered):", dates);
       console.log("Date types:", job.job_date_types);
@@ -179,6 +213,10 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
       // Create missing timesheets
       const timesheetsToCreate = [];
       for (const assignment of assignments) {
+        if (!assignment.technician_id || assignment.status === 'declined') {
+          continue;
+        }
+
         for (const date of dates) {
           const combo = `${assignment.technician_id}-${date}`;
           if (!existingCombos.has(combo)) {

--- a/src/hooks/useTimesheets.ts
+++ b/src/hooks/useTimesheets.ts
@@ -92,7 +92,6 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
           amount_eur_visible: visible?.amount_eur_visible ?? null,
           amount_breakdown_visible: visible?.amount_breakdown_visible ?? null,
           is_prep_day:
-            t.is_prep_day ||
             prepDayDates.has(t.date) ||
             isPrepDayBreakdown(visible?.amount_breakdown) ||
             isPrepDayBreakdown(visible?.amount_breakdown_visible),

--- a/src/hooks/useTimesheets.ts
+++ b/src/hooks/useTimesheets.ts
@@ -92,6 +92,7 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
           amount_eur_visible: visible?.amount_eur_visible ?? null,
           amount_breakdown_visible: visible?.amount_breakdown_visible ?? null,
           is_prep_day:
+            t.is_prep_day ||
             prepDayDates.has(t.date) ||
             isPrepDayBreakdown(visible?.amount_breakdown) ||
             isPrepDayBreakdown(visible?.amount_breakdown_visible),

--- a/src/lib/job-payout-email.ts
+++ b/src/lib/job-payout-email.ts
@@ -69,6 +69,9 @@ function buildTimesheetMap(rows: any[]): Map<string, TimesheetLine[]> {
         breakdown.overtime_amount_eur != null ? Number(breakdown.overtime_amount_eur) : undefined,
       total_eur: breakdown.total_eur != null ? Number(breakdown.total_eur) : undefined,
       is_evento: breakdown.is_evento === true,
+      is_prep_day: breakdown.is_prep_day === true,
+      prep_day_hourly_rate_eur:
+        breakdown.prep_day_hourly_rate_eur != null ? Number(breakdown.prep_day_hourly_rate_eur) : undefined,
     };
 
     const existing = map.get(row.technician_id) || [];
@@ -244,6 +247,14 @@ export async function sendJobPayoutEmails(
       ).sort();
       // Check if any timesheet is an evento type
       const hasEventoTimesheet = timesheetLines.some((line) => line.is_evento === true);
+      const prepDates = Array.from(
+        new Set(
+          timesheetLines
+            .filter((line) => line.is_prep_day === true)
+            .map((line) => line.date)
+            .filter((date): date is string => date != null)
+        )
+      ).sort();
 
       return {
         technician_id: attachment.technician_id,
@@ -262,6 +273,7 @@ export async function sendJobPayoutEmails(
         is_house_tech: attachment.is_house_tech ?? null,
         lpo_number: attachment.lpo_number ?? null,
         worked_dates: workedDates,
+        prep_dates: prepDates,
         is_evento: hasEventoTimesheet,
       };
     }),

--- a/src/lib/tour-payout-email.ts
+++ b/src/lib/tour-payout-email.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { TourJobRateQuote } from '@/types/tourRates';
 import { buildTourPayoutPdfFilename } from '@/utils/pdfFileNames';
-import type { TechnicianProfile } from '@/utils/rates-pdf-export';
+import type { TechnicianProfile, TimesheetLine } from '@/utils/rates-pdf-export';
 import { generateRateQuotePDF } from '@/utils/rates-pdf-export';
 
 export interface TourJobEmailJobDetails {
@@ -36,6 +36,7 @@ export interface TourJobEmailContextResult {
   profiles: (TechnicianProfile & { email?: string | null })[];
   lpoMap?: Map<string, string | null>;
   timesheetDateMap: Map<string, Set<string>>;
+  prepTimesheetMap: Map<string, TimesheetLine[]>;
   expenseMap: Map<string, number>;
   attachments: TourJobEmailAttachment[];
   missingEmails: string[];
@@ -98,11 +99,42 @@ async function fetchLpoMap(
 async function fetchTimesheets(client: SupabaseClient, jobId: string): Promise<any[]> {
   const { data, error } = await client
     .from('timesheets')
-    .select('technician_id, date, approved_by_manager')
+    .select('technician_id, date, approved_by_manager, amount_breakdown, amount_breakdown_visible')
     .eq('job_id', jobId)
     .eq('is_active', true);
   if (error) throw error;
   return data || [];
+}
+
+function buildPrepTimesheetMap(rows: any[]): Map<string, TimesheetLine[]> {
+  const map = new Map<string, TimesheetLine[]>();
+
+  rows.forEach((row) => {
+    if (row.approved_by_manager !== true) return;
+    const breakdown = (row.amount_breakdown || row.amount_breakdown_visible || {}) as Record<string, any>;
+    if (breakdown.is_prep_day !== true) return;
+
+    const line: TimesheetLine = {
+      date: row.date ?? null,
+      hours_rounded: Number(breakdown.hours_rounded ?? breakdown.worked_hours_rounded ?? 0) || 0,
+      base_day_eur: breakdown.base_day_eur != null ? Number(breakdown.base_day_eur) : undefined,
+      plus_10_12_hours: 0,
+      plus_10_12_amount_eur: 0,
+      overtime_hours: 0,
+      overtime_hour_eur: 0,
+      overtime_amount_eur: 0,
+      total_eur: breakdown.total_eur != null ? Number(breakdown.total_eur) : undefined,
+      is_prep_day: true,
+      prep_day_hourly_rate_eur:
+        breakdown.prep_day_hourly_rate_eur != null ? Number(breakdown.prep_day_hourly_rate_eur) : undefined,
+    };
+
+    const existing = map.get(row.technician_id) || [];
+    existing.push(line);
+    map.set(row.technician_id, existing);
+  });
+
+  return map;
 }
 
 export async function prepareTourJobEmailContext(
@@ -112,6 +144,7 @@ export async function prepareTourJobEmailContext(
   const job = await fetchJobDetails(supabase, jobId);
   const lpoMap = await fetchLpoMap(supabase, jobId);
   const timesheetRows = await fetchTimesheets(supabase, jobId);
+  const prepTimesheetMap = buildPrepTimesheetMap(timesheetRows);
 
   // Fetch expenses for tour date jobs
   const expenseMap = new Map<string, number>();
@@ -161,8 +194,9 @@ export async function prepareTourJobEmailContext(
         profiles,
         lpoMap,
         {
-            download: false,
-            timesheetMap: timesheetDateMap
+          download: false,
+          timesheetMap: timesheetDateMap,
+          prepTimesheetMap,
         }
       )) as Blob | void;
     } catch (error) {
@@ -208,6 +242,7 @@ export async function prepareTourJobEmailContext(
     profiles,
     lpoMap,
     timesheetDateMap,
+    prepTimesheetMap,
     expenseMap,
     attachments,
     missingEmails,
@@ -264,13 +299,19 @@ export async function sendTourJobEmails(
       // Manual payout override should be the source of truth for the amount communicated to the technician.
       const techExpenses = context.expenseMap.get(attachment.technician_id) ?? 0;
       const computedGrandTotalWithExpenses = computedGrandTotal + techExpenses;
+      const prepLines = context.prepTimesheetMap.get(attachment.technician_id) || [];
+      const prepTotal = prepLines.reduce((sum, line) => sum + Number(line.total_eur ?? 0), 0);
+      const prepDates = Array.from(
+        new Set(prepLines.map((line) => line.date).filter((date): date is string => date != null))
+      ).sort();
 
       // Overrides replace the base+extras portion; expenses are always added on top
-      // since they are reimbursements, not part of the negotiated rate.
+      // since they are reimbursements, not part of the negotiated rate. Prep days are
+      // approved fixed-rate timesheets and are added on top of the tour quote.
       const grandTotal =
         q.has_override && q.override_amount_eur != null
-          ? Number(q.override_amount_eur) + techExpenses
-          : computedGrandTotalWithExpenses;
+          ? Number(q.override_amount_eur) + prepTotal + techExpenses
+          : computedGrandTotalWithExpenses + prepTotal;
       const deduction = attachment.deduction_eur || 0;
 
       // Extract unique worked dates from timesheets
@@ -282,7 +323,7 @@ export async function sendTourJobEmails(
         email: attachment.email,
         full_name: attachment.full_name,
         totals: {
-          timesheets_total_eur: baseTotal, // base portion for tour rates
+          timesheets_total_eur: baseTotal + prepTotal, // tour quote base plus approved prep-day timesheets
           extras_total_eur: extrasTotal,
           expenses_total_eur: techExpenses,
           total_eur: grandTotal - deduction,
@@ -294,6 +335,7 @@ export async function sendTourJobEmails(
         is_house_tech: attachment.is_house_tech ?? null,
         lpo_number: attachment.lpo_number ?? null,
         worked_dates: workedDates,
+        prep_dates: prepDates,
       };
     }),
     missing_emails: context.missingEmails,

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -15,6 +15,7 @@ import { useTechnicianDashboardSubscriptions } from '@/hooks/useMobileRealtimeSu
 import { useTourRateSubscriptions } from '@/hooks/useTourRateSubscriptions';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { getCategoryFromAssignment } from '@/utils/roleCategory';
+import { hasPrepDayDateTypeForDate, isPrepDayBreakdown } from '@/utils/timesheetPrepDays';
 
 import { DashboardScreen } from '@/components/technician/DashboardScreen';
 import { JobsView } from '@/components/technician/JobsView';
@@ -44,6 +45,8 @@ interface TechnicianJobData {
   status?: string;
   created_at?: string;
   artist_count?: number;
+  has_prep_day_timesheet?: boolean;
+  job_date_types?: Array<{ date?: string | null; type?: string | null }> | null;
   preventive_resource_technician_id?: string | null;
   location?: { name: string } | null;
   job_documents?: Array<{
@@ -183,6 +186,7 @@ const TechnicianDashboard = () => {
           job_id,
           technician_id,
           date,
+          amount_breakdown,
           jobs!inner (
             id,
             title,
@@ -196,6 +200,7 @@ const TechnicianDashboard = () => {
             status,
             preventive_resource_technician_id,
             location:locations(name),
+            job_date_types(date, type),
             job_documents(
               id,
               file_name,
@@ -226,6 +231,17 @@ const TechnicianDashboard = () => {
         if (seenJobIds.has(row.job_id)) return false;
         seenJobIds.add(row.job_id);
         return true;
+      });
+
+      const prepTimesheetByJobId = new Map<string, boolean>();
+      (timesheetData || []).forEach((row) => {
+        const job = Array.isArray(row.jobs) ? row.jobs[0] : row.jobs;
+        const isPrepTimesheet =
+          hasPrepDayDateTypeForDate(job?.job_date_types, row.date) ||
+          isPrepDayBreakdown(row.amount_breakdown);
+        if (isPrepTimesheet) {
+          prepTimesheetByJobId.set(row.job_id, true);
+        }
       });
 
       const dedupedJobIds = Array.from(new Set(jobAssignments.map((row) => row.job_id)));
@@ -284,7 +300,8 @@ const TechnicianDashboard = () => {
             jobs: {
               ...job,
               location,
-              artist_count: artistCountByJob.get(row.job_id) || 0
+              artist_count: artistCountByJob.get(row.job_id) || 0,
+              has_prep_day_timesheet: prepTimesheetByJobId.get(row.job_id) === true,
             } as unknown as TechnicianJobData
           };
         })

--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -12,6 +12,7 @@ import { format, addMonths } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { getCategoryFromAssignment } from '@/utils/roleCategory';
 import { labelForCode } from '@/utils/roles';
+import { hasPrepDayDateTypeForDate, isPrepDayBreakdown } from '@/utils/timesheetPrepDays';
 
 import {
   LayoutDashboard, Calendar as CalendarIcon, User, Menu,
@@ -72,6 +73,8 @@ interface TechnicianJobData extends JobWithLocationAndDocs {
   color?: string;
   status?: string;
   artist_count?: number;
+  has_prep_day_timesheet?: boolean;
+  job_date_types?: Array<{ date?: string | null; type?: string | null }> | null;
   location?: JobWithLocationAndDocs['location'];
   job_documents?: JobWithLocationAndDocs['job_documents'];
 }
@@ -200,6 +203,7 @@ export default function TechnicianSuperApp() {
           job_id,
           technician_id,
           date,
+          amount_breakdown,
           jobs!inner (
             id,
             title,
@@ -214,6 +218,7 @@ export default function TechnicianSuperApp() {
             status,
             preventive_resource_technician_id,
             location:locations(name),
+            job_date_types(date, type),
             job_documents(
               id,
               file_name,
@@ -248,6 +253,19 @@ export default function TechnicianSuperApp() {
         if (seenJobIds.has(row.job_id)) return false;
         seenJobIds.add(row.job_id);
         return true;
+      });
+
+      const prepTimesheetByJobId = new Map<string, boolean>();
+      (timesheetData || []).forEach((row) => {
+        const job = (Array.isArray(row.jobs) ? row.jobs[0] : row.jobs) as unknown as JobWithLocationAndDocs & {
+          job_date_types?: Array<{ date?: string | null; type?: string | null }> | null;
+        };
+        const isPrepTimesheet =
+          hasPrepDayDateTypeForDate(job?.job_date_types, row.date) ||
+          isPrepDayBreakdown(row.amount_breakdown);
+        if (isPrepTimesheet) {
+          prepTimesheetByJobId.set(row.job_id, true);
+        }
       });
 
       const dedupedJobIds = Array.from(new Set(jobAssignments.map((row) => row.job_id)));
@@ -305,7 +323,8 @@ export default function TechnicianSuperApp() {
               ...job,
               created_at: job.created_at || '',
               job_type: job.job_type || 'single',
-              artist_count: artistCountByJob.get(row.job_id) || 0
+              artist_count: artistCountByJob.get(row.job_id) || 0,
+              has_prep_day_timesheet: prepTimesheetByJobId.get(row.job_id) === true,
             }
           };
         }) as TechnicianAssignment[];

--- a/src/pages/Timesheets.tsx
+++ b/src/pages/Timesheets.tsx
@@ -14,6 +14,7 @@ import { es } from 'date-fns/locale';
 import { useSearchParams } from "react-router-dom";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { isManagementRole } from '@/utils/permissions';
+import { hasPrepDayDateType } from '@/utils/timesheetPrepDays';
 
 export default function Timesheets() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -52,7 +53,8 @@ export default function Timesheets() {
         const type = String(job.job_type || '').toLowerCase();
         const isDryHire = type === 'dryhire' || type === 'dry_hire';
         const isTourDate = type === 'tourdate';
-        if (isDryHire || isTourDate) return false;
+        if (isDryHire) return false;
+        if (isTourDate) return hasPrepDayDateType(job.job_date_types);
         if (Array.isArray(job.job_date_types) && job.job_date_types.length > 0) {
           return job.job_date_types.some(
             (dt: { type?: string } | null | undefined) => dt?.type !== 'off' && dt?.type !== 'travel'
@@ -65,7 +67,12 @@ export default function Timesheets() {
   }, [jobs]);
 
   const selectedJob = jobs.find(job => job.id === selectedJobId);
-  const timesheetsDisabled = selectedJob && (selectedJob.job_type === 'dryhire' || selectedJob.job_type === 'tourdate');
+  const selectedJobType = String(selectedJob?.job_type || '').toLowerCase();
+  const timesheetsDisabled = selectedJob && (
+    selectedJobType === 'dryhire' ||
+    selectedJobType === 'dry_hire' ||
+    (selectedJobType === 'tourdate' && !hasPrepDayDateType(selectedJob.job_date_types))
+  );
 
 
   // Derived lists for filters

--- a/src/types/timesheet.ts
+++ b/src/types/timesheet.ts
@@ -22,11 +22,17 @@ export interface Timesheet {
   updated_at: string;
   // New 2025 rate calculator fields
   category?: 'tecnico' | 'especialista' | 'responsable';
+  is_prep_day?: boolean;
   amount_eur?: number;
   amount_breakdown?: {
     category: string;
+    is_prep_day?: boolean;
+    worked_hours?: number;
     worked_minutes: number;
     worked_hours_rounded: number;
+    hours_rounded?: number;
+    billable_hours?: number;
+    prep_day_hourly_rate_eur?: number;
     base_day_hours: number;
     mid_tier_hours: number;
     base_amount_eur: number;
@@ -46,8 +52,13 @@ export interface Timesheet {
   amount_eur_visible?: number | null;
   amount_breakdown_visible?: {
     category: string;
+    is_prep_day?: boolean;
+    worked_hours?: number;
     worked_minutes: number;
     worked_hours_rounded: number;
+    hours_rounded?: number;
+    billable_hours?: number;
+    prep_day_hourly_rate_eur?: number;
     base_day_hours: number;
     mid_tier_hours: number;
     base_amount_eur: number;

--- a/src/utils/rates-pdf-export.ts
+++ b/src/utils/rates-pdf-export.ts
@@ -20,6 +20,7 @@ const FIXED_TRAVEL_RATE_EUR = 20;
 const DEDUCTION_DISCLAIMER_TEXT = '* Se ha aplicado una deducción de 30€/día en concepto de IRPF por condición de no autónomo.';
 const TOUR_DEDUCTION_DISCLAIMER_TEXT = '* Deducción de 30€ en concepto de IRPF por condición de no autónomo ya aplicada a la tarifa base antes de multiplicadores.';
 const EVENTO_DISCLAIMER_TEXT = '* Evento: tarifa fija de 12h (base + plus) independientemente de las horas trabajadas.';
+const PREP_DAY_DISCLAIMER_TEXT = '* Día de preparación: importe calculado a 15€/h sobre horas redondeadas y separado de la tarifa normal del bolo.';
 const FIXED_TRAVEL_RATE_DISCLAIMER_TEXT = `* (plantilla): Tarifa fija de ${FIXED_TRAVEL_RATE_EUR}€ para días de viaje de técnicos en plantilla y gestión asignables.`;
 
 export interface TechnicianProfile {
@@ -93,6 +94,8 @@ export interface TimesheetLine {
   overtime_amount_eur?: number;
   total_eur?: number;
   is_evento?: boolean;
+  is_prep_day?: boolean;
+  prep_day_hourly_rate_eur?: number;
 }
 
 const CORPORATE_RED: [number, number, number] = [125, 1, 1];
@@ -339,7 +342,11 @@ export async function generateRateQuotePDF(
   jobDetails: JobDetails,
   profiles: TechnicianProfile[],
   lpoMap?: Map<string, string | null>,
-  options?: { download?: boolean; timesheetMap?: Map<string, Set<string>> }
+  options?: {
+    download?: boolean;
+    timesheetMap?: Map<string, Set<string>>;
+    prepTimesheetMap?: Map<string, TimesheetLine[]>;
+  }
 ): Promise<Blob | void> {
   const { jsPDF, autoTable } = await loadPdfLibs();
   const doc = new jsPDF();
@@ -378,6 +385,10 @@ export async function generateRateQuotePDF(
   doc.setTextColor(...TEXT_PRIMARY);
 
   const getTechName = getTechNameFactory(profiles);
+  const getPrepLines = (technicianId: string) => options?.prepTimesheetMap?.get(technicianId) || [];
+  const getPrepTotal = (technicianId: string) => (
+    getPrepLines(technicianId).reduce((sum, line) => sum + Number(line.total_eur ?? 0), 0)
+  );
 
   const quotesWithComputed = quotes.map((quote) => ({
     quote,
@@ -397,6 +408,9 @@ export async function generateRateQuotePDF(
     // For tour rate quotes, server already applies autonomo discount to base before multipliers.
     // Manual overrides are applied server-side (see v_tour_job_rate_quotes_2025).
     const effectiveTotal = resolveEffectiveTotal(quote, computed);
+    const prepLines = getPrepLines(quote.technician_id);
+    const prepTotal = getPrepTotal(quote.technician_id);
+    const effectiveTotalWithPrep = effectiveTotal + prepTotal;
 
     let baseCell: string;
     if (hasError) {
@@ -443,13 +457,23 @@ export async function generateRateQuotePDF(
       }
     }
 
+    if (prepLines.length > 0) {
+      const prepSummary = prepLines
+        .map((line) => {
+          const dateLabel = line.date ? format(new Date(line.date), 'P', { locale: es }) : '—';
+          return `${dateLabel}: ${line.hours_rounded ?? 0}h = ${formatCurrency(line.total_eur ?? 0)}`;
+        })
+        .join(' · ');
+      nameCellContent += `\nDía(s) preparación: ${prepSummary}`;
+    }
+
     return [
       nameCellContent,
       quote.is_house_tech ? 'Plantilla' : quote.category || '—',
       baseCell,
       hasError ? '—' : formatMultiplier(rawMultiplier),
       hasError ? '—' : formatCurrency(extrasTotal),
-      hasError ? '€0.00' : formatCurrency(effectiveTotal),
+      hasError ? '€0.00' : formatCurrency(effectiveTotalWithPrep),
     ];
   });
 
@@ -484,6 +508,10 @@ export async function generateRateQuotePDF(
     (sum, { computed }) => sum + computed.effectiveBase,
     0
   );
+  const totalPrepDays = quotesWithComputed.reduce(
+    (sum, { quote }) => sum + getPrepTotal(quote.technician_id),
+    0
+  );
   const totalExtras = quotesWithComputed.reduce(
     (sum, { computed }) => sum + computed.extrasTotal,
     0
@@ -504,7 +532,7 @@ export async function generateRateQuotePDF(
         ? Number(quote.override_amount_eur)
         : (serverTotal ?? computedTotal);
 
-    return sum + effectiveTotal;
+    return sum + effectiveTotal + getPrepTotal(quote.technician_id);
   }, 0);
 
   // Check if any quotes have autonomo discount applied by server
@@ -514,6 +542,7 @@ export async function generateRateQuotePDF(
 
   // Check if any quotes have manual override
   const anyOverride = quotes.some(quote => quote.has_override);
+  const anyPrepDay = totalPrepDays > 0;
   const vehicleDisclaimerNotes = Array.from(
     new Set(
       quotesWithComputed
@@ -527,7 +556,7 @@ export async function generateRateQuotePDF(
   );
 
   doc.setFillColor(...SUMMARY_BACKGROUND);
-  doc.roundedRect(14, finalY, summaryWidth, 32, 3, 3, 'F');
+  doc.roundedRect(14, finalY, summaryWidth, anyPrepDay ? 38 : 32, 3, 3, 'F');
 
   doc.setFont('helvetica', 'bold');
   doc.setFontSize(11);
@@ -539,15 +568,18 @@ export async function generateRateQuotePDF(
   doc.setTextColor(...TEXT_MUTED);
   doc.text(`Total Base: ${formatCurrency(totalBase)}`, 18, finalY + 18);
   doc.text(`Total Extras: ${formatCurrency(totalExtras)}`, 18, finalY + 26);
+  if (anyPrepDay) {
+    doc.text(`Total Preparación: ${formatCurrency(totalPrepDays)}`, 18, finalY + 34);
+  }
 
   const totalText = `Total General: ${formatCurrency(grandTotal)}`;
   doc.setFont('helvetica', 'bold');
   doc.setFontSize(12);
   doc.setTextColor(...CORPORATE_RED);
   const totalWidth = doc.getTextWidth(totalText);
-  doc.text(totalText, 14 + summaryWidth - totalWidth - 6, finalY + 22);
+  doc.text(totalText, 14 + summaryWidth - totalWidth - 6, finalY + (anyPrepDay ? 25 : 22));
 
-  let disclaimerY = finalY + 38;
+  let disclaimerY = finalY + (anyPrepDay ? 44 : 38);
   if (anyDeductionApplied) {
     doc.setFont('helvetica', 'italic');
     doc.setFontSize(8);
@@ -561,6 +593,14 @@ export async function generateRateQuotePDF(
     doc.setFontSize(8);
     doc.setTextColor(...CORPORATE_RED);
     doc.text('AVISO: Hay overrides manuales de pago (excepción). Administración debe validar con Dirección.', 14, disclaimerY);
+    disclaimerY += 6;
+  }
+
+  if (anyPrepDay) {
+    doc.setFont('helvetica', 'italic');
+    doc.setFontSize(8);
+    doc.setTextColor(...CORPORATE_RED);
+    doc.text(PREP_DAY_DISCLAIMER_TEXT, 14, disclaimerY);
     disclaimerY += 6;
   }
 
@@ -1046,6 +1086,11 @@ export async function generateJobPayoutPDF(
       return lines.some(l => l.is_evento === true);
   });
 
+  const anyPrepDay = payouts.some(p => {
+      const lines = timesheetMap?.get(p.technician_id) || [];
+      return lines.some(l => l.is_prep_day === true);
+  });
+
   // Check if any extras use house tech travel rate
   const anyHouseTechTravelRate = payouts.some(p => {
       const items = (p.extras_breakdown?.items as any[]) || [];
@@ -1096,6 +1141,14 @@ export async function generateJobPayoutPDF(
       doc.setFontSize(8);
       doc.setTextColor(...CORPORATE_RED);
       doc.text(EVENTO_DISCLAIMER_TEXT, 14, disclaimerY);
+      disclaimerY += 6;
+  }
+
+  if (anyPrepDay) {
+      doc.setFont('helvetica', 'italic');
+      doc.setFontSize(8);
+      doc.setTextColor(...CORPORATE_RED);
+      doc.text(PREP_DAY_DISCLAIMER_TEXT, 14, disclaimerY);
       disclaimerY += 6;
   }
 
@@ -1151,9 +1204,13 @@ export async function generateJobPayoutPDF(
       currentY += 5;
 
       const tableRows = lines.map((ln) => [
-        ln.date ? format(new Date(ln.date), 'P', { locale: es }) : '—',
+        ln.date
+          ? `${format(new Date(ln.date), 'P', { locale: es })}${ln.is_prep_day ? '\nDía preparación' : ''}`
+          : (ln.is_prep_day ? 'Día preparación' : '—'),
         `${ln.hours_rounded ?? 0}h`,
-        formatCurrency(ln.base_day_eur ?? 0),
+        ln.is_prep_day
+          ? `${formatCurrency(ln.base_day_eur ?? 0)}\n${formatCurrency(ln.prep_day_hourly_rate_eur ?? 15)}/h`
+          : formatCurrency(ln.base_day_eur ?? 0),
         ln.plus_10_12_amount_eur ? `${ln.plus_10_12_hours ?? 0}h = ${formatCurrency(ln.plus_10_12_amount_eur)}` : '—',
         (ln.overtime_hours ?? 0) > 0
           ? `${ln.overtime_hours}h × ${formatCurrency(ln.overtime_hour_eur ?? 0)} = ${formatCurrency(

--- a/src/utils/timesheet-pdf.ts
+++ b/src/utils/timesheet-pdf.ts
@@ -3,6 +3,7 @@ import { Job } from '@/types/job';
 import { format, parseISO } from 'date-fns';
 import { fetchJobLogo } from '@/utils/pdf/logoUtils';
 import { loadPdfLibs } from '@/utils/pdf/lazyPdf';
+import { isPrepDayTimesheet } from '@/utils/timesheetPrepDays';
 
 interface GenerateTimesheetPDFOptions {
   job: Job;
@@ -175,6 +176,7 @@ export const generateTimesheetPDF = async ({ job, timesheets, date }: GenerateTi
 
   // Prepare table data with date grouping
   const tableData = flattenedTimesheets.map((timesheet) => {
+    const isPrepDay = isPrepDayTimesheet(timesheet);
     const technicianName = `${timesheet.technician?.first_name || ''} ${timesheet.technician?.last_name || ''}`.trim();
     const startTime = formatTime(timesheet.start_time);
     const endTime = formatTime(timesheet.end_time);
@@ -211,6 +213,7 @@ export const generateTimesheetPDF = async ({ job, timesheets, date }: GenerateTi
 
     const row = [
       format(parseISO(timesheet.date), 'MMM dd'),
+      isPrepDay ? 'Prep Day' : 'Work',
       technicianName, 
       startTime, 
       endTime, 
@@ -231,7 +234,7 @@ export const generateTimesheetPDF = async ({ job, timesheets, date }: GenerateTi
   // Create the table using autoTable with updated headers
   autoTable(doc, {
     startY: yPosition,
-    head: [['Date', 'Technician', 'Start Time', 'End Time', 'Total Hours', 'Overtime', 'Signature']],
+    head: [['Date', 'Type', 'Technician', 'Start Time', 'End Time', 'Total Hours', 'Overtime', 'Signature']],
     body: tableData,
     theme: 'grid',
     headStyles: {
@@ -248,14 +251,15 @@ export const generateTimesheetPDF = async ({ job, timesheets, date }: GenerateTi
       fillColor: [248, 248, 248],
     },
     columnStyles: {
-      0: { cellWidth: 20 }, // Date (+2)
-      1: { cellWidth: 40 }, // Technician (+5)
-      2: { cellWidth: 20 }, // Start (+2)
-      3: { cellWidth: 20 }, // End (+2)
+      0: { cellWidth: 18 }, // Date
+      1: { cellWidth: 18 }, // Type
+      2: { cellWidth: 34 }, // Technician
+      3: { cellWidth: 18 }, // Start
+      4: { cellWidth: 18 }, // End
       // 4: { cellWidth: 15 }, // Break - Removed (15 width redistributed)
-      4: { cellWidth: 18 }, // Total (+3)
-      5: { cellWidth: 16 }, // Overtime (+1)
-      6: { cellWidth: 22 }, // Signature
+      5: { cellWidth: 18 }, // Total
+      6: { cellWidth: 16 }, // Overtime
+      7: { cellWidth: 22 }, // Signature
     },
     didDrawCell: (data: any) => {
       // Add signature images to the signature column

--- a/src/utils/timesheetPrepDays.ts
+++ b/src/utils/timesheetPrepDays.ts
@@ -1,0 +1,49 @@
+import type { Timesheet } from "@/types/timesheet";
+
+type TimesheetBreakdown =
+  | Timesheet["amount_breakdown"]
+  | Timesheet["amount_breakdown_visible"]
+  | Record<string, unknown>
+  | null
+  | undefined;
+
+export type JobDateTypeLike = {
+  date?: string | null;
+  type?: string | null;
+};
+
+export const isPrepDayBreakdown = (breakdown: TimesheetBreakdown): boolean => {
+  if (!breakdown || typeof breakdown !== "object") return false;
+  return (breakdown as Record<string, unknown>).is_prep_day === true;
+};
+
+export const isPrepDayTimesheet = (
+  timesheet: Pick<Timesheet, "amount_breakdown" | "amount_breakdown_visible"> & {
+    is_prep_day?: boolean | null;
+    category?: unknown;
+  },
+): boolean => (
+  timesheet.is_prep_day === true ||
+  timesheet.category === "prep_day" ||
+  isPrepDayBreakdown(timesheet.amount_breakdown) ||
+  isPrepDayBreakdown(timesheet.amount_breakdown_visible)
+);
+
+export const hasPrepDayDateType = (dateTypes: JobDateTypeLike[] | null | undefined): boolean => (
+  Array.isArray(dateTypes) && dateTypes.some((dateType) => dateType?.type === "prep_day")
+);
+
+export const hasPrepDayDateTypeForDate = (
+  dateTypes: JobDateTypeLike[] | null | undefined,
+  date?: string | null,
+): boolean => (
+  Boolean(date) &&
+  Array.isArray(dateTypes) &&
+  dateTypes.some((dateType) => dateType?.type === "prep_day" && dateType.date === date)
+);
+
+export const prepDayHourlyRate = (breakdown: TimesheetBreakdown): number | null => {
+  if (!breakdown || typeof breakdown !== "object") return null;
+  const rate = Number((breakdown as Record<string, unknown>).prep_day_hourly_rate_eur);
+  return Number.isFinite(rate) && rate > 0 ? rate : null;
+};

--- a/src/utils/timesheetPrepDays.ts
+++ b/src/utils/timesheetPrepDays.ts
@@ -1,11 +1,4 @@
-import type { Timesheet } from "@/types/timesheet";
-
-type TimesheetBreakdown =
-  | Timesheet["amount_breakdown"]
-  | Timesheet["amount_breakdown_visible"]
-  | Record<string, unknown>
-  | null
-  | undefined;
+type TimesheetBreakdown = unknown;
 
 export type JobDateTypeLike = {
   date?: string | null;
@@ -18,7 +11,9 @@ export const isPrepDayBreakdown = (breakdown: TimesheetBreakdown): boolean => {
 };
 
 export const isPrepDayTimesheet = (
-  timesheet: Pick<Timesheet, "amount_breakdown" | "amount_breakdown_visible"> & {
+  timesheet: {
+    amount_breakdown?: unknown;
+    amount_breakdown_visible?: unknown;
     is_prep_day?: boolean | null;
     category?: unknown;
   },

--- a/supabase/functions/send-job-payout-email/index.ts
+++ b/supabase/functions/send-job-payout-email/index.ts
@@ -49,6 +49,7 @@ interface TechnicianPayload {
   filename?: string;
   lpo_number?: string;
   worked_dates?: string[];
+  prep_dates?: string[];
   autonomo?: boolean | null;
   is_house_tech?: boolean | null;
   is_evento?: boolean;
@@ -351,7 +352,9 @@ serve(async (req) => {
       // Corporate-styled HTML, aligned with other emails
       const safeName = escapeHtml(tech.full_name || '');
       const workedServiceDates = parseWorkedDates(tech.worked_dates);
+      const prepServiceDates = parseWorkedDates(tech.prep_dates);
       const workedDatesText = formatWorkedDatesFromParsed(workedServiceDates);
+      const prepDatesText = prepServiceDates.length > 0 ? formatWorkedDatesFromParsed(prepServiceDates) : '';
       const fallbackJobDate = formatJobDate(body.job.start_time);
       const dateText =
         workedDatesText ||
@@ -435,11 +438,12 @@ serve(async (req) => {
                         <li><b>Partes aprobados:</b> ${parts}</li>
                         <li><b>Extras:</b> ${extras}</li>
                         ${hasExpenses ? `<li><b>Gastos aprobados:</b> ${expensesFormatted}</li>` : ''}
-                        ${hasDeduction ? `<li><b style="color:#b91c1c;">Deducción IRPF (estimada):</b> -${deductionFormatted}</li>` : ''}
+                       ${hasDeduction ? `<li><b style="color:#b91c1c;">Deducción IRPF (estimada):</b> -${deductionFormatted}</li>` : ''}
                         <li><b>Total general:</b> ${grand}</li>
                       </ul>
                        ${hasDeduction ? `<p style="margin:10px 0 0 0;font-size:12px;color:#b91c1c;">* Se ha aplicado una deducción de 30€/día por condición de no autónomo.</p>` : ''}
                        ${tech.is_evento ? `<p style="margin:10px 0 0 0;font-size:12px;color:#6b7280;">* Evento: tarifa fija de 12h (base + plus) independientemente de las horas trabajadas.</p>` : ''}
+                       ${prepDatesText ? `<p style="margin:10px 0 0 0;font-size:12px;color:#2563eb;">* Incluye día(s) de preparación (${escapeHtml(prepDatesText)}), calculados a 15€/h sobre horas redondeadas.</p>` : ''}
                     </div>
                   </td>
                 </tr>

--- a/supabase/migrations/20260605123000_ensure_prep_day_timesheets.sql
+++ b/supabase/migrations/20260605123000_ensure_prep_day_timesheets.sql
@@ -1,0 +1,150 @@
+CREATE OR REPLACE FUNCTION public.ensure_prep_day_timesheets_for_job_date(
+  _job_id uuid,
+  _date date
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_affected integer := 0;
+BEGIN
+  IF _job_id IS NULL OR _date IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.job_date_types jdt
+    WHERE jdt.job_id = _job_id
+      AND jdt.date = _date
+      AND jdt.type = 'prep_day'
+  ) THEN
+    RETURN 0;
+  END IF;
+
+  INSERT INTO public.timesheets (
+    job_id,
+    technician_id,
+    date,
+    source
+  )
+  SELECT
+    _job_id,
+    ja.technician_id,
+    _date,
+    'prep_day'
+  FROM public.job_assignments ja
+  WHERE ja.job_id = _job_id
+    AND ja.technician_id IS NOT NULL
+    AND COALESCE(ja.status, 'confirmed'::public.assignment_status) <> 'declined'::public.assignment_status
+  ON CONFLICT (job_id, technician_id, date)
+  DO UPDATE
+    SET is_active = true,
+        source = CASE
+          WHEN public.timesheets.source IS NULL OR public.timesheets.source = 'matrix' THEN 'prep_day'
+          ELSE public.timesheets.source
+        END,
+        updated_at = now()
+    WHERE public.timesheets.is_active IS DISTINCT FROM true;
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.ensure_prep_day_timesheets_for_job_date(uuid,date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.ensure_prep_day_timesheets_for_job_date(uuid,date) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.trg_refresh_timesheets_for_prep_day_date_type()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.type = 'prep_day' THEN
+      PERFORM public.refresh_timesheet_amounts_for_job_date(OLD.job_id, OLD.date);
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.type = 'prep_day'
+       AND (OLD.job_id IS DISTINCT FROM NEW.job_id OR OLD.date IS DISTINCT FROM NEW.date OR OLD.type IS DISTINCT FROM NEW.type) THEN
+      PERFORM public.refresh_timesheet_amounts_for_job_date(OLD.job_id, OLD.date);
+    END IF;
+
+    IF NEW.type = 'prep_day' THEN
+      PERFORM public.ensure_prep_day_timesheets_for_job_date(NEW.job_id, NEW.date);
+      PERFORM public.refresh_timesheet_amounts_for_job_date(NEW.job_id, NEW.date);
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' AND NEW.type = 'prep_day' THEN
+    PERFORM public.ensure_prep_day_timesheets_for_job_date(NEW.job_id, NEW.date);
+    PERFORM public.refresh_timesheet_amounts_for_job_date(NEW.job_id, NEW.date);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.trg_refresh_timesheets_for_prep_day_date_type() FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_prep_day record;
+BEGIN
+  IF NEW.job_id IS NULL
+     OR NEW.technician_id IS NULL
+     OR COALESCE(NEW.status, 'confirmed'::public.assignment_status) = 'declined'::public.assignment_status THEN
+    RETURN NEW;
+  END IF;
+
+  FOR v_prep_day IN
+    SELECT DISTINCT date
+    FROM public.job_date_types
+    WHERE job_id = NEW.job_id
+      AND type = 'prep_day'
+  LOOP
+    PERFORM public.ensure_prep_day_timesheets_for_job_date(NEW.job_id, v_prep_day.date);
+    PERFORM public.refresh_timesheet_amounts_for_job_date(NEW.job_id, v_prep_day.date);
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS t_aiu_ensure_prep_day_timesheets_for_assignment ON public.job_assignments;
+CREATE TRIGGER t_aiu_ensure_prep_day_timesheets_for_assignment
+AFTER INSERT OR UPDATE OF job_id, technician_id, status
+ON public.job_assignments
+FOR EACH ROW
+EXECUTE FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment();
+
+DO $$
+DECLARE
+  v_prep_day record;
+BEGIN
+  FOR v_prep_day IN
+    SELECT DISTINCT job_id, date
+    FROM public.job_date_types
+    WHERE type = 'prep_day'
+  LOOP
+    PERFORM public.ensure_prep_day_timesheets_for_job_date(v_prep_day.job_id, v_prep_day.date);
+    PERFORM public.refresh_timesheet_amounts_for_job_date(v_prep_day.job_id, v_prep_day.date);
+  END LOOP;
+END;
+$$;

--- a/tests/timesheets/critical-paths.test.ts
+++ b/tests/timesheets/critical-paths.test.ts
@@ -276,4 +276,46 @@ describe("Timesheets Critical Paths", () => {
     expect(screen.getByText(/total: €180\.00/i)).toBeInTheDocument();
     expect(screen.getAllByText(/aprobado/i)).not.toHaveLength(0);
   });
+
+  it("clearly labels prep-day timesheets and their hourly calculation", () => {
+    const timesheet = createTimesheet({
+      id: "ts-prep-day",
+      date: "2026-12-02",
+      status: "approved",
+      technician_id: "tech-1",
+      is_prep_day: true,
+      start_time: "09:00",
+      end_time: "14:00",
+      break_minutes: 0,
+      amount_breakdown_visible: {
+        is_prep_day: true,
+        worked_minutes: 300,
+        worked_hours_rounded: 5,
+        hours_rounded: 5,
+        billable_hours: 5,
+        prep_day_hourly_rate_eur: 15,
+        base_amount_eur: 75,
+        total_eur: 75,
+        notes: [],
+      },
+    });
+
+    renderTimesheetView({
+      timesheets: [timesheet],
+      payoutRows: [
+        {
+          technician_id: "tech-1",
+          timesheets_total_eur: 75,
+          extras_total_eur: 0,
+          total_eur: 75,
+        },
+      ],
+      ratesApproved: true,
+    });
+
+    expect(screen.getAllByText(/día de preparación/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/desglose de preparación/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/15\s*€\/h/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/total: €75\.00/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- surface prep-day timesheets in technician job cards and management job-card approval controls
- create/backfill prep-day timesheets when prep dates or assignments exist, including tourdate prep-day jobs
- label prep days clearly in timesheet UIs, payout PDFs, payout emails, and previews

## Validation
- npm run test:run -- tests/timesheets/critical-paths.test.ts src/components/technician/__tests__/TimesheetView.test.tsx src/components/jobs/cards/__tests__/JobCardActions.test.tsx src/components/jobs/__tests__/JobDetailsDialog.timesheet-pdf.test.ts
- npm run lint
- npm run build
- npm run test:run

## Deploy note
Includes Supabase migration: supabase/migrations/20260605123000_ensure_prep_day_timesheets.sql. Production migration dry-run/apply/dry-run confirmation is required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full "día de preparación" support across the app: prep-day badge, prep-rate label (e.g., "15 €/h"), prep-specific category/labels in lists and job cards, and conditional timesheet buttons for tour jobs with prep-days.
  * Payout emails and PDFs now show prep-day breakdowns, adjusted totals, and an "Incluye día(s) de preparación" note; prep dates listed per technician.
* **Behavior**
  * Timesheet creation and editing follow prep-day rules (no overtime/category, prep-hour calculations).
* **Tests**
  * Added tests verifying prep-day labels, calculations and export rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->