### PR TITLE
[codex] fix prep day timesheet scoping

### DIFF
--- a/src/hooks/useTimesheets.ts
+++ b/src/hooks/useTimesheets.ts
@@ -5,7 +5,7 @@ import { Timesheet } from "@/types/timesheet";
 import { toast } from "sonner";
 import { RATES_QUERY_KEYS } from "@/constants/ratesQueryKeys";
 import { isManagementRole } from "@/utils/permissions";
-import { isPrepDayBreakdown } from "@/utils/timesheetPrepDays";
+import { getTimesheetAutoCreateDatesForAssignment, isPrepDayBreakdown } from "@/utils/timesheetPrepDays";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -33,7 +33,26 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
       setIsError(false);
       console.log("Starting fetchTimesheets for jobId:", jobId);
 
-      const { data, error } = await supabase
+      const { data: jobMeta, error: jobMetaError } = await supabase
+        .from("jobs")
+        .select(`
+          job_type,
+          job_date_types(type, date)
+        `)
+        .eq("id", jobId)
+        .maybeSingle();
+      if (jobMetaError) {
+        console.warn("Error fetching timesheet job metadata:", jobMetaError);
+      }
+
+      const prepDayDates = new Set(
+        ((jobMeta?.job_date_types || []) as Array<{ type?: string | null; date?: string | null }>)
+          .filter((row) => row?.type === "prep_day" && row.date)
+          .map((row) => row.date as string),
+      );
+      const isTourDateJob = String(jobMeta?.job_type || "").toLowerCase() === "tourdate";
+
+      const { data: timesheetRows, error } = await supabase
         .from("timesheets")
         .select("*")
         .eq("job_id", jobId)
@@ -47,20 +66,14 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
         return;
       }
 
+      const data = isTourDateJob
+        ? (timesheetRows || []).filter((timesheet) => prepDayDates.has(timesheet.date))
+        : (timesheetRows || []);
+
       if (!data || data.length === 0) {
         setTimesheets([]);
         return;
       }
-
-      const { data: prepDayRows, error: prepDayError } = await supabase
-        .from("job_date_types")
-        .select("date")
-        .eq("job_id", jobId)
-        .eq("type", "prep_day");
-      if (prepDayError) {
-        console.warn("Error fetching prep day dates:", prepDayError);
-      }
-      const prepDayDates = new Set((prepDayRows || []).map((row) => row.date));
 
       const technicianIds = [...new Set(data.map(t => t.technician_id))];
       const { data: profiles } = await supabase
@@ -118,7 +131,7 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
       // Get job assignments and job details
       const { data: assignments, error: assignmentsError } = await supabase
         .from("job_assignments")
-        .select("technician_id, status")
+        .select("technician_id, status, single_day, assignment_date")
         .eq("job_id", jobId);
 
       console.log("Assignments fetched:", assignments, "Error:", assignmentsError);
@@ -187,13 +200,10 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
         return !dateType || !['off', 'travel', 'prep_day'].includes(dateType.type);
       });
 
-      const dates = Array.from(new Set(
-        jtype === 'tourdate'
-          ? prepDayDates
-          : [...prepDayDates, ...regularDates]
-      )).sort();
+      const regularDatesToCreate = jtype === 'tourdate' ? [] : regularDates;
 
-      console.log("Generated dates (filtered):", dates);
+      console.log("Generated regular dates (filtered):", regularDatesToCreate);
+      console.log("Prep day dates:", prepDayDates);
       console.log("Date types:", job.job_date_types);
 
       // Check which timesheets already exist
@@ -217,7 +227,13 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
           continue;
         }
 
