### PR TITLE
fix: make user deletion work + tighten Flex API authorization

### DIFF
--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,4 +1,3 @@
-
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
@@ -9,76 +8,102 @@ const corsHeaders = {
   'Access-Control-Max-Age': '86400',
 };
 
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+
 serve(async (req) => {
-  // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
 
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405);
+  }
+
   try {
-    // Get the user ID to delete from the request
-    const { userId } = await req.json();
-    
-    if (!userId) {
-      throw new Error('User ID is required');
+    let userId: string | undefined;
+    try {
+      ({ userId } = await req.json());
+    } catch {
+      return jsonResponse({ error: 'Invalid JSON body' }, 400);
     }
 
-    // Initialize Supabase client with service role key
+    if (!userId) {
+      return jsonResponse({ error: 'User ID is required' }, 400);
+    }
+
     const supabaseAdmin = createClient(
       Deno.env.get('SUPABASE_URL') ?? '',
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
     );
 
-    // Get the requesting user's session
-    const authHeader = req.headers.get('Authorization');
+    // AuthN of requester
+    const authHeader = req.headers.get('Authorization') ?? req.headers.get('authorization');
     if (!authHeader) {
-      throw new Error('No authorization header');
+      return jsonResponse({ error: 'Unauthorized' }, 401);
     }
 
-    // Verify the requesting user has management role
-    const { data: { user: requestingUser } } = await supabaseAdmin.auth.getUser(
-      authHeader.replace('Bearer ', '')
-    );
-
+    const token = authHeader.replace('Bearer ', '').trim();
+    const { data: { user: requestingUser } } = await supabaseAdmin.auth.getUser(token);
     if (!requestingUser) {
-      throw new Error('Not authenticated');
+      return jsonResponse({ error: 'Unauthorized' }, 401);
     }
 
-    // Get the requesting user's role
-    const { data: requestingProfile } = await supabaseAdmin
+    // AuthZ: require admin or management
+    const { data: requesterProfile, error: profileErr } = await supabaseAdmin
       .from('profiles')
       .select('role')
       .eq('id', requestingUser.id)
-      .single();
+      .maybeSingle();
 
-    if (!requestingProfile || !['admin', 'management'].includes(requestingProfile.role)) {
-      throw new Error('Unauthorized - admin or management role required');
+    if (profileErr) throw profileErr;
+    if (!requesterProfile || !['admin', 'management'].includes(requesterProfile.role)) {
+      return jsonResponse({ error: 'Unauthorized - admin or management role required' }, 403);
     }
 
-    console.log('Deleting user:', userId);
+    // Guard against self-deletion (would orphan the requester's own session/audit trail)
+    if (userId === requestingUser.id) {
+      return jsonResponse({ error: 'You cannot delete your own account' }, 400);
+    }
 
-    // Delete the user from auth.users (this will cascade to profiles due to the foreign key)
-    const { error: deleteError } = await supabaseAdmin.auth.admin.deleteUser(
-      userId
-    );
+    // Confirm the target exists for a clear 404 instead of a silent success
+    const { data: targetUser, error: getErr } = await supabaseAdmin.auth.admin.getUserById(userId);
+    if (getErr || !targetUser?.user) {
+      return jsonResponse({ error: 'User not found' }, 404);
+    }
+
+    console.log('Deleting user:', userId, 'requested by:', requestingUser.id);
+
+    // Deleting from auth.users cascades to profiles and, via the normalized
+    // ON DELETE rules, to all dependent records.
+    const { error: deleteError } = await supabaseAdmin.auth.admin.deleteUser(userId);
 
     if (deleteError) {
       console.error('Error deleting user:', deleteError);
-      throw deleteError;
+      // Surface the underlying reason (e.g. a foreign-key still blocking the
+      // delete) rather than a generic 400, so it is actionable.
+      return jsonResponse(
+        {
+          error: 'Failed to delete user',
+          details: deleteError.message,
+          code: (deleteError as { code?: string }).code,
+        },
+        502,
+      );
     }
 
-    return new Response(
-      JSON.stringify({ message: 'User deleted successfully' }), 
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+    return jsonResponse({ message: 'User deleted successfully' });
   } catch (error) {
     console.error('Error in delete-user function:', error);
-    return new Response(
-      JSON.stringify({ error: error.message }), 
-      { 
-        status: 400,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-      }
+    return jsonResponse(
+      {
+        error: 'Unexpected error',
+        details: (error as Error).message,
+      },
+      500,
     );
   }
 });

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,18 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Max-Age': '86400',
-};
-
-const jsonResponse = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), {
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-  });
+import { corsHeaders, jsonResponse } from "../_shared/http.ts";
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/secure-flex-api/index.ts
+++ b/supabase/functions/secure-flex-api/index.ts
@@ -106,12 +106,14 @@ serve(async (req) => {
     )
   } catch (error) {
     console.error("Error in secure-flex-api:", error)
-    const message = error.message || 'Internal server error'
+    const message = error instanceof Error ? error.message : 'Internal server error'
     const status = message.includes('authentication') || message.includes('Authorization header')
       ? 401
       : message.includes('Forbidden')
         ? 403
-        : 400
+        : message.includes('Could not verify') || message.includes('Missing required environment')
+          ? 500
+          : 400
     return new Response(
       JSON.stringify({ success: false, error: message }),
       {

--- a/supabase/functions/secure-flex-api/index.ts
+++ b/supabase/functions/secure-flex-api/index.ts
@@ -43,6 +43,20 @@ serve(async (req) => {
       throw new Error('Invalid authentication')
     }
 
+    // Authorization: only admin/management may proxy Flex API calls
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', user.id)
+      .maybeSingle()
+
+    if (profileError) {
+      throw new Error('Could not verify authorization')
+    }
+    if (!profile || !['admin', 'management'].includes(profile.role)) {
+      throw new Error('Forbidden - admin or management role required')
+    }
+
     // Parse request body
     const { endpoint, method = 'POST', payload } = await req.json()
     
@@ -92,14 +106,17 @@ serve(async (req) => {
     )
   } catch (error) {
     console.error("Error in secure-flex-api:", error)
+    const message = error.message || 'Internal server error'
+    const status = message.includes('authentication') || message.includes('Authorization header')
+      ? 401
+      : message.includes('Forbidden')
+        ? 403
+        : 400
     return new Response(
-      JSON.stringify({ 
-        success: false, 
-        error: error.message || 'Internal server error' 
-      }),
-      { 
+      JSON.stringify({ success: false, error: message }),
+      {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: error.message?.includes('authentication') ? 401 : 400,
+        status,
       },
     )
   }

--- a/supabase/migrations/20260609130000_fix_user_deletion_fk_actions.sql
+++ b/supabase/migrations/20260609130000_fix_user_deletion_fk_actions.sql
@@ -1,0 +1,146 @@
+-- Fix user deletion (codebase audit follow-up):
+--
+-- Deleting a user via auth.admin.deleteUser() cascades auth.users -> profiles
+-- (profiles_id_fkey is ON DELETE CASCADE), but dozens of foreign keys that
+-- reference profiles(id) or auth.users(id) were created WITHOUT an ON DELETE
+-- action, so they default to NO ACTION (RESTRICT). As soon as a user has done
+-- anything real -- sent a message, uploaded a document, created a preset, set a
+-- payout override, been assigned a task, etc. -- the cascade is blocked and the
+-- deletion fails. This is why "delete user" does not work.
+--
+-- This migration normalizes the ON DELETE behavior of every such constraint:
+--   * Attribution / audit columns (created_by, updated_by, uploaded_by,
+--     approved_by, rejected_by, resolved_by, reviewed_by, processed_by,
+--     assigned_by, set_by, completed_by, assigned_to, last_modified_by, ...)
+--     -> SET NULL: keep the record, clear the now-meaningless reference.
+--   * User-owned operational rows (messages, direct messages, assignment
+--     notifications, the user's own work records) -> CASCADE, consistent with
+--     the existing intent (timesheets, job_assignments, tour_assignments already
+--     cascade on user deletion).
+--
+-- Implemented with a session-local helper that looks the FK up by column, so it
+-- is robust to constraint naming and to which migration originally defined it.
+-- Missing tables/columns are skipped, so the migration is safe to run on any
+-- environment.
+
+CREATE OR REPLACE FUNCTION pg_temp.fix_user_fk(
+  p_table       text,
+  p_column      text,
+  p_ref_table   text,   -- 'profiles' (public) or 'users' (auth)
+  p_ref_schema  text,
+  p_action      text    -- 'SET NULL' or 'CASCADE'
+) RETURNS void
+LANGUAGE plpgsql
+AS $fn$
+DECLARE
+  v_conname text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = p_table AND column_name = p_column
+  ) THEN
+    RAISE NOTICE 'fix_user_fk: skip public.%.% (missing column)', p_table, p_column;
+    RETURN;
+  END IF;
+
+  -- Find the FK constraint on public.<p_table>(<p_column>) -> <ref schema>.<ref table>
+  SELECT con.conname INTO v_conname
+  FROM pg_constraint con
+  JOIN pg_class      rel  ON rel.oid  = con.conrelid
+  JOIN pg_namespace  nsp  ON nsp.oid  = rel.relnamespace
+  JOIN pg_class      frel ON frel.oid = con.confrelid
+  JOIN pg_namespace  fnsp ON fnsp.oid = frel.relnamespace
+  WHERE con.contype = 'f'
+    AND nsp.nspname  = 'public'
+    AND rel.relname  = p_table
+    AND fnsp.nspname = p_ref_schema
+    AND frel.relname = p_ref_table
+    AND (
+      SELECT array_agg(att.attname::text ORDER BY u.ord)
+      FROM unnest(con.conkey) WITH ORDINALITY AS u(attnum, ord)
+      JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = u.attnum
+    ) = ARRAY[p_column]
+  LIMIT 1;
+
+  IF v_conname IS NULL THEN
+    RAISE NOTICE 'fix_user_fk: no FK on public.%.% -> %.% (skip)', p_table, p_column, p_ref_schema, p_ref_table;
+    RETURN;
+  END IF;
+
+  EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', p_table, v_conname);
+
+  IF upper(p_action) = 'SET NULL' THEN
+    EXECUTE format('ALTER TABLE public.%I ALTER COLUMN %I DROP NOT NULL', p_table, p_column);
+  END IF;
+
+  EXECUTE format(
+    'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (%I) REFERENCES %I.%I(id) ON DELETE %s',
+    p_table, v_conname, p_column, p_ref_schema, p_ref_table, upper(p_action)
+  );
+
+  RAISE NOTICE 'fix_user_fk: public.%.% -> %.% now ON DELETE %', p_table, p_column, p_ref_schema, p_ref_table, upper(p_action);
+END;
+$fn$;
+
+DO $$
+BEGIN
+  -- ===================== references to auth.users =====================
+  -- Attribution columns -> SET NULL
+  PERFORM pg_temp.fix_user_fk('bug_reports',            'created_by',  'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('bug_reports',            'resolved_by', 'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('day_preset_assignments', 'assigned_by', 'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('feature_requests',       'created_by',  'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('festival_logos',         'uploaded_by', 'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('hoja_de_ruta',           'approved_by', 'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('hoja_de_ruta',           'created_by',  'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('hoja_de_ruta_templates', 'created_by',  'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('job_documents',          'uploaded_by', 'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('job_stage_plots',        'created_by',  'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('presets',                'created_by',  'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('soundvision_files',      'uploaded_by', 'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('sub_rentals',            'created_by',  'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('technician_work_records','reviewed_by', 'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('tour_documents',         'uploaded_by', 'users', 'auth', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('tour_logos',             'uploaded_by', 'users', 'auth', 'SET NULL');
+  -- User-owned data -> CASCADE
+  PERFORM pg_temp.fix_user_fk('technician_work_records','technician_id', 'users', 'auth', 'CASCADE');
+
+  -- ===================== references to public.profiles =====================
+  -- Attribution columns -> SET NULL
+  PERFORM pg_temp.fix_user_fk('announcements',                  'created_by',      'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('availability_conflicts',         'resolved_by',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('festival_artist_files',          'uploaded_by',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('flex_status_log',                'processed_by',    'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('hoja_de_ruta',                   'last_modified_by','profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('hoja_de_ruta_rooms',             'staff_member1_id','profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('hoja_de_ruta_rooms',             'staff_member2_id','profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('job_milestones',                 'completed_by',    'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('job_technician_payout_overrides','set_by',          'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('lights_job_tasks',               'assigned_to',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('lights_job_tasks',               'completed_by',    'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('sound_job_tasks',                'assigned_to',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('sound_job_tasks',                'completed_by',    'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('video_job_tasks',                'assigned_to',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('video_job_tasks',                'completed_by',    'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('administrative_job_tasks',       'assigned_to',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('administrative_job_tasks',       'completed_by',    'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('production_job_tasks',           'assigned_to',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('production_job_tasks',           'completed_by',    'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('task_documents',                 'uploaded_by',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('timesheet_audit_log',            'user_id',         'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('timesheets',                     'rejected_by',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('tour_accommodations',            'created_by',      'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('tour_assignments',               'assigned_by',     'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('tour_schedule_templates',        'created_by',      'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('tour_timeline_events',           'created_by',      'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('tour_travel_segments',           'created_by',      'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('staffing_campaigns',             'created_by',      'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('staffing_campaign_events',       'profile_id',      'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('job_technician_rate_mode_dates', 'created_by',      'profiles', 'public', 'SET NULL');
+  PERFORM pg_temp.fix_user_fk('job_technician_rate_mode_dates', 'updated_by',      'profiles', 'public', 'SET NULL');
+  -- User-owned data -> CASCADE
+  PERFORM pg_temp.fix_user_fk('assignment_notifications',       'technician_id',   'profiles', 'public', 'CASCADE');
+  PERFORM pg_temp.fix_user_fk('direct_messages',               'sender_id',       'profiles', 'public', 'CASCADE');
+  PERFORM pg_temp.fix_user_fk('direct_messages',               'recipient_id',    'profiles', 'public', 'CASCADE');
+  PERFORM pg_temp.fix_user_fk('messages',                       'sender_id',       'profiles', 'public', 'CASCADE');
+END $$;


### PR DESCRIPTION
## Summary

Continues the codebase-audit remediation, and fixes the reported **"delete user doesn't work"** bug along the way.

### 1. User deletion (the reported bug) — root cause + fix
Deleting a user calls `auth.admin.deleteUser()`, which relies on the cascade `auth.users → profiles` (`profiles_id_fkey` is `ON DELETE CASCADE`). But **~50 foreign keys referencing `profiles(id)` or `auth.users(id)` were created with no `ON DELETE` action**, so they default to `RESTRICT`. The moment a user has done anything real — sent a message, uploaded a document, created a preset, set a payout override, been assigned a task, filed a bug report, reviewed a work record — that cascade is blocked and deletion fails with a foreign-key violation.

New migration `20260609130000_fix_user_deletion_fk_actions.sql` normalizes every such constraint:
- **Attribution / audit columns** (`created_by`, `updated_by`, `uploaded_by`, `approved_by`, `rejected_by`, `resolved_by`, `reviewed_by`, `processed_by`, `assigned_by`, `set_by`, `completed_by`, `assigned_to`, `last_modified_by`, `staff_member*_id`) → **`ON DELETE SET NULL`**: keep the record, clear the now-meaningless reference.
- **User-owned operational rows** (`messages`, `direct_messages`, `assignment_notifications`, the user's own `technician_work_records`) → **`ON DELETE CASCADE`**, consistent with the existing intent (timesheets, job_assignments, tour_assignments already cascade on user deletion).

Implemented with a session-local helper (`pg_temp.fix_user_fk`) that resolves each FK **by column**, so it is robust to constraint naming and to which migration originally defined it, and it skips missing tables/columns (safe on any environment).

**Verified on an ephemeral Postgres 16**, reproducing the schema:
- Before: `DELETE FROM auth.users …` → `violates foreign key constraint "job_documents_uploaded_by_fkey"` (the exact bug).
- After: delete succeeds; profile cascades; attribution rows preserved with the reference set NULL; owned rows (`messages`) cascade-deleted; missing-table case skipped.

### 2. delete-user edge function hardening
- Proper HTTP status codes: `401` (no/invalid auth), `403` (not admin/management), `404` (target not found), `405` (wrong method), `502` (delete failed — surfaces the underlying DB error), `500` (unexpected) — instead of a blanket `400` that hid the real reason.
- **Self-deletion guard** (an admin can no longer delete their own account).
- Target-existence check for a clear `404` instead of a silent success.

### 3. secure-flex-api authorization gap (audit medium finding)
Previously **any authenticated user** could proxy Flex API calls — it only checked that the caller was logged in, not their role. Added an `admin`/`management` role check (returns `403` otherwise). This matches who actually uses it (tour folder creation, an admin/management action).

## Deliberately out of scope (with rationale)
- **`apply-flex-status` returning HTTP 200 on failure (H3):** both frontend callers (`JobStatusSelector`, `JobCardNew`) depend on the current "200 + `success` flag" body to extract rich Flex error messages (`response.exceptionMessage`). Switching to 4xx/5xx makes `data` null and would degrade those messages unless both call sites are reworked to parse `error.context` — worth doing, but as its own change with live-Flex verification.
- **Flex retry logic (H9):** Flex folder/workflow POSTs are non-idempotent, so blind retries risk duplicate folders / double status application. Safe retries need idempotency keys first; deferred rather than done unsafely.

## Verification
- Migration logic verified on ephemeral Postgres 16 (before/after delete + per-table outcomes).
- `npm run lint:functions`: 0 errors.
- Edge-function test suite: 51 pass.

## Deploy checklist
- [ ] Apply the migration (`npx supabase db push` or dashboard)
- [ ] Redeploy edge functions: `delete-user`, `secure-flex-api`
- [ ] Note: app code that reads `*_by` attribution fields may now receive `null` for actions taken by a since-deleted user — this is expected (UI should render these as "—"/unknown)

https://claude.ai/code/session_01AJF733qbHUtMoT3yUz4WUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJF733qbHUtMoT3yUz4WUE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secure Flex API now enforces role-based access control, restricting access to admin and management users only.

* **Bug Fixes**
  * Enhanced user deletion with stricter validation checks, preventing self-deletion and returning more specific error messages.
  * Improved database foreign-key deletion behavior to properly cascade deletions across related records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->