### PR TITLE
[codex] Fix WhatsApp group creation diagnostics

### DIFF
--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -19,6 +19,7 @@ import { deleteJobOptimistically } from "@/services/optimisticJobDeletionService
 import { createAllFoldersForJob } from "@/utils/flex-folders";
 import { format } from "date-fns";
 import { createSafeFolderName, sanitizeFolderName } from "@/utils/folderNameSanitizer";
+import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 import type { JobDocument } from './JobCardDocuments';
 import { JobCardNewDetailsOnly } from "./job-card-new/JobCardNewDetailsOnly";
 import { JobCardNewView } from "./job-card-new/JobCardNewView";
@@ -677,8 +678,11 @@ function JobCardNewFull({
         body: { job_id: job.id as string, department, stage_number: 0 }
       });
       if (error) {
-        // Even on error, lock may have been recorded. We'll refetch lock and inform user.
-        toast({ title: 'Grupo solicitado', description: 'Se ha solicitado la creación del grupo. El botón quedará bloqueado.', });
+        toast({
+          title: 'Error al crear grupo',
+          description: await extractFunctionErrorMessage(error),
+          variant: 'destructive',
+        });
       } else {
         const result = data as CreateWhatsappGroupResult | null;
         const warnings = result?.warnings;
@@ -691,9 +695,12 @@ function JobCardNewFull({
       }
       await Promise.all([refetchWaGroup(), refetchWaRequest()]);
     } catch (err: any) {
-      // Still lock; refetch
       await Promise.all([refetchWaGroup(), refetchWaRequest()]);
-      toast({ title: 'Grupo solicitado', description: 'Se ha solicitado la creación del grupo. El botón quedará bloqueado.' });
+      toast({
+        title: 'Error al crear grupo',
+        description: err?.message || String(err),
+        variant: 'destructive',
+      });
     }
   };
 

