### PR TITLE
[codex] Fix hoja de ruta program notes wrapping

### DIFF
--- a/src/utils/hoja-de-ruta/pdf/sections/__tests__/program.test.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/__tests__/program.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { EventData } from '../../core/pdf-types';
-import { PDFDocument } from '../../core/pdf-document';
-import { ProgramSection } from '../program';
+import type { EventData } from '@/utils/hoja-de-ruta/pdf/core/pdf-types';
+import { PDFDocument } from '@/utils/hoja-de-ruta/pdf/core/pdf-document';
+import { ProgramSection } from '@/utils/hoja-de-ruta/pdf/sections/program';
 
 const LONG_NOTE =
   'Mantener despejada la zona de carga durante toda la prueba y confirmar por intercom antes de mover cualquier equipo del escenario.';

--- a/src/utils/hoja-de-ruta/pdf/sections/__tests__/program.test.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/__tests__/program.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EventData } from '../../core/pdf-types';
+import { PDFDocument } from '../../core/pdf-document';
+import { ProgramSection } from '../program';
+
+const LONG_NOTE =
+  'Mantener despejada la zona de carga durante toda la prueba y confirmar por intercom antes de mover cualquier equipo del escenario.';
+
+type AutoTableState = {
+  columns: Array<{ width: number }>;
+  body: Array<{ cells: Record<number, { text: string[] }> }>;
+};
+
+const getLastTable = (pdfDoc: PDFDocument): AutoTableState =>
+  (pdfDoc.document as unknown as { lastAutoTable: AutoTableState }).lastAutoTable;
+
+describe('ProgramSection', () => {
+  it.each([
+    {
+      name: 'single-day programs',
+      eventData: {
+        programSchedule: [{ time: '10:00', item: 'Prueba', dept: 'Sonido', notes: LONG_NOTE }],
+      },
+    },
+    {
+      name: 'multi-day programs',
+      eventData: {
+        programScheduleDays: [
+          {
+            label: 'Día 1',
+            rows: [{ time: '10:00', item: 'Prueba', dept: 'Sonido', notes: LONG_NOTE }],
+          },
+        ],
+      },
+    },
+  ])('keeps long notes inside the printable table width for $name', ({ eventData }) => {
+    const pdfDoc = new PDFDocument();
+    const section = new ProgramSection(pdfDoc);
+
+    section.addProgramSection(eventData as EventData, 30, { includeScheduleText: false });
+
+    const table = getLastTable(pdfDoc);
+    const columnWidths = table.columns.map((column) => column.width);
+
+    expect(columnWidths).toEqual([24, 40, 45, 61]);
+    expect(columnWidths.reduce((total, width) => total + width, 0)).toBe(170);
+    expect(table.body[0].cells[3].text.length).toBeGreaterThan(1);
+  });
+});

--- a/src/utils/hoja-de-ruta/pdf/sections/program.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/program.ts
@@ -2,6 +2,13 @@ import { PDFDocument } from '../core/pdf-document';
 import { EventData } from '../core/pdf-types';
 import { DataValidators } from '../utils/validators';
 
+const PROGRAM_TABLE_COLUMN_STYLES = {
+  0: { cellWidth: 24 },
+  1: { cellWidth: 40 },
+  2: { cellWidth: 45 },
+  3: { cellWidth: 61 },
+};
+
 export class ProgramSection {
   constructor(private pdfDoc: PDFDocument) {}
 
@@ -40,13 +47,8 @@ export class ProgramSection {
             headStyles: { fillColor: [240, 240, 240], textColor: [51, 51, 51] },
             theme: 'grid',
             margin: { left: 20, right: 20 },
-            columnStyles: {
-              0: { cellWidth: 24 },
-              1: { cellWidth: 40 },
-              2: { cellWidth: 45 },
-              3: { cellWidth: 'auto' },
-            },
-            tableWidth: 'wrap',
+            columnStyles: PROGRAM_TABLE_COLUMN_STYLES,
+            tableWidth: 'auto',
           });
           yPosition = this.pdfDoc.getLastAutoTableY() + 12;
         } else {
@@ -75,13 +77,8 @@ export class ProgramSection {
         headStyles: { fillColor: [240, 240, 240], textColor: [51, 51, 51] },
         theme: 'grid',
         margin: { left: 20, right: 20 },
-        columnStyles: {
-          0: { cellWidth: 24 }, // time
-          1: { cellWidth: 40 }, // item
-          2: { cellWidth: 45 }, // dept
-          3: { cellWidth: 'auto' }, // notes
-        },
-        tableWidth: 'wrap',
+        columnStyles: PROGRAM_TABLE_COLUMN_STYLES,
+        tableWidth: 'auto',
       });
       yPosition = this.pdfDoc.getLastAutoTableY() + 12;
       renderedStructured = true;


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Affected route/feature: Hoja de Ruta PDF export, structured Programa section.
- Constrains the program table to the printable A4 width and assigns the notes column a fixed 61 mm width so long text wraps within the page.
- Adds regression coverage for both single-day and multi-day program schedules.
- Root cause: combining an auto-width notes column with `tableWidth: 'wrap'` allowed long content to determine a table width larger than the printable area.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: low
- Main risks: fixed column widths could reduce space for item or department text. The widths total the existing 170 mm printable area, all cells retain line-break overflow, and a rendered A4 PDF was visually checked for wrapping and legibility.

## Impact Checklist
- [x] Migration impact assessed: no database changes.
- [x] Realtime/subscription impact assessed: no realtime or subscription changes.
- [x] RLS/security impact assessed: no data-access or security changes.
- [x] Performance impact assessed: negligible; table layout uses fixed widths instead of content-derived widths.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed locally:
  - `npx vitest run src/utils/hoja-de-ruta/pdf/sections/__tests__/program.test.ts`
  - `npx eslint src/utils/hoja-de-ruta/pdf/sections/program.ts src/utils/hoja-de-ruta/pdf/sections/__tests__/program.test.ts`
  - `npm run lint`
  - `npm run test:run`
  - `npm run build`
- Results: focused tests passed; lint passed with the repository's existing warnings; all 160 test files and 996 tests passed; production build passed. A rendered A4 PDF was visually inspected with no clipping, overlap, or illegible notes.
- GitHub CI results:
  - `npm run typecheck`: passed
  - Governance gates: passed
  - `npm run test:critical`: passed
  - `npm run test:run`: passed
  - `npm run build`: passed
  - `npm run test:e2e (smoke)`: passed
  - Cloudflare Pages preview: passed

## Rollback Plan
- [x] I documented how to safely revert this change.
- Rollback steps: revert the commits from this PR. No data rollback, migration rollback, or service reconfiguration is required.

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no
- If yes, describe migration, impact, and backout plan: not applicable.
