### PR TITLE
[codex] Save power requirement sets on export

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.11.0",
-    "@vitest/coverage-v8": "^2.1.9",
+    "@vitest/coverage-v8": "^3.2.6",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
@@ -141,6 +141,6 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^6.3.3",
-    "vitest": "^2.1.9"
+    "vitest": "^3.2.6"
   }
 }

--- a/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
+++ b/src/features/technical-tools/power/__tests__/powerPersistence.test.ts
@@ -261,4 +261,52 @@ describe("technical power persistence payloads", () => {
       expect.arrayContaining([{ method: "is", args: ["stage_number", null] }])
     );
   });
+
+  it("clears a scoped generation when the exported table batch is empty", async () => {
+    const { client, operations } = createPowerRequirementTableClient();
+
+    await expect(
+      saveJobPowerRequirementTablesGeneration({
+        client,
+        department: "lights",
+        jobId: "job-1",
+        settings,
+        stage: { number: 1, name: "Main Stage" },
+        tables: [],
+      })
+    ).resolves.toEqual([]);
+
+    expect(operations).toEqual(
+      expect.arrayContaining([
+        { method: "delete", args: [] },
+        { method: "eq", args: ["job_id", "job-1"] },
+        { method: "eq", args: ["department", "lights"] },
+        { method: "eq", args: ["stage_number", 1] },
+      ])
+    );
+    expect(operations).not.toEqual(expect.arrayContaining([{ method: "insert", args: [expect.anything()] }]));
+    expect(operations).not.toEqual(expect.arrayContaining([{ method: "not", args: expect.any(Array) }]));
+  });
+
+  it("clears the department generation when an empty export has no selected stage", async () => {
+    const { client, operations } = createPowerRequirementTableClient();
+
+    await saveJobPowerRequirementTablesGeneration({
+      client,
+      department: "video",
+      jobId: "job-1",
+      settings,
+      tables: [],
+    });
+
+    expect(operations).toEqual(
+      expect.arrayContaining([
+        { method: "delete", args: [] },
+        { method: "eq", args: ["job_id", "job-1"] },
+        { method: "eq", args: ["department", "video"] },
+      ])
+    );
+    expect(operations).not.toEqual(expect.arrayContaining([{ method: "eq", args: ["stage_number", expect.anything()] }]));
+    expect(operations).not.toEqual(expect.arrayContaining([{ method: "is", args: ["stage_number", null] }]));
+  });
 });

