### PR TITLE
[codex] Add tour package size defaults

### DIFF
--- a/src/components/dashboard/TourChips.tsx
+++ b/src/components/dashboard/TourChips.tsx
@@ -50,6 +50,13 @@ export const TourChips = ({ onTourClick, readOnly = false }: TourChipsProps) => 
           tour_dates (
             id,
             date,
+            is_tour_pack_only,
+            sound_package_size,
+            lights_package_size,
+            video_package_size,
+            sound_default_set_id,
+            lights_default_set_id,
+            video_default_set_id,
             location:locations (name)
           )
         `)

--- a/src/components/jobs/EditJobDialog.tsx
+++ b/src/components/jobs/EditJobDialog.tsx
@@ -466,7 +466,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-h-[90vh] md:max-h-none md:h-auto overflow-y-auto md:overflow-visible">
+        <DialogContent className="w-[95vw] max-w-lg max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit Job</DialogTitle>
           </DialogHeader>

--- a/src/components/jobs/cards/JobCardHeader.tsx
+++ b/src/components/jobs/cards/JobCardHeader.tsx
@@ -11,6 +11,11 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useJobDistance } from "@/hooks/useJobDistance";
 import { getDateTypeMeta } from "@/constants/dateTypes";
 import { canEditJobs } from "@/utils/permissions";
+import {
+  getDepartmentPackageSize,
+  getPackageBadgeLabel,
+  isPackageDepartment,
+} from "@/utils/tourPackages";
 
 interface JobCardHeaderProps {
   job: any;
@@ -37,6 +42,10 @@ export const JobCardHeader: React.FC<JobCardHeaderProps> = ({
 }) => {
   const isMobile = useIsMobile();
   const distance = useJobDistance(job);
+  const packageDepartment = isPackageDepartment(department) ? department : null;
+  const packageSize = packageDepartment
+    ? getDepartmentPackageSize(job.tour_date, packageDepartment)
+    : null;
 
   const getDateTypeIcon = (jobId: string, date: Date, dateTypes: Record<string, any>) => {
     const key = `${jobId}-${format(date, "yyyy-MM-dd")}`;
@@ -75,11 +84,14 @@ export const JobCardHeader: React.FC<JobCardHeaderProps> = ({
             {getDateTypeIcon(job.id, new Date(job.start_time), dateTypes)}
             <h3 className={cn("font-medium break-words leading-tight", isMobile ? "text-base" : "text-lg")}>{job.title}</h3>
             {getBadgeForJobType(job.job_type)}
-            {job.tour_date?.is_tour_pack_only && (
+            {packageDepartment && packageSize && (
               <Badge className={cn("ml-2 gap-1 bg-blue-100 text-blue-700 hover:bg-blue-100", isMobile && "text-xs")}>
                 <Package className="h-3 w-3" />
-                <span className={cn(isMobile && "hidden")}>Tour Pack Only</span>
-                <span className={cn(!isMobile && "hidden")}>TP Only</span>
+                {getPackageBadgeLabel({
+                  department: packageDepartment,
+                  packageSize,
+                  mobile: isMobile,
+                })}
               </Badge>
             )}
             {job.invoicing_company && (

--- a/src/components/jobs/cards/__tests__/JobCardHeader.test.tsx
+++ b/src/components/jobs/cards/__tests__/JobCardHeader.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { JobCardHeader } from '../JobCardHeader';
+
+const { isMobileMock } = vi.hoisted(() => ({
+  isMobileMock: vi.fn(() => false),
+}));
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => isMobileMock(),
+}));
+
+vi.mock('@/hooks/useJobDistance', () => ({
+  useJobDistance: (): string | null => null,
+}));
+
+vi.mock('@/components/jobs/JobStatusSelector', () => ({
+  JobStatusSelector: (): null => null,
+}));
+
+const baseJob = {
+  id: 'job-1',
+  title: 'Tour Date Job',
+  job_type: 'tourdate',
+  start_time: '2026-06-16T08:00:00.000Z',
+  end_time: '2026-06-16T22:00:00.000Z',
+  location: { name: 'Bilbao Arena' },
+};
+
+const renderHeader = (job: any, department: any = 'sound') =>
+  render(
+    <JobCardHeader
+      job={job}
+      collapsed
+      onToggleCollapse={vi.fn()}
+      appliedBorderColor=""
+      appliedBgColor=""
+      dateTypes={{}}
+      department={department}
+    />
+  );
+
+describe('JobCardHeader package badges', () => {
+  beforeEach(() => {
+    isMobileMock.mockReturnValue(false);
+  });
+
+  it('renders Sound XL for a sound package date', () => {
+    renderHeader({
+      ...baseJob,
+      tour_date: { sound_package_size: 'xl', is_tour_pack_only: false },
+    });
+
+    expect(screen.getByText('Sound XL')).toBeInTheDocument();
+  });
+
+  it('renders Lights M and Video S for the current department only', () => {
+    const job = {
+      ...baseJob,
+      tour_date: {
+        sound_package_size: 'xl',
+        lights_package_size: 'm',
+        video_package_size: 's',
+        is_tour_pack_only: false,
+      },
+    };
+
+    const { rerender } = renderHeader(job, 'lights');
+    expect(screen.getByText('Lights M')).toBeInTheDocument();
+    expect(screen.queryByText('Sound XL')).not.toBeInTheDocument();
+
+    rerender(
+      <JobCardHeader
+        job={job}
+        collapsed
+        onToggleCollapse={vi.fn()}
+        appliedBorderColor=""
+        appliedBgColor=""
+        dateTypes={{}}
+        department="video"
+      />
+    );
+    expect(screen.getByText('Video S')).toBeInTheDocument();
+    expect(screen.queryByText('Lights M')).not.toBeInTheDocument();
+  });
+
+  it('uses legacy tour pack as S fallback for the viewed department', () => {
+    renderHeader({
+      ...baseJob,
+      tour_date: { is_tour_pack_only: true },
+    }, 'video');
+
+    expect(screen.getByText('Video S')).toBeInTheDocument();
+  });
+
+  it('renders no package badge when no package intent exists', () => {
+    renderHeader({
+      ...baseJob,
+      tour_date: { is_tour_pack_only: false },
+    });
+
+    expect(screen.queryByText(/Sound|Lights|Video/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Tour Pack Only')).not.toBeInTheDocument();
+    expect(screen.queryByText('TP Only')).not.toBeInTheDocument();
+  });
+
+  it('renders mobile compact labels', () => {
+    isMobileMock.mockReturnValue(true);
+    renderHeader({
+      ...baseJob,
+      tour_date: { sound_package_size: 'xl', is_tour_pack_only: false },
+    });
+
+    expect(screen.getByText('SX XL')).toBeInTheDocument();
+  });
+});

--- a/src/components/tours/RequestTourAvailabilityDialog.tsx
+++ b/src/components/tours/RequestTourAvailabilityDialog.tsx
@@ -9,7 +9,15 @@ import { buildTourSchedulePdfBlob } from '@/lib/tourPdfExport';
 import { uploadTourPdfWithRecord } from '@/utils/tourDocumentsUpload';
 import { isDepartmentManagementRole, isTechnicianRole } from '@/utils/permissions';
 
-type TourDateLite = { id: string; date: string; location?: { name?: string | null } | null; is_tour_pack_only?: boolean | null };
+type TourDateLite = {
+  id: string;
+  date: string;
+  location?: { name?: string | null } | null;
+  is_tour_pack_only?: boolean | null;
+  sound_package_size?: 'xl' | 'l' | 'm' | 's' | null;
+  lights_package_size?: 'xl' | 'l' | 'm' | 's' | null;
+  video_package_size?: 'xl' | 'l' | 'm' | 's' | null;
+};
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -48,7 +56,7 @@ export const RequestTourAvailabilityDialog: React.FC<Props> = ({ open, onOpenCha
       try {
         if (tourDates && tourDates.length) { setDates(tourDates); return; }
         const { data, error } = await dataLayerClient.from('tour_dates')
-          .select('id, date, is_tour_pack_only, location:locations(name)')
+          .select('id, date, is_tour_pack_only, sound_package_size, lights_package_size, video_package_size, location:locations(name)')
           .eq('tour_id', tourId)
           .order('date', { ascending: true });
         if (error) throw error;

--- a/src/components/tours/TourDateManagementDialog.tsx
+++ b/src/components/tours/TourDateManagementDialog.tsx
@@ -21,9 +21,9 @@ import {
   Edit,
   Package,
   Clock,
+  AlertTriangle,
 } from "lucide-react";
 import { TourDateFormFields } from "./TourDateFormFields";
-import { TourDateListItem } from "./TourDateListItem";
 import { useLocationManagement, LocationDetails } from "@/hooks/useLocationManagement";
 import { useTourDateRealtime } from "@/hooks/useTourDateRealtime";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -43,6 +43,19 @@ import {
   isSingleDayDateType,
   TOUR_DATE_TYPE_OPTIONS,
 } from "@/constants/dateTypes";
+import { useTourDefaultSets } from "@/hooks/useTourDefaultSets";
+import {
+  DEPARTMENT_PACKAGE_LABELS,
+  PACKAGE_DEPARTMENTS,
+  TOUR_PACKAGE_LABELS,
+  TOUR_PACKAGE_SIZES,
+  getDepartmentDefaultSetId,
+  getDepartmentPackageSize,
+  getPackageBadgeLabel,
+  resolveDefaultSetForTourDate,
+  type PackageDepartment,
+  type TourPackageSize,
+} from "@/utils/tourPackages";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -68,6 +81,12 @@ interface TourDateObject {
   start_date?: string;
   end_date?: string;
   is_tour_pack_only?: boolean;
+  sound_package_size?: TourPackageSize | null;
+  lights_package_size?: TourPackageSize | null;
+  video_package_size?: TourPackageSize | null;
+  sound_default_set_id?: string | null;
+  lights_default_set_id?: string | null;
+  video_default_set_id?: string | null;
 }
 
 interface TourDateManagementDialogProps {
@@ -86,6 +105,24 @@ const buildTourDateJobTitle = (tourName: string, location: string, tourDateType:
   return `${tourName} - ${getDateTypeMeta(tourDateType)?.labelEs || tourDateType} (${safeLocation})`;
 };
 
+type PackageSelectionState = Record<PackageDepartment, TourPackageSize | null>;
+type DefaultSetSelectionState = Record<PackageDepartment, string | null>;
+
+const emptyPackageSelection = (): PackageSelectionState => ({
+  sound: null,
+  lights: null,
+  video: null,
+});
+
+const emptyDefaultSetSelection = (): DefaultSetSelectionState => ({
+  sound: null,
+  lights: null,
+  video: null,
+});
+
+const packageSelectValue = (value: TourPackageSize | null) => value ?? "unassigned";
+const defaultSetSelectValue = (value: string | null) => value ?? "auto";
+
 export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> = ({
   open,
   onOpenChange,
@@ -96,6 +133,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { getOrCreateLocation, getOrCreateLocationWithDetails } = useLocationManagement();
+  const { defaultSets } = useTourDefaultSets(tourId || "");
 
   // Add real-time subscriptions
   const tourDateIds = React.useMemo(() => tourDates.map(d => d.id), [tourDates]);
@@ -115,6 +153,8 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
   const [editStartDate, setEditStartDate] = useState<string>("");
   const [editEndDate, setEditEndDate] = useState<string>("");
   const [editTourPackOnly, setEditTourPackOnly] = useState<boolean>(false);
+  const [editPackageSizes, setEditPackageSizes] = useState<PackageSelectionState>(emptyPackageSelection);
+  const [editDefaultSetIds, setEditDefaultSetIds] = useState<DefaultSetSelectionState>(emptyDefaultSetSelection);
   const [isDeletingDate, setIsDeletingDate] = useState<string | null>(null);
 
   // New date form state
@@ -124,6 +164,8 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
   const [newStartDate, setNewStartDate] = useState<string>("");
   const [newEndDate, setNewEndDate] = useState<string>("");
   const [newTourPackOnly, setNewTourPackOnly] = useState<boolean>(false);
+  const [newPackageSizes, setNewPackageSizes] = useState<PackageSelectionState>(emptyPackageSelection);
+  const [newDefaultSetIds, setNewDefaultSetIds] = useState<DefaultSetSelectionState>(emptyDefaultSetSelection);
   const [editLocationDetails, setEditLocationDetails] = useState<LocationDetails | null>(null);
 
   const { data: foldersExistenceMap } = useQuery({
@@ -145,12 +187,165 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
     enabled: tourDates.length > 0,
   });
 
+  const getUniqueDefaultSetId = (
+    department: PackageDepartment,
+    packageSize: TourPackageSize | null
+  ) => {
+    if (!packageSize) return null;
+    const matches = defaultSets.filter(
+      (set) => set.department === department && set.package_size === packageSize
+    );
+    return matches.length === 1 ? matches[0].id : null;
+  };
+
+  const buildPackageUpdatePayload = (
+    packageSizes: PackageSelectionState,
+    defaultSetIds: DefaultSetSelectionState
+  ) => ({
+    sound_package_size: packageSizes.sound,
+    lights_package_size: packageSizes.lights,
+    video_package_size: packageSizes.video,
+    sound_default_set_id:
+      defaultSetIds.sound || getUniqueDefaultSetId("sound", packageSizes.sound),
+    lights_default_set_id:
+      defaultSetIds.lights || getUniqueDefaultSetId("lights", packageSizes.lights),
+    video_default_set_id:
+      defaultSetIds.video || getUniqueDefaultSetId("video", packageSizes.video),
+  });
+
+  const applyTourPackShortcut = (
+    checked: boolean,
+    setTourPackOnly: (value: boolean) => void,
+    setPackageSizes: React.Dispatch<React.SetStateAction<PackageSelectionState>>,
+    setDefaultSetIds: React.Dispatch<React.SetStateAction<DefaultSetSelectionState>>
+  ) => {
+    setTourPackOnly(checked);
+    setPackageSizes(checked ? { sound: "s", lights: "s", video: "s" } : emptyPackageSelection());
+    setDefaultSetIds(emptyDefaultSetSelection());
+  };
+
+  const updatePackageSize = (
+    department: PackageDepartment,
+    value: string,
+    setPackageSizes: React.Dispatch<React.SetStateAction<PackageSelectionState>>,
+    setDefaultSetIds: React.Dispatch<React.SetStateAction<DefaultSetSelectionState>>
+  ) => {
+    const packageSize = value === "unassigned" ? null : (value as TourPackageSize);
+    setPackageSizes((prev) => ({ ...prev, [department]: packageSize }));
+    setDefaultSetIds((prev) => ({
+      ...prev,
+      [department]: prev[department] && packageSize ? prev[department] : null,
+    }));
+  };
+
+  const renderPackageControls = ({
+    packageSizes,
+    setPackageSizes,
+    defaultSetIds,
+    setDefaultSetIds,
+  }: {
+    packageSizes: PackageSelectionState;
+    setPackageSizes: React.Dispatch<React.SetStateAction<PackageSelectionState>>;
+    defaultSetIds: DefaultSetSelectionState;
+    setDefaultSetIds: React.Dispatch<React.SetStateAction<DefaultSetSelectionState>>;
+  }) => (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+      {PACKAGE_DEPARTMENTS.map((department) => {
+        const packageSize = packageSizes[department];
+        const selectableSets = defaultSets.filter(
+          (set) =>
+            set.department === department &&
+            (!packageSize || !set.package_size || set.package_size === packageSize)
+        );
+
+        return (
+          <div key={department} className="space-y-2 rounded-md border p-3">
+            <Label htmlFor={`${department}-package-size`} className="text-xs md:text-sm">
+              {DEPARTMENT_PACKAGE_LABELS[department]}
+            </Label>
+            <Select
+              value={packageSelectValue(packageSize)}
+              onValueChange={(value) =>
+                updatePackageSize(department, value, setPackageSizes, setDefaultSetIds)
+              }
+            >
+              <SelectTrigger id={`${department}-package-size`}>
+                <SelectValue placeholder="Package size" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="unassigned">Unassigned</SelectItem>
+                {TOUR_PACKAGE_SIZES.map((size) => (
+                  <SelectItem key={size} value={size}>
+                    {TOUR_PACKAGE_LABELS[size]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={defaultSetSelectValue(defaultSetIds[department])}
+              onValueChange={(value) =>
+                setDefaultSetIds((prev) => ({
+                  ...prev,
+                  [department]: value === "auto" ? null : value,
+                }))
+              }
+            >
+              <SelectTrigger aria-label={`${DEPARTMENT_PACKAGE_LABELS[department]} default set`}>
+                <SelectValue placeholder="Default set" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">Auto / no pin</SelectItem>
+                {selectableSets.map((set) => (
+                  <SelectItem key={set.id} value={set.id}>
+                    {set.name}
+                    {set.package_size ? ` (${TOUR_PACKAGE_LABELS[set.package_size]})` : " (Unassigned)"}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const renderPackageBadges = (dateObj: TourDateObject) => {
+    const badges = PACKAGE_DEPARTMENTS.map((department) => {
+      const packageSize = getDepartmentPackageSize(dateObj, department);
+      if (!packageSize) return null;
+
+      const resolution = resolveDefaultSetForTourDate({
+        tourDate: dateObj,
+        department,
+        defaultSets,
+      });
+      const needsAttention = resolution.status !== "resolved";
+
+      return (
+        <div
+          key={department}
+          className="flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-700 rounded text-xs"
+        >
+          <Package className="h-3 w-3" />
+          <span>{getPackageBadgeLabel({ department, packageSize })}</span>
+          {needsAttention && <AlertTriangle className="h-3 w-3 text-amber-600" />}
+        </div>
+      );
+    }).filter(Boolean);
+
+    return badges.length > 0 ? (
+      <div className="flex flex-wrap items-center gap-1">{badges}</div>
+    ) : null;
+  };
+
   const handleAddDate = async (
     location: string,
     tourDateType: DateType = "show",
     startDate: string,
     endDate: string,
-    isTourPackOnly: boolean = false
+    isTourPackOnly: boolean = false,
+    packageSizes: PackageSelectionState = emptyPackageSelection(),
+    defaultSetIds: DefaultSetSelectionState = emptyDefaultSetSelection()
   ) => {
     try {
       if (!tourId) {
@@ -179,6 +374,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
           rehearsal_days: rehearsalDays,
           location_id: locationId,
           is_tour_pack_only: isTourPackOnly,
+          ...buildPackageUpdatePayload(packageSizes, defaultSetIds),
         })
         .select(`
           id,
@@ -188,6 +384,12 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
           tour_date_type,
           rehearsal_days,
           is_tour_pack_only,
