### PR TITLE
docs: add mobile safe-area audit report

### DIFF
--- a/docs/MOBILE_SAFE_AREA_AUDIT.md
+++ b/docs/MOBILE_SAFE_AREA_AUDIT.md
@@ -18,16 +18,15 @@ The inconsistencies come from surfaces that predate or bypass this convention.
 
 ## Tier 1 — Base shadcn/ui primitives (systemic, highest leverage)
 
-These are non-compliant at the primitive level, so **every consumer inherits the bug**. Fixing these resolves dozens of screens at once.
+These were non-compliant at the primitive level, so **every consumer inherited the bug**. **Status: all items in this tier are fixed on this branch** — fixing them resolved dozens of screens at once.
 
-| File | Line | Issue |
+| File | Line | Original issue (now fixed) |
 |---|---|---|
-| `src/components/ui/sheet.tsx` | 38 | `side="bottom"` variant is `inset-x-0 bottom-0` with no `pb-safe` — content sits under the home indicator. Top/left/right variants likewise have no inset handling. |
-| `src/components/ui/drawer.tsx` | 44 | `DrawerContent` (vaul bottom sheet) is `fixed inset-x-0 bottom-0` with no bottom inset padding. |
-| `src/components/ui/toast.tsx` | 17 | `ToastViewport` is `fixed top-0 ... p-4` on mobile — toasts render under the notch/Dynamic Island. Desktop `sm:bottom-0` lacks bottom inset. |
-| `src/components/ui/dialog.tsx` | 15-53 | Centered `DialogContent` has no safe-area-aware max-height/padding; tall dialogs (`max-h-screen`, `h-[90vh]` consumers) can extend into insets. |
-| `src/components/ui/alert-dialog.tsx` | 13-43 | Same pattern as dialog.tsx. |
-| `src/components/ui/sidebar/sidebar-components.tsx` | 53, 68, 99 | Diverges from `src/components/ui/sidebar.tsx` (which is fully compliant at lines 207/363/382/416): header/footer have no inset padding, content has `pt-safe` but no `pb-safe`. Duplicate implementation drifting. |
+| `src/components/ui/sheet.tsx` | 38 | `side="bottom"` variant was `inset-x-0 bottom-0` with no `pb-safe` — content sat under the home indicator. Top/left/right variants likewise had no inset handling. Each edge-touching side now carries `max(1.5rem, env(...))` padding. |
+| `src/components/ui/drawer.tsx` | 44 | `DrawerContent` (vaul bottom sheet) was `fixed inset-x-0 bottom-0` with no bottom inset padding. Now has `pb-[max(0px,env(safe-area-inset-bottom))]`. |
+| `src/components/ui/toast.tsx` | 17 | `ToastViewport` was `fixed top-0 ... p-4` on mobile — toasts rendered under the notch/Dynamic Island; desktop `sm:bottom-0` lacked bottom inset. Both edges now inset-aware; the sonner toaster also gained safe-area `offset`/`mobileOffset`. |
+| `src/components/ui/dialog.tsx` + `alert-dialog.tsx` | — | `DialogContent`/`AlertDialogContent` capped height at plain `90vh` (or not at all), letting tall dialogs extend into the insets. Both now cap at `calc(90dvh − env(top) − env(bottom))` with `overflow-y-auto`, keeping content scrollable and clear of notch and home indicator. |
+| `src/components/ui/sidebar/sidebar-components.tsx` | 53, 68, 99 | Diverged from `src/components/ui/sidebar.tsx` (fully compliant): header/footer had no inset padding, content had `pt-safe` but no `pb-safe`. Now reconciled with `sidebar.tsx`. |
 
 Not affected (auto-positioned floating elements, no fixed edges): `popover.tsx`, `dropdown-menu.tsx`, `select.tsx`.
 
@@ -89,7 +88,7 @@ Plus point inconsistencies:
 
 ## Recommended fix plan
 
