### PR TITLE
refactor: standardize safe-area patterns (phase 4)

### DIFF
--- a/docs/MOBILE_SAFE_AREA_AUDIT.md
+++ b/docs/MOBILE_SAFE_AREA_AUDIT.md
@@ -96,8 +96,8 @@ Plus point inconsistencies:
 
 **Phase 3 — fixed elements + viewport heights (✅ done on this branch).** Tier 3 floats got `calc(... + env(safe-area-inset-bottom/top))` offsets; Tier 4 pages moved from `h-screen`/`100vh` to `h-dvh`/`100dvh` with inset terms where Layout chrome height varies; Auth page padded for both insets.
 
-**Phase 4 — standardization.**
-- Introduce a shared `--mobile-nav-height: 4.5rem` CSS var and replace all four hard-coded nav-height assumptions.
-- Pick ONE dialect (recommend the existing CSS utilities `.pt-safe-*`/`.pb-safe-*`, extending them as needed) and update `docs/mobile-guidelines.md` to deprecate the others.
-- Remove the redundant double padding in `Sound.tsx`.
-- Optionally add a lint/grep CI check flagging new `h-screen`, `100vh`, `fixed bottom-0`/`top-0` without an `env(safe-area-inset-*)` term.
+**Phase 4 — standardization (✅ done on this branch).**
+- `--mobile-nav-height: 4.5rem` CSS var introduced in `index.css`; all nav-height call sites (Layout, MobileAvailabilityView ×2, PushNotificationMatrix — which had the wrong `4rem` — and SysCalc) now derive from it.
+- Canonical dialect settled on the arbitrary-value `max(base, env(safe-area-inset-*))` pattern (what the primitives and technician modals already use); `docs/mobile-guidelines.md` rewritten accordingly. The unused Tailwind `safe-*` spacing tokens were removed from `tailwind.config.ts`; the `.pt-safe-*` CSS utilities remain as shorthand.
+- `Sound.tsx`'s redundant class + inline-style double padding collapsed into one class.
+- CI grep guard **skipped**: 51 `h-screen`/`100vh` occurrences remain in non-viewport contexts (inner panels, modals capped by parents), so a blanket check would be too noisy. Revisit if those get cleaned up.

--- a/docs/mobile-guidelines.md
+++ b/docs/mobile-guidelines.md
@@ -38,31 +38,38 @@ Examples:
 
 - if (atLeast('lg')) { ... }
 - if (between('sm', 'lg')) { ... }
-- const fullHeight = isMobile ? 'h-[calc(100vh-var(--safe-area-top)-var(--safe-area-bottom))]' : 'h-[calc(100vh-4rem)]'
+- const fullHeight = isMobile ? 'h-[calc(100dvh-var(--safe-area-top)-var(--safe-area-bottom))]' : 'h-[calc(100dvh-4rem)]'
 
 ## Safe-area utilities
 
-iOS and edge-to-edge devices require safe-area padding. We offer two ways to handle it:
+iOS and edge-to-edge devices require safe-area padding (`viewport-fit=cover` is set, so insets are real). **The canonical pattern is an arbitrary-value class with a base minimum:**
 
-1) Tailwind spacing tokens (theme.spacing)
+- `pt-[max(1rem,env(safe-area-inset-top))]` — edge-anchored top (headers, full-screen modal overlays)
+- `pb-[max(1.5rem,env(safe-area-inset-bottom))]` — edge-anchored bottom (bottom sheets, footers)
+- `bottom-[calc(1rem+env(safe-area-inset-bottom))]` — floating elements offset from the bottom edge
 
-- pt-safe-top, pb-safe-bottom, pl-safe-left, pr-safe-right
-- pt-safe-top-2/3/4 and pb-safe-bottom-2/3/4 add 0.5rem/0.75rem/1rem on top of the safe inset
+This is what the UI primitives (`sheet.tsx`, `drawer.tsx`, `toast.tsx`, `sidebar.tsx`) and the technician modals use. The CSS utility classes in `index.css` (`pt-safe`, `pb-safe`, `px-safe`, `pt-safe-2/3/4`, `pb-safe-2/3/4`) remain available as shorthand when no base minimum is needed.
 
-These work anywhere you can use spacing tokens, e.g. `pt-safe-top-3`.
+The old Tailwind spacing tokens (`safe-top`, `safe-bottom`, …) were unused and have been removed — don't reintroduce them.
 
-2) Utility classes in CSS
+Notes:
 
-- pt-safe, pb-safe, px-safe, py-safe
-- pt-safe-2/3/4 and pb-safe-2/3/4 mirror the sizes above
+- `SheetContent` applies its insets as inline styles so consumer classes can't strip them; opt out via the `style` prop if an inner element handles the inset.
+- Use top and bottom independently; avoid a single `py-` value when the two edges need different handling.
 
-Use top and bottom independently on mobile bars and headers. Avoid `py-` with a single token when top and bottom values need to be different.
+## Offsetting above the mobile nav
 