+          sound_package_size,
+          lights_package_size,
+          video_package_size,
+          sound_default_set_id,
+          lights_default_set_id,
+          video_default_set_id,
           location:locations (
             id,
             name
@@ -302,7 +504,9 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
     tourDateType: DateType,
     startDate: string,
     endDate: string,
-    isTourPackOnly: boolean
+    isTourPackOnly: boolean,
+    packageSizes: PackageSelectionState,
+    defaultSetIds: DefaultSetSelectionState
   ) => {
     try {
       if (!tourId) {
@@ -338,12 +542,19 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
           rehearsal_days: rehearsalDays,
           location_id: locationId,
           is_tour_pack_only: isTourPackOnly,
+          ...buildPackageUpdatePayload(packageSizes, defaultSetIds),
         })
         .eq("id", dateId)
         .select(`
           id,
           date,
           is_tour_pack_only,
+          sound_package_size,
+          lights_package_size,
+          video_package_size,
+          sound_default_set_id,
+          lights_default_set_id,
+          video_default_set_id,
           location:locations (
             id,
             name
@@ -711,6 +922,16 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
     setEditLocationValue(dateObj.location?.name || "");
     setEditTourDateType(dateObj.tour_date_type || 'show');
     setEditTourPackOnly(dateObj.is_tour_pack_only || false);
+    setEditPackageSizes({
+      sound: getDepartmentPackageSize(dateObj, "sound"),
+      lights: getDepartmentPackageSize(dateObj, "lights"),
+      video: getDepartmentPackageSize(dateObj, "video"),
+    });
+    setEditDefaultSetIds({
+      sound: getDepartmentDefaultSetId(dateObj, "sound"),
+      lights: getDepartmentDefaultSetId(dateObj, "lights"),
+      video: getDepartmentDefaultSetId(dateObj, "video"),
+    });
 
     if (dateObj.location) {
       setEditLocationDetails({
@@ -734,6 +955,8 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
     setEditStartDate("");
     setEditEndDate("");
     setEditTourPackOnly(false);
+    setEditPackageSizes(emptyPackageSelection());
+    setEditDefaultSetIds(emptyDefaultSetSelection());
     setEditLocationDetails(null);
   };
 
@@ -744,7 +967,9 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
       editTourDateType,
       editStartDate,
       editEndDate,
-      editTourPackOnly
+      editTourPackOnly,
+      editPackageSizes,
+      editDefaultSetIds
     );
     cancelEditing();
   };
@@ -855,12 +1080,25 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
                             <Checkbox
                               id="tour-pack-only-edit"
                               checked={editTourPackOnly}
-                              onCheckedChange={(checked) => setEditTourPackOnly(checked as boolean)}
+                              onCheckedChange={(checked) =>
+                                applyTourPackShortcut(
+                                  checked as boolean,
+                                  setEditTourPackOnly,
+                                  setEditPackageSizes,
+                                  setEditDefaultSetIds
+                                )
+                              }
                             />
                             <Label htmlFor="tour-pack-only-edit" className="text-xs md:text-sm">
-                              Tour Pack Only (skip PA pullsheet)
+                              Tour Pack / S package
                             </Label>
                           </div>
+                          {renderPackageControls({
+                            packageSizes: editPackageSizes,
+                            setPackageSizes: setEditPackageSizes,
+                            defaultSetIds: editDefaultSetIds,
+                            setDefaultSetIds: setEditDefaultSetIds,
+                          })}
                           <div className="flex flex-col-reverse sm:flex-row gap-2">
                             <Button variant="outline" onClick={cancelEditing} className="w-full sm:w-auto">
                               Cancel
@@ -876,13 +1114,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
                             <div className="flex flex-wrap items-center gap-2 text-xs md:text-sm">
                               <Calendar className="h-4 w-4 flex-shrink-0" />
                               <span>{format(new Date(dateObj.date), "MMM d, yyyy")}</span>
-                              {dateObj.is_tour_pack_only && (
-                                <div className="flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-700 rounded text-xs">
-                                  <Package className="h-3 w-3" />
-                                  <span className="hidden sm:inline">Tour Pack Only</span>
-                                  <span className="sm:hidden">TP Only</span>
-                                </div>
-                              )}
+                              {renderPackageBadges(dateObj)}
                             </div>
                             {dateObj.location?.name && (
                               <div className="flex items-center gap-2 text-xs md:text-sm text-muted-foreground">
@@ -951,12 +1183,25 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
                     <Checkbox
                       id="tour-pack-only"
                       checked={newTourPackOnly}
-                      onCheckedChange={(checked) => setNewTourPackOnly(checked as boolean)}
+                      onCheckedChange={(checked) =>
+                        applyTourPackShortcut(
+                          checked as boolean,
+                          setNewTourPackOnly,
+                          setNewPackageSizes,
+                          setNewDefaultSetIds
+                        )
+                      }
                     />
                     <Label htmlFor="tour-pack-only" className="text-xs md:text-sm">
-                      Tour Pack Only (skip PA pullsheet)
+                      Tour Pack / S package
                     </Label>
                   </div>
+                  {renderPackageControls({
+                    packageSizes: newPackageSizes,
+                    setPackageSizes: setNewPackageSizes,
+                    defaultSetIds: newDefaultSetIds,
+                    setDefaultSetIds: setNewDefaultSetIds,
+                  })}
                   <Button
                     onClick={() => {
                       if (!newStartDate || !newLocation) {
@@ -972,7 +1217,9 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
                         newTourDateType,
                         newStartDate,
                         newEndDate || newStartDate,
-                        newTourPackOnly
+                        newTourPackOnly,
+                        newPackageSizes,
+                        newDefaultSetIds
                       );
                       // Reset form
                       setNewLocation("");
@@ -981,6 +1228,8 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
                       setNewStartDate("");
                       setNewEndDate("");
                       setNewTourPackOnly(false);
+                      setNewPackageSizes(emptyPackageSelection());
+                      setNewDefaultSetIds(emptyDefaultSetSelection());
                     }}
                     className="w-full touch-manipulation"
                   >

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -3,8 +3,12 @@ import React, { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { FileText, Weight, Calculator, Trash2, Download, Calendar } from "lucide-react";
+import { FileText, Weight, Calculator, Trash2, Download, Calendar, Copy, AlertTriangle } from "lucide-react";
 import { exportToPDF } from "@/utils/pdfExport";
 import { fetchTourLogo } from "@/utils/pdf/logoUtils";
 import { dataLayerClient } from "@/services/dataLayerClient";
@@ -16,6 +20,19 @@ import { buildNormalizedTourPowerTables, computePowerTotalVa } from "@/utils/tou
 import { getDepartmentLabel } from "@/types/department";
 import type { TechnicalPowerDepartment } from "@/utils/technicalPowerTypes";
 import { getResolvedPowerPosition } from "@/utils/powerPositions";
+import {
+  DEPARTMENT_PACKAGE_LABELS,
+  TOUR_PACKAGE_LABELS,
+  TOUR_PACKAGE_SIZES,
+  getDepartmentPackageSize,
+  getPackageBadgeLabel,
+  getPackageResolutionMessage,
+  getPackageSetLabel,
+  isPackageDepartment,
+  resolveDefaultSetForTourDate,
+  type PackageDepartment,
+  type TourPackageSize,
+} from "@/utils/tourPackages";
 
 interface TourDefaultsManagerProps {
   open: boolean;
@@ -35,6 +52,14 @@ type TourPowerDefaultRow =
 interface TourDateWithLocation {
   id: string;
   date: string;
+  tour_id?: string | null;
+  is_tour_pack_only?: boolean | null;
+  sound_package_size?: TourPackageSize | null;
+  lights_package_size?: TourPackageSize | null;
+  video_package_size?: TourPackageSize | null;
+  sound_default_set_id?: string | null;
+  lights_default_set_id?: string | null;
+  video_default_set_id?: string | null;
   locations?: { name: string | null } | Array<{ name: string | null }> | null;
 }
 
@@ -112,29 +137,33 @@ const getPdfTypeLabel = (type: 'power' | 'weight') =>
 const getDefaultsPdfTitle = (
   tourName: string,
   department: string,
-  type: 'power' | 'weight'
-) => `${tourName} - ${getDepartmentLabel(department)} ${getPdfTypeLabel(type)} predeterminados`;
+  type: 'power' | 'weight',
+  packageLabel?: string
+) => `${tourName} - ${packageLabel || getDepartmentLabel(department)} ${getPdfTypeLabel(type)} predeterminados`;
 
 const getDefaultsPdfFilename = (
   tourName: string,
   department: string,
-  type: 'power' | 'weight'
-) => `${tourName} - ${getDepartmentLabel(department)} ${getPdfTypeLabel(type)} predeterminados.pdf`;
+  type: 'power' | 'weight',
+  packageLabel?: string
+) => `${tourName} - ${packageLabel || getDepartmentLabel(department)} ${getPdfTypeLabel(type)} predeterminados.pdf`;
 
 const getTourDatePdfTitle = (
   tourName: string,
   locationName: string,
   department: string,
-  type: 'power' | 'weight'
-) => `${tourName} - ${locationName} - ${getDepartmentLabel(department)} ${getPdfTypeLabel(type)}`;
+  type: 'power' | 'weight',
+  packageLabel?: string
+) => `${tourName} - ${locationName} - ${packageLabel || getDepartmentLabel(department)} ${getPdfTypeLabel(type)}`;
 
 const getTourDatePdfFilename = (
   tourName: string,
   dateStr: string,
   locationName: string,
   department: string,
-  type: 'power' | 'weight'
-) => `${tourName} - ${dateStr} - ${locationName} - ${getDepartmentLabel(department)} ${getPdfTypeLabel(type)}.pdf`;
+  type: 'power' | 'weight',
+  packageLabel?: string
+) => `${tourName} - ${dateStr} - ${locationName} - ${packageLabel || getDepartmentLabel(department)} ${getPdfTypeLabel(type)}.pdf`;
 
 // Legacy types for backward compatibility
 interface TourPowerDefault {
@@ -172,14 +201,23 @@ export const TourDefaultsManager = ({
   const { toast } = useToast();
   const [activeTab, setActiveTab] = useState('sound');
   const [tourDates, setTourDates] = useState<TourDateWithLocation[]>([]);
+  const [newSetName, setNewSetName] = useState('');
+  const [newSetDescription, setNewSetDescription] = useState('');
+  const [newSetPackageSize, setNewSetPackageSize] = useState<TourPackageSize | null>(null);
 
   // Use the new tour default sets hook
   const {
     defaultSets,
     defaultTables,
     isLoading: defaultSetsLoading,
+    createSet,
+    updateSet,
+    duplicateSet,
     deleteSet,
     deleteTable,
+    isCreatingSet,
+    isUpdatingSet,
+    isDuplicatingSet,
     isDeletingSet,
     isDeletingTable
   } = useTourDefaultSets(tour?.id || '');
@@ -206,6 +244,14 @@ export const TourDefaultsManager = ({
         .select(`
           id,
           date,
+          tour_id,
+          is_tour_pack_only,
+          sound_package_size,
+          lights_package_size,
+          video_package_size,
+          sound_default_set_id,
+          lights_default_set_id,
+          video_default_set_id,
           locations (
             name
           )
@@ -313,6 +359,123 @@ export const TourDefaultsManager = ({
     }
   };
 
+  const handleCreateSet = async (department: string) => {
+    if (!tour?.id || !isPackageDepartment(department)) return;
+    const trimmedName = newSetName.trim();
+    if (!trimmedName) {
+      toast({
+        title: 'Nombre requerido',
+        description: 'Introduce un nombre para el conjunto.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      await createSet({
+        tour_id: tour.id,
+        name: trimmedName,
+        description: newSetDescription.trim() || null,
+        department,
+        package_size: newSetPackageSize,
+      });
+      setNewSetName('');
+      setNewSetDescription('');
+      setNewSetPackageSize(null);
+    } catch (error) {
+      console.error('Error creating set:', error);
+    }
+  };
+
+  const handleDuplicateSet = async (setId: string) => {
+    const sourceSet = defaultSets.find((set) => set.id === setId);
+    if (!sourceSet) return;
+
+    try {
+      await duplicateSet({
+        setId,
+        name: `${sourceSet.name} Copy`,
+        description: sourceSet.description,
+        package_size: sourceSet.package_size,
+      });
+    } catch (error) {
+      console.error('Error duplicating set:', error);
+    }
+  };
+
+  const updateSetPackageSize = async (setId: string, value: string) => {
+    await updateSet({
+      setId,
+      updates: {
+        package_size: value === 'unassigned' ? null : (value as TourPackageSize),
+      },
+    });
+  };
+
+  const getDuplicatePackageWarnings = (department: string) => {
+    if (!isPackageDepartment(department)) return [];
+    return TOUR_PACKAGE_SIZES.flatMap((packageSize) => {
+      const matches = defaultSets.filter(
+        (set) => set.department === department && set.package_size === packageSize
+      );
+      if (matches.length <= 1) return [];
+      return [{
+        packageSize,
+        message: `Multiple ${DEPARTMENT_PACKAGE_LABELS[department]} ${TOUR_PACKAGE_LABELS[packageSize]} default sets exist. Date/package auto-resolution will be ambiguous unless a specific set is selected.`,
+      }];
+    });
+  };
+
+  const renderSetMetadata = (set: typeof defaultSets[number]) => {
+    const packageSize = set.package_size || null;
+    return (
+      <div className="space-y-2 min-w-[220px]">
+        <Input
+          defaultValue={set.name}
+          aria-label={`${set.name} set name`}
+          onBlur={(event) => {
+            const nextName = event.target.value.trim();
+            if (nextName && nextName !== set.name) {
+              void updateSet({ setId: set.id, updates: { name: nextName } });
+            }
+          }}
+        />
+        <Input
+          defaultValue={set.description || ''}
+          aria-label={`${set.name} set description`}
+          placeholder="Description"
+          onBlur={(event) => {
+            const nextDescription = event.target.value.trim() || null;
+            if (nextDescription !== (set.description || null)) {
+              void updateSet({ setId: set.id, updates: { description: nextDescription } });
+            }
+          }}
+        />
+        <Select
+          value={packageSize || 'unassigned'}
+          onValueChange={(value) => void updateSetPackageSize(set.id, value)}
+        >
+          <SelectTrigger aria-label={`${set.name} package size`}>
+            <SelectValue placeholder="Package size" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="unassigned">Unassigned</SelectItem>
+            {TOUR_PACKAGE_SIZES.map((size) => (
+              <SelectItem key={size} value={size}>
+                {TOUR_PACKAGE_LABELS[size]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {isPackageDepartment(set.department) && packageSize && (
+          <Badge variant="outline">
+            {getPackageBadgeLabel({ department: set.department, packageSize })}
+          </Badge>
+        )}
+      </div>
+    );
+  };
+
   // Helper function to get table name based on format
   const getTableName = (table: CombinedDefaultType): string => {
     if (isNewFormatTable(table)) {
@@ -367,9 +530,38 @@ export const TourDefaultsManager = ({
     return undefined;
   };
 
-  const handleBulkPDFExport = async (department: string, type: 'power' | 'weight') => {
+  const handleBulkPDFExport = async (
+    department: string,
+    type: 'power' | 'weight',
+    options?: { setId?: string; packageLabel?: string }
+  ) => {
     try {
-      const relevantDefaults = getDepartmentDefaults(department, type);
+      const departmentSets = defaultSets.filter((set) => set.department === department);
+      let relevantDefaults: CombinedDefaultType[];
+      let packageLabel = options?.packageLabel;
+
+      if (options?.setId) {
+        relevantDefaults = defaultTables.filter(
+          (table) => table.set_id === options.setId && table.table_type === type
+        );
+      } else if (departmentSets.length === 1) {
+        const set = departmentSets[0];
+        packageLabel = isPackageDepartment(department)
+          ? getPackageSetLabel(department, set.package_size || null, set)
+          : set.name;
+        relevantDefaults = defaultTables.filter(
+          (table) => table.set_id === set.id && table.table_type === type
+        );
+      } else if (departmentSets.length > 1) {
+        toast({
+          title: 'Seleccione un paquete',
+          description: `Hay varios conjuntos de ${getDepartmentLabel(department)}. Exporta desde un conjunto específico para no mezclar paquetes.`,
+          variant: 'destructive',
+        });
+        return;
+      } else {
+        relevantDefaults = getDepartmentDefaults(department, type);
+      }
 
       if (relevantDefaults.length === 0) {
         toast({
@@ -404,7 +596,7 @@ export const TourDefaultsManager = ({
         };
 
         const pdfBlob = await exportToPDF(
-          getDefaultsPdfTitle(tour.name, department, type),
+          getDefaultsPdfTitle(tour.name, department, type, packageLabel),
           tables,
           type,
           tour.name,
@@ -415,7 +607,7 @@ export const TourDefaultsManager = ({
           logoUrl
         );
 
-        const fileName = getDefaultsPdfFilename(tour.name, department, type);
+        const fileName = getDefaultsPdfFilename(tour.name, department, type, packageLabel);
         const url = window.URL.createObjectURL(pdfBlob);
         const a = document.createElement('a');
         a.href = url;
@@ -508,7 +700,7 @@ export const TourDefaultsManager = ({
       })();
 
       const pdfBlob = await exportToPDF(
-        getDefaultsPdfTitle(tour.name, department, type),
+        getDefaultsPdfTitle(tour.name, department, type, packageLabel),
         tables,
         type,
         tour.name,
@@ -519,7 +711,7 @@ export const TourDefaultsManager = ({
         logoUrl
       );
 
-      const fileName = getDefaultsPdfFilename(tour.name, department, type);
+      const fileName = getDefaultsPdfFilename(tour.name, department, type, packageLabel);
       const url = window.URL.createObjectURL(pdfBlob);
       const a = document.createElement('a');
       a.href = url;
@@ -590,8 +782,39 @@ export const TourDefaultsManager = ({
     type: 'power' | 'weight',
     logoUrl?: string
   ): Promise<boolean> => {
-    // Get defaults for this department and type
-    const defaultsData = getDepartmentDefaults(department, type);
+    let defaultsData: CombinedDefaultType[] = [];
+    let packageLabel: string | undefined;
+
+    if (isPackageDepartment(department)) {
+      const resolution = resolveDefaultSetForTourDate({
+        tourDate,
+        department,
+        defaultSets,
+      });
+
+      if (resolution.status === 'resolved') {
+        defaultsData = defaultTables.filter(
+          (table) => table.set_id === resolution.set.id && table.table_type === type
+        );
+        packageLabel = getPackageSetLabel(department, resolution.packageSize, resolution.set);
+      } else if (
+        resolution.status === 'missing' &&
+        !getDepartmentPackageSize(tourDate, department) &&
+        defaultSets.filter((set) => set.department === department).length === 0
+      ) {
+        defaultsData = getDepartmentDefaults(department, type);
+      } else {
+        const message = getPackageResolutionMessage(resolution);
+        toast({
+          title: 'No se puede exportar el paquete',
+          description: message || 'Selecciona un conjunto de valores por defecto válido para esta fecha.',
+          variant: 'destructive',
+        });
+        return false;
+      }
+    } else {
+      defaultsData = getDepartmentDefaults(department, type);
+    }
 
     // Check for any overrides for this tour date
     const overrideTable = type === 'power' ? 'tour_date_power_overrides' : 'tour_date_weight_overrides';
@@ -632,7 +855,7 @@ export const TourDefaultsManager = ({
       const dateStr = tourDate.date;
 
       const pdfBlob = await exportToPDF(
-        getTourDatePdfTitle(tour.name, locationName, department, type),
+        getTourDatePdfTitle(tour.name, locationName, department, type, packageLabel),
         tables,
         type,
         `${tour.name} - ${locationName}`,
@@ -648,7 +871,8 @@ export const TourDefaultsManager = ({
         dateStr,
         locationName,
         department,
-        type
+        type,
+        packageLabel
       );
       const url = window.URL.createObjectURL(pdfBlob);
       const a = document.createElement('a');
@@ -753,7 +977,7 @@ export const TourDefaultsManager = ({
     const dateStr = tourDate.date; // Pass ISO string directly for proper parsing
 
     const pdfBlob = await exportToPDF(
-      getTourDatePdfTitle(tour.name, locationName, department, type),
+      getTourDatePdfTitle(tour.name, locationName, department, type, packageLabel),
       combinedTables,
       type,
       `${tour.name} - ${locationName}`, // Include location in jobName for header
@@ -769,7 +993,8 @@ export const TourDefaultsManager = ({
       dateStr,
       locationName,
       department,
-      type
+      type,
+      packageLabel
     );
     const url = window.URL.createObjectURL(pdfBlob);
     const a = document.createElement('a');
@@ -785,18 +1010,81 @@ export const TourDefaultsManager = ({
   const renderDepartmentDefaults = (department: string) => {
     const powerTables = getDepartmentDefaults(department, 'power');
     const weightTables = getDepartmentDefaults(department, 'weight');
+    const duplicateWarnings = getDuplicatePackageWarnings(department);
 
     // Group new format tables by sets
     const departmentSets = defaultSets.filter(set => set.department === department);
-    const powerSets = departmentSets.filter(set => 
-      defaultTables.some(table => table.set_id === set.id && table.table_type === 'power')
-    );
-    const weightSets = departmentSets.filter(set => 
-      defaultTables.some(table => table.set_id === set.id && table.table_type === 'weight')
-    );
+    const powerSets = departmentSets;
+    const weightSets = departmentSets;
 
     return (
       <div className="space-y-6">
+        {isPackageDepartment(department) && (
+          <div className="border rounded-lg p-4 space-y-3">
+            <h4 className="font-semibold">Crear conjunto de paquete</h4>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+              <div className="space-y-2 md:col-span-1">
+                <Label htmlFor={`${department}-new-set-name`}>Nombre</Label>
+                <Input
+                  id={`${department}-new-set-name`}
+                  value={newSetName}
+                  onChange={(event) => setNewSetName(event.target.value)}
+                  placeholder={`${DEPARTMENT_PACKAGE_LABELS[department]} package`}
+                />
+              </div>
+              <div className="space-y-2 md:col-span-1">
+                <Label htmlFor={`${department}-new-set-description`}>Descripción</Label>
+                <Input
+                  id={`${department}-new-set-description`}
+                  value={newSetDescription}
+                  onChange={(event) => setNewSetDescription(event.target.value)}
+                  placeholder="Optional"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Package size</Label>
+                <Select
+                  value={newSetPackageSize || 'unassigned'}
+                  onValueChange={(value) =>
+                    setNewSetPackageSize(value === 'unassigned' ? null : (value as TourPackageSize))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Package size" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="unassigned">Unassigned</SelectItem>
+                    {TOUR_PACKAGE_SIZES.map((size) => (
+                      <SelectItem key={size} value={size}>
+                        {TOUR_PACKAGE_LABELS[size]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-end">
+                <Button
+                  onClick={() => handleCreateSet(department)}
+                  disabled={isCreatingSet}
+                  className="w-full"
+                >
+                  Crear conjunto
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {duplicateWarnings.map((warning) => (
+          <div
+            key={warning.packageSize}
+            className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"
+          >
+            <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+            <span>{warning.message}</span>
+          </div>
+        ))}
+
         {/* Power Defaults */}
         <div>
           <div className="flex items-center justify-between mb-4">
@@ -835,21 +1123,43 @@ export const TourDefaultsManager = ({
             return (
               <div key={set.id} className="mb-6 border rounded-lg p-4 bg-gray-50">
                 <div className="flex justify-between items-start mb-3">
-                  <div>
-                    <h5 className="font-medium text-lg">{set.name}</h5>
-                    {set.description && (
-                      <p className="text-sm text-muted-foreground">{set.description}</p>
-                    )}
+                  {renderSetMetadata(set)}
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        handleBulkPDFExport(department, 'power', {
+                          setId: set.id,
+                          packageLabel: isPackageDepartment(department)
+                            ? getPackageSetLabel(department, set.package_size || null, set)
+                            : set.name,
+                        })
+                      }
+                      disabled={setTables.length === 0}
+                    >
+                      <FileText className="h-4 w-4 mr-1" />
+                      PDF
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleDuplicateSet(set.id)}
+                      disabled={isDuplicatingSet}
+                    >
+                      <Copy className="h-4 w-4 mr-1" />
+                      Duplicar
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDeleteSet(set.id)}
+                      disabled={isDeletingSet || isUpdatingSet}
+                      className="text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleDeleteSet(set.id)}
-                    disabled={isDeletingSet}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
                 </div>
                 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -965,21 +1275,43 @@ export const TourDefaultsManager = ({
             return (
               <div key={set.id} className="mb-6 border rounded-lg p-4 bg-gray-50">
                 <div className="flex justify-between items-start mb-3">
-                  <div>
-                    <h5 className="font-medium text-lg">{set.name}</h5>
-                    {set.description && (
-                      <p className="text-sm text-muted-foreground">{set.description}</p>
-                    )}
+                  {renderSetMetadata(set)}
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        handleBulkPDFExport(department, 'weight', {
+                          setId: set.id,
+                          packageLabel: isPackageDepartment(department)
+                            ? getPackageSetLabel(department, set.package_size || null, set)
+                            : set.name,
+                        })
+                      }
+                      disabled={setTables.length === 0}
+                    >
+                      <FileText className="h-4 w-4 mr-1" />
+                      PDF
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleDuplicateSet(set.id)}
+                      disabled={isDuplicatingSet}
+                    >
+                      <Copy className="h-4 w-4 mr-1" />
+                      Duplicar
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDeleteSet(set.id)}
+                      disabled={isDeletingSet || isUpdatingSet}
+                      className="text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleDeleteSet(set.id)}
-                    disabled={isDeletingSet}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
                 </div>
                 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -1069,6 +1401,25 @@ export const TourDefaultsManager = ({
                     <p className="text-sm text-muted-foreground">
                       {getTourDateLocationName(tourDate)}
                     </p>
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {(['sound', 'lights', 'video'] as PackageDepartment[]).map((department) => {
+                        const packageSize = getDepartmentPackageSize(tourDate, department);
+                        if (!packageSize) return null;
+                        const resolution = resolveDefaultSetForTourDate({
+                          tourDate,
+                          department,
+                          defaultSets,
+                        });
+                        return (
+                          <Badge key={department} variant="outline" className="gap-1">
+                            {getPackageBadgeLabel({ department, packageSize })}
+                            {resolution.status !== 'resolved' && (
+                              <AlertTriangle className="h-3 w-3 text-amber-600" />
+                            )}
+                          </Badge>
+                        );
+                      })}
+                    </div>
                   </div>
                 </div>
                 

--- a/src/components/tours/TourManagementDialog.tsx
+++ b/src/components/tours/TourManagementDialog.tsx
@@ -96,8 +96,17 @@ export const TourManagementDialog = ({
   const handleBulkTourPackUpdate = async (tourPackOnly: boolean) => {
     setIsUpdatingTourPack(true);
     try {
+      const packageUpdates = {
+        sound_package_size: tourPackOnly ? ('s' as const) : null,
+        lights_package_size: tourPackOnly ? ('s' as const) : null,
+        video_package_size: tourPackOnly ? ('s' as const) : null,
+        sound_default_set_id: null as string | null,
+        lights_default_set_id: null as string | null,
+        video_default_set_id: null as string | null,
+      };
+
       const { error } = await dataLayerClient.from("tour_dates")
-        .update({ is_tour_pack_only: tourPackOnly })
+        .update({ is_tour_pack_only: tourPackOnly, ...packageUpdates })
         .eq("tour_id", tour.id);
 
       if (error) throw error;
@@ -252,7 +261,7 @@ export const TourManagementDialog = ({
                     <Package className="h-4 w-4 text-blue-600" />
                     <div>
                       <p className="text-sm font-medium">Modo Tour Pack Masivo</p>
-                      <p className="text-xs text-muted-foreground">Establecer todas las fechas de esta gira a Solo Tour Pack</p>
+                      <p className="text-xs text-muted-foreground">Establecer todas las fechas de esta gira como paquete S</p>
                     </div>
                   </div>
                   <div className="flex gap-2">

--- a/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
+++ b/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
@@ -27,6 +27,10 @@ vi.mock("@/integrations/supabase/client", () => ({
   supabase: mockSupabase,
 }));
 
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
 vi.mock("@/services/dataLayerClient", () => ({
   dataLayerClient: mockSupabase,
 }));
@@ -157,7 +161,7 @@ describe("TourDateManagementDialog", () => {
       />,
     );
 
-    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getAllByRole("combobox")[0]);
     await user.click(screen.getByRole("option", { name: /ensayo/i }));
     await user.type(screen.getByLabelText(/^location$/i), "Madrid Arena");
     await user.type(screen.getByLabelText(/start date/i), "2026-04-10");
@@ -178,6 +182,147 @@ describe("TourDateManagementDialog", () => {
       { job_id: "job-1", date: "2026-04-11", type: "rehearsal" },
       { job_id: "job-1", date: "2026-04-12", type: "rehearsal" },
     ]);
+  });
+
+  it("stores S package intent when creating a date with the Tour Pack shortcut and no default sets", async () => {
+    const user = userEvent.setup();
+    const tourDateBuilder = createMockQueryBuilder({
+      data: {
+        id: "tour-date-1",
+        date: "2026-04-10",
+        start_date: "2026-04-10",
+        end_date: "2026-04-10",
+        tour_date_type: "show",
+        rehearsal_days: 1,
+        is_tour_pack_only: true,
+        sound_package_size: "s",
+        lights_package_size: "s",
+        video_package_size: "s",
+        sound_default_set_id: null,
+        lights_default_set_id: null,
+        video_default_set_id: null,
+        location: { id: "location-1", name: "Bilbao Arena" },
+      },
+      error: null,
+    });
+    const tourBuilder = createMockQueryBuilder({
+      data: {
+        name: "World Tour",
+        color: "#123456",
+        tour_dates: [{ jobs: [{ job_departments: [{ department: "sound" }] }] }],
+      },
+      error: null,
+    });
+    const jobsBuilder = createMockQueryBuilder({ data: { id: "job-1" }, error: null });
+    const jobDepartmentsBuilder = createMockQueryBuilder({ data: null, error: null });
+    const jobDateTypesBuilder = createMockQueryBuilder({ data: null, error: null });
+
+    queueTableBuilders({
+      tour_default_sets: [createMockQueryBuilder({ data: [], error: null })],
+      tour_dates: [tourDateBuilder],
+      tours: [tourBuilder],
+      jobs: [jobsBuilder],
+      job_departments: [jobDepartmentsBuilder],
+      job_date_types: [jobDateTypesBuilder],
+    });
+
+    renderWithProviders(
+      <TourDateManagementDialog
+        open
+        onOpenChange={vi.fn()}
+        tourId="tour-1"
+        tourDates={[]}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^location$/i), "Bilbao Arena");
+    await user.type(screen.getByLabelText(/^date$/i), "2026-04-10");
+    await user.click(screen.getByLabelText(/tour pack \/ s package/i));
+    await user.click(screen.getByRole("button", { name: /añadir/i }));
+
+    await waitFor(() => {
+      expect(tourDateBuilder.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          is_tour_pack_only: true,
+          sound_package_size: "s",
+          lights_package_size: "s",
+          video_package_size: "s",
+          sound_default_set_id: null,
+          lights_default_set_id: null,
+          video_default_set_id: null,
+        }),
+      );
+    });
+  });
+
+  it("pins unique matching S default sets when creating a Tour Pack date", async () => {
+    const user = userEvent.setup();
+    const tourDateBuilder = createMockQueryBuilder({
+      data: {
+        id: "tour-date-1",
+        date: "2026-04-10",
+        start_date: "2026-04-10",
+        end_date: "2026-04-10",
+        tour_date_type: "show",
+        rehearsal_days: 1,
+        is_tour_pack_only: true,
+        location: { id: "location-1", name: "Bilbao Arena" },
+      },
+      error: null,
+    });
+    const tourBuilder = createMockQueryBuilder({
+      data: {
+        name: "World Tour",
+        color: "#123456",
+        tour_dates: [{ jobs: [{ job_departments: [{ department: "sound" }] }] }],
+      },
+      error: null,
+    });
+    const jobsBuilder = createMockQueryBuilder({ data: { id: "job-1" }, error: null });
+    const jobDepartmentsBuilder = createMockQueryBuilder({ data: null, error: null });
+    const jobDateTypesBuilder = createMockQueryBuilder({ data: null, error: null });
+
+    queueTableBuilders({
+      tour_default_sets: [
+        createMockQueryBuilder({
+          data: [
+            { id: "sound-s", tour_id: "tour-1", department: "sound", name: "Sound S", package_size: "s" },
+            { id: "lights-s", tour_id: "tour-1", department: "lights", name: "Lights S", package_size: "s" },
+            { id: "video-s", tour_id: "tour-1", department: "video", name: "Video S", package_size: "s" },
+          ],
+          error: null,
+        }),
+      ],
+      tour_dates: [tourDateBuilder],
+      tours: [tourBuilder],
+      jobs: [jobsBuilder],
+      job_departments: [jobDepartmentsBuilder],
+      job_date_types: [jobDateTypesBuilder],
+    });
+
+    renderWithProviders(
+      <TourDateManagementDialog
+        open
+        onOpenChange={vi.fn()}
+        tourId="tour-1"
+        tourDates={[]}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^location$/i), "Bilbao Arena");
+    await user.type(screen.getByLabelText(/^date$/i), "2026-04-10");
+    await user.click(screen.getByLabelText(/tour pack \/ s package/i));
+    await user.click(screen.getByRole("button", { name: /añadir/i }));
+
+    await waitFor(() => {
+      expect(tourDateBuilder.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sound_default_set_id: "sound-s",
+          lights_default_set_id: "lights-s",
+          video_default_set_id: "video-s",
+        }),
+      );
+    });
   });
 
   it("keeps rehearsal toggles as the pricing source of truth when editing a rehearsal date back to show", async () => {

--- a/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
+++ b/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
@@ -12,7 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ArrowLeft, Edit, FileText, Trash2 } from "lucide-react";
+import { ArrowLeft, Copy, Edit, FileText, Plus, Trash2 } from "lucide-react";
 import { TourOverrideModeHeader } from "@/components/tours/TourOverrideModeHeader";
 import { TechnicalStageSelector } from "@/features/technical-tools/stage/stageAllocation";
 import {
@@ -91,12 +91,23 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
     overrideData,
     isCreatingOverride,
     defaultSets,
+    selectedDefaultSet,
     selectedDefaultSetId,
     setSelectedDefaultSetId,
     selectedDefaultPackageSize,
     setSelectedDefaultPackageSize,
     newDefaultSetName,
     setNewDefaultSetName,
+    createEmptyDefaultSet,
+    copySourceSetId,
+    setCopySourceSetId,
+    copySourceTables,
+    selectedCopyTableIds,
+    selectedCopyTableCount,
+    allCopySourceTablesSelected,
+    toggleCopyTableSelection,
+    toggleAllCopySourceTables,
+    copySelectedDefaultTables,
     tourName,
     tourInfo,
     selectedStage,
@@ -135,9 +146,11 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
     removeTable,
     updateTableSettings,
     startEditingTable,
+    startEditingDefaultTable,
     startEditingOverride,
     saveTourDefault,
     saveDefaultTables,
+    handleDeleteDefaultTable,
     handleDeleteOverride,
     tourDefaultDisplayTables,
     readOnlyDefaultTables,
@@ -169,7 +182,7 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
   const generateButtonLabel =
     editing?.kind === "override"
       ? labels.updateOverride
-      : editing?.kind === "table"
+      : editing?.kind === "table" || editing?.kind === "default"
         ? labels.updateTable
         : isOverrideMode && !isTourDefaults
           ? labels.createOverride
@@ -177,6 +190,13 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
 
   const firstColumnTables = activeTables.slice(0, Math.ceil(activeTables.length / 2));
   const secondColumnTables = activeTables.slice(Math.ceil(activeTables.length / 2));
+  const copyButtonLabel = selectedDefaultSetId
+    ? copySourceSetId === selectedDefaultSetId
+      ? "Duplicar seleccionadas en este conjunto"
+      : "Copiar seleccionadas al conjunto en edición"
+    : "Crear conjunto y copiar seleccionadas";
+  const canCreateOrCopyDefaultSet =
+    Boolean(selectedDefaultSetId) || newDefaultSetName.trim().length > 0;
 
   const renderGeneratedTable = (table: PowerTable) => (
     <GeneratedPowerTableCard
@@ -337,6 +357,36 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                 {isTourDefaults && (
                   <div className="space-y-3 rounded-lg border p-4">
                     <h3 className="text-sm font-semibold">Conjunto por defecto</h3>
+                    {selectedDefaultSet ? (
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <p className="text-sm text-muted-foreground">
+                          Editando:{" "}
+                          <span className="font-medium text-foreground">
+                            {selectedDefaultSet.name}
+                            {selectedDefaultSet.package_size
+                              ? ` (${TOUR_PACKAGE_LABELS[selectedDefaultSet.package_size]})`
+                              : " (Sin asignar)"}
+                          </span>
+                        </p>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="w-full gap-2 sm:w-auto"
+                          onClick={() => {
+                            setSelectedDefaultSetId("");
+                            setNewDefaultSetName("");
+                          }}
+                        >
+                          <Plus className="h-4 w-4" />
+                          Crear otro conjunto
+                        </Button>
+                      </div>
+                    ) : defaultSets.length > 1 ? (
+                      <p className="text-sm text-amber-700">
+                        Selecciona un conjunto para ver, editar o añadir tablas a ese paquete.
+                      </p>
+                    ) : null}
                     <div className="space-y-2">
                       <Label>Conjunto existente</Label>
                       <Select
@@ -347,7 +397,7 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                           <SelectValue placeholder="Selecciona un conjunto" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="new">Crear conjunto</SelectItem>
+                          <SelectItem value="new">Crear nuevo conjunto</SelectItem>
                           {defaultSets.map((set) => (
                             <SelectItem key={set.id} value={set.id}>
                               {set.name}
@@ -389,6 +439,118 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                             </SelectContent>
                           </Select>
                         </div>
+                      </div>
+                    )}
+                    {!selectedDefaultSetId && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full gap-2"
+                        onClick={createEmptyDefaultSet}
+                        disabled={!newDefaultSetName.trim()}
+                      >
+                        <Plus className="h-4 w-4" />
+                        Crear conjunto vacío
+                      </Button>
+                    )}
+                    {defaultSets.length > 0 && (
+                      <div className="space-y-3 rounded-md border border-dashed p-3">
+                        <div>
+                          <h4 className="text-sm font-medium">Reutilizar tablas existentes</h4>
+                          <p className="text-xs text-muted-foreground">
+                            Elige un conjunto origen y copia solo las tablas que quieras al conjunto en edición.
+                          </p>
+                        </div>
+                        <div className="space-y-2">
+                          <Label>Copiar tablas desde</Label>
+                          <Select
+                            value={copySourceSetId}
+                            onValueChange={setCopySourceSetId}
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder="Selecciona conjunto origen" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {defaultSets.map((set) => (
+                                <SelectItem key={set.id} value={set.id}>
+                                  {set.name}
+                                  {set.package_size
+                                    ? ` (${TOUR_PACKAGE_LABELS[set.package_size]})`
+                                    : " (Sin asignar)"}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        {copySourceTables.length > 0 ? (
+                          <div className="space-y-3">
+                            <div className="flex items-center justify-between gap-3 text-sm">
+                              <label className="flex items-center gap-2">
+                                <Checkbox
+                                  checked={allCopySourceTablesSelected}
+                                  onCheckedChange={(checked) =>
+                                    toggleAllCopySourceTables(checked === true)
+                                  }
+                                />
+                                Seleccionar todas
+                              </label>
+                              <span className="text-xs text-muted-foreground">
+                                {selectedCopyTableCount}/{copySourceTables.length}
+                              </span>
+                            </div>
+                            <div className="max-h-44 space-y-2 overflow-y-auto pr-1">
+                              {copySourceTables.map((table) => (
+                                <label
+                                  key={table.defaultTableId || table.id}
+                                  className="flex items-start gap-2 rounded-md border bg-background p-2 text-sm"
+                                >
+                                  <Checkbox
+                                    checked={
+                                      Boolean(table.defaultTableId) &&
+                                      selectedCopyTableIds.includes(table.defaultTableId!)
+                                    }
+                                    onCheckedChange={(checked) =>
+                                      table.defaultTableId &&
+                                      toggleCopyTableSelection(
+                                        table.defaultTableId,
+                                        checked === true,
+                                      )
+                                    }
+                                  />
+                                  <span className="min-w-0 flex-1">
+                                    <span className="block truncate font-medium">
+                                      {table.name}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">
+                                      {((table.totalVa || table.totalWatts || 0) / 1000).toFixed(2)} kVA
+                                    </span>
+                                  </span>
+                                </label>
+                              ))}
+                            </div>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="w-full gap-2"
+                              onClick={copySelectedDefaultTables}
+                              disabled={
+                                selectedCopyTableCount === 0 || !canCreateOrCopyDefaultSet
+                              }
+                            >
+                              <Copy className="h-4 w-4" />
+                              {copyButtonLabel}
+                            </Button>
+                            {!canCreateOrCopyDefaultSet && (
+                              <p className="text-xs text-amber-700">
+                                Selecciona un conjunto destino o escribe un nombre para crear uno nuevo.
+                              </p>
+                            )}
+                          </div>
+                        ) : (
+                          <p className="text-sm text-muted-foreground">
+                            El conjunto origen seleccionado no tiene tablas de potencia guardadas.
+                          </p>
+                        )}
                       </div>
                     )}
                   </div>
@@ -504,17 +666,24 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                 )}
 
                 {/* Existing tour defaults */}
+                {isTourDefaults && !selectedDefaultSetId && defaultSets.length > 1 && (
+                  <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+                    Selecciona un conjunto por defecto para ver sus tablas. No se mezclan tablas de paquetes distintos.
+                  </div>
+                )}
                 {isTourDefaults && tourDefaultDisplayTables.length > 0 && (
                   <div className="space-y-4">
                     <h3 className="text-lg font-semibold text-blue-900">
-                      {labels.existingDefaultsHeading}
+                      {selectedDefaultSet
+                        ? `${labels.existingDefaultsHeading}: ${selectedDefaultSet.name}`
+                        : labels.existingDefaultsHeading}
                     </h3>
                     {tourDefaultDisplayTables.map((table) => (
                       <div
                         key={table.id}
                         className="border rounded-lg overflow-hidden bg-blue-50/30"
                       >
-                        <div className="bg-blue-100 px-4 py-3 flex justify-between items-center">
+                        <div className="bg-blue-100 px-4 py-3 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
                           <div className="flex items-center gap-2">
                             <h4 className="font-semibold text-blue-900">{table.name}</h4>
                             <Badge
@@ -524,6 +693,31 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                               {labels.defaultBadge}
                             </Badge>
                           </div>
+                          {table.defaultTableId && (
+                            <div className="flex gap-2">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => startEditingDefaultTable(table)}
+                                className="gap-2"
+                              >
+                                <Edit className="h-4 w-4" />
+                                {labels.edit}
+                              </Button>
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                onClick={() =>
+                                  table.defaultTableId &&
+                                  handleDeleteDefaultTable(table.defaultTableId)
+                                }
+                                className="gap-2"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                                {labels.deleteAction}
+                              </Button>
+                            </div>
+                          )}
                         </div>
                         <div className="p-4">
                           <PowerTableSummary

--- a/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
+++ b/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
@@ -336,22 +336,22 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
 
                 {isTourDefaults && (
                   <div className="space-y-3 rounded-lg border p-4">
-                    <h3 className="text-sm font-semibold">Default set</h3>
+                    <h3 className="text-sm font-semibold">Conjunto por defecto</h3>
                     <div className="space-y-2">
-                      <Label>Existing set</Label>
+                      <Label>Conjunto existente</Label>
                       <Select
                         value={selectedDefaultSetId || "new"}
                         onValueChange={(value) => setSelectedDefaultSetId(value === "new" ? "" : value)}
                       >
                         <SelectTrigger>
-                          <SelectValue placeholder="Select default set" />
+                          <SelectValue placeholder="Selecciona un conjunto" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="new">Create new set</SelectItem>
+                          <SelectItem value="new">Crear conjunto</SelectItem>
                           {defaultSets.map((set) => (
                             <SelectItem key={set.id} value={set.id}>
                               {set.name}
-                              {set.package_size ? ` (${TOUR_PACKAGE_LABELS[set.package_size]})` : " (Unassigned)"}
+                              {set.package_size ? ` (${TOUR_PACKAGE_LABELS[set.package_size]})` : " (Sin asignar)"}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -360,7 +360,7 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                     {!selectedDefaultSetId && (
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                         <div className="space-y-2">
-                          <Label htmlFor="newDefaultSetName">New set name</Label>
+                          <Label htmlFor="newDefaultSetName">Nombre del nuevo conjunto</Label>
                           <Input
                             id="newDefaultSetName"
                             value={newDefaultSetName}
@@ -369,7 +369,7 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                           />
                         </div>
                         <div className="space-y-2">
-                          <Label>Package size</Label>
+                          <Label>Tamaño de paquete</Label>
                           <Select
                             value={selectedDefaultPackageSize}
                             onValueChange={(value) =>
@@ -377,10 +377,10 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                             }
                           >
                             <SelectTrigger>
-                              <SelectValue placeholder="Package size" />
+                              <SelectValue placeholder="Tamaño de paquete" />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="unassigned">Unassigned</SelectItem>
+                              <SelectItem value="unassigned">Sin asignar</SelectItem>
                               {TOUR_PACKAGE_SIZES.map((size) => (
                                 <SelectItem key={size} value={size}>
                                   {TOUR_PACKAGE_LABELS[size]}

--- a/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
+++ b/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
@@ -28,6 +28,11 @@ import { PowerStagePlot } from "@/features/technical-tools/power/consumos/PowerS
 import { CopyToStageMenu } from "@/features/technical-tools/table-presets/CopyToStageMenu";
 import { QuickPresetsMenu } from "@/features/technical-tools/table-presets/QuickPresetsMenu";
 import { GeneratedPowerTableCard } from "./GeneratedPowerTableCard";
+import {
+  TOUR_PACKAGE_LABELS,
+  TOUR_PACKAGE_SIZES,
+  type TourPackageSize,
+} from "@/utils/tourPackages";
 
 const PowerTableSummary: React.FC<{
   table: PowerTable;
@@ -85,6 +90,13 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
     overrideLoading,
     overrideData,
     isCreatingOverride,
+    defaultSets,
+    selectedDefaultSetId,
+    setSelectedDefaultSetId,
+    selectedDefaultPackageSize,
+    setSelectedDefaultPackageSize,
+    newDefaultSetName,
+    setNewDefaultSetName,
     tourName,
     tourInfo,
     selectedStage,
@@ -319,6 +331,66 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                       onCheckedChange={(checked) => setFohSchukoRequired(!!checked)}
                     />
                     <Label htmlFor="foh-schuko">{labels.fohSchuko}</Label>
+                  </div>
+                )}
+
+                {isTourDefaults && (
+                  <div className="space-y-3 rounded-lg border p-4">
+                    <h3 className="text-sm font-semibold">Default set</h3>
+                    <div className="space-y-2">
+                      <Label>Existing set</Label>
+                      <Select
+                        value={selectedDefaultSetId || "new"}
+                        onValueChange={(value) => setSelectedDefaultSetId(value === "new" ? "" : value)}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select default set" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="new">Create new set</SelectItem>
+                          {defaultSets.map((set) => (
+                            <SelectItem key={set.id} value={set.id}>
+                              {set.name}
+                              {set.package_size ? ` (${TOUR_PACKAGE_LABELS[set.package_size]})` : " (Unassigned)"}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {!selectedDefaultSetId && (
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <div className="space-y-2">
+                          <Label htmlFor="newDefaultSetName">New set name</Label>
+                          <Input
+                            id="newDefaultSetName"
+                            value={newDefaultSetName}
+                            onChange={(event) => setNewDefaultSetName(event.target.value)}
+                            placeholder={`${tourName || "Tour"} ${labels.defaultBadge}`}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>Package size</Label>
+                          <Select
+                            value={selectedDefaultPackageSize}
+                            onValueChange={(value) =>
+                              setSelectedDefaultPackageSize(value as TourPackageSize | "unassigned")
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder="Package size" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="unassigned">Unassigned</SelectItem>
+                              {TOUR_PACKAGE_SIZES.map((size) => (
+                                <SelectItem key={size} value={size}>
+                                  {TOUR_PACKAGE_LABELS[size]}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
 

--- a/src/features/technical-tools/power/consumos/departmentConfigs.ts
+++ b/src/features/technical-tools/power/consumos/departmentConfigs.ts
@@ -104,15 +104,15 @@ const lightComponentDatabase: ConsumosComponent[] = [
 
 const ENGLISH_LABELS: ConsumosLabels = {
   title: "Power Calculator",
-  tourDefaultsBadge: "Tour Defaults Mode",
-  tourDefaultsNoticeTitle: "Tour Defaults Mode Active",
+  tourDefaultsBadge: "Modo Valores por Defecto",
+  tourDefaultsNoticeTitle: "Modo Conjunto por Defecto de Gira Activo",
   tourDefaultsNoticeBody:
-    "Any tables you create will be saved as global defaults for this tour. These defaults will apply to all tour dates unless specifically overridden.",
-  creatingDefaultsFor: "Creating defaults for:",
-  overrideBadge: "Override Mode",
-  overrideNoticeTitle: "Override Mode Active",
+    "Las tablas que crees se guardarán en el conjunto/paquete por defecto seleccionado. Las fechas de gira solo usarán ese conjunto cuando su paquete o pin explícito lo resuelva; las anulaciones por fecha siguen teniendo prioridad.",
+  creatingDefaultsFor: "Creando valores por defecto para:",
+  overrideBadge: "Modo Anulación",
+  overrideNoticeTitle: "Modo Anulación Activo",
   overrideNoticeBody:
-    "This job is part of a tour. Any tables you create will be saved as overrides for the specific tour date.",
+    "Este trabajo forma parte de una gira. Las tablas que crees se guardarán como anulaciones para la fecha de gira específica.",
   existingDefaultsHeading: "Existing Tour Defaults",
   readOnlyDefaultsHeading: "Tour Defaults (Read-Only)",
   existingOverridesHeading: "Existing Overrides",
@@ -259,9 +259,9 @@ const ENGLISH_LABELS: ConsumosLabels = {
 const SPANISH_LABELS: ConsumosLabels = {
   title: "Calculadora de Potencia",
   tourDefaultsBadge: "Modo Valores por Defecto",
-  tourDefaultsNoticeTitle: "Modo Valores por Defecto de Gira Activo",
+  tourDefaultsNoticeTitle: "Modo Conjunto por Defecto de Gira Activo",
   tourDefaultsNoticeBody:
-    "Las tablas que crees aquí se guardarán como valores por defecto para todas las fechas de la gira, salvo que se anulen específicamente.",
+    "Las tablas que crees se guardarán en el conjunto/paquete por defecto seleccionado. Las fechas de gira solo usarán ese conjunto cuando su paquete o pin explícito lo resuelva; las anulaciones por fecha siguen teniendo prioridad.",
   creatingDefaultsFor: "Creando valores por defecto para:",
   overrideBadge: "Modo Anulación",
   overrideNoticeTitle: "Modo Anulación Activo",

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -8,6 +8,7 @@ import { useTourDefaultSets } from "@/hooks/useTourDefaultSets";
 import { useTourPowerDefaults } from "@/hooks/useTourPowerDefaults";
 import { useTourDateOverrides } from "@/hooks/useTourDateOverrides";
 import { useTourOverrideMode } from "@/hooks/useTourOverrideMode";
+import type { TourPackageSize } from "@/utils/tourPackages";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { queryKeys } from "@/lib/react-query";
 import { exportToPDF } from "@/utils/pdfExport";
@@ -207,6 +208,16 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
   const { powerDefaults: legacyTourDefaults = [] } = useTourPowerDefaults(
     features.legacyTourDefaultsFallback ? tourIdParam || "" : "",
   );
+
+  const [selectedDefaultSetId, setSelectedDefaultSetId] = useState<string>("");
+  const [selectedDefaultPackageSize, setSelectedDefaultPackageSize] = useState<TourPackageSize | "unassigned">("unassigned");
+  const [newDefaultSetName, setNewDefaultSetName] = useState("");
+
+  useEffect(() => {
+    if (!isTourDefaults || selectedDefaultSetId || defaultSets.length !== 1) return;
+    setSelectedDefaultSetId(defaultSets[0].id);
+    setSelectedDefaultPackageSize(defaultSets[0].package_size || "unassigned");
+  }, [defaultSets, isTourDefaults, selectedDefaultSetId]);
 
   const { data: tourName = "" } = useQuery({
     queryKey: queryKeys.scope("tour", tourIdParam, "name"),
@@ -754,20 +765,32 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
   const resolvedSetIdRef = useRef<string | null>(null);
 
   const getOrCreateDefaultSetId = async (): Promise<string> => {
-    if (defaultSets.length > 0) {
-      resolvedSetIdRef.current = defaultSets[0].id;
-      return defaultSets[0].id;
+    if (selectedDefaultSetId) {
+      resolvedSetIdRef.current = selectedDefaultSetId;
+      return selectedDefaultSetId;
     }
     if (resolvedSetIdRef.current) return resolvedSetIdRef.current;
     if (pendingSetIdRef.current) return pendingSetIdRef.current;
+
+    const trimmedSetName = newDefaultSetName.trim();
+    if (!trimmedSetName) {
+      throw new Error("Select an existing default set or enter a name to create one.");
+    }
+
     const creation = createSet({
       tour_id: tourIdParam!,
-      name: config.defaultsSetName(tourName || tourIdParam || ""),
+      name: trimmedSetName,
       department,
       description: config.defaultsSetDescription,
+      package_size:
+        selectedDefaultPackageSize === "unassigned"
+          ? null
+          : selectedDefaultPackageSize,
     })
       .then((set) => {
         resolvedSetIdRef.current = set.id;
+        setSelectedDefaultSetId(set.id);
+        setNewDefaultSetName("");
         pendingSetIdRef.current = null;
         return set.id;
       })
@@ -927,7 +950,11 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
   // Tour defaults for display (new system with legacy fallback)
   const tourDefaultDisplayTables: PowerTable[] = useMemo(() => {
     const newSystemTables = (defaultTables || [])
-      .filter((table) => table.table_type === "power")
+      .filter(
+        (table) =>
+          table.table_type === "power" &&
+          (!selectedDefaultSetId || table.set_id === selectedDefaultSetId),
+      )
       .map((table) => {
         const rows: PowerTableRow[] = table.table_data?.rows || [];
         const snapshot = {
@@ -988,7 +1015,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       } as PowerTable;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultTables, legacyTourDefaults, features.legacyTourDefaultsFallback, safetyMargin, pf]);
+  }, [defaultTables, selectedDefaultSetId, legacyTourDefaults, features.legacyTourDefaultsFallback, safetyMargin, pf]);
 
   // Read-only defaults shown in URL override mode
   const readOnlyDefaultTables: PowerTable[] = useMemo(() => {
@@ -1382,6 +1409,13 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     overrideLoading,
     overrideData,
     isCreatingOverride,
+    defaultSets,
+    selectedDefaultSetId,
+    setSelectedDefaultSetId,
+    selectedDefaultPackageSize,
+    setSelectedDefaultPackageSize,
+    newDefaultSetName,
+    setNewDefaultSetName,
     tourName,
     tourInfo: getTourInfo(),
     selectedStage,

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { useJobSelection } from "@/hooks/useJobSelection";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
-import { useTourDefaultSets } from "@/hooks/useTourDefaultSets";
+import { useTourDefaultSets, type TourDefaultTable } from "@/hooks/useTourDefaultSets";
 import { useTourPowerDefaults } from "@/hooks/useTourPowerDefaults";
 import { useTourDateOverrides } from "@/hooks/useTourDateOverrides";
 import { useTourOverrideMode } from "@/hooks/useTourOverrideMode";
@@ -74,6 +74,7 @@ const CUSTOM_PDU_SELECT_VALUE = "Custom";
 
 type EditingTarget =
   | { kind: "table"; id: number | string }
+  | { kind: "default"; id: string }
   | { kind: "override"; id: string };
 
 type ConsumosJob = {
@@ -203,6 +204,8 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     createSet,
     createTable: createTourDefaultTable,
     updateTable: updateTourDefaultTable,
+    deleteTable: deleteTourDefaultTable,
+    copyTablesToSet: copyTourDefaultTablesToSet,
   } = useTourDefaultSets(tourIdParam || "", department);
 
   const { powerDefaults: legacyTourDefaults = [] } = useTourPowerDefaults(
@@ -212,12 +215,74 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
   const [selectedDefaultSetId, setSelectedDefaultSetId] = useState<string>("");
   const [selectedDefaultPackageSize, setSelectedDefaultPackageSize] = useState<TourPackageSize | "unassigned">("unassigned");
   const [newDefaultSetName, setNewDefaultSetName] = useState("");
+  const [isCreatingDefaultSet, setIsCreatingDefaultSet] = useState(false);
+  const [copySourceSetId, setCopySourceSetIdInternal] = useState<string>("");
+  const [selectedCopyTableIds, setSelectedCopyTableIds] = useState<string[]>([]);
+  const selectedDefaultSet =
+    defaultSets.find((set) => set.id === selectedDefaultSetId) || null;
+  const selectedCopySourceSet =
+    defaultSets.find((set) => set.id === copySourceSetId) || null;
+
+  const setCopySourceSetId = useCallback((setId: string) => {
+    setCopySourceSetIdInternal(setId);
+    setSelectedCopyTableIds([]);
+  }, []);
+
+  const selectDefaultSetId = useCallback(
+    (setId: string) => {
+      if (!setId && selectedDefaultSetId) {
+        setCopySourceSetIdInternal((current) => current || selectedDefaultSetId);
+      }
+      setIsCreatingDefaultSet(!setId);
+      setSelectedDefaultSetId(setId);
+      const set = defaultSets.find((candidate) => candidate.id === setId);
+      if (set) {
+        setSelectedDefaultPackageSize(set.package_size || "unassigned");
+      }
+    },
+    [defaultSets, selectedDefaultSetId],
+  );
 
   useEffect(() => {
-    if (!isTourDefaults || selectedDefaultSetId || defaultSets.length !== 1) return;
-    setSelectedDefaultSetId(defaultSets[0].id);
-    setSelectedDefaultPackageSize(defaultSets[0].package_size || "unassigned");
-  }, [defaultSets, isTourDefaults, selectedDefaultSetId]);
+    if (
+      !isTourDefaults ||
+      selectedDefaultSetId ||
+      isCreatingDefaultSet ||
+      defaultSets.length !== 1
+    ) {
+      return;
+    }
+    selectDefaultSetId(defaultSets[0].id);
+  }, [
+    defaultSets,
+    isCreatingDefaultSet,
+    isTourDefaults,
+    selectedDefaultSetId,
+    selectDefaultSetId,
+  ]);
+
+  useEffect(() => {
+    if (!isTourDefaults || copySourceSetId || defaultSets.length === 0) return;
+    setCopySourceSetIdInternal(selectedDefaultSetId || defaultSets[0].id);
+  }, [copySourceSetId, defaultSets, isTourDefaults, selectedDefaultSetId]);
+
+  useEffect(() => {
+    if (!copySourceSetId) {
+      setSelectedCopyTableIds([]);
+      return;
+    }
+    const availableIds = new Set(
+      defaultTables
+        .filter(
+          (table) =>
+            table.set_id === copySourceSetId && table.table_type === "power",
+        )
+        .map((table) => table.id),
+    );
+    setSelectedCopyTableIds((previous) =>
+      previous.filter((tableId) => availableIds.has(tableId)),
+    );
+  }, [copySourceSetId, defaultTables]);
 
   const { data: tourName = "" } = useQuery({
     queryKey: queryKeys.scope("tour", tourIdParam, "name"),
@@ -460,9 +525,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     setEditing(null);
   };
 
-  // Load an existing table (saved set, local, default or override) into the builder
-  const startEditingTable = (table: PowerTable) => {
-    if (table.id === undefined) return;
+  const loadPowerTableIntoBuilder = (table: PowerTable) => {
     setTableName(table.name);
     setCurrentRows(
       table.rows.length > 0
@@ -492,7 +555,19 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       setCustomPduType("");
     }
     setIncludesHoist(Boolean(table.includesHoist));
+  };
+
+  // Load an existing local table into the builder.
+  const startEditingTable = (table: PowerTable) => {
+    if (table.id === undefined) return;
+    loadPowerTableIntoBuilder(table);
     setEditing({ kind: "table", id: table.id });
+  };
+
+  const startEditingDefaultTable = (table: PowerTable) => {
+    if (!table.defaultTableId) return;
+    loadPowerTableIntoBuilder(table);
+    setEditing({ kind: "default", id: table.defaultTableId });
   };
 
   const startEditingOverride = (override: {
@@ -630,12 +705,13 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     });
   };
 
-  const persistDefaultTableUpdate = (table: PowerTable) => {
+  const persistDefaultTableUpdate = async (table: PowerTable) => {
     if (!table.defaultTableId) return;
     const settings = getTableSnapshotSettings(table);
-    updateTourDefaultTable({
+    await updateTourDefaultTable({
       tableId: table.defaultTableId,
       updates: {
+        table_name: table.name,
         table_data: buildPowerTableData(table, settings),
         total_value: table.totalWatts || 0,
         metadata: buildPowerTableMetadata(table, settings),
@@ -663,6 +739,19 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
         return;
       }
 
+      if (editing?.kind === "default") {
+        const updatedDefaultTable: PowerTable = {
+          ...builtTable,
+          id: `new-default-${editing.id}`,
+          isDefault: true,
+          defaultTableId: editing.id,
+        };
+        await persistDefaultTableUpdate(updatedDefaultTable);
+        toast({ title: labels.toastSuccess, description: labels.toastDefaultSaved });
+        resetCurrentTable();
+        return;
+      }
+
       if (editing?.kind === "table") {
         const original = tables.find((table) => table.id === editing.id);
         if (original) {
@@ -682,7 +771,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
             prev.map((table) => (table.id === editing.id ? merged : table)),
           );
           if (isTourDefaults && merged.defaultTableId) {
-            persistDefaultTableUpdate(merged);
+            await persistDefaultTableUpdate(merged);
           } else if (isOverrideMode && merged.overrideId) {
             await persistOverrideUpdate(merged, merged.overrideId);
             toast({ title: labels.toastSuccess, description: labels.toastOverrideUpdated });
@@ -752,7 +841,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     );
 
     if (isTourDefaults && updatedTable.defaultTableId) {
-      persistDefaultTableUpdate(updatedTable);
+      void persistDefaultTableUpdate(updatedTable);
     } else if (isOverrideMode && updatedTable.overrideId) {
       void persistOverrideUpdate(updatedTable, updatedTable.overrideId).catch((error) => {
         console.error("Error saving override table settings:", error);
@@ -762,14 +851,11 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
 
   // Tour defaults persistence
   const pendingSetIdRef = useRef<Promise<string> | null>(null);
-  const resolvedSetIdRef = useRef<string | null>(null);
 
   const getOrCreateDefaultSetId = async (): Promise<string> => {
     if (selectedDefaultSetId) {
-      resolvedSetIdRef.current = selectedDefaultSetId;
       return selectedDefaultSetId;
     }
-    if (resolvedSetIdRef.current) return resolvedSetIdRef.current;
     if (pendingSetIdRef.current) return pendingSetIdRef.current;
 
     const trimmedSetName = newDefaultSetName.trim();
@@ -788,8 +874,8 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
           : selectedDefaultPackageSize,
     })
       .then((set) => {
-        resolvedSetIdRef.current = set.id;
         setSelectedDefaultSetId(set.id);
+        setIsCreatingDefaultSet(false);
         setNewDefaultSetName("");
         pendingSetIdRef.current = null;
         return set.id;
@@ -800,6 +886,19 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       });
     pendingSetIdRef.current = creation;
     return creation;
+  };
+
+  const createEmptyDefaultSet = async () => {
+    try {
+      await getOrCreateDefaultSetId();
+    } catch (error: unknown) {
+      console.error("Error creating default set:", error);
+      toast({
+        title: labels.toastError,
+        description: labels.toastDefaultSaveError(getErrorMessage(error)),
+        variant: "destructive",
+      });
+    }
   };
 
   const saveTourDefault = async (table: PowerTable) => {
@@ -907,6 +1006,22 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     }
   };
 
+  const handleDeleteDefaultTable = async (defaultTableId: string) => {
+    try {
+      await deleteTourDefaultTable(defaultTableId);
+      if (editing?.kind === "default" && editing.id === defaultTableId) {
+        resetCurrentTable();
+      }
+    } catch (error) {
+      console.error("Error deleting default table:", error);
+      toast({
+        title: labels.toastError,
+        description: labels.toastDefaultsFailed([defaultTableId]),
+        variant: "destructive",
+      });
+    }
+  };
+
   const handleDeleteOverride = async (overrideId: string) => {
     try {
       await deleteOverride({ id: overrideId, table: "power" });
@@ -947,45 +1062,120 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     return { adjustedWatts, totalVa };
   };
 
+  const mapTourDefaultTableToPowerTable = (
+    table: TourDefaultTable,
+  ): PowerTable => {
+    const rows: PowerTableRow[] = table.table_data?.rows || [];
+    const snapshot = {
+      pf: table.metadata?.pf ?? table.table_data?.pf,
+      safetyMargin: table.metadata?.safetyMargin ?? table.table_data?.safetyMargin,
+    };
+    const { adjustedWatts, totalVa } = computeDisplayTotals(
+      table.total_value || 0,
+      rows,
+      snapshot,
+    );
+    return {
+      id: `new-default-${table.id}`,
+      name: table.table_name,
+      rows,
+      totalWatts: table.total_value,
+      adjustedWatts,
+      totalVa,
+      currentPerPhase: table.metadata?.current_per_phase || 0,
+      pduType: table.metadata?.pdu_type || "",
+      customPduType: table.metadata?.custom_pdu_type || undefined,
+      position: table.metadata?.position || undefined,
+      customPosition: table.metadata?.custom_position || undefined,
+      includesHoist: table.metadata?.includes_hoist || false,
+      snapshotSafetyMargin: table.metadata?.safetyMargin ?? table.table_data?.safetyMargin,
+      snapshotPhaseMode: table.metadata?.phaseMode ?? table.table_data?.phaseMode,
+      snapshotVoltage: table.metadata?.voltage ?? table.table_data?.voltage,
+      snapshotPowerFactor: table.metadata?.pf ?? table.table_data?.pf,
+      isDefault: true,
+      defaultTableId: table.id,
+    } as PowerTable;
+  };
+
+  const copySourceTables = (defaultTables || [])
+    .filter(
+      (table) =>
+        table.set_id === copySourceSetId && table.table_type === "power",
+    )
+    .map(mapTourDefaultTableToPowerTable);
+
+  const copySourceTableIds = copySourceTables
+    .map((table) => table.defaultTableId)
+    .filter((tableId): tableId is string => Boolean(tableId));
+  const selectedCopyTableCount = selectedCopyTableIds.filter((tableId) =>
+    copySourceTableIds.includes(tableId),
+  ).length;
+  const allCopySourceTablesSelected =
+    copySourceTableIds.length > 0 &&
+    selectedCopyTableCount === copySourceTableIds.length;
+
+  const toggleCopyTableSelection = (tableId: string, checked: boolean) => {
+    setSelectedCopyTableIds((previous) => {
+      if (checked) return Array.from(new Set([...previous, tableId]));
+      return previous.filter((selectedId) => selectedId !== tableId);
+    });
+  };
+
+  const toggleAllCopySourceTables = (checked: boolean) => {
+    setSelectedCopyTableIds(checked ? copySourceTableIds : []);
+  };
+
+  const copySelectedDefaultTables = async () => {
+    const selectedIds = selectedCopyTableIds.filter((tableId) =>
+      copySourceTableIds.includes(tableId),
+    );
+    if (selectedIds.length === 0) {
+      toast({
+        title: labels.toastError,
+        description: "Selecciona al menos una tabla para copiar.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      const targetSetId = selectedDefaultSetId || (await getOrCreateDefaultSetId());
+      await copyTourDefaultTablesToSet({
+        tableIds: selectedIds,
+        targetSetId,
+      });
+      setSelectedCopyTableIds([]);
+      setSelectedDefaultSetId(targetSetId);
+      setIsCreatingDefaultSet(false);
+    } catch (error: unknown) {
+      console.error("Error copying default tables:", error);
+      toast({
+        title: labels.toastError,
+        description: getErrorMessage(error),
+        variant: "destructive",
+      });
+    }
+  };
+
   // Tour defaults for display (new system with legacy fallback)
   const tourDefaultDisplayTables: PowerTable[] = useMemo(() => {
+    const canDisplayNewSystemTables =
+      Boolean(selectedDefaultSetId) || defaultSets.length <= 1;
     const newSystemTables = (defaultTables || [])
       .filter(
         (table) =>
+          canDisplayNewSystemTables &&
           table.table_type === "power" &&
           (!selectedDefaultSetId || table.set_id === selectedDefaultSetId),
       )
-      .map((table) => {
-        const rows: PowerTableRow[] = table.table_data?.rows || [];
-        const snapshot = {
-          pf: table.metadata?.pf ?? table.table_data?.pf,
-          safetyMargin: table.metadata?.safetyMargin ?? table.table_data?.safetyMargin,
-        };
-        const { adjustedWatts, totalVa } = computeDisplayTotals(
-          table.total_value || 0,
-          rows,
-          snapshot,
-        );
-        return {
-          id: `new-default-${table.id}`,
-          name: table.table_name,
-          rows,
-          totalWatts: table.total_value,
-          adjustedWatts,
-          totalVa,
-          currentPerPhase: table.metadata?.current_per_phase || 0,
-          pduType: table.metadata?.pdu_type || "",
-          customPduType: table.metadata?.custom_pdu_type || undefined,
-          position: table.metadata?.position || undefined,
-          customPosition: table.metadata?.custom_position || undefined,
-          includesHoist: table.metadata?.includes_hoist || false,
-          isDefault: true,
-          defaultTableId: table.id,
-        } as PowerTable;
-      });
+      .map(mapTourDefaultTableToPowerTable);
 
     if (newSystemTables.length > 0 || !features.legacyTourDefaultsFallback) {
       return newSystemTables;
+    }
+
+    if (defaultSets.length > 0) {
+      return [];
     }
 
     return legacyTourDefaults.map((legacyDefault) => {
@@ -1015,7 +1205,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       } as PowerTable;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultTables, selectedDefaultSetId, legacyTourDefaults, features.legacyTourDefaultsFallback, safetyMargin, pf]);
+  }, [defaultSets.length, defaultTables, selectedDefaultSetId, legacyTourDefaults, features.legacyTourDefaultsFallback, safetyMargin, pf]);
 
   // Read-only defaults shown in URL override mode
   const readOnlyDefaultTables: PowerTable[] = useMemo(() => {
@@ -1389,7 +1579,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       (table) => String(table.id) === plotTableId,
     );
     if (defaultTable?.defaultTableId) {
-      persistDefaultTableUpdate({ ...defaultTable, ...patch });
+      void persistDefaultTableUpdate({ ...defaultTable, ...patch });
     }
   };
 
@@ -1410,12 +1600,25 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     overrideData,
     isCreatingOverride,
     defaultSets,
+    selectedDefaultSet,
     selectedDefaultSetId,
-    setSelectedDefaultSetId,
+    setSelectedDefaultSetId: selectDefaultSetId,
+    isCreatingDefaultSet,
     selectedDefaultPackageSize,
     setSelectedDefaultPackageSize,
     newDefaultSetName,
     setNewDefaultSetName,
+    createEmptyDefaultSet,
+    copySourceSetId,
+    setCopySourceSetId,
+    selectedCopySourceSet,
+    copySourceTables,
+    selectedCopyTableIds,
+    selectedCopyTableCount,
+    allCopySourceTablesSelected,
+    toggleCopyTableSelection,
+    toggleAllCopySourceTables,
+    copySelectedDefaultTables,
     tourName,
     tourInfo: getTourInfo(),
     selectedStage,
@@ -1460,9 +1663,11 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     removeTable,
     updateTableSettings,
     startEditingTable,
+    startEditingDefaultTable,
     startEditingOverride,
     saveTourDefault,
     saveDefaultTables,
+    handleDeleteDefaultTable,
     handleDeleteOverride,
     tourDefaultDisplayTables,
     readOnlyDefaultTables,

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -18,6 +18,7 @@ export const useJobs = () => {
     // Documents and tour dates change less frequently; keep lower priority
     { table: 'job_documents', queryKey: queryKeys.scope('jobs'), priority: 'low' },
     { table: 'tour_dates', queryKey: queryKeys.scope('jobs'), priority: 'low' },
+    { table: 'tour_default_sets', queryKey: queryKeys.scope('jobs'), priority: 'low' },
     { table: 'tours', queryKey: queryKeys.scope('jobs'), priority: 'low' },
   ]);
 
@@ -81,6 +82,13 @@ export const useJobs = () => {
                 end_date,
                 tour_date_type,
                 is_tour_pack_only,
+                tour_id,
+                sound_package_size,
+                lights_package_size,
+                video_package_size,
+                sound_default_set_id,
+                lights_default_set_id,
+                video_default_set_id,
                 tour: tours(
                   id,
                   name,

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -33,6 +33,7 @@ export const useOptimizedJobs = (
     { table: 'flex_folders', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'locations', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'tour_dates', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
+    { table: 'tour_default_sets', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
     { table: 'tours', queryKey: queryKeys.scope('optimized-jobs'), priority: 'low' },
   ]);
 
@@ -107,7 +108,14 @@ export const useOptimizedJobs = (
           start_date,
           end_date,
           tour_date_type,
-          is_tour_pack_only
+          is_tour_pack_only,
+          tour_id,
+          sound_package_size,
+          lights_package_size,
+          video_package_size,
+          sound_default_set_id,
+          lights_default_set_id,
+          video_default_set_id
         ),
         flex_folders(
           id,

--- a/src/hooks/useTourDefaultSets.ts
+++ b/src/hooks/useTourDefaultSets.ts
@@ -5,12 +5,15 @@ import { useToast } from "@/hooks/use-toast";
 
 
 import { queryKeys } from "@/lib/react-query";
+import type { TourPackageSize } from "@/utils/tourPackages";
+
 export interface TourDefaultSet {
   id: string;
   tour_id: string;
   name: string;
-  description?: string;
+  description?: string | null;
   department: 'sound' | 'lights' | 'video';
+  package_size?: TourPackageSize | null;
   created_at: string;
   updated_at: string;
 }
@@ -47,7 +50,7 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
 
       const { data, error } = await query;
       if (error) throw error;
-      return data as TourDefaultSet[];
+      return (data || []) as TourDefaultSet[];
     },
     enabled: !!tourId,
   });
@@ -67,7 +70,7 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         .order("created_at", { ascending: true });
 
       if (error) throw error;
-      return data as TourDefaultTable[];
+      return (data || []) as TourDefaultTable[];
     },
     enabled: defaultSets.length > 0,
   });
@@ -95,6 +98,37 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
       toast({
         title: "Error",
         description: error.message || "Failed to create default set",
+        variant: "destructive",
+      });
+    },
+  });
+
+  // Update default set metadata
+  const updateSetMutation = useMutation({
+    mutationFn: async ({ setId, updates }: { setId: string, updates: Partial<Pick<TourDefaultSet, "name" | "description" | "package_size">> }) => {
+      const { data, error } = await supabase
+        .from("tour_default_sets")
+        .update(updates)
+        .eq("id", setId)
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data as TourDefaultSet;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-default-sets", tourId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("optimized-jobs") });
+      toast({
+        title: "Success",
+        description: "Default set updated successfully",
+      });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to update default set",
         variant: "destructive",
       });
     },
@@ -185,6 +219,75 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
     },
   });
 
+  // Duplicate default set and all child tables
+  const duplicateSetMutation = useMutation({
+    mutationFn: async ({
+      setId,
+      name,
+      description,
+      package_size,
+    }: {
+      setId: string;
+      name?: string;
+      description?: string | null;
+      package_size?: TourPackageSize | null;
+    }) => {
+      const sourceSet = defaultSets.find((set) => set.id === setId);
+      if (!sourceSet) {
+        throw new Error("Source default set not found");
+      }
+
+      const { data: newSet, error: setError } = await supabase
+        .from("tour_default_sets")
+        .insert({
+          tour_id: sourceSet.tour_id,
+          name: name || `${sourceSet.name} Copy`,
+          description: description ?? sourceSet.description ?? null,
+          department: sourceSet.department,
+          package_size: package_size ?? sourceSet.package_size ?? null,
+        })
+        .select()
+        .single();
+
+      if (setError) throw setError;
+
+      const sourceTables = defaultTables.filter((table) => table.set_id === setId);
+      if (sourceTables.length > 0) {
+        const { error: tablesError } = await supabase
+          .from("tour_default_tables")
+          .insert(
+            sourceTables.map((table) => ({
+              set_id: newSet.id,
+              table_name: table.table_name,
+              table_data: table.table_data,
+              table_type: table.table_type,
+              total_value: table.total_value,
+              metadata: table.metadata,
+            }))
+          );
+
+        if (tablesError) throw tablesError;
+      }
+
+      return newSet as TourDefaultSet;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-default-sets", tourId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-default-tables", tourId) });
+      toast({
+        title: "Success",
+        description: "Default set duplicated successfully",
+      });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to duplicate default set",
+        variant: "destructive",
+      });
+    },
+  });
+
   // Delete default table
   const deleteTableMutation = useMutation({
     mutationFn: async (tableId: string) => {
@@ -217,14 +320,18 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
     defaultTables,
     isLoading: setsLoading || tablesLoading,
     createSet: createSetMutation.mutateAsync,
+    updateSet: updateSetMutation.mutateAsync,
     createTable: createTableMutation.mutateAsync,
     updateTable: updateTableMutation.mutateAsync,
     deleteSet: deleteSetMutation.mutateAsync,
     deleteTable: deleteTableMutation.mutateAsync,
+    duplicateSet: duplicateSetMutation.mutateAsync,
     isCreatingSet: createSetMutation.isPending,
+    isUpdatingSet: updateSetMutation.isPending,
     isCreatingTable: createTableMutation.isPending,
     isUpdatingTable: updateTableMutation.isPending,
     isDeletingSet: deleteSetMutation.isPending,
     isDeletingTable: deleteTableMutation.isPending,
+    isDuplicatingSet: duplicateSetMutation.isPending,
   };
 };

--- a/src/hooks/useTourDefaultSets.ts
+++ b/src/hooks/useTourDefaultSets.ts
@@ -288,6 +288,56 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
     },
   });
 
+  // Copy selected child tables into an existing set
+  const copyTablesToSetMutation = useMutation({
+    mutationFn: async ({
+      tableIds,
+      targetSetId,
+    }: {
+      tableIds: string[];
+      targetSetId: string;
+    }) => {
+      const sourceTables = defaultTables.filter((table) => tableIds.includes(table.id));
+      if (sourceTables.length === 0) {
+        throw new Error("No default tables selected");
+      }
+
+      const { data, error } = await supabase
+        .from("tour_default_tables")
+        .insert(
+          sourceTables.map((table) => ({
+            set_id: targetSetId,
+            table_name:
+              table.set_id === targetSetId
+                ? `${table.table_name} Copy`
+                : table.table_name,
+            table_data: table.table_data,
+            table_type: table.table_type,
+            total_value: table.total_value,
+            metadata: table.metadata,
+          })),
+        )
+        .select();
+
+      if (error) throw error;
+      return data as TourDefaultTable[];
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-default-tables", tourId) });
+      toast({
+        title: "Success",
+        description: "Default table(s) copied successfully",
+      });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to copy default tables",
+        variant: "destructive",
+      });
+    },
+  });
+
   // Delete default table
   const deleteTableMutation = useMutation({
     mutationFn: async (tableId: string) => {
@@ -326,6 +376,7 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
     deleteSet: deleteSetMutation.mutateAsync,
     deleteTable: deleteTableMutation.mutateAsync,
     duplicateSet: duplicateSetMutation.mutateAsync,
+    copyTablesToSet: copyTablesToSetMutation.mutateAsync,
     isCreatingSet: createSetMutation.isPending,
     isUpdatingSet: updateSetMutation.isPending,
     isCreatingTable: createTableMutation.isPending,
@@ -333,5 +384,6 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
     isDeletingSet: deleteSetMutation.isPending,
     isDeletingTable: deleteTableMutation.isPending,
     isDuplicatingSet: duplicateSetMutation.isPending,
+    isCopyingTables: copyTablesToSetMutation.isPending,
   };
 };

--- a/src/hooks/useTourOverrideMode.ts
+++ b/src/hooks/useTourOverrideMode.ts
@@ -2,6 +2,14 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/lib/supabase';
 import { useToast } from '@/hooks/use-toast';
+import {
+  getPackageResolutionMessage,
+  isPackageDepartment,
+  resolveDefaultSetForTourDate,
+  type ResolveDefaultSetResult,
+  type TourDefaultSetLike,
+  type TourPackageDateLike,
+} from '@/utils/tourPackages';
 
 interface TourOverrideData {
   tourId: string;
@@ -11,6 +19,7 @@ interface TourOverrideData {
   locationName: string;
   defaults: any[];
   overrides: any[];
+  defaultSetResolution?: ResolveDefaultSetResult<TourDefaultSetLike>;
 }
 
 export const useTourOverrideMode = (
@@ -43,6 +52,14 @@ export const useTourOverrideMode = (
           .from('tour_dates')
           .select(`
             date,
+            tour_id,
+            is_tour_pack_only,
+            sound_package_size,
+            lights_package_size,
+            video_package_size,
+            sound_default_set_id,
+            lights_default_set_id,
+            video_default_set_id,
             locations (name)
           `)
           .eq('id', tourDateId)
@@ -50,17 +67,43 @@ export const useTourOverrideMode = (
 
         if (tourDateError) throw tourDateError;
 
-        // Fetch defaults for this tour and department
-        const { data: defaultTables, error: defaultsError } = await supabase
-          .from('tour_default_tables')
-          .select(`
-            *,
-            tour_default_sets!inner(tour_id, department)
-          `)
-          .eq('tour_default_sets.tour_id', tourId)
-          .eq('tour_default_sets.department', department);
+        let defaultTables: any[] = [];
+        let defaultSetResolution: ResolveDefaultSetResult<TourDefaultSetLike> | undefined;
 
-        if (defaultsError) throw defaultsError;
+        if (isPackageDepartment(department)) {
+          const { data: defaultSets, error: setsError } = await supabase
+            .from('tour_default_sets')
+            .select('*')
+            .eq('tour_id', tourId)
+            .eq('department', department);
+
+          if (setsError) throw setsError;
+
+          defaultSetResolution = resolveDefaultSetForTourDate({
+            tourDate: tourDateData as TourPackageDateLike,
+            department,
+            defaultSets: (defaultSets || []) as TourDefaultSetLike[],
+          });
+
+          if (defaultSetResolution.status === 'resolved') {
+            const { data, error: defaultsError } = await supabase
+              .from('tour_default_tables')
+              .select('*')
+              .eq('set_id', defaultSetResolution.set.id);
+
+            if (defaultsError) throw defaultsError;
+            defaultTables = data || [];
+          } else {
+            const message = getPackageResolutionMessage(defaultSetResolution);
+            if (message) {
+              toast({
+                title: 'Tour defaults need attention',
+                description: message,
+                variant: 'destructive',
+              });
+            }
+          }
+        }
 
         // Fetch existing overrides for this tour date and department
         const powerOverridesPromise = supabase
@@ -86,11 +129,12 @@ export const useTourOverrideMode = (
           tourName: tourData.name,
           tourDate: tourDateData.date,
           locationName: (tourDateData.locations as any)?.name || 'Unknown Location',
-          defaults: defaultTables || [],
+          defaults: defaultTables,
           overrides: [
             ...(powerOverrides.data || []),
             ...(weightOverrides.data || [])
-          ]
+          ],
+          defaultSetResolution,
         });
       } catch (error) {
         console.error('Error loading override data:', error);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -7978,11 +7978,17 @@ export type Database = {
           flex_folders_created: boolean | null
           id: string
           is_tour_pack_only: boolean | null
+          lights_default_set_id: string | null
+          lights_package_size: "xl" | "l" | "m" | "s" | null
           location_id: string | null
           rehearsal_days: number | null
+          sound_default_set_id: string | null
+          sound_package_size: "xl" | "l" | "m" | "s" | null
           start_date: string
           tour_date_type: Database["public"]["Enums"]["tour_date_type"] | null
           tour_id: string | null
+          video_default_set_id: string | null
+          video_package_size: "xl" | "l" | "m" | "s" | null
         }
         Insert: {
           created_at?: string
@@ -7991,11 +7997,17 @@ export type Database = {
           flex_folders_created?: boolean | null
           id?: string
           is_tour_pack_only?: boolean | null
+          lights_default_set_id?: string | null
+          lights_package_size?: "xl" | "l" | "m" | "s" | null
           location_id?: string | null
           rehearsal_days?: number | null
+          sound_default_set_id?: string | null
+          sound_package_size?: "xl" | "l" | "m" | "s" | null
           start_date: string
           tour_date_type?: Database["public"]["Enums"]["tour_date_type"] | null
           tour_id?: string | null
+          video_default_set_id?: string | null
+          video_package_size?: "xl" | "l" | "m" | "s" | null
         }
         Update: {
           created_at?: string
@@ -8004,13 +8016,26 @@ export type Database = {
           flex_folders_created?: boolean | null
           id?: string
           is_tour_pack_only?: boolean | null
+          lights_default_set_id?: string | null
+          lights_package_size?: "xl" | "l" | "m" | "s" | null
           location_id?: string | null
           rehearsal_days?: number | null
+          sound_default_set_id?: string | null
+          sound_package_size?: "xl" | "l" | "m" | "s" | null
           start_date?: string
           tour_date_type?: Database["public"]["Enums"]["tour_date_type"] | null
           tour_id?: string | null
+          video_default_set_id?: string | null
+          video_package_size?: "xl" | "l" | "m" | "s" | null
         }
         Relationships: [
+          {
+            foreignKeyName: "tour_dates_lights_default_set_id_fkey"
+            columns: ["lights_default_set_id"]
+            isOneToOne: false
+            referencedRelation: "tour_default_sets"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "tour_dates_location_id_fkey"
             columns: ["location_id"]
@@ -8019,10 +8044,24 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "tour_dates_sound_default_set_id_fkey"
+            columns: ["sound_default_set_id"]
+            isOneToOne: false
+            referencedRelation: "tour_default_sets"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "tour_dates_tour_id_fkey"
             columns: ["tour_id"]
             isOneToOne: false
             referencedRelation: "tours"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tour_dates_video_default_set_id_fkey"
+            columns: ["video_default_set_id"]
+            isOneToOne: false
+            referencedRelation: "tour_default_sets"
             referencedColumns: ["id"]
           },
         ]
@@ -8034,6 +8073,7 @@ export type Database = {
           description: string | null
           id: string
           name: string
+          package_size: "xl" | "l" | "m" | "s" | null
           tour_id: string
           updated_at: string
         }
@@ -8043,6 +8083,7 @@ export type Database = {
           description?: string | null
           id?: string
           name: string
+          package_size?: "xl" | "l" | "m" | "s" | null
           tour_id: string
           updated_at?: string
         }
@@ -8052,6 +8093,7 @@ export type Database = {
           description?: string | null
           id?: string
           name?: string
+          package_size?: "xl" | "l" | "m" | "s" | null
           tour_id?: string
           updated_at?: string
         }

--- a/src/lib/tourPdfExport.ts
+++ b/src/lib/tourPdfExport.ts
@@ -4,6 +4,12 @@ import { fetchTourLogo } from '@/utils/pdf/logoUtils';
 import { buildReadableFilename } from '@/utils/fileName';
 import { MADRID_TIMEZONE } from '@/utils/timezoneUtils';
 import {
+  PACKAGE_DEPARTMENTS,
+  getDepartmentPackageSize,
+  getPackageBadgeLabel,
+  type TourPackageSize,
+} from '@/utils/tourPackages';
+import {
   createPdfExportDocument,
   drawCorporatePdfHeader,
   getLastAutoTableY,
@@ -18,6 +24,9 @@ import {
 interface TourScheduleDate {
   date: string;
   is_tour_pack_only?: boolean | null;
+  sound_package_size?: TourPackageSize | null;
+  lights_package_size?: TourPackageSize | null;
+  video_package_size?: TourPackageSize | null;
   location?: {
     name?: string | null;
   } | null;
@@ -39,7 +48,13 @@ const tableRowsForTour = (tour: TourScheduleExport) =>
     format(parseISO(date.date), 'dd/MM/yyyy'),
     format(parseISO(date.date), 'EEEE'),
     date.location?.name || 'TBC',
-    date.is_tour_pack_only ? 'Tour Pack Only' : 'Full Setup',
+    PACKAGE_DEPARTMENTS
+      .map((department) => {
+        const packageSize = getDepartmentPackageSize(date, department);
+        return packageSize ? getPackageBadgeLabel({ department, packageSize }) : null;
+      })
+      .filter(Boolean)
+      .join(' · ') || 'Unassigned',
   ]);
 
 const drawTourScheduleHeader = async (

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -22,6 +22,7 @@ import {
 import type { TechnicalStage } from '@/features/technical-tools/stage/stageUtils';
 import { CopyToStageMenu } from '@/features/technical-tools/table-presets/CopyToStageMenu';
 import { QuickPresetsMenu } from '@/features/technical-tools/table-presets/QuickPresetsMenu';
+import type { TourPackageSize } from '@/utils/tourPackages';
 import {
   cloneTablesToStage,
   remapClusterIds,
@@ -212,6 +213,17 @@ const PesosTool: React.FC = () => {
     isLoading: defaultsLoading
   } = useTourDefaultSets(tourId || '', 'sound');
 
+  const [selectedDefaultSetId, setSelectedDefaultSetId] = useState<string>('');
+  const [selectedDefaultPackageSize, setSelectedDefaultPackageSize] = useState<TourPackageSize | 'unassigned'>('unassigned');
+  const [newDefaultSetName, setNewDefaultSetName] = useState('');
+
+  useEffect(() => {
+    if (!isTourDefaults && !isDefaults) return;
+    if (selectedDefaultSetId || defaultSets.length !== 1) return;
+    setSelectedDefaultSetId(defaultSets[0].id);
+    setSelectedDefaultPackageSize(defaultSets[0].package_size || 'unassigned');
+  }, [defaultSets, isDefaults, isTourDefaults, selectedDefaultSetId]);
+
   const {
     weightOverrides,
     createWeightOverride,
@@ -316,21 +328,25 @@ const PesosTool: React.FC = () => {
 
   // Helper function to get or create the set ID for sound department
   const getOrCreateSoundSetId = async (): Promise<string> => {
-    // Check if a sound set already exists
-    const existingSoundSet = defaultSets.find(set => set.department === 'sound');
-
-    if (existingSoundSet) {
-      return existingSoundSet.id;
+    if (selectedDefaultSetId) {
+      return selectedDefaultSetId;
     }
 
-    // Create a new sound set
+    const trimmedName = (newDefaultSetName || currentSetName).trim();
+    if (!trimmedName) {
+      throw new Error('Select an existing default set or enter a name to create one.');
+    }
+
     const newSet = await createSet({
       tour_id: tourId!,
-      name: `${tourName} Sound Defaults`,
+      name: trimmedName,
       department: 'sound',
-      description: 'Sound department weight defaults'
+      description: 'Sound department weight defaults',
+      package_size: selectedDefaultPackageSize === 'unassigned' ? null : selectedDefaultPackageSize
     });
 
+    setSelectedDefaultSetId(newSet.id);
+    setNewDefaultSetName('');
     return newSet.id;
   };
 
@@ -419,7 +435,7 @@ const PesosTool: React.FC = () => {
     if (isDefaults && defaultTables.length > 0) {
       // Group tables by set and convert to our local format
       const convertedTables = defaultTables
-        .filter(dt => dt.table_type === 'weight')
+        .filter(dt => dt.table_type === 'weight' && (!selectedDefaultSetId || dt.set_id === selectedDefaultSetId))
         .map((dt, index) => ({
           name: dt.table_name,
           rows: (dt.table_data?.rows || [{
@@ -441,7 +457,7 @@ const PesosTool: React.FC = () => {
         }));
       setTables(assignSuffixes(convertedTables));
     }
-  }, [isDefaults, defaultTables]);
+  }, [isDefaults, defaultTables, selectedDefaultSetId]);
 
   // Load tour date overrides when in tour date context
   useEffect(() => {
@@ -532,7 +548,8 @@ const PesosTool: React.FC = () => {
         tour_id: tourId,
         name: currentSetName,
         description: `Weight calculation set with ${tables.length} tables`,
-        department: 'sound'
+        department: 'sound',
+        package_size: selectedDefaultPackageSize === 'unassigned' ? null : selectedDefaultPackageSize
       });
 
       // Save each table as a default table
@@ -951,6 +968,12 @@ const PesosTool: React.FC = () => {
       resetCurrentTable={resetCurrentTable}
       defaultSets={defaultSets}
       defaultTables={defaultTables}
+      selectedDefaultSetId={selectedDefaultSetId}
+      setSelectedDefaultSetId={setSelectedDefaultSetId}
+      selectedDefaultPackageSize={selectedDefaultPackageSize}
+      setSelectedDefaultPackageSize={setSelectedDefaultPackageSize}
+      newDefaultSetName={newDefaultSetName}
+      setNewDefaultSetName={setNewDefaultSetName}
       deleteSet={deleteSet}
       weightOverrides={weightOverrides}
       deleteOverride={deleteOverride}

--- a/src/pages/pesos-tool/PesosToolView.tsx
+++ b/src/pages/pesos-tool/PesosToolView.tsx
@@ -12,6 +12,11 @@ import {
   TechnicalStageSelector,
   type TechnicalStage,
 } from "@/features/technical-tools/stage/stageAllocation";
+import {
+  TOUR_PACKAGE_LABELS,
+  TOUR_PACKAGE_SIZES,
+  type TourPackageSize,
+} from "@/utils/tourPackages";
 
 export interface PesosToolViewProps {
   handleBackNavigation: () => void;
@@ -53,6 +58,12 @@ export interface PesosToolViewProps {
   resetCurrentTable: () => void;
   defaultSets: any[];
   defaultTables: any[];
+  selectedDefaultSetId: string;
+  setSelectedDefaultSetId: (value: string) => void;
+  selectedDefaultPackageSize: TourPackageSize | "unassigned";
+  setSelectedDefaultPackageSize: (value: TourPackageSize | "unassigned") => void;
+  newDefaultSetName: string;
+  setNewDefaultSetName: (value: string) => void;
   deleteSet: (id: string) => void;
   weightOverrides: any[];
   deleteOverride: (args: { id: string; table: string }) => void;
@@ -102,6 +113,12 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
   resetCurrentTable,
   defaultSets,
   defaultTables,
+  selectedDefaultSetId,
+  setSelectedDefaultSetId,
+  selectedDefaultPackageSize,
+  setSelectedDefaultPackageSize,
+  newDefaultSetName,
+  setNewDefaultSetName,
   deleteSet,
   weightOverrides,
   deleteOverride,
@@ -228,6 +245,66 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                       onChange={(e) => setCurrentSetName(e.target.value)}
                       placeholder="Enter set name (e.g., 'Main Stage Rigging')"
                     />
+                  </div>
+                )}
+
+                {(isDefaults || isTourDefaults) && (
+                  <div className="space-y-3 rounded-lg border p-4">
+                    <h3 className="text-sm font-semibold">Sound default set</h3>
+                    <div className="space-y-2">
+                      <Label>Existing set</Label>
+                      <Select
+                        value={selectedDefaultSetId || "new"}
+                        onValueChange={(value) => setSelectedDefaultSetId(value === "new" ? "" : value)}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select default set" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="new">Create new set</SelectItem>
+                          {defaultSets.map((set) => (
+                            <SelectItem key={set.id} value={set.id}>
+                              {set.name}
+                              {set.package_size ? ` (${TOUR_PACKAGE_LABELS[set.package_size as TourPackageSize]})` : " (Unassigned)"}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {!selectedDefaultSetId && (
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <div className="space-y-2">
+                          <Label htmlFor="newWeightDefaultSetName">New set name</Label>
+                          <Input
+                            id="newWeightDefaultSetName"
+                            value={newDefaultSetName}
+                            onChange={(event) => setNewDefaultSetName(event.target.value)}
+                            placeholder="Sound S weights"
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>Package size</Label>
+                          <Select
+                            value={selectedDefaultPackageSize}
+                            onValueChange={(value) =>
+                              setSelectedDefaultPackageSize(value as TourPackageSize | "unassigned")
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder="Package size" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="unassigned">Unassigned</SelectItem>
+                              {TOUR_PACKAGE_SIZES.map((size) => (
+                                <SelectItem key={size} value={size}>
+                                  {TOUR_PACKAGE_LABELS[size]}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
 

--- a/src/pages/pesos-tool/PesosToolView.tsx
+++ b/src/pages/pesos-tool/PesosToolView.tsx
@@ -141,10 +141,10 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
               {isTourDefaults && (
                 <div className="flex items-center justify-center gap-2 mt-2">
                   <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
-                    Tour Defaults Mode
+                    Modo Valores por Defecto
                   </Badge>
                   <p className="text-sm text-muted-foreground">
-                    Creating defaults for: <span className="font-medium">{tourName}</span>
+                    Creando valores por defecto para: <span className="font-medium">{tourName}</span>
                   </p>
                 </div>
               )}
@@ -200,11 +200,11 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                   <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                     <div className="flex items-center gap-2">
                       <div className="h-2 w-2 bg-blue-500 rounded-full"></div>
-                      <p className="text-sm font-medium text-blue-900">Job Override Mode Active</p>
+                      <p className="text-sm font-medium text-blue-900">Modo Anulación de Trabajo Activo</p>
                     </div>
                     <p className="text-sm text-blue-700 mt-1">
-                      This job is part of a tour. Any tables you create will be saved as overrides for the specific tour
-                      date.
+                      Este trabajo forma parte de una gira. Las tablas que crees se guardarán como anulaciones para la
+                      fecha de gira específica.
                     </p>
                   </div>
                 )}
@@ -214,11 +214,12 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                   <div className="bg-green-50 border border-green-200 rounded-lg p-4">
                     <div className="flex items-center gap-2">
                       <div className="h-2 w-2 bg-green-500 rounded-full"></div>
-                      <p className="text-sm font-medium text-green-900">Tour Defaults Mode Active</p>
+                      <p className="text-sm font-medium text-green-900">Modo Conjunto por Defecto de Gira Activo</p>
                     </div>
                     <p className="text-sm text-green-700 mt-1">
-                      Any tables you create will be saved as global defaults for this tour. These defaults will apply to
-                      all tour dates unless specifically overridden.
+                      Las tablas que crees se guardarán en el conjunto/paquete de Sonido seleccionado. Las fechas de gira
+                      solo usarán ese conjunto cuando su paquete de Sonido o pin explícito lo resuelva; las anulaciones
+                      por fecha siguen teniendo prioridad.
                     </p>
                   </div>
                 )}
@@ -228,10 +229,10 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                   <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                     <div className="flex items-center gap-2">
                       <div className="h-2 w-2 bg-blue-500 rounded-full"></div>
-                      <p className="text-sm font-medium text-blue-900">Override Mode Active</p>
+                      <p className="text-sm font-medium text-blue-900">Modo Anulación Activo</p>
                     </div>
                     <p className="text-sm text-blue-700 mt-1">
-                      Any tables you create will be saved as overrides for this specific tour date.
+                      Las tablas que crees se guardarán como anulaciones para esta fecha de gira específica.
                     </p>
                   </div>
                 )}
@@ -250,22 +251,22 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
 
                 {(isDefaults || isTourDefaults) && (
                   <div className="space-y-3 rounded-lg border p-4">
-                    <h3 className="text-sm font-semibold">Sound default set</h3>
+                    <h3 className="text-sm font-semibold">Conjunto por defecto de Sonido</h3>
                     <div className="space-y-2">
-                      <Label>Existing set</Label>
+                      <Label>Conjunto existente</Label>
                       <Select
                         value={selectedDefaultSetId || "new"}
                         onValueChange={(value) => setSelectedDefaultSetId(value === "new" ? "" : value)}
                       >
                         <SelectTrigger>
-                          <SelectValue placeholder="Select default set" />
+                          <SelectValue placeholder="Selecciona un conjunto" />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="new">Create new set</SelectItem>
+                          <SelectItem value="new">Crear conjunto</SelectItem>
                           {defaultSets.map((set) => (
                             <SelectItem key={set.id} value={set.id}>
                               {set.name}
-                              {set.package_size ? ` (${TOUR_PACKAGE_LABELS[set.package_size as TourPackageSize]})` : " (Unassigned)"}
+                              {set.package_size ? ` (${TOUR_PACKAGE_LABELS[set.package_size as TourPackageSize]})` : " (Sin asignar)"}
                             </SelectItem>
                           ))}
                         </SelectContent>
@@ -274,16 +275,16 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                     {!selectedDefaultSetId && (
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                         <div className="space-y-2">
-                          <Label htmlFor="newWeightDefaultSetName">New set name</Label>
+                          <Label htmlFor="newWeightDefaultSetName">Nombre del nuevo conjunto</Label>
                           <Input
                             id="newWeightDefaultSetName"
                             value={newDefaultSetName}
                             onChange={(event) => setNewDefaultSetName(event.target.value)}
-                            placeholder="Sound S weights"
+                            placeholder="Pesos Sonido S"
                           />
                         </div>
                         <div className="space-y-2">
-                          <Label>Package size</Label>
+                          <Label>Tamaño de paquete</Label>
                           <Select
                             value={selectedDefaultPackageSize}
                             onValueChange={(value) =>
@@ -291,10 +292,10 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                             }
                           >
                             <SelectTrigger>
-                              <SelectValue placeholder="Package size" />
+                              <SelectValue placeholder="Tamaño de paquete" />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="unassigned">Unassigned</SelectItem>
+                              <SelectItem value="unassigned">Sin asignar</SelectItem>
                               {TOUR_PACKAGE_SIZES.map((size) => (
                                 <SelectItem key={size} value={size}>
                                   {TOUR_PACKAGE_LABELS[size]}

--- a/src/utils/__tests__/powerSummaryData.test.ts
+++ b/src/utils/__tests__/powerSummaryData.test.ts
@@ -753,6 +753,73 @@ describe('powerSummaryData', () => {
     expect(summary.totalSystemWatts).toBe(4300);
   });
 
+  it('uses only the resolved package default set for tourdate summaries', async () => {
+    const supabase = createMockSupabase({
+      tour_dates: [
+        {
+          id: 'tour-date-1',
+          tour_id: 'tour-1',
+          sound_package_size: 'xl',
+          is_tour_pack_only: false,
+          sound_default_set_id: null,
+          lights_default_set_id: null,
+          video_default_set_id: null,
+        },
+      ],
+      tour_date_power_overrides: [],
+      tour_power_defaults: [],
+      tour_default_sets: [
+        {
+          id: 'set-sound-xl',
+          tour_id: 'tour-1',
+          department: 'sound',
+          package_size: 'xl',
+        },
+        {
+          id: 'set-sound-s',
+          tour_id: 'tour-1',
+          department: 'sound',
+          package_size: 's',
+        },
+      ],
+      tour_default_tables: [
+        {
+          id: 'default-sound-xl',
+          set_id: 'set-sound-xl',
+          table_name: 'XL FoH',
+          table_type: 'power',
+          total_value: 3000,
+          metadata: { current_per_phase: 12, pdu_type: '63A', pf: 0.95 },
+          table_data: { rows: [{ quantity: '1' }] },
+          created_at: '2026-04-07T08:00:00.000Z',
+        },
+        {
+          id: 'default-sound-s',
+          set_id: 'set-sound-s',
+          table_name: 'S FoH',
+          table_type: 'power',
+          total_value: 1000,
+          metadata: { current_per_phase: 4, pdu_type: '32A', pf: 0.95 },
+          table_data: { rows: [{ quantity: '1' }] },
+          created_at: '2026-04-07T08:00:00.000Z',
+        },
+      ],
+    });
+
+    const summary = await loadTechnicalPowerSummaryData({
+      job: {
+        id: 'job-tour',
+        job_type: 'tourdate',
+        tour_id: 'tour-1',
+        tour_date_id: 'tour-date-1',
+      },
+      supabase,
+    });
+
+    expect(summary.departments.sound.rows.map((row) => row.name)).toEqual(['XL FoH']);
+    expect(summary.departments.sound.totalWatts).toBe(3000);
+  });
+
   it('treats legacy tour defaults with a null department as sound defaults', async () => {
     const supabase = createMockSupabase({
       tour_date_power_overrides: [],

--- a/src/utils/__tests__/tourPackages.test.ts
+++ b/src/utils/__tests__/tourPackages.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEPARTMENT_PACKAGE_LABELS,
+  DEPARTMENT_PACKAGE_PREFIX,
+  TOUR_PACKAGE_LABELS,
+  getDepartmentDefaultSetId,
+  getDepartmentPackageSize,
+  getPackageBadgeLabel,
+  resolveDefaultSetForTourDate,
+  type TourDefaultSetLike,
+} from '@/utils/tourPackages';
+
+const makeSet = (
+  overrides: Partial<TourDefaultSetLike> & Pick<TourDefaultSetLike, 'id' | 'department'>
+): TourDefaultSetLike => ({
+  tour_id: 'tour-1',
+  name: overrides.id,
+  package_size: null,
+  ...overrides,
+});
+
+describe('tourPackages', () => {
+  it('maps package labels and department labels/prefixes', () => {
+    expect(TOUR_PACKAGE_LABELS).toMatchObject({
+      xl: 'XL',
+      l: 'L',
+      m: 'M',
+      s: 'S',
+    });
+
+    expect(DEPARTMENT_PACKAGE_LABELS.sound).toBe('Sound');
+    expect(DEPARTMENT_PACKAGE_LABELS.lights).toBe('Lights');
+    expect(DEPARTMENT_PACKAGE_LABELS.video).toBe('Video');
+    expect(DEPARTMENT_PACKAGE_PREFIX.sound).toBe('SX');
+    expect(DEPARTMENT_PACKAGE_PREFIX.lights).toBe('LX');
+    expect(DEPARTMENT_PACKAGE_PREFIX.video).toBe('VX');
+  });
+
+  it('builds desktop and mobile badge labels', () => {
+    expect(getPackageBadgeLabel({ department: 'sound', packageSize: 'xl' })).toBe('Sound XL');
+    expect(getPackageBadgeLabel({ department: 'lights', packageSize: 'm' })).toBe('Lights M');
+    expect(getPackageBadgeLabel({ department: 'video', packageSize: 's' })).toBe('Video S');
+    expect(getPackageBadgeLabel({ department: 'sound', packageSize: 'xl', mobile: true })).toBe('SX XL');
+    expect(getPackageBadgeLabel({ department: 'lights', packageSize: 'm', mobile: true })).toBe('LX M');
+    expect(getPackageBadgeLabel({ department: 'video', packageSize: 's', mobile: true })).toBe('VX S');
+  });
+
+  it('reads package sizes and default set ids by department with legacy S fallback', () => {
+    const tourDate = {
+      sound_package_size: 'xl',
+      lights_package_size: 'm',
+      video_default_set_id: 'video-set',
+      is_tour_pack_only: true,
+    };
+
+    expect(getDepartmentPackageSize(tourDate, 'sound')).toBe('xl');
+    expect(getDepartmentPackageSize(tourDate, 'lights')).toBe('m');
+    expect(getDepartmentPackageSize(tourDate, 'video')).toBe('s');
+    expect(getDepartmentDefaultSetId(tourDate, 'video')).toBe('video-set');
+    expect(getDepartmentPackageSize({ is_tour_pack_only: false }, 'sound')).toBeNull();
+  });
+
+  it('resolves an explicit valid set before package matching', () => {
+    const sets = [
+      makeSet({ id: 'sound-s', department: 'sound', package_size: 's' }),
+      makeSet({ id: 'sound-custom', department: 'sound', package_size: null }),
+    ];
+
+    const result = resolveDefaultSetForTourDate({
+      tourDate: {
+        tour_id: 'tour-1',
+        sound_package_size: 's',
+        sound_default_set_id: 'sound-custom',
+      },
+      department: 'sound',
+      defaultSets: sets,
+    });
+
+    expect(result.status).toBe('resolved');
+    if (result.status === 'resolved') {
+      expect(result.source).toBe('explicit');
+      expect(result.set.id).toBe('sound-custom');
+    }
+  });
+
+  it('rejects explicit pins with mismatched package size', () => {
+    const result = resolveDefaultSetForTourDate({
+      tourDate: {
+        tour_id: 'tour-1',
+        sound_package_size: 's',
+        sound_default_set_id: 'sound-xl',
+      },
+      department: 'sound',
+      defaultSets: [makeSet({ id: 'sound-xl', department: 'sound', package_size: 'xl' })],
+    });
+
+    expect(result.status).toBe('invalid_explicit');
+    if (result.status === 'invalid_explicit') {
+      expect(result.reason).toBe('package_mismatch');
+    }
+  });
+
+  it('resolves a unique package match', () => {
+    const result = resolveDefaultSetForTourDate({
+      tourDate: { tour_id: 'tour-1', lights_package_size: 'm' },
+      department: 'lights',
+      defaultSets: [
+        makeSet({ id: 'lights-m', department: 'lights', package_size: 'm' }),
+        makeSet({ id: 'lights-s', department: 'lights', package_size: 's' }),
+      ],
+    });
+
+    expect(result.status).toBe('resolved');
+    if (result.status === 'resolved') {
+      expect(result.source).toBe('package_size');
+      expect(result.set.id).toBe('lights-m');
+    }
+  });
+
+  it('resolves legacy tour-pack dates as S', () => {
+    const result = resolveDefaultSetForTourDate({
+      tourDate: { tour_id: 'tour-1', is_tour_pack_only: true },
+      department: 'video',
+      defaultSets: [makeSet({ id: 'video-s', department: 'video', package_size: 's' })],
+    });
+
+    expect(result.status).toBe('resolved');
+    if (result.status === 'resolved') {
+      expect(result.source).toBe('legacy_tour_pack');
+      expect(result.packageSize).toBe('s');
+    }
+  });
+
+  it('uses single-set fallback for old tours without package intent', () => {
+    const result = resolveDefaultSetForTourDate({
+      tourDate: { tour_id: 'tour-1' },
+      department: 'sound',
+      defaultSets: [makeSet({ id: 'only-sound-set', department: 'sound' })],
+    });
+
+    expect(result.status).toBe('resolved');
+    if (result.status === 'resolved') {
+      expect(result.source).toBe('single_set_fallback');
+    }
+  });
+
+  it('returns missing or ambiguous instead of merging defaults', () => {
+    expect(
+      resolveDefaultSetForTourDate({
+        tourDate: { tour_id: 'tour-1', sound_package_size: 'xl' },
+        department: 'sound',
+        defaultSets: [],
+      }).status
+    ).toBe('missing');
+
+    const ambiguous = resolveDefaultSetForTourDate({
+      tourDate: { tour_id: 'tour-1', sound_package_size: 's' },
+      department: 'sound',
+      defaultSets: [
+        makeSet({ id: 'sound-s-a', department: 'sound', package_size: 's' }),
+        makeSet({ id: 'sound-s-b', department: 'sound', package_size: 's' }),
+      ],
+    });
+
+    expect(ambiguous.status).toBe('ambiguous');
+    if (ambiguous.status === 'ambiguous') {
+      expect(ambiguous.matches).toHaveLength(2);
+    }
+  });
+
+  it('rejects wrong explicit department and tour pins', () => {
+    const wrongDepartment = resolveDefaultSetForTourDate({
+      tourDate: { tour_id: 'tour-1', sound_default_set_id: 'lights-s' },
+      department: 'sound',
+      defaultSets: [makeSet({ id: 'lights-s', department: 'lights', package_size: 's' })],
+    });
+    expect(wrongDepartment.status).toBe('invalid_explicit');
+    if (wrongDepartment.status === 'invalid_explicit') {
+      expect(wrongDepartment.reason).toBe('wrong_department');
+    }
+
+    const wrongTour = resolveDefaultSetForTourDate({
+      tourDate: { tour_id: 'tour-1', sound_default_set_id: 'sound-other-tour' },
+      department: 'sound',
+      defaultSets: [
+        makeSet({
+          id: 'sound-other-tour',
+          department: 'sound',
+          tour_id: 'tour-2',
+          package_size: 's',
+        }),
+      ],
+    });
+    expect(wrongTour.status).toBe('invalid_explicit');
+    if (wrongTour.status === 'invalid_explicit') {
+      expect(wrongTour.reason).toBe('wrong_tour');
+    }
+  });
+});

--- a/src/utils/powerSummaryData.ts
+++ b/src/utils/powerSummaryData.ts
@@ -15,6 +15,12 @@ import {
   type TechnicalPowerDepartment,
   normalizeTechnicalPowerDepartments,
 } from '@/utils/technicalPowerTypes';
+import {
+  getDepartmentPackageSize,
+  isPackageDepartment,
+  resolveDefaultSetForTourDate,
+  type TourPackageDateLike,
+} from '@/utils/tourPackages';
 
 type TypedSupabaseClient = SupabaseClient<Database>;
 type PowerRequirementTableRow = Database['public']['Tables']['power_requirement_tables']['Row'];
@@ -376,17 +382,30 @@ const loadTourdateReferenceData = async ({
 }) => {
   let resolvedTourId = tourId || null;
 
+  const { data: tourDateRows, error: tourDateError } = await supabase
+    .from('tour_dates')
+    .select(`
+      id,
+      tour_id,
+      is_tour_pack_only,
+      sound_package_size,
+      lights_package_size,
+      video_package_size,
+      sound_default_set_id,
+      lights_default_set_id,
+      video_default_set_id
+    `)
+    .eq('id', tourDateId);
+
+  if (tourDateError) throw tourDateError;
+
+  const tourDate =
+    (tourDateRows?.[0] as TourPackageDateLike | undefined) ||
+    (resolvedTourId ? ({ tour_id: resolvedTourId } satisfies TourPackageDateLike) : null);
+
   if (!resolvedTourId) {
-    const { data: tourDateRows, error: tourDateError } = await supabase
-      .from('tour_dates')
-      .select('tour_id')
-      .eq('id', tourDateId);
-
-    if (tourDateError) throw tourDateError;
-
     resolvedTourId =
-      (tourDateRows?.[0] as Pick<TourDateRow, 'tour_id'> | undefined)?.tour_id ||
-      null;
+      (tourDate as Pick<TourDateRow, 'tour_id'> | null | undefined)?.tour_id || null;
   }
 
   const [
@@ -435,6 +454,7 @@ const loadTourdateReferenceData = async ({
     legacyDefaults: legacyDefaultsResponse.data || [],
     defaultSets: defaultSetsResponse.data || [],
     defaultTables: defaultTablesResponse.data || [],
+    tourDate,
   };
 };
 
@@ -446,7 +466,7 @@ const loadTourdatePowerData = async ({
   supabase: TypedSupabaseClient;
 }) => {
   const [
-    { overrides, legacyDefaults, defaultSets, defaultTables },
+    { overrides, legacyDefaults, defaultSets, defaultTables, tourDate },
     jobSpecificDepartments,
   ] = await Promise.all([
     loadTourdateReferenceData({
@@ -463,13 +483,19 @@ const loadTourdatePowerData = async ({
         (row) => row.department === department
       ) as TourDatePowerOverrideRow[];
 
-      const departmentSetIds = defaultSets
-        .filter((set) => set.department === department)
-        .map((set) => set.id);
+      const resolvedDefaultSet =
+        tourDate && isPackageDepartment(department)
+          ? resolveDefaultSetForTourDate({
+              tourDate,
+              department,
+              defaultSets,
+            })
+          : null;
 
-      const departmentDefaultTables = defaultTables.filter((table) =>
-        departmentSetIds.includes(table.set_id)
-      ) as TourDefaultTableRow[];
+      const departmentDefaultTables =
+        resolvedDefaultSet?.status === 'resolved'
+          ? (defaultTables.filter((table) => table.set_id === resolvedDefaultSet.set.id) as TourDefaultTableRow[])
+          : [];
 
       const departmentLegacyDefaults = legacyDefaults.filter(
         (row) => isMatchingLegacyPowerDefaultDepartment(department, row.department)
@@ -496,10 +522,21 @@ const loadTourdatePowerData = async ({
         return [department, jobSpecificSummary];
       }
 
+      const hasPackageIntent =
+        tourDate && isPackageDepartment(department)
+          ? Boolean(getDepartmentPackageSize(tourDate, department))
+          : false;
+      const canUseLegacyDefaults =
+        departmentDefaultTables.length === 0 &&
+        !hasPackageIntent &&
+        (!resolvedDefaultSet ||
+          resolvedDefaultSet.status === 'missing' ||
+          resolvedDefaultSet.status === 'resolved');
+
       const normalized = buildNormalizedTourPowerTables({
         department,
         defaultTables: departmentDefaultTables,
-        legacyDefaults: departmentLegacyDefaults,
+        legacyDefaults: canUseLegacyDefaults ? departmentLegacyDefaults : [],
       });
 
       return [

--- a/src/utils/tourPackages.ts
+++ b/src/utils/tourPackages.ts
@@ -1,0 +1,306 @@
+export type TourPackageSize = "xl" | "l" | "m" | "s";
+export type PackageDepartment = "sound" | "lights" | "video";
+
+export const TOUR_PACKAGE_SIZES: TourPackageSize[] = ["xl", "l", "m", "s"];
+export const PACKAGE_DEPARTMENTS: PackageDepartment[] = ["sound", "lights", "video"];
+
+export const TOUR_PACKAGE_LABELS: Record<TourPackageSize, string> = {
+  xl: "XL",
+  l: "L",
+  m: "M",
+  s: "S",
+};
+
+export const DEPARTMENT_PACKAGE_LABELS: Record<PackageDepartment, string> = {
+  sound: "Sound",
+  lights: "Lights",
+  video: "Video",
+};
+
+export const DEPARTMENT_PACKAGE_PREFIX: Record<PackageDepartment, string> = {
+  sound: "SX",
+  lights: "LX",
+  video: "VX",
+};
+
+export interface TourPackageDateLike {
+  tour_id?: string | null;
+  is_tour_pack_only?: boolean | null;
+  sound_package_size?: TourPackageSize | string | null;
+  lights_package_size?: TourPackageSize | string | null;
+  video_package_size?: TourPackageSize | string | null;
+  sound_default_set_id?: string | null;
+  lights_default_set_id?: string | null;
+  video_default_set_id?: string | null;
+}
+
+export interface TourDefaultSetLike {
+  id: string;
+  tour_id: string;
+  department: string | null;
+  name?: string | null;
+  package_size?: TourPackageSize | string | null;
+}
+
+export type ResolveDefaultSetResult<TSet extends TourDefaultSetLike = TourDefaultSetLike> =
+  | {
+      status: "resolved";
+      set: TSet;
+      source: "explicit" | "package_size" | "legacy_tour_pack" | "single_set_fallback";
+      packageSize: TourPackageSize | null;
+      department: PackageDepartment;
+    }
+  | {
+      status: "missing";
+      packageSize: TourPackageSize | null;
+      department: PackageDepartment;
+    }
+  | {
+      status: "ambiguous";
+      packageSize: TourPackageSize | null;
+      department: PackageDepartment;
+      matches: TSet[];
+    }
+  | {
+      status: "invalid_explicit";
+      packageSize: TourPackageSize | null;
+      department: PackageDepartment;
+      setId: string;
+      reason: "not_found" | "wrong_tour" | "wrong_department" | "package_mismatch";
+      set?: TSet;
+    };
+
+export const isTourPackageSize = (value: unknown): value is TourPackageSize =>
+  value === "xl" || value === "l" || value === "m" || value === "s";
+
+export const isPackageDepartment = (value: unknown): value is PackageDepartment =>
+  value === "sound" || value === "lights" || value === "video";
+
+const packageFieldByDepartment: Record<PackageDepartment, keyof TourPackageDateLike> = {
+  sound: "sound_package_size",
+  lights: "lights_package_size",
+  video: "video_package_size",
+};
+
+const defaultSetFieldByDepartment: Record<PackageDepartment, keyof TourPackageDateLike> = {
+  sound: "sound_default_set_id",
+  lights: "lights_default_set_id",
+  video: "video_default_set_id",
+};
+
+export const getDepartmentPackageSize = (
+  tourDate: TourPackageDateLike | null | undefined,
+  department: PackageDepartment
+): TourPackageSize | null => {
+  if (!tourDate) return null;
+
+  const value = tourDate[packageFieldByDepartment[department]];
+  if (isTourPackageSize(value)) return value;
+
+  if (tourDate.is_tour_pack_only === true) {
+    return "s";
+  }
+
+  return null;
+};
+
+export const getExplicitDepartmentPackageSize = (
+  tourDate: TourPackageDateLike | null | undefined,
+  department: PackageDepartment
+): TourPackageSize | null => {
+  if (!tourDate) return null;
+  const value = tourDate[packageFieldByDepartment[department]];
+  return isTourPackageSize(value) ? value : null;
+};
+
+export const getDepartmentDefaultSetId = (
+  tourDate: TourPackageDateLike | null | undefined,
+  department: PackageDepartment
+): string | null => {
+  if (!tourDate) return null;
+  const value = tourDate[defaultSetFieldByDepartment[department]];
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+export const getPackageBadgeLabel = ({
+  department,
+  packageSize,
+  mobile = false,
+}: {
+  department: PackageDepartment;
+  packageSize: TourPackageSize;
+  defaultSet?: TourDefaultSetLike | null;
+  mobile?: boolean;
+}) => {
+  const departmentLabel = mobile
+    ? DEPARTMENT_PACKAGE_PREFIX[department]
+    : DEPARTMENT_PACKAGE_LABELS[department];
+
+  return `${departmentLabel} ${TOUR_PACKAGE_LABELS[packageSize]}`;
+};
+
+export const getPackageSetLabel = (
+  department: PackageDepartment,
+  packageSize: TourPackageSize | null,
+  defaultSet?: TourDefaultSetLike | null
+) => {
+  const packageLabel = packageSize ? getPackageBadgeLabel({ department, packageSize }) : DEPARTMENT_PACKAGE_LABELS[department];
+  return defaultSet?.name ? `${packageLabel} - ${defaultSet.name}` : packageLabel;
+};
+
+const setMatchesTour = (tourDate: TourPackageDateLike, set: TourDefaultSetLike) =>
+  !tourDate.tour_id || set.tour_id === tourDate.tour_id;
+
+const setMatchesDepartment = (set: TourDefaultSetLike, department: PackageDepartment) =>
+  set.department === department;
+
+export const resolveDefaultSetForTourDate = <TSet extends TourDefaultSetLike>({
+  tourDate,
+  department,
+  defaultSets,
+}: {
+  tourDate: TourPackageDateLike;
+  department: PackageDepartment;
+  defaultSets: TSet[];
+}): ResolveDefaultSetResult<TSet> => {
+  const explicitPackageSize = getExplicitDepartmentPackageSize(tourDate, department);
+  const packageSize = getDepartmentPackageSize(tourDate, department);
+  const explicitSetId = getDepartmentDefaultSetId(tourDate, department);
+
+  if (explicitSetId) {
+    const explicitSet = defaultSets.find((set) => set.id === explicitSetId);
+    if (!explicitSet) {
+      return {
+        status: "invalid_explicit",
+        packageSize,
+        department,
+        setId: explicitSetId,
+        reason: "not_found",
+      };
+    }
+
+    if (!setMatchesTour(tourDate, explicitSet)) {
+      return {
+        status: "invalid_explicit",
+        packageSize,
+        department,
+        setId: explicitSetId,
+        reason: "wrong_tour",
+        set: explicitSet,
+      };
+    }
+
+    if (!setMatchesDepartment(explicitSet, department)) {
+      return {
+        status: "invalid_explicit",
+        packageSize,
+        department,
+        setId: explicitSetId,
+        reason: "wrong_department",
+        set: explicitSet,
+      };
+    }
+
+    if (
+      explicitPackageSize &&
+      explicitSet.package_size &&
+      explicitSet.package_size !== explicitPackageSize
+    ) {
+      return {
+        status: "invalid_explicit",
+        packageSize,
+        department,
+        setId: explicitSetId,
+        reason: "package_mismatch",
+        set: explicitSet,
+      };
+    }
+
+    return {
+      status: "resolved",
+      set: explicitSet,
+      source: "explicit",
+      packageSize,
+      department,
+    };
+  }
+
+  const departmentSets = defaultSets.filter(
+    (set) => setMatchesTour(tourDate, set) && setMatchesDepartment(set, department)
+  );
+
+  if (packageSize) {
+    const matches = departmentSets.filter((set) => set.package_size === packageSize);
+    if (matches.length === 1) {
+      return {
+        status: "resolved",
+        set: matches[0],
+        source: explicitPackageSize ? "package_size" : "legacy_tour_pack",
+        packageSize,
+        department,
+      };
+    }
+
+    if (matches.length > 1) {
+      return {
+        status: "ambiguous",
+        packageSize,
+        department,
+        matches,
+      };
+    }
+
+    return {
+      status: "missing",
+      packageSize,
+      department,
+    };
+  }
+
+  if (departmentSets.length === 1) {
+    return {
+      status: "resolved",
+      set: departmentSets[0],
+      source: "single_set_fallback",
+      packageSize: null,
+      department,
+    };
+  }
+
+  if (departmentSets.length > 1) {
+    return {
+      status: "ambiguous",
+      packageSize: null,
+      department,
+      matches: departmentSets,
+    };
+  }
+
+  return {
+    status: "missing",
+    packageSize: null,
+    department,
+  };
+};
+
+export const getPackageResolutionMessage = (
+  result: ResolveDefaultSetResult,
+  typeLabel = "default set"
+) => {
+  const departmentLabel = DEPARTMENT_PACKAGE_LABELS[result.department];
+  const packageLabel = result.packageSize ? ` ${TOUR_PACKAGE_LABELS[result.packageSize]}` : "";
+
+  if (result.status === "missing") {
+    return `${departmentLabel}${packageLabel} is selected for this tour date, but no ${departmentLabel}${packageLabel} ${typeLabel} exists yet.`;
+  }
+
+  if (result.status === "ambiguous") {
+    return `Multiple ${departmentLabel}${packageLabel} ${typeLabel}s exist. Select the exact set for this date.`;
+  }
+
+  if (result.status === "invalid_explicit") {
+    return `The selected ${departmentLabel} ${typeLabel} is no longer valid for this tour date.`;
+  }
+
+  return null;
+};

--- a/supabase/migrations/20260616120000_tour_package_size_defaults.sql
+++ b/supabase/migrations/20260616120000_tour_package_size_defaults.sql
@@ -1,0 +1,271 @@
+-- Tour package size defaults and per-date package intent.
+-- This is intentionally additive: existing tour dates, default sets, tables,
+-- and overrides remain valid.
+
+ALTER TABLE public.tour_default_sets
+  ADD COLUMN IF NOT EXISTS package_size text;
+
+ALTER TABLE public.tour_dates
+  ADD COLUMN IF NOT EXISTS sound_package_size text,
+  ADD COLUMN IF NOT EXISTS lights_package_size text,
+  ADD COLUMN IF NOT EXISTS video_package_size text,
+  ADD COLUMN IF NOT EXISTS sound_default_set_id uuid,
+  ADD COLUMN IF NOT EXISTS lights_default_set_id uuid,
+  ADD COLUMN IF NOT EXISTS video_default_set_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tour_default_sets_package_size_check'
+  ) THEN
+    ALTER TABLE public.tour_default_sets
+      ADD CONSTRAINT tour_default_sets_package_size_check
+      CHECK (package_size IS NULL OR package_size = ANY (ARRAY['xl'::text, 'l'::text, 'm'::text, 's'::text]));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tour_dates_sound_package_size_check'
+  ) THEN
+    ALTER TABLE public.tour_dates
+      ADD CONSTRAINT tour_dates_sound_package_size_check
+      CHECK (sound_package_size IS NULL OR sound_package_size = ANY (ARRAY['xl'::text, 'l'::text, 'm'::text, 's'::text]));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tour_dates_lights_package_size_check'
+  ) THEN
+    ALTER TABLE public.tour_dates
+      ADD CONSTRAINT tour_dates_lights_package_size_check
+      CHECK (lights_package_size IS NULL OR lights_package_size = ANY (ARRAY['xl'::text, 'l'::text, 'm'::text, 's'::text]));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tour_dates_video_package_size_check'
+  ) THEN
+    ALTER TABLE public.tour_dates
+      ADD CONSTRAINT tour_dates_video_package_size_check
+      CHECK (video_package_size IS NULL OR video_package_size = ANY (ARRAY['xl'::text, 'l'::text, 'm'::text, 's'::text]));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tour_dates_sound_default_set_id_fkey'
+  ) THEN
+    ALTER TABLE public.tour_dates
+      ADD CONSTRAINT tour_dates_sound_default_set_id_fkey
+      FOREIGN KEY (sound_default_set_id)
+      REFERENCES public.tour_default_sets(id)
+      ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tour_dates_lights_default_set_id_fkey'
+  ) THEN
+    ALTER TABLE public.tour_dates
+      ADD CONSTRAINT tour_dates_lights_default_set_id_fkey
+      FOREIGN KEY (lights_default_set_id)
+      REFERENCES public.tour_default_sets(id)
+      ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'tour_dates_video_default_set_id_fkey'
+  ) THEN
+    ALTER TABLE public.tour_dates
+      ADD CONSTRAINT tour_dates_video_default_set_id_fkey
+      FOREIGN KEY (video_default_set_id)
+      REFERENCES public.tour_default_sets(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_tour_default_sets_tour_department_package
+  ON public.tour_default_sets (tour_id, department, package_size);
+
+CREATE INDEX IF NOT EXISTS idx_tour_dates_sound_default_set_id
+  ON public.tour_dates (sound_default_set_id)
+  WHERE sound_default_set_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tour_dates_lights_default_set_id
+  ON public.tour_dates (lights_default_set_id)
+  WHERE lights_default_set_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tour_dates_video_default_set_id
+  ON public.tour_dates (video_default_set_id)
+  WHERE video_default_set_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.validate_tour_date_default_set_pin(
+  p_default_set_id uuid,
+  p_tour_id uuid,
+  p_department text,
+  p_package_size text
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_set record;
+BEGIN
+  IF p_default_set_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT tour_id, department, package_size
+    INTO v_set
+  FROM public.tour_default_sets
+  WHERE id = p_default_set_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Tour default set % does not exist', p_default_set_id
+      USING ERRCODE = '23503';
+  END IF;
+
+  IF v_set.tour_id IS DISTINCT FROM p_tour_id THEN
+    RAISE EXCEPTION 'Tour default set % belongs to a different tour', p_default_set_id
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF v_set.department IS DISTINCT FROM p_department THEN
+    RAISE EXCEPTION 'Tour default set % belongs to department %, expected %',
+      p_default_set_id, v_set.department, p_department
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF p_package_size IS NOT NULL
+    AND v_set.package_size IS NOT NULL
+    AND v_set.package_size IS DISTINCT FROM p_package_size
+  THEN
+    RAISE EXCEPTION 'Tour default set % package size % does not match selected package size %',
+      p_default_set_id, v_set.package_size, p_package_size
+      USING ERRCODE = '23514';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.validate_tour_date_default_set_pins()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM public.validate_tour_date_default_set_pin(
+    NEW.sound_default_set_id,
+    NEW.tour_id,
+    'sound',
+    NEW.sound_package_size
+  );
+
+  PERFORM public.validate_tour_date_default_set_pin(
+    NEW.lights_default_set_id,
+    NEW.tour_id,
+    'lights',
+    NEW.lights_package_size
+  );
+
+  PERFORM public.validate_tour_date_default_set_pin(
+    NEW.video_default_set_id,
+    NEW.tour_id,
+    'video',
+    NEW.video_package_size
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER trg_validate_tour_date_default_set_pins
+  BEFORE INSERT OR UPDATE OF
+    tour_id,
+    sound_package_size,
+    lights_package_size,
+    video_package_size,
+    sound_default_set_id,
+    lights_default_set_id,
+    video_default_set_id
+  ON public.tour_dates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.validate_tour_date_default_set_pins();
+
+UPDATE public.tour_default_sets
+SET package_size = 's'
+WHERE package_size IS NULL
+  AND (
+    lower(coalesce(name, '') || ' ' || coalesce(description, '')) LIKE '%tour pack%'
+    OR lower(coalesce(name, '') || ' ' || coalesce(description, '')) LIKE '%tourpack%'
+    OR lower(coalesce(name, '') || ' ' || coalesce(description, '')) LIKE '%pack s%'
+    OR coalesce(name, '') ~ '(^|[^[:alnum:]])[sS]([^[:alnum:]]|$)'
+    OR coalesce(description, '') ~ '(^|[^[:alnum:]])[sS]([^[:alnum:]]|$)'
+  );
+
+UPDATE public.tour_dates
+SET
+  sound_package_size = coalesce(sound_package_size, 's'),
+  lights_package_size = coalesce(lights_package_size, 's'),
+  video_package_size = coalesce(video_package_size, 's')
+WHERE is_tour_pack_only IS TRUE;
+
+WITH unique_s_sets AS (
+  SELECT tour_id, department, min(id) AS default_set_id, count(*) AS match_count
+  FROM public.tour_default_sets
+  WHERE package_size = 's'
+    AND department = ANY (ARRAY['sound'::text, 'lights'::text, 'video'::text])
+  GROUP BY tour_id, department
+  HAVING count(*) = 1
+)
+UPDATE public.tour_dates td
+SET sound_default_set_id = unique_s_sets.default_set_id
+FROM unique_s_sets
+WHERE td.is_tour_pack_only IS TRUE
+  AND td.sound_default_set_id IS NULL
+  AND td.tour_id = unique_s_sets.tour_id
+  AND unique_s_sets.department = 'sound';
+
+WITH unique_s_sets AS (
+  SELECT tour_id, department, min(id) AS default_set_id, count(*) AS match_count
+  FROM public.tour_default_sets
+  WHERE package_size = 's'
+    AND department = ANY (ARRAY['sound'::text, 'lights'::text, 'video'::text])
+  GROUP BY tour_id, department
+  HAVING count(*) = 1
+)
+UPDATE public.tour_dates td
+SET lights_default_set_id = unique_s_sets.default_set_id
+FROM unique_s_sets
+WHERE td.is_tour_pack_only IS TRUE
+  AND td.lights_default_set_id IS NULL
+  AND td.tour_id = unique_s_sets.tour_id
+  AND unique_s_sets.department = 'lights';
+
+WITH unique_s_sets AS (
+  SELECT tour_id, department, min(id) AS default_set_id, count(*) AS match_count
+  FROM public.tour_default_sets
+  WHERE package_size = 's'
+    AND department = ANY (ARRAY['sound'::text, 'lights'::text, 'video'::text])
+  GROUP BY tour_id, department
+  HAVING count(*) = 1
+)
+UPDATE public.tour_dates td
+SET video_default_set_id = unique_s_sets.default_set_id
+FROM unique_s_sets
+WHERE td.is_tour_pack_only IS TRUE
+  AND td.video_default_set_id IS NULL
+  AND td.tour_id = unique_s_sets.tour_id
+  AND unique_s_sets.department = 'video';
+
+COMMENT ON COLUMN public.tour_default_sets.package_size IS
+  'Optional tour package size for this default set: xl, l, m, or s. Null keeps legacy/unassigned default sets valid.';
+
+COMMENT ON COLUMN public.tour_dates.sound_package_size IS
+  'Sound package size intent for this tour date. Legacy is_tour_pack_only dates are treated as sound S when null.';
+COMMENT ON COLUMN public.tour_dates.lights_package_size IS
+  'Lights package size intent for this tour date. Legacy is_tour_pack_only dates are treated as lights S when null.';
+COMMENT ON COLUMN public.tour_dates.video_package_size IS
+  'Video package size intent for this tour date. Legacy is_tour_pack_only dates are treated as video S when null.';
+
+COMMENT ON COLUMN public.tour_dates.sound_default_set_id IS
+  'Optional explicit sound default set pin for package resolution.';
+COMMENT ON COLUMN public.tour_dates.lights_default_set_id IS
+  'Optional explicit lights default set pin for package resolution.';
+COMMENT ON COLUMN public.tour_dates.video_default_set_id IS
+  'Optional explicit video default set pin for package resolution.';

--- a/supabase/migrations/20260616120000_tour_package_size_defaults.sql
+++ b/supabase/migrations/20260616120000_tour_package_size_defaults.sql
@@ -206,7 +206,7 @@ SET
 WHERE is_tour_pack_only IS TRUE;
 
 WITH unique_s_sets AS (
-  SELECT tour_id, department, min(id) AS default_set_id, count(*) AS match_count
+  SELECT tour_id, department, min(id::text)::uuid AS default_set_id, count(*) AS match_count
   FROM public.tour_default_sets
   WHERE package_size = 's'
     AND department = ANY (ARRAY['sound'::text, 'lights'::text, 'video'::text])
@@ -222,7 +222,7 @@ WHERE td.is_tour_pack_only IS TRUE
   AND unique_s_sets.department = 'sound';
 
 WITH unique_s_sets AS (
-  SELECT tour_id, department, min(id) AS default_set_id, count(*) AS match_count
+  SELECT tour_id, department, min(id::text)::uuid AS default_set_id, count(*) AS match_count
   FROM public.tour_default_sets
   WHERE package_size = 's'
     AND department = ANY (ARRAY['sound'::text, 'lights'::text, 'video'::text])
@@ -238,7 +238,7 @@ WHERE td.is_tour_pack_only IS TRUE
   AND unique_s_sets.department = 'lights';
 
 WITH unique_s_sets AS (
-  SELECT tour_id, department, min(id) AS default_set_id, count(*) AS match_count
+  SELECT tour_id, department, min(id::text)::uuid AS default_set_id, count(*) AS match_count
   FROM public.tour_default_sets
   WHERE package_size = 's'
     AND department = ANY (ARRAY['sound'::text, 'lights'::text, 'video'::text])


### PR DESCRIPTION
## Summary
- Add package-size intent and optional exact default-set pins for tour dates by department.
- Add package-aware default-set resolution so exports and tools resolve one set instead of merging all department sets.
- Update tour date/default-set management UI, Project Management job card package badges, power/weight default-set flows, and tour schedule wording.
- Add Supabase migration and update generated database types for the new nullable package/pin fields.

## Impact
- `is_tour_pack_only` remains as legacy compatibility, with S-package fallback where needed.
- Existing default-set tables and override precedence are preserved.
- Package departments are limited to sound/lights/video; production remains out of package scope.

## Validation
- `npm install --legacy-peer-deps`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run typecheck`
- `git diff --check`