### PR TITLE
fix: harden worst security offenders from codebase audit

### DIFF
--- a/docs/CODEBASE_AUDIT_2026-06-09.md
+++ b/docs/CODEBASE_AUDIT_2026-06-09.md
@@ -1,0 +1,168 @@
+# Full Codebase Audit — 2026-06-09
+
+**Scope:** entire repository at `main` (`d4b2ff6`, PR #677). Six parallel domain audits (security, code quality, database, edge functions, testing/CI, frontend architecture) plus local verification (install, lint, typecheck, test runs, `npm audit`).
+
+**Codebase size:** ~278,870 LOC across 1,222 TS/TSX files in `src/`, 65 edge functions, 135 migrations (145 tables), 144 unit test files + 12 Playwright specs.
+
+---
+
+## Executive Summary
+
+The platform is architecturally mature — centralized query-key factories, a unified realtime subscription manager with multi-tab leader election, comprehensive DB indexing, RLS on 141/145 tables, and a disciplined migration history. Local health checks all pass: **lint 0 errors**, **`tsc --noEmit` clean**, **critical test suite green**.
+
+However, the audit found **3 verified critical security issues** that should be fixed before anything else, plus a cluster of high-severity issues in edge functions and a structural testing gap around the money-handling paths (staffing orchestrator, job deletion cascades).
+
+### Scorecard
+
+| Domain | Grade | Headline |
+|---|---|---|
+| Security | ⚠️ **At risk** | Anon can read timesheets/profiles via REST; SSRF in image-proxy; default password in create-user |
+| Database schema | B+ | Excellent indexing & integrity; 3 SECURITY DEFINER fns missing `search_path` |
+| Edge functions | C+ | apply-flex-status always returns 200; no retry logic; heavy email duplication |
+| Code quality | B− | 25 files >1,000 LOC; ~5,000 LOC duplicated; 491 files using `any` |
+| Testing & CI | C+ | 10.4% test ratio; staffing orchestrator (52KB) untested; no coverage thresholds |
+| Frontend perf | A− | Strong chunking/lazy-loading; 39 subscriptions bypass the unified manager |
+| Dependencies | B | 4 moderate vulns (quill XSS accepted in SECURITY.md; uuid via exceljs) |
+
+---
+
+## 1. Critical Findings (fix first)
+
+### C1. Anonymous SELECT access to sensitive tables — `USING (true)` policies for `anon`
+`supabase/migrations/00000000000000_production_schema.sql:8962-8972`
+
+12 tables have policies like:
+
+```sql
+CREATE POLICY "anon_timesheets_select_for_realtime" ON "public"."timesheets" FOR SELECT TO "anon" USING (true);
+CREATE POLICY "anon_profiles_select_for_realtime"   ON "public"."profiles"   FOR SELECT TO "anon" USING (true);
+```
+
+Also: `announcements`, `job_assignments`, `job_departments`, `job_documents`, `job_required_roles`, `jobs`, `locations`, `logistics_event_departments`, `logistics_events`, `tours`.
+
+Although named "for_realtime" (wallboard support), an RLS SELECT policy applies to **all** access paths — anyone holding the public anon key (it ships in the JS bundle) can query the full `timesheets` table (wage data) and `profiles` table (email, DNI, phone) via plain PostgREST, no login required. Most of these tables are also in the `supabase_realtime` publication, so changes stream live too.
+
+**Remediation:** drop the anon policies; serve the wallboard exclusively through the already-tokenized `wallboard-feed` edge function (which uses the service role), or expose sanitized views with only display-safe columns.
+
+### C2. SSRF in `image-proxy` edge function
+`supabase/functions/image-proxy/index.ts:16-24`
+
+```ts
+const { url } = await req.json();
+const response = await fetch(url);   // no scheme/host/IP validation
+```
+
+Arbitrary server-side fetch: internal services, cloud metadata endpoints, network probing.
+**Remediation:** allowlist expected hosts (e.g. Flex/Supabase storage), enforce `https:`, block private IP ranges, add timeout + size cap.
+
+### C3. Hardcoded default password in `create-user`
+`supabase/functions/create-user/index.ts:100`
+
+```ts
+password: 'default',
+...
+needs_password_change: true,   // flag only — not enforced at login
+```
+
+Every admin-created account starts with the password `default`; nothing blocks login before the password is changed.
+**Remediation:** generate a random per-user temporary password (or use invite/magic-link flow) and hard-enforce password change before granting a session.
+
+---
+
+## 2. High-Severity Findings
+
+| # | Finding | Location | Notes |
+|---|---|---|---|
+| H1 | `wallboard-auth` falls back to hardcoded secrets (`demo-wallboard-token`, `wallboard-dev-secret`) when env vars are missing | `supabase/functions/wallboard-auth/index.ts:5-7` | Fail fast instead of falling back |
+| H2 | `wallboard-debug` is unauthenticated and returns 30 days of job inventory (titles, statuses, schedule) | `supabase/functions/wallboard-debug/index.ts` | Add token check or delete the function |
+| H3 | `apply-flex-status` returns HTTP 200 on missing auth, Flex API failures, and internal errors — clients can't detect failure; Flex state silently desyncs | `supabase/functions/apply-flex-status/index.ts:217,358,363` | Return 401/500/207 appropriately |
+| H4 | 3 `SECURITY DEFINER` functions missing `SET search_path` (search-path injection / privilege escalation) | `20260208100000_create_achievement_tables.sql:138,~354`; `20260208140000_trigger_evaluate_achievements_on_job_complete.sql:8` | Add `SET search_path = public`; 50+ other functions already do this correctly |
+| H5 | Wildcard CORS (`Access-Control-Allow-Origin: *`) on 24+ edge functions, including state-changing and service-role-backed ones | All `corsHeaders` in `supabase/functions/` | Restrict to sector-pro.work origins |
+| H6 | `staffing-click` logs full request headers and URL query params, including the auth token | `supabase/functions/staffing-click/index.ts:21-34` | Redact tokens in logs |
+| H7 | 39 direct `supabase.channel()` calls bypass the unified subscription manager — no dedup, no reconnect invalidation, no route-aware cleanup | e.g. `useOptimizedMatrixData.ts` (4), `useStaffingCampaignRealtime.ts` (4), `useStaffingRealtime.ts` (3), `JobCardNew.tsx`, `JobAssignmentMatrix.tsx` (2), +12 more files | Migrate to `UnifiedSubscriptionManager.subscribeToTable()` |
+| H8 | Staffing orchestrator (1,511 LOC, candidate scoring + payroll-adjacent) has **zero unit tests**; job deletion cascade services also untested | `supabase/functions/staffing-orchestrator/`, `src/services/jobDeletionService.ts`, `src/services/deleteJobAssignments.ts` | Highest-risk test gap in the repo |
+| H9 | No Flex API retry/timeout in 7 of 9 Flex functions — transient network failures become permanent desyncs; `create-flex-folders` is not idempotent (re-runs create duplicate folders) | `create-flex-folders`, `manage-flex-crew-assignments`, `sync-flex-crew-for-job`, etc. | Shared `fetchWithRetry` + pre-existence check |
+
+---
+
+## 3. Medium-Severity Findings
+
+**Security / data**
+- `wallboard-feed` uses the service-role key with token auth but no rate limiting (`wallboard-feed/index.ts:219`).
+- Public artist form endpoints lack rate limiting / abuse controls (token entropy itself is fine).
+- `secure-flex-api` checks authentication but not role/department — any logged-in user can call Flex operations.
+- `get-mapbox-token` is unauthenticated with wildcard CORS (public-by-design token, but enables third-party quota abuse).
+- `PayoutEmailPreview.tsx:383` renders generated HTML via `dangerouslySetInnerHTML` with a hand-rolled `escapeHtml` — adopt DOMPurify or render in a sandboxed iframe.
+- Staffing-orchestrator bulk sends are not transaction-safe (partial failure leaves inconsistent state, still returns 200); state transitions not enforced server-side (`staffing-orchestrator/index.ts:614,1137+`).
+- Timesheets use an `is_active` soft-delete flag; any query missing `WHERE is_active = true` silently includes voided entries in payroll math. Needs a code-level sweep + regression test.
+
+**Code health**
+- **God components:** 25 files >1,000 LOC. Worst: `TourOpsManagementHub.tsx` (2,116), `LightsConsumosTool.tsx` (1,426), `rates-pdf-export.ts` (1,419), `JobCardNew.tsx` (1,348, 33 hooks), `StaffingCampaignPanel.tsx` (1,297).
+- **Duplication (~5,000 LOC):** the three Consumos tools (`ConsumosTool` / `VideoConsumosTool` / `LightsConsumosTool`, ~3,500 LOC, ~90% identical) and three PDF exporters (`rates-pdf-export.ts`, `artistPdfExport.ts`, `artistTablePdfExport.ts`, 3,365 LOC sharing jsPDF setup/table/logo logic).
+- **Split-brain Supabase client import:** 106 files import `@/lib/supabase-client` vs 83 using the documented `@/integrations/supabase/client`. Consolidate and add a lint rule.
+- **Type safety:** 342 files with `: any`, 149 with `as any` (~2,800 instances). Hotspots: `JobCardNewView.tsx` (22), `OptimizedAssignmentMatrixView.tsx` (19), `JobDetailsInfoTab.tsx` (16 `as any`).
+- **Email functions:** 10 `send-*` functions each re-implement Brevo setup, HTML templates, and error handling; only 1 uses `_shared/corporateEmailTemplate.ts`.
+- **React Query staleTime/gcTime** set ad hoc in 30+ places (2s–10min) with no preset helper — cache coherence is unpredictable across tabs.
+- **Service worker chunk-mismatch handling** is reactive (auto-reload up to 3×) rather than preventive (no chunk-manifest validation).
+
+**Testing / CI**
+- Test-to-source ratio ~10.4% (industry norm 20–40%). Full suite: 144 files; E2E runs against a mocked Supabase, never a real database.
+- No coverage thresholds in `vitest.config.ts` — untested code merges silently.
+- CI installs dependencies 7× per PR with no npm cache (~15–20 min wasted per run).
+- Only 8 of 65 edge functions have any tests.
+- Docs drift: CLAUDE.md says "30 critical workflow tests" but `test:critical` runs 18 files / 89 tests (all passing).
+
+---
+
+## 4. Low / Informational
+
+- **npm audit:** 4 moderate prod vulns — `quill` ≤2.0.3 XSS via react-quill (**accepted risk in SECURITY.md**), `uuid` <11.1.1 via exceljs; dev-only `minimatch` ReDoS and `tar` traversal (via @capacitor/assets). No high/critical.
+- **Outdated majors** (mostly intentional pins per CLAUDE.md): React 18→19, react-router 6→7, zod 3→4, Tailwind 3→4, vite 6→8, date-fns 3→4 (pinned), recharts 2→3.
+- 452 files contain `console.log` (~1,500 calls; stripped in prod builds — readability issue only).
+- 68 floating `.then()` chains without `.catch()`; 4 empty catch blocks.
+- `src/legacy/` (1,327 LOC) confirmed unreferenced — safe to delete.
+- Zero TODO/FIXME/HACK markers; only 4 `@ts-ignore` (all justified); only 10 `exhaustive-deps` disables in 1,222 files — good discipline.
+- Two toast systems (sonner in 82 files vs `use-toast` wrapper) — consolidate.
+- 6 mobile components use `div onClick` without role/tabindex (a11y).
+- One edge function (`import-users`) pins ancient `deno.land/std@0.182.0`; most use floating `@supabase/supabase-js@2` — pin a minor version.
+- `lucide-react` 0.462 is far behind; low risk.
+
+**Strengths worth keeping:** vite manual chunks + lazy loading of pdf/maps/spreadsheet libs is correctly enforced (no static imports from eager paths); provider stack is well-ordered (`SubscriptionProvider` uses `useSyncExternalStore`); Zustand stores all use selective subscription; DB indexing is comprehensive (218 FKs, filtered + GIST indexes, no missing FK indexes found); cascade triggers (tour → job assignments → timesheets) are guarded against recursion; migration hygiene is strong (consistent timestamps, 503 idempotency guards).
+
+---
+
+## 5. Verification performed locally
+
+| Check | Result |
+|---|---|
+| `npm install --legacy-peer-deps` | OK |
+| `npm run lint` | 0 errors, 413 warnings (`no-explicit-any`) |
+| `npx tsc --noEmit` | Clean |
+| `npm run test:critical` | 18 files, 89 tests — all pass |
+| `npm run test:run` (full suite) | 144 files, 919 tests — all pass (~60s) |
+| `npm audit` | 4 moderate (see above), 0 high/critical |
+| Critical security claims (C1–C3, H1–H2) | Verified directly in source |
+
+---
+
+## 6. Prioritized Action Plan
+
+**Week 1 — security blockers**
+1. Drop/replace the 12 anon `USING (true)` policies (C1) — route wallboard data through `wallboard-feed` or sanitized views.
+2. Add SSRF guards to `image-proxy` (C2).
+3. Replace the `'default'` password flow in `create-user` (C3).
+4. Remove hardcoded fallbacks in `wallboard-auth` (H1); auth-gate or delete `wallboard-debug` (H2).
+5. Add `SET search_path = public` to the 3 achievement functions (H4).
+
+**Week 2–3 — operational correctness**
+6. Fix `apply-flex-status` status codes (H3); add shared `fetchWithRetry` to Flex functions and idempotency to `create-flex-folders` (H9).
+7. Restrict CORS to known origins across edge functions (H5); redact tokens from `staffing-click` logs (H6).
+8. Add coverage thresholds to vitest + npm cache to CI (2h, big payoff).
+9. Write unit tests for staffing-orchestrator scoring and job-deletion cascades (H8).
+
+**Next quarter — structural debt**
+10. Migrate 39 direct `supabase.channel()` calls to the unified subscription manager (H7).
+11. Consolidate Supabase client imports (106 files) and delete `src/legacy/`.
+12. Merge the three Consumos tools into one parameterized component; extract a shared PDF builder.
+13. Extract shared Brevo email utility + templates for the 10 send-* functions.
+14. Introduce `queryOptionsPresets` for staleTime/gcTime; phased `any` reduction starting with matrix/job-card domains.

--- a/supabase/functions/create-user/index.ts
+++ b/supabase/functions/create-user/index.ts
@@ -94,10 +94,12 @@ serve(async (req) => {
       return jsonResponse({ error: 'Unauthorized' }, 403);
     }
 
-    // Create auth user with a standard default password
+    // Create auth user with a random throwaway password. It is never disclosed:
+    // the user sets their real password via the "Olvidé mi contraseña" reset flow.
+    const tempPassword = `${crypto.randomUUID()}-${crypto.randomUUID()}`;
     const { data: authData, error: authError } = await supabaseAdmin.auth.admin.createUser({
       email,
-      password: 'default',
+      password: tempPassword,
       email_confirm: true,
       user_metadata: {
         first_name: firstName,

--- a/supabase/functions/image-proxy/index.ts
+++ b/supabase/functions/image-proxy/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -7,42 +8,97 @@ const corsHeaders = {
   "Access-Control-Max-Age": "86400",
 };
 
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_IMAGE_BYTES = 15 * 1024 * 1024;
+
+const PRIVATE_IPV4_RANGES = [
+  /^0\./,
+  /^10\./,
+  /^127\./,
+  /^169\.254\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+];
+
+function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, "");
+  if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local") || host.endsWith(".internal")) {
+    return true;
+  }
+  // IPv6 literals (URL hostname keeps brackets) — block all to avoid ::1 / unique-local tricks
+  if (host.startsWith("[")) return true;
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) {
+    return PRIVATE_IPV4_RANGES.some((range) => range.test(host));
+  }
+  return false;
+}
+
+const jsonError = (message: string, status: number) =>
+  new Response(JSON.stringify({ error: message }), {
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+    status,
+  });
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }
 
   try {
+    // Require an authenticated platform user
+    const authHeader = req.headers.get("Authorization") ?? "";
+    const token = authHeader.replace("Bearer ", "").trim();
+    if (!token) return jsonError("Unauthorized", 401);
+
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+    const { data: { user } } = await supabaseAdmin.auth.getUser(token);
+    if (!user) return jsonError("Unauthorized", 401);
+
     const { url } = await req.json();
-    if (!url) {
-      return new Response(JSON.stringify({ error: "URL is required" }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-        status: 400,
-      });
+    if (!url) return jsonError("URL is required", 400);
+
+    let target: URL;
+    try {
+      target = new URL(url);
+    } catch {
+      return jsonError("Invalid URL", 400);
+    }
+    if (target.protocol !== "https:") {
+      return jsonError("Only https URLs are allowed", 400);
+    }
+    if (isBlockedHost(target.hostname)) {
+      return jsonError("Host not allowed", 400);
     }
 
-    const response = await fetch(url);
+    const response = await fetch(target, {
+      redirect: "error",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
     if (!response.ok) {
-      return new Response(
-        JSON.stringify({ error: "Failed to fetch image" }),
-        {
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-          status: response.status,
-        }
-      );
+      return jsonError("Failed to fetch image", response.status);
+    }
+
+    const contentType = response.headers.get("Content-Type") || "";
+    if (!contentType.startsWith("image/")) {
+      return jsonError("URL did not return an image", 415);
+    }
+    const contentLength = Number(response.headers.get("Content-Length") || 0);
+    if (contentLength > MAX_IMAGE_BYTES) {
+      return jsonError("Image too large", 413);
     }
 
     const imageBlob = await response.blob();
-    const headers = {
-      ...corsHeaders,
-      "Content-Type": response.headers.get("Content-Type") || "image/jpeg",
-    };
+    if (imageBlob.size > MAX_IMAGE_BYTES) {
+      return jsonError("Image too large", 413);
+    }
 
-    return new Response(imageBlob, { headers });
-  } catch (error) {
-    return new Response(JSON.stringify({ error: error.message }), {
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-      status: 500,
+    return new Response(imageBlob, {
+      headers: { ...corsHeaders, "Content-Type": contentType },
     });
+  } catch (error) {
+    return jsonError(error instanceof Error ? error.message : String(error), 500);
   }
 });

--- a/supabase/functions/import-users/index.ts
+++ b/supabase/functions/import-users/index.ts
@@ -51,10 +51,11 @@ serve(async (req) => {
 
     for (const record of records) {
       try {
-        // Create auth user with default password
+        // Create auth user with a random throwaway password. It is never disclosed:
+        // the user sets their real password via the "Olvidé mi contraseña" reset flow.
         const { data: authData, error: authError } = await supabase.auth.admin.createUser({
           email: record.email,
-          password: 'default',
+          password: `${crypto.randomUUID()}-${crypto.randomUUID()}`,
           email_confirm: true,
           user_metadata: {
             first_name: record.firstName,

--- a/supabase/functions/send-onboarding-email/index.ts
+++ b/supabase/functions/send-onboarding-email/index.ts
@@ -170,8 +170,7 @@ serve(async (req) => {
                     <div style="background:#eef2ff;border:1px solid #c7d2fe;border-radius:8px;padding:12px 14px;color:#1f2937;font-size:14px;">
                       <b>Tu acceso</b><br/>
                       Usuario: <span style="font-family:monospace">${normalizedEmail}</span><br/>
-                      Contraseña inicial: <span style="font-family:monospace">default</span><br/>
-                      <span style="color:#6b7280">Por seguridad, cambia tu contraseña tras el primer inicio de sesión. Si ya la cambiaste, ignora este paso.</span>
+                      <span style="color:#6b7280">Para establecer tu contraseña, pulsa "Olvidé mi contraseña" en la pantalla de acceso y recibirás un enlace para crearla. Si ya tienes contraseña, ignora este paso.</span>
                     </div>
                     <div style="margin-top:10px;display:flex;gap:10px;flex-wrap:wrap;">
                       <a href="${loginUrl}" style="display:inline-block;background:#111827;color:#ffffff;padding:10px 14px;border-radius:8px;text-decoration:none;font-weight:700;">Ir a Iniciar Sesión</a>
@@ -302,8 +301,8 @@ serve(async (req) => {
         primer día.
       </p>
       <p style="color:#dbeafe;">
-        Nota: tu contraseña actual es la predeterminada (default). Por tu seguridad, te recomendamos cambiarla la primera vez que
-        accedas a la plataforma desde la sección de <strong>Perfil</strong>.
+        Nota: si todavía no has establecido tu contraseña, pulsa "Olvidé mi contraseña" en la pantalla de acceso y
+        recibirás un enlace para crearla. Después podrás cambiarla cuando quieras desde la sección de <strong>Perfil</strong>.
       </p>
 
       <div class="card" style="background-color:#14263f;border-radius:8px;padding:15px;margin:20px 0;">

--- a/supabase/functions/send-timesheet-reminder/index.ts
+++ b/supabase/functions/send-timesheet-reminder/index.ts
@@ -300,12 +300,12 @@ serve(async (req) => {
               <div style="background:#f9fafb;border:1px solid #e5e7eb;padding:16px;border-radius:6px;margin:20px 0;">
                 <div style="color:#6b7280;font-size:13px;line-height:1.5;">
                   <strong style="color:#374151;">Instrucciones de acceso:</strong><br/>
-                  Si es la primera vez que accedes a la plataforma, tus credenciales son:
+                  Si es la primera vez que accedes a la plataforma:
                   <ul style="margin:8px 0;padding-left:20px;">
                     <li><strong>Usuario:</strong> ${technician.email}</li>
-                    <li><strong>Contraseña:</strong> default</li>
+                    <li><strong>Contraseña:</strong> pulsa "Olvidé mi contraseña" en la pantalla de acceso y recibirás un enlace para crearla.</li>
                   </ul>
-                  Te recomendamos cambiar tu contraseña tras el primer acceso desde tu perfil.
+                  Después podrás cambiarla cuando quieras desde tu perfil.
                 </div>
               </div>
 

--- a/supabase/functions/wallboard-auth/index.ts
+++ b/supabase/functions/wallboard-auth/index.ts
@@ -1,10 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { create, getNumericDate, Header, Payload } from "https://deno.land/x/djwt@v3.0.2/mod.ts";
 
-// Allow fallbacks for local/dev to avoid runtime crashes; prod should set both env vars
-const FALLBACK_SHARED_TOKEN = Deno.env.get("VITE_WALLBOARD_TOKEN") ?? "demo-wallboard-token";
-const WALLBOARD_SHARED_TOKEN = Deno.env.get("WALLBOARD_SHARED_TOKEN") ?? FALLBACK_SHARED_TOKEN;
-const WALLBOARD_JWT_SECRET = Deno.env.get("WALLBOARD_JWT_SECRET") ?? "wallboard-dev-secret";
+// No hardcoded fallbacks: if the secrets are not configured, requests fail closed.
+const WALLBOARD_SHARED_TOKEN = Deno.env.get("WALLBOARD_SHARED_TOKEN") ?? Deno.env.get("VITE_WALLBOARD_TOKEN") ?? "";
+const WALLBOARD_JWT_SECRET = Deno.env.get("WALLBOARD_JWT_SECRET") ?? "";
 const WALLBOARD_PRESET_SLUG = Deno.env.get("WALLBOARD_PRESET_SLUG") ?? "almacen";
 const missingSecrets = [
   !WALLBOARD_SHARED_TOKEN && "WALLBOARD_SHARED_TOKEN",
@@ -13,7 +12,7 @@ const missingSecrets = [
 
 if (missingSecrets.length > 0) {
   console.error(
-    `Missing required wallboard auth secrets: ${missingSecrets.join(", ")}. Using fallbacks; set env vars in production.`
+    `Missing required wallboard auth secrets: ${missingSecrets.join(", ")}. All requests will be rejected until they are set.`
   );
 }
 const MIN_TTL_SECONDS = 8 * 60 * 60; // 8 hours minimum
@@ -44,6 +43,12 @@ async function sign(payload: Payload) {
 serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: cors() });
   try {
+    if (missingSecrets.length > 0) {
+      return new Response(JSON.stringify({ error: "Wallboard auth is not configured" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json", ...cors() },
+      });
+    }
     const url = new URL(req.url);
     let presetFromReq = (url.searchParams.get("presetSlug") ?? url.searchParams.get("preset") ?? "").trim().toLowerCase();
     let token = url.searchParams.get("wallboardToken");

--- a/supabase/functions/wallboard-debug/index.ts
+++ b/supabase/functions/wallboard-debug/index.ts
@@ -3,13 +3,14 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const WALLBOARD_SHARED_TOKEN = Deno.env.get("WALLBOARD_SHARED_TOKEN") ?? Deno.env.get("VITE_WALLBOARD_TOKEN") ?? "";
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, {
       headers: {
         "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
+        "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform, x-wallboard-token",
         "Access-Control-Allow-Methods": "GET, OPTIONS",
   "Access-Control-Max-Age": "86400",
       },
@@ -17,6 +18,22 @@ serve(async (req) => {
   }
 
   try {
+    // Debug endpoint exposes job data; require the wallboard shared token.
+    if (!WALLBOARD_SHARED_TOKEN) {
+      return new Response(JSON.stringify({ error: "WALLBOARD_SHARED_TOKEN is not configured" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      });
+    }
+    const url = new URL(req.url);
+    const provided = req.headers.get("x-wallboard-token") ?? url.searchParams.get("wallboardToken") ?? "";
+    if (provided !== WALLBOARD_SHARED_TOKEN) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      });
+    }
+
     const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
     const now = new Date();
     const todayStart = new Date(now);

--- a/supabase/migrations/20260609120000_security_hardening_anon_access.sql
+++ b/supabase/migrations/20260609120000_security_hardening_anon_access.sql
@@ -1,0 +1,99 @@
+-- Security hardening (codebase audit 2026-06-09):
+--
+-- 1. Remove anon SELECT policies on sensitive tables. They were added for the
+--    wallboard's realtime display, but RLS SELECT policies apply to every access
+--    path, so anyone holding the public anon key could read timesheets (wages),
+--    profiles (email/DNI/phone), job assignments, etc. via PostgREST without
+--    logging in. The wallboard reads data exclusively through the tokenized
+--    wallboard-auth/wallboard-feed edge functions (service role), and the other
+--    public surfaces (artist form, tour guest links) use their own scoped tables
+--    or token-validated RPCs, so no anon table access is required.
+--
+-- 2. Fix SELECT policies written as USING (true OR <role checks>): the leading
+--    "true" short-circuits the role checks and grants read access to everyone,
+--    including anon. Replaced with an authenticated-only check, which preserves
+--    the effective behavior for every logged-in user (the policy already granted
+--    them all access) while closing the anonymous path.
+--
+-- 3. Add SET search_path to the achievement SECURITY DEFINER functions, which
+--    were missing it (search_path injection / privilege escalation risk).
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop anon-only realtime SELECT policies
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "anon_announcements_select_for_realtime" ON public.announcements;
+DROP POLICY IF EXISTS "anon_job_assignments_select_for_realtime" ON public.job_assignments;
+DROP POLICY IF EXISTS "anon_job_departments_select_for_realtime" ON public.job_departments;
+DROP POLICY IF EXISTS "anon_job_documents_select_for_realtime" ON public.job_documents;
+DROP POLICY IF EXISTS "anon_job_required_roles_select_for_realtime" ON public.job_required_roles;
+DROP POLICY IF EXISTS "anon_jobs_select_for_realtime" ON public.jobs;
+DROP POLICY IF EXISTS "anon_locations_select_for_realtime" ON public.locations;
+DROP POLICY IF EXISTS "anon_logistics_event_departments_select_for_realtime" ON public.logistics_event_departments;
+DROP POLICY IF EXISTS "anon_logistics_events_select_for_realtime" ON public.logistics_events;
+DROP POLICY IF EXISTS "anon_profiles_select_for_realtime" ON public.profiles;
+DROP POLICY IF EXISTS "anon_timesheets_select_for_realtime" ON public.timesheets;
+
+-- The tours wallboard policy also covered anon; keep it for authenticated only.
+DO $$
+BEGIN
+  ALTER POLICY "Allow wallboard to read tour status" ON public.tours TO authenticated;
+EXCEPTION
+  WHEN undefined_object THEN NULL;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Close the "USING (true OR ...)" SELECT policies to authenticated users
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  pol record;
+BEGIN
+  FOR pol IN
+    SELECT *
+    FROM (VALUES
+      ('p_job_date_types_public_select_e0ccdb', 'job_date_types'),
+      ('p_job_departments_public_select_ce698d', 'job_departments'),
+      ('p_locations_public_select_6df21f', 'locations'),
+      ('p_tour_dates_public_select_8f4344', 'tour_dates'),
+      ('p_tour_default_sets_public_select_8341a3', 'tour_default_sets'),
+      ('p_tour_default_tables_public_select_fead6e', 'tour_default_tables'),
+      ('p_tour_power_defaults_public_select_5dba2b', 'tour_power_defaults'),
+      ('p_tour_weight_defaults_public_select_b2dacf', 'tour_weight_defaults'),
+      ('p_tours_public_select_5a6a0b', 'tours')
+    ) AS t(polname, tablename)
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM pg_policies
+      WHERE schemaname = 'public' AND policyname = pol.polname AND tablename = pol.tablename
+    ) THEN
+      EXECUTE format(
+        'ALTER POLICY %I ON public.%I USING ((( SELECT auth.uid() ) IS NOT NULL))',
+        pol.polname, pol.tablename
+      );
+    END IF;
+  END LOOP;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Pin search_path on achievement SECURITY DEFINER functions
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  ALTER FUNCTION public.evaluate_user_achievements(uuid) SET search_path = public;
+EXCEPTION
+  WHEN undefined_function THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER FUNCTION public.evaluate_daily_achievements() SET search_path = public;
+EXCEPTION
+  WHEN undefined_function THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER FUNCTION public.trigger_evaluate_achievements_on_job_complete() SET search_path = public;
+EXCEPTION
+  WHEN undefined_function THEN NULL;
+END $$;


### PR DESCRIPTION
## Summary

Fixes the critical findings from the full codebase audit (report included in this PR: `docs/CODEBASE_AUDIT_2026-06-09.md`).

### 1. Anonymous read access to sensitive data (Critical)
New migration `20260609120000_security_hardening_anon_access.sql`:
- **Drops 11 `FOR SELECT TO anon USING (true)` policies** on `timesheets`, `profiles`, `job_assignments`, `jobs`, `job_departments`, `job_documents`, `job_required_roles`, `announcements`, `locations`, `logistics_events`, `logistics_event_departments`. Anyone holding the public anon key (it ships in the JS bundle) could read all wage data and personal info (DNI/phone/email) via PostgREST without logging in.
- **Restricts the tours wallboard policy** (`Allow wallboard to read tour status`) to `authenticated`.
- **Closes 9 `USING (true OR <role checks>)` SELECT policies** — the leading `true` short-circuited the role checks, granting anon read access. Replaced with `auth.uid() IS NOT NULL`, which preserves the exact effective behavior for every logged-in user while closing the anonymous path.
- **Pins `search_path = public`** on the 3 achievement `SECURITY DEFINER` functions (search-path injection risk).

Verified safe: the wallboard reads exclusively through the tokenized `wallboard-auth`/`wallboard-feed` edge functions (service role); the public artist form only touches `festival_*` tables; tour guest links use the token-validated `get_tour_guest_payload` RPC. No public surface relies on direct anon table access.

### 2. Hardcoded `'default'` password (Critical)
- `create-user` and `import-users` now create accounts with a random throwaway password that is never disclosed; users set their real password through the existing "Olvidé mi contraseña" reset flow.
- `send-onboarding-email` and `send-timesheet-reminder` no longer print the default password — they now direct users to the reset flow.

### 3. SSRF in `image-proxy` (Critical)
Previously fetched any URL from the request body with no validation. Now requires an authenticated user and enforces: https-only, private IP/localhost/internal host blocking, no redirects, 10s timeout, 15MB size cap, and `image/*` content-type check. (The function has no callers in the repo, so requiring auth breaks nothing.)

### 4. Wallboard hardening (High)
- `wallboard-auth`: removed hardcoded fallback secrets (`demo-wallboard-token` / `wallboard-dev-secret`); requests now fail closed with a 500 if `WALLBOARD_SHARED_TOKEN` / `WALLBOARD_JWT_SECRET` are unset.
- `wallboard-debug`: previously unauthenticated and returned 30 days of job inventory; now requires the wallboard shared token.

## Deploy checklist
- [ ] Apply the migration (`npx supabase db push` or dashboard)
- [ ] Confirm `WALLBOARD_SHARED_TOKEN` and `WALLBOARD_JWT_SECRET` secrets are set **before** deploying `wallboard-auth` (it now fails closed)
- [ ] Redeploy edge functions: `create-user`, `import-users`, `send-onboarding-email`, `send-timesheet-reminder`, `wallboard-auth`, `wallboard-debug`, `image-proxy`
- [ ] Follow-up: existing accounts created before this change still have the `default` password if the user never changed it — consider a one-off admin reset for accounts that have never signed in

## Verification
- `npm run lint` and `npm run lint:functions`: 0 errors
- `npx tsc --noEmit`: clean
- Full Vitest suite: 144 files / 919 tests pass; edge-function tests: 51 pass
- Critical anon-policy, password, and SSRF claims verified directly against source before fixing

https://claude.ai/code/session_01AJF733qbHUtMoT3yUz4WUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJF733qbHUtMoT3yUz4WUE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced authentication and access controls for image proxy, user provisioning, and wallboard services
- Restricted anonymous access to sensitive data and features
- Updated user onboarding and timesheet reminder emails with password reset instructions
- Strengthened secret validation to fail securely when configuration is missing

**Documentation**
- Added comprehensive codebase security audit report

<!-- end of auto-generated comment: release notes by coderabbit.ai -->