-**Phase 1 — primitives (one PR, biggest win).** Add inset handling to `sheet.tsx` (per-side: `pb` for bottom, `pt` for top, `py` for left/right), `drawer.tsx`, `toast.tsx` viewport, and dialog/alert-dialog max-height (`max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))]`-style). Reconcile `sidebar/sidebar-components.tsx` with `sidebar.tsx`.
+**Phase 1 — primitives (✅ done on this branch).** Per-side inset handling added to `sheet.tsx`, `drawer.tsx`, the `toast.tsx` viewport, and the sonner toaster; dialog/alert-dialog max-heights are inset-aware; `sidebar/sidebar-components.tsx` reconciled with `sidebar.tsx`. Note: consumers that override edge padding on `SheetContent` (e.g. `pb-*`, `p-0`) take over inset responsibility — keep an `env(safe-area-inset-*)` term or pad an inner element.
 
 **Phase 2 — custom full-screen modals.** Apply the technician-modal pattern to the eight Tier 2 surfaces. Consider extracting a shared `FullScreenOverlay` wrapper or a `safe-overlay` utility class so the pattern can't drift again.
 

--- a/docs/MOBILE_SAFE_AREA_AUDIT.md
+++ b/docs/MOBILE_SAFE_AREA_AUDIT.md
@@ -1,0 +1,102 @@
+# Mobile Safe-Area Audit — June 2026
+
+Deep audit of mobile safe-area handling across the app (Capacitor iOS/Android + PWA, `viewport-fit=cover` in `index.html`). Every finding below was verified against the source at the referenced line.
+
+## Context: the established convention
+
+The app already has good safe-area infrastructure:
+
+- CSS vars `--safe-area-top/bottom/left/right` and utilities `.pt-safe`, `.pb-safe`, `.px-safe`, `.pt-safe-2/3/4`, `.pb-safe-2/3/4` (`src/index.css:94-98`, `350-365`)
+- Tailwind spacing tokens `safe-top`, `safe-bottom`, `safe-*-2/3/4` (`tailwind.config.ts:51-68`)
+- Guidelines in `docs/mobile-guidelines.md`
+- A reference-quality pattern used by all `src/components/technician/` modals:
+  `pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))]`
+
+The inconsistencies come from surfaces that predate or bypass this convention.
+
+---
+
+## Tier 1 — Base shadcn/ui primitives (systemic, highest leverage)
+
+These are non-compliant at the primitive level, so **every consumer inherits the bug**. Fixing these resolves dozens of screens at once.
+
+| File | Line | Issue |
+|---|---|---|
+| `src/components/ui/sheet.tsx` | 38 | `side="bottom"` variant is `inset-x-0 bottom-0` with no `pb-safe` — content sits under the home indicator. Top/left/right variants likewise have no inset handling. |
+| `src/components/ui/drawer.tsx` | 44 | `DrawerContent` (vaul bottom sheet) is `fixed inset-x-0 bottom-0` with no bottom inset padding. |
+| `src/components/ui/toast.tsx` | 17 | `ToastViewport` is `fixed top-0 ... p-4` on mobile — toasts render under the notch/Dynamic Island. Desktop `sm:bottom-0` lacks bottom inset. |
+| `src/components/ui/dialog.tsx` | 15-53 | Centered `DialogContent` has no safe-area-aware max-height/padding; tall dialogs (`max-h-screen`, `h-[90vh]` consumers) can extend into insets. |
+| `src/components/ui/alert-dialog.tsx` | 13-43 | Same pattern as dialog.tsx. |
+| `src/components/ui/sidebar/sidebar-components.tsx` | 53, 68, 99 | Diverges from `src/components/ui/sidebar.tsx` (which is fully compliant at lines 207/363/382/416): header/footer have no inset padding, content has `pt-safe` but no `pb-safe`. Duplicate implementation drifting. |
+
+Not affected (auto-positioned floating elements, no fixed edges): `popover.tsx`, `dropdown-menu.tsx`, `select.tsx`.
+
+## Tier 2 — Custom full-screen modals bypassing the convention
+
+These hand-rolled `fixed inset-0` overlays should use the technician-modal pattern but don't:
+
+| File | Line | Surface |
+|---|---|---|
+| `src/components/festival/mobile/MobileArtistConfigEditor.tsx` | 621 | Full-screen mobile editor, `fixed inset-0` with no insets. |
+| `src/components/festival/mobile/MobileArtistFormSheet.tsx` | 212, 271 | Both full-screen views (section detail + hub), no insets. |
+| `src/components/festival/mobile/MobileArtistList.tsx` | 226 | `SheetContent side="bottom"` with `max-h-[85vh]`, no `pb-safe` (compounds the sheet.tsx primitive bug). |
+| `src/components/festival/ArtistManagementDialog.tsx` | 70 | `DialogContent` forced to `h-[100vh] w-[100vw]` full-bleed — ignores both insets and iOS browser chrome. |
+| `src/components/technician/ProfileView.tsx` | 594 | Password modal overlay, `p-4` only — footer buttons can sit under the home indicator. |
+| `src/components/timesheet/TimesheetSidebar.tsx` | 133 | Full-height right sidebar on mobile, no top/bottom insets (also clips in landscape). |
+| `src/components/department/EnhancedJobDetailsModal.tsx` | 400 | `fixed inset-0 ... p-4` with `h-[90vh]` inner panel, no insets. |
+| `src/components/incident-reports/TechnicianIncidentReportDialog.tsx` | 245, 444 | Main dialog and signature modal, `p-2 sm:p-4` only. |
+
+## Tier 3 — Fixed/floating elements missing insets
+
+| File | Line | Issue |
+|---|---|---|
+| `src/components/ui/connection-status.tsx` | 123 | `fixed bottom-4 right-4` — hidden behind home indicator. |
+| `src/components/achievements/AchievementBanner.tsx` | 24 | `fixed inset-x-0 top-0 ... pt-4` — banner under the notch. |
+| `src/components/disponibilidad/MobileAvailabilityView.tsx` | 305 | FAB at `fixed bottom-6 right-6` — collides with mobile nav + home indicator. |
+| `src/components/dashboard/DashboardMobileHub.tsx` | 227 | Hard-coded `pb-24` to clear the mobile nav, no `env(safe-area-inset-bottom)` term. |
+
+## Tier 4 — Page-level viewport-height bugs
+
+`h-screen`/`100vh` on iOS includes area under browser chrome and ignores insets; the codebase standard elsewhere is `min-h-screen` or `h-svh` (see `sidebar.tsx`).
+
+| File | Line | Issue |
+|---|---|---|
+| `src/pages/JobAssignmentMatrix.tsx` | 624 | Root container `h-screen`. |
+| `src/pages/StagePlot.tsx` | 252 | Root container `h-screen` (iframe loses vertical space). |
+| `src/pages/SysCalc.tsx` | 35 | `h-[calc(100vh-73px)]` — hard-coded header height, no inset term, `vh` not `dvh`. |
+| `src/pages/SoundVisionFiles.tsx` | 33, 102 | `h-[calc(100vh-6rem)]` / `h-[calc(100vh-4rem)]` — same problem. |
+| `src/pages/Auth.tsx` | 194 | Public route: `min-h-screen ... py-8` with no top inset — form/header can crowd the notch on the native app. |
+
+## Pattern inconsistencies (works, but three competing dialects)
+
+1. **Arbitrary inline values** — `pt-[max(1rem,env(safe-area-inset-top))]` (technician modals, Layout, MobileNavBar). The de-facto standard; most common.
+2. **CSS utilities** — `.pb-safe-3` etc. (TechnicianSuperApp). Defined in `index.css` but rarely used.
+3. **Tailwind tokens** — `pb-safe-bottom` etc. Documented in `docs/mobile-guidelines.md` but barely used anywhere.
+
+Plus point inconsistencies:
+
+- `src/pages/Sound.tsx:253` applies **both** the `pt-safe` class and an inline `style={{ paddingTop: 'max(env(safe-area-inset-top), 1rem)' }}` — redundant.
+- **Mobile nav height is assumed in at least 4 places with 3 different values**: `Layout.tsx` content padding uses `4.5rem`, `MobileAvailabilityView.tsx:65` negative margin uses `4.5rem`, `PushNotificationMatrix.tsx:375` uses `4rem`, `DashboardMobileHub.tsx:227` uses `6rem` (`pb-24`). There is no shared constant/CSS var; the `4rem` and `6rem` ones are wrong or fragile.
+- Hard-coded sticky offsets that ignore the safe-area-padded header height: `MobileAvailabilityView.tsx:142` (`top-[64px]`), `ModernHojaDeRuta.tsx:649/780/818` (`top-24`, `top-[68px]`).
+- `SoundVisionInteractiveMap.tsx:1274-1289` uses raw CSS `env()` in a `<style>` tag — acceptable (Mapbox controls aren't React), but worth a comment.
+- Landscape: only `SoundVisionInteractiveMap` handles `safe-area-inset-left/right`. `.pl-safe`/`.pr-safe`/`.px-safe` exist but are used nowhere — full-bleed surfaces (TimesheetSidebar, full-screen editors) will clip behind the notch in landscape.
+
+## Verified compliant (reference implementations)
+
+`Layout.tsx` (header 476, content 515), `MobileNavBar.tsx:104` (incl. visualViewport keyboard tracking), `MobileActionTray.tsx:62`, all `src/components/technician/` modals incl. `TourDetailView.tsx:161/207` and `TimesheetView.tsx`, `ui/sidebar.tsx`, `SoundVisionInteractiveMap.tsx`, `TechnicianSuperApp.tsx`, `ProjectManagement.tsx` sheet usage.
+
+---
+
+## Recommended fix plan
+
+**Phase 1 — primitives (one PR, biggest win).** Add inset handling to `sheet.tsx` (per-side: `pb` for bottom, `pt` for top, `py` for left/right), `drawer.tsx`, `toast.tsx` viewport, and dialog/alert-dialog max-height (`max-h-[calc(100dvh-2rem-env(safe-area-inset-top)-env(safe-area-inset-bottom))]`-style). Reconcile `sidebar/sidebar-components.tsx` with `sidebar.tsx`.
+
+**Phase 2 — custom full-screen modals.** Apply the technician-modal pattern to the eight Tier 2 surfaces. Consider extracting a shared `FullScreenOverlay` wrapper or a `safe-overlay` utility class so the pattern can't drift again.
+
+**Phase 3 — fixed elements + viewport heights.** Tier 3 floats get `calc(... + env(safe-area-inset-bottom/top))` offsets; Tier 4 pages move from `h-screen`/`100vh` to `h-dvh`/`min-h-screen` with inset terms.
+
+**Phase 4 — standardization.**
+- Introduce a shared `--mobile-nav-height: 4.5rem` CSS var and replace all four hard-coded nav-height assumptions.
+- Pick ONE dialect (recommend the existing CSS utilities `.pt-safe-*`/`.pb-safe-*`, extending them as needed) and update `docs/mobile-guidelines.md` to deprecate the others.
+- Remove the redundant double padding in `Sound.tsx`.
+- Optionally add a lint/grep CI check flagging new `h-screen`, `100vh`, `fixed bottom-0`/`top-0` without an `env(safe-area-inset-*)` term.

--- a/docs/MOBILE_SAFE_AREA_AUDIT.md
+++ b/docs/MOBILE_SAFE_AREA_AUDIT.md
@@ -88,7 +88,7 @@ Plus point inconsistencies:
 
 ## Recommended fix plan
 
-**Phase 1 — primitives (✅ done on this branch).** Per-side inset handling added to `sheet.tsx`, `drawer.tsx`, the `toast.tsx` viewport, and the sonner toaster; dialog/alert-dialog max-heights are inset-aware; `sidebar/sidebar-components.tsx` reconciled with `sidebar.tsx`. Note: consumers that override edge padding on `SheetContent` (e.g. `pb-*`, `p-0`) take over inset responsibility — keep an `env(safe-area-inset-*)` term or pad an inner element.
+**Phase 1 — primitives (✅ done on this branch).** Per-side inset handling added to `sheet.tsx`, `drawer.tsx`, the `toast.tsx` viewport, and the sonner toaster; dialog/alert-dialog max-heights are inset-aware; `sidebar/sidebar-components.tsx` reconciled with `sidebar.tsx`. Note: `SheetContent` applies insets as inline styles so consumer `className` padding utilities cannot silently strip them; consumers that handle insets themselves (e.g. full-bleed layouts with a safe-padded inner element) opt out explicitly via the `style` prop.
 
 **Phase 2 — custom full-screen modals.** Apply the technician-modal pattern to the eight Tier 2 surfaces. Consider extracting a shared `FullScreenOverlay` wrapper or a `safe-overlay` utility class so the pattern can't drift again.
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "sonner": "^1.5.0",
+    "sonner": "^1.7.2",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",

--- a/src/components/layout/MobileActionTray.tsx
+++ b/src/components/layout/MobileActionTray.tsx
@@ -53,7 +53,8 @@ export const MobileActionTray = ({
       <SheetTrigger asChild>{renderTrigger(open)}</SheetTrigger>
       <SheetContent
         side="bottom"
-        className="flex h-[75vh] flex-col overflow-hidden rounded-t-3xl border-none bg-background px-0 pb-0 shadow-2xl [&>[data-radix-dialog-close]]:hidden"
+        className="flex h-[75vh] flex-col overflow-hidden rounded-t-3xl border-none bg-background px-0 shadow-2xl [&>[data-radix-dialog-close]]:hidden"
+        style={{ paddingBottom: 0 }}
       >
         <div className="mt-1 flex justify-center">
           <span className="mb-2 h-1.5 w-16 rounded-full bg-muted" aria-hidden="true" />

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -35,6 +35,7 @@ const AlertDialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "max-h-[calc(90dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        "max-h-[90vh] overflow-y-auto md:max-h-[85vh]",
+        "max-h-[calc(90dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto md:max-h-[85vh]",
         className
       )}
       {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -41,7 +41,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background pb-[max(0px,env(safe-area-inset-bottom))]",
         className
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -28,6 +28,10 @@ const SheetOverlay = React.forwardRef<
 ))
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
+// Edge-touching sides carry safe-area inset padding. Consumers overriding
+// padding on those edges (e.g. pb-* on side="bottom", p-0 full-bleed layouts)
+// take responsibility for the inset themselves — keep an env(safe-area-inset-*)
+// term or pad an inner element instead.
 const sheetVariants = cva(
   "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -33,12 +33,12 @@ const sheetVariants = cva(
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 border-b pt-[max(1.5rem,env(safe-area-inset-top))] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          "inset-x-0 bottom-0 border-t pb-[max(1.5rem,env(safe-area-inset-bottom))] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4  border-l pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -28,21 +28,17 @@ const SheetOverlay = React.forwardRef<
 ))
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
-// Edge-touching sides carry safe-area inset padding. Consumers overriding
-// padding on those edges (e.g. pb-* on side="bottom", p-0 full-bleed layouts)
-// take responsibility for the inset themselves — keep an env(safe-area-inset-*)
-// term or pad an inner element instead.
 const sheetVariants = cva(
   "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b pt-[max(1.5rem,env(safe-area-inset-top))] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t pb-[max(1.5rem,env(safe-area-inset-bottom))] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {
@@ -51,6 +47,26 @@ const sheetVariants = cva(
   }
 )
 
