### PR TITLE
[codex] Fix logistics PDF venue resolution

### DIFF
--- a/src/components/hoja-de-ruta/sections/ModernEventSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernEventSection.tsx
@@ -265,7 +265,14 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
                   value={eventData.venue.address}
                   onChange={(e) => setEventData(prev => ({
                     ...prev,
-                    venue: { ...prev.venue, address: e.target.value }
+                    // Free-text edits invalidate coordinates selected for the
+                    // previous address. The map/QR will geocode the new text
+                    // until the user selects a precise place again.
+                    venue: {
+                      ...prev.venue,
+                      address: e.target.value,
+                      coordinates: undefined,
+                    }
                   }))}
                   placeholder="Ej. Calle Mayor 123, Madrid"
                   className="border-2 focus:border-purple-300"

--- a/src/components/hoja-de-ruta/sections/ModernVenueSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernVenueSection.tsx
@@ -264,7 +264,9 @@ export const ModernVenueSection: React.FC<ModernVenueSectionProps> = ({
                                 ...prev.venue,
                                 name: name || prev.venue.name,
                                 address: address || prev.venue.address,
-                                coordinates: coordinates || prev.venue.coordinates,
+                                // Never retain coordinates from a previous
+                                // place after selecting a different venue.
+                                coordinates,
                               }
                             }))
                           }

--- a/src/features/festival-management/__tests__/venue-resolution.test.ts
+++ b/src/features/festival-management/__tests__/venue-resolution.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveFestivalVenueData } from "@/features/festival-management/queries";
+
+describe("resolveFestivalVenueData", () => {
+  const catalogLocation = {
+    name: "Catalog venue",
+    formatted_address: "Wrong catalog address",
+    latitude: 40.1,
+    longitude: -3.1,
+  };
+
+  it("uses the saved Hoja venue for production/festival outputs", () => {
+    expect(resolveFestivalVenueData({
+      venue_name: "Plaza Mayor",
+      venue_address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+      venue_latitude: 40.4552,
+      venue_longitude: -3.4776,
+    }, catalogLocation)).toEqual({
+      address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+      coordinates: { lat: 40.4552, lng: -3.4776 },
+    });
+  });
+
+  it("uses the catalog location only when the Hoja has no venue", () => {
+    expect(resolveFestivalVenueData(null, catalogLocation)).toEqual({
+      address: "Wrong catalog address",
+      coordinates: { lat: 40.1, lng: -3.1 },
+    });
+  });
+});

--- a/src/features/festival-management/queries.ts
+++ b/src/features/festival-management/queries.ts
@@ -4,6 +4,10 @@ import {
   buildFestivalStageOptions,
   buildJobDates,
 } from "@/features/festival-management/selectors";
