### PR TITLE
[codex] Fix prep-day multi-date assignment regression

### DIFF
--- a/src/components/matrix/AssignJobDialog.tsx
+++ b/src/components/matrix/AssignJobDialog.tsx
@@ -36,7 +36,7 @@ import {
   AlertDialogTitle
 } from '@/components/ui/alert-dialog';
 import { Loader2, Calendar as CalendarIcon, Clock, CalendarDays, CalendarRange } from 'lucide-react';
-import { format, startOfDay } from 'date-fns';
+import { format } from 'date-fns';
 import { useQuery } from '@tanstack/react-query';
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { toast } from 'sonner';
@@ -86,6 +86,10 @@ const parseDateKey = fromMadridDateKey;
 
 const sortDateKeys = uniqueSortedDateKeys;
 
+/**
+ * Returns every job date that may receive an assignment, including prep/rehearsal
+ * typed dates before the main job span while excluding non-work travel/off days.
+ */
 export const getAssignableJobDateKeys = (job: AssignableJob | null | undefined) => {
   if (!job) return [] as string[];
 
@@ -395,12 +399,15 @@ export const AssignJobDialog = ({
             .single();
 
           if (jobData) {
-            const startDate = startOfDay(new Date(jobData.start_time));
-            const endDate = startOfDay(new Date(jobData.end_time));
+            const startKey = normalizeDateKey(jobData.start_time);
+            const endKey = normalizeDateKey(jobData.end_time);
+            if (!startKey || !endKey) return [];
             const dates: string[] = [];
 
-            for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
-              dates.push(formatDateKey(d));
+            let cursorKey = startKey;
+            while (cursorKey <= endKey) {
+              dates.push(cursorKey);
+              cursorKey = addMadridCalendarDays(cursorKey, 1);
             }
             return dates;
           }

--- a/src/components/matrix/AssignJobDialog.tsx
+++ b/src/components/matrix/AssignJobDialog.tsx
@@ -47,6 +47,8 @@ import { checkTimeConflictEnhanced, ConflictCheckResult } from '@/utils/technici
 import { toggleTimesheetDay } from '@/services/toggleTimesheetDay';
 import { removeTimesheetAssignment } from '@/services/removeTimesheetAssignment';
 import { syncTimesheetCategoriesForAssignment } from '@/services/syncTimesheetCategories';
+import { normalizeDateKey, uniqueSortedDateKeys } from '@/utils/assignmentWorkDates';
+import { addMadridCalendarDays, formatMadridDateKey, fromMadridDateKey } from '@/utils/timezoneUtils';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -78,23 +80,11 @@ interface AssignJobDialogProps {
 
 const EXCLUDED_ASSIGNABLE_DATE_TYPES = new Set(['off', 'travel']);
 
-const formatDateKey = (value: Date) => format(value, 'yyyy-MM-dd');
+const formatDateKey = formatMadridDateKey;
 
-const parseDateKey = (value: string) => new Date(`${value}T00:00:00`);
+const parseDateKey = fromMadridDateKey;
 
-const nextDateKey = (value: string) => {
-  const next = parseDateKey(value);
-  next.setDate(next.getDate() + 1);
-  return formatDateKey(next);
-};
-
-const sortDateKeys = (keys: Iterable<string>) => Array.from(new Set(keys)).sort();
-
-const normalizeDateKey = (value: string | null | undefined) => {
-  if (!value) return null;
-  const key = String(value).slice(0, 10);
-  return /^\d{4}-\d{2}-\d{2}$/.test(key) ? key : null;
-};
+const sortDateKeys = uniqueSortedDateKeys;
 
 export const getAssignableJobDateKeys = (job: AssignableJob | null | undefined) => {
   if (!job) return [] as string[];
@@ -115,15 +105,16 @@ export const getAssignableJobDateKeys = (job: AssignableJob | null | undefined) 
   });
 
   if (job.start_time) {
-    const startKey = formatDateKey(new Date(job.start_time));
-    const endKey = job.end_time ? formatDateKey(new Date(job.end_time)) : startKey;
+    const startKey = normalizeDateKey(job.start_time);
+    const endKey = normalizeDateKey(job.end_time) ?? startKey;
+    if (!startKey) return sortDateKeys(keys);
     let cursorKey = startKey;
 
     while (cursorKey <= endKey) {
       if (!excludedTypedDates.has(cursorKey)) {
         keys.add(cursorKey);
       }
-      cursorKey = nextDateKey(cursorKey);
+      cursorKey = addMadridCalendarDays(cursorKey, 1);
     }
   }
 

--- a/src/components/matrix/AssignJobDialog.tsx
+++ b/src/components/matrix/AssignJobDialog.tsx
@@ -50,22 +50,85 @@ import { syncTimesheetCategoriesForAssignment } from '@/services/syncTimesheetCa
 
 
 import { queryKeys } from "@/lib/react-query";
+
+type AssignableJobDateType = {
+  date?: string | null;
+  type?: string | null;
+};
+
+type AssignableJob = {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+  color?: string | null;
+  status: string;
+  job_date_types?: AssignableJobDateType[] | null;
+};
+
 interface AssignJobDialogProps {
   open: boolean;
   onClose: () => void;
   technicianId: string;
   date: Date;
-  availableJobs: Array<{
-    id: string;
-    title: string;
-    start_time: string;
-    end_time: string;
-    color?: string;
-    status: string;
-  }>;
+  availableJobs: AssignableJob[];
   existingAssignment?: any;
   preSelectedJobId?: string;
 }
+
+const EXCLUDED_ASSIGNABLE_DATE_TYPES = new Set(['off', 'travel']);
+
+const formatDateKey = (value: Date) => format(value, 'yyyy-MM-dd');
+
+const parseDateKey = (value: string) => new Date(`${value}T00:00:00`);
+
+const nextDateKey = (value: string) => {
+  const next = parseDateKey(value);
+  next.setDate(next.getDate() + 1);
+  return formatDateKey(next);
+};
+
+const sortDateKeys = (keys: Iterable<string>) => Array.from(new Set(keys)).sort();
+
+const normalizeDateKey = (value: string | null | undefined) => {
+  if (!value) return null;
+  const key = String(value).slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(key) ? key : null;
+};
+
+export const getAssignableJobDateKeys = (job: AssignableJob | null | undefined) => {
+  if (!job) return [] as string[];
+
+  const keys = new Set<string>();
+  const excludedTypedDates = new Set<string>();
+  const dateTypes = Array.isArray(job.job_date_types) ? job.job_date_types : [];
+
+  dateTypes.forEach((row) => {
+    const key = normalizeDateKey(row?.date);
+    if (!key) return;
+    const type = String(row?.type || '').toLowerCase();
+    if (EXCLUDED_ASSIGNABLE_DATE_TYPES.has(type)) {
+      excludedTypedDates.add(key);
+      return;
+    }
+    keys.add(key);
+  });
+
+  if (job.start_time) {
+    const startKey = formatDateKey(new Date(job.start_time));
+    const endKey = job.end_time ? formatDateKey(new Date(job.end_time)) : startKey;
+    let cursorKey = startKey;
+
+    while (cursorKey <= endKey) {
+      if (!excludedTypedDates.has(cursorKey)) {
+        keys.add(cursorKey);
+      }
+      cursorKey = nextDateKey(cursorKey);
+    }
+  }
+
+  return sortDateKeys(keys);
+};
 
 export const AssignJobDialog = ({
   open,
@@ -145,6 +208,11 @@ export const AssignJobDialog = ({
 
   const hasExistingTimesheetsForSelectedJob = (existingTimesheets?.length ?? 0) > 0;
   const isModifyingSelectedJob = isModifyingSameJobByContext || hasExistingTimesheetsForSelectedJob;
+  const existingTimesheetDateKeys = useMemo(
+    () => sortDateKeys((existingTimesheets || []).map((existingDate) => normalizeDateKey(existingDate)).filter((key): key is string => Boolean(key))),
+    [existingTimesheets],
+  );
+  const existingTimesheetDateSet = useMemo(() => new Set(existingTimesheetDateKeys), [existingTimesheetDateKeys]);
 
   // Set initial role if reassigning
   React.useEffect(() => {
@@ -317,6 +385,38 @@ export const AssignJobDialog = ({
         assignment_source: 'direct' as const,
       } as const;
 
+      const coverageDates: string[] = await (async () => {
+        if (coverageMode === 'multi') {
+          const uniqueKeys = sortDateKeys((multiDates || []).map((multiDate) => formatDateKey(multiDate)));
+          if (uniqueKeys.length === 0) {
+            throw new Error('Selecciona al menos una fecha');
+          }
+          return uniqueKeys;
+        }
+        if (coverageMode === 'single' && assignmentDate) {
+          return [assignmentDate];
+        }
+        if (coverageMode === 'full') {
+          // For full job coverage, get all dates from job start to end
+          const { data: jobData } = await dataLayerClient.from('jobs')
+            .select('start_time, end_time')
+            .eq('id', selectedJobId)
+            .single();
+
+          if (jobData) {
+            const startDate = startOfDay(new Date(jobData.start_time));
+            const endDate = startOfDay(new Date(jobData.end_time));
+            const dates: string[] = [];
+
+            for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+              dates.push(formatDateKey(d));
+            }
+            return dates;
+          }
+        }
+        return [];
+      })();
+
       // Before writing, check if an assignment already exists for this job + technician
       const { data: existingRow } = await dataLayerClient.from('job_assignments')
         .select('job_id, technician_id, single_day, assignment_date, status')
@@ -324,13 +424,19 @@ export const AssignJobDialog = ({
         .eq('technician_id', technicianId)
         .maybeSingle();
 
-      // For multi-date selection, mark as single_day=true with first date to avoid assigning full job span
+      // For multi-date selection, keep the base row single-day scoped without implying full job coverage.
       const desiredSingleDay = coverageMode !== 'full';
-      const desiredAssignmentDate = coverageMode === 'single'
-        ? assignmentDate
-        : coverageMode === 'multi' && multiDates && multiDates.length > 0
-          ? format(multiDates[0], 'yyyy-MM-dd')
-          : null;
+      const desiredAssignmentDate = desiredSingleDay ? coverageDates[0] ?? null : null;
+      const preserveExistingScopedDate =
+        Boolean(existingRow) &&
+        isModifyingSelectedJob &&
+        modificationMode === 'add' &&
+        coverageMode !== 'full' &&
+        Boolean(existingRow?.assignment_date);
+      const nextSingleDay = preserveExistingScopedDate ? existingRow?.single_day ?? desiredSingleDay : desiredSingleDay;
+      const nextAssignmentDate = preserveExistingScopedDate
+        ? existingRow?.assignment_date ?? desiredAssignmentDate
+        : desiredAssignmentDate;
 
       if (existingRow) {
         // Update the existing base row (whole job or single) to align with the requested coverage
@@ -343,8 +449,8 @@ export const AssignJobDialog = ({
           // Do not downgrade a confirmed assignment to invited
           status: existingRow.status === 'confirmed' && basePayload.status !== 'confirmed' ? 'confirmed' : basePayload.status,
           response_time: basePayload.status === 'confirmed' ? basePayload.response_time : existingRow.status === 'confirmed' ? (existingRow as any).response_time ?? null : null,
-          single_day: desiredSingleDay,
-          assignment_date: desiredAssignmentDate,
+          single_day: nextSingleDay,
+          assignment_date: nextAssignmentDate,
           assignment_source: basePayload.assignment_source,
         };
 
@@ -397,38 +503,6 @@ export const AssignJobDialog = ({
       } else {
         existingDates = existingTimesheets || [];
       }
-
-      const coverageDates: string[] = await (async () => {
-        if (coverageMode === 'multi') {
-          const uniqueKeys = Array.from(new Set((multiDates || []).map(d => format(d, 'yyyy-MM-dd'))));
-          if (uniqueKeys.length === 0) {
-            throw new Error('Selecciona al menos una fecha');
-          }
-          return uniqueKeys;
-        }
-        if (coverageMode === 'single' && assignmentDate) {
-          return [assignmentDate];
-        }
-        if (coverageMode === 'full') {
-          // For full job coverage, get all dates from job start to end
-          const { data: jobData } = await dataLayerClient.from('jobs')
-            .select('start_time, end_time')
-            .eq('id', selectedJobId)
-            .single();
-
-          if (jobData) {
-            const startDate = startOfDay(new Date(jobData.start_time));
-            const endDate = startOfDay(new Date(jobData.end_time));
-            const dates: string[] = [];
-
-            for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
-              dates.push(format(d, 'yyyy-MM-dd'));
-            }
-            return dates;
-          }
-        }
-        return [];
-      })();
 
       // Smart timesheet management based on modification mode
       if (isModifyingSelectedJob) {
@@ -708,22 +782,54 @@ export const AssignJobDialog = ({
     setAssignAsConfirmed(checked === true);
   };
 
-  // Build selected job date range to constrain calendar selection
+  // Build selected job dates to constrain calendar selection.
   const selectedJobMeta = useMemo(() => {
     const j = selectedJob;
-    if (!j) return null as null | { start?: Date; end?: Date };
-    const s = j.start_time ? new Date(j.start_time) : undefined;
-    const e = j.end_time ? new Date(j.end_time) : s;
-    if (s) s.setHours(0, 0, 0, 0);
-    if (e) e.setHours(0, 0, 0, 0);
-    return { start: s, end: e };
+    if (!j) return null as null | { dateKeys: Set<string> };
+    const dateKeys = new Set(getAssignableJobDateKeys(j));
+    return { dateKeys };
   }, [selectedJob]);
 
-  const isAllowedDate = (d: Date) => {
-    if (!selectedJobMeta?.start || !selectedJobMeta?.end) return true;
-    const t = new Date(d); t.setHours(0, 0, 0, 0);
-    return t >= selectedJobMeta.start && t <= selectedJobMeta.end;
-  };
+  const isAllowedDate = React.useCallback((d: Date) => {
+    const key = formatDateKey(d);
+    if (existingTimesheetDateSet.has(key)) return true;
+    if (!selectedJobMeta || selectedJobMeta.dateKeys.size === 0) return true;
+    return selectedJobMeta.dateKeys.has(key);
+  }, [existingTimesheetDateSet, selectedJobMeta]);
+
+  React.useEffect(() => {
+    if (!open || coverageMode !== 'multi' || !isModifyingSelectedJob || existingTimesheetDateKeys.length === 0) {
+      return;
+    }
+
+    setMultiDates((currentDates) => {
+      const nextByKey = new Map<string, Date>();
+      currentDates.forEach((currentDate) => {
+        if (isAllowedDate(currentDate)) {
+          nextByKey.set(formatDateKey(currentDate), currentDate);
+        }
+      });
+      existingTimesheetDateKeys.forEach((existingDateKey) => {
+        const existingDate = parseDateKey(existingDateKey);
+        if (isAllowedDate(existingDate)) {
+          nextByKey.set(existingDateKey, existingDate);
+        }
+      });
+
+      const nextDates = Array.from(nextByKey.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([, nextDate]) => nextDate);
+      const currentKey = currentDates.map(formatDateKey).sort().join('|');
+      const nextKey = nextDates.map(formatDateKey).join('|');
+      return currentKey === nextKey ? currentDates : nextDates;
+    });
+  }, [
+    open,
+    coverageMode,
+    isModifyingSelectedJob,
+    existingTimesheetDateKeys,
+    isAllowedDate,
+  ]);
 
   const formatJobRange = (start?: string | null, end?: string | null) => {
     if (!start || !end) return null;

--- a/supabase/migrations/20260608120000_preserve_assignment_dialog_prep_day_timesheets.sql
+++ b/supabase/migrations/20260608120000_preserve_assignment_dialog_prep_day_timesheets.sql
@@ -1,0 +1,79 @@
+CREATE OR REPLACE FUNCTION public.deactivate_unassigned_prep_day_timesheet(
+  _job_id uuid,
+  _technician_id uuid,
+  _date date
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_affected integer := 0;
+BEGIN
+  IF _job_id IS NULL OR _technician_id IS NULL OR _date IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  UPDATE public.timesheets t
+  SET is_active = false,
+      updated_at = now()
+  WHERE t.job_id = _job_id
+    AND t.technician_id = _technician_id
+    AND t.date = _date
+    AND COALESCE(t.is_active, true)
+    AND EXISTS (
+      SELECT 1
+      FROM public.job_date_types jdt
+      WHERE jdt.job_id = t.job_id
+        AND jdt.date = t.date
+        AND jdt.type = 'prep_day'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.job_assignments ja
+      WHERE ja.job_id = t.job_id
+        AND ja.technician_id = t.technician_id
+        AND COALESCE(ja.status, 'confirmed'::public.assignment_status) <> 'declined'::public.assignment_status
+        AND COALESCE(ja.single_day, false)
+        AND ja.assignment_date = t.date
+    )
+    AND (
+      t.source IS NULL
+      OR t.source = 'prep_day'
+      OR (
+        t.source IS DISTINCT FROM 'assignment-dialog'
+        AND (
+          t.category = 'prep_day'
+          OR t.amount_breakdown ->> 'is_prep_day' = 'true'
+        )
+      )
+    );
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.deactivate_unassigned_prep_day_timesheet(uuid,uuid,date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.deactivate_unassigned_prep_day_timesheet(uuid,uuid,date) TO service_role;
+
+UPDATE public.timesheets t
+SET is_active = true,
+    updated_at = now()
+WHERE t.source = 'assignment-dialog'
+  AND COALESCE(t.is_active, false) IS DISTINCT FROM true
+  AND EXISTS (
+    SELECT 1
+    FROM public.job_date_types jdt
+    WHERE jdt.job_id = t.job_id
+      AND jdt.date = t.date
+      AND jdt.type = 'prep_day'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM public.job_assignments ja
+    WHERE ja.job_id = t.job_id
+      AND ja.technician_id = t.technician_id
+      AND COALESCE(ja.status, 'confirmed'::public.assignment_status) <> 'declined'::public.assignment_status
+  );

--- a/tests/assignments/critical-paths.test.ts
+++ b/tests/assignments/critical-paths.test.ts
@@ -58,7 +58,7 @@ vi.mock("@/services/syncTimesheetCategories", () => ({
   syncTimesheetCategoriesForAssignment: syncTimesheetCategoriesMock,
 }));
 
-import { AssignJobDialog } from "@/components/matrix/AssignJobDialog";
+import { AssignJobDialog, getAssignableJobDateKeys } from "@/components/matrix/AssignJobDialog";
 
 async function getActualConflictCheck() {
   const actual = await vi.importActual<typeof import("@/utils/technicianAvailability")>(
@@ -122,11 +122,10 @@ const configureDialogSupabase = ({
   endTime?: string;
 } = {}) => {
   const insertMock = vi.fn().mockResolvedValue({ error: null });
+  const updateBuilder = createMockQueryBuilder({ data: null, error: null });
 
   mockSupabase.from.mockImplementation((table: string) => {
     if (table === "job_assignments") {
-      const updateBuilder = createMockQueryBuilder({ data: null, error: null });
-
       return {
         select: vi.fn((columns: string) => {
           if (columns === "job_id, technician_id, single_day, assignment_date, status") {
@@ -179,17 +178,37 @@ const configureDialogSupabase = ({
     return createMockQueryBuilder();
   });
 
-  return { insertMock };
+  return { insertMock, updateMock: updateBuilder.update };
 };
 
 const renderAssignmentDialog = async ({
   date = new Date("2026-12-01T00:00:00Z"),
   switchToSingleDay = false,
+  switchToMultiDay = false,
+  existingTimesheetDates = [],
+  availableJobs = [baseJob],
+  submit = true,
 }: {
   date?: Date;
   switchToSingleDay?: boolean;
+  switchToMultiDay?: boolean;
+  existingTimesheetDates?: string[];
+  availableJobs?: typeof baseJob[];
+  submit?: boolean;
 } = {}) => {
   const user = userEvent.setup();
+  if (existingTimesheetDates.length > 0) {
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: any[] }) => {
+      const key = queryKey[0];
+      if (key === "technician") {
+        return { data: defaultTechnician, isLoading: false };
+      }
+      if (key === "existing-timesheets") {
+        return { data: existingTimesheetDates, isLoading: false };
+      }
+      return { data: undefined, isLoading: false };
+    });
+  }
 
   render(
     React.createElement(AssignJobDialog, {
@@ -197,7 +216,7 @@ const renderAssignmentDialog = async ({
       onClose: vi.fn(),
       technicianId: "tech-1",
       date,
-      availableJobs: [baseJob],
+      availableJobs,
       preSelectedJobId: baseJob.id,
     }),
   );
@@ -210,8 +229,13 @@ const renderAssignmentDialog = async ({
   if (switchToSingleDay) {
     await user.click(screen.getByRole("tab", { name: /día suelto/i }));
   }
+  if (switchToMultiDay) {
+    await user.click(screen.getByRole("tab", { name: /varios días/i }));
+  }
 
-  await user.click(screen.getByRole("button", { name: /asignar trabajo/i }));
+  if (submit) {
+    await user.click(screen.getByRole("button", { name: /asignar trabajo/i }));
+  }
 
   return { user };
 };
@@ -379,6 +403,21 @@ describe("Assignments Critical Paths", () => {
   });
 
   describe("Coverage modes", () => {
+    it("includes prep days before the tour date in assignable picker dates", () => {
+      expect(
+        getAssignableJobDateKeys({
+          ...baseJob,
+          start_time: "2026-06-11T08:00:00Z",
+          end_time: "2026-06-11T20:00:00Z",
+          job_date_types: [
+            { date: "2026-06-08", type: "prep_day" },
+            { date: "2026-06-09", type: "prep_day" },
+            { date: "2026-06-10", type: "travel" },
+          ],
+        }),
+      ).toEqual(["2026-06-08", "2026-06-09", "2026-06-11"]);
+    });
+
     it("creates a single-day assignment and toggles only the selected date", async () => {
       const { insertMock } = configureDialogSupabase();
 
@@ -414,6 +453,66 @@ describe("Assignments Critical Paths", () => {
         dateIso: "2026-12-02",
         present: true,
         source: "assignment-dialog",
+      });
+    });
+
+    it("keeps existing scoped assignment metadata when adding a prep date", async () => {
+      const { updateMock } = configureDialogSupabase({
+        existingAssignmentRow: {
+          job_id: "job-1",
+          technician_id: "tech-1",
+          single_day: true,
+          assignment_date: "2026-12-01",
+          status: "invited",
+        },
+        existingTimesheetDates: ["2026-12-01"],
+      });
+
+      await renderAssignmentDialog({
+        date: new Date("2026-12-02T00:00:00Z"),
+        switchToSingleDay: true,
+        existingTimesheetDates: ["2026-12-01"],
+      });
+
+      await waitFor(() => {
+        expect(updateMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            single_day: true,
+            assignment_date: "2026-12-01",
+          }),
+        );
+      });
+      expect(toggleTimesheetDayMock).toHaveBeenCalledTimes(1);
+      expect(toggleTimesheetDayMock).toHaveBeenCalledWith({
+        jobId: "job-1",
+        technicianId: "tech-1",
+        dateIso: "2026-12-02",
+        present: true,
+        source: "assignment-dialog",
+      });
+    });
+
+    it("preselects existing timesheet dates when using multi-day add mode", async () => {
+      configureDialogSupabase({
+        existingAssignmentRow: {
+          job_id: "job-1",
+          technician_id: "tech-1",
+          single_day: true,
+          assignment_date: "2026-12-01",
+          status: "invited",
+        },
+        existingTimesheetDates: ["2026-12-01", "2026-12-02"],
+      });
+
+      await renderAssignmentDialog({
+        date: new Date("2026-12-01T00:00:00Z"),
+        switchToMultiDay: true,
+        existingTimesheetDates: ["2026-12-01", "2026-12-02"],
+        submit: false,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/2 día\(s\) seleccionado\(s\)/i)).toBeInTheDocument();
       });
     });
 

--- a/tests/timesheets/prep-day-scope-migration.test.ts
+++ b/tests/timesheets/prep-day-scope-migration.test.ts
@@ -6,6 +6,10 @@ const migration = readFileSync(
   "supabase/migrations/20260605203000_scope_prep_day_timesheets_to_assignments.sql",
   "utf8",
 );
+const hotfixMigration = readFileSync(
+  "supabase/migrations/20260608120000_preserve_assignment_dialog_prep_day_timesheets.sql",
+  "utf8",
+);
 
 describe("prep day timesheet scope migration", () => {
   it("creates prep-day timesheets only for assignments scoped to that prep date", () => {
@@ -25,5 +29,12 @@ describe("prep day timesheet scope migration", () => {
     expect(migration).toMatch(/deactivate_unassigned_prep_day_timesheet/);
     expect(migration).toMatch(/SET is_active = false/);
     expect(migration).toMatch(/jdt\.type = 'prep_day'/);
+  });
+
+  it("preserves explicitly added assignment-dialog prep-day timesheets", () => {
+    expect(hotfixMigration).toMatch(/deactivate_unassigned_prep_day_timesheet/);
+    expect(hotfixMigration).toMatch(/t\.source IS DISTINCT FROM 'assignment-dialog'/);
+    expect(hotfixMigration).toMatch(/t\.source = 'assignment-dialog'/);
+    expect(hotfixMigration).toMatch(/SET is_active = true/);
   });
 });


### PR DESCRIPTION
## Summary
- Include typed job dates, including tour prep days, in the assignment dialog date picker instead of constraining it only to the job start/end span.
- Preselect existing active timesheet dates when modifying a job in multi-day add mode.
- Preserve the existing scoped `job_assignments.assignment_date` in add mode so adding another day does not move the base assignment row.
- Add a Supabase hotfix migration so explicit `assignment-dialog` prep-day timesheets are not deactivated by the prep-day scoping trigger, plus a repair update for already-deactivated explicit rows.

## Root Cause
Prep days are stored in `job_date_types` before the tour date, but the assignment dialog only allowed dates inside `jobs.start_time`/`jobs.end_time`. Separately, the prep-day scoping trigger treated explicit assignment-dialog prep-day timesheets as generated prep rows, so updating the single assignment metadata date could deactivate the previously added prep-day timesheet.

## Risk Assessment
Risk level: Low to moderate.

Main risks:
- Assignment date selection now includes typed prep/rehearsal job dates, so incorrect typed dates on a job can become assignable.
- The migration changes prep-day timesheet cleanup behavior only for rows explicitly sourced from `assignment-dialog`.
- The repair update can reactivate previously deactivated explicit prep-day timesheets when a non-declined assignment still exists.

Mitigations:
- Travel/off typed dates remain excluded from assignment selection.
- Existing generated prep-day cleanup behavior remains in place for non-`assignment-dialog` rows.
- Tests cover prep-day selection, add-mode assignment-date preservation, multi-day preselection, and migration behavior.

## Migration Impact
This PR includes one Supabase migration: `20260608120000_preserve_assignment_dialog_prep_day_timesheets.sql`.

Impact:
- Replaces `public.deactivate_unassigned_prep_day_timesheet()` with a narrower version that preserves explicit assignment-dialog prep-day timesheets.
- Reactivates affected `assignment-dialog` prep-day timesheets where a matching non-declined assignment still exists.
- Does not change RLS policies, table shape, indexes, or client-side database contracts.

Production requirement:
- Run `supabase db push --dry-run`.
- Apply the pending migration with `supabase db push`.
- Run `supabase db push --dry-run` again and confirm the remote database is up to date before merging.

## Impact Checklist
- Database migration: Yes, additive/narrow behavior change to one trigger function plus a repair update.
- RLS/security: No policy changes; function remains `SECURITY DEFINER` with the existing `public` search path.
- Realtime/subscriptions: No subscription or channel changes.
- Performance: Low impact; repair query is scoped to inactive assignment-dialog prep-day timesheets.
- Mobile/PWA runtime: UI date picker behavior changes only in the assignment dialog.
- Backward compatibility: Preserved; existing schema and assignment/timesheet contracts remain unchanged.

## Rollback Plan
- If the UI behavior regresses before merge, revert the PR branch commit(s) and rerun validation.
- If the production migration has already been applied, ship a follow-up migration restoring the previous cleanup function behavior and, if needed, deactivate incorrectly restored prep-day rows after confirming affected assignment IDs.
- If production issues appear after merge, revert the merge commit on `main`, deploy the revert, and apply the database rollback migration if the issue is tied to trigger behavior.

## Validation
- `npm run governance:source`
- `npm run test:run -- tests/assignments/critical-paths.test.ts tests/timesheets/prep-day-scope-migration.test.ts`
- `npm run test:run` (144 files, 910 tests)
- `npm run lint` (passes; existing warning backlog remains)
- `npm run build`

## Deployment Note
Cloudflare preview deploy is green. This PR includes a Supabase migration, so merge only after the production dry-run/apply/dry-run sequence is clean.
