### PR TITLE
fix: add safe-area insets to custom full-screen modals (phase 2)

### DIFF
--- a/docs/MOBILE_SAFE_AREA_AUDIT.md
+++ b/docs/MOBILE_SAFE_AREA_AUDIT.md
@@ -32,7 +32,7 @@ Not affected (auto-positioned floating elements, no fixed edges): `popover.tsx`,
 
 ## Tier 2 — Custom full-screen modals bypassing the convention
 
-These hand-rolled `fixed inset-0` overlays should use the technician-modal pattern but don't:
+These hand-rolled `fixed inset-0` overlays bypassed the technician-modal pattern. **Status: all items in this tier are fixed on this branch** — full-screen views pad their root with `env()` insets, centered modal overlays use the technician pattern, and `MobileArtistList`'s bottom sheet was resolved by the Phase 1 `SheetContent` fix.
 
 | File | Line | Surface |
 |---|---|---|
@@ -90,7 +90,7 @@ Plus point inconsistencies:
 
 **Phase 1 — primitives (✅ done on this branch).** Per-side inset handling added to `sheet.tsx`, `drawer.tsx`, the `toast.tsx` viewport, and the sonner toaster; dialog/alert-dialog max-heights are inset-aware; `sidebar/sidebar-components.tsx` reconciled with `sidebar.tsx`. Note: `SheetContent` applies insets as inline styles so consumer `className` padding utilities cannot silently strip them; consumers that handle insets themselves (e.g. full-bleed layouts with a safe-padded inner element) opt out explicitly via the `style` prop.
 
-**Phase 2 — custom full-screen modals.** Apply the technician-modal pattern to the eight Tier 2 surfaces. Consider extracting a shared `FullScreenOverlay` wrapper or a `safe-overlay` utility class so the pattern can't drift again.
+**Phase 2 — custom full-screen modals (✅ done on this branch).** The technician-modal pattern applied to all Tier 2 surfaces; `ArtistManagementDialog` also moved from `100vh` to `dvh`, and `EnhancedJobDetailsModal`'s inner panel from `h-[90vh]` to `h-[90dvh] max-h-full`. A shared `FullScreenOverlay` wrapper remains a good future refactor so the pattern can't drift again.
 
 **Phase 3 — fixed elements + viewport heights.** Tier 3 floats get `calc(... + env(safe-area-inset-bottom/top))` offsets; Tier 4 pages move from `h-screen`/`100vh` to `h-dvh`/`min-h-screen` with inset terms.
 