--- a/src/features/technical-tools/power/powerPersistence.ts
+++ b/src/features/technical-tools/power/powerPersistence.ts
@@ -135,19 +135,24 @@ const deleteStalePowerRequirementGenerationRows = async ({
   department: TechnicalDepartment;
   keepIds: string[];
   jobId: string;
-  stageNumber: number | null;
+  stageNumber?: number | null;
 }) => {
   let deleteQuery = client
     .from("power_requirement_tables")
     .delete()
     .eq("job_id", jobId)
-    .eq("department", department)
-    .not("id", "in", formatPostgrestInList(keepIds));
+    .eq("department", department);
 
-  deleteQuery =
-    stageNumber === null
-      ? deleteQuery.is("stage_number", null)
-      : deleteQuery.eq("stage_number", stageNumber);
+  if (keepIds.length > 0) {
+    deleteQuery = deleteQuery.not("id", "in", formatPostgrestInList(keepIds));
+  }
+
+  if (stageNumber !== undefined) {
+    deleteQuery =
+      stageNumber === null
+        ? deleteQuery.is("stage_number", null)
+        : deleteQuery.eq("stage_number", stageNumber);
+  }
 
   const { error } = await deleteQuery;
   if (error) throw error;
@@ -224,7 +229,16 @@ export const saveJobPowerRequirementTablesGeneration = async ({
   stage?: TechnicalStage | null;
   tables: PowerTable[];
 }): Promise<SavedPowerRequirementGenerationTable[]> => {
-  if (tables.length === 0) return [];
+  if (tables.length === 0) {
+    await deleteStalePowerRequirementGenerationRows({
+      client,
+      department,
+      keepIds: [],
+      jobId,
+      stageNumber: stage?.number,
+    });
+    return [];
+  }
 
   const payloads = tables.map((table) =>
     buildPowerRequirementInsert({

--- a/src/pages/ConsumosTool.tsx
+++ b/src/pages/ConsumosTool.tsx
@@ -27,8 +27,6 @@ import {
   buildPowerTableData,
   buildPowerTableMetadata,
   buildTourPowerDefaultTable,
-  deleteJobPowerRequirementTable,
-  saveJobPowerRequirementTable,
   saveJobPowerRequirementTablesGeneration,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
@@ -216,33 +214,6 @@ const ConsumosTool: React.FC = () => {
     ? tables.filter((table) => isSameTechnicalStage(table.stageNumber, selectedStage))
     : tables;
 
-  const savePowerRequirementTable = async (
-    table: Table,
-    { showToast = true }: { showToast?: boolean } = {},
-  ) => {
-    try {
-      const powerRequirementId = await saveJobPowerRequirementTable({
-        client: dataLayerClient,
-        department: 'sound',
-        generationTimestamp: table.generationTimestamp,
-        jobId: selectedJobId,
-        settings: getPowerSettings(),
-        stage: selectedStage,
-        table,
-      });
-
-      if (showToast) {
-        toast({ title: "Success", description: "Power requirement table saved successfully" });
-      }
-
-      return powerRequirementId;
-    } catch (error: any) {
-      console.error('Error saving power requirement table:', error);
-      toast({ title: "Error", description: "Failed to save power requirement table", variant: "destructive" });
-      return table.powerRequirementId;
-    }
-  };
-
   // NEW: Save as tour defaults using the new system
   const { createTable: _createTourDefaultTableInternal } = { createTable: createTourDefaultTable }; // keep name stable
   const saveTourDefault = async (table: Table) => {
@@ -336,20 +307,13 @@ const ConsumosTool: React.FC = () => {
       },
     }) as Table;
 
-    let tableToAdd = newTable;
-
     if (isTourDefaults) {
       // user can tweak before saving defaults
     } else if (isJobOverrideMode) {
       await saveTourOverride(newTable);
-    } else if (selectedJobId) {
-      const powerRequirementId = await savePowerRequirementTable(newTable);
-      if (powerRequirementId) {
-        tableToAdd = { ...newTable, powerRequirementId };
-      }
     }
 
-    setTables((prev) => [...prev, tableToAdd]);
+    setTables((prev) => [...prev, newTable]);
     resetCurrentTable();
   };
 
@@ -371,22 +335,7 @@ const ConsumosTool: React.FC = () => {
       return;
     }
 
-    if (!selectedJobId || isTourDefaults || isJobOverrideMode || !tableToRemove?.powerRequirementId) {
-      setTables((prev) => prev.filter((table) => table.id !== tableId));
-      return;
-    }
-
-    try {
-      await deleteJobPowerRequirementTable({
-        client: dataLayerClient,
-        jobId: selectedJobId,
-        table: tableToRemove,
-      });
-      setTables((prev) => prev.filter((table) => table.id !== tableId));
-    } catch (error) {
-      console.error('Error deleting power requirement table:', error);
-      toast({ title: "Error", description: "Failed to delete power requirement table", variant: "destructive" });
-    }
+    setTables((prev) => prev.filter((table) => table.id !== tableId));
   };
 
   // Save unsaved default tables
@@ -450,15 +399,6 @@ const ConsumosTool: React.FC = () => {
           override_data: buildPowerTableData(updatedTable, getPowerSettings()),
         }
       });
-    } else if (selectedJobId) {
-      const powerRequirementId = await savePowerRequirementTable(updatedTable, { showToast: false });
-      if (powerRequirementId && powerRequirementId !== updatedTable.powerRequirementId) {
-        setTables((prev) =>
-          prev.map((table) =>
-            table.id === tableId ? { ...table, powerRequirementId } : table
-          )
-        );
-      }
     }
   };
 
