### PR TITLE
[codex] Fix power summary latest requirements

### DIFF
--- a/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
+++ b/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
@@ -6,6 +6,7 @@ import {
   buildPowerRequirementInsert,
   buildTourPowerDefaultTable,
   getPowerReportUploadCategory,
+  saveJobPowerRequirementTable,
 } from "@/features/technical-tools/power/powerPersistence";
 
 const table = {
@@ -22,6 +23,54 @@ const settings = {
   powerFactor: 0.9,
   safetyMargin: 20,
   voltage: 400,
+};
+
+const createPowerRequirementTableClient = () => {
+  const operations: Array<{ method: string; args: unknown[] }> = [];
+
+  const createBuilder = () => {
+    const builder: any = {
+      delete: vi.fn(() => {
+        operations.push({ method: "delete", args: [] });
+        return builder;
+      }),
+      eq: vi.fn((column: string, value: unknown) => {
+        operations.push({ method: "eq", args: [column, value] });
+        return builder;
+      }),
+      insert: vi.fn((payload: unknown) => {
+        operations.push({ method: "insert", args: [payload] });
+        return builder;
+      }),
+      is: vi.fn((column: string, value: unknown) => {
+        operations.push({ method: "is", args: [column, value] });
+        return builder;
+      }),
+      neq: vi.fn((column: string, value: unknown) => {
+        operations.push({ method: "neq", args: [column, value] });
+        return builder;
+      }),
+      select: vi.fn((columns?: string) => {
+        operations.push({ method: "select", args: [columns] });
+        return builder;
+      }),
+      single: vi.fn(async () => ({ data: { id: "new-power-requirement-id" }, error: null })),
+      then: (resolve: (value: unknown) => unknown, reject?: (reason: unknown) => unknown) =>
+        Promise.resolve({ data: null, error: null }).then(resolve, reject),
+    };
+
+    return builder;
+  };
+
+  return {
+    client: {
+      from: vi.fn((tableName: string) => {
+        operations.push({ method: "from", args: [tableName] });
+        return createBuilder();
+      }),
+    } as any,
+    operations,
+  };
 };
 
 describe("technical power persistence payloads", () => {
@@ -86,5 +135,60 @@ describe("technical power persistence payloads", () => {
 
     expect(buildPowerTableData(table, lightsSettings)).not.toHaveProperty("pf");
     expect(buildPowerTableMetadata(table, lightsSettings)).not.toHaveProperty("pf");
+  });
+
+  it("removes older same-scope generations after inserting a fresh job table", async () => {
+    const { client, operations } = createPowerRequirementTableClient();
+
+    await expect(
+      saveJobPowerRequirementTable({
+        client,
+        department: "sound",
+        jobId: "job-1",
+        settings,
+        table,
+      })
+    ).resolves.toBe("new-power-requirement-id");
+
+    expect(operations).toEqual(
+      expect.arrayContaining([
+        { method: "delete", args: [] },
+        { method: "eq", args: ["job_id", "job-1"] },
+        { method: "eq", args: ["department", "sound"] },
+        { method: "neq", args: ["id", "new-power-requirement-id"] },
+        { method: "is", args: ["stage_number", null] },
+      ])
+    );
+    expect(operations).not.toEqual(
+      expect.arrayContaining([{ method: "eq", args: ["table_name", "Main"] }])
+    );
+  });
+
+  it("limits fresh-generation cleanup to the selected stage", async () => {
+    const { client, operations } = createPowerRequirementTableClient();
+
+    await saveJobPowerRequirementTable({
+      client,
+      department: "sound",
+      jobId: "job-1",
+      settings,
+      stage: { number: 2, name: "Club Stage" },
+      table,
+    });
+
+    const deleteIndex = operations.findIndex((operation) => operation.method === "delete");
+    const cleanupOperations = operations.slice(deleteIndex);
+
+    expect(cleanupOperations).toEqual(
+      expect.arrayContaining([
+        { method: "eq", args: ["job_id", "job-1"] },
+        { method: "eq", args: ["department", "sound"] },
+        { method: "eq", args: ["stage_number", 2] },
+        { method: "neq", args: ["id", "new-power-requirement-id"] },
+      ])
+    );
+    expect(cleanupOperations).not.toEqual(
+      expect.arrayContaining([{ method: "is", args: ["stage_number", null] }])
+    );
   });
 });

--- a/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
+++ b/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildPowerTableData,
@@ -24,6 +24,8 @@ const settings = {
   safetyMargin: 20,
   voltage: 400,
 };
+
+const successfulResponse = <T>(data: T): { data: T; error: null } => ({ data, error: null });
 
 const createPowerRequirementTableClient = () => {
   const operations: Array<{ method: string; args: unknown[] }> = [];
@@ -54,9 +56,9 @@ const createPowerRequirementTableClient = () => {
         operations.push({ method: "select", args: [columns] });
         return builder;
       }),
-      single: vi.fn(async () => ({ data: { id: "new-power-requirement-id" }, error: null })),
+      single: vi.fn(async () => successfulResponse({ id: "new-power-requirement-id" })),
       then: (resolve: (value: unknown) => unknown, reject?: (reason: unknown) => unknown) =>
-        Promise.resolve({ data: null, error: null }).then(resolve, reject),
+        Promise.resolve(successfulResponse(null)).then(resolve, reject),
     };
 
     return builder;