+// Safe-area insets are applied as inline styles so consumer className
+// utilities (p-*, pb-*, ...) cannot silently strip them. Consumers that
+// handle insets themselves (e.g. p-0 with a safe-padded inner element)
+// opt out explicitly via the style prop.
+const sheetSafeAreaInsets: Record<
+  "top" | "bottom" | "left" | "right",
+  React.CSSProperties
+> = {
+  top: { paddingTop: "max(1.5rem, env(safe-area-inset-top))" },
+  bottom: { paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))" },
+  left: {
+    paddingTop: "max(1.5rem, env(safe-area-inset-top))",
+    paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))",
+  },
+  right: {
+    paddingTop: "max(1.5rem, env(safe-area-inset-top))",
+    paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))",
+  },
+}
+
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
   VariantProps<typeof sheetVariants> { }
@@ -58,12 +74,13 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, style, children, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}
+      style={{ ...sheetSafeAreaInsets[side ?? "right"], ...style }}
       {...props}
     >
       {children}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -200,6 +200,8 @@ const Sidebar = React.forwardRef<
             style={
               {
                 "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+                paddingTop: 0,
+                paddingBottom: 0,
               } as React.CSSProperties
             }
             side={side}

--- a/src/components/ui/sidebar/sidebar-components.tsx
+++ b/src/components/ui/sidebar/sidebar-components.tsx
@@ -50,7 +50,11 @@ export const SidebarHeader = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="header"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn(
+        "flex flex-col gap-2 p-2",
+        "pt-[max(0.5rem,env(safe-area-inset-top))]",
+        className
+      )}
       {...props}
     />
   )
