### PR TITLE
[codex] Fix power requirements generation grouping

### DIFF
--- a/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
+++ b/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
@@ -7,6 +7,7 @@ import {
   buildTourPowerDefaultTable,
   getPowerReportUploadCategory,
   saveJobPowerRequirementTable,
+  saveJobPowerRequirementTablesGeneration,
 } from "@/features/technical-tools/power/powerPersistence";
 
 const table = {
@@ -31,6 +32,8 @@ const createPowerRequirementTableClient = () => {
   const operations: Array<{ method: string; args: unknown[] }> = [];
 
   const createBuilder = () => {
+    let insertedPayload: unknown;
+
     const builder: any = {
       delete: vi.fn(() => {
         operations.push({ method: "delete", args: [] });
@@ -41,6 +44,7 @@ const createPowerRequirementTableClient = () => {
         return builder;
       }),
       insert: vi.fn((payload: unknown) => {
+        insertedPayload = payload;
         operations.push({ method: "insert", args: [payload] });
         return builder;
       }),
@@ -52,13 +56,25 @@ const createPowerRequirementTableClient = () => {
         operations.push({ method: "neq", args: [column, value] });
         return builder;
       }),
+      not: vi.fn((column: string, operator: string, value: unknown) => {
+        operations.push({ method: "not", args: [column, operator, value] });
+        return builder;
+      }),
       select: vi.fn((columns?: string) => {
         operations.push({ method: "select", args: [columns] });
         return builder;
       }),
       single: vi.fn(async () => successfulResponse({ id: "new-power-requirement-id" })),
-      then: (resolve: (value: unknown) => unknown, reject?: (reason: unknown) => unknown) =>
-        Promise.resolve(successfulResponse(null)).then(resolve, reject),
+      then: (resolve: (value: unknown) => unknown, reject?: (reason: unknown) => unknown) => {
+        const insertedRows = Array.isArray(insertedPayload)
+          ? insertedPayload.map((payload: any, index) => ({
+              id: `new-power-requirement-id-${index + 1}`,
+              stage_number: payload.stage_number ?? null,
+            }))
+          : null;
+
+        return Promise.resolve(successfulResponse(insertedRows)).then(resolve, reject);
+      },
     };
 
     return builder;
@@ -139,7 +155,7 @@ describe("technical power persistence payloads", () => {
     expect(buildPowerTableMetadata(table, lightsSettings)).not.toHaveProperty("pf");
   });
 
-  it("removes older same-scope generations after inserting a fresh job table", async () => {
+  it("does not remove sibling sets after inserting a single job table", async () => {
     const { client, operations } = createPowerRequirementTableClient();
 
     await expect(
@@ -152,30 +168,82 @@ describe("technical power persistence payloads", () => {
       })
     ).resolves.toBe("new-power-requirement-id");
 
+    expect(operations).not.toEqual(expect.arrayContaining([{ method: "delete", args: [] }]));
+  });
+
+  it("replaces older same-scope generations after saving a timestamped table batch", async () => {
+    const { client, operations } = createPowerRequirementTableClient();
+    const generationTimestamp = "2026-04-07T09:00:00.000Z";
+
+    await expect(
+      saveJobPowerRequirementTablesGeneration({
+        client,
+        department: "sound",
+        generationTimestamp,
+        jobId: "job-1",
+        settings,
+        tables: [
+          { ...table, id: "main", name: "Main" },
+          { ...table, id: "delay", name: "Delay" },
+        ],
+      })
+    ).resolves.toEqual([
+      {
+        generationTimestamp,
+        powerRequirementId: "new-power-requirement-id-1",
+        tableId: "main",
+      },
+      {
+        generationTimestamp,
+        powerRequirementId: "new-power-requirement-id-2",
+        tableId: "delay",
+      },
+    ]);
+
     expect(operations).toEqual(
       expect.arrayContaining([
         { method: "delete", args: [] },
         { method: "eq", args: ["job_id", "job-1"] },
         { method: "eq", args: ["department", "sound"] },
-        { method: "neq", args: ["id", "new-power-requirement-id"] },
+        {
+          method: "not",
+          args: [
+            "id",
+            "in",
+            '("new-power-requirement-id-1","new-power-requirement-id-2")',
+          ],
+        },
         { method: "is", args: ["stage_number", null] },
       ])
     );
-    expect(operations).not.toEqual(
-      expect.arrayContaining([{ method: "eq", args: ["table_name", "Main"] }])
+
+    const insertOperation = operations.find((operation) => operation.method === "insert");
+    expect(insertOperation?.args[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          created_at: generationTimestamp,
+          table_data: expect.objectContaining({ generationTimestamp }),
+          table_name: "Main",
+        }),
+        expect.objectContaining({
+          created_at: generationTimestamp,
+          table_data: expect.objectContaining({ generationTimestamp }),
+          table_name: "Delay",
+        }),
+      ])
     );
   });
 
-  it("limits fresh-generation cleanup to the selected stage", async () => {
+  it("limits timestamped generation cleanup to each selected stage", async () => {
     const { client, operations } = createPowerRequirementTableClient();
 
-    await saveJobPowerRequirementTable({
+    await saveJobPowerRequirementTablesGeneration({
       client,
       department: "sound",
       jobId: "job-1",
       settings,
       stage: { number: 2, name: "Club Stage" },
-      table,
+      tables: [table],
     });
 
     const deleteIndex = operations.findIndex((operation) => operation.method === "delete");
@@ -186,7 +254,7 @@ describe("technical power persistence payloads", () => {
         { method: "eq", args: ["job_id", "job-1"] },
         { method: "eq", args: ["department", "sound"] },
         { method: "eq", args: ["stage_number", 2] },
-        { method: "neq", args: ["id", "new-power-requirement-id"] },
+        { method: "not", args: ["id", "in", '("new-power-requirement-id-1")'] },
       ])
     );
     expect(cleanupOperations).not.toEqual(

--- a/src/features/technical-tools/power/powerPersistence.ts
+++ b/src/features/technical-tools/power/powerPersistence.ts
@@ -10,14 +10,30 @@ import { getTechnicalStageStorageScope } from "@/features/technical-tools/stage/
 
 type PowerPersistenceClient = Pick<typeof typedSupabase, "from">;
 type PowerRequirementInsertPayload = ReturnType<typeof buildPowerRequirementInsert>;
+type PowerRequirementSettingsResolver =
+  | (PowerElectricalSettings & { powerFactor?: number })
+  | ((table: PowerTable) => PowerElectricalSettings & { powerFactor?: number });
+
+type SavedPowerRequirementGenerationTable = {
+  generationTimestamp: string;
+  powerRequirementId: string;
+  tableId?: PowerTable["id"];
+};
 
 export const getPowerReportUploadCategory = (department: TechnicalDepartment) =>
   department === "lights" ? "calculators/lights-consumos" : "calculators/consumos";
 
-export const buildPowerTableData = (table: PowerTable, settings: PowerElectricalSettings & { powerFactor?: number }) => {
+export const buildPowerTableData = (
+  table: PowerTable,
+  settings: PowerElectricalSettings & { powerFactor?: number },
+  options: { generationTimestamp?: string } = {},
+) => {
   const payload = {
     rows: table.rows,
     ...(table.id !== undefined ? { sourceTableId: String(table.id) } : {}),
+    ...(options.generationTimestamp || table.generationTimestamp
+      ? { generationTimestamp: options.generationTimestamp || table.generationTimestamp }
+      : {}),
     ...(table.stageNumber ? { stageNumber: table.stageNumber } : {}),
     ...(table.stageName ? { stageName: table.stageName } : {}),
     safetyMargin: settings.safetyMargin,
@@ -62,20 +78,24 @@ const getPowerTableStage = (
 
 export const buildPowerRequirementInsert = ({
   department,
+  generationTimestamp,
   jobId,
   settings,
   stage,
   table,
 }: {
   department: TechnicalDepartment;
+  generationTimestamp?: string;
   jobId: string;
   settings?: PowerElectricalSettings & { powerFactor?: number };
   stage?: TechnicalStage | null;
   table: PowerTable;
 }) => {
   const tableStage = getPowerTableStage(table, stage);
+  const resolvedGenerationTimestamp = generationTimestamp || table.generationTimestamp;
 
   return {
+    ...(resolvedGenerationTimestamp ? { created_at: resolvedGenerationTimestamp } : {}),
     job_id: jobId,
     department,
     stage_number: tableStage?.number ?? null,
@@ -89,46 +109,59 @@ export const buildPowerRequirementInsert = ({
     custom_position: table.customPosition || null,
     table_data: (settings ? buildPowerTableData({
       ...table,
+      generationTimestamp: resolvedGenerationTimestamp,
       stageName: tableStage?.name ?? table.stageName,
       stageNumber: tableStage?.number ?? table.stageNumber,
-    }, settings) : ({
+    }, settings, { generationTimestamp: resolvedGenerationTimestamp }) : ({
       rows: table.rows,
+      ...(resolvedGenerationTimestamp ? { generationTimestamp: resolvedGenerationTimestamp } : {}),
       ...(tableStage ? { stageNumber: tableStage.number, stageName: tableStage.name } : {}),
     } as unknown as Json)),
     includes_hoist: table.includesHoist || false,
   };
 };
 
-const deletePreviousPowerRequirementGenerations = async ({
+const formatPostgrestInList = (values: string[]) =>
+  `(${values.map((value) => `"${value.replace(/"/g, '\\"')}"`).join(",")})`;
+
+const deleteStalePowerRequirementGenerationRows = async ({
   client,
-  insertedId,
+  department,
+  keepIds,
   jobId,
-  payload,
+  stageNumber,
 }: {
   client: PowerPersistenceClient;
-  insertedId: string;
+  department: TechnicalDepartment;
+  keepIds: string[];
   jobId: string;
-  payload: PowerRequirementInsertPayload;
+  stageNumber: number | null;
 }) => {
   let deleteQuery = client
     .from("power_requirement_tables")
     .delete()
     .eq("job_id", jobId)
-    .eq("department", payload.department)
-    .neq("id", insertedId);
+    .eq("department", department)
+    .not("id", "in", formatPostgrestInList(keepIds));
 
   deleteQuery =
-    payload.stage_number === null
+    stageNumber === null
       ? deleteQuery.is("stage_number", null)
-      : deleteQuery.eq("stage_number", payload.stage_number);
+      : deleteQuery.eq("stage_number", stageNumber);
 
   const { error } = await deleteQuery;
   if (error) throw error;
 };
 
+const resolvePowerRequirementSettings = (
+  settings: PowerRequirementSettingsResolver,
+  table: PowerTable,
+) => (typeof settings === "function" ? settings(table) : settings);
+
 export const saveJobPowerRequirementTable = async ({
   client,
   department,
+  generationTimestamp,
   jobId,
   settings,
   stage,
@@ -136,6 +169,7 @@ export const saveJobPowerRequirementTable = async ({
 }: {
   client: PowerPersistenceClient;
   department: TechnicalDepartment;
+  generationTimestamp?: string;
   jobId: string;
   settings?: PowerElectricalSettings & { powerFactor?: number };
   stage?: TechnicalStage | null;
@@ -143,6 +177,7 @@ export const saveJobPowerRequirementTable = async ({
 }): Promise<string> => {
   const payload = buildPowerRequirementInsert({
     department,
+    generationTimestamp,
     jobId,
     settings,
     stage,
@@ -169,15 +204,77 @@ export const saveJobPowerRequirementTable = async ({
     .single();
 
   if (error) throw error;
-  const insertedId = data.id as string;
-  await deletePreviousPowerRequirementGenerations({
-    client,
-    insertedId,
-    jobId,
-    payload,
+  return data.id as string;
+};
+
+export const saveJobPowerRequirementTablesGeneration = async ({
+  client,
+  department,
+  generationTimestamp = new Date().toISOString(),
+  jobId,
+  settings,
+  stage,
+  tables,
+}: {
+  client: PowerPersistenceClient;
+  department: TechnicalDepartment;
+  generationTimestamp?: string;
+  jobId: string;
+  settings: PowerRequirementSettingsResolver;
+  stage?: TechnicalStage | null;
+  tables: PowerTable[];
+}): Promise<SavedPowerRequirementGenerationTable[]> => {
+  if (tables.length === 0) return [];
+
+  const payloads = tables.map((table) =>
+    buildPowerRequirementInsert({
+      department,
+      generationTimestamp,
+      jobId,
+      settings: resolvePowerRequirementSettings(settings, table),
+      stage,
+      table,
+    })
+  );
+
+  const { data, error } = await client
+    .from("power_requirement_tables")
+    .insert(payloads)
+    .select("id, stage_number");
+
+  if (error) throw error;
+
+  const insertedRows = (data || []) as Array<{ id: string; stage_number: number | null }>;
+  const savedTables = insertedRows.map((row, index) => ({
+    generationTimestamp,
+    powerRequirementId: row.id,
+    tableId: tables[index]?.id,
+  }));
+
+  const keepIdsByStage = new Map<string, { ids: string[]; stageNumber: number | null }>();
+  insertedRows.forEach((row, index) => {
+    const stageNumber = typeof row.stage_number === "number"
+      ? row.stage_number
+      : payloads[index]?.stage_number ?? null;
+    const stageKey = stageNumber === null ? "no-stage" : `stage-${stageNumber}`;
+    const stageGroup = keepIdsByStage.get(stageKey) || { ids: [], stageNumber };
+    stageGroup.ids.push(row.id);
+    keepIdsByStage.set(stageKey, stageGroup);
   });
 
-  return insertedId;
+  await Promise.all(
+    [...keepIdsByStage.values()].map((stageGroup) =>
+      deleteStalePowerRequirementGenerationRows({
+        client,
+        department,
+        keepIds: stageGroup.ids,
+        jobId,
+        stageNumber: stageGroup.stageNumber,
+      })
+    )
+  );
+
+  return savedTables;
 };
 
 export const deleteJobPowerRequirementTable = async ({

--- a/src/features/technical-tools/power/types.ts
+++ b/src/features/technical-tools/power/types.ts
@@ -22,6 +22,7 @@ export type PowerTableRow = {
 export type PowerTable = {
   id?: number | string;
   powerRequirementId?: string;
+  generationTimestamp?: string;
   stageNumber?: number | null;
   stageName?: string | null;
   name: string;

--- a/src/pages/ConsumosTool.tsx
+++ b/src/pages/ConsumosTool.tsx
@@ -29,6 +29,7 @@ import {
   buildTourPowerDefaultTable,
   deleteJobPowerRequirementTable,
   saveJobPowerRequirementTable,
+  saveJobPowerRequirementTablesGeneration,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
@@ -223,6 +224,7 @@ const ConsumosTool: React.FC = () => {
       const powerRequirementId = await saveJobPowerRequirementTable({
         client: dataLayerClient,
         department: 'sound',
+        generationTimestamp: table.generationTimestamp,
         jobId: selectedJobId,
         settings: getPowerSettings(),
         stage: selectedStage,
@@ -475,6 +477,30 @@ const ConsumosTool: React.FC = () => {
         : isTourDefaults
           ? tourDefaultTables
           : activeTables;
+
+      if (!isTourDefaults && !isJobOverrideMode && selectedJobId && allTables.length > 0) {
+        const savedTables = await saveJobPowerRequirementTablesGeneration({
+          client: dataLayerClient,
+          department: 'sound',
+          jobId: selectedJobId,
+          settings: getPowerSettings(),
+          stage: selectedStage,
+          tables: allTables,
+        });
+
+        setTables((storedTables) =>
+          storedTables.map((storedTable) => {
+            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
+            return savedTable
+              ? {
+                  ...storedTable,
+                  generationTimestamp: savedTable.generationTimestamp,
+                  powerRequirementId: savedTable.powerRequirementId,
+                }
+              : storedTable;
+          })
+        );
+      }
 
       const totalSystemWatts = allTables.reduce((sum, table) => sum + (table.totalWatts || 0), 0);
       const totalSystemAmps = allTables.reduce((sum, table) => sum + (table.currentPerPhase || 0), 0);

--- a/src/pages/LightsConsumosTool.tsx
+++ b/src/pages/LightsConsumosTool.tsx
@@ -38,6 +38,7 @@ import {
   buildTourPowerDefaultTable,
   deleteJobPowerRequirementTable,
   saveJobPowerRequirementTable,
+  saveJobPowerRequirementTablesGeneration,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
@@ -176,6 +177,7 @@ interface Table {
   customPosition?: string;
   includesHoist?: boolean;
   id?: number | string;
+  generationTimestamp?: string;
   isDefault?: boolean;
   defaultTableId?: string;
   // snapshot of settings at generation time, used for persisting tour defaults
@@ -590,6 +592,7 @@ const LightsConsumosTool: React.FC = () => {
       const powerRequirementId = await saveJobPowerRequirementTable({
         client: dataLayerClient,
         department: 'lights',
+        generationTimestamp: table.generationTimestamp,
         jobId: selectedJobId,
         settings: getPowerSettings({
           phaseMode: table.snapshotPhaseMode,
@@ -808,6 +811,37 @@ const LightsConsumosTool: React.FC = () => {
       const allTables = isOverrideMode
         ? [...defaultTables, ...tables]
         : activeTables;
+
+      if (!isTourDefaults && !isOverrideMode && selectedJobId && allTables.length > 0) {
+        const savedTables = await saveJobPowerRequirementTablesGeneration({
+          client: dataLayerClient,
+          department: 'lights',
+          jobId: selectedJobId,
+          settings: (table) => {
+            const lightsTable = table as Table;
+            return getPowerSettings({
+              phaseMode: lightsTable.snapshotPhaseMode,
+              safetyMargin: lightsTable.snapshotSafetyMargin,
+              voltage: lightsTable.snapshotVoltage,
+            });
+          },
+          stage: selectedStage,
+          tables: allTables,
+        });
+
+        setTables((storedTables) =>
+          storedTables.map((storedTable) => {
+            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
+            return savedTable
+              ? {
+                  ...storedTable,
+                  generationTimestamp: savedTable.generationTimestamp,
+                  powerRequirementId: savedTable.powerRequirementId,
+                }
+              : storedTable;
+          })
+        );
+      }
 
       let logoUrl: string | undefined = undefined;
       try {

--- a/src/pages/VideoConsumosTool.tsx
+++ b/src/pages/VideoConsumosTool.tsx
@@ -25,6 +25,7 @@ import {
   buildTourPowerDefaultTable,
   deleteJobPowerRequirementTable,
   saveJobPowerRequirementTable,
+  saveJobPowerRequirementTablesGeneration,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
 import {
@@ -75,6 +76,7 @@ interface Table {
   position?: string;
   customPosition?: string;
   id?: number | string;
+  generationTimestamp?: string;
   includesHoist?: boolean;
   isDefault?: boolean;
 }
@@ -295,6 +297,7 @@ const VideoConsumosTool: React.FC = () => {
       const powerRequirementId = await saveJobPowerRequirementTable({
         client: dataLayerClient,
         department: 'video',
+        generationTimestamp: table.generationTimestamp,
         jobId: selectedJobId,
         settings: getPowerSettings(),
         stage: selectedStage,
@@ -472,6 +475,30 @@ const VideoConsumosTool: React.FC = () => {
       const allTables = isOverrideMode 
         ? [...defaultTables, ...tables]
         : activeTables;
+
+      if (!isTourDefaults && !isOverrideMode && selectedJobId && allTables.length > 0) {
+        const savedTables = await saveJobPowerRequirementTablesGeneration({
+          client: dataLayerClient,
+          department: 'video',
+          jobId: selectedJobId,
+          settings: getPowerSettings(),
+          stage: selectedStage,
+          tables: allTables,
+        });
+
+        setTables((storedTables) =>
+          storedTables.map((storedTable) => {
+            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
+            return savedTable
+              ? {
+                  ...storedTable,
+                  generationTimestamp: savedTable.generationTimestamp,
+                  powerRequirementId: savedTable.powerRequirementId,
+                }
+              : storedTable;
+          })
+        );
+      }
 
       // Generate power summary for consumos reports
       const totalSystemWatts = allTables.reduce((sum, table) => sum + (table.totalWatts || 0), 0);

--- a/src/pages/consumos-tool/types.ts
+++ b/src/pages/consumos-tool/types.ts
@@ -23,6 +23,7 @@ export interface Table {
   customPosition?: string;
   id?: number | string;
   includesHoist?: boolean;
+  generationTimestamp?: string;
   isDefault?: boolean;
   isOverride?: boolean;
   overrideId?: string;

--- a/src/utils/__tests__/powerSummaryData.test.ts
+++ b/src/utils/__tests__/powerSummaryData.test.ts
@@ -232,7 +232,7 @@ describe('powerSummaryData', () => {
     expect(summary.departments.sound.rows[0].notes).toContain('CEE32A');
   });
 
-  it('keeps only the newest table for the same department and stage even when table names differ', async () => {
+  it('keeps different legacy sets separate for the same department and stage', async () => {
     const supabase = createMockSupabase({
       power_requirement_tables: [
         {
@@ -279,9 +279,99 @@ describe('powerSummaryData', () => {
       supabase,
     });
 
-    expect(summary.departments.sound.rows).toHaveLength(1);
-    expect(summary.departments.sound.rows[0].name).toBe('Side PA');
-    expect(summary.departments.sound.rows[0].positionLabel).toBe('Stage 2');
+    expect(summary.departments.sound.rows).toHaveLength(2);
+    expect(summary.departments.sound.rows.map((row) => row.name)).toEqual([
+      'Main PA',
+      'Side PA',
+    ]);
+  });
+
+  it('keeps every row from the latest timestamped generation for a department and stage', async () => {
+    const supabase = createMockSupabase({
+      power_requirement_tables: [
+        {
+          id: 'sound-old-main',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'Old Main',
+          total_watts: 1000,
+          current_per_phase: 4,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: {
+            generationTimestamp: '2026-04-07T08:00:00.000Z',
+            sourceTableId: 'old-main',
+            rows: [{ quantity: '1', componentId: '1', watts: '1000' }],
+          },
+        },
+        {
+          id: 'sound-old-delay',
+          created_at: '2026-04-07T08:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'Old Delay',
+          total_watts: 1200,
+          current_per_phase: 5,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: {
+            generationTimestamp: '2026-04-07T08:00:00.000Z',
+            sourceTableId: 'old-delay',
+            rows: [{ quantity: '1', componentId: '1', watts: '1200' }],
+          },
+        },
+        {
+          id: 'sound-new-main',
+          created_at: '2026-04-07T09:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'Main PA',
+          total_watts: 3000,
+          current_per_phase: 12,
+          pdu_type: '63A',
+          custom_pdu_type: null,
+          includes_hoist: false,
+          table_data: {
+            generationTimestamp: '2026-04-07T09:00:00.000Z',
+            sourceTableId: 'new-main',
+            rows: [{ quantity: '1', componentId: '1', watts: '3000' }],
+          },
+        },
+        {
+          id: 'sound-new-delay',
+          created_at: '2026-04-07T09:00:00.000Z',
+          job_id: 'job-1',
+          department: 'sound',
+          table_name: 'Delay PA',
+          total_watts: 2000,
+          current_per_phase: 8,
+          pdu_type: '32A',
+          custom_pdu_type: null,
+          includes_hoist: true,
+          table_data: {
+            generationTimestamp: '2026-04-07T09:00:00.000Z',
+            sourceTableId: 'new-delay',
+            rows: [{ quantity: '1', componentId: '1', watts: '2000' }],
+          },
+        },
+      ],
+    });
+
+    const summary = await loadTechnicalPowerSummaryData({
+      job: { id: 'job-1', job_type: 'single' },
+      supabase,
+    });
+
+    expect(summary.departments.sound.rows).toHaveLength(2);
+    expect(summary.departments.sound.rows.map((row) => row.name)).toEqual([
+      'Main PA',
+      'Delay PA',
+    ]);
+    expect(summary.departments.sound.totalWatts).toBe(5000);
+    expect(summary.departments.sound.rows[1].notes).toContain('CEE32A');
   });
 
   it('keeps same saved table identity separate per festival stage', async () => {
@@ -408,6 +498,75 @@ describe('powerSummaryData', () => {
 
     expect(text).toContain('Potencia Total: 29000.00W');
     expect(text).not.toContain('Potencia Total: 31500.00W');
+  });
+
+  it('formats every row from the latest timestamped generation in hoja de ruta power text', () => {
+    const text = formatPowerRequirementsText([
+      {
+        id: 'sound-old-main',
+        created_at: '2026-04-07T08:00:00.000Z',
+        job_id: 'job-1',
+        department: 'sound',
+        stage_number: null,
+        stage_name: null,
+        table_name: 'Old Main',
+        total_watts: 1000,
+        current_per_phase: 4,
+        pdu_type: '32A',
+        custom_pdu_type: null,
+        custom_position: null,
+        position: null,
+        includes_hoist: false,
+        table_data: {
+          generationTimestamp: '2026-04-07T08:00:00.000Z',
+          rows: [],
+        },
+      } as any,
+      {
+        id: 'sound-new-main',
+        created_at: '2026-04-07T09:00:00.000Z',
+        job_id: 'job-1',
+        department: 'sound',
+        stage_number: null,
+        stage_name: null,
+        table_name: 'Main PA',
+        total_watts: 3000,
+        current_per_phase: 12,
+        pdu_type: '63A',
+        custom_pdu_type: null,
+        custom_position: null,
+        position: null,
+        includes_hoist: false,
+        table_data: {
+          generationTimestamp: '2026-04-07T09:00:00.000Z',
+          rows: [],
+        },
+      } as any,
+      {
+        id: 'sound-new-delay',
+        created_at: '2026-04-07T09:00:00.000Z',
+        job_id: 'job-1',
+        department: 'sound',
+        stage_number: null,
+        stage_name: null,
+        table_name: 'Delay PA',
+        total_watts: 2000,
+        current_per_phase: 8,
+        pdu_type: '32A',
+        custom_pdu_type: null,
+        custom_position: null,
+        position: null,
+        includes_hoist: false,
+        table_data: {
+          generationTimestamp: '2026-04-07T09:00:00.000Z',
+          rows: [],
+        },
+      } as any,
+    ]);
+
+    expect(text).toContain('SOUND - Main PA:');
+    expect(text).toContain('SOUND - Delay PA:');
+    expect(text).not.toContain('Old Main');
   });
 
   it('keeps numeric stage zero when formatting hoja de ruta power text', () => {

--- a/src/utils/powerSummaryData.ts
+++ b/src/utils/powerSummaryData.ts
@@ -124,12 +124,49 @@ const getPowerRequirementStageKey = (row: PowerRequirementTableRow) => {
   return stageName ? `stage-name-${stageName.toLowerCase()}` : 'no-stage';
 };
 
+const getPowerRequirementGenerationTimestamp = (row: PowerRequirementTableRow) => {
+  if (!isRecord(row.table_data)) return null;
+
+  const generationTimestamp = row.table_data.generationTimestamp;
+  return typeof generationTimestamp === 'string' && generationTimestamp.trim()
+    ? generationTimestamp.trim()
+    : null;
+};
+
+const getPowerRequirementSourceTimestamp = (row: PowerRequirementTableRow) => {
+  if (!isRecord(row.table_data)) return null;
+
+  const sourceTableId = row.table_data.sourceTableId;
+  if (typeof sourceTableId === 'number' && Number.isFinite(sourceTableId)) {
+    return sourceTableId;
+  }
+
+  if (typeof sourceTableId === 'string') {
+    const parsed = Number(sourceTableId);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+const parseTimestampValue = (timestamp: string | null | undefined) => {
+  if (!timestamp) return 0;
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
 const comparePowerRequirementTablesByFreshness = (
   left: IndexedPowerRequirementTableRow,
   right: IndexedPowerRequirementTableRow
 ) => {
-  const leftTimestamp = left.row.created_at ? Date.parse(left.row.created_at) : 0;
-  const rightTimestamp = right.row.created_at ? Date.parse(right.row.created_at) : 0;
+  const leftTimestamp =
+    parseTimestampValue(getPowerRequirementGenerationTimestamp(left.row)) ||
+    getPowerRequirementSourceTimestamp(left.row) ||
+    parseTimestampValue(left.row.created_at);
+  const rightTimestamp =
+    parseTimestampValue(getPowerRequirementGenerationTimestamp(right.row)) ||
+    getPowerRequirementSourceTimestamp(right.row) ||
+    parseTimestampValue(right.row.created_at);
 
   if (leftTimestamp !== rightTimestamp) {
     return leftTimestamp - rightTimestamp;
@@ -144,33 +181,94 @@ const comparePowerRequirementTablesByFreshness = (
   return left.inputIndex - right.inputIndex;
 };
 
-const getPowerRequirementTableCurrentKey = (
+const getPowerRequirementScopeKey = (
   row: PowerRequirementTableRow,
   department: TechnicalPowerDepartment
 ) => `${department}:${getPowerRequirementStageKey(row)}`;
 
+const getLegacyPowerRequirementTableIdentityKey = (
+  row: PowerRequirementTableRow,
+  department: TechnicalPowerDepartment
+) =>
+  [
+    getPowerRequirementScopeKey(row, department),
+    row.table_name?.trim().toLowerCase() || 'unnamed',
+    row.position?.trim().toLowerCase() || '',
+    row.custom_position?.trim().toLowerCase() || '',
+  ].join(':');
+
+const compareGenerationTimestamp = (left: string, right: string) => {
+  const leftTimestamp = parseTimestampValue(left);
+  const rightTimestamp = parseTimestampValue(right);
+
+  if (leftTimestamp !== rightTimestamp) {
+    return leftTimestamp - rightTimestamp;
+  }
+
+  return left.localeCompare(right);
+};
+
 export const getCurrentPowerRequirementTables = (
   rows: PowerRequirementTableRow[]
 ): PowerRequirementTableRow[] => {
-  const latestRows = new Map<string, IndexedPowerRequirementTableRow>();
+  const rowsByScope = new Map<string, IndexedPowerRequirementTableRow[]>();
 
   rows.forEach((row, inputIndex) => {
     const department = row.department as TechnicalPowerDepartment | null;
     if (!department) return;
 
-    const dedupKey = getPowerRequirementTableCurrentKey(row, department);
-    const current = latestRows.get(dedupKey);
-    const indexedRow = { row, inputIndex };
-
-    if (
-      !current ||
-      comparePowerRequirementTablesByFreshness(indexedRow, current) >= 0
-    ) {
-      latestRows.set(dedupKey, indexedRow);
-    }
+    const scopeKey = getPowerRequirementScopeKey(row, department);
+    rowsByScope.set(scopeKey, [...(rowsByScope.get(scopeKey) || []), { row, inputIndex }]);
   });
 
-  return [...latestRows.values()]
+  const currentRows: IndexedPowerRequirementTableRow[] = [];
+
+  rowsByScope.forEach((scopeRows) => {
+    const rowsWithGeneration = scopeRows.filter((value) =>
+      getPowerRequirementGenerationTimestamp(value.row)
+    );
+
+    if (rowsWithGeneration.length > 0) {
+      const latestGeneration = rowsWithGeneration.reduce<string | null>(
+        (latest, value) => {
+          const generationTimestamp = getPowerRequirementGenerationTimestamp(value.row);
+          if (!generationTimestamp) return latest;
+          if (!latest || compareGenerationTimestamp(generationTimestamp, latest) > 0) {
+            return generationTimestamp;
+          }
+          return latest;
+        },
+        null
+      );
+
+      currentRows.push(
+        ...rowsWithGeneration.filter(
+          (value) => getPowerRequirementGenerationTimestamp(value.row) === latestGeneration
+        )
+      );
+      return;
+    }
+
+    const latestLegacyRows = new Map<string, IndexedPowerRequirementTableRow>();
+    scopeRows.forEach((indexedRow) => {
+      const department = indexedRow.row.department as TechnicalPowerDepartment | null;
+      if (!department) return;
+
+      const identityKey = getLegacyPowerRequirementTableIdentityKey(indexedRow.row, department);
+      const current = latestLegacyRows.get(identityKey);
+
+      if (
+        !current ||
+        comparePowerRequirementTablesByFreshness(indexedRow, current) >= 0
+      ) {
+        latestLegacyRows.set(identityKey, indexedRow);
+      }
+    });
+
+    currentRows.push(...latestLegacyRows.values());
+  });
+
+  return currentRows
     .sort(comparePowerRequirementTablesByFreshness)
     .map((value) => value.row);
 };


### PR DESCRIPTION
## Summary
- Preserve multiple power requirement set rows for a job instead of collapsing a department/stage to one row.
- Stamp normal Sound/Lights/Video power report exports with a shared `generationTimestamp` and replace only rows outside that saved generation.
- Make resumen/hoja power aggregation use all rows from the latest timestamped generation per department/stage, with a legacy fallback that keeps separate set rows and dedupes only matching legacy set identities.

## Root cause
The previous hotfix keyed current rows only by department + stage. That prevented stale generations from combining, but it also collapsed legitimate multiple set rows in the same department/stage. The real current-generation boundary is timestamp-based: all rows from the latest generated batch are current.

## Risk Assessment
Risk level: medium.

This touches the persistence path for normal power report exports and the aggregation path used by resumen and hoja de ruta power text. The main risk is generation cleanup deleting too much; the cleanup now runs only after a full batch insert and keeps the inserted IDs for each department/stage scope.

## Impact Checklist
- Database migration: none; generation timestamp is stored in existing `table_data` JSON and `created_at` for the batch rows.
- Supabase RLS/security: no schema or policy changes.
- Realtime/subscriptions: not affected.
- Performance: one batch insert plus scoped cleanup on normal report export; summary grouping remains in-memory over existing query results.
- User-facing behavior: resumen keeps all current set rows from the latest generation and stops mixing old generations.

## Rollback Plan
Revert this PR to restore the previous department/stage-only grouping behavior. No database rollback is required because no migration is included.

## Migration Impact
No Supabase migrations are included. No production database push is required; merging to `main` is the deploy path.

## Validation
- `npm install --legacy-peer-deps`
- `npm run typecheck`
- `npx vitest run src/features/technical-tools/power/__tests__/powerPersistence.test.ts src/utils/__tests__/powerSummaryData.test.ts`
- `npm run test:run` passed: 144 test files, 917 tests.
- `npm run lint` passed with 0 errors; existing repo warnings remain.
- `npm run build` passed.