--- a/src/features/technical-tools/power/powerPersistence.ts
+++ b/src/features/technical-tools/power/powerPersistence.ts
@@ -9,6 +9,7 @@ import type { TechnicalStage } from "@/features/technical-tools/stage/stageUtils
 import { getTechnicalStageStorageScope } from "@/features/technical-tools/stage/stageUtils";
 
 type PowerPersistenceClient = Pick<typeof typedSupabase, "from">;
+type PowerRequirementInsertPayload = ReturnType<typeof buildPowerRequirementInsert>;
 
 export const getPowerReportUploadCategory = (department: TechnicalDepartment) =>
   department === "lights" ? "calculators/lights-consumos" : "calculators/consumos";
@@ -98,6 +99,33 @@ export const buildPowerRequirementInsert = ({
   };
 };
 
+const deletePreviousPowerRequirementGenerations = async ({
+  client,
+  insertedId,
+  jobId,
+  payload,
+}: {
+  client: PowerPersistenceClient;
+  insertedId: string;
+  jobId: string;
+  payload: PowerRequirementInsertPayload;
+}) => {
+  let deleteQuery = client
+    .from("power_requirement_tables")
+    .delete()
+    .eq("job_id", jobId)
+    .eq("department", payload.department)
+    .neq("id", insertedId);
+
+  deleteQuery =
+    payload.stage_number === null
+      ? deleteQuery.is("stage_number", null)
+      : deleteQuery.eq("stage_number", payload.stage_number);
+
+  const { error } = await deleteQuery;
+  if (error) throw error;
+};
+
 export const saveJobPowerRequirementTable = async ({
   client,
   department,
@@ -141,7 +169,15 @@ export const saveJobPowerRequirementTable = async ({
     .single();
 
   if (error) throw error;
-  return data.id as string;
+  const insertedId = data.id as string;
+  await deletePreviousPowerRequirementGenerations({
+    client,
+    insertedId,
+    jobId,
+    payload,
+  });
+
+  return insertedId;
 };
 
 export const deleteJobPowerRequirementTable = async ({

--- a/src/utils/__tests__/powerSummaryData.test.ts
+++ b/src/utils/__tests__/powerSummaryData.test.ts
@@ -143,6 +143,54 @@ describe('powerSummaryData', () => {
     expect(summary.departments.sound.rows[0].notes).toContain('CEE32A');
   });
 
+  it('keeps only the newest same-name generation when a corrected table changes rows', async () => {
+    const supabase = createMockSupabase({
+      power_requirement_tables: [
+        {
+          id: 'sound-old',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'MAIN L',
+          total_watts: 31500,
+          current_per_phase: 57.43,
+          pdu_type: 'CEE125A 3P+N+G',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: {
+            sourceTableId: '1744012800000',
+            rows: [{ quantity: '1', componentId: '1', watts: '31500' }],
+          },
+        },
+        {
+          id: 'sound-new',
+          created_at: '2026-04-07T09:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'MAIN L',
+          total_watts: 29000,
+          current_per_phase: 52.9,
+          pdu_type: 'CEE63A 3P+N+G',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: {
+            sourceTableId: '1744016400000',
+            rows: [{ quantity: '1', componentId: '1', watts: '29000' }],
+          },
+        },
+      ],
+    });
+
+    const summary = await loadTechnicalPowerSummaryData({
+      job: { id: 'job-1', job_type: 'single' },
+      supabase,
+    });
+
+    expect(summary.departments.sound.rows).toHaveLength(1);
+    expect(summary.departments.sound.rows[0].totalWatts).toBe(29000);
+    expect(summary.departments.sound.rows[0].pduLabel).toBe('CEE63A 3P+N+G');
+  });
+
   it('uses input order instead of lexicographic ids to break duplicate save freshness ties', async () => {
     const supabase = createMockSupabase({
       power_requirement_tables: [
@@ -184,7 +232,7 @@ describe('powerSummaryData', () => {
     expect(summary.departments.sound.rows[0].notes).toContain('CEE32A');
   });
 
-  it('keeps multiple current tables for the same department when they have distinct saved identities', async () => {
+  it('keeps only the newest table for the same department and stage even when table names differ', async () => {
     const supabase = createMockSupabase({
       power_requirement_tables: [
         {
@@ -210,7 +258,7 @@ describe('powerSummaryData', () => {
           created_at: '2026-04-07T08:05:00.000Z',
           job_id: 'job-1',
           department: 'sound',
-          table_name: 'Main PA',
+          table_name: 'Side PA',
           total_watts: 1200,
           current_per_phase: 5,
           pdu_type: '32A',
@@ -231,11 +279,9 @@ describe('powerSummaryData', () => {
       supabase,
     });
 
-    expect(summary.departments.sound.rows).toHaveLength(2);
-    expect(summary.departments.sound.rows.map((row) => row.positionLabel)).toEqual([
-      'Stage 1',
-      'Stage 2',
-    ]);
+    expect(summary.departments.sound.rows).toHaveLength(1);
+    expect(summary.departments.sound.rows[0].name).toBe('Side PA');
+    expect(summary.departments.sound.rows[0].positionLabel).toBe('Stage 2');
   });
 
   it('keeps same saved table identity separate per festival stage', async () => {
@@ -314,6 +360,54 @@ describe('powerSummaryData', () => {
         } as any,
       ])
     ).toContain('SOUND - Main Stage - Main PA:');
+  });
+
+  it('formats only the latest same-name generation in hoja de ruta power text', () => {
+    const text = formatPowerRequirementsText([
+      {
+        id: 'sound-old',
+        created_at: '2026-04-07T08:00:00.000Z',
+        job_id: 'job-1',
+        department: 'sound',
+        stage_number: null,
+        stage_name: null,
+        table_name: 'MAIN L',
+        total_watts: 31500,
+        current_per_phase: 57.43,
+        pdu_type: 'CEE125A 3P+N+G',
+        custom_pdu_type: null,
+        custom_position: null,
+        position: null,
+        includes_hoist: false,
+        table_data: {
+          sourceTableId: '1744012800000',
+          rows: [{ quantity: '1', componentId: '1', watts: '31500' }],
+        },
+      } as any,
+      {
+        id: 'sound-new',
+        created_at: '2026-04-07T09:00:00.000Z',
+        job_id: 'job-1',
+        department: 'sound',
+        stage_number: null,
+        stage_name: null,
+        table_name: 'MAIN L',
+        total_watts: 29000,
+        current_per_phase: 52.9,
+        pdu_type: 'CEE63A 3P+N+G',
+        custom_pdu_type: null,
+        custom_position: null,
+        position: null,
+        includes_hoist: false,
+        table_data: {
+          sourceTableId: '1744016400000',
+          rows: [{ quantity: '1', componentId: '1', watts: '29000' }],
+        },
+      } as any,
+    ]);
+
+    expect(text).toContain('Potencia Total: 29000.00W');
+    expect(text).not.toContain('Potencia Total: 31500.00W');
   });
 
   it('keeps numeric stage zero when formatting hoja de ruta power text', () => {

--- a/src/utils/powerSummaryData.ts
+++ b/src/utils/powerSummaryData.ts
@@ -88,26 +88,6 @@ const mapPowerRequirementTable = (
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const getPowerRequirementRowsSignature = (row: PowerRequirementTableRow) => {
-  if (!isRecord(row.table_data) || !Array.isArray(row.table_data.rows)) {
-    return null;
-  }
-
-  try {
-    return JSON.stringify(row.table_data.rows);
-  } catch {
-    return null;
-  }
-};
-
-const getPowerRequirementSourceTableId = (row: PowerRequirementTableRow) => {
-  if (!isRecord(row.table_data)) return null;
-  const sourceTableId = row.table_data.sourceTableId;
-  return typeof sourceTableId === 'string' && sourceTableId.trim()
-    ? sourceTableId.trim()
-    : null;
-};
-
 const getPowerRequirementStageNumber = (row: PowerRequirementTableRow) => {
   if (typeof row.stage_number === 'number') return row.stage_number;
   if (!isRecord(row.table_data)) return null;
@@ -167,22 +147,7 @@ const comparePowerRequirementTablesByFreshness = (
 const getPowerRequirementTableCurrentKey = (
   row: PowerRequirementTableRow,
   department: TechnicalPowerDepartment
-) => {
-  const stageKey = getPowerRequirementStageKey(row);
-  const sourceTableId = getPowerRequirementSourceTableId(row);
-  if (sourceTableId) {
-    return `${department}:${stageKey}:source:${sourceTableId}`;
-  }
-
-  const normalizedName = row.table_name?.trim().toLowerCase();
-  const rowSignature = getPowerRequirementRowsSignature(row);
-
-  if (normalizedName && rowSignature) {
-    return `${department}:${stageKey}:legacy:${normalizedName}:${rowSignature}`;
-  }
-
-  return `${department}:row:${row.id}`;
-};
+) => `${department}:${getPowerRequirementStageKey(row)}`;
 
 export const getCurrentPowerRequirementTables = (
   rows: PowerRequirementTableRow[]


### PR DESCRIPTION
## Summary
- Keep the resumen power data aligned to the latest generated requirements per department/stage.
- Replace older persisted rows when a fresh power requirements table is generated for the same job, department, and stage scope.
- Preserve multiple power rows only when they represent different stages.

## Root cause
The resumen aggregation treated independently generated power requirement tables as separate current rows. For single-stage jobs, regenerating a department table could leave older tables in the summary, causing totals to combine stale and current data.

## Risk Assessment
Risk level: low to medium.

The change is scoped to power requirement table persistence and technical power summary aggregation. The main behavioral risk is incorrectly collapsing rows that should remain separate; tests cover single-stage replacement, same department/table regeneration, renamed regenerated tables, and multi-stage preservation.

## Impact Checklist
- Database migration: none.
- Supabase RLS/security: no policy or schema changes.
- Realtime/subscriptions: not affected.
- Performance: summary deduplication is simpler than before; persistence adds one cleanup delete after successful insert.
- User-facing behavior: resumen documents should now show only the latest generated table per department/stage, with multiple rows only for different stages.

## Rollback Plan
Revert the PR commits to restore the previous persistence and summary aggregation behavior. No database rollback is required because this hotfix does not add migrations.

## Migration Impact
No Supabase migrations are included. No production database push is required; merging to `main` is the deploy path.

## Validation
- `npm run typecheck` passed.
- `npm run test:run` passed: 144 test files, 914 tests.
- `npm run lint` passed with 0 errors; existing repo warnings remain.
- `npm run build` passed.
- GitHub CI passed: governance, lint, typecheck, build, critical tests, full test run, smoke e2e, Cloudflare Pages, and CodeRabbit.