### PR TITLE
fix: keep hoja de ruta in sync with assignments, logistics and staff edits

### DIFF
--- a/src/components/hoja-de-ruta/sections/ModernAccommodationSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernAccommodationSection.tsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { motion, AnimatePresence } from "framer-motion";
 import { Bed, Plus, Trash2, User, Hotel, MapPin, Building2 } from "lucide-react";
 import { Accommodation, RoomAssignment, EventData } from "@/types/hoja-de-ruta";
+import { staffOptionValue } from "@/utils/hoja-de-ruta/staffSync";
 import { AddressAutocomplete } from "@/components/maps/AddressAutocomplete";
 import { HotelAutocomplete } from "@/components/maps/HotelAutocomplete";
 import { GoogleMap } from "@/components/maps/GoogleMap";
@@ -251,7 +252,7 @@ export const ModernAccommodationSection: React.FC<ModernAccommodationSectionProp
                                 <SelectContent>
                                   <SelectItem value="__none__">Sin asignar</SelectItem>
                                   {eventData.staff.map((staff, staffIndex) => (
-                                    <SelectItem key={staffIndex} value={staffIndex.toString()}>
+                                    <SelectItem key={staffIndex} value={staffOptionValue(staff, staffIndex)}>
                                       {staff.name} {staff.surname1}
                                     </SelectItem>
                                   ))}
@@ -272,7 +273,7 @@ export const ModernAccommodationSection: React.FC<ModernAccommodationSectionProp
                                   <SelectContent>
                                     <SelectItem value="__none__">Sin asignar</SelectItem>
                                     {eventData.staff.map((staff, staffIndex) => (
-                                      <SelectItem key={staffIndex} value={staffIndex.toString()}>
+                                      <SelectItem key={staffIndex} value={staffOptionValue(staff, staffIndex)}>
                                         {staff.name} {staff.surname1}
                                       </SelectItem>
                                     ))}