--- a/src/components/department/EnhancedJobDetailsModal.tsx
+++ b/src/components/department/EnhancedJobDetailsModal.tsx
@@ -397,8 +397,8 @@ export const EnhancedJobDetailsModal = ({ theme, isDark, job, onClose, userRole,
     };
 
     return (
-        <div className={`fixed inset-0 z-50 flex items-center justify-center ${theme.modalOverlay} p-4 animate-in fade-in duration-200`}>
-            <div className={`w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] h-[90vh] ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${theme.divider} shadow-2xl flex flex-col overflow-hidden overflow-x-hidden animate-in zoom-in-95 duration-200`}>
+        <div className={`fixed inset-0 z-50 flex items-center justify-center ${theme.modalOverlay} p-4 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200`}>
+            <div className={`w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] h-[90dvh] max-h-full ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${theme.divider} shadow-2xl flex flex-col overflow-hidden overflow-x-hidden animate-in zoom-in-95 duration-200`}>
 
                 {/* Header */}
                 <div className={`p-4 border-b ${theme.divider} flex justify-between items-center shrink-0`}>

--- a/src/components/festival/ArtistManagementDialog.tsx
+++ b/src/components/festival/ArtistManagementDialog.tsx
@@ -67,7 +67,7 @@ export const ArtistManagementDialog = ({
   // Desktop: standard dialog
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="flex h-[100vh] max-h-[100vh] md:max-h-[100vh] w-[100vw] max-w-[100vw] flex-col gap-0 overflow-hidden rounded-none sm:rounded-none p-0">
+      <DialogContent className="flex h-dvh max-h-dvh md:max-h-dvh w-[100vw] max-w-[100vw] flex-col gap-0 overflow-hidden rounded-none sm:rounded-none p-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
         <DialogHeader className="border-b px-4 py-3 sm:px-6">
           <DialogTitle>
             {artist ? "Editar Artista" : "Agregar Artista"}

--- a/src/components/festival/mobile/MobileArtistConfigEditor.tsx
+++ b/src/components/festival/mobile/MobileArtistConfigEditor.tsx
@@ -618,7 +618,7 @@ export const MobileArtistConfigEditor = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-background flex flex-col animate-in slide-in-from-right duration-200">
+    <div className="fixed inset-0 z-50 bg-background flex flex-col pt-[max(0px,env(safe-area-inset-top))] pb-[max(0px,env(safe-area-inset-bottom))] animate-in slide-in-from-right duration-200">
       {/* Header */}
       <div className="flex items-center gap-3 p-4 border-b shrink-0">
         <button

--- a/src/components/festival/mobile/MobileArtistFormSheet.tsx
+++ b/src/components/festival/mobile/MobileArtistFormSheet.tsx
@@ -209,7 +209,7 @@ export const MobileArtistFormSheet = ({
   if (activeSection !== 'hub') {
     const meta = SECTION_META[activeSection];
     return (
-      <div className="fixed inset-0 z-50 bg-background flex flex-col animate-in slide-in-from-right duration-200">
+      <div className="fixed inset-0 z-50 bg-background flex flex-col pt-[max(0px,env(safe-area-inset-top))] pb-[max(0px,env(safe-area-inset-bottom))] animate-in slide-in-from-right duration-200">
         {/* Header */}
         <div className="flex items-center gap-3 p-4 border-b shrink-0">
           <button
@@ -268,7 +268,7 @@ export const MobileArtistFormSheet = ({
 
   // Hub view: BasicInfo + section navigation + submit
   return (
-    <div className="fixed inset-0 z-50 bg-background flex flex-col">
+    <div className="fixed inset-0 z-50 bg-background flex flex-col pt-[max(0px,env(safe-area-inset-top))] pb-[max(0px,env(safe-area-inset-bottom))]">
       {/* Header */}
       <div className="flex items-center gap-3 p-4 border-b shrink-0">
         <button

--- a/src/components/incident-reports/TechnicianIncidentReportDialog.tsx
+++ b/src/components/incident-reports/TechnicianIncidentReportDialog.tsx
@@ -242,7 +242,7 @@ export const TechnicianIncidentReportDialog = ({
       </div>
 
       {isOpen && (
-        <div className={`fixed inset-0 z-[70] flex items-center justify-center ${t.modalOverlay} p-2 sm:p-4 animate-in fade-in duration-200 overflow-y-auto`}>
+        <div className={`fixed inset-0 z-[70] flex items-center justify-center ${t.modalOverlay} p-2 sm:p-4 pt-[max(0.5rem,env(safe-area-inset-top))] pb-[max(0.5rem,env(safe-area-inset-bottom))] sm:pt-[max(1rem,env(safe-area-inset-top))] sm:pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200 overflow-y-auto`}>
           <div className={`w-full max-w-2xl max-h-[90dvh] my-auto ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${t.divider} shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200 flex flex-col`}>
 
             {/* Header */}
@@ -441,7 +441,7 @@ export const TechnicianIncidentReportDialog = ({
 
       {/* Signature Dialog */}
       {isSignatureDialogOpen && (
-        <div className={`fixed inset-0 z-[80] flex items-center justify-center ${t.modalOverlay} p-4 animate-in fade-in duration-200`}>
+        <div className={`fixed inset-0 z-[80] flex items-center justify-center ${t.modalOverlay} p-4 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200`}>
           <div className={`w-full max-w-md ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${t.divider} shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200`}>
             <div className={`p-4 border-b ${t.divider} flex justify-between items-center`}>
               <h3 className={`font-bold ${t.textMain}`}>Firma Digital</h3>

--- a/src/components/technician/ProfileView.tsx
+++ b/src/components/technician/ProfileView.tsx
@@ -591,7 +591,7 @@ export const ProfileView = ({ theme, isDark, user, userProfile, toggleTheme }: P
 
             {/* Password Change Modal */}
             {showPasswordModal && (
-                <div className={`fixed inset-0 z-[70] flex items-center justify-center ${theme.modalOverlay} p-4 animate-in fade-in duration-200`}>
+                <div className={`fixed inset-0 z-[70] flex items-center justify-center ${theme.modalOverlay} p-4 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200`}>
                     <div className={`w-full max-w-md ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${theme.divider} shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200`}>
                         {/* Header */}
                         <div className={`p-4 border-b ${theme.divider} flex justify-between items-center`}>

--- a/src/components/timesheet/TimesheetSidebar.tsx
+++ b/src/components/timesheet/TimesheetSidebar.tsx
@@ -138,7 +138,7 @@ export const TimesheetSidebar = ({ isOpen, onClose }: TimesheetSidebarProps) => 
       />
 
       {/* Sidebar */}
-      <div className="fixed right-0 top-0 h-full w-96 bg-background border-l border-border shadow-lg overflow-hidden flex flex-col">
+      <div className="fixed right-0 top-0 h-full w-96 bg-background border-l border-border shadow-lg overflow-hidden flex flex-col pt-[max(0px,env(safe-area-inset-top))] pb-[max(0px,env(safe-area-inset-bottom))] pr-[max(0px,env(safe-area-inset-right))]">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
Phase 2 of the mobile safe-area audit (`docs/MOBILE_SAFE_AREA_AUDIT.md`, Tier 2): applies the technician-modal safe-area pattern to the hand-rolled full-screen overlays that bypass the shadcn primitives fixed in #690.

## Changes

- **Festival mobile artist editor + form sheet** (`MobileArtistConfigEditor`, `MobileArtistFormSheet` hub and section views): root containers get `pt/pb-[max(0px,env(safe-area-inset-*))]` so headers clear the notch and footer buttons clear the home indicator.
- **`ArtistManagementDialog`**: full-bleed dialog moves from `h-[100vh]`/`max-h-[100vh]` to `h-dvh`/`max-h-dvh` and gains top/bottom inset padding.
- **`ProfileView` password modal, `EnhancedJobDetailsModal`, `TechnicianIncidentReportDialog` (main + signature)**: centered-modal overlays get inset-aware padding (`pt/pb-[max(base,env(...))]`), including `sm:`-prefixed variants where responsive `sm:p-4` would otherwise override the base inset classes.
- **`EnhancedJobDetailsModal` panel**: `h-[90vh]` → `h-[90dvh] max-h-full`, so the panel respects the inset-padded overlay instead of overflowing it on iOS.
- **`TimesheetSidebar`**: full-height right panel gains top/bottom insets plus `safe-area-inset-right` for notched landscape.
- `MobileArtistList`'s bottom sheet (the remaining Tier 2 item) needed no change — it was resolved by the `SheetContent` primitive fix in #690.
- Audit doc updated to mark Tier 2 and Phase 2 as done.

All edits are className-only and use the established `max(base, env(safe-area-inset-*))` dialect; no visual change on devices without insets.

## Validation

- Production build passes
- ESLint: 0 errors on all touched files (warnings are pre-existing `no-explicit-any`)
- Changes are pure className string edits — no logic touched

https://claude.ai/code/session_0124tVPKPtRUUPcQgVrXFWHk

---
_Generated by [Claude Code](https://claude.ai/code/session_0124tVPKPtRUUPcQgVrXFWHk)_