### PR TITLE
[codex] Add Hoja de Ruta print section exclusions

### DIFF
--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -76,6 +76,8 @@ import {
   getHojaDeRutaPdfSectionLabel,
   type GeneratedHojaDeRutaPdf,
   type HojaDeRutaPdfSectionId,
+  type HojaDeRutaPrintSectionId,
+  normalizeHojaDeRutaPrintSections,
 } from "@/utils/hoja-de-ruta/pdf";
 import type { EventData, HojaDeRutaMetadata } from "@/types/hoja-de-ruta";
 import type { LucideIcon } from "lucide-react";
@@ -255,6 +257,28 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     }
   };
 
+  const buildFullDocumentPdfOptions = () => {
+    const excludedSections = normalizeHojaDeRutaPrintSections(eventData.printExcludedSections);
+    return excludedSections.length > 0 ? { excludedSections } : undefined;
+  };
+
+  const handlePrintExclusionChange = (
+    sectionId: HojaDeRutaPrintSectionId,
+    isExcluded: boolean
+  ) => {
+    setEventData((prev) => {
+      const currentSections = normalizeHojaDeRutaPrintSections(prev.printExcludedSections);
+      const nextSections = isExcluded
+        ? Array.from(new Set([...currentSections, sectionId]))
+        : currentSections.filter((id) => id !== sectionId);
+
+      return {
+        ...prev,
+        printExcludedSections: nextSections,
+      };
+    });
+  };
+
   const openGeneratedPdfPreview = (generatedPdf: GeneratedHojaDeRutaPdf) => {
     setPdfPreview({
       url: URL.createObjectURL(generatedPdf.blob),
@@ -313,7 +337,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
         jobDetails?.title || "",
         jobDetails?.start_time || undefined,
         toast,
-        accommodations
+        accommodations,
+        buildFullDocumentPdfOptions()
       );
 
       // PDF generation and download is handled within the generatePDF function
@@ -399,7 +424,7 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
         jobDetails?.start_time || undefined,
         undefined,
         accommodations,
-        sectionId ? { sections: [sectionId] } : undefined
+        sectionId ? { sections: [sectionId] } : buildFullDocumentPdfOptions()
       );
 
       openGeneratedPdfPreview(generatedPdf);
@@ -616,6 +641,11 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
     ...section,
     label: getHojaDeRutaPdfSectionLabel(section.id),
   }));
+
+  const excludedPrintSections = normalizeHojaDeRutaPrintSections(eventData.printExcludedSections);
+  const excludedPrintSectionSet = new Set<HojaDeRutaPrintSectionId>(excludedPrintSections);
+  const isPrintSectionExcluded = (sectionId: HojaDeRutaPrintSectionId) =>
+    excludedPrintSectionSet.has(sectionId);
 
   if (isLoadingHojaDeRuta) {
     return (
@@ -867,6 +897,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                         jobDetails={null}
                         onAutoPopulate={handleLoadJobData}
                         hideJobSelection={!!jobId}
+                        isPrintSectionExcluded={isPrintSectionExcluded}
+                        onPrintSectionExcludedChange={handlePrintExclusionChange}
                       />
                     </TabsContent>
 
@@ -886,6 +918,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                         }}
                         handleVenueMapUrl={handleVenueMapUrl}
                         appendVenuePreviews={appendVenuePreviews}
+                        isPrintSectionExcluded={isPrintSectionExcluded}
+                        onPrintSectionExcludedChange={handlePrintExclusionChange}
                       />
                     </TabsContent>
 
@@ -893,6 +927,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                       <ModernWeatherSection
                         eventData={eventData}
                         setEventData={setEventData}
+                        isPrintSectionExcluded={isPrintSectionExcluded}
+                        onPrintSectionExcludedChange={handlePrintExclusionChange}
                       />
                     </TabsContent>
 
@@ -902,6 +938,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                         onContactChange={handleContactChange}
                         onAddContact={addContact}
                         onRemoveContact={removeContact}
+                        isPrintSectionExcluded={isPrintSectionExcluded}
+                        onPrintSectionExcludedChange={handlePrintExclusionChange}
                       />
                     </TabsContent>
 
@@ -911,6 +949,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                         onStaffChange={handleStaffChange}
                         onAddStaff={addStaffMember}
                         onRemoveStaff={removeStaffMember}
+                        isPrintSectionExcluded={isPrintSectionExcluded}
+                        onPrintSectionExcludedChange={handlePrintExclusionChange}
                       />
                     </TabsContent>
 
@@ -920,6 +960,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                         onUpdate={updateTravelArrangement}
                         onAdd={addTravelArrangement}
                         onRemove={removeTravelArrangement}
+                        isPrintSectionExcluded={isPrintSectionExcluded}
+                        onPrintSectionExcludedChange={handlePrintExclusionChange}
                       />
                     </TabsContent>
 
@@ -939,6 +981,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                          onRemoveAccommodation={removeAccommodation}
                          onAddRoom={addRoom}
                          onRemoveRoom={removeRoom}
+                         isPrintSectionExcluded={isPrintSectionExcluded}
+                         onPrintSectionExcludedChange={handlePrintExclusionChange}
                        />
                     </TabsContent>
 
@@ -951,6 +995,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                          onRemoveTransport={removeTransport}
                          onImportTransports={importTransports}
                          jobId={jobId || selectedJobId}
+                         isPrintSectionExcluded={isPrintSectionExcluded}
+                         onPrintSectionExcludedChange={handlePrintExclusionChange}
                        />
                      </TabsContent>
 
@@ -958,6 +1004,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                       <ModernScheduleSection
                         eventData={eventData}
                         setEventData={setEventData}
+                        isPrintSectionExcluded={isPrintSectionExcluded}
+                        onPrintSectionExcludedChange={handlePrintExclusionChange}
                       />
                     </TabsContent>
 
@@ -966,6 +1014,8 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
                         eventData={eventData}
                         onUpdateEventData={setEventData}
                         accommodations={accommodations}
+                        isPrintSectionExcluded={isPrintSectionExcluded}
+                        onPrintSectionExcludedChange={handlePrintExclusionChange}
                       />
                     </TabsContent>
                   </motion.div>

--- a/src/components/hoja-de-ruta/components/PrintSectionExclusionToggle.tsx
+++ b/src/components/hoja-de-ruta/components/PrintSectionExclusionToggle.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
+
+interface PrintSectionExclusionToggleProps {
+  sectionId: HojaDeRutaPrintSectionId;
+  isExcluded: boolean;
+  onExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
+  className?: string;
+}
+
+export const PrintSectionExclusionToggle: React.FC<PrintSectionExclusionToggleProps> = ({
+  sectionId,
+  isExcluded,
+  onExcludedChange,
+  className,
+}) => {
+  const checkboxId = `print-exclusion-${sectionId}`;
+
+  return (
+    <div className={cn("flex shrink-0 items-center gap-2", className)}>
+      <Checkbox
+        id={checkboxId}
+        checked={isExcluded}
+        onCheckedChange={(checked) => onExcludedChange(sectionId, checked === true)}
+      />
+      <Label htmlFor={checkboxId} className="cursor-pointer whitespace-nowrap text-sm font-medium text-muted-foreground">
+        Excluir al imprimir
+      </Label>
+    </div>
+  );
+};