--- a/src/components/hoja-de-ruta/sections/ModernTransportSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernTransportSection.tsx
@@ -120,6 +120,9 @@ export const ModernTransportSection: React.FC<ModernTransportSectionProps> = ({
       if (error) throw error;
 
       if (!logisticsEvents || logisticsEvents.length === 0) {
+        // Still sync with the empty snapshot so transports imported from
+        // logistics events that were deleted disappear from the hoja.
+        onImportTransports([]);
         toast({
           title: "Sin datos",
           description: "No se encontraron eventos logísticos para este trabajo",

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
@@ -3,6 +3,10 @@ import { EventData } from '@/types/hoja-de-ruta';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { formatPowerRequirementsText } from '@/utils/powerSummaryData';
+import {
+  mergeStaffWithAssignments,
+  remapAccommodationStaffReferences,
+} from '@/utils/hoja-de-ruta/staffSync';
 
 export const resolvePowerRequirementsForHojaInitialization = ({
   savedPowerRequirements,
@@ -21,6 +25,7 @@ export const useHojaDeRutaInitialization = (
   selectedJobId: string,
   hojaDeRuta: any,
   isLoadingHojaDeRuta: boolean,
+  isInitialized: boolean,
   setEventData: React.Dispatch<React.SetStateAction<EventData>>,
   setTravelArrangements: any,
   setAccommodations: any,
@@ -246,10 +251,12 @@ export const useHojaDeRutaInitialization = (
     }
   }, [toast, loadCurrentJobAssignments, fetchPowerRequirements, setEventData, setHasBasicJobData, setDataSource]);
 
-  // Initialize form with current job assignments, then merge with saved data if exists
+  // Initialize form with current job assignments, then merge with saved data if exists.
+  // Runs once per job selection: hojaDeRuta refetches (window focus, post-save
+  // invalidation) must not re-run this, or they would wipe unsaved edits.
   useEffect(() => {
-    if (!selectedJobId || isLoadingHojaDeRuta) return;
-    
+    if (!selectedJobId || isLoadingHojaDeRuta || isInitialized) return;
+
     console.log("🔄 INITIALIZATION: Initialization effect triggered for job:", selectedJobId);
     
     const initializeFormData = async () => {
@@ -287,77 +294,14 @@ export const useHojaDeRutaInitialization = (
         setDataSource('saved');
         
         const savedEventData = hojaDeRuta.eventData;
-        // Merge saved staff with current assignments, preserving saved DNI and manual entries
-        type StaffEntry = NonNullable<EventData['staff']>[number];
-        const mergeStaff = (
-          saved: StaffEntry[] = [],
-          assigned: StaffEntry[] = [],
-        ) => {
-          const norm = (s?: string) => (s || '').trim().toLowerCase();
-          const nameKey = (p: StaffEntry) => `${norm(p?.name)}|${norm(p?.surname1)}`;
-
-          const mergeTwo = (a: StaffEntry, s: StaffEntry): StaffEntry => ({
-            ...a,
-            ...s,
-            // Prefer saved DNI/position if present; otherwise take the assignment-derived values
-            dni: s.dni || a.dni || '',
-            position: s.position || a.position || '',
-            technician_id: s.technician_id || a.technician_id,
-            phone: s.phone || a.phone || '',
-            role: s.role || a.role,
-          });
-
-          // Start from saved order.
-          const result: StaffEntry[] = (saved || []).map((p) => ({ ...p }));
-          const usedAssigned = new Set<number>();
-
-          // PASS 1: match by technician_id (reliable)
-          const savedIndexByTechId = new Map<string, number>();
-          result.forEach((p, idx) => {
-            if (p?.technician_id) savedIndexByTechId.set(p.technician_id, idx);
-          });
-
-          assigned.forEach((a, aIdx) => {
-            const tid = a?.technician_id;
-            if (!tid) return;
-            const sIdx = savedIndexByTechId.get(tid);
-            if (sIdx == null) return;
-            result[sIdx] = mergeTwo(a, result[sIdx]);
-            usedAssigned.add(aIdx);
-          });
-
-          // PASS 2: match remaining legacy saved entries (no technician_id) by name|surname1
-          const legacySavedByName = new Map<string, number[]>();
-          result.forEach((p, idx) => {
-            if (p?.technician_id) return;
-            const k = nameKey(p);
-            if (!k || k === '|') return;
-            const arr = legacySavedByName.get(k) || [];
-            arr.push(idx);
-            legacySavedByName.set(k, arr);
-          });
-
-          assigned.forEach((a, aIdx) => {
-            if (usedAssigned.has(aIdx)) return;
-            const k = nameKey(a);
-            const arr = legacySavedByName.get(k);
-            if (!arr || arr.length === 0) return;
-            const sIdx = arr.shift()!;
-            result[sIdx] = mergeTwo(a, result[sIdx]);
-            usedAssigned.add(aIdx);
-            if (arr.length === 0) legacySavedByName.delete(k);
-          });
-
-          // Append any remaining assigned staff not present in saved data.
-          assigned.forEach((a, aIdx) => {
-            if (usedAssigned.has(aIdx)) return;
-            result.push({ ...a });
-          });
-
-          return result;
-        };
-
-        const mergedStaff = mergeStaff(savedEventData?.staff || [], staffFromAssignments || []);
+        // Merge saved staff with current assignments: keeps saved DNIs and
+        // manual entries, appends new assignments, and prunes entries whose
+        // assignment was removed so they disappear from the hoja.
+        const savedStaff = savedEventData?.staff || [];
+        const { staff: mergedStaff, savedIndexMap } = mergeStaffWithAssignments(
+          savedStaff,
+          staffFromAssignments || [],
+        );
         
         setEventData({
           eventName: savedEventData?.eventName || jobData.title || "",
@@ -406,14 +350,19 @@ export const useHojaDeRutaInitialization = (
         });
 
         // Set travel arrangements using transformed data
-        if (hojaDeRuta.travelArrangements && hojaDeRuta.travelArrangements.length > 0) {
-          setTravelArrangements(hojaDeRuta.travelArrangements);
-        }
+        setTravelArrangements(hojaDeRuta.travelArrangements || []);
 
-        // Set accommodations using transformed data  
-        if (hojaDeRuta.accommodations && hojaDeRuta.accommodations.length > 0) {
-          setAccommodations(hojaDeRuta.accommodations);
-        }
+        // Set accommodations, remapping room staff references against the
+        // merged staff list (room assignments stored array indexes, which go
+        // stale when staff entries are pruned or reordered)
+        setAccommodations(
+          remapAccommodationStaffReferences(
+            hojaDeRuta.accommodations || [],
+            savedStaff,
+            savedIndexMap,
+            mergedStaff,
+          ),
+        );
         
         toast({
           title: "✅ Datos cargados",
@@ -477,7 +426,7 @@ export const useHojaDeRutaInitialization = (
     };
 
     initializeFormData();
-  }, [selectedJobId, hojaDeRuta, isLoadingHojaDeRuta, loadCurrentJobAssignments, fetchPowerRequirements, toast, setEventData, setTravelArrangements, setAccommodations, setIsInitialized, setHasSavedData, setDataSource]);
+  }, [selectedJobId, hojaDeRuta, isLoadingHojaDeRuta, isInitialized, loadCurrentJobAssignments, fetchPowerRequirements, toast, setEventData, setTravelArrangements, setAccommodations, setIsInitialized, setHasSavedData, setDataSource]);
 
   return {
     autoPopulateBasicJobData,

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
@@ -35,8 +35,8 @@ export const useHojaDeRutaInitialization = (
   setDataSource: React.Dispatch<React.SetStateAction<'none' | 'saved' | 'job' | 'mixed'>>
 ) => {
   const { toast } = useToast();
-  // Job id whose initialization is currently in flight (see the effect below)
-  const initializingJobRef = useRef<string | null>(null);
+  // Token of the initialization run currently in flight (see the effect below)
+  const initializingRunRef = useRef<{ jobId: string } | null>(null);
 
   const buildClientContacts = (jobData: { client_name?: string | null; client_phone?: string | null }) =>
     jobData.client_name ? [{
@@ -70,6 +70,66 @@ export const useHojaDeRutaInitialization = (
       merged.push({ name, role, phone });
     });
     return merged.length ? merged : [{ name: "", role: "", phone: "" }];
+  };
+
+  const formatJobEventDates = (jobData: { start_time?: string | null; end_time?: string | null }) => {
+    const startDate = jobData.start_time ? new Date(jobData.start_time) : null;
+    const endDate = jobData.end_time ? new Date(jobData.end_time) : null;
+
+    let eventDates = "";
+    if (startDate && endDate) {
+      eventDates = startDate.toDateString() === endDate.toDateString()
+        ? startDate.toLocaleDateString('es-ES')
+        : `${startDate.toLocaleDateString('es-ES')} - ${endDate.toLocaleDateString('es-ES')}`;
+    }
+
+    return { startDate, endDate, eventDates };
+  };
+
+  // Builds the EventData used when there is no saved hoja for the job, shared
+  // by the initialization effect and autoPopulateBasicJobData.
+  const buildEventDataFromJob = ({
+    jobData,
+    staffFromAssignments,
+    tourContacts,
+    powerRequirementsText,
+  }: {
+    jobData: any;
+    staffFromAssignments: NonNullable<EventData['staff']>;
+    tourContacts: Array<{ name: string; role: string; phone: string }>;
+    powerRequirementsText: string;
+  }): EventData => {
+    const { startDate, eventDates } = formatJobEventDates(jobData);
+
+    return {
+      eventName: jobData.title || "",
+      eventDates,
+      venue: {
+        name: jobData.location?.name || "",
+        address: jobData.location?.formatted_address || "",
+        coordinates: jobData.location?.latitude != null && jobData.location?.longitude != null
+          ? { lat: jobData.location.latitude, lng: jobData.location.longitude }
+          : undefined,
+      },
+      contacts: mergeContacts(
+        buildClientContacts(jobData as { client_name?: string | null; client_phone?: string | null }),
+        tourContacts,
+      ),
+      logistics: {
+        transport: [],
+        loadingDetails: "",
+        unloadingDetails: "",
+        equipmentLogistics: "",
+      },
+      staff: staffFromAssignments.length > 0 ? staffFromAssignments : [{ name: "", surname1: "", surname2: "", position: "", dni: "" }],
+      schedule: startDate ? `Load in: ${startDate.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}` : "",
+      powerRequirements: powerRequirementsText || "",
+      auxiliaryNeeds: "",
+      auxiliaryStaffSetupQty: 0,
+      auxiliaryStaffDismantleQty: 0,
+      auxiliaryMachinery: [],
+      weather: undefined,
+    };
   };
 
   // Fetch power requirements for a job
@@ -177,49 +237,12 @@ export const useHojaDeRutaInitialization = (
 
       const { jobData, staffFromAssignments, tourContacts } = assignmentData;
 
-      // Prepare basic event data
-      const startDate = jobData.start_time ? new Date(jobData.start_time) : null;
-      const endDate = jobData.end_time ? new Date(jobData.end_time) : null;
-      
-      let eventDates = "";
-      if (startDate && endDate) {
-        if (startDate.toDateString() === endDate.toDateString()) {
-          eventDates = startDate.toLocaleDateString('es-ES');
-        } else {
-          eventDates = `${startDate.toLocaleDateString('es-ES')} - ${endDate.toLocaleDateString('es-ES')}`;
-        }
-      }
-
-      const basicEventData: EventData = {
-        eventName: jobData.title || "",
-        eventDates,
-        venue: {
-          name: jobData.location?.name || "",
-          address: jobData.location?.formatted_address || "",
-          coordinates: jobData.location?.latitude != null && jobData.location?.longitude != null
-            ? { lat: jobData.location.latitude, lng: jobData.location.longitude }
-            : undefined,
-        },
-        contacts: mergeContacts(
-          buildClientContacts(jobData as { client_name?: string | null; client_phone?: string | null }),
-          tourContacts,
-        ),
-        logistics: {
-          transport: [],
-          loadingDetails: "",
-          unloadingDetails: "",
-          equipmentLogistics: "",
-        },
-        staff: staffFromAssignments.length > 0 ? staffFromAssignments : [{ name: "", surname1: "", surname2: "", position: "", dni: "" }],
-        schedule: startDate ? `Load in: ${startDate.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}` : "",
-        // Use fetched power requirements from database
-        powerRequirements: powerRequirementsText || "",
-        auxiliaryNeeds: "",
-        auxiliaryStaffSetupQty: 0,
-        auxiliaryStaffDismantleQty: 0,
-        auxiliaryMachinery: [],
-        weather: undefined,
-      };
+      const basicEventData = buildEventDataFromJob({
+        jobData,
+        staffFromAssignments,
+        tourContacts,
+        powerRequirementsText,
+      });
 
       console.log("✅ INITIALIZATION: Setting basic job data with assignments:", {
         eventName: basicEventData.eventName,
@@ -259,9 +282,14 @@ export const useHojaDeRutaInitialization = (
   useEffect(() => {
     if (!selectedJobId || isLoadingHojaDeRuta || isInitialized) return;
     // The async initialization below sets isInitialized only when it finishes;
-    // block concurrent runs (e.g. a refetch landing mid-initialization).
-    if (initializingJobRef.current === selectedJobId) return;
-    initializingJobRef.current = selectedJobId;
+    // block concurrent runs for the same job (e.g. a refetch landing
+    // mid-initialization).
+    if (initializingRunRef.current?.jobId === selectedJobId) return;
+    const runToken = { jobId: selectedJobId };
+    initializingRunRef.current = runToken;
+    // A newer run (job change) replaces the token; stale completions must not
+    // apply their results over the newer job's state.
+    const isCurrentRun = () => initializingRunRef.current === runToken;
 
     console.log("🔄 INITIALIZATION: Initialization effect triggered for job:", selectedJobId);
 
@@ -272,6 +300,13 @@ export const useHojaDeRutaInitialization = (
         fetchPowerRequirements(selectedJobId)
       ]);
 
+      // Everything below is synchronous, so this single check after the only
+      // await guards every state mutation in this run.
+      if (!isCurrentRun()) {
+        console.log("⏭️ INITIALIZATION: Discarding stale initialization for job:", selectedJobId);
+        return;
+      }
+
       if (!assignmentData) {
         console.log("❌ INITIALIZATION: No assignment data available");
         setIsInitialized(true);
@@ -279,19 +314,7 @@ export const useHojaDeRutaInitialization = (
       }
 
       const { jobData, staffFromAssignments, tourContacts } = assignmentData;
-      
-      // Prepare basic event data from job
-      const startDate = jobData.start_time ? new Date(jobData.start_time) : null;
-      const endDate = jobData.end_time ? new Date(jobData.end_time) : null;
-      
-      let eventDates = "";
-      if (startDate && endDate) {
-        if (startDate.toDateString() === endDate.toDateString()) {
-          eventDates = startDate.toLocaleDateString('es-ES');
-        } else {
-          eventDates = `${startDate.toLocaleDateString('es-ES')} - ${endDate.toLocaleDateString('es-ES')}`;
-        }
-      }
+      const { startDate, eventDates } = formatJobEventDates(jobData);
 
       // If we have saved data, merge current assignments with saved data
       if (hojaDeRuta) {
@@ -379,39 +402,13 @@ export const useHojaDeRutaInitialization = (
         console.log("🆕 INITIALIZATION: No saved data, using current job data with assignments");
         setHasSavedData(false);
         setDataSource('job');
-        
-        const basicEventData: EventData = {
-          eventName: jobData.title || "",
-          eventDates,
-          venue: {
-            name: jobData.location?.name || "",
-            address: jobData.location?.formatted_address || "",
-            coordinates: jobData.location?.latitude != null && jobData.location?.longitude != null
-              ? { lat: jobData.location.latitude, lng: jobData.location.longitude }
-              : undefined,
-          },
-          contacts: mergeContacts(
-            buildClientContacts(jobData as { client_name?: string | null; client_phone?: string | null }),
-            tourContacts,
-          ),
-          logistics: {
-            transport: [],
-            loadingDetails: "",
-            unloadingDetails: "",
-            equipmentLogistics: "",
-          },
-          staff: staffFromAssignments.length > 0 ? staffFromAssignments : [{ name: "", surname1: "", surname2: "", position: "", dni: "" }],
-          schedule: startDate ? `Load in: ${startDate.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}` : "",
-          // Use fetched power requirements from database
-          powerRequirements: powerRequirementsText || "",
-          auxiliaryNeeds: "",
-          auxiliaryStaffSetupQty: 0,
-          auxiliaryStaffDismantleQty: 0,
-          auxiliaryMachinery: [],
-          weather: undefined,
-        };
 
-        setEventData(basicEventData);
+        setEventData(buildEventDataFromJob({
+          jobData,
+          staffFromAssignments,
+          tourContacts,
+          powerRequirementsText,
+        }));
         setTravelArrangements([]);
         setAccommodations([]);
 
@@ -432,8 +429,8 @@ export const useHojaDeRutaInitialization = (
     };
 
     initializeFormData().finally(() => {
-      if (initializingJobRef.current === selectedJobId) {
-        initializingJobRef.current = null;
+      if (isCurrentRun()) {
+        initializingRunRef.current = null;
       }
     });
   }, [selectedJobId, hojaDeRuta, isLoadingHojaDeRuta, isInitialized, loadCurrentJobAssignments, fetchPowerRequirements, toast, setEventData, setTravelArrangements, setAccommodations, setIsInitialized, setHasSavedData, setDataSource]);

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { EventData } from '@/types/hoja-de-ruta';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
@@ -35,6 +35,8 @@ export const useHojaDeRutaInitialization = (
   setDataSource: React.Dispatch<React.SetStateAction<'none' | 'saved' | 'job' | 'mixed'>>
 ) => {
   const { toast } = useToast();
+  // Job id whose initialization is currently in flight (see the effect below)
+  const initializingJobRef = useRef<string | null>(null);
 
   const buildClientContacts = (jobData: { client_name?: string | null; client_phone?: string | null }) =>
     jobData.client_name ? [{
@@ -256,9 +258,13 @@ export const useHojaDeRutaInitialization = (
   // invalidation) must not re-run this, or they would wipe unsaved edits.
   useEffect(() => {
     if (!selectedJobId || isLoadingHojaDeRuta || isInitialized) return;
+    // The async initialization below sets isInitialized only when it finishes;
+    // block concurrent runs (e.g. a refetch landing mid-initialization).
+    if (initializingJobRef.current === selectedJobId) return;
+    initializingJobRef.current = selectedJobId;
 
     console.log("🔄 INITIALIZATION: Initialization effect triggered for job:", selectedJobId);
-    
+
     const initializeFormData = async () => {
       // Always load current job assignments and power requirements first
       const [assignmentData, powerRequirementsText] = await Promise.all([
@@ -425,7 +431,11 @@ export const useHojaDeRutaInitialization = (
       setIsInitialized(true);
     };
 
-    initializeFormData();
+    initializeFormData().finally(() => {
+      if (initializingJobRef.current === selectedJobId) {
+        initializingJobRef.current = null;
+      }
+    });
   }, [selectedJobId, hojaDeRuta, isLoadingHojaDeRuta, isInitialized, loadCurrentJobAssignments, fetchPowerRequirements, toast, setEventData, setTravelArrangements, setAccommodations, setIsInitialized, setHasSavedData, setDataSource]);
 
   return {

--- a/src/hooks/useHojaDeRutaForm.ts
+++ b/src/hooks/useHojaDeRutaForm.ts
@@ -6,6 +6,10 @@ import { useHojaDeRutaPersistence } from "./useHojaDeRutaPersistence";
 import { useHojaDeRutaState } from "./hoja-de-ruta/useHojaDeRutaState";
 import { useHojaDeRutaInitialization } from "./hoja-de-ruta/useHojaDeRutaInitialization";
 import { useHojaDeRutaSave } from "./hoja-de-ruta/useHojaDeRutaSave";
+import {
+  adjustAccommodationsForStaffRemoval,
+  syncTransportsWithLogistics,
+} from "@/utils/hoja-de-ruta/staffSync";
 
 export const useHojaDeRutaForm = (venueImages: { image_path: string; image_type: string }[] = []) => {
   const { toast } = useToast();
@@ -38,6 +42,7 @@ export const useHojaDeRutaForm = (venueImages: { image_path: string; image_type:
   const {
     hojaDeRuta,
     isLoading: isLoadingHojaDeRuta,
+    isFetching: isFetchingHojaDeRuta,
     fetchError,
     saveHojaDeRuta,
     isSaving,
@@ -77,7 +82,10 @@ export const useHojaDeRutaForm = (venueImages: { image_path: string; image_type:
   const { autoPopulateBasicJobData } = useHojaDeRutaInitialization(
     selectedJobId,
     hojaDeRuta,
-    isLoadingHojaDeRuta,
+    // Wait for in-flight refetches so initialization never runs on stale
+    // cached data (it only runs once per job selection).
+    isLoadingHojaDeRuta || isFetchingHojaDeRuta,
+    isInitialized,
     setEventData,
     setTravelArrangements,
     setAccommodations,
@@ -211,6 +219,7 @@ export const useHojaDeRutaForm = (venueImages: { image_path: string; image_type:
   }, [setEventData]);
 
   const removeStaffMember = useCallback((index: number) => {
+    const removedEntry = eventData.staff?.[index];
     setEventData(prev => {
       const next = (prev.staff || []).filter((_, i) => i !== index);
       return {
@@ -218,7 +227,10 @@ export const useHojaDeRutaForm = (venueImages: { image_path: string; image_type:
         staff: next.length > 0 ? next : [{ name: '', surname1: '', surname2: '', position: '', dni: '' }],
       };
     });
-  }, [setEventData]);
+    // Keep room assignments consistent: clear references to the removed
+    // person and shift index-based references down.
+    setAccommodations(prev => adjustAccommodationsForStaffRemoval(prev, index, removedEntry));
+  }, [setEventData, setAccommodations, eventData.staff]);
 
   const updateTravelArrangement = useCallback((index: number, field: string, value: string | undefined) => {
     setTravelArrangements(prev => 
@@ -357,42 +369,12 @@ export const useHojaDeRutaForm = (venueImages: { image_path: string; image_type:
       ...prev,
       logistics: {
         ...prev.logistics,
-        transport: (() => {
-          const current = Array.isArray(prev.logistics.transport) ? [...prev.logistics.transport] : [];
-
-          transports.forEach((incoming) => {
-            const sourceId = incoming.source_logistics_event_id || null;
-            if (sourceId) {
-              const existingIndex = current.findIndex(
-                (transport) => transport.source_logistics_event_id === sourceId
-              );
-
-              if (existingIndex >= 0) {
-                const existing = current[existingIndex];
-                const shouldSyncDateTime = !existing.date_time || !String(existing.date_time).trim();
-                current[existingIndex] = {
-                  ...existing,
-                  transport_type: incoming.transport_type,
-                  license_plate: incoming.license_plate,
-                  company: incoming.company,
-                  // Preserve any manually-edited Hoja de Ruta datetime; only sync if empty.
-                  date_time: shouldSyncDateTime ? incoming.date_time : existing.date_time,
-                  source_logistics_event_id: sourceId,
-                  is_hoja_relevant: incoming.is_hoja_relevant ?? true,
-                  logistics_categories: incoming.logistics_categories || [],
-                  driver_name: incoming.driver_name ?? existing.driver_name,
-                  driver_phone: incoming.driver_phone ?? existing.driver_phone,
-                  has_return: incoming.has_return ?? existing.has_return,
-                };
-                return;
-              }
-            }
-
-            current.push(incoming);
-          });
-
-          return current;
-        })()
+        // Full sync against the logistics snapshot: prunes transports whose
+        // logistics event was deleted, keeps manual edits and manual rows.
+        transport: syncTransportsWithLogistics(
+          Array.isArray(prev.logistics.transport) ? prev.logistics.transport : [],
+          transports
+        )
       }
     }));
   }, [setEventData]);

--- a/src/hooks/useHojaDeRutaPersistence.ts
+++ b/src/hooks/useHojaDeRutaPersistence.ts
@@ -113,7 +113,7 @@ export const useHojaDeRutaPersistence = (
   const { onSuccess, onError, onSettled } = callbacks;
 
   // Fetch existing hoja de ruta data with new structure
-  const { data: hojaDeRuta, isLoading, error: fetchError } = useQuery({
+  const { data: hojaDeRuta, isLoading, isFetching, error: fetchError } = useQuery({
     queryKey: queryKeys.scope('hoja-de-ruta', jobId),
     queryFn: async () => {
       if (!jobId) return null;
@@ -748,6 +748,7 @@ export const useHojaDeRutaPersistence = (
   return {
     hojaDeRuta: hojaDeRuta || null,
     isLoading,
+    isFetching,
     fetchError,
     saveHojaDeRuta: saveHojaDeRuta.mutateAsync,
     isSaving: saveHojaDeRuta.isPending,

--- a/src/utils/hoja-de-ruta/__tests__/staffSync.test.ts
+++ b/src/utils/hoja-de-ruta/__tests__/staffSync.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  adjustAccommodationsForStaffRemoval,
+  mergeStaffWithAssignments,
+  remapAccommodationStaffReferences,
+  staffOptionValue,
+  syncTransportsWithLogistics,
+} from "@/utils/hoja-de-ruta/staffSync";
+
+const assigned = (technicianId: string, name: string, position = "Técnico") => ({
+  technician_id: technicianId,
+  name,
+  surname1: `${name}-S`,
+  surname2: "",
+  position,
+  dni: "",
+  phone: "",
+  role: "house_tech",
+});
+
+describe("mergeStaffWithAssignments", () => {
+  it("prunes saved entries whose assignment was removed", () => {
+    const saved = [
+      { technician_id: "t1", name: "Ana", surname1: "A", dni: "111A" },
+      { technician_id: "t2", name: "Bea", surname1: "B", dni: "222B" },
+    ];
+    const { staff, savedIndexMap } = mergeStaffWithAssignments(saved, [
+      assigned("t2", "Bea"),
+    ]);
+
+    expect(staff).toHaveLength(1);
+    expect(staff[0].technician_id).toBe("t2");
+    // saved DNI is preserved on the surviving entry
+    expect(staff[0].dni).toBe("222B");
+    expect(savedIndexMap).toEqual([-1, 0]);
+  });
+
+  it("keeps manual entries (no technician_id) and appends new assignments", () => {
+    const saved = [
+      { name: "Manual", surname1: "Guy", position: "Runner", dni: "" },
+      { technician_id: "t1", name: "Ana", surname1: "A", dni: "111A" },
+    ];
+    const { staff, savedIndexMap } = mergeStaffWithAssignments(saved, [
+      assigned("t1", "Ana"),
+      assigned("t3", "Carlos"),
+    ]);
+
+    expect(staff.map((s) => s.name)).toEqual(["Manual", "Ana", "Carlos"]);
+    expect(savedIndexMap).toEqual([0, 1]);
+  });
+
+  it("matches legacy saved entries by name and enriches them with technician_id", () => {
+    const saved = [{ name: "Ana", surname1: "Ana-S", position: "FoH", dni: "111A" }];
+    const { staff } = mergeStaffWithAssignments(saved, [assigned("t1", "Ana", "Mon")]);
+
+    expect(staff).toHaveLength(1);
+    expect(staff[0].technician_id).toBe("t1");
+    // saved position and DNI win over assignment-derived values
+    expect(staff[0].position).toBe("FoH");
+    expect(staff[0].dni).toBe("111A");
+  });
+});
+
+describe("remapAccommodationStaffReferences", () => {
+  const savedStaff = [
+    { technician_id: "t1", name: "Ana", surname1: "A" },
+    { name: "Manual", surname1: "Guy" },
+    { technician_id: "t2", name: "Bea", surname1: "B" },
+  ];
+
+  it("migrates index references to technician_id and shifts manual indexes", () => {
+    // t1 was unassigned → pruned; Manual moves to index 0, t2 to index 1
+    const { staff: merged, savedIndexMap } = mergeStaffWithAssignments(savedStaff, [
+      assigned("t2", "Bea"),
+    ]);
+    const accommodations = [
+      {
+        hotel_name: "Hotel",
+        rooms: [
+          { room_type: "double" as const, staff_member1_id: "0", staff_member2_id: "1" },
+          { room_type: "single" as const, staff_member1_id: "2", staff_member2_id: "" },
+        ],
+      },
+    ];
+
+    const remapped = remapAccommodationStaffReferences(
+      accommodations,
+      savedStaff,
+      savedIndexMap,
+      merged,
+    );
+
+    // index 0 referenced t1 (pruned) → cleared
+    expect(remapped[0].rooms[0].staff_member1_id).toBe("");
+    // index 1 was the manual entry → its new index
+    expect(remapped[0].rooms[0].staff_member2_id).toBe("0");
+    // index 2 referenced t2 → migrated to stable technician_id
+    expect(remapped[0].rooms[1].staff_member1_id).toBe("t2");
+  });
+
+  it("clears technician_id references to pruned staff and keeps valid ones", () => {
+    const { staff: merged, savedIndexMap } = mergeStaffWithAssignments(savedStaff, [
+      assigned("t2", "Bea"),
+    ]);
+    const accommodations = [
+      {
+        rooms: [
+          { room_type: "double" as const, staff_member1_id: "t1", staff_member2_id: "t2" },
+        ],
+      },
+    ];
+
+    const remapped = remapAccommodationStaffReferences(
+      accommodations,
+      savedStaff,
+      savedIndexMap,
+      merged,
+    );
+
+    expect(remapped[0].rooms[0].staff_member1_id).toBe("");
+    expect(remapped[0].rooms[0].staff_member2_id).toBe("t2");
+  });
+});
+
+describe("adjustAccommodationsForStaffRemoval", () => {
+  it("clears references to the removed member and shifts higher indexes", () => {
+    const accommodations = [
+      {
+        rooms: [
+          { room_type: "double" as const, staff_member1_id: "1", staff_member2_id: "2" },
+          { room_type: "single" as const, staff_member1_id: "0", staff_member2_id: "" },
+          { room_type: "single" as const, staff_member1_id: "t9", staff_member2_id: "" },
+        ],
+      },
+    ];
+
+    const adjusted = adjustAccommodationsForStaffRemoval(accommodations, 1, {
+      technician_id: "t9",
+      name: "Bea",
+    });
+
+    expect(adjusted[0].rooms[0].staff_member1_id).toBe("");
+    expect(adjusted[0].rooms[0].staff_member2_id).toBe("1");
+    expect(adjusted[0].rooms[1].staff_member1_id).toBe("0");
+    // technician_id reference to the removed member is cleared too
+    expect(adjusted[0].rooms[2].staff_member1_id).toBe("");
+  });
+});
+
+describe("staffOptionValue", () => {
+  it("uses technician_id when present, the index otherwise", () => {
+    expect(staffOptionValue({ technician_id: "t1", name: "Ana" }, 3)).toBe("t1");
+    expect(staffOptionValue({ name: "Manual" }, 3)).toBe("3");
+  });
+});
+
+describe("syncTransportsWithLogistics", () => {
+  const sourced = (sourceId: string, extra: Record<string, unknown> = {}) => ({
+    id: `local-${sourceId}`,
+    transport_type: "trailer",
+    source_logistics_event_id: sourceId,
+    date_time: "",
+    ...extra,
+  });
+
+  it("prunes transports whose logistics event disappeared and keeps manual rows", () => {
+    const current = [
+      sourced("ev1"),
+      sourced("ev2"),
+      { id: "manual-1", transport_type: "furgoneta", date_time: "2026-06-10T08:00" },
+    ];
+
+    const next = syncTransportsWithLogistics(current, [sourced("ev2")]);
+
+    expect(next.map((t) => t.id)).toEqual(["local-ev2", "manual-1"]);
+  });
+
+  it("clears all sourced transports when the snapshot is empty", () => {
+    const current = [sourced("ev1"), { id: "manual-1", transport_type: "4m" }];
+    const next = syncTransportsWithLogistics(current, []);
+    expect(next.map((t) => t.id)).toEqual(["manual-1"]);
+  });
+
+  it("preserves manually edited datetime on matched transports and appends new events", () => {
+    const current = [sourced("ev1", { date_time: "2026-06-10T07:30" })];
+    const incoming = [
+      sourced("ev1", { date_time: "2026-06-10T09:00", license_plate: "1234-ABC" }),
+      sourced("ev3", { date_time: "2026-06-11T10:00" }),
+    ];
+
+    const next = syncTransportsWithLogistics(current, incoming);
+
+    expect(next).toHaveLength(2);
+    expect(next[0].date_time).toBe("2026-06-10T07:30");
+    expect(next[0].license_plate).toBe("1234-ABC");
+    expect(next[1].source_logistics_event_id).toBe("ev3");
+  });
+});

--- a/src/utils/hoja-de-ruta/__tests__/staffSync.test.ts
+++ b/src/utils/hoja-de-ruta/__tests__/staffSync.test.ts
@@ -155,7 +155,21 @@ describe("staffOptionValue", () => {
 });
 
 describe("syncTransportsWithLogistics", () => {
-  const sourced = (sourceId: string, extra: Record<string, unknown> = {}) => ({
+  interface TransportTest {
+    id: string;
+    transport_type: string;
+    source_logistics_event_id: string;
+    date_time: string;
+    license_plate?: string;
+    company?: string;
+    driver_name?: string;
+    driver_phone?: string;
+    has_return?: boolean;
+    is_hoja_relevant?: boolean;
+    logistics_categories?: unknown[];
+  }
+
+  const sourced = (sourceId: string, extra: Partial<TransportTest> = {}): TransportTest => ({
     id: `local-${sourceId}`,
     transport_type: "trailer",
     source_logistics_event_id: sourceId,

--- a/src/utils/hoja-de-ruta/__tests__/staffSync.test.ts
+++ b/src/utils/hoja-de-ruta/__tests__/staffSync.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { Transport } from "@/types/hoja-de-ruta";
 import {
   adjustAccommodationsForStaffRemoval,
   mergeStaffWithAssignments,
@@ -155,21 +156,7 @@ describe("staffOptionValue", () => {
 });
 
 describe("syncTransportsWithLogistics", () => {
-  interface TransportTest {
-    id: string;
-    transport_type: string;
-    source_logistics_event_id: string;
-    date_time: string;
-    license_plate?: string;
-    company?: string;
-    driver_name?: string;
-    driver_phone?: string;
-    has_return?: boolean;
-    is_hoja_relevant?: boolean;
-    logistics_categories?: unknown[];
-  }
-
-  const sourced = (sourceId: string, extra: Partial<TransportTest> = {}): TransportTest => ({
+  const sourced = (sourceId: string, extra: Partial<Transport> = {}): Transport => ({
     id: `local-${sourceId}`,
     transport_type: "trailer",
     source_logistics_event_id: sourceId,
@@ -178,7 +165,7 @@ describe("syncTransportsWithLogistics", () => {
   });
 
   it("prunes transports whose logistics event disappeared and keeps manual rows", () => {
-    const current = [
+    const current: Transport[] = [
       sourced("ev1"),
       sourced("ev2"),
       { id: "manual-1", transport_type: "furgoneta", date_time: "2026-06-10T08:00" },
@@ -190,7 +177,7 @@ describe("syncTransportsWithLogistics", () => {
   });
 
   it("clears all sourced transports when the snapshot is empty", () => {
-    const current = [sourced("ev1"), { id: "manual-1", transport_type: "4m" }];
+    const current: Transport[] = [sourced("ev1"), { id: "manual-1", transport_type: "4m" }];
     const next = syncTransportsWithLogistics(current, []);
     expect(next.map((t) => t.id)).toEqual(["manual-1"]);
   });

--- a/src/utils/hoja-de-ruta/staffSync.ts
+++ b/src/utils/hoja-de-ruta/staffSync.ts
@@ -1,0 +1,266 @@
+import type { Accommodation, EventData, RoomAssignment } from "@/types/hoja-de-ruta";
+
+export type HojaStaffEntry = NonNullable<EventData["staff"]>[number];
+
+const norm = (value?: string) => (value || "").trim().toLowerCase();
+const nameKey = (entry: HojaStaffEntry) => `${norm(entry?.name)}|${norm(entry?.surname1)}`;
+
+const mergeTwo = (assigned: HojaStaffEntry, saved: HojaStaffEntry): HojaStaffEntry => ({
+  ...assigned,
+  ...saved,
+  // Prefer saved DNI/position if present; otherwise take the assignment-derived values
+  dni: saved.dni || assigned.dni || "",
+  position: saved.position || assigned.position || "",
+  technician_id: saved.technician_id || assigned.technician_id,
+  phone: saved.phone || assigned.phone || "",
+  role: saved.role || assigned.role,
+});
+
+export type MergedStaffResult = {
+  staff: HojaStaffEntry[];
+  /**
+   * Maps each index of the saved staff array to its index in the merged
+   * array, or -1 when the entry was pruned (its assignment was removed).
+   */
+  savedIndexMap: number[];
+};
+
+/**
+ * Merges the staff list saved with the hoja de ruta with the job's current
+ * assignments:
+ * - saved entries that reference a technician no longer assigned are pruned,
+ *   so removing an assignment removes the person from the hoja (the bug this
+ *   fixes); manual entries without technician_id are always preserved
+ * - matched entries keep saved DNI/position edits
+ * - newly assigned technicians are appended
+ */
+export const mergeStaffWithAssignments = (
+  saved: HojaStaffEntry[] = [],
+  assigned: HojaStaffEntry[] = [],
+): MergedStaffResult => {
+  const assignedTechIds = new Set(
+    assigned.map((entry) => entry?.technician_id).filter(Boolean) as string[],
+  );
+
+  // Prune saved entries whose source assignment disappeared.
+  const savedIndexMap: number[] = new Array(saved.length).fill(-1);
+  const result: HojaStaffEntry[] = [];
+  saved.forEach((entry, savedIndex) => {
+    if (entry?.technician_id && !assignedTechIds.has(entry.technician_id)) return;
+    savedIndexMap[savedIndex] = result.length;
+    result.push({ ...entry });
+  });
+
+  const usedAssigned = new Set<number>();
+
+  // PASS 1: match by technician_id (reliable)
+  const keptIndexByTechId = new Map<string, number>();
+  result.forEach((entry, index) => {
+    if (entry?.technician_id) keptIndexByTechId.set(entry.technician_id, index);
+  });
+
+  assigned.forEach((entry, assignedIndex) => {
+    const technicianId = entry?.technician_id;
+    if (!technicianId) return;
+    const keptIndex = keptIndexByTechId.get(technicianId);
+    if (keptIndex == null) return;
+    result[keptIndex] = mergeTwo(entry, result[keptIndex]);
+    usedAssigned.add(assignedIndex);
+  });
+
+  // PASS 2: match remaining legacy saved entries (no technician_id) by name|surname1
+  const legacySavedByName = new Map<string, number[]>();
+  result.forEach((entry, index) => {
+    if (entry?.technician_id) return;
+    const key = nameKey(entry);
+    if (!key || key === "|") return;
+    const indexes = legacySavedByName.get(key) || [];
+    indexes.push(index);
+    legacySavedByName.set(key, indexes);
+  });
+
+  assigned.forEach((entry, assignedIndex) => {
+    if (usedAssigned.has(assignedIndex)) return;
+    const key = nameKey(entry);
+    const indexes = legacySavedByName.get(key);
+    if (!indexes || indexes.length === 0) return;
+    const keptIndex = indexes.shift()!;
+    result[keptIndex] = mergeTwo(entry, result[keptIndex]);
+    usedAssigned.add(assignedIndex);
+    if (indexes.length === 0) legacySavedByName.delete(key);
+  });
+
+  // Append any remaining assigned staff not present in saved data.
+  assigned.forEach((entry, assignedIndex) => {
+    if (usedAssigned.has(assignedIndex)) return;
+    result.push({ ...entry });
+  });
+
+  return { staff: result, savedIndexMap };
+};
+
+/**
+ * Stable select value for a staff member in room assignments: technician_id
+ * when the entry comes from job staffing, the array index otherwise. The PDF
+ * generator resolves both forms.
+ */
+export const staffOptionValue = (entry: HojaStaffEntry, index: number) =>
+  entry?.technician_id || index.toString();
+
+const isIndexReference = (value: string) => /^\d+$/.test(value);
+
+const remapRoomReference = (
+  value: string | undefined,
+  savedStaff: HojaStaffEntry[],
+  savedIndexMap: number[],
+  mergedStaff: HojaStaffEntry[],
+): string => {
+  if (!value) return "";
+
+  if (isIndexReference(value)) {
+    const savedIndex = Number(value);
+    if (savedIndex < 0 || savedIndex >= savedStaff.length) return "";
+    const mergedIndex = savedIndexMap[savedIndex];
+    if (mergedIndex == null || mergedIndex < 0) return "";
+    return staffOptionValue(mergedStaff[mergedIndex], mergedIndex);
+  }
+
+  // technician_id reference: clear it when that technician was pruned
+  const stillPresent = mergedStaff.some((entry) => entry?.technician_id === value);
+  return stillPresent ? value : "";
+};
+
+/**
+ * Room assignments historically stored the staff array index, which breaks as
+ * soon as the staff list shrinks or reorders. This remaps every reference
+ * against the saved staff order, migrating index references to the stable
+ * technician_id where available and clearing references to pruned staff.
+ */
+export const remapAccommodationStaffReferences = (
+  accommodations: Accommodation[],
+  savedStaff: HojaStaffEntry[],
+  savedIndexMap: number[],
+  mergedStaff: HojaStaffEntry[],
+): Accommodation[] =>
+  accommodations.map((accommodation) => ({
+    ...accommodation,
+    rooms: (accommodation.rooms || []).map((room: RoomAssignment) => ({
+      ...room,
+      staff_member1_id: remapRoomReference(
+        room.staff_member1_id,
+        savedStaff,
+        savedIndexMap,
+        mergedStaff,
+      ),
+      staff_member2_id: remapRoomReference(
+        room.staff_member2_id,
+        savedStaff,
+        savedIndexMap,
+        mergedStaff,
+      ),
+    })),
+  }));
+
+const adjustReferenceForRemoval = (
+  value: string | undefined,
+  removedIndex: number,
+  removedEntry?: HojaStaffEntry,
+): string => {
+  if (!value) return "";
+  if (isIndexReference(value)) {
+    const index = Number(value);
+    if (index === removedIndex) return "";
+    return index > removedIndex ? String(index - 1) : value;
+  }
+  if (removedEntry?.technician_id && value === removedEntry.technician_id) return "";
+  return value;
+};
+
+/**
+ * Keeps room assignments consistent when a staff member is removed from the
+ * hoja: references to the removed person are cleared and index-based
+ * references after them shift down by one.
+ */
+export const adjustAccommodationsForStaffRemoval = (
+  accommodations: Accommodation[],
+  removedIndex: number,
+  removedEntry?: HojaStaffEntry,
+): Accommodation[] =>
+  accommodations.map((accommodation) => ({
+    ...accommodation,
+    rooms: (accommodation.rooms || []).map((room: RoomAssignment) => ({
+      ...room,
+      staff_member1_id: adjustReferenceForRemoval(
+        room.staff_member1_id,
+        removedIndex,
+        removedEntry,
+      ),
+      staff_member2_id: adjustReferenceForRemoval(
+        room.staff_member2_id,
+        removedIndex,
+        removedEntry,
+      ),
+    })),
+  }));
+
+/**
+ * Synchronizes hoja transports with a fresh snapshot of the job's logistics
+ * events: transports imported from logistics that no longer exist (or are no
+ * longer hoja-relevant) are pruned, matched ones keep manual edits, and new
+ * events are appended. Manually created transports are untouched.
+ */
+export const syncTransportsWithLogistics = <
+  T extends {
+    source_logistics_event_id?: string;
+    date_time?: string;
+    [key: string]: unknown;
+  },
+>(
+  current: T[],
+  incoming: T[],
+): T[] => {
+  const incomingSourceIds = new Set(
+    incoming
+      .map((transport) => transport.source_logistics_event_id)
+      .filter(Boolean) as string[],
+  );
+
+  // Drop sourced transports whose logistics event disappeared from the snapshot
+  const next = current.filter(
+    (transport) =>
+      !transport.source_logistics_event_id ||
+      incomingSourceIds.has(transport.source_logistics_event_id),
+  );
+
+  incoming.forEach((incomingTransport) => {
+    const sourceId = incomingTransport.source_logistics_event_id || null;
+    if (sourceId) {
+      const existingIndex = next.findIndex(
+        (transport) => transport.source_logistics_event_id === sourceId,
+      );
+      if (existingIndex >= 0) {
+        const existing = next[existingIndex];
+        const shouldSyncDateTime =
+          !existing.date_time || !String(existing.date_time).trim();
+        next[existingIndex] = {
+          ...existing,
+          transport_type: incomingTransport.transport_type,
+          license_plate: incomingTransport.license_plate,
+          company: incomingTransport.company,
+          // Preserve any manually-edited Hoja de Ruta datetime; only sync if empty.
+          date_time: shouldSyncDateTime ? incomingTransport.date_time : existing.date_time,
+          source_logistics_event_id: sourceId,
+          is_hoja_relevant: incomingTransport.is_hoja_relevant ?? true,
+          logistics_categories: incomingTransport.logistics_categories || [],
+          driver_name: incomingTransport.driver_name ?? existing.driver_name,
+          driver_phone: incomingTransport.driver_phone ?? existing.driver_phone,
+          has_return: incomingTransport.has_return ?? existing.has_return,
+        } as T;
+        return;
+      }
+    }
+    next.push(incomingTransport);
+  });
+
+  return next;
+};

--- a/src/utils/hoja-de-ruta/staffSync.ts
+++ b/src/utils/hoja-de-ruta/staffSync.ts
@@ -1,4 +1,9 @@
-import type { Accommodation, EventData, RoomAssignment } from "@/types/hoja-de-ruta";
+import type {
+  Accommodation,
+  EventData,
+  RoomAssignment,
+  Transport,
+} from "@/types/hoja-de-ruta";
 
 export type HojaStaffEntry = NonNullable<EventData["staff"]>[number];
 
@@ -109,11 +114,21 @@ export const staffOptionValue = (entry: HojaStaffEntry, index: number) =>
 
 const isIndexReference = (value: string) => /^\d+$/.test(value);
 
+const mapRoomStaffReferences = (
+  room: RoomAssignment,
+  mapReference: (value: string | undefined) => string,
+): RoomAssignment => ({
+  ...room,
+  staff_member1_id: mapReference(room.staff_member1_id),
+  staff_member2_id: mapReference(room.staff_member2_id),
+});
+
 const remapRoomReference = (
   value: string | undefined,
   savedStaff: HojaStaffEntry[],
   savedIndexMap: number[],
   mergedStaff: HojaStaffEntry[],
+  mergedTechnicianIds: Set<string>,
 ): string => {
   if (!value) return "";
 
@@ -121,13 +136,12 @@ const remapRoomReference = (
     const savedIndex = Number(value);
     if (savedIndex < 0 || savedIndex >= savedStaff.length) return "";
     const mergedIndex = savedIndexMap[savedIndex];
-    if (mergedIndex == null || mergedIndex < 0) return "";
-    return staffOptionValue(mergedStaff[mergedIndex], mergedIndex);
+    const target = mergedIndex != null && mergedIndex >= 0 ? mergedStaff[mergedIndex] : undefined;
+    return target ? staffOptionValue(target, mergedIndex) : "";
   }
 
   // technician_id reference: clear it when that technician was pruned
-  const stillPresent = mergedStaff.some((entry) => entry?.technician_id === value);
-  return stillPresent ? value : "";
+  return mergedTechnicianIds.has(value) ? value : "";
 };
 
 /**
@@ -141,25 +155,19 @@ export const remapAccommodationStaffReferences = (
   savedStaff: HojaStaffEntry[],
   savedIndexMap: number[],
   mergedStaff: HojaStaffEntry[],
-): Accommodation[] =>
-  accommodations.map((accommodation) => ({
+): Accommodation[] => {
+  const mergedTechnicianIds = new Set(
+    mergedStaff.map((entry) => entry?.technician_id).filter(Boolean) as string[],
+  );
+  return accommodations.map((accommodation) => ({
     ...accommodation,
-    rooms: (accommodation.rooms || []).map((room: RoomAssignment) => ({
-      ...room,
-      staff_member1_id: remapRoomReference(
-        room.staff_member1_id,
-        savedStaff,
-        savedIndexMap,
-        mergedStaff,
+    rooms: (accommodation.rooms || []).map((room) =>
+      mapRoomStaffReferences(room, (value) =>
+        remapRoomReference(value, savedStaff, savedIndexMap, mergedStaff, mergedTechnicianIds),
       ),
-      staff_member2_id: remapRoomReference(
-        room.staff_member2_id,
-        savedStaff,
-        savedIndexMap,
-        mergedStaff,
-      ),
-    })),
+    ),
   }));
+};
 
 const adjustReferenceForRemoval = (
   value: string | undefined,
@@ -188,19 +196,11 @@ export const adjustAccommodationsForStaffRemoval = (
 ): Accommodation[] =>
   accommodations.map((accommodation) => ({
     ...accommodation,
-    rooms: (accommodation.rooms || []).map((room: RoomAssignment) => ({
-      ...room,
-      staff_member1_id: adjustReferenceForRemoval(
-        room.staff_member1_id,
-        removedIndex,
-        removedEntry,
+    rooms: (accommodation.rooms || []).map((room) =>
+      mapRoomStaffReferences(room, (value) =>
+        adjustReferenceForRemoval(value, removedIndex, removedEntry),
       ),
-      staff_member2_id: adjustReferenceForRemoval(
-        room.staff_member2_id,
-        removedIndex,
-        removedEntry,
-      ),
-    })),
+    ),
   }));
 
 /**
@@ -209,16 +209,10 @@ export const adjustAccommodationsForStaffRemoval = (
  * longer hoja-relevant) are pruned, matched ones keep manual edits, and new
  * events are appended. Manually created transports are untouched.
  */
-export const syncTransportsWithLogistics = <
-  T extends {
-    source_logistics_event_id?: string;
-    date_time?: string;
-    [key: string]: unknown;
-  },
->(
-  current: T[],
-  incoming: T[],
-): T[] => {
+export const syncTransportsWithLogistics = (
+  current: Transport[],
+  incoming: Transport[],
+): Transport[] => {
   const incomingSourceIds = new Set(
     incoming
       .map((transport) => transport.source_logistics_event_id)
@@ -255,7 +249,7 @@ export const syncTransportsWithLogistics = <
           driver_name: incomingTransport.driver_name ?? existing.driver_name,
           driver_phone: incomingTransport.driver_phone ?? existing.driver_phone,
           has_return: incomingTransport.has_return ?? existing.has_return,
-        } as T;
+        };
         return;
       }
     }


### PR DESCRIPTION
Fixes the reported Hoja de Ruta staleness bug (removed assignments not disappearing from the staff section) plus several related sync bugs found while auditing the hydration flow.

## 1. Removed assignments now disappear from the staff section (reported bug)
The saved-data merge in `useHojaDeRutaInitialization` started from the saved staff list and only ever merged/appended current assignments — it never removed anything, so a technician whose assignment was deleted stayed in the hoja forever. Saved entries whose `technician_id` is no longer among the job's assignments are now pruned; manually added staff (no `technician_id`) are always preserved, and saved DNI/position edits still win for surviving entries.

## 2. Room assignments no longer point at the wrong person
Rooms stored the **staff array index** as `staff_member1_id`/`staff_member2_id`, so any staff removal or reorder silently shifted room assignments onto the wrong person (and the pruning above would have made this worse). Now:
- At load, all room references are remapped against the merged staff list, migrating index references to the stable `technician_id` where available (the PDF generator already resolves `technician_id` references) and clearing references to pruned staff.
- Removing a staff member from the form clears their room references and shifts the remaining index-based references down.
- The accommodation section's staff selects now store `technician_id` for assignment-derived staff going forward.

## 3. "Importar desde Logística" is now a real sync
The import merged by `source_logistics_event_id` but never pruned, so transports imported from logistics events that were later deleted (or marked not hoja-relevant) could never be cleaned up by re-importing. The import now treats the fetch as a snapshot: stale sourced transports are pruned (including when zero relevant events remain), manual transports are untouched, and manually edited fields/datetimes on matched rows are still preserved.

## 4. Unsaved edits no longer wiped by background refetches (data loss)
The initialization effect re-ran on every `hojaDeRuta` query identity change. With the global query client refetching on window focus, **switching tabs mid-edit rebuilt the entire form from fetched data, silently discarding unsaved edits** (it also re-merged and re-toasted after every save). Initialization now runs once per job selection and waits for in-flight refetches, so it never initializes from stale cache and never clobbers an in-progress form.

## 5. Empty saved travel/accommodations now clear those sections
The saved-data branch only set travel/accommodations when non-empty, which could leave stale values in place.

All merge/remap/sync logic was extracted to `src/utils/hoja-de-ruta/staffSync.ts` with unit tests (18 tests in the hoja areas).

## Verification
- Full Vitest suite: 963 tests passing
- `tsc --noEmit` clean, production build succeeds

https://claude.ai/code/session_01H94KiU6VHMmFhGoWYUysqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01H94KiU6VHMmFhGoWYUysqW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Staff selectors use stable identifiers so room staff assignments remain consistent after updates.
  * Transport list fully clears and syncs when no logistics events are available.
  * Initialization no longer reruns during in-flight refetches, preventing stale overwrites.
  * Room accommodations remap reliably when staff are removed or changed.

* **Refactor**
  * Staff and transport sync logic reorganized for more reliable behavior; initialization/data-building consolidated.

* **Tests**
  * Added comprehensive tests covering staff/assignment sync, accommodation remapping, and transport syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->