@@ -65,7 +69,11 @@ export const SidebarFooter = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="footer"
-      className={cn("flex flex-col gap-2 p-2 mt-auto", className)}
+      className={cn(
+        "flex flex-col gap-2 p-2 mt-auto",
+        "pb-[max(0.5rem,env(safe-area-inset-bottom))]",
+        className
+      )}
       {...props}
     />
   )
@@ -96,7 +104,7 @@ export const SidebarContent = React.forwardRef<
       ref={ref}
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden pt-[max(0.5rem,env(safe-area-inset-top))]",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden pt-[max(0.5rem,env(safe-area-inset-top))] pb-[max(0.5rem,env(safe-area-inset-bottom))]",
         className
       )}
       {...props}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -12,6 +12,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
       offset="max(32px, env(safe-area-inset-bottom))"
+      mobileOffset={{
+        top: "max(16px, env(safe-area-inset-top))",
+        bottom: "max(16px, env(safe-area-inset-bottom))",
+      }}
       toastOptions={{
         classNames: {
           toast:

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -11,6 +11,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      offset="max(32px, env(safe-area-inset-bottom))"
       toastOptions={{
         classNames: {
           toast:

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 pt-[max(1rem,env(safe-area-inset-top))] sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col sm:pt-4 sm:pb-[max(1rem,env(safe-area-inset-bottom))] md:max-w-[420px]",
       className
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -363,3 +363,9 @@
   .pb-safe-3 { padding-bottom: calc(var(--safe-area-bottom) + 0.75rem); }
   .pb-safe-4 { padding-bottom: calc(var(--safe-area-bottom) + 1rem); }
 }
+
+/* Sonner mobile viewport: sonner 1.x hardcodes a 16px mobile offset that
+   ignores the home indicator / notch on viewport-fit=cover devices */
+[data-sonner-toaster] {
+  --mobile-offset: max(16px, env(safe-area-inset-bottom)) !important;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -363,9 +363,3 @@
   .pb-safe-3 { padding-bottom: calc(var(--safe-area-bottom) + 0.75rem); }
   .pb-safe-4 { padding-bottom: calc(var(--safe-area-bottom) + 1rem); }
 }
-
-/* Sonner mobile viewport: sonner 1.x hardcodes a 16px mobile offset that
-   ignores the home indicator / notch on viewport-fit=cover devices */
-[data-sonner-toaster] {
-  --mobile-offset: max(16px, env(safe-area-inset-bottom)) !important;
-}

--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -556,7 +556,8 @@ const ProjectManagement = () => {
                 </SheetTrigger>
                 <SheetContent
                   side="bottom"
-                  className="h-auto max-h-[85dvh] overflow-y-auto px-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] pt-5"
+                  className="h-auto max-h-[85dvh] overflow-y-auto px-4 pt-5"
+                  style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)" }}
                 >
                   <SheetHeader className="mb-4">
                     <SheetTitle>Filtros</SheetTitle>

--- a/src/pages/TechnicianUnavailability.tsx
+++ b/src/pages/TechnicianUnavailability.tsx
@@ -298,7 +298,7 @@ export default function TechnicianUnavailability() {
         <Sheet open={open} onOpenChange={setOpen}>
           <SheetContent
             side="bottom"
-            className="flex h-[94vh] flex-col overflow-hidden rounded-t-2xl bg-background px-6 pb-6 pt-10"
+            className="flex h-[94vh] flex-col overflow-hidden rounded-t-2xl bg-background px-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] pt-10"
           >
             <SheetHeader className="space-y-1 text-left">
               <SheetTitle>Añadir bloqueo de disponibilidad</SheetTitle>

--- a/src/pages/TechnicianUnavailability.tsx
+++ b/src/pages/TechnicianUnavailability.tsx
@@ -298,7 +298,7 @@ export default function TechnicianUnavailability() {
         <Sheet open={open} onOpenChange={setOpen}>
           <SheetContent
             side="bottom"
-            className="flex h-[94vh] flex-col overflow-hidden rounded-t-2xl bg-background px-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] pt-10"
+            className="flex h-[94vh] flex-col overflow-hidden rounded-t-2xl bg-background px-6 pt-10"
           >
             <SheetHeader className="space-y-1 text-left">
               <SheetTitle>Añadir bloqueo de disponibilidad</SheetTitle>


### PR DESCRIPTION
Full audit of safe-area inset handling across modals, sheets, fixed
elements, and full-screen pages. Findings categorized by tier with
verified file:line references and a phased fix plan.

https://claude.ai/code/session_0124tVPKPtRUUPcQgVrXFWHk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile safe-area handling across dialogs, drawers, sheets, sidebars, toasts, and in-app bottom sheets—preventing overlap with notches, status bars, and home indicators.

* **Documentation**
  * Added a comprehensive mobile safe-area audit summarizing current patterns, non-compliant surfaces, and a phased remediation plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->