### PR TITLE
[codex] fix tour hoja whatsapp attachment

### DIFF
--- a/scripts/governance/dependency-audit-baseline.json
+++ b/scripts/governance/dependency-audit-baseline.json
@@ -15,13 +15,19 @@
     "1114680",
     "1116451",
     "1119441",
-    "1120679"
+    "1120679",
+    "1120782"
   ],
   "exceptions": [
     {
       "advisoryId": "1120679",
       "package": "esbuild",
       "rationale": "The vulnerable Deno module path is not used; this repository consumes esbuild through Node and Vite 6. The patched esbuild 0.28 line breaks Vite 6 target transforms, so remove this exception during the planned Vite major migration."
+    },
+    {
+      "advisoryId": "1120782",
+      "package": "tar",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x. @capacitor/assets is already at its latest release and npm audit reports no fixAvailable path for that nested CLI; remove this exception when @capacitor/assets publishes a compatible release that no longer depends on the vulnerable tar range."
     }
   ],
   "vulnerabilityCounts": {

--- a/src/components/jobs/cards/job-card-actions/__tests__/hojaDeRutaAttachment.test.ts
+++ b/src/components/jobs/cards/job-card-actions/__tests__/hojaDeRutaAttachment.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isJobHojaDeRutaDocument,
+  isTourHojaDeRutaDocument,
+  pickLatestJobHojaDeRutaDocument,
+  pickLatestTourHojaDeRutaDocument,
+} from "@/components/jobs/cards/job-card-actions/hojaDeRutaAttachment";
+
+describe("hojaDeRutaAttachment", () => {
+  it("matches current generated job Hoja de Ruta paths", () => {
+    expect(isJobHojaDeRutaDocument({
+      id: "doc-1",
+      file_name: "Hoja de Ruta - Show.pdf",
+      file_path: "hojas-de-ruta/job-1/Hoja de Ruta - Show.pdf",
+    }, "job-1")).toBe(true);
+  });
+
+  it("matches legacy job-scoped Hoja de Ruta paths", () => {
+    expect(isJobHojaDeRutaDocument({
+      id: "doc-1",
+      file_name: "Hoja de Ruta - Tour.pdf",
+      file_path: "job-1/Hoja de Ruta - Tour.pdf",
+    }, "job-1")).toBe(true);
+  });
+
+  it("does not treat other hoja-style documents as route sheets", () => {
+    expect(isJobHojaDeRutaDocument({
+      id: "doc-1",
+      file_name: "Hoja de Gastos.pdf",
+      file_path: "job-1/Hoja de Gastos.pdf",
+    }, "job-1")).toBe(false);
+  });
+
+  it("does not attach non-PDF route sheet lookalikes", () => {
+    expect(isJobHojaDeRutaDocument({
+      id: "doc-1",
+      file_name: "Hoja de Ruta.docx",
+      file_path: "job-1/Hoja de Ruta.docx",
+      file_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    }, "job-1")).toBe(false);
+  });
+
+  it("picks the first matching job document from an upload-descending list", () => {
+    const selected = pickLatestJobHojaDeRutaDocument([
+      {
+        id: "calc",
+        file_name: "Resumen Potencia.pdf",
+        file_path: "calculators/pesos/job-1/Resumen Potencia.pdf",
+      },
+      {
+        id: "hoja",
+        file_name: "Hoja de Ruta - Show.pdf",
+        file_path: "hojas-de-ruta/job-1/Hoja de Ruta - Show.pdf",
+      },
+    ], "job-1");
+
+    expect(selected).toMatchObject({ id: "hoja", source: "job_documents" });
+  });
+
+  it("matches tour-document Hoja de Ruta records without matching generic schedules", () => {
+    expect(isTourHojaDeRutaDocument({
+      id: "schedule",
+      file_name: "tour_schedule.pdf",
+      file_path: "schedules/tour-1/tour_schedule.pdf",
+    })).toBe(false);
+
+    const selected = pickLatestTourHojaDeRutaDocument([
+      {
+        id: "schedule",
+        file_name: "tour_schedule.pdf",
+        file_path: "schedules/tour-1/tour_schedule.pdf",
+      },
+      {
+        id: "tour-hoja",
+        file_name: "Hoja de Ruta - Tour Date.pdf",
+        file_path: "schedules/tour-1/Hoja de Ruta - Tour Date.pdf",
+      },
+    ]);
+
+    expect(selected).toMatchObject({ id: "tour-hoja", source: "tour_documents" });
+  });
+});

--- a/src/components/jobs/cards/job-card-actions/__tests__/hojaDeRutaAttachment.test.ts
+++ b/src/components/jobs/cards/job-card-actions/__tests__/hojaDeRutaAttachment.test.ts
@@ -4,6 +4,7 @@ import {
   isJobHojaDeRutaDocument,
   isTourHojaDeRutaDocument,
   pickLatestJobHojaDeRutaDocument,
+  pickLatestLinkedJobHojaDeRutaDocument,
   pickLatestTourHojaDeRutaDocument,
 } from "@/components/jobs/cards/job-card-actions/hojaDeRutaAttachment";
 
@@ -41,21 +42,62 @@ describe("hojaDeRutaAttachment", () => {
     }, "job-1")).toBe(false);
   });
 
