### PR TITLE
Fix tour payout email timesheet query

### DIFF
--- a/src/lib/__tests__/tour-payout-email-prep-days.test.ts
+++ b/src/lib/__tests__/tour-payout-email-prep-days.test.ts
@@ -1,11 +1,64 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildPrepTimesheetDateMap,
   buildPrepTimesheetMap,
+  fetchTourJobEmailTimesheets,
 } from "@/lib/tour-payout-email";
 
 describe("tour payout prep-day timesheet documentation", () => {
+  it("fetches tour email timesheets without selecting virtual visible amount columns", async () => {
+    type QueryResult = {
+      data: Array<Record<string, unknown>>;
+      error: null;
+    };
+    type EqQuery = {
+      eq: (column: string, value: unknown) => EqQuery | Promise<QueryResult>;
+    };
+
+    let selectedColumns = "";
+    const filters: Array<[string, unknown]> = [];
+    const query: EqQuery = {
+      eq: vi.fn((column: string, value: unknown) => {
+        filters.push([column, value]);
+        if (filters.length === 1) return query;
+        return Promise.resolve({
+          data: [
+            {
+              technician_id: "tech-1",
+              job_id: "job-1",
+              date: "2026-06-01",
+              approved_by_manager: true,
+              amount_breakdown: { is_prep_day: true, total_eur: 75 },
+            },
+          ],
+          error: null,
+        });
+      }),
+    };
+    const select = vi.fn((columns: string) => {
+      selectedColumns = columns;
+      return query;
+    });
+    const supabase = {
+      from: vi.fn(() => ({ select })),
+    };
+
+    const rows = await fetchTourJobEmailTimesheets(
+      supabase as unknown as Parameters<typeof fetchTourJobEmailTimesheets>[0],
+      "job-1"
+    );
+
+    expect(supabase.from).toHaveBeenCalledWith("timesheets");
+    expect(selectedColumns).toBe("technician_id, job_id, date, approved_by_manager, amount_breakdown");
+    expect(selectedColumns).not.toContain("amount_breakdown_visible");
+    expect(filters).toEqual([
+      ["job_id", "job-1"],
+      ["is_active", true],
+    ]);
+    expect(rows).toHaveLength(1);
+  });
+
   it("keeps only approved prep-day rows in the prep timesheet map", () => {
     const map = buildPrepTimesheetMap([
       {

--- a/src/lib/tour-payout-email.ts
+++ b/src/lib/tour-payout-email.ts
@@ -96,10 +96,10 @@ async function fetchLpoMap(
   return new Map((data || []).map((row: any) => [row.technician_id, row.lpo_number || null]));
 }
 
-async function fetchTimesheets(client: SupabaseClient, jobId: string): Promise<any[]> {
+export async function fetchTourJobEmailTimesheets(client: SupabaseClient, jobId: string): Promise<any[]> {
   const { data, error } = await client
     .from('timesheets')
-    .select('technician_id, date, approved_by_manager, amount_breakdown, amount_breakdown_visible')
+    .select('technician_id, job_id, date, approved_by_manager, amount_breakdown')
     .eq('job_id', jobId)
     .eq('is_active', true);
   if (error) throw error;
@@ -161,7 +161,7 @@ export async function prepareTourJobEmailContext(
   const { jobId, supabase, quotes, profiles } = input;
   const job = await fetchJobDetails(supabase, jobId);
   const lpoMap = await fetchLpoMap(supabase, jobId);
-  const timesheetRows = await fetchTimesheets(supabase, jobId);
+  const timesheetRows = await fetchTourJobEmailTimesheets(supabase, jobId);
   const prepTimesheetMap = buildPrepTimesheetMap(timesheetRows);
 
   // Fetch expenses for tour date jobs


### PR DESCRIPTION
## Summary
- Stop selecting the virtual `amount_breakdown_visible` field from the direct `timesheets` REST query used by tour payout emails.
- Keep the existing prep-day parser compatible with rows that include visible breakdowns from RPC sources.
- Add regression coverage for the exact Supabase select/filter chain used by tour payout email prep-day timesheets.

## Risk Assessment
Risk level: Low. The change narrows one REST select list to physical `timesheets` columns and preserves the existing `job_id` and `is_active` filters. Main risk is missing prep-day breakdown data for payout PDFs, covered by existing prep-day mapping tests and the new query regression.

## Impact Checklist
- Database migrations: No
- Supabase RLS changes: No
- Realtime behavior: No
- Edge Functions: No
- Performance: Neutral; the selected column list is smaller.

## Rollback Plan
Revert commit `03ae90c9` or restore the previous `fetchTimesheets` helper implementation in `src/lib/tour-payout-email.ts`. No database rollback is needed.

## Migration Impact
No schema, RPC, or migration changes are included. Existing production schema remains compatible.

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run test:run -- src/lib/__tests__/tour-payout-email-prep-days.test.ts`
- `npm run build`