--- a/src/components/hoja-de-ruta/components/__tests__/PrintSectionExclusionToggle.test.tsx
+++ b/src/components/hoja-de-ruta/components/__tests__/PrintSectionExclusionToggle.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrintSectionExclusionToggle } from "@/components/hoja-de-ruta/components/PrintSectionExclusionToggle";
+
+describe("PrintSectionExclusionToggle", () => {
+  it("calls back with the section id and checked state", async () => {
+    const user = userEvent.setup();
+    const onExcludedChange = vi.fn();
+
+    render(
+      <PrintSectionExclusionToggle
+        sectionId="power"
+        isExcluded={false}
+        onExcludedChange={onExcludedChange}
+      />
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Excluir al imprimir" }));
+
+    expect(onExcludedChange).toHaveBeenCalledWith("power", true);
+  });
+
+  it("explains when a section is excluded", () => {
+    render(
+      <PrintSectionExclusionToggle
+        sectionId="staff"
+        isExcluded
+        onExcludedChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("checkbox", { name: "Excluir al imprimir" })).toBeChecked();
+  });
+});

--- a/src/components/hoja-de-ruta/sections/ModernAccommodationSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernAccommodationSection.tsx
@@ -11,6 +11,8 @@ import { staffOptionValue } from "@/utils/hoja-de-ruta/staffSync";
 import { AddressAutocomplete } from "@/components/maps/AddressAutocomplete";
 import { HotelAutocomplete } from "@/components/maps/HotelAutocomplete";
 import { GoogleMap } from "@/components/maps/GoogleMap";
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 
 interface ModernAccommodationSectionProps {
   accommodations: Accommodation[];
@@ -21,6 +23,8 @@ interface ModernAccommodationSectionProps {
   onRemoveAccommodation: (index: number) => void;
   onAddRoom: (accommodationIndex: number) => void;
   onRemoveRoom: (accommodationIndex: number, roomIndex: number) => void;
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernAccommodationSection: React.FC<ModernAccommodationSectionProps> = ({
@@ -32,6 +36,8 @@ export const ModernAccommodationSection: React.FC<ModernAccommodationSectionProp
   onRemoveAccommodation,
   onAddRoom,
   onRemoveRoom,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   const [expandedMaps, setExpandedMaps] = useState<Record<string, boolean>>({});
 
@@ -49,20 +55,27 @@ export const ModernAccommodationSection: React.FC<ModernAccommodationSectionProp
     >
       <Card className="border-2">
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-3">
             <CardTitle className="flex items-center gap-2">
               <Bed className="w-5 h-5 text-pink-600" />
               Alojamiento
             </CardTitle>
-            <Button
-              onClick={onAddAccommodation}
-              size="sm"
-              variant="outline"
-              className="gap-2"
-            >
-              <Plus className="w-4 h-4" />
-              Añadir Hotel
-            </Button>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <PrintSectionExclusionToggle
+                sectionId="accommodation"
+                isExcluded={isPrintSectionExcluded("accommodation")}
+                onExcludedChange={onPrintSectionExcludedChange}
+              />
+              <Button
+                onClick={onAddAccommodation}
+                size="sm"
+                variant="outline"
+                className="gap-2"
+              >
+                <Plus className="w-4 h-4" />
+                Añadir Hotel
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>

--- a/src/components/hoja-de-ruta/sections/ModernContactsSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernContactsSection.tsx
@@ -6,12 +6,16 @@ import { Button } from "@/components/ui/button";
 import { motion, AnimatePresence } from "framer-motion";
 import { Phone, Plus, Trash2, User, Briefcase } from "lucide-react";
 import { EventData } from "@/types/hoja-de-ruta";
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 
 interface ModernContactsSectionProps {
   eventData: EventData;
   onContactChange: (index: number, field: string, value: string) => void;
   onAddContact: () => void;
   onRemoveContact: (index: number) => void;
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernContactsSection: React.FC<ModernContactsSectionProps> = ({
@@ -19,6 +23,8 @@ export const ModernContactsSection: React.FC<ModernContactsSectionProps> = ({
   onContactChange,
   onAddContact,
   onRemoveContact,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   return (
     <motion.div
@@ -27,20 +33,27 @@ export const ModernContactsSection: React.FC<ModernContactsSectionProps> = ({
     >
       <Card className="border-2">
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-3">
             <CardTitle className="flex items-center gap-2">
               <Phone className="w-5 h-5 text-purple-600" />
               Contactos del Evento
             </CardTitle>
-            <Button
-              onClick={onAddContact}
-              size="sm"
-              variant="outline"
-              className="gap-2"
-            >
-              <Plus className="w-4 h-4" />
-              Añadir Contacto
-            </Button>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <PrintSectionExclusionToggle
+                sectionId="contacts"
+                isExcluded={isPrintSectionExcluded("contacts")}
+                onExcludedChange={onPrintSectionExcludedChange}
+              />
+              <Button
+                onClick={onAddContact}
+                size="sm"
+                variant="outline"
+                className="gap-2"
+              >
+                <Plus className="w-4 h-4" />
+                Añadir Contacto
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>

--- a/src/components/hoja-de-ruta/sections/ModernEventSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernEventSection.tsx
@@ -10,6 +10,8 @@ import { Calendar, Plus, Sparkles, Trash2, Zap, Building2 } from "lucide-react";
 import type { AuxiliaryMachineryType, EventData } from "@/types/hoja-de-ruta";
 import { PlaceAutocomplete } from "@/components/maps/PlaceAutocomplete";
 import { AUXILIARY_MACHINERY_OPTIONS } from "@/constants/hojaDeRutaAuxiliaryNeeds";
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 
 interface ModernEventSectionProps {
   eventData: EventData;
@@ -21,6 +23,8 @@ interface ModernEventSectionProps {
   jobDetails: any;
   onAutoPopulate: () => void;
   hideJobSelection?: boolean;
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
@@ -33,6 +37,8 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
   jobDetails,
   onAutoPopulate,
   hideJobSelection = false,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   const handleVenueSelect = (place: any) => {
     setEventData(prev => ({
@@ -196,10 +202,17 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
       >
         <Card className="border-2">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Sparkles className="w-5 h-5 text-purple-600" />
-              Información del Evento
-            </CardTitle>
+            <div className="flex items-start justify-between gap-3">
+              <CardTitle className="flex items-center gap-2">
+                <Sparkles className="w-5 h-5 text-purple-600" />
+                Información del Evento
+              </CardTitle>
+              <PrintSectionExclusionToggle
+                sectionId="event-details"
+                isExcluded={isPrintSectionExcluded("event-details")}
+                onExcludedChange={onPrintSectionExcludedChange}
+              />
+            </div>
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="grid grid-cols-2 gap-6">
@@ -261,7 +274,14 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
             </div>
 
             <div className="space-y-4">
-              <Label className="text-sm font-medium">Necesidades Auxiliares</Label>
+              <div className="flex items-start justify-between gap-3">
+                <Label className="text-sm font-medium">Necesidades Auxiliares</Label>
+                <PrintSectionExclusionToggle
+                  sectionId="aux-needs"
+                  isExcluded={isPrintSectionExcluded("aux-needs")}
+                  onExcludedChange={onPrintSectionExcludedChange}
+                />
+              </div>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">

--- a/src/components/hoja-de-ruta/sections/ModernLogisticsSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernLogisticsSection.tsx
@@ -6,6 +6,8 @@ import { motion } from "framer-motion";
 import { Building2, Package, ArrowDown, ArrowUp } from "lucide-react";
 import { EventData, Transport } from "@/types/hoja-de-ruta";
 import { ModernTransportSection } from "./ModernTransportSection";
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 
 interface ModernLogisticsSectionProps {
   eventData: EventData;
@@ -15,6 +17,8 @@ interface ModernLogisticsSectionProps {
   onRemoveTransport: (index: number) => void;
   onImportTransports: (transports: Transport[]) => void;
   jobId?: string;  // Add jobId prop
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernLogisticsSection: React.FC<ModernLogisticsSectionProps> = ({
@@ -25,6 +29,8 @@ export const ModernLogisticsSection: React.FC<ModernLogisticsSectionProps> = ({
   onRemoveTransport,
   onImportTransports,
   jobId,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   return (
     <motion.div
@@ -39,13 +45,27 @@ export const ModernLogisticsSection: React.FC<ModernLogisticsSectionProps> = ({
         onRemoveTransport={onRemoveTransport}
         onImportTransports={onImportTransports}
         jobId={jobId}
+        headerControls={
+          <PrintSectionExclusionToggle
+            sectionId="logistics-transport"
+            isExcluded={isPrintSectionExcluded("logistics-transport")}
+            onExcludedChange={onPrintSectionExcludedChange}
+          />
+        }
       />
       <Card className="border">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Building2 className="w-5 h-5 text-primary" />
-            Logística del Evento
-          </CardTitle>
+          <div className="flex items-start justify-between gap-3">
+            <CardTitle className="flex items-center gap-2">
+              <Building2 className="w-5 h-5 text-primary" />
+              Logística del Evento
+            </CardTitle>
+            <PrintSectionExclusionToggle
+              sectionId="logistics-details"
+              isExcluded={isPrintSectionExcluded("logistics-details")}
+              onExcludedChange={onPrintSectionExcludedChange}
+            />
+          </div>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/components/hoja-de-ruta/sections/ModernRestaurantSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernRestaurantSection.tsx
@@ -19,6 +19,8 @@ import {
 import { PlacesRestaurantService } from '@/utils/hoja-de-ruta/services/places-restaurant-service';
 import type { Restaurant, EventData, Accommodation } from '@/types/hoja-de-ruta';
 import { useToast } from '@/hooks/use-toast';
+import { PrintSectionExclusionToggle } from '../components/PrintSectionExclusionToggle';
+import type { HojaDeRutaPrintSectionId } from '@/utils/hoja-de-ruta/pdf';
 import {
   Select,
   SelectContent,
@@ -31,9 +33,17 @@ interface ModernRestaurantSectionProps {
   eventData: EventData;
   onUpdateEventData: (data: EventData) => void;
   accommodations?: Accommodation[];
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
-export function ModernRestaurantSection({ eventData, onUpdateEventData, accommodations = [] }: ModernRestaurantSectionProps) {
+export function ModernRestaurantSection({
+  eventData,
+  onUpdateEventData,
+  accommodations = [],
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
+}: ModernRestaurantSectionProps) {
   const [restaurants, setRestaurants] = useState<Restaurant[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [searchRadius, setSearchRadius] = useState('2000');
@@ -180,9 +190,16 @@ export function ModernRestaurantSection({ eventData, onUpdateEventData, accommod
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-2 mb-4">
-        <UtensilsCrossed className="h-5 w-5 text-primary" />
-        <h2 className="text-xl font-semibold">Recomendaciones de Restaurantes</h2>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <UtensilsCrossed className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-semibold">Recomendaciones de Restaurantes</h2>
+        </div>
+        <PrintSectionExclusionToggle
+          sectionId="restaurants"
+          isExcluded={isPrintSectionExcluded("restaurants")}
+          onExcludedChange={onPrintSectionExcludedChange}
+        />
       </div>
 
       {/* Search Controls */}

--- a/src/components/hoja-de-ruta/sections/ModernScheduleSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernScheduleSection.tsx
@@ -8,15 +8,21 @@ import { EventData } from "@/types/hoja-de-ruta";
 import { ScheduleBuilder } from "@/components/schedule/ScheduleBuilder";
 import { MultiDayScheduleBuilder } from "@/components/schedule/MultiDayScheduleBuilder";
 import { useMemo } from "react";
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 
 interface ModernScheduleSectionProps {
   eventData: EventData;
   setEventData: React.Dispatch<React.SetStateAction<EventData>>;
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernScheduleSection: React.FC<ModernScheduleSectionProps> = ({
   eventData,
   setEventData,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   const programRows = useMemo(() => eventData.programSchedule ?? [], [eventData.programSchedule]);
   const programDays = useMemo(() => eventData.programScheduleDays ?? [], [eventData.programScheduleDays]);
@@ -33,15 +39,29 @@ export const ModernScheduleSection: React.FC<ModernScheduleSectionProps> = ({
         onChange={(days) => setEventData(prev => ({ ...prev, programScheduleDays: days, programSchedule: days?.[0]?.rows || [] }))}
         dayTitle="Programa"
         subtitle={eventData.eventName ? `${eventData.eventName}${eventData.eventDates ? ' • ' + eventData.eventDates : ''}` : undefined}
+        scheduleHeaderControls={
+          <PrintSectionExclusionToggle
+            sectionId="program"
+            isExcluded={isPrintSectionExcluded("program")}
+            onExcludedChange={onPrintSectionExcludedChange}
+          />
+        }
       />
 
       {/* Legacy free-text (keep for now) */}
       <Card className="border-2">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Activity className="w-5 h-5 text-red-600" />
-            Programa (Texto Libre)
-          </CardTitle>
+          <div className="flex items-start justify-between gap-3">
+            <CardTitle className="flex items-center gap-2">
+              <Activity className="w-5 h-5 text-red-600" />
+              Programa (Texto Libre)
+            </CardTitle>
+            <PrintSectionExclusionToggle
+              sectionId="schedule-notes"
+              isExcluded={isPrintSectionExcluded("schedule-notes")}
+              onExcludedChange={onPrintSectionExcludedChange}
+            />
+          </div>
         </CardHeader>
         <CardContent>
           <Textarea
@@ -56,10 +76,17 @@ export const ModernScheduleSection: React.FC<ModernScheduleSectionProps> = ({
       {/* Power Requirements Card */}
       <Card className="border-2">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Zap className="w-5 h-5 text-yellow-600" />
-            Requisitos de Energía
-          </CardTitle>
+          <div className="flex items-start justify-between gap-3">
+            <CardTitle className="flex items-center gap-2">
+              <Zap className="w-5 h-5 text-yellow-600" />
+              Requisitos de Energía
+            </CardTitle>
+            <PrintSectionExclusionToggle
+              sectionId="power"
+              isExcluded={isPrintSectionExcluded("power")}
+              onExcludedChange={onPrintSectionExcludedChange}
+            />
+          </div>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-3">

--- a/src/components/hoja-de-ruta/sections/ModernStaffSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernStaffSection.tsx
@@ -9,12 +9,16 @@ import { Users, Plus, Trash2, User, IdCard, Briefcase } from "lucide-react";
 import { EventData } from "@/types/hoja-de-ruta";
 import { ProfileAutocomplete } from "../components/ProfileAutocomplete";
 import { dataLayerClient } from "@/services/dataLayerClient";
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 interface ModernStaffSectionProps {
   eventData: EventData;
   onStaffChange: (index: number, field: string, value: string) => void;
   onAddStaff: () => void;
   onRemoveStaff: (index: number) => void;
   onProfileSelect?: (index: number, profileData: any) => void;
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernStaffSection: React.FC<ModernStaffSectionProps> = ({
@@ -23,6 +27,8 @@ export const ModernStaffSection: React.FC<ModernStaffSectionProps> = ({
   onAddStaff,
   onRemoveStaff,
   onProfileSelect,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   const handleProfileSelect = async (index: number, profile: any) => {
     console.debug('[ModernStaffSection] Profile selected', { index, profile });
@@ -66,20 +72,27 @@ export const ModernStaffSection: React.FC<ModernStaffSectionProps> = ({
     >
       <Card className="border-2">
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-3">
             <CardTitle className="flex items-center gap-2">
               <Users className="w-5 h-5 text-orange-600" />
               Personal del Evento
             </CardTitle>
-            <Button
-              onClick={onAddStaff}
-              size="sm"
-              variant="outline"
-              className="gap-2"
-            >
-              <Plus className="w-4 h-4" />
-              Añadir Personal
-            </Button>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <PrintSectionExclusionToggle
+                sectionId="staff"
+                isExcluded={isPrintSectionExcluded("staff")}
+                onExcludedChange={onPrintSectionExcludedChange}
+              />
+              <Button
+                onClick={onAddStaff}
+                size="sm"
+                variant="outline"
+                className="gap-2"
+              >
+                <Plus className="w-4 h-4" />
+                Añadir Personal
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>

--- a/src/components/hoja-de-ruta/sections/ModernTransportSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernTransportSection.tsx
@@ -24,6 +24,7 @@ interface ModernTransportSectionProps {
   onRemoveTransport: (index: number) => void;
   onImportTransports: (transports: Transport[]) => void;
   jobId?: string;  // Add jobId prop to fetch logistics events
+  headerControls?: React.ReactNode;
 }
 
 export const ModernTransportSection: React.FC<ModernTransportSectionProps> = ({
@@ -33,6 +34,7 @@ export const ModernTransportSection: React.FC<ModernTransportSectionProps> = ({
   onRemoveTransport,
   onImportTransports,
   jobId,
+  headerControls,
 }) => {
   const { toast } = useToast();
   const [isImporting, setIsImporting] = useState(false);
@@ -186,7 +188,8 @@ export const ModernTransportSection: React.FC<ModernTransportSectionProps> = ({
             <Truck className="w-5 h-5 text-primary" />
             Transporte
           </CardTitle>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {headerControls}
             {jobId && (
               <Button
                 onClick={handleImportFromLogistics}

--- a/src/components/hoja-de-ruta/sections/ModernTravelSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernTravelSection.tsx
@@ -10,12 +10,16 @@ import { Car, Plus, Trash2, Plane, Bus, Train, MapPin, Clock, User, Phone, Hash 
 import { TravelArrangement } from "@/types/hoja-de-ruta";
 import { AddressAutocomplete } from "@/components/maps/AddressAutocomplete";
 import { formatInTimeZone, toZonedTime } from 'date-fns-tz';
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 
 interface ModernTravelSectionProps {
   travelArrangements: TravelArrangement[];
   onUpdate: (index: number, field: keyof TravelArrangement, value: string | undefined) => void;
   onAdd: () => void;
   onRemove: (index: number) => void;
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernTravelSection: React.FC<ModernTravelSectionProps> = ({
@@ -23,6 +27,8 @@ export const ModernTravelSection: React.FC<ModernTravelSectionProps> = ({
   onUpdate,
   onAdd,
   onRemove,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   const getTransportIcon = (type: string) => {
     switch (type) {
@@ -89,20 +95,27 @@ export const ModernTravelSection: React.FC<ModernTravelSectionProps> = ({
     >
       <Card className="border-2">
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-3">
             <CardTitle className="flex items-center gap-2">
               <Car className="w-5 h-5 text-cyan-600" />
               Transporte y Viajes
             </CardTitle>
-            <Button
-              onClick={onAdd}
-              size="sm"
-              variant="outline"
-              className="gap-2"
-            >
-              <Plus className="w-4 h-4" />
-              Añadir Viaje
-            </Button>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <PrintSectionExclusionToggle
+                sectionId="travel"
+                isExcluded={isPrintSectionExcluded("travel")}
+                onExcludedChange={onPrintSectionExcludedChange}
+              />
+              <Button
+                onClick={onAdd}
+                size="sm"
+                variant="outline"
+                className="gap-2"
+              >
+                <Plus className="w-4 h-4" />
+                Añadir Viaje
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>

--- a/src/components/hoja-de-ruta/sections/ModernVenueSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernVenueSection.tsx
@@ -11,6 +11,8 @@ import { AddressAutocomplete } from "@/components/maps/AddressAutocomplete";
 import { PlaceAutocomplete } from "@/components/maps/PlaceAutocomplete";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { PlacesImageService } from "@/utils/hoja-de-ruta/pdf/services/places-image-service";
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 
 interface ModernVenueSectionProps {
   eventData: EventData;
@@ -22,6 +24,8 @@ interface ModernVenueSectionProps {
   onVenueMapUpload: (file: File) => void;
   handleVenueMapUrl: (url: string) => void;
   appendVenuePreviews: (dataUrls: string[]) => void;
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernVenueSection: React.FC<ModernVenueSectionProps> = ({
@@ -34,6 +38,8 @@ export const ModernVenueSection: React.FC<ModernVenueSectionProps> = ({
   onVenueMapUpload,
   handleVenueMapUrl,
   appendVenuePreviews,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   const [dragOver, setDragOver] = useState(false);
   const [staticMapUrl, setStaticMapUrl] = useState<string | null>(null);
@@ -229,70 +235,77 @@ export const ModernVenueSection: React.FC<ModernVenueSectionProps> = ({
                 <MapPin className="w-5 h-5 text-emerald-600" />
                 Ubicación del Venue
               </div>
-              <Dialog>
-                <DialogTrigger asChild>
-                  <Button variant="outline" size="sm" className="gap-2">
-                    <Settings className="w-4 h-4" />
-                    Editar Ubicación
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="max-w-2xl">
-                  <DialogHeader>
-                    <DialogTitle>Configurar Ubicación del Venue</DialogTitle>
-                  </DialogHeader>
-                  <div className="space-y-4">
-                    <div>
-                      <Label htmlFor="venue-name">Nombre del Venue</Label>
-                      <PlaceAutocomplete
-                        value={eventData.venue.name || ''}
-                        onSelect={({ name, address, coordinates }) =>
-                          setEventData(prev => ({
-                            ...prev,
-                            venue: {
-                              ...prev.venue,
-                              name: name || prev.venue.name,
-                              address: address || prev.venue.address,
-                              coordinates: coordinates || prev.venue.coordinates,
-                            }
-                          }))
-                        }
-                        placeholder="Buscar venue o lugar..."
-                      />
-                    </div>
-                    <div>
-                      <Label>Dirección del Venue</Label>
-                      <AddressAutocomplete
-                        value={eventData.venue.address || ''}
-                        onChange={(address, coordinates) => {
-                          setEventData(prev => ({
-                            ...prev,
-                            venue: {
-                              ...prev.venue,
-                              address,
-                              coordinates
-                            }
-                          }));
-                        }}
-                        placeholder="Buscar dirección..."
-                      />
-                    </div>
-                    {(eventData.venue.address || eventData.venue.coordinates) && (
+              <div className="flex flex-wrap items-center justify-end gap-2">
+                <PrintSectionExclusionToggle
+                  sectionId="venue"
+                  isExcluded={isPrintSectionExcluded("venue")}
+                  onExcludedChange={onPrintSectionExcludedChange}
+                />
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button variant="outline" size="sm" className="gap-2">
+                      <Settings className="w-4 h-4" />
+                      Editar Ubicación
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent className="max-w-2xl">
+                    <DialogHeader>
+                      <DialogTitle>Configurar Ubicación del Venue</DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-4">
                       <div>
-                        <Label>Vista Previa del Mapa</Label>
-                        <GoogleMap
-                          address={eventData.venue.address}
-                          coordinates={eventData.venue.coordinates}
-                          height="250px"
-                          interactive={true}
-                          showMarker={true}
-                          onLocationSelect={handleLocationUpdate}
-                          onStaticMapUrlChange={setStaticMapUrl}
+                        <Label htmlFor="venue-name">Nombre del Venue</Label>
+                        <PlaceAutocomplete
+                          value={eventData.venue.name || ''}
+                          onSelect={({ name, address, coordinates }) =>
+                            setEventData(prev => ({
+                              ...prev,
+                              venue: {
+                                ...prev.venue,
+                                name: name || prev.venue.name,
+                                address: address || prev.venue.address,
+                                coordinates: coordinates || prev.venue.coordinates,
+                              }
+                            }))
+                          }
+                          placeholder="Buscar venue o lugar..."
                         />
                       </div>
-                    )}
-                  </div>
-                </DialogContent>
-              </Dialog>
+                      <div>
+                        <Label>Dirección del Venue</Label>
+                        <AddressAutocomplete
+                          value={eventData.venue.address || ''}
+                          onChange={(address, coordinates) => {
+                            setEventData(prev => ({
+                              ...prev,
+                              venue: {
+                                ...prev.venue,
+                                address,
+                                coordinates
+                              }
+                            }));
+                          }}
+                          placeholder="Buscar dirección..."
+                        />
+                      </div>
+                      {(eventData.venue.address || eventData.venue.coordinates) && (
+                        <div>
+                          <Label>Vista Previa del Mapa</Label>
+                          <GoogleMap
+                            address={eventData.venue.address}
+                            coordinates={eventData.venue.coordinates}
+                            height="250px"
+                            interactive={true}
+                            showMarker={true}
+                            onLocationSelect={handleLocationUpdate}
+                            onStaticMapUrlChange={setStaticMapUrl}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              </div>
             </CardTitle>
           </CardHeader>
           <CardContent>

--- a/src/components/hoja-de-ruta/sections/ModernWeatherSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernWeatherSection.tsx
@@ -6,15 +6,21 @@ import { motion } from "framer-motion";
 import { CloudSun, RefreshCw, AlertTriangle, Loader2 } from "lucide-react";
 import { getWeatherForJob, formatWeatherDisplay } from "@/utils/weather/weatherApi";
 import { EventData, WeatherData } from "@/types/hoja-de-ruta";
+import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
 
 interface ModernWeatherSectionProps {
   eventData: EventData;
   setEventData: React.Dispatch<React.SetStateAction<EventData>>;
+  isPrintSectionExcluded: (sectionId: HojaDeRutaPrintSectionId) => boolean;
+  onPrintSectionExcludedChange: (sectionId: HojaDeRutaPrintSectionId, isExcluded: boolean) => void;
 }
 
 export const ModernWeatherSection: React.FC<ModernWeatherSectionProps> = ({
   eventData,
   setEventData,
+  isPrintSectionExcluded,
+  onPrintSectionExcludedChange,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -89,7 +95,12 @@ export const ModernWeatherSection: React.FC<ModernWeatherSectionProps> = ({
               <CloudSun className="w-5 h-5" />
               Previsión Meteorológica
             </CardTitle>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <PrintSectionExclusionToggle
+                sectionId="weather"
+                isExcluded={isPrintSectionExcluded("weather")}
+                onExcludedChange={onPrintSectionExcludedChange}
+              />
               {lastFetch && (
                 <Badge variant="outline" className="text-xs">
                   Actualizado: {lastFetch.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}

--- a/src/components/schedule/MultiDayScheduleBuilder.tsx
+++ b/src/components/schedule/MultiDayScheduleBuilder.tsx
@@ -12,6 +12,7 @@ type MultiDayScheduleBuilderProps = {
   onChange: (days: ProgramDay[]) => void;
   dayTitle?: string; // e.g., "Programa"
   subtitle?: string;
+  scheduleHeaderControls?: React.ReactNode;
 };
 
 export const MultiDayScheduleBuilder: React.FC<MultiDayScheduleBuilderProps> = ({
@@ -19,6 +20,7 @@ export const MultiDayScheduleBuilder: React.FC<MultiDayScheduleBuilderProps> = (
   onChange,
   dayTitle = 'Programa',
   subtitle,
+  scheduleHeaderControls,
 }) => {
   const initialDays = useMemo<ProgramDay[]>(() => {
     if (Array.isArray(value) && value.length > 0) return value;
@@ -140,6 +142,7 @@ export const MultiDayScheduleBuilder: React.FC<MultiDayScheduleBuilderProps> = (
           snapMinutes={15}
           title={`${dayTitle} — ${activeDay?.label || `Día ${active + 1}`}${activeDay?.date ? ` (${activeDay.date})` : ''}`}
           hideExport
+          headerControls={scheduleHeaderControls}
         />
       </CardContent>
     </Card>
@@ -147,4 +150,3 @@ export const MultiDayScheduleBuilder: React.FC<MultiDayScheduleBuilderProps> = (
 };
 
 export default MultiDayScheduleBuilder;
-

--- a/src/components/schedule/ScheduleBuilder.tsx
+++ b/src/components/schedule/ScheduleBuilder.tsx
@@ -17,6 +17,7 @@ type ScheduleBuilderProps = {
   title?: string;
   subtitle?: string;
   hideExport?: boolean;
+  headerControls?: React.ReactNode;
 };
 
 const defaultPresets: Array<Pick<ProgramRow, 'item' | 'dept' | 'notes'>> = [
@@ -40,6 +41,7 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
   title = 'Programa del Día',
   subtitle,
   hideExport = false,
+  headerControls,
 }) => {
   const [rows, setRows] = useState<ProgramRow[]>(value || []);
   const [snap, setSnap] = useState<5 | 10 | 15 | 20 | 30>(snapMinutes);
@@ -178,6 +180,7 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
         <CardTitle className="flex items-center justify-between">
           <span>Constructor de Programa</span>
           <div className="flex items-center gap-2">
+            {headerControls}
             <Label className="text-xs text-muted-foreground">Snap</Label>
             <select
               className="border rounded px-2 py-1 text-xs"

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaData.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaData.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { EventData, TravelArrangement, Accommodation, Restaurant } from '@/types/hoja-de-ruta';
 import type { Json } from '@/integrations/supabase/types';
+import { normalizeHojaDeRutaPrintSections } from '@/utils/hoja-de-ruta/pdf/section-options';
 
 /**
  * Normalizes a datetime value to a valid UTC ISO string for database storage.
@@ -118,6 +119,7 @@ export const useHojaDeRutaData = () => {
         aux_machinery_requirements: Array.isArray(eventData.auxiliaryMachinery)
           ? eventData.auxiliaryMachinery.filter(item => item.quantity > 0) as unknown as Json
           : [] as unknown as Json,
+        print_excluded_sections: normalizeHojaDeRutaPrintSections(eventData.printExcludedSections) as unknown as Json,
         status: 'draft',
         last_modified: new Date().toISOString()
       };

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
@@ -129,6 +129,7 @@ export const useHojaDeRutaInitialization = (
       auxiliaryStaffDismantleQty: 0,
       auxiliaryMachinery: [],
       weather: undefined,
+      printExcludedSections: [],
     };
   };
 
@@ -376,6 +377,7 @@ export const useHojaDeRutaInitialization = (
           // Restaurants
           restaurants: savedEventData?.restaurants || undefined,
           selectedRestaurants: savedEventData?.selectedRestaurants || undefined,
+          printExcludedSections: savedEventData?.printExcludedSections || [],
         });
 
         // Set travel arrangements using transformed data

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaState.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaState.ts
@@ -19,6 +19,7 @@ const initialEventData: EventData = {
   auxiliaryStaffSetupQty: 0,
   auxiliaryStaffDismantleQty: 0,
   auxiliaryMachinery: [],
+  printExcludedSections: [],
 };
 
 export const useHojaDeRutaState = () => {
@@ -52,6 +53,7 @@ export const useHojaDeRutaState = () => {
                      (eventData.auxiliaryStaffSetupQty ?? 0) > 0 ||
                      (eventData.auxiliaryStaffDismantleQty ?? 0) > 0 ||
                      (eventData.auxiliaryMachinery?.some(item => (item.quantity ?? 0) > 0) ?? false) ||
+                     (eventData.printExcludedSections?.length ?? 0) > 0 ||
                      eventData.contacts.some(c => c.name) ||
                      eventData.staff.some(s => s.name) || 
                      travelArrangements.length > 0 ||

--- a/src/hooks/useHojaDeRutaForm.ts
+++ b/src/hooks/useHojaDeRutaForm.ts
@@ -167,6 +167,7 @@ export const useHojaDeRutaForm = (venueImages: { image_path: string; image_type:
                      (eventData.auxiliaryStaffSetupQty ?? 0) > 0 ||
                      (eventData.auxiliaryStaffDismantleQty ?? 0) > 0 ||
                      (eventData.auxiliaryMachinery?.some(item => (item.quantity ?? 0) > 0) ?? false) ||
+                     (eventData.printExcludedSections?.length ?? 0) > 0 ||
                      eventData.contacts?.some(c => c.name) ||
                      eventData.staff?.some(s => s.name) || 
                      travelArrangements.length > 0 ||

--- a/src/hooks/useHojaDeRutaPersistence.ts
+++ b/src/hooks/useHojaDeRutaPersistence.ts
@@ -13,6 +13,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { isAuxiliaryMachineryType } from "@/constants/hojaDeRutaAuxiliaryNeeds";
+import { normalizeHojaDeRutaPrintSections } from "@/utils/hoja-de-ruta/pdf/section-options";
 
 
 
@@ -264,7 +265,8 @@ export const useHojaDeRutaPersistence = (
         auxiliaryStaffSetupQty: toSafeNonNegativeInt(mainData.aux_staff_setup_qty),
         auxiliaryStaffDismantleQty: toSafeNonNegativeInt(mainData.aux_staff_dismantle_qty),
         auxiliaryMachinery: normalizeAuxiliaryMachinery(mainData.aux_machinery_requirements),
-        weather: (Array.isArray(mainData.weather_data) ? mainData.weather_data : []) as unknown as WeatherData[]
+        weather: (Array.isArray(mainData.weather_data) ? mainData.weather_data : []) as unknown as WeatherData[],
+        printExcludedSections: normalizeHojaDeRutaPrintSections(mainData.print_excluded_sections),
       };
 
       // Transform accommodations data
@@ -356,6 +358,7 @@ export const useHojaDeRutaPersistence = (
         aux_staff_dismantle_qty: auxiliaryStaffDismantleQty,
         aux_machinery_requirements: auxiliaryMachinery as unknown as Json,
         weather_data: eventData.weather as unknown as Json || null,
+        print_excluded_sections: normalizeHojaDeRutaPrintSections(eventData.printExcludedSections) as unknown as Json,
         updated_at: now,
         last_modified: now,
         last_modified_by: userId

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2648,6 +2648,7 @@ export type Database = {
           local_contacts: Json | null
           logistics_info: Json | null
           power_requirements: string | null
+          print_excluded_sections: Json
           program_schedule_json: Json | null
           restaurants_info: Json | null
           schedule: string | null
@@ -2683,6 +2684,7 @@ export type Database = {
           local_contacts?: Json | null
           logistics_info?: Json | null
           power_requirements?: string | null
+          print_excluded_sections?: Json
           program_schedule_json?: Json | null
           restaurants_info?: Json | null
           schedule?: string | null
@@ -2718,6 +2720,7 @@ export type Database = {
           local_contacts?: Json | null
           logistics_info?: Json | null
           power_requirements?: string | null
+          print_excluded_sections?: Json
           program_schedule_json?: Json | null
           restaurants_info?: Json | null
           schedule?: string | null

--- a/src/types/hoja-de-ruta.ts
+++ b/src/types/hoja-de-ruta.ts
@@ -1,4 +1,5 @@
 import type { LogisticsHojaCategory } from "@/constants/logisticsHojaCategories";
+import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf/section-options";
 
 // Core interfaces - most comprehensive version first
 export interface WeatherData {
@@ -161,6 +162,7 @@ export interface EventData {
   weather?: WeatherData[];
   restaurants?: Restaurant[];
   selectedRestaurants?: string[];
+  printExcludedSections?: HojaDeRutaPrintSectionId[];
   metadata?: HojaDeRutaMetadata;
 }
 

--- a/src/utils/hoja-de-ruta/pdf/__tests__/section-options.test.ts
+++ b/src/utils/hoja-de-ruta/pdf/__tests__/section-options.test.ts
@@ -6,6 +6,8 @@ import {
   getHojaDeRutaPdfSelectionLabel,
   HOJA_DE_RUTA_PDF_SECTIONS,
   isHojaDeRutaPdfSectionId,
+  normalizeHojaDeRutaPdfSections,
+  normalizeHojaDeRutaPrintSections,
 } from "@/utils/hoja-de-ruta/pdf/section-options";
 
 describe("hoja de ruta PDF section options", () => {
@@ -37,5 +39,26 @@ describe("hoja de ruta PDF section options", () => {
   it("guards section ids", () => {
     expect(isHojaDeRutaPdfSectionId("event")).toBe(true);
     expect(isHojaDeRutaPdfSectionId("not-a-section")).toBe(false);
+  });
+
+  it("normalizes persisted section lists", () => {
+    expect(normalizeHojaDeRutaPdfSections(["event", "venue", "event", "bad", 1])).toEqual([
+      "event",
+      "venue",
+    ]);
+    expect(normalizeHojaDeRutaPdfSections("event")).toEqual([]);
+  });
+
+  it("normalizes persisted print subsection lists", () => {
+    expect(normalizeHojaDeRutaPrintSections(["power", "program", "power", "bad", 1])).toEqual([
+      "power",
+      "program",
+    ]);
+    expect(normalizeHojaDeRutaPrintSections(["schedule"])).toEqual([
+      "program",
+      "schedule-notes",
+      "power",
+    ]);
+    expect(normalizeHojaDeRutaPrintSections("power")).toEqual([]);
   });
 });

--- a/src/utils/hoja-de-ruta/pdf/core/pdf-types.ts
+++ b/src/utils/hoja-de-ruta/pdf/core/pdf-types.ts
@@ -8,6 +8,7 @@ import type {
   ImagePreviews
 } from '@/types/hoja-de-ruta';
 import type { HojaDeRutaPdfSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
+import type { HojaDeRutaPrintSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
 
 export type {
   EventData,
@@ -49,6 +50,7 @@ export interface PDFGenerationOptions {
   includeLogisticsTransport?: boolean;
   dedupeTransportAcrossSections?: boolean;
   sections?: HojaDeRutaPdfSectionId[];
+  excludedSections?: HojaDeRutaPrintSectionId[];
 }
 
 export interface DriverCertificatePDFGenerationOptions {

--- a/src/utils/hoja-de-ruta/pdf/index.ts
+++ b/src/utils/hoja-de-ruta/pdf/index.ts
@@ -2,7 +2,10 @@ export { PDFEngine } from '@/utils/hoja-de-ruta/pdf/pdf-engine';
 export {
   getHojaDeRutaPdfSectionLabel,
   getHojaDeRutaPdfSelectionLabel,
-  HOJA_DE_RUTA_PDF_SECTIONS
+  HOJA_DE_RUTA_PDF_SECTIONS,
+  HOJA_DE_RUTA_PRINT_SECTIONS,
+  getHojaDeRutaPrintSectionLabel,
+  normalizeHojaDeRutaPrintSections,
 } from '@/utils/hoja-de-ruta/pdf/section-options';
 export type {
   DriverCertificatePDFGenerationOptions,
@@ -10,6 +13,7 @@ export type {
   PDFGenerationOptions,
 } from '@/utils/hoja-de-ruta/pdf/core/pdf-types';
 export type { HojaDeRutaPdfSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
+export type { HojaDeRutaPrintSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
 import { PDFEngine } from '@/utils/hoja-de-ruta/pdf/pdf-engine';
 import { DriverCertificatePDFEngine } from '@/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine';
 import type {
@@ -29,7 +33,7 @@ const createPDFEngine = (
   jobDate?: string,
   toast?: PDFGenerationOptions['toast'],
   accommodations?: PDFGenerationOptions['accommodations'],
-  pdfOptions?: Pick<PDFGenerationOptions, 'sections'>
+  pdfOptions?: Pick<PDFGenerationOptions, 'sections' | 'excludedSections'>
 ) => new PDFEngine({
   eventData,
   travelArrangements,
@@ -57,7 +61,7 @@ export const generatePDF = async (
   jobDate?: string,
   toast?: PDFGenerationOptions['toast'],
   accommodations?: PDFGenerationOptions['accommodations'],
-  pdfOptions?: Pick<PDFGenerationOptions, 'sections'>
+  pdfOptions?: Pick<PDFGenerationOptions, 'sections' | 'excludedSections'>
 ): Promise<void> => {
   const engine = createPDFEngine(
     eventData,
@@ -87,7 +91,7 @@ export const generatePDFPreview = async (
   jobDate?: string,
   toast?: PDFGenerationOptions['toast'],
   accommodations?: PDFGenerationOptions['accommodations'],
-  pdfOptions?: Pick<PDFGenerationOptions, 'sections'>
+  pdfOptions?: Pick<PDFGenerationOptions, 'sections' | 'excludedSections'>
 ): Promise<GeneratedHojaDeRutaPdf> => {
   const engine = createPDFEngine(
     eventData,

--- a/src/utils/hoja-de-ruta/pdf/pdf-engine.ts
+++ b/src/utils/hoja-de-ruta/pdf/pdf-engine.ts
@@ -9,8 +9,12 @@ import { FooterService } from './services/footer-service';
 import {
   getHojaDeRutaPdfSectionFilenameLabel,
   getHojaDeRutaPdfSelectionLabel,
+  normalizeHojaDeRutaPrintSections,
 } from '@/utils/hoja-de-ruta/pdf/section-options';
-import type { HojaDeRutaPdfSectionId } from '@/utils/hoja-de-ruta/pdf/section-options';
+import type {
+  HojaDeRutaPdfSectionId,
+  HojaDeRutaPrintSectionId,
+} from '@/utils/hoja-de-ruta/pdf/section-options';
 
 export class PDFEngine {
   private pdfDoc: PDFDocument;
@@ -19,6 +23,7 @@ export class PDFEngine {
   private logoData?: string;
   private hasCoverPage = true;
   private renderedSectionCount = 0;
+  private excludedSections = new Set<HojaDeRutaPrintSectionId>();
 
   constructor(private options: PDFGenerationOptions) {
     this.pdfDoc = new PDFDocument();
@@ -62,12 +67,15 @@ export class PDFEngine {
       selectedJobId,
       jobTitle,
     } = this.options;
-    const selectedSections = this.options.sections?.length ? this.options.sections : undefined;
-    const sectionSelection = selectedSections ? new Set(selectedSections) : undefined;
-    const selectedSectionLabel = selectedSections
-      ? getHojaDeRutaPdfSelectionLabel(selectedSections) ?? "Secciones seleccionadas"
+    this.excludedSections = new Set(normalizeHojaDeRutaPrintSections(this.options.excludedSections));
+
+    const requestedSections = this.options.sections?.length ? this.options.sections : undefined;
+    const selectedSections = requestedSections;
+    const sectionSelection = requestedSections ? new Set(selectedSections) : undefined;
+    const selectedSectionLabel = requestedSections
+      ? getHojaDeRutaPdfSelectionLabel(requestedSections) ?? "Secciones seleccionadas"
       : undefined;
-    this.hasCoverPage = !sectionSelection;
+    this.hasCoverPage = !requestedSections;
     this.renderedSectionCount = 0;
 
     // Load logo first (used on cover and in page header)
@@ -115,7 +123,7 @@ export class PDFEngine {
     if (sectionSelection) {
       await this.generateSelectedSections(sectionSelection);
       if (this.renderedSectionCount === 0) {
-        this.addEmptySectionPage(selectedSections);
+        this.addEmptySectionPage(requestedSections);
       }
     } else {
       await this.generateFullDocument();
@@ -132,14 +140,23 @@ export class PDFEngine {
 
   private async generateFullDocument(): Promise<void> {
     // Each major section starts on a new page as per requirements.
-    if (this.contentSections.hasEventDetailsData(this.options.eventData) || this.contentSections.hasVenueData(this.options.eventData)) {
-      let currentY = this.addSectionHeader("Detalles y Venue");
+    const includeEvent = !this.isPrintSectionExcluded("event-details") && this.contentSections.hasEventDetailsData(this.options.eventData);
+    const includeVenue = !this.isPrintSectionExcluded("venue") && this.contentSections.hasVenueData(this.options.eventData);
 
-      if (this.contentSections.hasEventDetailsData(this.options.eventData)) {
+    if (includeEvent || includeVenue) {
+      let currentY = this.addSectionHeader(
+        includeEvent && includeVenue
+          ? "Detalles y Venue"
+          : includeEvent
+            ? "Detalles del Evento"
+            : "Venue"
+      );
+
+      if (includeEvent) {
         currentY = this.contentSections.addEventDetailsSection(this.options.eventData, currentY);
       }
 
-      if (this.contentSections.hasVenueData(this.options.eventData)) {
+      if (includeVenue) {
         await this.contentSections.addVenueSection(
           this.options.eventData,
           this.options.venueMapPreview,
@@ -151,12 +168,12 @@ export class PDFEngine {
 
     await this.addWeatherSectionIfAvailable();
 
-    if (this.contentSections.hasContactsData(this.options.eventData)) {
+    if (!this.isPrintSectionExcluded("contacts") && this.contentSections.hasContactsData(this.options.eventData)) {
       const currentY = this.addSectionHeader("Contactos");
       this.contentSections.addContactsSection(this.options.eventData, currentY);
     }
 
-    if (this.contentSections.hasStaffData(this.options.eventData)) {
+    if (!this.isPrintSectionExcluded("staff") && this.contentSections.hasStaffData(this.options.eventData)) {
       const currentY = this.addSectionHeader("Personal");
       this.contentSections.addStaffSection(this.options.eventData, currentY);
     }
@@ -166,7 +183,7 @@ export class PDFEngine {
     const includeTravelArrangements = this.options.includeTravelArrangements ?? true;
     const includeLogisticsTransport = this.options.includeLogisticsTransport ?? true;
 
-    if (includeTravelArrangements && this.contentSections.hasTravelData(this.options.travelArrangements)) {
+    if (!this.isPrintSectionExcluded("travel") && includeTravelArrangements && this.contentSections.hasTravelData(this.options.travelArrangements)) {
       const currentY = this.addSectionHeader("Viajes");
       await this.contentSections.addTravelSection(
         this.options.travelArrangements,
@@ -175,7 +192,7 @@ export class PDFEngine {
       );
     }
 
-    if (this.contentSections.hasAccommodationData(this.options.accommodations)) {
+    if (!this.isPrintSectionExcluded("accommodation") && this.contentSections.hasAccommodationData(this.options.accommodations)) {
       const currentY = this.addSectionHeader("Alojamientos");
       await this.contentSections.addAccommodationSection(
         this.options.accommodations || [],
@@ -185,7 +202,7 @@ export class PDFEngine {
       );
     }
 
-    if (includeAggregatedRooming && this.contentSections.hasRoomingData(this.options.accommodations)) {
+    if (!this.isPrintSectionExcluded("accommodation") && includeAggregatedRooming && this.contentSections.hasRoomingData(this.options.accommodations)) {
       const currentY = this.addSectionHeader("Rooming");
       this.contentSections.addRoomingSection(
         this.options.accommodations || [],
@@ -194,27 +211,54 @@ export class PDFEngine {
       );
     }
 
-    if (includeLogisticsTransport && this.contentSections.hasLogisticsData(this.options.eventData)) {
-      const currentY = this.addSectionHeader("Transportes");
-      this.contentSections.addLogisticsSection(this.options.eventData, currentY);
+    const includeLogisticsTransportSection =
+      !this.isPrintSectionExcluded("logistics-transport") &&
+      includeLogisticsTransport &&
+      this.contentSections.hasLogisticsTransportData(this.options.eventData);
+    const includeLogisticsDetailsSection =
+      !this.isPrintSectionExcluded("logistics-details") &&
+      this.contentSections.hasLogisticsDetailsData(this.options.eventData);
+
+    if (includeLogisticsTransportSection || includeLogisticsDetailsSection) {
+      const currentY = this.addSectionHeader(
+        includeLogisticsTransportSection && includeLogisticsDetailsSection
+          ? "Logística"
+          : includeLogisticsTransportSection
+            ? "Transportes"
+            : "Logística del Evento"
+      );
+      this.contentSections.addLogisticsSection(this.options.eventData, currentY, {
+        includeTransport: includeLogisticsTransportSection,
+        includeDetails: includeLogisticsDetailsSection,
+      });
     }
 
-    if (this.contentSections.hasPowerData(this.options.eventData)) {
+    if (!this.isPrintSectionExcluded("power") && this.contentSections.hasPowerData(this.options.eventData)) {
       const currentY = this.addSectionHeader("Requerimientos eléctricos");
       this.contentSections.addPowerSection(this.options.eventData, currentY);
     }
 
-    if (this.contentSections.hasAuxNeedsData(this.options.eventData)) {
+    if (!this.isPrintSectionExcluded("aux-needs") && this.contentSections.hasAuxNeedsData(this.options.eventData)) {
       const currentY = this.addSectionHeader("Necesidades auxiliares");
       this.contentSections.addAuxNeedsSection(this.options.eventData, currentY);
     }
 
-    if (this.contentSections.hasProgramData(this.options.eventData)) {
+    const includeStructuredProgram =
+      !this.isPrintSectionExcluded("program") &&
+      this.contentSections.hasStructuredProgramData(this.options.eventData);
+    const includeScheduleText =
+      !this.isPrintSectionExcluded("schedule-notes") &&
+      this.contentSections.hasScheduleTextData(this.options.eventData);
+
+    if (includeStructuredProgram || includeScheduleText) {
       const currentY = this.addSectionHeader("Programa");
-      this.contentSections.addProgramSection(this.options.eventData, currentY);
+      this.contentSections.addProgramSection(this.options.eventData, currentY, {
+        includeStructured: includeStructuredProgram,
+        includeScheduleText,
+      });
     }
 
-    if (this.contentSections.hasRestaurantsData(this.options.eventData)) {
+    if (!this.isPrintSectionExcluded("restaurants") && this.contentSections.hasRestaurantsData(this.options.eventData)) {
       const currentY = this.addSectionHeader("Restaurantes");
       await this.contentSections.addRestaurantsSection(this.options.eventData, currentY);
     }
@@ -299,6 +343,10 @@ export class PDFEngine {
   }
 
   private async addWeatherSectionIfAvailable(): Promise<void> {
+    if (this.isPrintSectionExcluded("weather")) {
+      return;
+    }
+
     if (this.contentSections.hasWeatherData(this.options.eventData)) {
       const currentY = this.addSectionHeader("Clima");
       this.contentSections.addWeatherSection(this.options.eventData, currentY);
@@ -345,6 +393,10 @@ export class PDFEngine {
     return this.contentSections.hasVenueData(this.options.eventData) ||
       Boolean(this.options.venueMapPreview) ||
       Boolean(this.options.imagePreviews?.venue?.length);
+  }
+
+  private isPrintSectionExcluded(sectionId: HojaDeRutaPrintSectionId): boolean {
+    return this.excludedSections.has(sectionId);
   }
 
   private createGeneratedPDF(): GeneratedHojaDeRutaPdf {

--- a/src/utils/hoja-de-ruta/pdf/section-options.ts
+++ b/src/utils/hoja-de-ruta/pdf/section-options.ts
@@ -19,8 +19,98 @@ const SECTION_BY_ID = new Map<HojaDeRutaPdfSectionId, (typeof HOJA_DE_RUTA_PDF_S
 
 const SECTION_ID_SET = new Set<string>(HOJA_DE_RUTA_PDF_SECTIONS.map((section) => section.id));
 
+export const HOJA_DE_RUTA_PRINT_SECTIONS = [
+  { id: "event-details", label: "Información del Evento", parentSectionId: "event" },
+  { id: "aux-needs", label: "Necesidades Auxiliares", parentSectionId: "event" },
+  { id: "venue", label: "Lugar", parentSectionId: "venue" },
+  { id: "weather", label: "Clima", parentSectionId: "weather" },
+  { id: "contacts", label: "Contactos", parentSectionId: "contacts" },
+  { id: "staff", label: "Personal", parentSectionId: "staff" },
+  { id: "travel", label: "Viajes", parentSectionId: "travel" },
+  { id: "accommodation", label: "Alojamiento", parentSectionId: "accommodation" },
+  { id: "logistics-transport", label: "Transporte", parentSectionId: "logistics" },
+  { id: "logistics-details", label: "Logística del Evento", parentSectionId: "logistics" },
+  { id: "program", label: "Programa", parentSectionId: "schedule" },
+  { id: "schedule-notes", label: "Programa (Texto Libre)", parentSectionId: "schedule" },
+  { id: "power", label: "Requisitos de Energía", parentSectionId: "schedule" },
+  { id: "restaurants", label: "Restaurantes", parentSectionId: "restaurants" },
+] as const satisfies readonly {
+  id: string;
+  label: string;
+  parentSectionId: HojaDeRutaPdfSectionId;
+}[];
+
+export type HojaDeRutaPrintSectionId = (typeof HOJA_DE_RUTA_PRINT_SECTIONS)[number]["id"];
+
+const PRINT_SECTION_BY_ID = new Map<HojaDeRutaPrintSectionId, (typeof HOJA_DE_RUTA_PRINT_SECTIONS)[number]>(
+  HOJA_DE_RUTA_PRINT_SECTIONS.map((section) => [section.id, section])
+);
+
+const PRINT_SECTION_ID_SET = new Set<string>(HOJA_DE_RUTA_PRINT_SECTIONS.map((section) => section.id));
+
+const LEGACY_PRINT_SECTION_EXPANSIONS: Record<HojaDeRutaPdfSectionId, HojaDeRutaPrintSectionId[]> = {
+  event: ["event-details", "aux-needs"],
+  venue: ["venue"],
+  weather: ["weather"],
+  contacts: ["contacts"],
+  staff: ["staff"],
+  travel: ["travel"],
+  accommodation: ["accommodation"],
+  logistics: ["logistics-transport", "logistics-details"],
+  schedule: ["program", "schedule-notes", "power"],
+  restaurants: ["restaurants"],
+};
+
 export const isHojaDeRutaPdfSectionId = (value: string): value is HojaDeRutaPdfSectionId =>
   SECTION_ID_SET.has(value);
+
+export const normalizeHojaDeRutaPdfSections = (value: unknown): HojaDeRutaPdfSectionId[] => {
+  if (!Array.isArray(value)) return [];
+
+  const normalized: HojaDeRutaPdfSectionId[] = [];
+  const seen = new Set<HojaDeRutaPdfSectionId>();
+
+  value.forEach((sectionId) => {
+    if (typeof sectionId !== "string" || !isHojaDeRutaPdfSectionId(sectionId)) return;
+    if (seen.has(sectionId)) return;
+
+    seen.add(sectionId);
+    normalized.push(sectionId);
+  });
+
+  return normalized;
+};
+
+export const isHojaDeRutaPrintSectionId = (value: string): value is HojaDeRutaPrintSectionId =>
+  PRINT_SECTION_ID_SET.has(value);
+
+export const normalizeHojaDeRutaPrintSections = (value: unknown): HojaDeRutaPrintSectionId[] => {
+  if (!Array.isArray(value)) return [];
+
+  const normalized: HojaDeRutaPrintSectionId[] = [];
+  const seen = new Set<HojaDeRutaPrintSectionId>();
+
+  const addSection = (sectionId: HojaDeRutaPrintSectionId) => {
+    if (seen.has(sectionId)) return;
+    seen.add(sectionId);
+    normalized.push(sectionId);
+  };
+
+  value.forEach((sectionId) => {
+    if (typeof sectionId !== "string") return;
+
+    if (isHojaDeRutaPrintSectionId(sectionId)) {
+      addSection(sectionId);
+      return;
+    }
+
+    if (isHojaDeRutaPdfSectionId(sectionId)) {
+      LEGACY_PRINT_SECTION_EXPANSIONS[sectionId].forEach(addSection);
+    }
+  });
+
+  return normalized;
+};
 
 export const getHojaDeRutaPdfSectionLabel = (sectionId: HojaDeRutaPdfSectionId): string =>
   SECTION_BY_ID.get(sectionId)?.label ?? sectionId;
@@ -35,3 +125,6 @@ export const getHojaDeRutaPdfSelectionLabel = (
   if (sectionIds.length === 1) return getHojaDeRutaPdfSectionLabel(sectionIds[0]);
   return "Secciones seleccionadas";
 };
+
+export const getHojaDeRutaPrintSectionLabel = (sectionId: HojaDeRutaPrintSectionId): string =>
+  PRINT_SECTION_BY_ID.get(sectionId)?.label ?? sectionId;

--- a/src/utils/hoja-de-ruta/pdf/sections/content-sections.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/content-sections.ts
@@ -95,8 +95,12 @@ export class ContentSections {
     return this.scheduleSection.addScheduleSection(eventData, yPosition);
   }
 
-  addLogisticsSection(eventData: EventData, yPosition: number): number {
-    return this.logisticsSection.addLogisticsSection(eventData, yPosition);
+  addLogisticsSection(
+    eventData: EventData,
+    yPosition: number,
+    options?: { includeTransport?: boolean; includeDetails?: boolean }
+  ): number {
+    return this.logisticsSection.addLogisticsSection(eventData, yPosition, options);
   }
 
   addDeliveryCertificateSection(
@@ -123,8 +127,12 @@ export class ContentSections {
     return this.auxNeedsSection.addAuxNeedsSection(eventData, yPosition);
   }
 
-  addProgramSection(eventData: EventData, yPosition: number): number {
-    return this.programSection.addProgramSection(eventData, yPosition);
+  addProgramSection(
+    eventData: EventData,
+    yPosition: number,
+    options?: { includeStructured?: boolean; includeScheduleText?: boolean }
+  ): number {
+    return this.programSection.addProgramSection(eventData, yPosition, options);
   }
 
   async addRestaurantsSection(eventData: EventData, yPosition: number): Promise<number> {
@@ -186,15 +194,23 @@ export class ContentSections {
   }
 
   hasLogisticsData(eventData: EventData): boolean {
+    return this.hasLogisticsTransportData(eventData) || this.hasLogisticsDetailsData(eventData);
+  }
+
+  hasLogisticsTransportData(eventData: EventData): boolean {
     if (!eventData.logistics) return false;
 
-    const { transport = [], loadingDetails, unloadingDetails, equipmentLogistics } = eventData.logistics;
-    const hasTransportEntries = Array.isArray(transport) && transport.some(item => DataValidators.hasData(item));
-    const hasDetails = DataValidators.hasData(loadingDetails) ||
+    const { transport = [] } = eventData.logistics;
+    return Array.isArray(transport) && transport.some(item => DataValidators.hasData(item));
+  }
+
+  hasLogisticsDetailsData(eventData: EventData): boolean {
+    if (!eventData.logistics) return false;
+
+    const { loadingDetails, unloadingDetails, equipmentLogistics } = eventData.logistics;
+    return DataValidators.hasData(loadingDetails) ||
       DataValidators.hasData(unloadingDetails) ||
       DataValidators.hasData(equipmentLogistics);
-
-    return hasTransportEntries || hasDetails;
   }
 
   hasDeliveryCertificateData(eventData: EventData): boolean {
@@ -218,10 +234,18 @@ export class ContentSections {
   }
 
   hasProgramData(eventData: EventData): boolean {
+    return this.hasStructuredProgramData(eventData) || this.hasScheduleTextData(eventData);
+  }
+
+  hasStructuredProgramData(eventData: EventData): boolean {
     const hasStructured = Array.isArray(eventData.programSchedule) && eventData.programSchedule.length > 0;
-    const hasMulti = Array.isArray((eventData as any).programScheduleDays) && (eventData as any).programScheduleDays.some((d: any) => Array.isArray(d.rows) && d.rows.length > 0);
-    const hasLegacy = !!(eventData.schedule && eventData.schedule.trim().length > 0);
-    return hasMulti || hasStructured || hasLegacy;
+    const hasMulti = Array.isArray((eventData as any).programScheduleDays) &&
+      (eventData as any).programScheduleDays.some((d: any) => Array.isArray(d.rows) && d.rows.length > 0);
+    return hasMulti || hasStructured;
+  }
+
+  hasScheduleTextData(eventData: EventData): boolean {
+    return !!(eventData.schedule && eventData.schedule.trim().length > 0);
   }
 
   hasRestaurantsData(eventData: EventData): boolean {

--- a/src/utils/hoja-de-ruta/pdf/sections/logistics.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/logistics.ts
@@ -7,15 +7,21 @@ import { formatLogisticsHojaCategories } from "@/constants/logisticsHojaCategori
 export class LogisticsSection {
   constructor(private pdfDoc: PDFDocument) {}
 
-  addLogisticsSection(eventData: EventData, yPosition: number): number {
+  addLogisticsSection(
+    eventData: EventData,
+    yPosition: number,
+    options: { includeTransport?: boolean; includeDetails?: boolean } = {}
+  ): number {
     const logistics = eventData.logistics;
     if (!logistics) return yPosition;
     const lineHeight = 6;
+    const includeTransport = options.includeTransport ?? true;
+    const includeDetails = options.includeDetails ?? true;
 
     yPosition = this.pdfDoc.checkPageBreak(yPosition, 30);
 
     // Transportes section with complete field set
-    if (logistics.transport && logistics.transport.length > 0) {
+    if (includeTransport && logistics.transport && logistics.transport.length > 0) {
       // Start table immediately; section header is already printed by the page header
 
       const transportData = logistics.transport.map(transport => [
@@ -54,7 +60,7 @@ export class LogisticsSection {
     }
 
     // Loading details
-    if (DataValidators.hasData(logistics.loadingDetails)) {
+    if (includeDetails && DataValidators.hasData(logistics.loadingDetails)) {
       yPosition = this.pdfDoc.checkPageBreak(yPosition, 30);
       
       this.pdfDoc.setText(12, [125, 1, 1]);
@@ -72,7 +78,7 @@ export class LogisticsSection {
     }
 
     // Unloading details
-    if (DataValidators.hasData(logistics.unloadingDetails)) {
+    if (includeDetails && DataValidators.hasData(logistics.unloadingDetails)) {
       yPosition = this.pdfDoc.checkPageBreak(yPosition, 30);
       
       this.pdfDoc.setText(12, [125, 1, 1]);
@@ -90,7 +96,7 @@ export class LogisticsSection {
     }
 
     // Equipment logistics
-    if (DataValidators.hasData(logistics.equipmentLogistics)) {
+    if (includeDetails && DataValidators.hasData(logistics.equipmentLogistics)) {
       yPosition = this.pdfDoc.checkPageBreak(yPosition, 30);
       
       this.pdfDoc.setText(12, [125, 1, 1]);

--- a/src/utils/hoja-de-ruta/pdf/sections/program.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/program.ts
@@ -5,13 +5,20 @@ import { DataValidators } from '../utils/validators';
 export class ProgramSection {
   constructor(private pdfDoc: PDFDocument) {}
 
-  addProgramSection(eventData: EventData, yPosition: number): number {
+  addProgramSection(
+    eventData: EventData,
+    yPosition: number,
+    options: { includeStructured?: boolean; includeScheduleText?: boolean } = {}
+  ): number {
     // Start directly after the section header; no repeated subtitle
     yPosition = this.pdfDoc.checkPageBreak(yPosition, 30);
+    const includeStructured = options.includeStructured ?? true;
+    const includeScheduleText = options.includeScheduleText ?? true;
+    let renderedStructured = false;
 
     // If multi-day structured program exists
     const anyEvent = eventData as any;
-    if (Array.isArray(anyEvent.programScheduleDays) && anyEvent.programScheduleDays.some((d: any) => d?.rows?.length > 0)) {
+    if (includeStructured && Array.isArray(anyEvent.programScheduleDays) && anyEvent.programScheduleDays.some((d: any) => d?.rows?.length > 0)) {
       for (const [idx, day] of anyEvent.programScheduleDays.entries()) {
         const title = `${day?.label || `Día ${idx + 1}`}${day?.date ? ` (${day.date})` : ''}`;
         this.pdfDoc.setText(12, [125, 1, 1]);
@@ -48,11 +55,11 @@ export class ProgramSection {
 
         yPosition = this.pdfDoc.checkPageBreak(yPosition, 24);
       }
-      return yPosition;
+      renderedStructured = true;
     }
 
     // If structured single-day program exists, render a table; otherwise fallback to legacy text
-    if (eventData.programSchedule && eventData.programSchedule.length > 0) {
+    if (!renderedStructured && includeStructured && eventData.programSchedule && eventData.programSchedule.length > 0) {
       // Render as a grid using autoTable wrapper
       const body = eventData.programSchedule.map((r) => [
         r.time || '',
@@ -76,11 +83,20 @@ export class ProgramSection {
         },
         tableWidth: 'wrap',
       });
-      return this.pdfDoc.getLastAutoTableY() + 12;
+      yPosition = this.pdfDoc.getLastAutoTableY() + 12;
+      renderedStructured = true;
     }
 
     this.pdfDoc.setText(10, [51, 51, 51]);
-    if (DataValidators.hasData(eventData.schedule)) {
+    if (includeScheduleText && DataValidators.hasData(eventData.schedule)) {
+      if (renderedStructured) {
+        yPosition = this.pdfDoc.checkPageBreak(yPosition, 18);
+        this.pdfDoc.setText(12, [125, 1, 1]);
+        this.pdfDoc.addText("Programa (Texto Libre)", 20, yPosition);
+        yPosition += 10;
+        this.pdfDoc.setText(10, [51, 51, 51]);
+      }
+
       const lineHeight = 6;
       const scheduleLines = eventData.schedule!
         .split(/\r?\n/)

--- a/supabase/migrations/20260612120000_add_hoja_de_ruta_print_exclusions.sql
+++ b/supabase/migrations/20260612120000_add_hoja_de_ruta_print_exclusions.sql
@@ -1,0 +1,20 @@
+-- Store per-subsection print exclusions for Hoja de Ruta PDFs.
+alter table public.hoja_de_ruta
+  add column if not exists print_excluded_sections jsonb not null default '[]'::jsonb;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'hoja_de_ruta_print_excluded_sections_is_array'
+      and conrelid = 'public.hoja_de_ruta'::regclass
+  ) then
+    alter table public.hoja_de_ruta
+      add constraint hoja_de_ruta_print_excluded_sections_is_array
+      check (jsonb_typeof(print_excluded_sections) = 'array');
+  end if;
+end $$;
+
+comment on column public.hoja_de_ruta.print_excluded_sections is
+  'Array of Hoja de Ruta printable subsection ids excluded from full-document printing.';


### PR DESCRIPTION
## Summary
- Adds persisted Hoja de Ruta print-exclusion preferences for individual printable subsections.
- Places an `Excluir al imprimir` checkbox on each printable card/area, including `Programa`, `Programa (Texto Libre)`, and `Requisitos de Energía` independently.
- Updates full-document PDF generation so excluded subsections are omitted without suppressing sibling subsections, while explicit section exports still export the selected top-level section.

## Notes
- Adds `hoja_de_ruta.print_excluded_sections` as a JSONB array of printable subsection IDs.
- Normalization expands legacy top-level IDs to matching subsection IDs for compatibility with any existing saved values from the first implementation.

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now exclude specific document sections from PDF printing via new "Excluir al imprimir" checkboxes across all major sections: event details, venue, weather, contacts, staff, travel, accommodation, restaurants, logistics, schedule, and power requirements.
  * Exclusion preferences are saved and restored with the document.

* **Tests**
  * Added test coverage for print exclusion toggle functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->