### PR TITLE
fix: safe-area for fixed elements and viewport-height pages (phase 3)

### DIFF
--- a/docs/MOBILE_SAFE_AREA_AUDIT.md
+++ b/docs/MOBILE_SAFE_AREA_AUDIT.md
@@ -47,6 +47,8 @@ These hand-rolled `fixed inset-0` overlays bypassed the technician-modal pattern
 
 ## Tier 3 — Fixed/floating elements missing insets
 
+**Status: fixed on this branch**, except `DashboardMobileHub` — on re-verification its `pb-24` is internal spacing inside Layout's already nav-padded main (`pb-[calc(4.5rem+env(...))]`), not a clipping bug, so it was left as is. The MobileAvailabilityView FAB and SysCalc's mobile tip (same bug class, found during the fix) are now offset above the mobile nav (`calc(4.5rem + env(safe-area-inset-bottom) + gap)`).
+
 | File | Line | Issue |
 |---|---|---|
 | `src/components/ui/connection-status.tsx` | 123 | `fixed bottom-4 right-4` — hidden behind home indicator. |
@@ -56,7 +58,7 @@ These hand-rolled `fixed inset-0` overlays bypassed the technician-modal pattern
 
 ## Tier 4 — Page-level viewport-height bugs
 
-`h-screen`/`100vh` on iOS includes area under browser chrome and ignores insets; the codebase standard elsewhere is `min-h-screen` or `h-svh` (see `sidebar.tsx`).
+`h-screen`/`100vh` on iOS includes area under browser chrome and ignores insets; the codebase standard elsewhere is `min-h-screen` or `h-svh` (see `sidebar.tsx`). **Status: fixed on this branch** — `h-screen` roots moved to `h-dvh`, `100vh` calcs to `100dvh` (the SoundVision map page additionally subtracts `env(safe-area-inset-top)` since Layout's header grows with the inset), and the Auth page gained inset-aware vertical padding on both variants.
 
 | File | Line | Issue |
 |---|---|---|
@@ -92,7 +94,7 @@ Plus point inconsistencies:
 
 **Phase 2 — custom full-screen modals (✅ done on this branch).** The technician-modal pattern applied to all Tier 2 surfaces; `ArtistManagementDialog` also moved from `100vh` to `dvh`, and `EnhancedJobDetailsModal`'s inner panel from `h-[90vh]` to `h-[90dvh] max-h-full`. A shared `FullScreenOverlay` wrapper remains a good future refactor so the pattern can't drift again.
 
-**Phase 3 — fixed elements + viewport heights.** Tier 3 floats get `calc(... + env(safe-area-inset-bottom/top))` offsets; Tier 4 pages move from `h-screen`/`100vh` to `h-dvh`/`min-h-screen` with inset terms.
+**Phase 3 — fixed elements + viewport heights (✅ done on this branch).** Tier 3 floats got `calc(... + env(safe-area-inset-bottom/top))` offsets; Tier 4 pages moved from `h-screen`/`100vh` to `h-dvh`/`100dvh` with inset terms where Layout chrome height varies; Auth page padded for both insets.
 
 **Phase 4 — standardization.**
 - Introduce a shared `--mobile-nav-height: 4.5rem` CSS var and replace all four hard-coded nav-height assumptions.

--- a/src/components/achievements/AchievementBanner.tsx
+++ b/src/components/achievements/AchievementBanner.tsx
@@ -21,7 +21,7 @@ export function AchievementBanner() {
   };
 
   return (
-    <div className="fixed inset-x-0 top-0 z-[100] flex justify-center px-4 pt-4 pointer-events-none">
+    <div className="fixed inset-x-0 top-0 z-[100] flex justify-center px-4 pt-[calc(1rem+env(safe-area-inset-top))] pointer-events-none">
       <div className="pointer-events-auto w-full max-w-md animate-in slide-in-from-top-4 fade-in duration-500">
         <div className="relative overflow-hidden rounded-xl border border-primary/30 bg-card shadow-lg">
           {/* Dismiss */}

--- a/src/components/disponibilidad/MobileAvailabilityView.tsx
+++ b/src/components/disponibilidad/MobileAvailabilityView.tsx
@@ -302,7 +302,7 @@ export function MobileAvailabilityView({
             </div>
 
             {/* Floating Action Button / Bottom Sheet */}
-            <div className="fixed bottom-6 right-6 z-50">
+            <div className="fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom)+1.5rem)] right-6 z-50">
                 <Sheet>
                     <SheetTrigger asChild>
                         <Button

--- a/src/components/ui/connection-status.tsx
+++ b/src/components/ui/connection-status.tsx
@@ -120,7 +120,7 @@ export function ConnectionStatus({
   }
   
   return (
-    <div className={`fixed bottom-4 right-4 z-50 max-w-md transition-all duration-300 ease-in-out ${className || ''}`}>
+    <div className={`fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] right-4 z-50 max-w-md transition-all duration-300 ease-in-out ${className || ''}`}>
       {isVisible && (
         <Card className={`shadow-lg ${
           connectionStatus === 'connecting' ? 'bg-blue-50' :

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -160,7 +160,7 @@ const Auth = () => {
   // Show legacy forms for signup/recovery
   if (showSignUp || showForgotPassword || isRecovery) {
     return (
-      <div className="auth-no-oauth min-h-screen flex flex-col px-4 py-8 md:py-12 bg-slate-50">
+      <div className="auth-no-oauth min-h-screen flex flex-col px-4 py-8 pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] md:py-12 bg-slate-50">
         <div className="container max-w-lg mx-auto flex-1 flex flex-col">
           <div className="text-center mb-8">
             <h1 className="text-4xl font-bold mb-2 text-slate-900">Bienvenido</h1>
@@ -232,7 +232,7 @@ const Auth = () => {
       </div>
 
       {/* Main content */}
-      <div className="relative z-10 min-h-screen flex items-center justify-center px-4 py-8">
+      <div className="relative z-10 min-h-screen flex items-center justify-center px-4 py-8 pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))]">
         <div className="w-full max-w-md">
           {/* Logo and branding */}
           <div className="text-center mb-8">

--- a/src/pages/JobAssignmentMatrix.tsx
+++ b/src/pages/JobAssignmentMatrix.tsx
@@ -621,7 +621,7 @@ export default function JobAssignmentMatrix() {
         : `${outstandingJobsCount} trabajo${outstandingJobsCount === 1 ? '' : 's'} pendiente${outstandingJobsCount === 1 ? '' : 's'}`;
 
   return (
-    <div className="h-screen flex flex-col bg-background">
+    <div className="h-dvh flex flex-col bg-background">
       <MatrixPageControls
         selectedDepartment={selectedDepartment}
         defaultDepartment={defaultDepartment}

--- a/src/pages/SoundVisionFiles.tsx
+++ b/src/pages/SoundVisionFiles.tsx
@@ -30,7 +30,7 @@ const SoundVisionFiles = () => {
 
   if (isLoading) {
     return (
-      <div className="w-full h-[calc(100vh-6rem)] flex items-center justify-center bg-background text-foreground">
+      <div className="w-full h-[calc(100dvh-6rem)] flex items-center justify-center bg-background text-foreground">
         <div className="flex items-center gap-2">
           <Loader2 className="h-6 w-6 animate-spin text-primary" />
           <span className="text-muted-foreground">Cargando...</span>
@@ -99,7 +99,7 @@ const SoundVisionFiles = () => {
   };
 
   return (
-    <div className="w-full h-[calc(100vh-4rem)] p-0 m-0 overflow-hidden relative">
+    <div className="w-full h-[calc(100dvh-4rem-env(safe-area-inset-top))] p-0 m-0 overflow-hidden relative">
       <SoundVisionInteractiveMap
         theme={mapTheme}
         isDark={isDark}

--- a/src/pages/StagePlot.tsx
+++ b/src/pages/StagePlot.tsx
@@ -249,7 +249,7 @@ export default function StagePlot() {
   };
 
   return (
-    <div className="flex flex-col h-screen bg-background">
+    <div className="flex flex-col h-dvh bg-background">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b bg-card">
         <div className="flex items-center gap-4">

--- a/src/pages/SysCalc.tsx
+++ b/src/pages/SysCalc.tsx
@@ -32,7 +32,7 @@ const SysCalc = () => {
       </div>
 
       {/* Calculator iframe */}
-      <div className="w-full h-[calc(100vh-73px)] relative">
+      <div className="w-full h-[calc(100dvh-73px)] relative">
         <iframe
           key={iframeKey}
           src={sysCalcUrl}
@@ -83,7 +83,7 @@ const SysCalc = () => {
 
       {/* Mobile helper text */}
       {isMobile && (
-        <div className="fixed bottom-4 left-4 right-4 bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-400">
+        <div className="fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom)+1rem)] left-4 right-4 bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-400">
           <p className="font-medium">💡 Tip: Rotate your device to landscape for better viewing</p>
         </div>
       )}


### PR DESCRIPTION
Phase 3 of the mobile safe-area audit (`docs/MOBILE_SAFE_AREA_AUDIT.md`): Tier 3 floating elements and Tier 4 viewport-height pages. Follows #690 (primitives) and #691 (full-screen modals).

## Tier 3 — floating/fixed elements

- **Connection status badge**: `bottom-4` → `bottom-[calc(1rem+env(safe-area-inset-bottom))]` so it clears the home indicator.
- **Achievement banner**: `pt-4` → `pt-[calc(1rem+env(safe-area-inset-top))]` so it clears the notch.
- **MobileAvailabilityView FAB**: raised above the mobile nav — `bottom-[calc(4.5rem+env(safe-area-inset-bottom)+1.5rem)]` (4.5rem matches Layout's nav constant).
- **SysCalc mobile tip** (found during the fix, same bug class): was `fixed bottom-4` hidden behind the nav bar; now offset above it.

## Tier 4 — viewport heights

- **JobAssignmentMatrix, StagePlot**: root `h-screen` → `h-dvh` (on iOS, `vh` includes area under browser chrome).
- **SysCalc iframe, SoundVisionFiles**: `calc(100vh-…)` → `calc(100dvh-…)`; the SoundVision map page additionally subtracts `env(safe-area-inset-top)` because Layout's safe-padded header grows by that amount on notched devices.
- **Auth page** (public route, both light/dark variants): vertical padding is now `max(2rem, env(safe-area-inset-top/bottom))` so the form can't crowd the notch in the native app.

## Skipped with reason

- **`DashboardMobileHub` `pb-24`** (flagged in the audit): on re-verification it renders inside Layout's main, which already pads `calc(4.5rem + env(safe-area-inset-bottom))` for the nav — the `pb-24` is internal spacing, not a clipping bug. Left unchanged; audit doc updated to record this.

## Validation

- Production build passes
- ESLint: 0 errors on all touched files (warnings are pre-existing `no-explicit-any`)
- All changes are className-only; desktop rendering is identical (`dvh` ≡ `vh` and `env()` ≡ 0 without insets)

https://claude.ai/code/session_0124tVPKPtRUUPcQgVrXFWHk

---
_Generated by [Claude Code](https://claude.ai/code/session_0124tVPKPtRUUPcQgVrXFWHk)_