-  it("picks the first matching job document from an upload-descending list", () => {
+  it("does not attach files with unsafe PDF-looking names", () => {
+    expect(isJobHojaDeRutaDocument({
+      id: "doc-1",
+      file_name: "Hoja de Ruta.pdf.exe",
+      file_path: "job-1/Hoja de Ruta.pdf.exe",
+      file_type: "application/x-msdownload",
+    }, "job-1")).toBe(false);
+  });
+
+  it("accepts the PDF MIME type even when the filename has no extension", () => {
+    expect(isJobHojaDeRutaDocument({
+      id: "doc-1",
+      file_name: "Hoja de Ruta - Show",
+      file_path: "hojas-de-ruta/job-1/Hoja de Ruta - Show",
+      file_type: "application/pdf; charset=binary",
+    }, "job-1")).toBe(true);
+  });
+
+  it("picks the latest matching job document by upload time", () => {
     const selected = pickLatestJobHojaDeRutaDocument([
       {
-        id: "calc",
-        file_name: "Resumen Potencia.pdf",
-        file_path: "calculators/pesos/job-1/Resumen Potencia.pdf",
+        id: "old-hoja",
+        file_name: "Hoja de Ruta - Old.pdf",
+        file_path: "hojas-de-ruta/job-1/Hoja de Ruta - Old.pdf",
+        uploaded_at: "2026-06-16T10:00:00Z",
       },
       {
-        id: "hoja",
-        file_name: "Hoja de Ruta - Show.pdf",
-        file_path: "hojas-de-ruta/job-1/Hoja de Ruta - Show.pdf",
+        id: "new-hoja",
+        file_name: "Hoja de Ruta - New.pdf",
+        file_path: "hojas-de-ruta/job-1/Hoja de Ruta - New.pdf",
+        uploaded_at: "2026-06-16T12:00:00Z",
       },
     ], "job-1");
 
-    expect(selected).toMatchObject({ id: "hoja", source: "job_documents" });
+    expect(selected).toMatchObject({ id: "new-hoja", source: "job_documents" });
+  });
+
+  it("picks the latest linked job Hoja de Ruta across all candidate jobs", () => {
+    const selected = pickLatestLinkedJobHojaDeRutaDocument([
+      {
+        id: "job-2-hoja",
+        job_id: "job-2",
+        file_name: "Hoja de Ruta - Linked 2.pdf",
+        file_path: "hojas-de-ruta/job-2/Hoja de Ruta - Linked 2.pdf",
+        uploaded_at: "2026-06-16T10:00:00Z",
+      },
+      {
+        id: "job-3-hoja",
+        job_id: "job-3",
+        file_name: "Hoja de Ruta - Linked 3.pdf",
+        file_path: "hojas-de-ruta/job-3/Hoja de Ruta - Linked 3.pdf",
+        uploaded_at: "2026-06-16T12:00:00Z",
+      },
+    ], ["job-2", "job-3"]);
+
+    expect(selected).toMatchObject({ id: "job-3-hoja", source: "job_documents" });
   });
 
   it("matches tour-document Hoja de Ruta records without matching generic schedules", () => {

--- a/src/components/jobs/cards/job-card-actions/hojaDeRutaAttachment.ts
+++ b/src/components/jobs/cards/job-card-actions/hojaDeRutaAttachment.ts
@@ -2,6 +2,7 @@ export type HojaDeRutaAttachmentSource = "job_documents" | "tour_documents";
 
 export type HojaDeRutaAttachmentRow = {
   id: string;
+  job_id?: string | null;
   file_name: string | null;
   file_path: string | null;
   file_type?: string | null;
@@ -26,9 +27,21 @@ const hasHojaDeRutaText = (doc: HojaDeRutaAttachmentRow) => {
 };
 
 const isPdfDocument = (doc: HojaDeRutaAttachmentRow) => {
-  const text = normalizeText(`${doc.file_type || ""} ${doc.file_name || ""} ${doc.file_path || ""}`);
-  return text.includes("pdf");
+  const mimeType = (doc.file_type || "").split(";")[0].trim().toLowerCase();
+  if (mimeType === "application/pdf") return true;
+
+  return [doc.file_name, doc.file_path].some((value) =>
+    /\.pdf$/i.test(normalizePath(value))
+  );
 };
+
+const uploadedAtMs = (doc: HojaDeRutaAttachmentRow) => {
+  const value = doc.uploaded_at ? Date.parse(doc.uploaded_at) : NaN;
+  return Number.isFinite(value) ? value : 0;
+};
+
+const byNewestUpload = (a: HojaDeRutaAttachmentRow, b: HojaDeRutaAttachmentRow) =>
+  uploadedAtMs(b) - uploadedAtMs(a);
 
 export const isJobHojaDeRutaDocument = (doc: HojaDeRutaAttachmentRow, jobId: string) => {
   const path = normalizePath(doc.file_path);
@@ -52,13 +65,36 @@ export const pickLatestJobHojaDeRutaDocument = (
   docs: HojaDeRutaAttachmentRow[] | null | undefined,
   jobId: string
 ): HojaDeRutaAttachmentDoc | null => {
-  const doc = (docs || []).find((candidate) => isJobHojaDeRutaDocument(candidate, jobId));
+  const doc = (docs || [])
+    .filter((candidate) => isJobHojaDeRutaDocument(candidate, jobId))
+    .sort(byNewestUpload)[0];
+  return doc ? { ...doc, source: "job_documents" } : null;
+};
+
+export const pickLatestLinkedJobHojaDeRutaDocument = (
+  docs: HojaDeRutaAttachmentRow[] | null | undefined,
+  linkedJobIds: string[]
+): HojaDeRutaAttachmentDoc | null => {
+  const linkedJobIdSet = new Set(linkedJobIds);
+  const doc = (docs || [])
+    .filter((candidate) => {
+      const candidateJobId = candidate.job_id || null;
+      return Boolean(
+        candidateJobId &&
+        linkedJobIdSet.has(candidateJobId) &&
+        isJobHojaDeRutaDocument(candidate, candidateJobId)
+      );
+    })
+    .sort(byNewestUpload)[0];
+
   return doc ? { ...doc, source: "job_documents" } : null;
 };
 
 export const pickLatestTourHojaDeRutaDocument = (
   docs: HojaDeRutaAttachmentRow[] | null | undefined
 ): HojaDeRutaAttachmentDoc | null => {
-  const doc = (docs || []).find(isTourHojaDeRutaDocument);
+  const doc = (docs || [])
+    .filter(isTourHojaDeRutaDocument)
+    .sort(byNewestUpload)[0];
   return doc ? { ...doc, source: "tour_documents" } : null;
 };

--- a/src/components/jobs/cards/job-card-actions/hojaDeRutaAttachment.ts
+++ b/src/components/jobs/cards/job-card-actions/hojaDeRutaAttachment.ts
@@ -1,0 +1,64 @@
+export type HojaDeRutaAttachmentSource = "job_documents" | "tour_documents";
+
+export type HojaDeRutaAttachmentRow = {
+  id: string;
+  file_name: string | null;
+  file_path: string | null;
+  file_type?: string | null;
+  uploaded_at?: string | null;
+};
+
+export type HojaDeRutaAttachmentDoc = HojaDeRutaAttachmentRow & {
+  source: HojaDeRutaAttachmentSource;
+};
+
+const normalizeText = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+const normalizePath = (value: string | null | undefined) => (value || "").replace(/^\/+/, "");
+
+const hasHojaDeRutaText = (doc: HojaDeRutaAttachmentRow) => {
+  const text = normalizeText(`${doc.file_name || ""} ${doc.file_path || ""}`);
+  return text.includes("hoja") && (text.includes("ruta") || text.includes("route"));
+};
+
+const isPdfDocument = (doc: HojaDeRutaAttachmentRow) => {
+  const text = normalizeText(`${doc.file_type || ""} ${doc.file_name || ""} ${doc.file_path || ""}`);
+  return text.includes("pdf");
+};
+
+export const isJobHojaDeRutaDocument = (doc: HojaDeRutaAttachmentRow, jobId: string) => {
+  const path = normalizePath(doc.file_path);
+  if (!path) return false;
+  if (!isPdfDocument(doc)) return false;
+  if (path.startsWith(`hojas-de-ruta/${jobId}/`)) return true;
+  if (path.startsWith("hojas-de-ruta/") && hasHojaDeRutaText(doc)) return true;
+  if (path.startsWith(`${jobId}/`) && hasHojaDeRutaText(doc)) return true;
+  return hasHojaDeRutaText(doc);
+};
+
+export const isTourHojaDeRutaDocument = (doc: HojaDeRutaAttachmentRow) => {
+  const path = normalizePath(doc.file_path);
+  if (!path) return false;
+  if (!isPdfDocument(doc)) return false;
+  if (path.startsWith("hojas-de-ruta/")) return true;
+  return hasHojaDeRutaText(doc);
+};
+
+export const pickLatestJobHojaDeRutaDocument = (
+  docs: HojaDeRutaAttachmentRow[] | null | undefined,
+  jobId: string
+): HojaDeRutaAttachmentDoc | null => {
+  const doc = (docs || []).find((candidate) => isJobHojaDeRutaDocument(candidate, jobId));
+  return doc ? { ...doc, source: "job_documents" } : null;
+};
+
+export const pickLatestTourHojaDeRutaDocument = (
+  docs: HojaDeRutaAttachmentRow[] | null | undefined
+): HojaDeRutaAttachmentDoc | null => {
+  const doc = (docs || []).find(isTourHojaDeRutaDocument);
+  return doc ? { ...doc, source: "tour_documents" } : null;
+};

--- a/src/components/jobs/cards/job-card-actions/types.ts
+++ b/src/components/jobs/cards/job-card-actions/types.ts
@@ -140,6 +140,8 @@ export type WaSendResult = {
 export type WaProdHojaDeRutaDoc = {
   id: string;
   file_name: string | null;
+  file_path?: string | null;
+  source?: "job_documents" | "tour_documents";
 };
 
 export type TourdateSelectorInfo = {

--- a/src/components/jobs/cards/job-card-actions/useProductionWhatsapp.ts
+++ b/src/components/jobs/cards/job-card-actions/useProductionWhatsapp.ts
@@ -9,6 +9,7 @@ import {
 } from "@/components/jobs/cards/job-card-actions/jobActionFormatters";
 import {
   pickLatestJobHojaDeRutaDocument,
+  pickLatestLinkedJobHojaDeRutaDocument,
   pickLatestTourHojaDeRutaDocument,
   type HojaDeRutaAttachmentRow,
 } from "@/components/jobs/cards/job-card-actions/hojaDeRutaAttachment";
@@ -130,7 +131,7 @@ export const useProductionWhatsapp = ({
     queryFn: async (): Promise<WaProdHojaDeRutaDoc | null> => {
       const findJobHojaDocument = async (jobId: string): Promise<WaProdHojaDeRutaDoc | null> => {
         const { data, error } = await dataLayerClient.from("job_documents")
-          .select("id, file_name, file_path, file_type, uploaded_at")
+          .select("id, job_id, file_name, file_path, file_type, uploaded_at")
           .eq("job_id", jobId)
           .order("uploaded_at", { ascending: false })
           .limit(25);
@@ -146,8 +147,7 @@ export const useProductionWhatsapp = ({
         const { data: hojaRows, error: hojaError } = await dataLayerClient.from("hoja_de_ruta")
           .select("job_id")
           .eq("tour_date_id", job.tour_date_id)
-          .order("created_at", { ascending: false })
-          .limit(10);
+          .order("created_at", { ascending: false });
 
         if (hojaError) throw hojaError;
 
@@ -157,8 +157,17 @@ export const useProductionWhatsapp = ({
             .filter((id): id is string => Boolean(id && id !== job.id))
         ));
 
-        for (const linkedJobId of linkedJobIds) {
-          const linkedJobDoc = await findJobHojaDocument(linkedJobId);
+        if (linkedJobIds.length > 0) {
+          const { data: linkedDocs, error: linkedDocsError } = await dataLayerClient.from("job_documents")
+            .select("id, job_id, file_name, file_path, file_type, uploaded_at")
+            .in("job_id", linkedJobIds)
+            .order("uploaded_at", { ascending: false });
+
+          if (linkedDocsError) throw linkedDocsError;
+          const linkedJobDoc = pickLatestLinkedJobHojaDeRutaDocument(
+            linkedDocs as HojaDeRutaAttachmentRow[] | null,
+            linkedJobIds
+          );
           if (linkedJobDoc) return linkedJobDoc;
         }
       }

--- a/src/components/jobs/cards/job-card-actions/useProductionWhatsapp.ts
+++ b/src/components/jobs/cards/job-card-actions/useProductionWhatsapp.ts
@@ -27,6 +27,7 @@ import { createQueryKey } from "@/lib/optimized-react-query";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import type { Department } from "@/types/department";
 import { isManagementRole } from "@/utils/permissions";
+import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 
 export type ProductionWhatsappState = ReturnType<typeof useProductionWhatsapp>;
 
@@ -261,7 +262,7 @@ export const useProductionWhatsapp = ({
       });
 
       if (error) {
-        toast({ title: "Error al enviar", description: error.message, variant: "destructive" });
+        toast({ title: "Error al enviar", description: await extractFunctionErrorMessage(error), variant: "destructive" });
         return;
       }
 
@@ -281,7 +282,8 @@ export const useProductionWhatsapp = ({
       });
       setWaProdOpen(false);
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+      const fallback = error instanceof Error ? error.message : String(error);
+      const message = await extractFunctionErrorMessage(error, fallback);
       toast({ title: "Error", description: message, variant: "destructive" });
     } finally {
       setWaProdSending(false);

--- a/src/components/jobs/cards/job-card-actions/useProductionWhatsapp.ts
+++ b/src/components/jobs/cards/job-card-actions/useProductionWhatsapp.ts
@@ -8,6 +8,11 @@ import {
   resolveSuggestedCallTime,
 } from "@/components/jobs/cards/job-card-actions/jobActionFormatters";
 import {
+  pickLatestJobHojaDeRutaDocument,
+  pickLatestTourHojaDeRutaDocument,
+  type HojaDeRutaAttachmentRow,
+} from "@/components/jobs/cards/job-card-actions/hojaDeRutaAttachment";
+import {
   MADRID_TIME_ZONE,
   type JobCardJob,
   type JobAssignmentRow,
@@ -116,18 +121,58 @@ export const useProductionWhatsapp = ({
   });
 
   const { data: waProdHojaDeRutaDoc = null, isLoading: waProdHojaDeRutaLoading } = useQuery({
-    queryKey: createQueryKey.whatsapp.prodHojaDeRutaDocByJob(job.id),
+    queryKey: [
+      ...createQueryKey.whatsapp.prodHojaDeRutaDocByJob(job.id),
+      job.tour_date_id ?? null,
+      job.tour_id ?? job.tour?.id ?? null,
+    ],
     queryFn: async (): Promise<WaProdHojaDeRutaDoc | null> => {
-      const { data, error } = await dataLayerClient.from("job_documents")
-        .select("id, file_name")
-        .eq("job_id", job.id)
-        .like("file_path", `hojas-de-ruta/${job.id}/%`)
-        .order("uploaded_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
+      const findJobHojaDocument = async (jobId: string): Promise<WaProdHojaDeRutaDoc | null> => {
+        const { data, error } = await dataLayerClient.from("job_documents")
+          .select("id, file_name, file_path, file_type, uploaded_at")
+          .eq("job_id", jobId)
+          .order("uploaded_at", { ascending: false })
+          .limit(25);
 
-      if (error) throw error;
-      return (data as WaProdHojaDeRutaDoc | null) || null;
+        if (error) throw error;
+        return pickLatestJobHojaDeRutaDocument(data as HojaDeRutaAttachmentRow[] | null, jobId);
+      };
+
+      const directJobDoc = await findJobHojaDocument(job.id);
+      if (directJobDoc) return directJobDoc;
+
+      if (job.tour_date_id) {
+        const { data: hojaRows, error: hojaError } = await dataLayerClient.from("hoja_de_ruta")
+          .select("job_id")
+          .eq("tour_date_id", job.tour_date_id)
+          .order("created_at", { ascending: false })
+          .limit(10);
+
+        if (hojaError) throw hojaError;
+
+        const linkedJobIds = Array.from(new Set(
+          ((hojaRows as Array<{ job_id: string | null }> | null) || [])
+            .map((row) => row.job_id)
+            .filter((id): id is string => Boolean(id && id !== job.id))
+        ));
+
+        for (const linkedJobId of linkedJobIds) {
+          const linkedJobDoc = await findJobHojaDocument(linkedJobId);
+          if (linkedJobDoc) return linkedJobDoc;
+        }
+      }
+
+      const tourId = job.tour_id || job.tour?.id || null;
+      if (!tourId) return null;
+
+      const { data: tourDocs, error: tourDocsError } = await dataLayerClient.from("tour_documents")
+        .select("id, file_name, file_path, file_type, uploaded_at")
+        .eq("tour_id", tourId)
+        .order("uploaded_at", { ascending: false })
+        .limit(25);
+
+      if (tourDocsError) throw tourDocsError;
+      return pickLatestTourHojaDeRutaDocument(tourDocs as HojaDeRutaAttachmentRow[] | null);
     },
     enabled: Boolean(waProdOpen && canSendProductionWhatsapp && job?.id),
     staleTime: 30_000,

--- a/src/utils/hoja-de-ruta/__tests__/pdf-upload.test.ts
+++ b/src/utils/hoja-de-ruta/__tests__/pdf-upload.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeHojaPdfFileName } from "@/utils/hoja-de-ruta/pdf-upload";
+
+describe("sanitizeHojaPdfFileName", () => {
+  it("removes diacritics from generated Hoja filenames while preserving readable spaces", () => {
+    expect(sanitizeHojaPdfFileName(
+      "Hoja de Ruta - Fiestas Populares Torrejón - 2026-06-16 12-30-00.pdf"
+    )).toBe("Hoja de Ruta - Fiestas Populares Torrejon - 2026-06-16 12-30-00.pdf");
+  });
+
+  it("removes path separators and illegal storage filename characters", () => {
+    expect(sanitizeHojaPdfFileName("Hoja_de_Ruta: Tour/Leg?.pdf"))
+      .toBe("Hoja de Ruta Tour Leg.pdf");
+  });
+});

--- a/src/utils/hoja-de-ruta/pdf-upload.ts
+++ b/src/utils/hoja-de-ruta/pdf-upload.ts
@@ -12,6 +12,19 @@ interface UploadPdfToJobOptions {
   kind?: HojaPdfDocumentKind;
 }
 
+export const sanitizeHojaPdfFileName = (fileName: string): string => {
+  const sanitized = fileName
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/_/g, ' ')
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+\./g, '.')
+    .trim();
+
+  return sanitized || 'Hoja de Ruta.pdf';
+};
+
 export const uploadPdfToJob = async (
   jobId: string,
   pdfBlob: Blob,
@@ -23,12 +36,7 @@ export const uploadPdfToJob = async (
     const folderBase = HOJA_PDF_FOLDER_BY_KIND[kind];
 
     // Sanitize filename for storage while preserving human-readable spaces.
-    const sanitizedFileName = fileName
-      .replace(/_/g, ' ')
-      .replace(/[<>:"/\\|?*\x00-\x1F]/g, ' ') // illegal file/path chars
-      .replace(/\s+/g, ' ')
-      .replace(/\s+\./g, '.')
-      .trim();
+    const sanitizedFileName = sanitizeHojaPdfFileName(fileName);
 
     const folderPath = `${folderBase}/${jobId}`;
     const filePath = `${folderPath}/${sanitizedFileName}`;
@@ -74,7 +82,8 @@ export const uploadPdfToJob = async (
       .from("job-documents")
       .upload(filePath, pdfBlob, {
         cacheControl: '3600',
-        upsert: false
+        upsert: false,
+        contentType: 'application/pdf',
       });
 
     console.log('Upload result:', { uploadData, uploadError });

--- a/supabase/functions/send-job-whatsapp-message/index.ts
+++ b/supabase/functions/send-job-whatsapp-message/index.ts
@@ -69,6 +69,187 @@ async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: numbe
   }
 }
 
+type SupabaseAdminClient = ReturnType<typeof createClient>;
+
+type HojaDocumentRow = {
+  id?: string;
+  file_name?: string | null;
+  file_path?: string | null;
+  file_type?: string | null;
+  uploaded_at?: string | null;
+};
+
+type HojaAttachment = {
+  source: "job_documents" | "tour_documents";
+  bucket: "job-documents" | "job_documents" | "tour-documents";
+  path: string;
+  filename: string;
+};
+
+const DEPT_PREFIXES = new Set(["sound", "lights", "video", "production", "logistics", "administrative"]);
+
+const normalizeObjectPath = (value: string | null | undefined) => (value || "").replace(/^\/+/, "");
+
+const normalizeText = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+const hasHojaDeRutaText = (doc: HojaDocumentRow) => {
+  const text = normalizeText(`${doc.file_name || ""} ${doc.file_path || ""}`);
+  return text.includes("hoja") && (text.includes("ruta") || text.includes("route"));
+};
+
+const isPdfDocument = (doc: HojaDocumentRow) => {
+  const text = normalizeText(`${doc.file_type || ""} ${doc.file_name || ""} ${doc.file_path || ""}`);
+  return text.includes("pdf");
+};
+
+function resolveJobDocumentBucket(filePath: string): "job-documents" | "job_documents" {
+  const first = normalizeObjectPath(filePath).split("/")[0] || "";
+  return DEPT_PREFIXES.has(first) ? "job_documents" : "job-documents";
+}
+
+function isJobHojaDeRutaDocument(doc: HojaDocumentRow, jobId: string): boolean {
+  const path = normalizeObjectPath(doc.file_path);
+  if (!path) return false;
+  if (!isPdfDocument(doc)) return false;
+  if (path.startsWith(`hojas-de-ruta/${jobId}/`)) return true;
+  if (path.startsWith("hojas-de-ruta/") && hasHojaDeRutaText(doc)) return true;
+  if (path.startsWith(`${jobId}/`) && hasHojaDeRutaText(doc)) return true;
+  return hasHojaDeRutaText(doc);
+}
+
+function isTourHojaDeRutaDocument(doc: HojaDocumentRow): boolean {
+  const path = normalizeObjectPath(doc.file_path);
+  if (!path) return false;
+  if (!isPdfDocument(doc)) return false;
+  if (path.startsWith("hojas-de-ruta/")) return true;
+  return hasHojaDeRutaText(doc);
+}
+
+function toHojaAttachment(
+  source: HojaAttachment["source"],
+  doc: HojaDocumentRow,
+  bucket: HojaAttachment["bucket"],
+): HojaAttachment | null {
+  const path = normalizeObjectPath(doc.file_path);
+  if (!path) return null;
+  return {
+    source,
+    bucket,
+    path,
+    filename: (doc.file_name || "Hoja de Ruta.pdf").toString(),
+  };
+}
+
+async function findLatestJobHojaAttachment(
+  supabaseAdmin: SupabaseAdminClient,
+  jobId: string,
+): Promise<HojaAttachment | null> {
+  const { data, error } = await supabaseAdmin
+    .from("job_documents")
+    .select("id, file_name, file_path, file_type, uploaded_at")
+    .eq("job_id", jobId)
+    .order("uploaded_at", { ascending: false })
+    .limit(25);
+
+  if (error) throw error;
+
+  const doc = ((data || []) as HojaDocumentRow[]).find((row) => isJobHojaDeRutaDocument(row, jobId));
+  if (!doc?.file_path) return null;
+  return toHojaAttachment("job_documents", doc, resolveJobDocumentBucket(doc.file_path));
+}
+
+async function findLinkedHojaJobIdsForTourDate(
+  supabaseAdmin: SupabaseAdminClient,
+  tourDateId: string,
+  currentJobId: string,
+): Promise<string[]> {
+  const { data, error } = await supabaseAdmin
+    .from("hoja_de_ruta")
+    .select("job_id")
+    .eq("tour_date_id", tourDateId)
+    .order("created_at", { ascending: false })
+    .limit(10);
+
+  if (error) throw error;
+
+  return Array.from(new Set(
+    ((data || []) as Array<{ job_id?: string | null }>)
+      .map((row) => row.job_id)
+      .filter((id): id is string => Boolean(id && id !== currentJobId))
+  ));
+}
+
+async function resolveTourIdFromTourDate(
+  supabaseAdmin: SupabaseAdminClient,
+  tourDateId: string | null,
+): Promise<string | null> {
+  if (!tourDateId) return null;
+
+  const { data, error } = await supabaseAdmin
+    .from("tour_dates")
+    .select("tour_id")
+    .eq("id", tourDateId)
+    .maybeSingle();
+
+  if (error) throw error;
+  const tourId = (data as { tour_id?: string | null } | null)?.tour_id;
+  return typeof tourId === "string" && tourId ? tourId : null;
+}
+
+async function findLatestTourHojaAttachment(
+  supabaseAdmin: SupabaseAdminClient,
+  tourId: string,
+): Promise<HojaAttachment | null> {
+  const { data, error } = await supabaseAdmin
+    .from("tour_documents")
+    .select("id, file_name, file_path, file_type, uploaded_at")
+    .eq("tour_id", tourId)
+    .order("uploaded_at", { ascending: false })
+    .limit(25);
+
+  if (error) throw error;
+
+  const doc = ((data || []) as HojaDocumentRow[]).find(isTourHojaDeRutaDocument);
+  return doc ? toHojaAttachment("tour_documents", doc, "tour-documents") : null;
+}
+
+async function resolveHojaAttachment(
+  supabaseAdmin: SupabaseAdminClient,
+  jobId: string,
+): Promise<HojaAttachment | null> {
+  const directJobDoc = await findLatestJobHojaAttachment(supabaseAdmin, jobId);
+  if (directJobDoc) return directJobDoc;
+
+  const { data: jobRow, error: jobErr } = await supabaseAdmin
+    .from("jobs")
+    .select("id, tour_id, tour_date_id")
+    .eq("id", jobId)
+    .maybeSingle();
+
+  if (jobErr) throw jobErr;
+
+  const jobContext = (jobRow || {}) as { tour_id?: string | null; tour_date_id?: string | null };
+  const tourDateId = typeof jobContext.tour_date_id === "string" ? jobContext.tour_date_id : null;
+
+  if (tourDateId) {
+    const linkedJobIds = await findLinkedHojaJobIdsForTourDate(supabaseAdmin, tourDateId, jobId);
+    for (const linkedJobId of linkedJobIds) {
+      const linkedJobDoc = await findLatestJobHojaAttachment(supabaseAdmin, linkedJobId);
+      if (linkedJobDoc) return linkedJobDoc;
+    }
+  }
+
+  const tourId = typeof jobContext.tour_id === "string" && jobContext.tour_id
+    ? jobContext.tour_id
+    : await resolveTourIdFromTourDate(supabaseAdmin, tourDateId);
+
+  return tourId ? findLatestTourHojaAttachment(supabaseAdmin, tourId) : null;
+}
+
 serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   if (req.method !== "POST") return jsonResponse({ error: "Method Not Allowed" }, { status: 405 });
@@ -137,26 +318,16 @@ serve(async (req: Request) => {
     const attachHojaDeRuta = Boolean(body.attach_hoja_de_ruta);
     let attachment: { url: string; filename: string } | null = null;
     if (attachHojaDeRuta) {
-      const { data: docRows, error: docErr } = await supabaseAdmin
-        .from("job_documents")
-        .select("file_name, file_path")
-        .eq("job_id", jobId)
-        .like("file_path", `hojas-de-ruta/${jobId}/%`)
-        .order("uploaded_at", { ascending: false })
-        .limit(1);
-
-      if (docErr) throw docErr;
-
-      const doc = docRows?.[0];
-      if (!doc?.file_path) {
+      const doc = await resolveHojaAttachment(supabaseAdmin, jobId);
+      if (!doc) {
         return jsonResponse({ error: "Bad Request", reason: "hoja_de_ruta_not_found" }, { status: 400 });
       }
 
       // 7 days: the link must stay alive in the chat, not just survive the send.
       // (Used both by sendFile and by the WAHA Core text-link fallback.)
       const { data: signed, error: signErr } = await supabaseAdmin.storage
-        .from("job-documents")
-        .createSignedUrl(doc.file_path, 60 * 60 * 24 * 7);
+        .from(doc.bucket)
+        .createSignedUrl(doc.path, 60 * 60 * 24 * 7);
 
       if (signErr || !signed?.signedUrl) {
         console.error("Failed to sign Hoja de Ruta URL:", signErr);
@@ -165,7 +336,7 @@ serve(async (req: Request) => {
 
       attachment = {
         url: signed.signedUrl,
-        filename: (doc.file_name || "Hoja de Ruta.pdf").toString(),
+        filename: doc.filename,
       };
     }
 

--- a/supabase/functions/send-job-whatsapp-message/index.ts
+++ b/supabase/functions/send-job-whatsapp-message/index.ts
@@ -250,9 +250,19 @@ async function resolveHojaAttachment(
   return tourId ? findLatestTourHojaAttachment(supabaseAdmin, tourId) : null;
 }
 
+function logRejection(
+  reason: string,
+  details: Record<string, unknown> = {},
+) {
+  console.warn("send-job-whatsapp-message rejected", { reason, ...details });
+}
+
 serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
-  if (req.method !== "POST") return jsonResponse({ error: "Method Not Allowed" }, { status: 405 });
+  if (req.method !== "POST") {
+    logRejection("method_not_allowed", { method: req.method });
+    return jsonResponse({ error: "Method Not Allowed" }, { status: 405 });
+  }
 
   try {
     const supabaseAdmin = createClient(
@@ -261,9 +271,11 @@ serve(async (req: Request) => {
     );
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) {
+      logRejection("missing_authorization_header");
       return jsonResponse({ error: "Unauthorized", reason: "Missing Authorization header" }, { status: 401 });
     }
     if (!authHeader.startsWith("Bearer ")) {
+      logRejection("invalid_auth_scheme");
       return jsonResponse({ error: "Unauthorized", reason: "Invalid auth scheme" }, { status: 401 });
     }
 
@@ -271,6 +283,7 @@ serve(async (req: Request) => {
     const { data: userData } = await supabaseAdmin.auth.getUser(token);
     const actorId = userData?.user?.id || null;
     if (!actorId) {
+      logRejection("invalid_actor");
       return jsonResponse({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -284,10 +297,12 @@ serve(async (req: Request) => {
     const dept = normalizeDept(actorProfile?.department || null);
 
     if (!(role === "admin" || dept === "production")) {
+      logRejection("forbidden_actor", { actorId, role, department: actorProfile?.department || null });
       return jsonResponse({ error: "Forbidden" }, { status: 403 });
     }
 
     if (!actorProfile?.waha_endpoint) {
+      logRejection("missing_waha_endpoint", { actorId, role, department: actorProfile?.department || null });
       return jsonResponse({ error: "Forbidden", reason: "User not authorized for WhatsApp operations" }, { status: 403 });
     }
 
@@ -298,18 +313,22 @@ serve(async (req: Request) => {
     const jobId = (body.job_id || "").toString().trim();
 
     if (!message) {
+      logRejection("empty_message", { actorId, jobId: jobId || null });
       return jsonResponse({ error: "Bad Request", reason: "Empty message" }, { status: 400 });
     }
 
     if (!jobId) {
+      logRejection("missing_job_id", { actorId });
       return jsonResponse({ error: "Bad Request", reason: "Missing job_id" }, { status: 400 });
     }
 
     if (dedupedRecipientIds.length === 0) {
+      logRejection("no_recipients", { actorId, jobId });
       return jsonResponse({ error: "Bad Request", reason: "No recipients" }, { status: 400 });
     }
 
     if (dedupedRecipientIds.length > 80) {
+      logRejection("too_many_recipients", { actorId, jobId, recipientCount: dedupedRecipientIds.length });
       return jsonResponse({ error: "Bad Request", reason: "Too many recipients" }, { status: 400 });
     }
 
@@ -320,6 +339,7 @@ serve(async (req: Request) => {
     if (attachHojaDeRuta) {
       const doc = await resolveHojaAttachment(supabaseAdmin, jobId);
       if (!doc) {
+        logRejection("hoja_de_ruta_not_found", { actorId, jobId });
         return jsonResponse({ error: "Bad Request", reason: "hoja_de_ruta_not_found" }, { status: 400 });
       }
 
@@ -352,6 +372,7 @@ serve(async (req: Request) => {
     const allowedIds = new Set((assignmentRows || []).map((r) => r.technician_id as string));
     const disallowed = dedupedRecipientIds.filter((id) => !allowedIds.has(id));
     if (disallowed.length > 0) {
+      logRejection("disallowed_recipients", { actorId, jobId, disallowedCount: disallowed.length });
       return jsonResponse(
         {
           error: "Forbidden",
@@ -375,6 +396,13 @@ serve(async (req: Request) => {
       dailyLimit: dailyRecipientLimit,
     });
     if (!quota.allowed) {
+      logRejection("daily_quota_exceeded", {
+        actorId,
+        jobId,
+        recipientCount: dedupedRecipientIds.length,
+        usedToday: quota.usedToday,
+        dailyLimit: quota.dailyLimit,
+      });
       return jsonResponse(
         {
           error: "Too Many Requests",

--- a/supabase/functions/send-job-whatsapp-message/index.ts
+++ b/supabase/functions/send-job-whatsapp-message/index.ts
@@ -73,6 +73,7 @@ type SupabaseAdminClient = ReturnType<typeof createClient>;
 
 type HojaDocumentRow = {
   id?: string;
+  job_id?: string | null;
   file_name?: string | null;
   file_path?: string | null;
   file_type?: string | null;
@@ -102,9 +103,21 @@ const hasHojaDeRutaText = (doc: HojaDocumentRow) => {
 };
 
 const isPdfDocument = (doc: HojaDocumentRow) => {
-  const text = normalizeText(`${doc.file_type || ""} ${doc.file_name || ""} ${doc.file_path || ""}`);
-  return text.includes("pdf");
+  const mimeType = (doc.file_type || "").split(";")[0].trim().toLowerCase();
+  if (mimeType === "application/pdf") return true;
+
+  return [doc.file_name, doc.file_path].some((value) =>
+    /\.pdf$/i.test(normalizeObjectPath(value))
+  );
 };
+
+const uploadedAtMs = (doc: HojaDocumentRow) => {
+  const value = doc.uploaded_at ? Date.parse(doc.uploaded_at) : NaN;
+  return Number.isFinite(value) ? value : 0;
+};
+
+const byNewestUpload = (a: HojaDocumentRow, b: HojaDocumentRow) =>
+  uploadedAtMs(b) - uploadedAtMs(a);
 
 function resolveJobDocumentBucket(filePath: string): "job-documents" | "job_documents" {
   const first = normalizeObjectPath(filePath).split("/")[0] || "";
@@ -157,7 +170,35 @@ async function findLatestJobHojaAttachment(
 
   if (error) throw error;
 
-  const doc = ((data || []) as HojaDocumentRow[]).find((row) => isJobHojaDeRutaDocument(row, jobId));
+  const doc = ((data || []) as HojaDocumentRow[])
+    .filter((row) => isJobHojaDeRutaDocument(row, jobId))
+    .sort(byNewestUpload)[0];
+  if (!doc?.file_path) return null;
+  return toHojaAttachment("job_documents", doc, resolveJobDocumentBucket(doc.file_path));
+}
+
+async function findLatestLinkedJobHojaAttachment(
+  supabaseAdmin: SupabaseAdminClient,
+  linkedJobIds: string[],
+): Promise<HojaAttachment | null> {
+  if (linkedJobIds.length === 0) return null;
+
+  const { data, error } = await supabaseAdmin
+    .from("job_documents")
+    .select("id, job_id, file_name, file_path, file_type, uploaded_at")
+    .in("job_id", linkedJobIds)
+    .order("uploaded_at", { ascending: false });
+
+  if (error) throw error;
+
+  const linkedJobIdSet = new Set(linkedJobIds);
+  const doc = ((data || []) as HojaDocumentRow[])
+    .filter((row) => {
+      const rowJobId = row.job_id || null;
+      return Boolean(rowJobId && linkedJobIdSet.has(rowJobId) && isJobHojaDeRutaDocument(row, rowJobId));
+    })
+    .sort(byNewestUpload)[0];
+
   if (!doc?.file_path) return null;
   return toHojaAttachment("job_documents", doc, resolveJobDocumentBucket(doc.file_path));
 }
@@ -171,8 +212,7 @@ async function findLinkedHojaJobIdsForTourDate(
     .from("hoja_de_ruta")
     .select("job_id")
     .eq("tour_date_id", tourDateId)
-    .order("created_at", { ascending: false })
-    .limit(10);
+    .order("created_at", { ascending: false });
 
   if (error) throw error;
 
@@ -213,7 +253,9 @@ async function findLatestTourHojaAttachment(
 
   if (error) throw error;
 
-  const doc = ((data || []) as HojaDocumentRow[]).find(isTourHojaDeRutaDocument);
+  const doc = ((data || []) as HojaDocumentRow[])
+    .filter(isTourHojaDeRutaDocument)
+    .sort(byNewestUpload)[0];
   return doc ? toHojaAttachment("tour_documents", doc, "tour-documents") : null;
 }
 
@@ -237,10 +279,8 @@ async function resolveHojaAttachment(
 
   if (tourDateId) {
     const linkedJobIds = await findLinkedHojaJobIdsForTourDate(supabaseAdmin, tourDateId, jobId);
-    for (const linkedJobId of linkedJobIds) {
-      const linkedJobDoc = await findLatestJobHojaAttachment(supabaseAdmin, linkedJobId);
-      if (linkedJobDoc) return linkedJobDoc;
-    }
+    const linkedJobDoc = await findLatestLinkedJobHojaAttachment(supabaseAdmin, linkedJobIds);
+    if (linkedJobDoc) return linkedJobDoc;
   }
 
   const tourId = typeof jobContext.tour_id === "string" && jobContext.tour_id
@@ -295,13 +335,14 @@ serve(async (req: Request) => {
 
     const role = (actorProfile?.role || "").toLowerCase();
     const dept = normalizeDept(actorProfile?.department || null);
+    const wahaEndpoint = (actorProfile?.waha_endpoint || "").trim();
 
     if (!(role === "admin" || dept === "production")) {
       logRejection("forbidden_actor", { actorId, role, department: actorProfile?.department || null });
       return jsonResponse({ error: "Forbidden" }, { status: 403 });
     }
 
-    if (!actorProfile?.waha_endpoint) {
+    if (!wahaEndpoint) {
       logRejection("missing_waha_endpoint", { actorId, role, department: actorProfile?.department || null });
       return jsonResponse({ error: "Forbidden", reason: "User not authorized for WhatsApp operations" }, { status: 403 });
     }
@@ -437,7 +478,7 @@ serve(async (req: Request) => {
 
     type WahaConfigRow = { session?: string; api_key?: string };
 
-    const base = normalizeBase(actorProfile.waha_endpoint);
+    const base = normalizeBase(wahaEndpoint);
     const { data: cfg, error: cfgErr } = await supabaseAdmin.rpc("get_waha_config", { base_url: base });
     if (cfgErr) console.warn("get_waha_config RPC failed, falling back to env vars:", cfgErr.message);
     const row = (cfg as WahaConfigRow[] | null)?.[0];


### PR DESCRIPTION
## What changed

- Broadened the production WhatsApp Hoja de Ruta attachment lookup so tour-date jobs can find the latest generated Hoja PDF from the current job, a linked tour-date Hoja job, or a tour-level Hoja document.
- Added shared client-side matching for Hoja de Ruta PDF documents, including current `hojas-de-ruta/<jobId>/...` paths and legacy job-scoped paths.
- Updated `send-job-whatsapp-message` to resolve the matching document server-side before sending any text, then sign the correct storage bucket (`job-documents`, legacy `job_documents`, or `tour-documents`).
- Addressed review feedback by fetching all linked tour-date Hoja candidates, selecting the newest linked job attachment by `uploaded_at`, trimming WAHA endpoints before validation/use, and requiring strict PDF MIME or final `.pdf` extension checks.
- Surfaced structured Edge Function rejection reasons in the production WhatsApp dialog instead of only showing the generic Supabase invoke error.
- Added low-noise warning logs for expected early Edge Function rejections such as missing WAHA endpoint, forbidden actor, empty message, missing Hoja de Ruta, disallowed recipients, and quota failures.
- Normalized generated Hoja upload filenames to remove diacritics, covering names like `Fiestas Populares Torrejón`, and explicitly upload generated PDFs with `contentType: application/pdf`.
- Added matcher/upload tests covering current paths, legacy paths, linked-job candidate ordering, tour documents, generic schedules, non-PDF lookalikes, unsafe `.pdf.exe` names, MIME-only PDFs, and generated filename normalization.
- Documented the newly surfaced npm advisory `1120782` as a targeted governance exception because it is pulled through the latest `@capacitor/assets` release and npm reports no safe fix path for that nested `@capacitor/cli` 5.x dependency.

## Root cause

The WhatsApp flow only looked for `job_documents` rows under `hojas-de-ruta/<jobId>/...` and always signed from `job-documents`. Tour-date and legacy/generated document records can be linked through `hoja_de_ruta.tour_date_id` or live in a different document bucket/path, so the checkbox could be disabled or the Edge Function could reject the attachment as `hoja_de_ruta_not_found`.

The linked tour-date fallback also selected the first linked job with a document rather than the newest candidate across the linked set. Server PDF detection was too loose, and whitespace-only WAHA endpoints could pass initial validation before failing downstream.

## Impact

Production users should now be able to attach a generated Hoja de Ruta PDF when sending job WhatsApp messages for tour dates, while the Edge Function still fails before sending any text if no valid PDF can be resolved.

For Ricardo Barco / WAHA5, the pasted profile should pass the server authorization checks because the profile has `department: production`, `role: management`, and `waha_endpoint: https://waha5.sector-pro.work`. If the request reaches `send-job-whatsapp-message` and exits early, the function should now emit a structured rejection warning and the UI should show the specific returned reason.

For the single job `Fiestas Populares Torrejón`, generated Hoja PDF auto-upload now avoids accented storage filenames while keeping the document name readable.

## Validation

- `npm run lint` — passed with existing warnings
- `npm run test:run` — 162 files, 1007 tests passed
- `npm run build` — passed, with existing Vite chunk warnings
- `npm run typecheck` — passed
- `npm run governance` — passed
- Focused tests for Hoja attachment matching and Hoja upload filename normalization — passed