+import {
+  normalizeVenueCoordinates,
+  resolveHojaVenue,
+} from "@/utils/hoja-de-ruta/venue-resolution";
 import type {
   ArtistRiderFile,
   FestivalDocumentsData,
@@ -21,59 +25,69 @@ type LocationRow = {
 };
 
 type HojaVenueRow = {
+  venue_name?: string | null;
   venue_address?: string | null;
   venue_latitude?: number | null;
   venue_longitude?: number | null;
 };
 
-const mapLocationVenueData = (location: LocationRow | null | undefined): FestivalVenueData => ({
-  address: (location?.formatted_address || location?.name || undefined) as string | undefined,
-  coordinates:
-    typeof location?.latitude === "number" && typeof location?.longitude === "number"
-      ? { lat: location.latitude, lng: location.longitude }
-      : undefined,
-});
+export const resolveFestivalVenueData = (
+  hojaData: HojaVenueRow | null | undefined,
+  location: LocationRow | null | undefined
+): FestivalVenueData => {
+  const venue = resolveHojaVenue({
+    name: hojaData?.venue_name,
+    address: hojaData?.venue_address,
+    coordinates: {
+      lat: hojaData?.venue_latitude,
+      lng: hojaData?.venue_longitude,
+    },
+  }, {
+    name: location?.name,
+    address: location?.formatted_address || location?.name,
+    coordinates: normalizeVenueCoordinates({
+      lat: location?.latitude,
+      lng: location?.longitude,
+    }),
+  });
 
-const mapHojaVenueData = (hojaData: HojaVenueRow | null | undefined): FestivalVenueData => ({
-  address: hojaData?.venue_address || undefined,
-  coordinates:
-    typeof hojaData?.venue_latitude === "number" && typeof hojaData?.venue_longitude === "number"
-      ? { lat: hojaData.venue_latitude, lng: hojaData.venue_longitude }
-      : undefined,
-});
+  return {
+    address: venue.address || undefined,
+    coordinates: venue.coordinates,
+  };
+};
 
-const fetchHojaVenueData = async (jobId: string): Promise<FestivalVenueData> => {
+const fetchHojaVenueData = async (jobId: string): Promise<HojaVenueRow | null> => {
   const { data, error } = await supabase
     .from("hoja_de_ruta")
-    .select("venue_address, venue_latitude, venue_longitude")
+    .select("venue_name, venue_address, venue_latitude, venue_longitude")
     .eq("job_id", jobId)
     .maybeSingle();
 
   if (error || !data) {
-    return {};
+    return null;
   }
 
-  return mapHojaVenueData(data);
+  return data;
 };
 
 const fetchVenueData = async (jobId: string, job: FestivalJob): Promise<FestivalVenueData> => {
-  if (!job.location_id) {
-    console.log("Job has no location_id; attempting hoja_de_ruta fallback");
-    return fetchHojaVenueData(jobId);
+  const [hojaData, locationResult] = await Promise.all([
+    fetchHojaVenueData(jobId),
+    job.location_id
+      ? supabase
+          .from("locations")
+          .select("name, formatted_address, latitude, longitude")
+          .eq("id", job.location_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+  ]);
+
+  if (locationResult.error) {
+    console.warn("Unable to load catalog location for festival venue; using saved Hoja venue:", locationResult.error);
   }
 
-  const { data: location, error } = await supabase
-    .from("locations")
-    .select("name, formatted_address, latitude, longitude")
-    .eq("id", job.location_id)
-    .single();
-
-  if (!error && location) {
-    return mapLocationVenueData(location);
-  }
-
-  console.log("No location found for job; falling back to hoja_de_ruta if available");
-  return fetchHojaVenueData(jobId);
+  return resolveFestivalVenueData(hojaData, locationResult.error ? null : locationResult.data);
 };
 
 const fetchJobDates = async (jobId: string, job: FestivalJob) => {

--- a/src/hooks/useHojaDeRutaPersistence.ts
+++ b/src/hooks/useHojaDeRutaPersistence.ts
@@ -14,6 +14,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { isAuxiliaryMachineryType } from "@/constants/hojaDeRutaAuxiliaryNeeds";
 import { normalizeHojaDeRutaPrintSections } from "@/utils/hoja-de-ruta/pdf/section-options";
+import {
+  normalizeVenueCoordinates,
+  resolveHojaVenue,
+} from "@/utils/hoja-de-ruta/venue-resolution";
 
 
 
@@ -183,7 +187,8 @@ export const useHojaDeRutaPersistence = (
 
       console.log("🔄 FETCH: Transforming data to frontend format");
 
-      // Attempt to get venue from the job's location as the primary source
+      // Load the job location only as a fallback. The saved Hoja venue may be
+      // intentionally corrected or more precise than the catalog location.
       let venueFromJob: { name?: string; address?: string; coordinates?: { lat: number; lng: number } } | null = null;
       try {
         const { data: jobRec, error: jobErr } = await supabase
@@ -202,9 +207,10 @@ export const useHojaDeRutaPersistence = (
             venueFromJob = {
               name: loc.name || undefined,
               address: (loc.formatted_address || loc.name) || undefined,
-              coordinates: (typeof loc.latitude === 'number' && typeof loc.longitude === 'number')
-                ? { lat: loc.latitude, lng: loc.longitude }
-                : undefined,
+              coordinates: normalizeVenueCoordinates({
+                lat: loc.latitude,
+                lng: loc.longitude,
+              }),
             };
           }
         }
@@ -216,14 +222,14 @@ export const useHojaDeRutaPersistence = (
       const eventData: EventData = {
         eventName: mainData.event_name || '',
         eventDates: mainData.event_dates || '',
-        venue: venueFromJob || {
+        venue: resolveHojaVenue({
           name: mainData.venue_name || '',
           address: mainData.venue_address || '',
           coordinates: mainData.venue_latitude != null && mainData.venue_longitude != null ? {
             lat: Number(mainData.venue_latitude),
             lng: Number(mainData.venue_longitude)
           } : undefined
-        },
+        }, venueFromJob),
         contacts: contacts?.length ? contacts.map(c => ({
           name: c.name,
           role: c.role || '',

--- a/src/utils/hoja-de-ruta/__tests__/load-hoja-de-ruta-pdf-data.test.ts
+++ b/src/utils/hoja-de-ruta/__tests__/load-hoja-de-ruta-pdf-data.test.ts
@@ -1,47 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fromMock } = vi.hoisted(() => ({
-  fromMock: vi.fn(),
-}));
+import {
+  createMockQueryBuilder,
+  mockSupabase,
+  resetMockSupabase,
+  type MockSupabaseResult,
+} from "@/test/mockSupabase";
 
 vi.mock("@/integrations/supabase/client", () => ({
-  supabase: {
-    from: fromMock,
-  },
+  supabase: mockSupabase,
 }));
 
 import { loadHojaDeRutaPdfData } from "@/utils/hoja-de-ruta/load-hoja-de-ruta-pdf-data";
 
-type QueryResult = {
-  data: unknown;
-  error: unknown;
-};
-
-const createQuery = (result: QueryResult) => {
-  const query: {
-    select: ReturnType<typeof vi.fn>;
-    eq: ReturnType<typeof vi.fn>;
-    maybeSingle: ReturnType<typeof vi.fn>;
-    then: Promise<QueryResult>["then"];
-  } = {
-    select: vi.fn(),
-    eq: vi.fn(),
-    maybeSingle: vi.fn(),
-    then: Promise.resolve(result).then.bind(Promise.resolve(result)),
-  };
-
-  query.select.mockReturnValue(query);
-  query.eq.mockReturnValue(query);
-  query.maybeSingle.mockResolvedValue(result);
-
-  return query;
-};
-
 describe("loadHojaDeRutaPdfData", () => {
   beforeEach(() => {
-    fromMock.mockReset();
+    resetMockSupabase();
 
-    const results: Record<string, QueryResult> = {
+    const results: Record<string, MockSupabaseResult> = {
       hoja_de_ruta: {
         data: {
           id: "hoja-1",
@@ -73,7 +49,13 @@ describe("loadHojaDeRutaPdfData", () => {
       },
     };
 
-    fromMock.mockImplementation((table: string) => createQuery(results[table]));
+    mockSupabase.from.mockImplementation((table: string) => {
+      const result = results[table];
+      if (!result) {
+        throw new Error(`Unexpected mocked table: ${table}`);
+      }
+      return createMockQueryBuilder(result);
+    });
   });
 
   it("keeps the saved Hoja venue when a department can also read the job catalog location", async () => {

--- a/src/utils/hoja-de-ruta/__tests__/load-hoja-de-ruta-pdf-data.test.ts
+++ b/src/utils/hoja-de-ruta/__tests__/load-hoja-de-ruta-pdf-data.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fromMock } = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: fromMock,
+  },
+}));
+
+import { loadHojaDeRutaPdfData } from "@/utils/hoja-de-ruta/load-hoja-de-ruta-pdf-data";
+
+type QueryResult = {
+  data: unknown;
+  error: unknown;
+};
+
+const createQuery = (result: QueryResult) => {
+  const query: {
+    select: ReturnType<typeof vi.fn>;
+    eq: ReturnType<typeof vi.fn>;
+    maybeSingle: ReturnType<typeof vi.fn>;
+    then: Promise<QueryResult>["then"];
+  } = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn(),
+    then: Promise.resolve(result).then.bind(Promise.resolve(result)),
+  };
+
+  query.select.mockReturnValue(query);
+  query.eq.mockReturnValue(query);
+  query.maybeSingle.mockResolvedValue(result);
+
+  return query;
+};
+
+describe("loadHojaDeRutaPdfData", () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+
+    const results: Record<string, QueryResult> = {
+      hoja_de_ruta: {
+        data: {
+          id: "hoja-1",
+          event_name: "Fiestas Populares Torrejón",
+          event_dates: "18-23 junio",
+          venue_name: "Plaza Mayor",
+          venue_address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+          venue_latitude: 40.4552,
+          venue_longitude: -3.4776,
+          schedule: "",
+        },
+        error: null,
+      },
+      hoja_de_ruta_contacts: { data: [], error: null },
+      hoja_de_ruta_transport: { data: [], error: null },
+      hoja_de_ruta_images: { data: [], error: null },
+      jobs: {
+        data: { location_id: "catalog-location" },
+        error: null,
+      },
+      locations: {
+        data: {
+          name: "Wrong catalog venue",
+          formatted_address: "Wrong catalog address",
+          latitude: 40.1,
+          longitude: -3.1,
+        },
+        error: null,
+      },
+    };
+
+    fromMock.mockImplementation((table: string) => createQuery(results[table]));
+  });
+
+  it("keeps the saved Hoja venue when a department can also read the job catalog location", async () => {
+    const result = await loadHojaDeRutaPdfData("job-1");
+
+    expect(result?.eventData.venue).toEqual({
+      name: "Plaza Mayor",
+      address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+      coordinates: { lat: 40.4552, lng: -3.4776 },
+    });
+  });
+});

--- a/src/utils/hoja-de-ruta/__tests__/venue-resolution.test.ts
+++ b/src/utils/hoja-de-ruta/__tests__/venue-resolution.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeVenueCoordinates,
+  resolveHojaVenue,
+} from "@/utils/hoja-de-ruta/venue-resolution";
+
+describe("resolveHojaVenue", () => {
+  const jobVenue = {
+    name: "Catalog venue",
+    address: "Wrong catalog address",
+    coordinates: { lat: 40.1, lng: -3.1 },
+  };
+
+  it("keeps a saved Hoja venue authoritative over the job location", () => {
+    expect(resolveHojaVenue({
+      name: "Plaza Mayor",
+      address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+      coordinates: { lat: 40.4552, lng: -3.4776 },
+    }, jobVenue)).toEqual({
+      name: "Plaza Mayor",
+      address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+      coordinates: { lat: 40.4552, lng: -3.4776 },
+    });
+  });
+
+  it("does not mix job coordinates with a different saved address", () => {
+    expect(resolveHojaVenue({
+      name: "Plaza Mayor",
+      address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+    }, jobVenue)).toEqual({
+      name: "Plaza Mayor",
+      address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+    });
+  });
+
+  it("uses job coordinates when both sources refer to the same address", () => {
+    expect(resolveHojaVenue({
+      name: "Plaza Mayor",
+      address: "PL. MAYOR, 28850 TORREJÓN DE ARDOZ, MADRID, ESPAÑA",
+    }, {
+      ...jobVenue,
+      address: "Pl. Mayor, 28850 Torrejon de Ardoz, Madrid, Espana",
+    })).toEqual({
+      name: "Plaza Mayor",
+      address: "PL. MAYOR, 28850 TORREJÓN DE ARDOZ, MADRID, ESPAÑA",
+      coordinates: { lat: 40.1, lng: -3.1 },
+    });
+  });
+
+  it("does not attach a job address to saved coordinates without an address", () => {
+    expect(resolveHojaVenue({
+      name: "Pinned venue",
+      coordinates: { lat: 40.4552, lng: -3.4776 },
+    }, jobVenue)).toEqual({
+      name: "Pinned venue",
+      address: "",
+      coordinates: { lat: 40.4552, lng: -3.4776 },
+    });
+  });
+
+  it("falls back to the job venue when Hoja has no venue data", () => {
+    expect(resolveHojaVenue(null, jobVenue)).toEqual(jobVenue);
+  });
+});
+
+describe("normalizeVenueCoordinates", () => {
+  it("accepts numeric database strings and rejects invalid ranges", () => {
+    expect(normalizeVenueCoordinates({ lat: "40.4552", lng: "-3.4776" })).toEqual({
+      lat: 40.4552,
+      lng: -3.4776,
+    });
+    expect(normalizeVenueCoordinates({ lat: 120, lng: -3.4776 })).toBeUndefined();
+  });
+});

--- a/src/utils/hoja-de-ruta/__tests__/venue-resolution.test.ts
+++ b/src/utils/hoja-de-ruta/__tests__/venue-resolution.test.ts
@@ -72,4 +72,11 @@ describe("normalizeVenueCoordinates", () => {
     });
     expect(normalizeVenueCoordinates({ lat: 120, lng: -3.4776 })).toBeUndefined();
   });
+
+  it("rejects partially numeric coordinate strings", () => {
+    expect(normalizeVenueCoordinates({
+      lat: "40.4552abc",
+      lng: "-3.4776",
+    })).toBeUndefined();
+  });
 });

--- a/src/utils/hoja-de-ruta/load-hoja-de-ruta-pdf-data.ts
+++ b/src/utils/hoja-de-ruta/load-hoja-de-ruta-pdf-data.ts
@@ -2,6 +2,10 @@ import { formatInTimeZone } from 'date-fns-tz';
 
 import { supabase } from '@/integrations/supabase/client';
 import type { EventData, Transport } from '@/types/hoja-de-ruta';
+import {
+  normalizeVenueCoordinates,
+  resolveHojaVenue,
+} from '@/utils/hoja-de-ruta/venue-resolution';
 
 const MADRID_TIMEZONE = 'Europe/Madrid';
 
@@ -25,15 +29,6 @@ const normalizeTransportType = (value: string | null | undefined): Transport['tr
   }
 
   return 'furgoneta';
-};
-
-const toCoordinate = (value: unknown): number | undefined => {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value === 'string' && value.trim()) {
-    const parsed = Number.parseFloat(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return undefined;
 };
 
 export interface HojaDeRutaPdfData {
@@ -71,7 +66,9 @@ export const loadHojaDeRutaPdfData = async (jobId: string): Promise<HojaDeRutaPd
   if (contactsError) throw contactsError;
   if (transportError) throw transportError;
   if (imagesError) throw imagesError;
-  if (jobError) throw jobError;
+  if (jobError) {
+    console.warn('Unable to load job location for Hoja de Transportes; using saved Hoja venue:', jobError);
+  }
 
   let venueFromJob:
     | {
@@ -81,34 +78,37 @@ export const loadHojaDeRutaPdfData = async (jobId: string): Promise<HojaDeRutaPd
       }
     | undefined;
 
-  if (jobRow?.location_id) {
+  if (!jobError && jobRow?.location_id) {
     const { data: locationData, error: locationError } = await supabase
       .from('locations')
       .select('name,formatted_address,latitude,longitude')
       .eq('id', jobRow.location_id)
       .maybeSingle();
 
-    if (locationError) throw locationError;
+    if (locationError) {
+      console.warn('Unable to load catalog location for Hoja de Transportes; using saved Hoja venue:', locationError);
+    }
 
-    if (locationData) {
-      const lat = toCoordinate(locationData.latitude);
-      const lng = toCoordinate(locationData.longitude);
-
+    if (!locationError && locationData) {
       venueFromJob = {
         name: locationData.name || undefined,
         address: locationData.formatted_address || locationData.name || undefined,
-        coordinates: lat !== undefined && lng !== undefined ? { lat, lng } : undefined,
+        coordinates: normalizeVenueCoordinates({
+          lat: locationData.latitude,
+          lng: locationData.longitude,
+        }),
       };
     }
   }
 
-  const venueLat = toCoordinate(mainData.venue_latitude);
-  const venueLng = toCoordinate(mainData.venue_longitude);
-  const mappedVenue = venueFromJob || {
+  const mappedVenue = resolveHojaVenue({
     name: mainData.venue_name || '',
     address: mainData.venue_address || '',
-    coordinates: venueLat !== undefined && venueLng !== undefined ? { lat: venueLat, lng: venueLng } : undefined,
-  };
+    coordinates: {
+      lat: mainData.venue_latitude,
+      lng: mainData.venue_longitude,
+    },
+  }, venueFromJob);
 
   const mappedContacts = (contacts || []).map((contact) => ({
     name: contact.name || '',

--- a/src/utils/hoja-de-ruta/pdf/__tests__/map-service.test.ts
+++ b/src/utils/hoja-de-ruta/pdf/__tests__/map-service.test.ts
@@ -14,6 +14,14 @@ describe("MapService venue destinations", () => {
     );
   });
 
+  it("supports a coordinate-only venue", () => {
+    expect(MapService.generateVenueDestinationUrl({
+      coordinates: { lat: 40.4552, lng: -3.4776 },
+    })).toBe(
+      "https://www.google.com/maps/dir/?api=1&destination=40.4552%2C-3.4776"
+    );
+  });
+
   it("falls back to the saved address when coordinates are unavailable", () => {
     const url = MapService.generateVenueDestinationUrl({
       address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",

--- a/src/utils/hoja-de-ruta/pdf/__tests__/map-service.test.ts
+++ b/src/utils/hoja-de-ruta/pdf/__tests__/map-service.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { MapService } from "@/utils/hoja-de-ruta/pdf/services/map-service";
+
+describe("MapService venue destinations", () => {
+  it("prefers exact venue coordinates over address geocoding", () => {
+    const url = MapService.generateVenueDestinationUrl({
+      address: "An ambiguous plaza name",
+      coordinates: { lat: 40.4552, lng: -3.4776 },
+    });
+
+    expect(url).toBe(
+      "https://www.google.com/maps/dir/?api=1&destination=40.4552%2C-3.4776"
+    );
+  });
+
+  it("falls back to the saved address when coordinates are unavailable", () => {
+    const url = MapService.generateVenueDestinationUrl({
+      address: "Pl. Mayor, 28850 Torrejón de Ardoz, Madrid, España",
+    });
+
+    expect(url).toContain(
+      "destination=Pl.%20Mayor%2C%2028850%20Torrej%C3%B3n%20de%20Ardoz"
+    );
+  });
+});

--- a/src/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine.ts
+++ b/src/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine.ts
@@ -136,7 +136,8 @@ export class DriverCertificatePDFEngine {
   private async addVenueSection(eventData: EventData, yPosition: number, venueMapPreview: string | null): Promise<number> {
     const venueName = (eventData.venue?.name || '').trim();
     const venueAddress = (eventData.venue?.address || '').trim();
-    const hasVenueData = Boolean(venueName || venueAddress || venueMapPreview);
+    const venueDestinationUrl = MapService.generateVenueDestinationUrl(eventData.venue);
+    const hasVenueData = Boolean(venueName || venueDestinationUrl || venueMapPreview);
     if (!hasVenueData) return yPosition;
 
     yPosition = this.addSectionTitle('Recinto', yPosition);

--- a/src/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine.ts
+++ b/src/utils/hoja-de-ruta/pdf/driver-certificate-pdf-engine.ts
@@ -158,7 +158,7 @@ export class DriverCertificatePDFEngine {
 
     const mapWidth = this.pdfDoc.dimensions.width - 40;
     const mapHeight = 65;
-    const mapDataUrl = await this.resolveVenueMapDataUrl(venueAddress, venueMapPreview, mapWidth, mapHeight);
+    const mapDataUrl = await this.resolveVenueMapDataUrl(eventData.venue, venueMapPreview, mapWidth, mapHeight);
 
     if (mapDataUrl) {
       yPosition = this.pdfDoc.checkPageBreak(yPosition, 75);
@@ -567,20 +567,21 @@ export class DriverCertificatePDFEngine {
   }
 
   private async resolveVenueMapDataUrl(
-    venueAddress: string,
+    venue: EventData['venue'],
     venueMapPreview: string | null,
     mapWidth: number,
     mapHeight: number
   ): Promise<string | null> {
-    if (venueAddress) {
+    const destinationUrl = MapService.generateVenueDestinationUrl(venue);
+    if (destinationUrl) {
       try {
-        const mapDataUrl = await MapService.getMapImageForAddress(venueAddress, mapWidth, mapHeight);
+        const mapDataUrl = await MapService.getMapImageForVenue(venue, mapWidth, mapHeight);
         if (mapDataUrl) return mapDataUrl;
       } catch (error) {
         console.warn('Unable to fetch venue map for driver certificate:', error);
       }
     }
 
-    return venueMapPreview || null;
+    return destinationUrl ? null : venueMapPreview || null;
   }
 }

--- a/src/utils/hoja-de-ruta/pdf/sections/venue.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/venue.ts
@@ -89,8 +89,10 @@ export class VenueSection {
       yPosition += imgHeight + 10;
     }
 
-    // Add map and QR (generate map via geocoding; fall back to passed preview)
-    if (eventData.venue?.address) {
+    // Prefer exact saved coordinates. Address geocoding is only a fallback,
+    // preventing ambiguous text from pointing the PDF at another venue.
+    const destinationUrl = MapService.generateVenueDestinationUrl(eventData.venue);
+    if (destinationUrl || venueMapPreview) {
       yPosition = this.pdfDoc.checkPageBreak(yPosition, 120);
 
       const leftMargin = 20;
@@ -101,20 +103,27 @@ export class VenueSection {
       const { width: pageWidth } = this.pdfDoc.dimensions;
       const availableWidth = pageWidth - leftMargin - rightMargin;
       const desiredMapWidth = 100;
-      const sideBySide = availableWidth >= (desiredMapWidth + gap + qrSize);
-      const mapW = sideBySide ? desiredMapWidth : availableWidth;
+      const includeQr = Boolean(destinationUrl);
+      const sideBySide = includeQr && availableWidth >= (desiredMapWidth + gap + qrSize);
+      const mapW = includeQr && sideBySide ? desiredMapWidth : availableWidth;
       const mapX = leftMargin;
       const mapY = yPosition;
       const qrX = sideBySide ? Math.min(leftMargin + mapW + gap, pageWidth - rightMargin - qrSize) : leftMargin;
       const qrY = sideBySide ? yPosition : (yPosition + mapHeight + 10);
 
       let mapDataUrl: string | null = null;
-      try {
-        mapDataUrl = await MapService.getMapImageForAddress(eventData.venue.address, mapW, mapHeight);
-      } catch (e) {
-        console.warn('Venue map fetch failed, will fallback to preview:', e);
+      if (destinationUrl) {
+        try {
+          mapDataUrl = await MapService.getMapImageForVenue(eventData.venue, mapW, mapHeight);
+        } catch (e) {
+          console.warn('Venue map fetch failed:', e);
+        }
       }
-      if (!mapDataUrl && venueMapPreview) {
+
+      // A preview has no stored address/coordinate provenance. Only use it
+      // when there is no venue locator to verify, never as a fallback for a
+      // different saved address.
+      if (!destinationUrl && venueMapPreview) {
         mapDataUrl = venueMapPreview;
       }
 
@@ -138,21 +147,24 @@ export class VenueSection {
       }
 
       // Add QR code for directions (destination-only so device uses current location)
-      try {
-        const destUrl = MapService.generateDestinationUrl(eventData.venue.address);
-        const qrData = await QRService.generateQRCode(destUrl);
-        this.pdfDoc.addImage(qrData, 'PNG', qrX, qrY, qrSize, qrSize);
-        
-        // Make QR code clickable
-        this.pdfDoc.addLink(destUrl, qrX, qrY, qrSize, qrSize);
-        
-        this.pdfDoc.setText(8, [51, 51, 51]);
-        this.pdfDoc.addText('Escanea para direcciones', qrX, qrY + qrSize + 6);
-      } catch (error) {
-        console.error('Error generating venue QR:', error);
+      if (destinationUrl) {
+        try {
+          const qrData = await QRService.generateQRCode(destinationUrl);
+          this.pdfDoc.addImage(qrData, 'PNG', qrX, qrY, qrSize, qrSize);
+
+          // Make QR code clickable
+          this.pdfDoc.addLink(destinationUrl, qrX, qrY, qrSize, qrSize);
+
+          this.pdfDoc.setText(8, [51, 51, 51]);
+          this.pdfDoc.addText('Escanea para direcciones', qrX, qrY + qrSize + 6);
+        } catch (error) {
+          console.error('Error generating venue QR:', error);
+        }
       }
 
-      const blockBottom = sideBySide ? Math.max(mapY + mapHeight, qrY + qrSize) : (qrY + qrSize);
+      const blockBottom = includeQr
+        ? (sideBySide ? Math.max(mapY + mapHeight, qrY + qrSize) : qrY + qrSize)
+        : mapY + mapHeight;
       yPosition = blockBottom + 15;
     }
 

--- a/src/utils/hoja-de-ruta/pdf/services/map-service.ts
+++ b/src/utils/hoja-de-ruta/pdf/services/map-service.ts
@@ -1,4 +1,6 @@
 import { supabase } from '@/lib/supabase';
+import type { EventData } from '@/types/hoja-de-ruta';
+import { normalizeVenueCoordinates } from '@/utils/hoja-de-ruta/venue-resolution';
 
 export class MapService {
   private static geocodeCache: Map<string, { lat: number; lng: number }> = new Map();
@@ -104,6 +106,31 @@ export class MapService {
     const baseUrl = 'https://www.google.com/maps/dir/';
     const params = `?api=1&destination=${encodeURIComponent(destination)}`;
     return `${baseUrl}${params}`;
+  }
+
+  static generateVenueDestinationUrl(venue: EventData['venue']): string | null {
+    const coordinates = normalizeVenueCoordinates(venue?.coordinates);
+    if (coordinates) {
+      return this.generateDestinationUrl(`${coordinates.lat},${coordinates.lng}`);
+    }
+
+    const address = venue?.address?.trim();
+    return address ? this.generateDestinationUrl(address) : null;
+  }
+
+  static async getMapImageForVenue(
+    venue: EventData['venue'],
+    width: number,
+    height: number,
+    zoom: number = 14
+  ): Promise<string | null> {
+    const coordinates = normalizeVenueCoordinates(venue?.coordinates);
+    if (coordinates) {
+      return this.getStaticMapDataUrl(coordinates.lat, coordinates.lng, width, height, zoom);
+    }
+
+    const address = venue?.address?.trim();
+    return address ? this.getMapImageForAddress(address, width, height, zoom) : null;
   }
 
   /**

--- a/src/utils/hoja-de-ruta/venue-resolution.ts
+++ b/src/utils/hoja-de-ruta/venue-resolution.ts
@@ -1,0 +1,72 @@
+import type { EventData } from "@/types/hoja-de-ruta";
+
+type VenueCoordinatesInput = {
+  lat?: unknown;
+  lng?: unknown;
+};
+
+export type HojaVenueSource = {
+  name?: string | null;
+  address?: string | null;
+  coordinates?: VenueCoordinatesInput | null;
+};
+
+const normalizeText = (value: string | null | undefined): string => value?.trim() || "";
+
+const normalizeAddressForComparison = (value: string): string =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+
+export const normalizeVenueCoordinates = (
+  value: VenueCoordinatesInput | null | undefined
+): { lat: number; lng: number } | undefined => {
+  const lat = typeof value?.lat === "number" ? value.lat : Number.parseFloat(String(value?.lat ?? ""));
+  const lng = typeof value?.lng === "number" ? value.lng : Number.parseFloat(String(value?.lng ?? ""));
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return undefined;
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return undefined;
+
+  return { lat, lng };
+};
+
+/**
+ * Resolves the venue stored in Hoja de Ruta against the job location fallback.
+ *
+ * A saved Hoja venue is authoritative because it may intentionally differ from
+ * the job's catalog location. Job coordinates are only reused when the saved
+ * address is empty or clearly matches the job address; otherwise mixing them
+ * would make the displayed address and PDF map point to different places.
+ */
+export const resolveHojaVenue = (
+  savedVenue: HojaVenueSource | null | undefined,
+  jobVenue: HojaVenueSource | null | undefined
+): NonNullable<EventData["venue"]> => {
+  const savedName = normalizeText(savedVenue?.name);
+  const savedAddress = normalizeText(savedVenue?.address);
+  const savedCoordinates = normalizeVenueCoordinates(savedVenue?.coordinates);
+
+  const jobName = normalizeText(jobVenue?.name);
+  const jobAddress = normalizeText(jobVenue?.address);
+  const jobCoordinates = normalizeVenueCoordinates(jobVenue?.coordinates);
+
+  const addressesMatch =
+    Boolean(savedAddress && jobAddress) &&
+    normalizeAddressForComparison(savedAddress) === normalizeAddressForComparison(jobAddress);
+
+  // Coordinates identify a location even when no formatted address was saved.
+  // In that case, do not attach an unrelated job-catalog address to them.
+  const address = savedAddress || (!savedCoordinates ? jobAddress : "");
+  const coordinates =
+    savedCoordinates ||
+    (!savedAddress || addressesMatch ? jobCoordinates : undefined);
+
+  return {
+    name: savedName || jobName,
+    address,
+    ...(coordinates ? { coordinates } : {}),
+  };
+};

--- a/src/utils/hoja-de-ruta/venue-resolution.ts
+++ b/src/utils/hoja-de-ruta/venue-resolution.ts
@@ -21,13 +21,26 @@ const normalizeAddressForComparison = (value: string): string =>
     .replace(/[^\p{L}\p{N}]+/gu, " ")
     .trim();
 
+const parseCoordinate = (value: unknown): number | undefined => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string") return undefined;
+
+  const normalized = value.trim();
+  if (!/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(normalized)) {
+    return undefined;
+  }
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
 export const normalizeVenueCoordinates = (
   value: VenueCoordinatesInput | null | undefined
 ): { lat: number; lng: number } | undefined => {
-  const lat = typeof value?.lat === "number" ? value.lat : Number.parseFloat(String(value?.lat ?? ""));
-  const lng = typeof value?.lng === "number" ? value.lng : Number.parseFloat(String(value?.lng ?? ""));
+  const lat = parseCoordinate(value?.lat);
+  const lng = parseCoordinate(value?.lng);
 
-  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return undefined;
+  if (lat === undefined || lng === undefined) return undefined;
   if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return undefined;
 
   return { lat, lng };

--- a/src/utils/pdf/festivalPdfGenerator.ts
+++ b/src/utils/pdf/festivalPdfGenerator.ts
@@ -619,7 +619,9 @@ export const generateAndMergeFestivalPDFs = async (
             jobTitle: jobTitle || 'Festival',
             logoUrl,
             venue: {
-              address: resolvedVenue.address || jobData.description || undefined,
+              address:
+                resolvedVenue.address ||
+                (!resolvedVenue.coordinates ? jobData.description || undefined : undefined),
               coordinates: resolvedVenue.coordinates,
             },
             jobDates

--- a/src/utils/pdf/festivalPdfGenerator.ts
+++ b/src/utils/pdf/festivalPdfGenerator.ts
@@ -17,6 +17,10 @@ import { generateWeatherPDF, WeatherPdfData } from './weatherPdfGenerator';
 import { ensurePublicArtistFormLinks } from '../publicArtistFormLinks';
 import { buildReadableFilename } from '@/utils/fileName';
 import {
+  normalizeVenueCoordinates,
+  resolveHojaVenue,
+} from '@/utils/hoja-de-ruta/venue-resolution';
+import {
   attachShiftAssignmentsAndProfiles,
   buildArtistTableArtists,
   buildInfrastructureArtists,
@@ -538,16 +542,68 @@ export const generateAndMergeFestivalPDFs = async (
       console.log("Starting weather PDF generation");
       
       try {
-        // Fetch job details to get location info
-        const { data: jobData, error: jobError } = await supabase
-          .from("jobs")
-          .select("*")
-          .eq("id", jobId)
-          .single();
+        const [
+          { data: jobData, error: jobError },
+          { data: hojaVenue, error: hojaVenueError },
+        ] = await Promise.all([
+          supabase
+            .from("jobs")
+            .select("start_time, end_time, location_id, description")
+            .eq("id", jobId)
+            .single(),
+          supabase
+            .from("hoja_de_ruta")
+            .select("venue_name, venue_address, venue_latitude, venue_longitude")
+            .eq("job_id", jobId)
+            .maybeSingle(),
+        ]);
         
         if (jobError) {
           console.error("Error fetching job data for weather:", jobError);
         } else {
+          if (hojaVenueError) {
+            console.warn("Unable to load saved Hoja venue for festival weather PDF:", hojaVenueError);
+          }
+
+          let catalogLocation:
+            | {
+                name?: string | null;
+                formatted_address?: string | null;
+                latitude?: number | null;
+                longitude?: number | null;
+              }
+            | null = null;
+
+          if (jobData.location_id) {
+            const { data, error } = await supabase
+              .from("locations")
+              .select("name, formatted_address, latitude, longitude")
+              .eq("id", jobData.location_id)
+              .maybeSingle();
+
+            if (error) {
+              console.warn("Unable to load catalog location for festival weather PDF:", error);
+            } else {
+              catalogLocation = data;
+            }
+          }
+
+          const resolvedVenue = resolveHojaVenue({
+            name: hojaVenue?.venue_name,
+            address: hojaVenue?.venue_address,
+            coordinates: {
+              lat: hojaVenue?.venue_latitude,
+              lng: hojaVenue?.venue_longitude,
+            },
+          }, {
+            name: catalogLocation?.name,
+            address: catalogLocation?.formatted_address || catalogLocation?.name,
+            coordinates: normalizeVenueCoordinates({
+              lat: catalogLocation?.latitude,
+              lng: catalogLocation?.longitude,
+            }),
+          });
+
           // Get job dates
           const startDate = new Date(jobData.start_time);
           const endDate = new Date(jobData.end_time);
@@ -563,7 +619,8 @@ export const generateAndMergeFestivalPDFs = async (
             jobTitle: jobTitle || 'Festival',
             logoUrl,
             venue: {
-              address: jobData.description // Using description as venue address fallback
+              address: resolvedVenue.address || jobData.description || undefined,
+              coordinates: resolvedVenue.coordinates,
             },
             jobDates
           };


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Affected route/feature: Hoja de Ruta venue editing, logistics/driver PDFs, festival PDFs, and festival weather exports.

Saved Hoja de Ruta venue data is now authoritative over the job catalog location. This prevents corrected venue addresses from being replaced by stale catalog addresses and prevents PDF maps/QR codes from pointing to coordinates belonging to a different venue.

The change centralizes venue resolution and strict coordinate normalization, clears stale coordinates after free-text edits or venue changes, prefers exact coordinates for map/QR destinations, supports coordinate-only venues, and adds regression coverage across festival and logistics PDF data paths.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: low
- Main risks: Incorrect fallback behavior when only part of a venue is saved, malformed coordinate strings, or map previews generated for an older address. Regression tests cover source precedence, coordinate reuse, coordinate-only venues, malformed/out-of-range coordinates, and map destination generation.

## Impact Checklist
- [x] Migration impact assessed: no schema changes.
- [x] Realtime/subscription impact assessed: no changes.
- [x] RLS/security impact assessed: existing reads and RLS behavior are preserved.
- [x] Performance impact assessed: venue and location reads are parallelized where possible; no material runtime impact expected.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm install --legacy-peer-deps`
  - `npm run lint`
  - `npm run typecheck`
  - `npm run governance`
  - `npm run test:critical`
  - `npm run test:run`
  - `npm run build`
  - `npm run budget:bundle`
  - targeted ESLint and venue regression tests after follow-up changes
- Results: all commands passed. Latest full Vitest suite: 168 files and 1,038 tests passed. Lint completed with 0 errors and existing warnings. GitHub Chromium E2E passed on the prior reviewed head and will rerun for the final commit.

## Rollback Plan
- [x] I documented how to safely revert this change.
- Rollback steps: revert commits `a29696fc`, `ccfe8b2c`, and `0e68cc70`; no database or deployment rollback is required.

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no