-Examples:
+The fixed mobile nav bar's base height is exposed as `--mobile-nav-height` (4.5rem, defined in `index.css`; keep in sync with `MobileNavBar.tsx`). Anything positioned above the nav, or padding content so it clears the nav, must use:
 
-- Header: `pt-safe` or `pt-safe-3`
-- Bottom bar: `pb-safe` or `pb-safe-3`
-- Edge gutters: `px-safe`
+```
+calc(var(--mobile-nav-height) + env(safe-area-inset-bottom) [+ gap])
+```
+
+Never hard-code 4rem/4.5rem/6rem nav offsets. `Layout.tsx`'s main already pads mobile content with this value — pages inside Layout only need extra offsets for `fixed` elements.
+
+## Viewport heights
+
+Never use `h-screen` or `100vh` for viewport-level containers — on iOS they include the area under browser chrome. Use `h-dvh` / `100dvh` (or `min-h-screen` when only a minimum is needed). When subtracting a safe-area-padded header (like Layout's), subtract `env(safe-area-inset-top)` too: `h-[calc(100dvh-4rem-env(safe-area-inset-top))]`.
 
 ## Spacing scale additions
 

--- a/src/components/disponibilidad/MobileAvailabilityView.tsx
+++ b/src/components/disponibilidad/MobileAvailabilityView.tsx
@@ -62,7 +62,7 @@ export function MobileAvailabilityView({
     };
 
     return (
-        <div className={cn("flex flex-col min-h-screen -mx-3 -mt-4 -mb-[calc(4.5rem+env(safe-area-inset-bottom))]", theme.bg)}>
+        <div className={cn("flex flex-col min-h-screen -mx-3 -mt-4 -mb-[calc(var(--mobile-nav-height)+env(safe-area-inset-bottom))]", theme.bg)}>
             {/* Header */}
             <div className={cn("border-b p-4 sticky top-0 z-20", theme.card, theme.divider)}>
                 <div className="flex items-center justify-between mb-3">
@@ -302,7 +302,7 @@ export function MobileAvailabilityView({
             </div>
 
             {/* Floating Action Button / Bottom Sheet */}
-            <div className="fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom)+1.5rem)] right-6 z-50">
+            <div className="fixed bottom-[calc(var(--mobile-nav-height)+env(safe-area-inset-bottom)+1.5rem)] right-6 z-50">
                 <Sheet>
                     <SheetTrigger asChild>
                         <Button

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -512,7 +512,7 @@ const Layout = () => {
               suppressChrome || mobileFullscreenRoutes
                 ? "pb-6"
                 : isMobile
-                  ? "pb-[calc(4.5rem+env(safe-area-inset-bottom))]"
+                  ? "pb-[calc(var(--mobile-nav-height)+env(safe-area-inset-bottom))]"
                   : "pb-10",
             )}
           >

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -97,6 +97,8 @@ export const MobileNavBar = ({
     : undefined
 
   const nav = (
+    // If the nav's height or base padding changes, update --mobile-nav-height
+    // in index.css — content offsets above the nav are derived from it.
     <nav
       role="navigation"
       aria-label="Navegación principal"

--- a/src/components/settings/PushNotificationMatrix.tsx
+++ b/src/components/settings/PushNotificationMatrix.tsx
@@ -372,7 +372,7 @@ export function PushNotificationMatrix() {
 
   if (isMobile) {
     return (
-      <Collapsible open={isOpen} onOpenChange={setIsOpen} className="fixed bottom-[calc(4rem+env(safe-area-inset-bottom))] left-0 right-0 z-30">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen} className="fixed bottom-[calc(var(--mobile-nav-height)+env(safe-area-inset-bottom))] left-0 right-0 z-30">
         <Card className="rounded-t-lg rounded-b-none border-x-0 border-b-0 shadow-lg">
           <CollapsibleTrigger asChild>
             <CardHeader className="cursor-pointer hover:bg-accent/50 transition-colors pb-3">

--- a/src/index.css
+++ b/src/index.css
@@ -96,6 +96,10 @@
     --safe-area-bottom: env(safe-area-inset-bottom);
     --safe-area-left: env(safe-area-inset-left);
     --safe-area-right: env(safe-area-inset-right);
+    /* Height of the fixed MobileNavBar (content + base padding, excluding
+       its safe-area inset). Anything offset above the nav must use
+       calc(var(--mobile-nav-height) + env(safe-area-inset-bottom) [+ gap]) */
+    --mobile-nav-height: 4.5rem;
     /* Mobile typography scale */
     --text-xs: clamp(0.75rem, 0.68rem + 0.3vw, 0.8rem);
     --text-sm: clamp(0.875rem, 0.82rem + 0.35vw, 0.95rem);

--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -250,7 +250,7 @@ const Sound = () => {
     <div className="min-h-screen bg-background text-foreground">
       {/* Mobile View - Full Screen Hub */}
       {isMobile && (
-        <div className="px-4 pt-safe pb-24 space-y-4" style={{ paddingTop: 'max(env(safe-area-inset-top), 1rem)' }}>
+        <div className="px-4 pt-[max(1rem,env(safe-area-inset-top))] pb-24 space-y-4">
           <DepartmentMobileHub
             department={currentDepartment}
             title="Departamento de sonido"

--- a/src/pages/SysCalc.tsx
+++ b/src/pages/SysCalc.tsx
@@ -83,7 +83,7 @@ const SysCalc = () => {
 
       {/* Mobile helper text */}
       {isMobile && (
-        <div className="fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom)+1rem)] left-4 right-4 bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-400">
+        <div className="fixed bottom-[calc(var(--mobile-nav-height)+env(safe-area-inset-bottom)+1rem)] left-4 right-4 bg-blue-500/10 border border-blue-500/20 rounded-lg p-3 text-xs text-blue-400">
           <p className="font-medium">💡 Tip: Rotate your device to landscape for better viewing</p>
         </div>
       )}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,24 +47,14 @@ export default {
         '32': ['32px', { lineHeight: '1.2' }],
         '30': ['30px', { lineHeight: '1.2' }],
       },
-      // Extended spacing scale including common gaps and iOS safe area tokens
+      // Extended spacing scale for common gaps. Safe-area handling uses
+      // arbitrary values (max(base,env(safe-area-inset-*))) or the .pt-safe-*
+      // utilities in index.css — see docs/mobile-guidelines.md.
       spacing: {
         18: "4.5rem",
         22: "5.5rem",
         26: "6.5rem",
         30: "7.5rem",
-        // Safe-area raw tokens
-        "safe-top": "env(safe-area-inset-top)",
-        "safe-bottom": "env(safe-area-inset-bottom)",
-        "safe-left": "env(safe-area-inset-left)",
-        "safe-right": "env(safe-area-inset-right)",
-        // Safe-area plus common paddings
-        "safe-top-2": "calc(env(safe-area-inset-top) + 0.5rem)",
-        "safe-top-3": "calc(env(safe-area-inset-top) + 0.75rem)",
-        "safe-top-4": "calc(env(safe-area-inset-top) + 1rem)",
-        "safe-bottom-2": "calc(env(safe-area-inset-bottom) + 0.5rem)",
-        "safe-bottom-3": "calc(env(safe-area-inset-bottom) + 0.75rem)",
-        "safe-bottom-4": "calc(env(safe-area-inset-bottom) + 1rem)",
       },
       colors: {
         border: "hsl(var(--border))",


### PR DESCRIPTION
Phase 4 (final) of the mobile safe-area audit (`docs/MOBILE_SAFE_AREA_AUDIT.md`): standardization. Follows #690 (primitives), #691 (full-screen modals), #692 (fixed elements + viewport heights).

## Changes

- **Shared `--mobile-nav-height: 4.5rem` CSS var** (`index.css`, next to the safe-area vars). All five nav-offset call sites now derive from it instead of hard-coding the height: `Layout.tsx` content padding, `MobileAvailabilityView` (negative margin + FAB), `PushNotificationMatrix` — **which was using a wrong `4rem`, so its mobile collapsible now sits flush with the nav instead of 8px into it** — and SysCalc's mobile tip. A comment in `MobileNavBar.tsx` ties the var to the nav so they can't drift silently.
- **One canonical dialect.** `docs/mobile-guidelines.md`'s safe-area section is rewritten around the arbitrary-value `max(base, env(safe-area-inset-*))` pattern that the primitives and technician modals already use, with the `.pt-safe-*` CSS utilities kept as shorthand. Added sections for nav offsets (`calc(var(--mobile-nav-height) + env(...))`) and viewport heights (`dvh`, never `h-screen`/`100vh` at viewport level).
- **Removed the unused Tailwind `safe-*` spacing tokens** from `tailwind.config.ts` — verified zero usages in any utility position across `src/`.
- **`Sound.tsx`**: collapsed the redundant `pt-safe` class + inline `paddingTop` style into a single `pt-[max(1rem,env(safe-area-inset-top))]` class (identical computed value).

## Skipped with reason

- **CI grep guard** (optional audit item): 51 `h-screen`/`100vh` occurrences remain in non-viewport contexts (inner panels, modals capped by parents), so a blanket check would be too noisy to be useful. Recorded in the audit doc for a future cleanup.

## Validation

- Production build passes; built CSS contains the `--mobile-nav-height` definition and all derived classes (11 references)
- ESLint: 0 errors on all touched files (warnings pre-existing)
- Token removal verified safe: no `*-safe-top/bottom/left/right` class usage anywhere in `src/`
- `PushNotificationMatrix` is the only intentional visual change (8px correction); everything else is value-identical refactoring

This completes all four phases of the audit.

https://claude.ai/code/session_0124tVPKPtRUUPcQgVrXFWHk

---
_Generated by [Claude Code](https://claude.ai/code/session_0124tVPKPtRUUPcQgVrXFWHk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated mobile guidelines and safety standards documentation to reflect improved viewport height and safe-area handling.

* **Bug Fixes**
  * Fixed inconsistent mobile navigation area positioning across components to use standardized measurements.
  * Improved safe-area inset handling on mobile devices for consistent spacing.

* **Chores**
  * Standardized mobile layout spacing calculations and removed deprecated safe-area configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->