--- a/src/features/festival-management/__tests__/selectors.test.ts
+++ b/src/features/festival-management/__tests__/selectors.test.ts
@@ -76,7 +76,9 @@ describe("festival management selectors", () => {
     expect(normalizeFestivalWhatsappStage({ currentStage: 0, department: "sound", maxStages: 3 })).toBe(1);
     expect(normalizeFestivalWhatsappStage({ currentStage: 2, department: "video", maxStages: 3 })).toBe(2);
     expect(normalizeFestivalWhatsappStage({ currentStage: 2, department: "lights", maxStages: 3 })).toBe(0);
+    expect(normalizeFestivalWhatsappStage({ currentStage: 1, department: "sound", maxStages: 1 })).toBe(0);
     expect(requiresFestivalWhatsappStage(2, "sound")).toBe(true);
+    expect(requiresFestivalWhatsappStage(1, "sound")).toBe(false);
     expect(requiresFestivalWhatsappStage(2, "lights")).toBe(false);
     expect(buildFestivalWhatsappStageOptions([], 2)).toEqual([
       { number: 1, name: "Stage 1" },

--- a/src/features/festival-management/commands.ts
+++ b/src/features/festival-management/commands.ts
@@ -16,31 +16,7 @@ import { createAllFoldersForJob, openFlexElement } from "@/utils/flex-folders";
 import { resolveJobDocLocation } from "@/utils/jobDocuments";
 import { generateAndMergeFestivalPDFs } from "@/utils/pdf/festivalPdfGenerator";
 import { generateIndividualStagePDFs } from "@/utils/pdf/individualStagePdfGenerator";
-
-const extractFunctionErrorMessage = async (error: unknown) => {
-  const fallback = error instanceof Error ? error.message : "Edge Function request failed";
-  const response = (error as { context?: Response })?.context;
-  if (!response || typeof response.clone !== "function") return fallback;
-
-  try {
-    const payload = await response.clone().json();
-    if (!payload || typeof payload !== "object") return fallback;
-    const data = payload as {
-      details?: string;
-      error?: string;
-      message?: string;
-      reason?: string;
-      response?: string;
-      status?: number;
-    };
-    const title = data.error || data.message || fallback;
-    const detail = data.reason || data.details || data.response;
-    const status = data.status ? ` (${data.status})` : "";
-    return detail ? `${title}${status}: ${detail}` : `${title}${status}`;
-  } catch {
-    return fallback;
-  }
-};
+import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 
 export const getJobDocumentSignedUrl = async (docEntry: JobDocumentEntry) => {
   const { bucket, path } = resolveJobDocLocation(docEntry.file_path);

--- a/src/pages/TourManagement.tsx
+++ b/src/pages/TourManagement.tsx
@@ -45,6 +45,7 @@ import { exportTourPDF } from "@/lib/tourPdfExport";
 import { useToast } from "@/hooks/use-toast";
 import { useFlexUuid } from "@/hooks/useFlexUuid";
 import { isManagementRole, isTechnicianRole } from "@/utils/permissions";
+import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 import createFolderIcon from "@/assets/icons/icon.png";
 import { TourDateFlexButton } from "@/components/tours/TourDateFlexButton";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -244,7 +245,7 @@ export const TourManagement = ({ tour, tourJobId }: TourManagementProps) => {
         body: { job_id: jobRow.id, department: waDepartment, stage_number: 0 }
       });
       if (fnErr) {
-        toast({ title: 'Error al crear grupo', description: fnErr.message, variant: 'destructive' });
+        toast({ title: 'Error al crear grupo', description: await extractFunctionErrorMessage(fnErr), variant: 'destructive' });
       } else {
         toast({ title: 'Solicitado', description: 'Se solicitó la creación del grupo de WhatsApp. Se finalizará en breve.' });
         setIsWaDialogOpen(false);

--- a/src/utils/__tests__/supabaseFunctionError.test.ts
+++ b/src/utils/__tests__/supabaseFunctionError.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { extractFunctionErrorMessage } from "../supabaseFunctionError";
+
+describe("extractFunctionErrorMessage", () => {
+  it("includes Edge Function body details, status, and request id", async () => {
+    const error = {
+      message: "FunctionsHttpError",
+      context: new Response(JSON.stringify({
+        error: "WAHA group creation failed",
+        request_id: "request-1",
+        response: "Session disconnected",
+        status: 500,
+      })),
+    };
+
+    await expect(extractFunctionErrorMessage(error)).resolves.toBe(
+      "WAHA group creation failed (500) [request-1]: Session disconnected",
+    );
+  });
+
+  it("falls back to the top-level error message when the body cannot be parsed", async () => {
+    const error = {
+      message: "Edge Function returned a non-2xx status code",
+      context: new Response("not-json"),
+    };
+
+    await expect(extractFunctionErrorMessage(error)).resolves.toBe(
+      "Edge Function returned a non-2xx status code",
+    );
+  });
+});

--- a/src/utils/supabaseFunctionError.ts
+++ b/src/utils/supabaseFunctionError.ts
@@ -1,0 +1,57 @@
+type FunctionErrorPayload = {
+  details?: unknown;
+  error?: unknown;
+  message?: unknown;
+  reason?: unknown;
+  request_id?: unknown;
+  response?: unknown;
+  status?: unknown;
+};
+
+const DEFAULT_FALLBACK = "Edge Function request failed";
+const MAX_DETAIL_LENGTH = 800;
+
+const toDisplayString = (value: unknown) => {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return undefined;
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const truncateDetail = (value: string) => {
+  if (value.length <= MAX_DETAIL_LENGTH) return value;
+  return `${value.slice(0, MAX_DETAIL_LENGTH)}...`;
+};
+
+export const extractFunctionErrorMessage = async (
+  error: unknown,
+  fallback = DEFAULT_FALLBACK,
+) => {
+  const candidate = error as { details?: unknown; message?: unknown };
+  const fallbackMessage = toDisplayString(candidate?.details) || toDisplayString(candidate?.message) || fallback;
+  const response = (error as { context?: Response })?.context;
+  if (!response || typeof response.clone !== "function") return fallbackMessage;
+
+  try {
+    const payload = await response.clone().json();
+    if (!payload || typeof payload !== "object") return fallbackMessage;
+
+    const data = payload as FunctionErrorPayload;
+    const title = toDisplayString(data.error) || toDisplayString(data.message) || fallbackMessage;
+    const detail = toDisplayString(data.reason) || toDisplayString(data.details) || toDisplayString(data.response);
+    const status = toDisplayString(data.status);
+    const requestId = toDisplayString(data.request_id);
+    const statusSuffix = status ? ` (${status})` : "";
+    const requestSuffix = requestId ? ` [${requestId}]` : "";
+
+    return detail
+      ? `${title}${statusSuffix}${requestSuffix}: ${truncateDetail(detail)}`
+      : `${title}${statusSuffix}${requestSuffix}`;
+  } catch {
+    return fallbackMessage;
+  }
+};

--- a/supabase/functions/create-user/index.ts
+++ b/supabase/functions/create-user/index.ts
@@ -37,6 +37,25 @@ const getErrorStatus = (error: unknown) => {
   return Number.isInteger(status) && status >= 400 && status < 600 ? status : 400;
 };
 
+const isEmailExistsError = (error: unknown) => {
+  const candidate = error as { code?: string; message?: string; status?: number };
+  const message = candidate?.message?.toLowerCase() ?? '';
+  return (
+    candidate?.code === 'email_exists' ||
+    (candidate?.status === 422 && message.includes('already') && message.includes('registered')) ||
+    (message.includes('email') && (message.includes('already') || message.includes('exists')))
+  );
+};
+
+const duplicateEmailResponse = () =>
+  jsonResponse(
+    {
+      error: 'A user with this email address has already been registered',
+      code: 'email_exists',
+    },
+    409,
+  );
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -94,52 +113,73 @@ serve(async (req) => {
       return jsonResponse({ error: 'Unauthorized' }, 403);
     }
 
+    const { data: existingProfile, error: existingProfileErr } = await supabaseAdmin
+      .from('profiles')
+      .select('id')
+      .eq('email', email)
+      .maybeSingle();
+
+    if (existingProfileErr) throw existingProfileErr;
+    if (existingProfile) {
+      return duplicateEmailResponse();
+    }
+
+    const role = normalizeOptional(body.role) ?? 'technician';
+    const nickname = normalizeOptional(body.nickname);
+    const department = normalizeOptional(body.department);
+    const phone = normalizeOptional(body.phone);
+    const dni = normalizeOptional(body.dni);
+    const residencia = normalizeOptional(body.residencia);
+    const flexResourceId = normalizeOptional(body.flex_resource_id);
+
     // Create auth user with a random throwaway password. It is never disclosed:
     // the user sets their real password via the "Olvidé mi contraseña" reset flow.
-    const tempPassword = `${crypto.randomUUID()}-${crypto.randomUUID()}`;
+    const tempPassword = crypto.randomUUID();
     const { data: authData, error: authError } = await supabaseAdmin.auth.admin.createUser({
       email,
       password: tempPassword,
       email_confirm: true,
       user_metadata: {
         first_name: firstName,
-        nickname: normalizeOptional(body.nickname),
+        nickname,
         last_name: lastName,
-        phone: normalizeOptional(body.phone),
-        department: normalizeOptional(body.department),
-        dni: normalizeOptional(body.dni),
-        residencia: normalizeOptional(body.residencia),
+        phone,
+        department,
+        dni,
+        residencia,
         needs_password_change: true,
       },
     });
 
     if (authError) {
-      if ((authError as { code?: string }).code === 'email_exists') {
-        return jsonResponse(
-          {
-            error: 'A user with this email address has already been registered',
-            code: 'email_exists',
-          },
-          409,
-        );
+      if (isEmailExistsError(authError)) {
+        return duplicateEmailResponse();
       }
       throw authError;
     }
 
-    // Optionally set role and flex_resource_id if provided
-    const updates: Record<string, any> = {};
-    const role = normalizeOptional(body.role);
-    const nickname = normalizeOptional(body.nickname);
-    const flexResourceId = normalizeOptional(body.flex_resource_id);
-    if (role) updates.role = role;
-    if (nickname) updates.nickname = nickname;
-    if (flexResourceId) updates.flex_resource_id = flexResourceId;
-    if (Object.keys(updates).length > 0) {
-      const { error: updErr } = await supabaseAdmin
-        .from('profiles')
-        .update(updates)
-        .eq('id', authData.user.id);
-      if (updErr) throw updErr;
+    const { error: profileUpsertErr } = await supabaseAdmin
+      .from('profiles')
+      .upsert({
+        id: authData.user.id,
+        email,
+        first_name: firstName,
+        last_name: lastName,
+        phone,
+        department,
+        dni,
+        residencia,
+        role,
+        nickname,
+        flex_resource_id: flexResourceId,
+      }, { onConflict: 'id' });
+
+    if (profileUpsertErr) {
+      const { error: rollbackErr } = await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+      if (rollbackErr) {
+        console.error('create-user rollback error:', rollbackErr);
+      }
+      throw profileUpsertErr;
     }
 
     return jsonResponse({ id: authData.user.id, email: authData.user.email });

--- a/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
+++ b/supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
@@ -3,12 +3,25 @@ import { describe, expect, it } from "vitest";
 import {
   buildWahaGroupParticipants,
   collectFestivalStageRecipients,
+  normalizePhone,
   phoneToWahaJid,
 } from "../recipientUtils.ts";
 
 describe("WAHA participant helpers", () => {
   it("converts phone numbers to WAHA JIDs", () => {
     expect(phoneToWahaJid("+34 611 111 111")).toBe("34611111111@c.us");
+  });
+
+  it("normalizes Spanish shorthand and international WhatsApp numbers", () => {
+    expect(normalizePhone("611 111 111", "+34")).toEqual({ ok: true, value: "+34611111111" });
+    expect(normalizePhone("34611111111", "+34")).toEqual({ ok: true, value: "+34611111111" });
+    expect(normalizePhone("+351 912 345 678", "+34")).toEqual({ ok: true, value: "+351912345678" });
+    expect(normalizePhone("00351 912 345 678", "+34")).toEqual({ ok: true, value: "+351912345678" });
+    expect(normalizePhone("351912345678", "+34")).toEqual({ ok: true, value: "+351912345678" });
+  });
+
+  it("rejects ambiguous non-Spanish local numbers without a country code", () => {
+    expect(normalizePhone("912 345 678", "+34")).toEqual({ ok: false, reason: "missing_country_code" });
   });
 
   it("excludes the actor/session JID from WAHA group creation participants", () => {

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -20,6 +20,88 @@ interface CreateRequest {
   stage_number?: number | string;
 }
 
+type WahaFallbackAttempt = {
+  id: string;
+  status?: number;
+  body?: string;
+  message?: string;
+};
+
+const MAX_LOG_BODY_LENGTH = 1200;
+
+function truncateForLog(value: string, maxLength = MAX_LOG_BODY_LENGTH) {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...[truncated ${value.length - maxLength} chars]`;
+}
+
+function redactWahaParticipantId(id: string) {
+  return id.replace(/\d{7,15}(?=@c\.us)/g, (digits) => `***${digits.slice(-4)}`);
+}
+
+function sanitizeWahaResponseForLog(body: string) {
+  return truncateForLog(
+    body
+      .replace(/\d{7,15}(?=@c\.us)/g, (digits) => `***${digits.slice(-4)}`)
+      .replace(/\+\d{7,15}/g, (phone) => `***${phone.slice(-4)}`),
+  );
+}
+
+function wahaHostFromBase(base: string) {
+  try {
+    return new URL(base).host;
+  } catch {
+    return 'invalid-base-url';
+  }
+}
+
+function logWahaCreateFailure({
+  base,
+  department,
+  fallbackAttempts,
+  hasApiKey,
+  message,
+  participantCount,
+  requestId,
+  response,
+  session,
+  stageNumber,
+  status,
+  step,
+}: {
+  base: string;
+  department: Dept;
+  fallbackAttempts?: WahaFallbackAttempt[];
+  hasApiKey: boolean;
+  message?: string;
+  participantCount: number;
+  requestId: string;
+  response?: string;
+  session: string;
+  stageNumber: number;
+  status?: number;
+  step: string;
+}) {
+  console.error('create-whatsapp-group WAHA create-group failed', {
+    base_host: wahaHostFromBase(base),
+    department,
+    fallback_attempts: fallbackAttempts?.map((attempt) => ({
+      body: attempt.body ? sanitizeWahaResponseForLog(attempt.body) : undefined,
+      id: redactWahaParticipantId(attempt.id),
+      message: attempt.message,
+      status: attempt.status,
+    })),
+    has_api_key: hasApiKey,
+    message,
+    participant_count: participantCount,
+    request_id: requestId,
+    response: response ? sanitizeWahaResponseForLog(response) : undefined,
+    session,
+    stage_number: stageNumber,
+    status,
+    step,
+  });
+}
+
 function normalizePhone(raw: string, defaultCountry: string): { ok: true; value: string } | { ok: false; reason: string } {
   if (!raw) return { ok: false, reason: 'empty' };
   const trimmed = raw.trim();
@@ -43,6 +125,7 @@ function normalizePhone(raw: string, defaultCountry: string): { ok: true; value:
 serve(async (req: Request) => {
   if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
   if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+  const requestId = crypto.randomUUID();
 
   const supabaseAdmin = createClient(
     Deno.env.get('SUPABASE_URL') ?? '',
@@ -342,7 +425,14 @@ serve(async (req: Request) => {
       return b.replace(/\/+$/, '');
     };
     const base = normalizeBase(actor.waha_endpoint || 'https://waha.sector-pro.work');
-    const { data: cfg } = await supabaseAdmin.rpc('get_waha_config', { base_url: base });
+    const { data: cfg, error: cfgErr } = await supabaseAdmin.rpc('get_waha_config', { base_url: base });
+    if (cfgErr) {
+      console.warn('create-whatsapp-group WAHA config lookup failed', {
+        base_host: wahaHostFromBase(base),
+        message: cfgErr.message,
+        request_id: requestId,
+      });
+    }
     const apiKey = (cfg?.[0] as any)?.api_key || Deno.env.get('WAHA_API_KEY') || '';
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (apiKey) headers['X-API-Key'] = apiKey;
@@ -389,6 +479,15 @@ serve(async (req: Request) => {
       // Create the group per WAHA API: POST /api/{session}/groups { name, participants: [{id}] }
       const groupUrl = `${base}/api/${encodeURIComponent(session)}/groups`;
       let groupRes: Response;
+      console.info('create-whatsapp-group WAHA create-group request', {
+        base_host: wahaHostFromBase(base),
+        department,
+        has_api_key: Boolean(apiKey),
+        participant_count: creationGroupParticipants.length,
+        request_id: requestId,
+        session,
+        stage_number: effectiveStageNumber,
+      });
       try {
         groupRes = await fetch(groupUrl, {
           method: 'POST',
@@ -396,13 +495,25 @@ serve(async (req: Request) => {
           body: JSON.stringify({ name: subject, participants: creationGroupParticipants })
         });
       } catch (fe) {
-        return new Response(JSON.stringify({ error: 'WAHA request failed', step: 'create-group', url: groupUrl, message: (fe as Error)?.message || String(fe) }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+        const message = (fe as Error)?.message || String(fe);
+        logWahaCreateFailure({
+          base,
+          hasApiKey: Boolean(apiKey),
+          message,
+          participantCount: creationGroupParticipants.length,
+          requestId,
+          session,
+          department,
+          stageNumber: effectiveStageNumber,
+          step: 'create-group-fetch',
+        });
+        return new Response(JSON.stringify({ error: 'WAHA request failed', request_id: requestId, step: 'create-group', url: groupUrl, message }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
       }
       if (!groupRes.ok) {
         const txt = await groupRes.text().catch(() => '');
         if (groupRes.status >= 500 && groupRes.status < 600 && creationGroupParticipants.length > 1) {
           // Fallback: try real assigned participants one by one when WAHA rejects bulk creation.
-          const fallbackErrors: Array<{ id: string; status?: number; body?: string; message?: string }> = [];
+          const fallbackErrors: WahaFallbackAttempt[] = [];
           for (const candidate of creationGroupParticipants) {
             const fallbackRes = await fetch(groupUrl, {
               method: 'POST',
@@ -429,10 +540,35 @@ serve(async (req: Request) => {
           }
 
           if (!usedFallback) {
-            return new Response(JSON.stringify({ error: 'WAHA group creation failed', status: groupRes.status, url: groupUrl, response: txt, fallbackAttempts: fallbackErrors, firstAttempt: { status: groupRes.status, body: txt } }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+            logWahaCreateFailure({
+              base,
+              fallbackAttempts: fallbackErrors,
+              hasApiKey: Boolean(apiKey),
+              participantCount: creationGroupParticipants.length,
+              requestId,
+              response: txt,
+              session,
+              department,
+              stageNumber: effectiveStageNumber,
+              status: groupRes.status,
+              step: 'create-group-response-with-fallbacks',
+            });
+            return new Response(JSON.stringify({ error: 'WAHA group creation failed', request_id: requestId, status: groupRes.status, url: groupUrl, response: txt, fallbackAttempts: fallbackErrors, firstAttempt: { status: groupRes.status, body: txt } }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
           }
         } else {
-          return new Response(JSON.stringify({ error: 'WAHA group creation failed', status: groupRes.status, url: groupUrl, response: txt }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+          logWahaCreateFailure({
+            base,
+            hasApiKey: Boolean(apiKey),
+            participantCount: creationGroupParticipants.length,
+            requestId,
+            response: txt,
+            session,
+            department,
+            stageNumber: effectiveStageNumber,
+            status: groupRes.status,
+            step: 'create-group-response',
+          });
+          return new Response(JSON.stringify({ error: 'WAHA group creation failed', request_id: requestId, status: groupRes.status, url: groupUrl, response: txt }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
         }
       }
       // Read body as text first to parse and also return on failure

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import {
   buildWahaGroupParticipants,
+  normalizePhone,
   phoneToWahaJid,
   resolveFestivalStageTechnicianIds,
 } from "./recipientUtils.ts";
@@ -27,6 +28,23 @@ type WahaFallbackAttempt = {
   message?: string;
 };
 
+type WahaParticipantLogEntry = {
+  id: string;
+  label?: string;
+  source?: string;
+};
+
+type WahaContactDiagnostic = {
+  body?: string;
+  chatId?: string;
+  id: string;
+  label?: string;
+  numberExists?: boolean;
+  ok: boolean;
+  source?: string;
+  status?: number;
+};
+
 const MAX_LOG_BODY_LENGTH = 1200;
 
 function truncateForLog(value: string, maxLength = MAX_LOG_BODY_LENGTH) {
@@ -36,6 +54,10 @@ function truncateForLog(value: string, maxLength = MAX_LOG_BODY_LENGTH) {
 
 function redactWahaParticipantId(id: string) {
   return id.replace(/\d{7,15}(?=@c\.us)/g, (digits) => `***${digits.slice(-4)}`);
+}
+
+function redactWahaGroupId(id: string) {
+  return id.replace(/\d{7,15}(?=@g\.us)/g, (digits) => `***${digits.slice(-4)}`);
 }
 
 function sanitizeWahaResponseForLog(body: string) {
@@ -69,6 +91,10 @@ function shouldSkipCreateGroupFallback(body: string) {
   return errorText.includes('rate-overlimit') || errorText.includes('bad-request');
 }
 
+function isWahaBadRequest(body: string) {
+  return extractWahaErrorText(body).includes('bad-request');
+}
+
 function wahaHostFromBase(base: string) {
   try {
     return new URL(base).host;
@@ -79,11 +105,13 @@ function wahaHostFromBase(base: string) {
 
 function logWahaCreateFailure({
   base,
+  contactDiagnostics,
   department,
   fallbackAttempts,
   hasApiKey,
   message,
   participantCount,
+  participants,
   requestId,
   response,
   session,
@@ -92,11 +120,13 @@ function logWahaCreateFailure({
   step,
 }: {
   base: string;
+  contactDiagnostics?: WahaContactDiagnostic[];
   department: Dept;
   fallbackAttempts?: WahaFallbackAttempt[];
   hasApiKey: boolean;
   message?: string;
   participantCount: number;
+  participants?: WahaParticipantLogEntry[];
   requestId: string;
   response?: string;
   session: string;
@@ -106,6 +136,7 @@ function logWahaCreateFailure({
 }) {
   console.error('create-whatsapp-group WAHA create-group failed', {
     base_host: wahaHostFromBase(base),
+    contact_diagnostics: contactDiagnostics,
     department,
     fallback_attempts: fallbackAttempts?.map((attempt) => ({
       body: attempt.body ? sanitizeWahaResponseForLog(attempt.body) : undefined,
@@ -116,6 +147,7 @@ function logWahaCreateFailure({
     has_api_key: hasApiKey,
     message,
     participant_count: participantCount,
+    participants,
     request_id: requestId,
     response: response ? sanitizeWahaResponseForLog(response) : undefined,
     session,
@@ -125,24 +157,63 @@ function logWahaCreateFailure({
   });
 }
 
-function normalizePhone(raw: string, defaultCountry: string): { ok: true; value: string } | { ok: false; reason: string } {
-  if (!raw) return { ok: false, reason: 'empty' };
-  const trimmed = raw.trim();
-  if (!trimmed) return { ok: false, reason: 'empty' };
-  // Remove spaces, dashes, parentheses
-  let digits = trimmed.replace(/[\s\-()]/g, '');
-  if (digits.startsWith('00')) digits = '+' + digits.slice(2);
-  if (!digits.startsWith('+')) {
-    // Heuristic: if appears to be Spanish mobile (9 digits starting with 6/7), prefix +34
-    if (/^[67]\d{8}$/.test(digits)) {
-      digits = '+34' + digits;
-    } else {
-      const cc = defaultCountry.startsWith('+') ? defaultCountry : `+${defaultCountry}`;
-      digits = cc + digits;
+async function diagnoseWahaContacts({
+  base,
+  headers,
+  participantLogByJid,
+  participants,
+  session,
+}: {
+  base: string;
+  headers: Record<string, string>;
+  participantLogByJid: Map<string, WahaParticipantLogEntry>;
+  participants: Array<{ id: string }>;
+  session: string;
+}): Promise<WahaContactDiagnostic[]> {
+  const diagnostics: WahaContactDiagnostic[] = [];
+
+  for (const [index, participant] of participants.entries()) {
+    if (index > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+
+    const phone = participant.id.replace(/@c\.us$/, '');
+    const participantLog = participantLogByJid.get(participant.id);
+    const params = new URLSearchParams({ phone, session });
+    const checkUrl = `${base}/api/contacts/check-exists?${params.toString()}`;
+
+    try {
+      const res = await fetch(checkUrl, { method: 'GET', headers });
+      const body = await res.text().catch(() => '');
+      let parsed: { chatId?: string; numberExists?: boolean } = {};
+      try {
+        parsed = body ? JSON.parse(body) : {};
+      } catch {
+        parsed = {};
+      }
+
+      diagnostics.push({
+        body: res.ok ? undefined : sanitizeWahaResponseForLog(body),
+        chatId: parsed.chatId ? redactWahaParticipantId(parsed.chatId) : undefined,
+        id: participantLog?.id || redactWahaParticipantId(participant.id),
+        label: participantLog?.label,
+        numberExists: typeof parsed.numberExists === 'boolean' ? parsed.numberExists : undefined,
+        ok: res.ok,
+        source: participantLog?.source,
+        status: res.status,
+      });
+    } catch (err) {
+      diagnostics.push({
+        body: (err as Error)?.message || String(err),
+        id: participantLog?.id || redactWahaParticipantId(participant.id),
+        label: participantLog?.label,
+        ok: false,
+        source: participantLog?.source,
+      });
     }
   }
-  if (!/^\+\d{7,15}$/.test(digits)) return { ok: false, reason: 'invalid_format' };
-  return { ok: true, value: digits };
+
+  return diagnostics;
 }
 
 serve(async (req: Request) => {
@@ -285,6 +356,7 @@ serve(async (req: Request) => {
     const defaultCC = Deno.env.get('WA_DEFAULT_COUNTRY_CODE') || '+34';
     const crewParticipants: string[] = [];
     const supplementalParticipants: string[] = [];
+    const participantDetailsByPhone = new Map<string, { label: string; source: string }>();
     const missing: string[] = [];
     const invalid: string[] = [];
 
@@ -292,6 +364,7 @@ serve(async (req: Request) => {
       profile: { first_name?: string | null; last_name?: string | null; phone?: string | null } | null | undefined,
       fallbackName = 'Tecnico',
       target: string[] = crewParticipants,
+      source = 'crew',
     ) => {
       const fullName = `${profile?.first_name ?? ''} ${profile?.last_name ?? ''}`.trim() || fallbackName;
       const rawPhone = (profile?.phone || '').trim();
@@ -302,6 +375,9 @@ serve(async (req: Request) => {
       const norm = normalizePhone(rawPhone, defaultCC);
       if (norm.ok) {
         target.push(norm.value);
+        if (!participantDetailsByPhone.has(norm.value)) {
+          participantDetailsByPhone.set(norm.value, { label: fullName, source });
+        }
         return true;
       }
 
@@ -392,7 +468,12 @@ serve(async (req: Request) => {
     // Always include management user for the department (if phone exists and matches department)
     if (actor?.phone && actor?.department && actor.department === department) {
       const norm = normalizePhone(actor.phone, defaultCC);
-      if (norm.ok) supplementalParticipants.push(norm.value);
+      if (norm.ok) {
+        supplementalParticipants.push(norm.value);
+        if (!participantDetailsByPhone.has(norm.value)) {
+          participantDetailsByPhone.set(norm.value, { label: 'Requesting manager', source: 'actor' });
+        }
+      }
     }
 
     // Buddy system: Javier auto-adds Carlos, Carlos auto-adds Javier (department sound)
@@ -411,7 +492,12 @@ serve(async (req: Request) => {
             .maybeSingle();
           if (buddy?.phone) {
             const norm = normalizePhone(buddy.phone, defaultCC);
-            if (norm.ok) supplementalParticipants.push(norm.value);
+            if (norm.ok) {
+              supplementalParticipants.push(norm.value);
+              if (!participantDetailsByPhone.has(norm.value)) {
+                participantDetailsByPhone.set(norm.value, { label: 'Department buddy', source: 'buddy' });
+              }
+            }
           }
         } catch { /* ignore */ }
       }
@@ -486,6 +572,20 @@ serve(async (req: Request) => {
       actorJid: actorJidCandidate,
       participants: supplementalParticipantPhones,
     });
+    const participantLogByJid = new Map<string, WahaParticipantLogEntry>(
+      uniqueParticipants.map((phone) => {
+        const jid = phoneToWahaJid(phone);
+        const details = participantDetailsByPhone.get(phone);
+        return [jid, {
+          id: redactWahaParticipantId(jid),
+          label: details?.label,
+          source: details?.source,
+        }];
+      }),
+    );
+    const creationParticipantLogs = creationGroupParticipants.map((participant) =>
+      participantLogByJid.get(participant.id) || { id: redactWahaParticipantId(participant.id) }
+    );
 
     if (creationGroupParticipants.length === 0) {
       const message = effectiveStageNumber > 0
@@ -524,6 +624,7 @@ serve(async (req: Request) => {
           hasApiKey: Boolean(apiKey),
           message,
           participantCount: creationGroupParticipants.length,
+          participants: creationParticipantLogs,
           requestId,
           session,
           department,
@@ -534,11 +635,21 @@ serve(async (req: Request) => {
       }
       if (!groupRes.ok) {
         const txt = await groupRes.text().catch(() => '');
+        const shouldSkipFallback = shouldSkipCreateGroupFallback(txt);
+        const contactDiagnostics = isWahaBadRequest(txt)
+          ? await diagnoseWahaContacts({
+            base,
+            headers,
+            participantLogByJid,
+            participants: creationGroupParticipants,
+            session,
+          })
+          : undefined;
         if (
           groupRes.status >= 500 &&
           groupRes.status < 600 &&
           creationGroupParticipants.length > 1 &&
-          !shouldSkipCreateGroupFallback(txt)
+          !shouldSkipFallback
         ) {
           // Fallback: try real assigned participants one by one when WAHA rejects bulk creation.
           const fallbackErrors: WahaFallbackAttempt[] = [];
@@ -573,6 +684,7 @@ serve(async (req: Request) => {
               fallbackAttempts: fallbackErrors,
               hasApiKey: Boolean(apiKey),
               participantCount: creationGroupParticipants.length,
+              participants: creationParticipantLogs,
               requestId,
               response: txt,
               session,
@@ -586,8 +698,10 @@ serve(async (req: Request) => {
         } else {
           logWahaCreateFailure({
             base,
+            contactDiagnostics,
             hasApiKey: Boolean(apiKey),
             participantCount: creationGroupParticipants.length,
+            participants: creationParticipantLogs,
             requestId,
             response: txt,
             session,

--- a/supabase/functions/create-whatsapp-group/index.ts
+++ b/supabase/functions/create-whatsapp-group/index.ts
@@ -46,6 +46,29 @@ function sanitizeWahaResponseForLog(body: string) {
   );
 }
 
+function extractWahaErrorText(body: string) {
+  try {
+    const parsed = JSON.parse(body) as {
+      exception?: { details?: unknown; message?: unknown };
+      message?: unknown;
+    };
+    const exceptionText = [parsed?.exception?.message, parsed?.exception?.details]
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .join(' ');
+    if (exceptionText) return exceptionText.toLowerCase();
+    if (typeof parsed?.message === 'string') return parsed.message.toLowerCase();
+  } catch {
+    // Fall back to a plain text search below.
+  }
+
+  return body.toLowerCase();
+}
+
+function shouldSkipCreateGroupFallback(body: string) {
+  const errorText = extractWahaErrorText(body);
+  return errorText.includes('rate-overlimit') || errorText.includes('bad-request');
+}
+
 function wahaHostFromBase(base: string) {
   try {
     return new URL(base).host;
@@ -511,7 +534,12 @@ serve(async (req: Request) => {
       }
       if (!groupRes.ok) {
         const txt = await groupRes.text().catch(() => '');
-        if (groupRes.status >= 500 && groupRes.status < 600 && creationGroupParticipants.length > 1) {
+        if (
+          groupRes.status >= 500 &&
+          groupRes.status < 600 &&
+          creationGroupParticipants.length > 1 &&
+          !shouldSkipCreateGroupFallback(txt)
+        ) {
           // Fallback: try real assigned participants one by one when WAHA rejects bulk creation.
           const fallbackErrors: WahaFallbackAttempt[] = [];
           for (const candidate of creationGroupParticipants) {

--- a/supabase/functions/create-whatsapp-group/recipientUtils.ts
+++ b/supabase/functions/create-whatsapp-group/recipientUtils.ts
@@ -23,6 +23,41 @@ export type FestivalStageRecipientResolution = {
   technicianIds: string[];
 };
 
+export function normalizePhone(raw: string, defaultCountry: string): { ok: true; value: string } | { ok: false; reason: string } {
+  if (!raw) return { ok: false, reason: 'empty' };
+  const trimmed = raw.trim();
+  if (!trimmed) return { ok: false, reason: 'empty' };
+
+  let digits = trimmed.replace(/[\s\-()]/g, '');
+  if (digits.startsWith('00')) digits = '+' + digits.slice(2);
+
+  if (digits.startsWith('+')) {
+    return /^\+\d{7,15}$/.test(digits)
+      ? { ok: true, value: digits }
+      : { ok: false, reason: 'invalid_format' };
+  }
+
+  if (/^[67]\d{8}$/.test(digits)) {
+    return { ok: true, value: '+34' + digits };
+  }
+
+  const defaultCountryDigits = defaultCountry.replace(/\D/g, '');
+  if (
+    defaultCountryDigits &&
+    digits.startsWith(defaultCountryDigits) &&
+    digits.length >= defaultCountryDigits.length + 7 &&
+    digits.length <= 15
+  ) {
+    return { ok: true, value: '+' + digits };
+  }
+
+  if (/^[1-9]\d{9,14}$/.test(digits)) {
+    return { ok: true, value: '+' + digits };
+  }
+
+  return { ok: false, reason: 'missing_country_code' };
+}
+
 const ROLE_PREFIX_BY_DEPARTMENT: Record<Dept, string> = {
   sound: 'SND-',
   lights: 'LGT-',


### PR DESCRIPTION
## Summary
- persist the already deployed create-user hotfix in the repo
- add WhatsApp group creation diagnostics for WAHA failures
- surface Edge Function response bodies in WhatsApp group creation UI paths
- normalize international WhatsApp participant numbers before sending them to WAHA

## Validation
- npx vitest run supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts src/utils/__tests__/supabaseFunctionError.test.ts src/features/festival-management/__tests__/selectors.test.ts
- npx eslint supabase/functions/create-whatsapp-group/index.ts supabase/functions/create-whatsapp-group/recipientUtils.ts supabase/functions/create-whatsapp-group/__tests__/recipientUtils.test.ts
- deployed create-whatsapp-group Edge Function to Supabase, latest verified version 429