### PR TITLE
fix: allow deleting users with tour guest links

### DIFF
--- a/supabase/migrations/20260609203500_fix_tour_guest_links_user_delete.sql
+++ b/supabase/migrations/20260609203500_fix_tour_guest_links_user_delete.sql
@@ -1,0 +1,28 @@
+-- User deletion follow-up:
+-- PR #679 normalized the known profile/auth user references, but
+-- tour_guest_links.created_by still referenced profiles(id) with the default
+-- NO ACTION behavior. That blocks auth.admin.deleteUser() for users who created
+-- guest links. Keep the guest link and clear the deleted creator reference.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'tour_guest_links'
+      AND column_name = 'created_by'
+  ) THEN
+    ALTER TABLE public.tour_guest_links
+      DROP CONSTRAINT IF EXISTS tour_guest_links_created_by_fkey;
+
+    ALTER TABLE public.tour_guest_links
+      ALTER COLUMN created_by DROP NOT NULL;
+
+    ALTER TABLE public.tour_guest_links
+      ADD CONSTRAINT tour_guest_links_created_by_fkey
+      FOREIGN KEY (created_by)
+      REFERENCES public.profiles(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;

--- a/supabase/migrations/20260609204000_fix_transport_requests_user_delete.sql
+++ b/supabase/migrations/20260609204000_fix_transport_requests_user_delete.sql
@@ -1,0 +1,20 @@
+-- User deletion follow-up:
+-- transport_requests.created_by already has ON DELETE SET NULL, but the column
+-- was still NOT NULL. Postgres cannot apply SET NULL unless the referencing
+-- column accepts NULL, so users who created transport requests could not be
+-- deleted.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'transport_requests'
+      AND column_name = 'created_by'
+      AND is_nullable = 'NO'
+  ) THEN
+    ALTER TABLE public.transport_requests
+      ALTER COLUMN created_by DROP NOT NULL;
+  END IF;
+END $$;

--- a/supabase/migrations/20260609204500_harden_user_delete_cascade_triggers.sql
+++ b/supabase/migrations/20260609204500_harden_user_delete_cascade_triggers.sql
@@ -1,0 +1,52 @@
+-- User deletion follow-up:
+-- auth.admin.deleteUser() runs through GoTrue's database role while cascading
+-- from auth.users -> profiles -> operational rows. Some DELETE triggers on
+-- cascade targets perform cross-table cleanup with invoker privileges, which
+-- can fail during the auth-driven cascade and surface only as a generic GoTrue
+-- "Database error deleting user". Run those cleanup triggers as their function
+-- owner with pinned search paths.
+
+DO $$
+BEGIN
+  ALTER FUNCTION public.delete_timesheets_on_assignment_removal()
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public;
+EXCEPTION
+  WHEN undefined_function THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER FUNCTION public.cascade_delete_tour_assignment()
+    SECURITY DEFINER
+    SET search_path = public;
+EXCEPTION
+  WHEN undefined_function THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER FUNCTION public.cleanup_tour_assignments_from_jobs()
+    SECURITY DEFINER
+    SET search_path = public;
+EXCEPTION
+  WHEN undefined_function THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER FUNCTION public.trg_log_assignment_delete()
+    SECURITY DEFINER
+    SET search_path = public;
+EXCEPTION
+  WHEN undefined_function THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER FUNCTION public.refresh_soundvision_file_review_stats()
+    SECURITY DEFINER
+    SET search_path = public;
+EXCEPTION
+  WHEN undefined_function THEN NULL;
+END $$;


### PR DESCRIPTION
## Summary
- add a follow-up migration for user deletion
- change tour_guest_links.created_by to ON DELETE SET NULL

## Production
- already applied to linked production project syldobdcdsgfgjtbuwxm
- verified zero remaining NO ACTION/RESTRICT FKs to auth.users or public.profiles

## Validation
- supabase db push --dry-run reports remote DB is up to date
- catalog check: tour_guest_links_created_by_fkey is ON DELETE SET NULL