### PR TITLE
feat: surface tour docs, riders, and tour pack badge on job cards

### DIFF
--- a/src/components/jobs/cards/JobCardHeader.tsx
+++ b/src/components/jobs/cards/JobCardHeader.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ChevronDown, ChevronUp, Clock, MapPin } from "lucide-react";
+import { ChevronDown, ChevronUp, Clock, MapPin, Package } from "lucide-react";
 import { Department } from "@/types/department";
 import { JobStatusSelector } from "@/components/jobs/JobStatusSelector";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -75,6 +75,13 @@ export const JobCardHeader: React.FC<JobCardHeaderProps> = ({
             {getDateTypeIcon(job.id, new Date(job.start_time), dateTypes)}
             <h3 className={cn("font-medium break-words leading-tight", isMobile ? "text-base" : "text-lg")}>{job.title}</h3>
             {getBadgeForJobType(job.job_type)}
+            {job.tour_date?.is_tour_pack_only && (
+              <Badge className={cn("ml-2 gap-1 bg-blue-100 text-blue-700 hover:bg-blue-100", isMobile && "text-xs")}>
+                <Package className="h-3 w-3" />
+                <span className={cn(isMobile && "hidden")}>Tour Pack Only</span>
+                <span className={cn(!isMobile && "hidden")}>TP Only</span>
+              </Badge>
+            )}
             {job.invoicing_company && (
               <Badge variant="outline" className={cn("ml-2", isMobile && "text-xs")}>
                 {job.invoicing_company}

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -231,6 +231,7 @@ function JobCardNewFull({
   // Collapsible sections (collapsed by default)
   const [docsCollapsed, setDocsCollapsed] = useState(true);
   const [ridersCollapsed, setRidersCollapsed] = useState(true);
+  const [tourDocsCollapsed, setTourDocsCollapsed] = useState(true);
   const isFestivalLike = isFestivalLikeJobType(job?.job_type);
 
   // Track if we've already opened the modal from URL param to prevent race condition
@@ -251,10 +252,10 @@ function JobCardNewFull({
     onHojaDeRutaOpened?.();
   }, [openHojaDeRuta, isProjectManagementPage, onHojaDeRutaOpened]);
 
-  // Load artists then rider files (2-step RLS-friendly)
+  // Load artists then rider files (2-step RLS-friendly) for all job types except dry hire
   const { data: cardArtists = [] } = useQuery({
     queryKey: queryKeys.scope('jobcard-artists', job.id),
-    enabled: !!job?.id && isFestivalLike,
+    enabled: !!job?.id && job.job_type !== 'dryhire',
     queryFn: async () => {
       const { data, error } = await dataLayerClient.from('festival_artists')
         .select('id, name')
@@ -284,6 +285,44 @@ function JobCardNewFull({
       return (data || []) as Array<{ id: string; file_name: string; file_path: string; uploaded_at: string; artist_id: string }>;
     }
   });
+
+  // Load tour documents for jobs linked to a tour (e.g. tourdate jobs)
+  const cardTourId: string | null = job.tour_id || job.tour_date?.tour?.id || null;
+  const { data: tourDocuments = [] } = useQuery({
+    queryKey: queryKeys.scope('jobcard-tour-documents', job.id, cardTourId),
+    enabled: !!cardTourId && job.job_type !== 'dryhire',
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient.from('tour_documents')
+        .select('id, file_name, file_path, uploaded_at')
+        .eq('tour_id', cardTourId)
+        .order('uploaded_at', { ascending: false });
+      if (error) throw error;
+      return (data || []) as Array<{ id: string; file_name: string; file_path: string; uploaded_at: string }>;
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  const viewTourDocument = async (file: { file_path: string }) => {
+    const { data } = await dataLayerClient.storage
+      .from('tour-documents')
+      .createSignedUrl(file.file_path, 3600);
+    if (data?.signedUrl) window.open(data.signedUrl, '_blank', 'noopener');
+  };
+
+  const downloadTourDocument = async (file: { file_path: string; file_name: string }) => {
+    const { data } = await dataLayerClient.storage
+      .from('tour-documents')
+      .download(file.file_path);
+    if (!data) return;
+    const url = window.URL.createObjectURL(data);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = file.file_name;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+  };
 
   const viewRider = async (file: { file_path: string }) => {
     const { data } = await dataLayerClient.storage
@@ -1277,6 +1316,11 @@ function JobCardNewFull({
       setRidersCollapsed={setRidersCollapsed}
       viewRider={viewRider}
       downloadRider={downloadRider}
+      tourDocuments={tourDocuments}
+      tourDocsCollapsed={tourDocsCollapsed}
+      setTourDocsCollapsed={setTourDocsCollapsed}
+      viewTourDocument={viewTourDocument}
+      downloadTourDocument={downloadTourDocument}
       soundTasks={soundTasks}
       reqSummary={reqSummary}
       requiredVsAssigned={requiredVsAssigned}

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -303,25 +303,47 @@ function JobCardNewFull({
   });
 
   const viewTourDocument = async (file: { file_path: string }) => {
-    const { data } = await dataLayerClient.storage
-      .from('tour-documents')
-      .createSignedUrl(file.file_path, 3600);
-    if (data?.signedUrl) window.open(data.signedUrl, '_blank', 'noopener');
+    try {
+      const { data, error } = await dataLayerClient.storage
+        .from('tour-documents')
+        .createSignedUrl(file.file_path, 3600);
+      if (error) throw error;
+      if (data?.signedUrl) window.open(data.signedUrl, '_blank', 'noopener');
+    } catch (error) {
+      console.error('Error viewing tour document:', error);
+      toast({
+        title: "Error",
+        description: "No se pudo abrir el documento de la gira",
+        variant: "destructive"
+      });
+    }
   };
 
   const downloadTourDocument = async (file: { file_path: string; file_name: string }) => {
-    const { data } = await dataLayerClient.storage
-      .from('tour-documents')
-      .download(file.file_path);
-    if (!data) return;
-    const url = window.URL.createObjectURL(data);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = file.file_name;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    window.URL.revokeObjectURL(url);
+    let url: string | null = null;
+    try {
+      const { data, error } = await dataLayerClient.storage
+        .from('tour-documents')
+        .download(file.file_path);
+      if (error) throw error;
+      if (!data) return;
+      url = window.URL.createObjectURL(data);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = file.file_name;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error('Error downloading tour document:', error);
+      toast({
+        title: "Error",
+        description: "No se pudo descargar el documento de la gira",
+        variant: "destructive"
+      });
+    } finally {
+      if (url) window.URL.revokeObjectURL(url);
+    }
   };
 
   const viewRider = async (file: { file_path: string }) => {

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createPortal } from "react-dom";
+import { format } from "date-fns";
 import { useReducedMotion } from "framer-motion";
 import { ChevronDown, ChevronRight, Download, Eye, FileText, Loader2, NotebookPen } from "lucide-react";
 
@@ -88,6 +89,12 @@ export interface JobCardNewViewProps {
   setRidersCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
   viewRider: (file: { file_path: string }) => void | Promise<void>;
   downloadRider: (file: { file_path: string; file_name: string }) => void | Promise<void>;
+
+  tourDocuments: Array<{ id: string; file_name: string; file_path: string; uploaded_at: string }>;
+  tourDocsCollapsed: boolean;
+  setTourDocsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+  viewTourDocument: (file: { file_path: string }) => void | Promise<void>;
+  downloadTourDocument: (file: { file_path: string; file_name: string }) => void | Promise<void>;
 
   soundTasks: any;
   reqSummary: any;
@@ -202,6 +209,11 @@ export function JobCardNewView({
   setRidersCollapsed,
   viewRider,
   downloadRider,
+  tourDocuments,
+  tourDocsCollapsed,
+  setTourDocsCollapsed,
+  viewTourDocument,
+  downloadTourDocument,
   soundTasks,
   reqSummary,
   requiredVsAssigned,
@@ -531,6 +543,52 @@ export function JobCardNewView({
                           onDeleteDocument={(document) => handleDeleteDocument(document)}
                           showTitle={false}
                         />
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {tourDocuments.length > 0 && (
+                  <div className="mt-2">
+                    <button
+                      type="button"
+                      className="w-full flex items-center justify-between text-left px-2 py-1 rounded hover:bg-accent/40"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setTourDocsCollapsed((prev) => !prev);
+                      }}
+                    >
+                      <span className="text-sm font-medium">Tour Documents ({tourDocuments.length})</span>
+                      {tourDocsCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                    </button>
+                    {!tourDocsCollapsed && (
+                      <div className="mt-1 space-y-2">
+                        {tourDocuments.map((file) => (
+                          <div
+                            key={file.id}
+                            className="flex items-center justify-between p-2 rounded-md bg-accent/20 hover:bg-accent/30 transition-colors"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <div className="flex flex-col">
+                              <span className="text-sm font-medium">{file.file_name}</span>
+                              <span className="text-xs text-muted-foreground">
+                                {format(new Date(file.uploaded_at), "MMM d, yyyy")}
+                              </span>
+                            </div>
+                            <div className="flex gap-2">
+                              <button className="p-1 hover:bg-accent rounded" title="View" onClick={() => viewTourDocument(file)}>
+                                <Eye className="h-4 w-4" />
+                              </button>
+                              <button
+                                className="p-1 hover:bg-accent rounded"
+                                title="Download"
+                                onClick={() => downloadTourDocument(file)}
+                              >
+                                <Download className="h-4 w-4" />
+                              </button>
+                            </div>
+                          </div>
+                        ))}
                       </div>
                     )}
                   </div>

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -106,7 +106,8 @@ export const useOptimizedJobs = (
           date,
           start_date,
           end_date,
-          tour_date_type
+          tour_date_type,
+          is_tour_pack_only
         ),
         flex_folders(
           id,


### PR DESCRIPTION
- Show tour documents in a collapsible section on job cards for jobs
  linked to a tour (e.g. tourdate jobs), with view/download via signed
  URLs from the tour-documents bucket
- Show artist riders on job cards for all job types except dry hire
  (previously festival/ciclo only)
- Add a Tour Pack Only badge to the job card header when the linked
  tour date has is_tour_pack_only set; include the flag in the
  useOptimizedJobs tour_date select

https://claude.ai/code/session_01HWTpnZKcsCvsF9oc7tK1CD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Tour Pack Only" indicator badge on job listings
  * Added collapsible "Tour Documents" section with view and download options for tour-related documents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->