### PR TITLE
feat: opción de adjuntar Hoja de Ruta (PDF) en el WhatsApp de citación

### DIFF
--- a/src/components/jobs/cards/job-card-actions/ProductionWhatsappDialog.tsx
+++ b/src/components/jobs/cards/job-card-actions/ProductionWhatsappDialog.tsx
@@ -168,6 +168,30 @@ export const ProductionWhatsappDialog = ({ state }: ProductionWhatsappDialogProp
               className="min-h-[140px]"
             />
           </div>
+
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id="wa-attach-hoja-de-ruta"
+              checked={state.waProdAttachHojaDeRuta}
+              onCheckedChange={(next) => state.setWaProdAttachHojaDeRuta(Boolean(next))}
+              disabled={state.waProdHojaDeRutaLoading || !state.waProdHojaDeRutaDoc}
+            />
+            <div className="space-y-1">
+              <Label
+                htmlFor="wa-attach-hoja-de-ruta"
+                className={cn("font-normal", !state.waProdHojaDeRutaLoading && !state.waProdHojaDeRutaDoc && "text-muted-foreground")}
+              >
+                Enviar Hoja de Ruta (PDF) como seguimiento
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {state.waProdHojaDeRutaLoading
+                  ? "Comprobando si hay Hoja de Ruta disponible…"
+                  : state.waProdHojaDeRutaDoc
+                    ? `Se enviará "${state.waProdHojaDeRutaDoc.file_name || "Hoja de Ruta.pdf"}" tras el mensaje de citación.`
+                    : "No hay Hoja de Ruta generada para este trabajo."}
+              </p>
+            </div>
+          </div>
         </div>
 
         <DialogFooter>

--- a/src/components/jobs/cards/job-card-actions/ProductionWhatsappDialog.tsx
+++ b/src/components/jobs/cards/job-card-actions/ProductionWhatsappDialog.tsx
@@ -187,7 +187,7 @@ export const ProductionWhatsappDialog = ({ state }: ProductionWhatsappDialogProp
                 {state.waProdHojaDeRutaLoading
                   ? "Comprobando si hay Hoja de Ruta disponible…"
                   : state.waProdHojaDeRutaDoc
-                    ? `Se enviará "${state.waProdHojaDeRutaDoc.file_name || "Hoja de Ruta.pdf"}" tras el mensaje de citación.`
+                    ? `Se enviará "${state.waProdHojaDeRutaDoc.file_name || "Hoja de Ruta.pdf"}" tras el mensaje de citación (como PDF adjunto o enlace de descarga).`
                     : "No hay Hoja de Ruta generada para este trabajo."}
               </p>
             </div>

--- a/src/components/jobs/cards/job-card-actions/types.ts
+++ b/src/components/jobs/cards/job-card-actions/types.ts
@@ -131,6 +131,13 @@ export type WaSendResult = {
   sentCount: number;
   failed: Array<{ recipient_id: string; reason: string }>;
   job_id: string | null;
+  attachmentSentCount?: number;
+  attachmentFailed?: Array<{ recipient_id: string; reason: string }>;
+};
+
+export type WaProdHojaDeRutaDoc = {
+  id: string;
+  file_name: string | null;
 };
 
 export type TourdateSelectorInfo = {

--- a/src/components/jobs/cards/job-card-actions/types.ts
+++ b/src/components/jobs/cards/job-card-actions/types.ts
@@ -132,6 +132,8 @@ export type WaSendResult = {
   failed: Array<{ recipient_id: string; reason: string }>;
   job_id: string | null;
   attachmentSentCount?: number;
+  /** How many attachments were delivered as a download link (WAHA Core fallback). */
+  attachmentLinkFallbackCount?: number;
   attachmentFailed?: Array<{ recipient_id: string; reason: string }>;
 };
 

--- a/src/components/jobs/cards/job-card-actions/useProductionWhatsapp.ts
+++ b/src/components/jobs/cards/job-card-actions/useProductionWhatsapp.ts
@@ -12,6 +12,7 @@ import {
   type JobCardJob,
   type JobAssignmentRow,
   type WaProdAssignment,
+  type WaProdHojaDeRutaDoc,
   type WaProdTimesheetRow,
   type WaSendResult,
 } from "@/components/jobs/cards/job-card-actions/types";
@@ -61,6 +62,7 @@ export const useProductionWhatsapp = ({
   const [waProdMessage, setWaProdMessage] = React.useState<string>("");
   const [waProdDirty, setWaProdDirty] = React.useState(false);
   const [waProdSending, setWaProdSending] = React.useState(false);
+  const [waProdAttachHojaDeRuta, setWaProdAttachHojaDeRuta] = React.useState(false);
 
   const { data: waProdAssignments = [], isLoading: waProdAssignmentsLoading } = useQuery({
     queryKey: createQueryKey.whatsapp.prodAssignmentsByJob(job.id),
@@ -108,6 +110,24 @@ export const useProductionWhatsapp = ({
 
       if (error) throw error;
       return (data as WaProdTimesheetRow[] | null) || [];
+    },
+    enabled: Boolean(waProdOpen && canSendProductionWhatsapp && job?.id),
+    staleTime: 30_000,
+  });
+
+  const { data: waProdHojaDeRutaDoc = null, isLoading: waProdHojaDeRutaLoading } = useQuery({
+    queryKey: createQueryKey.whatsapp.prodHojaDeRutaDocByJob(job.id),
+    queryFn: async (): Promise<WaProdHojaDeRutaDoc | null> => {
+      const { data, error } = await dataLayerClient.from("job_documents")
+        .select("id, file_name")
+        .eq("job_id", job.id)
+        .like("file_path", `hojas-de-ruta/${job.id}/%`)
+        .order("uploaded_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (error) throw error;
+      return (data as WaProdHojaDeRutaDoc | null) || null;
     },
     enabled: Boolean(waProdOpen && canSendProductionWhatsapp && job?.id),
     staleTime: 30_000,
@@ -183,12 +203,15 @@ export const useProductionWhatsapp = ({
         return;
       }
 
+      const attachHojaDeRuta = waProdAttachHojaDeRuta && Boolean(waProdHojaDeRutaDoc);
+
       setWaProdSending(true);
       const { data, error } = await dataLayerClient.functions.invoke<WaSendResult>("send-job-whatsapp-message", {
         body: {
           job_id: job?.id,
           message: trimmed,
           recipient_ids: waProdRecipientIds,
+          attach_hoja_de_ruta: attachHojaDeRuta,
         },
       });
 
@@ -199,11 +222,17 @@ export const useProductionWhatsapp = ({
 
       const sent = data?.sentCount ?? null;
       const failed = data?.failed?.length ?? 0;
+      const descriptionParts = [
+        sent !== null ? `Enviados: ${sent}. Fallos: ${failed}.` : `Mensaje enviado. Fallos: ${failed}.`,
+      ];
+      if (attachHojaDeRuta) {
+        const attachmentSent = data?.attachmentSentCount ?? 0;
+        const attachmentFailed = data?.attachmentFailed?.length ?? 0;
+        descriptionParts.push(`Hoja de Ruta: ${attachmentSent} enviadas, ${attachmentFailed} fallos.`);
+      }
       toast({
         title: "Enviado",
-        description: sent !== null
-          ? `Enviados: ${sent}. Fallos: ${failed}.`
-          : `Mensaje enviado. Fallos: ${failed}.`,
+        description: descriptionParts.join(" "),
       });
       setWaProdOpen(false);
     } catch (error: unknown) {
@@ -212,7 +241,7 @@ export const useProductionWhatsapp = ({
     } finally {
       setWaProdSending(false);
     }
-  }, [job?.id, toast, waProdMessage, waProdRecipientIds]);
+  }, [job?.id, toast, waProdMessage, waProdRecipientIds, waProdAttachHojaDeRuta, waProdHojaDeRutaDoc]);
 
   React.useEffect(() => {
     if (!waProdOpen) return;
@@ -240,6 +269,7 @@ export const useProductionWhatsapp = ({
     setWaProdRecipientIds([]);
     setWaProdCallTime(suggested);
     setWaProdDirty(false);
+    setWaProdAttachHojaDeRuta(false);
     setWaProdMessage(buildProductionWhatsappTemplate(job, { groupKey: "all", callTime: suggested }));
     setWaProdOpen(true);
   }, [job]);
@@ -249,6 +279,7 @@ export const useProductionWhatsapp = ({
     if (!open) {
       setWaProdRecipientIds([]);
       setWaProdDirty(false);
+      setWaProdAttachHojaDeRuta(false);
     }
   }, []);
 
@@ -259,6 +290,7 @@ export const useProductionWhatsapp = ({
     handleProductionDialogOpenChange,
     handleWaProdSend,
     openProductionWhatsappDialog,
+    setWaProdAttachHojaDeRuta,
     setWaProdCallTime,
     setWaProdDateGroup,
     setWaProdDirty,
@@ -267,9 +299,12 @@ export const useProductionWhatsapp = ({
     setWaProdRecipientIds,
     waProdAssignments,
     waProdAssignmentsLoading,
+    waProdAttachHojaDeRuta,
     waProdCallTime,
     waProdDateGroup,
     waProdGroups,
+    waProdHojaDeRutaDoc,
+    waProdHojaDeRutaLoading,
     waProdMessage,
     waProdOpen,
     waProdRecipientIds,

--- a/src/lib/optimized-react-query.ts
+++ b/src/lib/optimized-react-query.ts
@@ -120,6 +120,8 @@ export const createQueryKey = {
     prodAssignmentsByJob: (jobId: string) => [...createQueryKey.whatsapp.all, 'prod-assignments', jobId] as const,
     /** Timesheets (source of truth) used to derive worked dates for WhatsApp date grouping. */
     prodTimesheetsByJob: (jobId: string) => [...createQueryKey.whatsapp.all, 'prod-timesheets', jobId] as const,
+    /** Latest Hoja de Ruta PDF document available to attach to WhatsApp messages. */
+    prodHojaDeRutaDocByJob: (jobId: string) => [...createQueryKey.whatsapp.all, 'prod-hoja-de-ruta-doc', jobId] as const,
   },
   profiles: {
     all: ['profiles'] as const,

--- a/supabase/functions/send-job-whatsapp-message/index.ts
+++ b/supabase/functions/send-job-whatsapp-message/index.ts
@@ -11,6 +11,8 @@ type SendRequest = {
   recipient_ids?: string[];
   /** Optional job ID for telemetry/debugging. */
   job_id?: string;
+  /** When true, send the latest Hoja de Ruta PDF as a follow-up message after the text. */
+  attach_hoja_de_ruta?: boolean;
 };
 
 /** Normalize a WAHA base URL (ensures protocol, strips trailing slashes). */
@@ -129,6 +131,41 @@ serve(async (req: Request) => {
       return jsonResponse({ error: "Bad Request", reason: "Too many recipients" }, { status: 400 });
     }
 
+    // Resolve the Hoja de Ruta attachment up-front so a missing document fails
+    // the request before any text message goes out.
+    const attachHojaDeRuta = Boolean(body.attach_hoja_de_ruta);
+    let attachment: { url: string; filename: string } | null = null;
+    if (attachHojaDeRuta) {
+      const { data: docRows, error: docErr } = await supabaseAdmin
+        .from("job_documents")
+        .select("file_name, file_path")
+        .eq("job_id", jobId)
+        .like("file_path", `hojas-de-ruta/${jobId}/%`)
+        .order("uploaded_at", { ascending: false })
+        .limit(1);
+
+      if (docErr) throw docErr;
+
+      const doc = docRows?.[0];
+      if (!doc?.file_path) {
+        return jsonResponse({ error: "Bad Request", reason: "hoja_de_ruta_not_found" }, { status: 400 });
+      }
+
+      const { data: signed, error: signErr } = await supabaseAdmin.storage
+        .from("job-documents")
+        .createSignedUrl(doc.file_path, 3600);
+
+      if (signErr || !signed?.signedUrl) {
+        console.error("Failed to sign Hoja de Ruta URL:", signErr);
+        return jsonResponse({ error: "Internal Server Error", reason: "hoja_de_ruta_sign_failed" }, { status: 500 });
+      }
+
+      attachment = {
+        url: signed.signedUrl,
+        filename: (doc.file_name || "Hoja de Ruta.pdf").toString(),
+      };
+    }
+
     // Security: restrict recipients to technicians assigned to this job.
     const { data: assignmentRows, error: asgErr } = await supabaseAdmin
       .from("job_assignments")
@@ -196,12 +233,69 @@ serve(async (req: Request) => {
       },
     ] as const;
 
+    const fileAttemptsFor = (chatId: string, file: { url: string; filename: string }) => [
+      {
+        url: `${base}/api/${encodeURIComponent(session)}/sendFile`,
+        body: { chatId, file: { url: file.url, filename: file.filename, mimetype: "application/pdf" } },
+      },
+      {
+        url: `${base}/api/sendFile`,
+        body: { chatId, file: { url: file.url, filename: file.filename, mimetype: "application/pdf" }, session },
+      },
+    ] as const;
+
     const timeoutMs = Number(Deno.env.get("WAHA_FETCH_TIMEOUT_MS") || 9000);
+
+    /** Try each WAHA endpoint variant in order; succeed on the first OK response. */
+    const runAttempts = async (
+      attempts: ReadonlyArray<{ url: string; body: unknown }>,
+    ): Promise<{ ok: true } | { ok: false; reason: string }> => {
+      let lastErr = "send_failed";
+      for (const attempt of attempts) {
+        try {
+          const res = await fetchWithTimeout(attempt.url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(attempt.body),
+          }, timeoutMs);
+
+          const contentType = res.headers.get("content-type") || "";
+          const payload = /application\/json/i.test(contentType)
+            ? await res.json().catch(() => null)
+            : await res.text().catch(() => null);
+
+          if (!res.ok) {
+            lastErr = `http_${res.status}`;
+            continue;
+          }
+
+          if (payload && typeof payload === "object") {
+            const obj = payload as Record<string, unknown>;
+            if (obj.success === false) {
+              lastErr = typeof obj.message === "string" ? obj.message : "waha_success_false";
+              continue;
+            }
+            if (typeof obj.error === "string") {
+              lastErr = obj.error;
+              continue;
+            }
+          }
+
+          return { ok: true } as const;
+        } catch (e) {
+          lastErr = e instanceof Error ? e.message : String(e);
+        }
+      }
+      return { ok: false, reason: lastErr } as const;
+    };
 
     // Concurrency note: Deno JS is single-threaded, so mutating `queue`/`sentCount` is safe
     // as long as we only do it between `await` points (which we do in this loop).
     const queue = [...sendTargets];
     const concurrency = Math.max(1, Math.min(4, Number(Deno.env.get("WAHA_SEND_CONCURRENCY") || 4)));
+
+    let attachmentSentCount = 0;
+    const attachmentFailed: Array<{ recipient_id: string; reason: string }> = [];
 
     const worker = async () => {
       while (queue.length) {
@@ -216,53 +310,34 @@ serve(async (req: Request) => {
         }
         const chatId = norm.value.replace(/^\+/, "").replace(/\D/g, "") + "@c.us";
 
-        let ok = false;
-        let lastErr = "send_failed";
-        for (const attempt of attemptsFor(chatId)) {
-          try {
-            const res = await fetchWithTimeout(attempt.url, {
-              method: "POST",
-              headers,
-              body: JSON.stringify(attempt.body),
-            }, timeoutMs);
-
-            const contentType = res.headers.get("content-type") || "";
-            const payload = /application\/json/i.test(contentType)
-              ? await res.json().catch(() => null)
-              : await res.text().catch(() => null);
-
-            if (!res.ok) {
-              lastErr = `http_${res.status}`;
-              continue;
-            }
-
-            if (payload && typeof payload === "object") {
-              const obj = payload as Record<string, unknown>;
-              if (obj.success === false) {
-                lastErr = typeof obj.message === "string" ? obj.message : "waha_success_false";
-                continue;
-              }
-              if (typeof obj.error === "string") {
-                lastErr = obj.error;
-                continue;
-              }
-            }
-
-            ok = true;
-            break;
-          } catch (e) {
-            lastErr = e instanceof Error ? e.message : String(e);
-          }
+        const textResult = await runAttempts(attemptsFor(chatId));
+        if (!textResult.ok) {
+          failed.push({ recipient_id: rid, reason: textResult.reason });
+          continue;
         }
+        sentCount += 1;
 
-        if (ok) sentCount += 1;
-        else failed.push({ recipient_id: rid, reason: lastErr });
+        // Follow-up: Hoja de Ruta PDF only after the text message succeeded.
+        if (attachment) {
+          const fileResult = await runAttempts(fileAttemptsFor(chatId, attachment));
+          if (fileResult.ok) attachmentSentCount += 1;
+          else attachmentFailed.push({ recipient_id: rid, reason: fileResult.reason });
+        }
       }
     };
 
     await Promise.all(Array.from({ length: concurrency }).map(() => worker()));
 
-    return jsonResponse({ success: true, sentCount, failed, job_id: jobId || null }, { status: 200 });
+    return jsonResponse(
+      {
+        success: true,
+        sentCount,
+        failed,
+        job_id: jobId || null,
+        ...(attachment ? { attachmentSentCount, attachmentFailed } : {}),
+      },
+      { status: 200 },
+    );
   } catch (err) {
     console.error("send-job-whatsapp-message error:", err);
     return jsonResponse({ error: "Internal Server Error" }, { status: 500 });

--- a/supabase/functions/send-job-whatsapp-message/index.ts
+++ b/supabase/functions/send-job-whatsapp-message/index.ts
@@ -151,9 +151,11 @@ serve(async (req: Request) => {
         return jsonResponse({ error: "Bad Request", reason: "hoja_de_ruta_not_found" }, { status: 400 });
       }
 
+      // 7 days: the link must stay alive in the chat, not just survive the send.
+      // (Used both by sendFile and by the WAHA Core text-link fallback.)
       const { data: signed, error: signErr } = await supabaseAdmin.storage
         .from("job-documents")
-        .createSignedUrl(doc.file_path, 3600);
+        .createSignedUrl(doc.file_path, 60 * 60 * 24 * 7);
 
       if (signErr || !signed?.signedUrl) {
         console.error("Failed to sign Hoja de Ruta URL:", signErr);
@@ -244,6 +246,22 @@ serve(async (req: Request) => {
       },
     ] as const;
 
+    // WAHA Core fallback: sending files is a Plus feature, so when sendFile is
+    // unavailable we deliver the PDF as a signed download link via plain text.
+    const linkAttemptsFor = (chatId: string, file: { url: string; filename: string }) => {
+      const text = `📄 Hoja de Ruta: ${file.filename}\n${file.url}\n(Enlace de descarga válido durante 7 días)`;
+      return [
+        {
+          url: `${base}/api/${encodeURIComponent(session)}/sendText`,
+          body: { chatId, text, linkPreview: false },
+        },
+        {
+          url: `${base}/api/sendText`,
+          body: { chatId, text, session, linkPreview: false },
+        },
+      ] as const;
+    };
+
     const timeoutMs = Number(Deno.env.get("WAHA_FETCH_TIMEOUT_MS") || 9000);
 
     /** Try each WAHA endpoint variant in order; succeed on the first OK response. */
@@ -295,6 +313,7 @@ serve(async (req: Request) => {
     const concurrency = Math.max(1, Math.min(4, Number(Deno.env.get("WAHA_SEND_CONCURRENCY") || 4)));
 
     let attachmentSentCount = 0;
+    let attachmentLinkFallbackCount = 0;
     const attachmentFailed: Array<{ recipient_id: string; reason: string }> = [];
 
     const worker = async () => {
@@ -318,10 +337,20 @@ serve(async (req: Request) => {
         sentCount += 1;
 
         // Follow-up: Hoja de Ruta PDF only after the text message succeeded.
+        // Native attachment first (WAHA Plus); download link as text otherwise.
         if (attachment) {
           const fileResult = await runAttempts(fileAttemptsFor(chatId, attachment));
-          if (fileResult.ok) attachmentSentCount += 1;
-          else attachmentFailed.push({ recipient_id: rid, reason: fileResult.reason });
+          if (fileResult.ok) {
+            attachmentSentCount += 1;
+          } else {
+            const linkResult = await runAttempts(linkAttemptsFor(chatId, attachment));
+            if (linkResult.ok) {
+              attachmentSentCount += 1;
+              attachmentLinkFallbackCount += 1;
+            } else {
+              attachmentFailed.push({ recipient_id: rid, reason: linkResult.reason });
+            }
+          }
         }
       }
     };
@@ -334,7 +363,7 @@ serve(async (req: Request) => {
         sentCount,
         failed,
         job_id: jobId || null,
-        ...(attachment ? { attachmentSentCount, attachmentFailed } : {}),
+        ...(attachment ? { attachmentSentCount, attachmentLinkFallbackCount, attachmentFailed } : {}),
       },
       { status: 200 },
     );


### PR DESCRIPTION
- Checkbox en ProductionWhatsappDialog para enviar la última Hoja de Ruta
  como mensaje de seguimiento tras la citación
- El hook consulta job_documents (hojas-de-ruta/{jobId}/) para detectar
  si existe PDF y deshabilita la opción si no hay documento
- La edge function send-job-whatsapp-message acepta attach_hoja_de_ruta,
  firma una URL temporal del PDF y lo envía vía WAHA sendFile tras cada
  texto enviado con éxito; reporta attachmentSentCount/attachmentFailed

https://claude.ai/code/session_01VVcocUABuSbsf2Rfj1uctB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now optionally attach route sheet (Hoja de Ruta) PDF documents as follow-ups when sending production WhatsApp messages for jobs.
  * Delivery reports now include attachment success and failure metrics, with automatic fallback to download links when direct PDF delivery is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->