-        for (const date of dates) {
+        const datesForAssignment = getTimesheetAutoCreateDatesForAssignment(
+          assignment,
+          regularDatesToCreate,
+          prepDayDates,
+        );
+
+        for (const date of datesForAssignment) {
           const combo = `${assignment.technician_id}-${date}`;
           if (!existingCombos.has(combo)) {
             // Let DB trigger resolve category - don't set it here to keep creation simple

--- a/src/lib/__tests__/tour-payout-email-prep-days.test.ts
+++ b/src/lib/__tests__/tour-payout-email-prep-days.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPrepTimesheetDateMap,
+  buildPrepTimesheetMap,
+} from "@/lib/tour-payout-email";
+
+describe("tour payout prep-day timesheet documentation", () => {
+  it("keeps only approved prep-day rows in the prep timesheet map", () => {
+    const map = buildPrepTimesheetMap([
+      {
+        technician_id: "tech-1",
+        date: "2026-05-31",
+        approved_by_manager: true,
+        amount_breakdown: {
+          is_prep_day: true,
+          hours_rounded: 6,
+          base_day_eur: 90,
+          prep_day_hourly_rate_eur: 15,
+          total_eur: 90,
+        },
+      },
+      {
+        technician_id: "tech-1",
+        date: "2026-06-01",
+        approved_by_manager: true,
+        amount_breakdown: {
+          is_prep_day: false,
+          hours_rounded: 8,
+          total_eur: 160,
+        },
+      },
+      {
+        technician_id: "tech-2",
+        date: "2026-05-31",
+        approved_by_manager: false,
+        amount_breakdown: {
+          is_prep_day: true,
+          hours_rounded: 5,
+          total_eur: 75,
+        },
+      },
+    ]);
+
+    expect(map.get("tech-1")).toEqual([
+      expect.objectContaining({
+        date: "2026-05-31",
+        hours_rounded: 6,
+        is_prep_day: true,
+        prep_day_hourly_rate_eur: 15,
+        total_eur: 90,
+      }),
+    ]);
+    expect(map.has("tech-2")).toBe(false);
+  });
+
+  it("builds tour worked-date documentation only from approved prep-day lines", () => {
+    const prepMap = buildPrepTimesheetMap([
+      {
+        technician_id: "tech-1",
+        date: "2026-05-31",
+        approved_by_manager: true,
+        amount_breakdown: {
+          is_prep_day: true,
+          hours_rounded: 6,
+          total_eur: 90,
+        },
+      },
+      {
+        technician_id: "tech-1",
+        date: "2026-06-01",
+        approved_by_manager: true,
+        amount_breakdown: {
+          is_prep_day: false,
+          hours_rounded: 8,
+          total_eur: 160,
+        },
+      },
+    ]);
+
+    const dateMap = buildPrepTimesheetDateMap(prepMap);
+
+    expect(Array.from(dateMap.get("tech-1") || [])).toEqual(["2026-05-31"]);
+  });
+});

--- a/src/lib/tour-payout-email.ts
+++ b/src/lib/tour-payout-email.ts
@@ -106,7 +106,7 @@ async function fetchTimesheets(client: SupabaseClient, jobId: string): Promise<a
   return data || [];
 }
 
-function buildPrepTimesheetMap(rows: any[]): Map<string, TimesheetLine[]> {
+export function buildPrepTimesheetMap(rows: any[]): Map<string, TimesheetLine[]> {
   const map = new Map<string, TimesheetLine[]>();
 
   rows.forEach((row) => {
@@ -137,6 +137,24 @@ function buildPrepTimesheetMap(rows: any[]): Map<string, TimesheetLine[]> {
   return map;
 }
 
+export function buildPrepTimesheetDateMap(
+  prepTimesheetMap: Map<string, TimesheetLine[]>
+): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+
+  prepTimesheetMap.forEach((lines, technicianId) => {
+    const dates = lines
+      .map((line) => line.date)
+      .filter((date): date is string => Boolean(date));
+
+    if (dates.length > 0) {
+      map.set(technicianId, new Set(dates));
+    }
+  });
+
+  return map;
+}
+
 export async function prepareTourJobEmailContext(
   input: TourJobEmailInput
 ): Promise<TourJobEmailContextResult> {
@@ -162,13 +180,7 @@ export async function prepareTourJobEmailContext(
     console.warn('[tour-payout-email] Failed to fetch expenses:', e);
   }
 
-  // Build Timesheet Date Set Map
-  const timesheetDateMap = new Map<string, Set<string>>();
-  timesheetRows.forEach(row => {
-      if (!row.technician_id || !row.date) return;
-      if (!timesheetDateMap.has(row.technician_id)) timesheetDateMap.set(row.technician_id, new Set());
-      timesheetDateMap.get(row.technician_id)!.add(row.date);
-  });
+  const timesheetDateMap = buildPrepTimesheetDateMap(prepTimesheetMap);
 
   const profileMap = new Map(profiles.map((p) => [p.id, p]));
   const attachments: TourJobEmailAttachment[] = [];

--- a/src/utils/__tests__/timesheetPrepDays.test.ts
+++ b/src/utils/__tests__/timesheetPrepDays.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPrepDayDatesForAssignment,
+  getTimesheetAutoCreateDatesForAssignment,
+  isAssignmentScopedToPrepDay,
+} from "@/utils/timesheetPrepDays";
+
+describe("prep day assignment scoping", () => {
+  it("matches only non-declined single-day assignments for the exact prep date", () => {
+    expect(isAssignmentScopedToPrepDay({
+      technician_id: "tech-1",
+      status: "confirmed",
+      single_day: true,
+      assignment_date: "2026-06-01",
+    }, "2026-06-01")).toBe(true);
+
+    expect(isAssignmentScopedToPrepDay({
+      technician_id: "tech-1",
+      status: "confirmed",
+      single_day: false,
+      assignment_date: "2026-06-01",
+    }, "2026-06-01")).toBe(false);
+
+    expect(isAssignmentScopedToPrepDay({
+      technician_id: "tech-1",
+      status: "declined",
+      single_day: true,
+      assignment_date: "2026-06-01",
+    }, "2026-06-01")).toBe(false);
+  });
+
+  it("returns only prep dates assigned to that technician row", () => {
+    expect(getPrepDayDatesForAssignment({
+      technician_id: "tech-1",
+      status: "confirmed",
+      single_day: true,
+      assignment_date: "2026-06-02T00:00:00Z",
+    }, ["2026-06-01", "2026-06-02"])).toEqual(["2026-06-02"]);
+  });
+
+  it("does not expand prep-only assignments to regular timesheet dates", () => {
+    expect(getTimesheetAutoCreateDatesForAssignment({
+      technician_id: "tech-1",
+      status: "confirmed",
+      single_day: true,
+      assignment_date: "2026-05-31",
+    }, ["2026-06-01"], ["2026-05-31"])).toEqual(["2026-05-31"]);
+  });
+
+  it("keeps full assignments on regular dates without adding unassigned prep days", () => {
+    expect(getTimesheetAutoCreateDatesForAssignment({
+      technician_id: "tech-1",
+      status: "confirmed",
+      single_day: false,
+      assignment_date: null,
+    }, ["2026-06-01"], ["2026-05-31"])).toEqual(["2026-06-01"]);
+  });
+});

--- a/src/utils/timesheetPrepDays.ts
+++ b/src/utils/timesheetPrepDays.ts
@@ -5,6 +5,19 @@ export type JobDateTypeLike = {
   type?: string | null;
 };
 
+export type PrepDayAssignmentLike = {
+  assignment_date?: string | null;
+  single_day?: boolean | null;
+  status?: string | null;
+  technician_id?: string | null;
+};
+
+const toDateKey = (date?: string | null): string | null => {
+  if (!date) return null;
+  const key = String(date).trim().slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(key) ? key : null;
+};
+
 export const isPrepDayBreakdown = (breakdown: TimesheetBreakdown): boolean => {
   if (!breakdown || typeof breakdown !== "object") return false;
   return (breakdown as Record<string, unknown>).is_prep_day === true;
@@ -36,6 +49,37 @@ export const hasPrepDayDateTypeForDate = (
   Array.isArray(dateTypes) &&
   dateTypes.some((dateType) => dateType?.type === "prep_day" && dateType.date === date)
 );
+
+export const isAssignmentScopedToPrepDay = (
+  assignment: PrepDayAssignmentLike | null | undefined,
+  prepDayDate: string,
+): boolean => (
+  Boolean(assignment?.technician_id) &&
+  assignment?.status !== "declined" &&
+  assignment?.single_day === true &&
+  toDateKey(assignment?.assignment_date) === prepDayDate
+);
+
+export const getPrepDayDatesForAssignment = (
+  assignment: PrepDayAssignmentLike | null | undefined,
+  prepDayDates: string[],
+): string[] => prepDayDates.filter((date) => isAssignmentScopedToPrepDay(assignment, date));
+
+export const getTimesheetAutoCreateDatesForAssignment = (
+  assignment: PrepDayAssignmentLike | null | undefined,
+  regularDates: string[],
+  prepDayDates: string[],
+): string[] => {
+  const assignmentDate = toDateKey(assignment?.assignment_date);
+  const regularDatesForAssignment = assignment?.single_day === true
+    ? regularDates.filter((date) => date === assignmentDate)
+    : regularDates;
+
+  return Array.from(new Set([
+    ...regularDatesForAssignment,
+    ...getPrepDayDatesForAssignment(assignment, prepDayDates),
+  ])).sort();
+};
 
 export const prepDayHourlyRate = (breakdown: TimesheetBreakdown): number | null => {
   if (!breakdown || typeof breakdown !== "object") return null;

--- a/supabase/migrations/20260605203000_scope_prep_day_timesheets_to_assignments.sql
+++ b/supabase/migrations/20260605203000_scope_prep_day_timesheets_to_assignments.sql
@@ -1,0 +1,214 @@
+CREATE OR REPLACE FUNCTION public.deactivate_unassigned_prep_day_timesheet(
+  _job_id uuid,
+  _technician_id uuid,
+  _date date
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_affected integer := 0;
+BEGIN
+  IF _job_id IS NULL OR _technician_id IS NULL OR _date IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  UPDATE public.timesheets t
+  SET is_active = false,
+      updated_at = now()
+  WHERE t.job_id = _job_id
+    AND t.technician_id = _technician_id
+    AND t.date = _date
+    AND COALESCE(t.is_active, true)
+    AND EXISTS (
+      SELECT 1
+      FROM public.job_date_types jdt
+      WHERE jdt.job_id = t.job_id
+        AND jdt.date = t.date
+        AND jdt.type = 'prep_day'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.job_assignments ja
+      WHERE ja.job_id = t.job_id
+        AND ja.technician_id = t.technician_id
+        AND COALESCE(ja.status, 'confirmed'::public.assignment_status) <> 'declined'::public.assignment_status
+        AND COALESCE(ja.single_day, false)
+        AND ja.assignment_date = t.date
+    )
+    AND (
+      t.source IS NULL
+      OR t.source = 'prep_day'
+      OR t.category = 'prep_day'
+      OR t.amount_breakdown ->> 'is_prep_day' = 'true'
+    );
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.deactivate_unassigned_prep_day_timesheet(uuid,uuid,date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.deactivate_unassigned_prep_day_timesheet(uuid,uuid,date) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.ensure_prep_day_timesheets_for_job_date(
+  _job_id uuid,
+  _date date
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_affected integer := 0;
+BEGIN
+  IF _job_id IS NULL OR _date IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.job_date_types jdt
+    WHERE jdt.job_id = _job_id
+      AND jdt.date = _date
+      AND jdt.type = 'prep_day'
+  ) THEN
+    RETURN 0;
+  END IF;
+
+  INSERT INTO public.timesheets (
+    job_id,
+    technician_id,
+    date,
+    source
+  )
+  SELECT
+    _job_id,
+    ja.technician_id,
+    _date,
+    'prep_day'
+  FROM public.job_assignments ja
+  WHERE ja.job_id = _job_id
+    AND ja.technician_id IS NOT NULL
+    AND COALESCE(ja.status, 'confirmed'::public.assignment_status) <> 'declined'::public.assignment_status
+    AND COALESCE(ja.single_day, false)
+    AND ja.assignment_date = _date
+  ON CONFLICT (job_id, technician_id, date)
+  DO UPDATE
+    SET is_active = true,
+        source = CASE
+          WHEN public.timesheets.source IS NULL OR public.timesheets.source = 'matrix' THEN 'prep_day'
+          ELSE public.timesheets.source
+        END,
+        updated_at = now()
+    WHERE public.timesheets.is_active IS DISTINCT FROM true;
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.ensure_prep_day_timesheets_for_job_date(uuid,date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.ensure_prep_day_timesheets_for_job_date(uuid,date) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+     AND OLD.job_id IS NOT NULL
+     AND OLD.technician_id IS NOT NULL
+     AND OLD.assignment_date IS NOT NULL THEN
+    PERFORM public.deactivate_unassigned_prep_day_timesheet(
+      OLD.job_id,
+      OLD.technician_id,
+      OLD.assignment_date
+    );
+  END IF;
+
+  IF NEW.job_id IS NULL
+     OR NEW.technician_id IS NULL
+     OR NEW.assignment_date IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.job_date_types jdt
+    WHERE jdt.job_id = NEW.job_id
+      AND jdt.date = NEW.assignment_date
+      AND jdt.type = 'prep_day'
+  ) THEN
+    IF COALESCE(NEW.status, 'confirmed'::public.assignment_status) <> 'declined'::public.assignment_status
+       AND COALESCE(NEW.single_day, false) THEN
+      PERFORM public.ensure_prep_day_timesheets_for_job_date(NEW.job_id, NEW.assignment_date);
+      PERFORM public.refresh_timesheet_amounts_for_job_date(NEW.job_id, NEW.assignment_date);
+    ELSE
+      PERFORM public.deactivate_unassigned_prep_day_timesheet(
+        NEW.job_id,
+        NEW.technician_id,
+        NEW.assignment_date
+      );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS t_aiu_ensure_prep_day_timesheets_for_assignment ON public.job_assignments;
+CREATE TRIGGER t_aiu_ensure_prep_day_timesheets_for_assignment
+AFTER INSERT OR UPDATE OF job_id, technician_id, status, single_day, assignment_date
+ON public.job_assignments
+FOR EACH ROW
+EXECUTE FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment();
+
+DO $$
+DECLARE
+  v_prep_day record;
+BEGIN
+  FOR v_prep_day IN
+    SELECT DISTINCT job_id, date
+    FROM public.job_date_types
+    WHERE type = 'prep_day'
+  LOOP
+    PERFORM public.ensure_prep_day_timesheets_for_job_date(v_prep_day.job_id, v_prep_day.date);
+    PERFORM public.refresh_timesheet_amounts_for_job_date(v_prep_day.job_id, v_prep_day.date);
+  END LOOP;
+
+  UPDATE public.timesheets t
+  SET is_active = false,
+      updated_at = now()
+  WHERE COALESCE(t.is_active, true)
+    AND EXISTS (
+      SELECT 1
+      FROM public.job_date_types jdt
+      WHERE jdt.job_id = t.job_id
+        AND jdt.date = t.date
+        AND jdt.type = 'prep_day'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.job_assignments ja
+      WHERE ja.job_id = t.job_id
+        AND ja.technician_id = t.technician_id
+        AND COALESCE(ja.status, 'confirmed'::public.assignment_status) <> 'declined'::public.assignment_status
+        AND COALESCE(ja.single_day, false)
+        AND ja.assignment_date = t.date
+    )
+    AND (
+      t.source IS NULL
+      OR t.source = 'prep_day'
+      OR t.category = 'prep_day'
+      OR t.amount_breakdown ->> 'is_prep_day' = 'true'
+    );
+END;
+$$;

--- a/supabase/migrations/20260605203000_scope_prep_day_timesheets_to_assignments.sql
+++ b/supabase/migrations/20260605203000_scope_prep_day_timesheets_to_assignments.sql
@@ -121,6 +121,20 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.job_id IS NOT NULL
+       AND OLD.technician_id IS NOT NULL
+       AND OLD.assignment_date IS NOT NULL THEN
+      PERFORM public.deactivate_unassigned_prep_day_timesheet(
+        OLD.job_id,
+        OLD.technician_id,
+        OLD.assignment_date
+      );
+    END IF;
+
+    RETURN OLD;
+  END IF;
+
   IF TG_OP = 'UPDATE'
      AND OLD.job_id IS NOT NULL
      AND OLD.technician_id IS NOT NULL
@@ -165,8 +179,15 @@ $$;
 REVOKE EXECUTE ON FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment() FROM PUBLIC;
 
 DROP TRIGGER IF EXISTS t_aiu_ensure_prep_day_timesheets_for_assignment ON public.job_assignments;
+DROP TRIGGER IF EXISTS t_ad_ensure_prep_day_timesheets_for_assignment ON public.job_assignments;
 CREATE TRIGGER t_aiu_ensure_prep_day_timesheets_for_assignment
 AFTER INSERT OR UPDATE OF job_id, technician_id, status, single_day, assignment_date
+ON public.job_assignments
+FOR EACH ROW
+EXECUTE FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment();
+
+CREATE TRIGGER t_ad_ensure_prep_day_timesheets_for_assignment
+AFTER DELETE
 ON public.job_assignments
 FOR EACH ROW
 EXECUTE FUNCTION public.trg_ensure_prep_day_timesheets_for_assignment();

--- a/tests/timesheets/prep-day-scope-migration.test.ts
+++ b/tests/timesheets/prep-day-scope-migration.test.ts
@@ -18,6 +18,7 @@ describe("prep day timesheet scope migration", () => {
     expect(migration).toMatch(
       /AFTER INSERT OR UPDATE OF job_id, technician_id, status, single_day, assignment_date/i,
     );
+    expect(migration).toMatch(/AFTER DELETE/i);
   });
 
   it("deactivates prep-day rows without a matching prep-day assignment", () => {

--- a/tests/timesheets/prep-day-scope-migration.test.ts
+++ b/tests/timesheets/prep-day-scope-migration.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260605203000_scope_prep_day_timesheets_to_assignments.sql",
+  "utf8",
+);
+
+describe("prep day timesheet scope migration", () => {
+  it("creates prep-day timesheets only for assignments scoped to that prep date", () => {
+    expect(migration).toMatch(/COALESCE\(ja\.single_day,\s*false\)/);
+    expect(migration).toMatch(/ja\.assignment_date\s*=\s*_date/);
+    expect(migration).toMatch(/ja\.assignment_date\s*=\s*t\.date/);
+  });
+
+  it("re-runs the assignment trigger when prep-day assignment scope changes", () => {
+    expect(migration).toMatch(
+      /AFTER INSERT OR UPDATE OF job_id, technician_id, status, single_day, assignment_date/i,
+    );
+  });
+
+  it("deactivates prep-day rows without a matching prep-day assignment", () => {
+    expect(migration).toMatch(/deactivate_unassigned_prep_day_timesheet/);
+    expect(migration).toMatch(/SET is_active = false/);
+    expect(migration).toMatch(/jdt\.type = 'prep_day'/);
+  });
+});


### PR DESCRIPTION
## Summary
- Scope prep-day timesheet auto-creation to `single_day` assignments on the exact prep-day date.
- Keep tourdate jobs on fixed-rate payout behavior by suppressing normal tourdate timesheet auto-creation and filtering tourdate timesheet UI to prep-day rows only.
- Replace the prep-day DB trigger/function behavior so it creates prep-day timesheets only for techs assigned to that prep day, and deactivates over-broad prep-day rows created by the previous regression.
- Keep payout documentation clear by building tour payout worked/prep date documentation from approved prep-day lines only.

## Root Cause
The prior prep-day support treated every non-declined job assignment as eligible for each prep-day timesheet. Tourdate assignments are fixed-rate and should not be expanded into timesheets except for the tech/date rows explicitly assigned as prep days.

## Validation
- `npm install --legacy-peer-deps`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warning debt remains)
- `npm run test:run` (144 files, 905 tests)
- `npm run build` (passes; existing Vite dynamic-import/chunk-size warnings remain)

## Deployment Note
Includes Supabase migration `20260605203000_scope_prep_day_timesheets_to_assignments.sql`. Before merge, run production `supabase db push --dry-run`, apply the migration to the linked production project, then confirm a follow-up dry run is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tour job timesheets for prep days are now automatically created and scoped to assigned technicians, streamlining timesheet management.
  * Enhanced prep-day date handling ensures timesheets are correctly linked to job assignments and prep dates.

* **Tests**
  * Added test coverage for prep-day timesheet scoping, assignment matching, and automatic date management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->