@@ -477,30 +417,6 @@ const ConsumosTool: React.FC = () => {
         : isTourDefaults
           ? tourDefaultTables
           : activeTables;
-
-      if (!isTourDefaults && !isJobOverrideMode && selectedJobId && allTables.length > 0) {
-        const savedTables = await saveJobPowerRequirementTablesGeneration({
-          client: dataLayerClient,
-          department: 'sound',
-          jobId: selectedJobId,
-          settings: getPowerSettings(),
-          stage: selectedStage,
-          tables: allTables,
-        });
-
-        setTables((storedTables) =>
-          storedTables.map((storedTable) => {
-            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
-            return savedTable
-              ? {
-                  ...storedTable,
-                  generationTimestamp: savedTable.generationTimestamp,
-                  powerRequirementId: savedTable.powerRequirementId,
-                }
-              : storedTable;
-          })
-        );
-      }
 
       const totalSystemWatts = allTables.reduce((sum, table) => sum + (table.totalWatts || 0), 0);
       const totalSystemAmps = allTables.reduce((sum, table) => sum + (table.currentPerPhase || 0), 0);
@@ -561,6 +477,30 @@ const ConsumosTool: React.FC = () => {
         if (completedTasksCount > 0) {
           console.log(`Auto-completed ${completedTasksCount} sound Consumos task(s)`);
         }
+      }
+
+      if (!isTourDefaults && !isJobOverrideMode && selectedJobId) {
+        const savedTables = await saveJobPowerRequirementTablesGeneration({
+          client: dataLayerClient,
+          department: 'sound',
+          jobId: selectedJobId,
+          settings: getPowerSettings(),
+          stage: selectedStage,
+          tables: allTables,
+        });
+
+        setTables((storedTables) =>
+          storedTables.map((storedTable) => {
+            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
+            return savedTable
+              ? {
+                  ...storedTable,
+                  generationTimestamp: savedTable.generationTimestamp,
+                  powerRequirementId: savedTable.powerRequirementId,
+                }
+              : storedTable;
+          })
+        );
       }
 
       toast({

--- a/src/pages/LightsConsumosTool.tsx
+++ b/src/pages/LightsConsumosTool.tsx
@@ -36,8 +36,6 @@ import {
   buildPowerTableData,
   buildPowerTableMetadata,
   buildTourPowerDefaultTable,
-  deleteJobPowerRequirementTable,
-  saveJobPowerRequirementTable,
   saveJobPowerRequirementTablesGeneration,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
@@ -565,59 +563,44 @@ const LightsConsumosTool: React.FC = () => {
 
   const recommendPDU = (currentLine: number) => recommendPowerPdu(currentLine, pduOptions);
 
-  const savePowerRequirementTable = async (
+  const saveTourOverrideTable = async (
     table: Table,
     { showToast = true }: { showToast?: boolean } = {},
   ) => {
-    if (isOverrideMode && overrideData) {
-      // Save as override for tour date
-      const overrideSuccess = await saveOverride('power', buildLegacyPowerOverridePayload({
-        settings: getPowerSettings(),
-        table,
-      }));
-
-      if (overrideSuccess) {
-        toast({
-          title: "Success",
-          description: "Override saved for tour date",
-        });
-      }
+    if (!isOverrideMode || !overrideData) {
       return table.powerRequirementId;
     }
 
-    // Original job-based save logic
-    if (!selectedJobId) return;
+    const overrideSuccess = await saveOverride('power', buildLegacyPowerOverridePayload({
+      settings: getPowerSettings(),
+      table,
+    }));
 
-    try {
-      const powerRequirementId = await saveJobPowerRequirementTable({
-        client: dataLayerClient,
-        department: 'lights',
-        generationTimestamp: table.generationTimestamp,
-        jobId: selectedJobId,
-        settings: getPowerSettings({
-          phaseMode: table.snapshotPhaseMode,
-          safetyMargin: table.snapshotSafetyMargin,
-          voltage: table.snapshotVoltage,
-        }),
-        stage: selectedStage,
-        table,
+    if (overrideSuccess && showToast) {
+      toast({
+        title: "Success",
+        description: "Override saved for tour date",
       });
+    }
 
-      if (showToast) {
+    return table.powerRequirementId;
+  };
+
+  const saveTourOverrideTableWithErrorHandling = async (
+    table: Table,
+    options: { showToast?: boolean } = {},
+  ) => {
+    try {
+      return await saveTourOverrideTable(table, options);
+    } catch (error: unknown) {
+      console.error('Error saving tour override table:', error);
+      if (options.showToast !== false) {
         toast({
-          title: "Éxito",
-          description: "La tabla de requerimientos de potencia se ha guardado exitosamente",
+          title: "Error",
+          description: "Error al guardar la anulación de potencia",
+          variant: "destructive",
         });
       }
-
-      return powerRequirementId;
-    } catch (error: unknown) {
-      console.error('Error saving power requirement table:', error);
-      toast({
-        title: "Error",
-        description: "Error al guardar la tabla de requerimientos de potencia",
-        variant: "destructive",
-      });
       return table.powerRequirementId;
     }
   };
@@ -685,18 +668,13 @@ const LightsConsumosTool: React.FC = () => {
       snapshotVoltage: voltage,
     };
 
-    let tableToAdd = newTable;
-
     if (isTourDefaults) {
       // user can review before saving defaults
-    } else if (isOverrideMode || selectedJobId) {
-      const powerRequirementId = await savePowerRequirementTable(newTable);
-      if (powerRequirementId) {
-        tableToAdd = { ...newTable, powerRequirementId };
-      }
+    } else if (isOverrideMode) {
+      await saveTourOverrideTableWithErrorHandling(newTable);
     }
 
-    setTables((prev) => [...prev, tableToAdd]);
+    setTables((prev) => [...prev, newTable]);
     resetCurrentTable();
   };
 
@@ -729,26 +707,7 @@ const LightsConsumosTool: React.FC = () => {
         return;
       }
 
-      if (!selectedJobId || isTourDefaults || isOverrideMode || !tableToRemove?.powerRequirementId) {
-        setTables((prev) => prev.filter((table) => table.id !== tableId));
-        return;
-      }
-
-      try {
-        await deleteJobPowerRequirementTable({
-          client: dataLayerClient,
-          jobId: selectedJobId,
-          table: tableToRemove,
-        });
-        setTables((prev) => prev.filter((table) => table.id !== tableId));
-      } catch (error) {
-        console.error('Error deleting power requirement table:', error);
-        toast({
-          title: "Error",
-          description: "Error al eliminar la tabla de requerimientos de potencia",
-          variant: "destructive",
-        });
-      }
+      setTables((prev) => prev.filter((table) => table.id !== tableId));
     }
   };
 
@@ -770,8 +729,8 @@ const LightsConsumosTool: React.FC = () => {
                 metadata: buildPowerTableMetadata(updatedTable, settings),
               },
             });
-          } else if (!isTourDefaults && (isOverrideMode || selectedJobId)) {
-            void savePowerRequirementTable(updatedTable, { showToast: false })
+          } else if (isOverrideMode) {
+            void saveTourOverrideTableWithErrorHandling(updatedTable, { showToast: false })
               .then((powerRequirementId) => {
                 if (powerRequirementId && powerRequirementId !== updatedTable.powerRequirementId) {
                   setTables((storedTables) =>
@@ -811,37 +770,6 @@ const LightsConsumosTool: React.FC = () => {
       const allTables = isOverrideMode
         ? [...defaultTables, ...tables]
         : activeTables;
-
-      if (!isTourDefaults && !isOverrideMode && selectedJobId && allTables.length > 0) {
-        const savedTables = await saveJobPowerRequirementTablesGeneration({
-          client: dataLayerClient,
-          department: 'lights',
-          jobId: selectedJobId,
-          settings: (table) => {
-            const lightsTable = table as Table;
-            return getPowerSettings({
-              phaseMode: lightsTable.snapshotPhaseMode,
-              safetyMargin: lightsTable.snapshotSafetyMargin,
-              voltage: lightsTable.snapshotVoltage,
-            });
-          },
-          stage: selectedStage,
-          tables: allTables,
-        });
-
-        setTables((storedTables) =>
-          storedTables.map((storedTable) => {
-            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
-            return savedTable
-              ? {
-                  ...storedTable,
-                  generationTimestamp: savedTable.generationTimestamp,
-                  powerRequirementId: savedTable.powerRequirementId,
-                }
-              : storedTable;
-          })
-        );
-      }
 
       let logoUrl: string | undefined = undefined;
       try {
@@ -895,6 +823,37 @@ const LightsConsumosTool: React.FC = () => {
         if (completedTasksCount > 0) {
           console.log(`Auto-completed ${completedTasksCount} lights Consumos task(s)`);
         }
+      }
+
+      if (!isTourDefaults && !isOverrideMode && selectedJobId) {
+        const savedTables = await saveJobPowerRequirementTablesGeneration({
+          client: dataLayerClient,
+          department: 'lights',
+          jobId: selectedJobId,
+          settings: (table) => {
+            const lightsTable = table as Table;
+            return getPowerSettings({
+              phaseMode: lightsTable.snapshotPhaseMode,
+              safetyMargin: lightsTable.snapshotSafetyMargin,
+              voltage: lightsTable.snapshotVoltage,
+            });
+          },
+          stage: selectedStage,
+          tables: allTables,
+        });
+
+        setTables((storedTables) =>
+          storedTables.map((storedTable) => {
+            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
+            return savedTable
+              ? {
+                  ...storedTable,
+                  generationTimestamp: savedTable.generationTimestamp,
+                  powerRequirementId: savedTable.powerRequirementId,
+                }
+              : storedTable;
+          })
+        );
       }
 
       toast({

--- a/src/pages/VideoConsumosTool.tsx
+++ b/src/pages/VideoConsumosTool.tsx
@@ -23,8 +23,6 @@ import { PowerTableControls } from '@/features/technical-tools/power/PowerTableC
 import {
   buildLegacyPowerOverridePayload,
   buildTourPowerDefaultTable,
-  deleteJobPowerRequirementTable,
-  saveJobPowerRequirementTable,
   saveJobPowerRequirementTablesGeneration,
   uploadPowerReportAndCompleteTask,
 } from '@/features/technical-tools/power/powerPersistence';
@@ -269,56 +267,37 @@ const VideoConsumosTool: React.FC = () => {
     ? tables.filter((table) => isSameTechnicalStage(table.stageNumber, selectedStage))
     : tables;
 
-  const savePowerRequirementTable = async (
+  const saveTourOverrideTable = async (
     table: Table,
     { showToast = true }: { showToast?: boolean } = {},
   ) => {
-    if (isOverrideMode && overrideData) {
-      // Save as override for tour date
+    if (!isOverrideMode || !overrideData) {
+      return table.powerRequirementId;
+    }
+
+    try {
       const overrideSuccess = await saveOverride('power', buildLegacyPowerOverridePayload({
         settings: getPowerSettings(),
         table,
       }));
 
-      if (overrideSuccess) {
+      if (overrideSuccess && showToast) {
         toast({
           title: "Success",
           description: "Override saved for tour date",
         });
       }
+
       return table.powerRequirementId;
-    }
-
-    if (!selectedJobId) {
-      return table.powerRequirementId;
-    }
-
-    try {
-      const powerRequirementId = await saveJobPowerRequirementTable({
-        client: dataLayerClient,
-        department: 'video',
-        generationTimestamp: table.generationTimestamp,
-        jobId: selectedJobId,
-        settings: getPowerSettings(),
-        stage: selectedStage,
-        table,
-      });
-
+    } catch (error: any) {
+      console.error('Error saving tour override table:', error);
       if (showToast) {
         toast({
-          title: "Success",
-          description: "Power requirement table saved successfully",
+          title: "Error",
+          description: "Failed to save power override table",
+          variant: "destructive"
         });
       }
-
-      return powerRequirementId;
-    } catch (error: any) {
-      console.error('Error saving power requirement table:', error);
-      toast({
-        title: "Error",
-        description: "Failed to save power requirement table",
-        variant: "destructive"
-      });
       return table.powerRequirementId;
     }
   };
@@ -347,19 +326,14 @@ const VideoConsumosTool: React.FC = () => {
       },
     }) as Table;
 
-    let tableToAdd = newTable;
-    
     // Save based on mode
     if (isTourDefaults) {
       await saveTourDefault(newTable);
-    } else if (isOverrideMode || selectedJobId) {
-      const powerRequirementId = await savePowerRequirementTable(newTable);
-      if (powerRequirementId) {
-        tableToAdd = { ...newTable, powerRequirementId };
-      }
+    } else if (isOverrideMode) {
+      await saveTourOverrideTable(newTable);
     }
-    
-    setTables((prev) => [...prev, tableToAdd]);
+
+    setTables((prev) => [...prev, newTable]);
     resetCurrentTable();
   };
 
@@ -386,26 +360,7 @@ const VideoConsumosTool: React.FC = () => {
         return;
       }
 
-      if (!selectedJobId || isTourDefaults || isOverrideMode || !tableToRemove?.powerRequirementId) {
-        setTables((prev) => prev.filter((table) => table.id !== tableId));
-        return;
-      }
-
-      try {
-        await deleteJobPowerRequirementTable({
-          client: dataLayerClient,
-          jobId: selectedJobId,
-          table: tableToRemove,
-        });
-        setTables((prev) => prev.filter((table) => table.id !== tableId));
-      } catch (error) {
-        console.error('Error deleting power requirement table:', error);
-        toast({
-          title: "Error",
-          description: "Failed to delete power requirement table",
-          variant: "destructive",
-        });
-      }
+      setTables((prev) => prev.filter((table) => table.id !== tableId));
     }
   };
 
@@ -414,7 +369,7 @@ const VideoConsumosTool: React.FC = () => {
       return;
     }
 
-    if (!isOverrideMode && !selectedJobId) {
+    if (!isOverrideMode) {
       return;
     }
 
@@ -427,7 +382,7 @@ const VideoConsumosTool: React.FC = () => {
     pendingTableSaveTimeoutsRef.current[timeoutKey] = window.setTimeout(() => {
       delete pendingTableSaveTimeoutsRef.current[timeoutKey];
 
-      void savePowerRequirementTable(table, { showToast: false }).then((powerRequirementId) => {
+      void saveTourOverrideTable(table, { showToast: false }).then((powerRequirementId) => {
         if (powerRequirementId && powerRequirementId !== table.powerRequirementId) {
           setTables((prev) =>
             prev.map((storedTable) =>
@@ -476,30 +431,6 @@ const VideoConsumosTool: React.FC = () => {
         ? [...defaultTables, ...tables]
         : activeTables;
 
-      if (!isTourDefaults && !isOverrideMode && selectedJobId && allTables.length > 0) {
-        const savedTables = await saveJobPowerRequirementTablesGeneration({
-          client: dataLayerClient,
-          department: 'video',
-          jobId: selectedJobId,
-          settings: getPowerSettings(),
-          stage: selectedStage,
-          tables: allTables,
-        });
-
-        setTables((storedTables) =>
-          storedTables.map((storedTable) => {
-            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
-            return savedTable
-              ? {
-                  ...storedTable,
-                  generationTimestamp: savedTable.generationTimestamp,
-                  powerRequirementId: savedTable.powerRequirementId,
-                }
-              : storedTable;
-          })
-        );
-      }
-
       // Generate power summary for consumos reports
       const totalSystemWatts = allTables.reduce((sum, table) => sum + (table.totalWatts || 0), 0);
       const totalSystemAmps = allTables.reduce((sum, table) => sum + (table.currentPerPhase || 0), 0);
@@ -543,7 +474,7 @@ const VideoConsumosTool: React.FC = () => {
       // Auto-complete video Consumos tasks only after successful upload
       // This automation is department-specific: only video department tasks are affected
       let completedTasksCount = 0;
-      if (!isTourDefaults && selectedJobId) {
+      if (!isTourDefaults && !isOverrideMode && selectedJobId) {
         completedTasksCount = await uploadPowerReportAndCompleteTask({
           department: 'video',
           fileName,
@@ -555,6 +486,28 @@ const VideoConsumosTool: React.FC = () => {
         if (completedTasksCount > 0) {
           console.log(`Auto-completed ${completedTasksCount} video Consumos task(s)`);
         }
+
+        const savedTables = await saveJobPowerRequirementTablesGeneration({
+          client: dataLayerClient,
+          department: 'video',
+          jobId: selectedJobId,
+          settings: getPowerSettings(),
+          stage: selectedStage,
+          tables: allTables,
+        });
+
+        setTables((storedTables) =>
+          storedTables.map((storedTable) => {
+            const savedTable = savedTables.find((saved) => saved.tableId === storedTable.id);
+            return savedTable
+              ? {
+                  ...storedTable,
+                  generationTimestamp: savedTable.generationTimestamp,
+                  powerRequirementId: savedTable.powerRequirementId,
+                }
+              : storedTable;
+          })
+        );
         
         toast({
           title: 'Success',


### PR DESCRIPTION
## Summary
- Stop normal Sound/Lights/Video calculator generate, edit, and remove actions from writing individual job power requirement rows.
- Persist job power requirements only from the Export & Upload flow, saving the exported department set as one shared timestamped generation after the PDF upload succeeds.
- Allow empty exported sets to clear the scoped persisted generation, preventing stale power rows from remaining in resumen/hoja output.
- Bump Vitest packages to 3.2.6 to resolve the new dependency-audit advisory without changing the Vite major.

## Root cause
Power requirement rows were still being written one table at a time from calculator interactions. That means rows belonging to the same visible report set could receive different timestamps, making timestamp-based generation selection unreliable.

## Risk Assessment
Risk level: medium.

This changes when normal job power requirements are persisted. The main behavior change is intentional: draft calculator changes no longer affect resumen/hoja data until the PDF is exported and uploaded. Tour defaults and tour override persistence remain on their existing separate paths.

## Impact Checklist
- Database migration: none.
- Supabase RLS/security: no schema or policy changes.
- Realtime/subscriptions: not affected.
- User-facing behavior: resumen/hoja power rows now represent the last exported/uploaded calculator set per department/stage instead of intermediate generated tables.
- Dependency audit: resolves advisory ID 1120126 by moving `vitest` and `@vitest/coverage-v8` to `^3.2.6`.

## Rollback Plan
Revert this PR to restore per-table job persistence from calculator interactions. No database rollback is required.

## Validation
- `npm install --legacy-peer-deps`
- `npm run governance`
- `npm run typecheck`
- `npx vitest run src/features/technical-tools/power/__tests__/powerPersistence.test.ts src/utils/__tests__/powerSummaryData.test.ts`
- `npm run test:run` passed: 144 files, 919 tests.
- `npm run lint` passed with 0 errors; existing repo warnings remain.
- `npm run build` passed with existing Vite chunk/dynamic import warnings.
