### PR TITLE
[codex] Remove stale client field references

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -583,7 +583,6 @@ const Layout = () => {
             task={unacknowledgedTasks[currentTaskIndex]}
             jobOrTourName={unacknowledgedTasks[currentTaskIndex]?.jobOrTourName || ''}
             jobOrTourType={unacknowledgedTasks[currentTaskIndex]?.jobOrTourType || 'job'}
-            client={unacknowledgedTasks[currentTaskIndex]?.client}
             onDismiss={handleSingleTaskDismiss}
             onViewAll={handleViewAllTasks}
             totalPendingCount={unacknowledgedTasks.length}

--- a/src/components/tasks/PendingTasksModal.tsx
+++ b/src/components/tasks/PendingTasksModal.tsx
@@ -146,9 +146,6 @@ export const PendingTasksModal: React.FC<PendingTasksModalProps> = ({
                           )}
                           <h3 className="font-semibold">{group.name}</h3>
                         </div>
-                        {group.client && (
-                          <p className="text-sm text-muted-foreground mt-1">{group.client}</p>
-                        )}
                       </div>
                       <Badge variant="secondary">
                         {group.tasks.length} {group.tasks.length === 1 ? 'tarea' : 'tareas'}

--- a/src/components/tasks/SingleTaskPopup.tsx
+++ b/src/components/tasks/SingleTaskPopup.tsx
@@ -33,7 +33,6 @@ interface SingleTaskPopupProps {
   task: Task | null;
   jobOrTourName: string;
   jobOrTourType: 'job' | 'tour' | 'global';
-  client?: string;
   onDismiss: () => void;
   onViewAll: () => void;
   totalPendingCount: number;
@@ -64,7 +63,6 @@ export const SingleTaskPopup: React.FC<SingleTaskPopupProps> = ({
   task,
   jobOrTourName,
   jobOrTourType,
-  client,
   onDismiss,
   onViewAll,
   totalPendingCount,
@@ -110,9 +108,6 @@ export const SingleTaskPopup: React.FC<SingleTaskPopupProps> = ({
               )}
               <h3 className="font-semibold">{jobOrTourName}</h3>
             </div>
-            {client && (
-              <p className="text-sm text-muted-foreground mt-1">{client}</p>
-            )}
           </div>
 
           {/* Task Details */}

--- a/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
+++ b/src/hooks/hoja-de-ruta/useHojaDeRutaInitialization.ts
@@ -38,13 +38,6 @@ export const useHojaDeRutaInitialization = (
   // Token of the initialization run currently in flight (see the effect below)
   const initializingRunRef = useRef<{ jobId: string } | null>(null);
 
-  const buildClientContacts = (jobData: { client_name?: string | null; client_phone?: string | null }) =>
-    jobData.client_name ? [{
-      name: jobData.client_name,
-      role: "Cliente",
-      phone: jobData.client_phone || ""
-    }] : [{ name: "", role: "", phone: "" }];
-
   const normalizeTourContacts = (value: unknown) => {
     if (!Array.isArray(value)) return [];
     return value
@@ -111,10 +104,7 @@ export const useHojaDeRutaInitialization = (
           ? { lat: jobData.location.latitude, lng: jobData.location.longitude }
           : undefined,
       },
-      contacts: mergeContacts(
-        buildClientContacts(jobData as { client_name?: string | null; client_phone?: string | null }),
-        tourContacts,
-      ),
+      contacts: mergeContacts(tourContacts),
       logistics: {
         transport: [],
         loadingDetails: "",
@@ -347,10 +337,7 @@ export const useHojaDeRutaInitialization = (
           },
           contacts: savedEventData?.contacts?.length > 0
             ? mergeContacts(savedEventData.contacts, tourContacts)
-            : mergeContacts(
-                buildClientContacts(jobData as { client_name?: string | null; client_phone?: string | null }),
-                tourContacts,
-              ),
+            : mergeContacts(tourContacts),
           logistics: savedEventData?.logistics || {
             transport: [],
             loadingDetails: "",

--- a/src/hooks/useFlatPendingTasks.ts
+++ b/src/hooks/useFlatPendingTasks.ts
@@ -13,7 +13,6 @@ export interface FlatPendingTask {
   // Context from parent group
   jobOrTourName: string;
   jobOrTourType: 'job' | 'tour' | 'global';
-  client?: string;
 }
 
 /**
@@ -34,7 +33,6 @@ export function useFlatPendingTasks(userId: string | null, userRole: string | nu
           ...task,
           jobOrTourName: group.name,
           jobOrTourType: group.type,
-          client: group.client,
         });
       });
     });

--- a/src/hooks/useJobIntegration.ts
+++ b/src/hooks/useJobIntegration.ts
@@ -55,15 +55,6 @@ export const useJobIntegration = (jobId: string) => {
       }
     }
 
-    const contacts = [];
-    if (jobDetails.client_name) {
-      contacts.push({
-        name: jobDetails.client_name,
-        role: "Cliente",
-        phone: jobDetails.client_phone || ""
-      });
-    }
-
     const staff = jobDetails.job_assignments?.map((assignment: any) => ({
       name: assignment.profiles?.first_name || "",
       surname1: assignment.profiles?.last_name || "",
@@ -78,7 +69,7 @@ export const useJobIntegration = (jobId: string) => {
         name: jobDetails.venue || "",
         address: jobDetails.location || ""
       },
-      contacts: contacts.length > 0 ? contacts : [{ name: "", role: "", phone: "" }],
+      contacts: [{ name: "", role: "", phone: "" }],
       staff: staff.length > 0 ? staff : [{ name: "", surname1: "", surname2: "", position: "" }],
       logistics: {
         transport: [],

--- a/src/hooks/usePendingTasks.ts
+++ b/src/hooks/usePendingTasks.ts
@@ -20,7 +20,6 @@ export interface PendingTask {
   created_at: string;
   updated_at: string;
   job_name: string | null;
-  client: string | null;
   tour_name: string | null;
   assignee_first_name: string | null;
   assignee_last_name: string | null;
@@ -31,7 +30,6 @@ export interface GroupedPendingTask {
   id: string;
   type: 'job' | 'tour' | 'global';
   name: string;
-  client?: string;
   tasks: Array<{
     id: string;
     department: 'sound' | 'lights' | 'video' | 'production' | 'administrative';
@@ -124,7 +122,6 @@ export function usePendingTasks(userId: string | null, userRole: string | null, 
             id: groupId,
             type,
             name,
-            client: isGlobal ? undefined : (task.client || undefined),
             tasks: [],
           });
         }

--- a/src/pages/ProjectManagement.tsx
+++ b/src/pages/ProjectManagement.tsx
@@ -165,7 +165,7 @@ const ProjectManagement = () => {
       : (selectedJobTypes.length === 0 ||
         selectedJobTypes.map(t => t.toLowerCase()).includes(String(job.job_type || '').toLowerCase()));
     const matchesStatus = selectedJobStatuses.length === 0 || selectedJobStatuses.includes(job.status);
-    const searchableValues = [job.title, job.client, job.location?.name, job.location?.formatted_address]
+    const searchableValues = [job.title, job.location?.name, job.location?.formatted_address]
       .filter(Boolean)
       .map((value: string) => normalizeSearchText(value));
     const matchesSearch =

--- a/supabase/functions/send-timesheet-reminder/__tests__/clientFieldRegression.test.ts
+++ b/supabase/functions/send-timesheet-reminder/__tests__/clientFieldRegression.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const functionSource = readFileSync(resolve(__dirname, "../index.ts"), "utf8");
+
+describe("send-timesheet-reminder client field regression", () => {
+  it("does not query or render removed job client fields", () => {
+    expect(functionSource).not.toContain("client_name");
+    expect(functionSource).not.toContain("client_phone");
+    expect(functionSource).not.toContain("<strong>Cliente:</strong>");
+  });
+});

--- a/supabase/functions/send-timesheet-reminder/index.ts
+++ b/supabase/functions/send-timesheet-reminder/index.ts
@@ -124,7 +124,7 @@ serve(async (req) => {
     // Fetch job details separately since there's no foreign key
     const { data: job, error: jobError } = await supabaseAdmin
       .from('jobs')
-      .select('id, title, client_name')
+      .select('id, title')
       .eq('id', timesheet.job_id)
       .single()
 
@@ -198,7 +198,6 @@ serve(async (req) => {
       .replace(/'/g, '&#39;');
     const safeTechName = escapeHtml(techName || 'técnico');
     const safeJobTitle = escapeHtml(jobTitle);
-    const safeClientName = job?.client_name ? escapeHtml(String(job.client_name)) : '';
     const safeTechnicianEmail = escapeHtml(technician.email);
 
     const statusLabel = timesheet.status === 'draft'
@@ -309,13 +308,6 @@ serve(async (req) => {
                       <strong>Trabajo:</strong> ${safeJobTitle}
                     </td>
                   </tr>
-                  ${job?.client_name ? `
-                  <tr>
-                    <td style="padding:12px 16px;font-size:14px;color:#374151;border-bottom:1px solid #e5e7eb;">
-                      <strong>Cliente:</strong> ${safeClientName}
-                    </td>
-                  </tr>
-                  ` : ''}
                   <tr>
                     <td style="padding:12px 16px;font-size:14px;color:#374151;border-bottom:1px solid #e5e7eb;">
                       <strong>Fecha:</strong> ${new Date(timesheet.date).toLocaleDateString('es-ES', {


### PR DESCRIPTION
## Summary

- Remove the stale `client_name` select and email rendering from `send-timesheet-reminder`.
- Remove legacy client-field plumbing from pending task UI, hoja de ruta initialization, job integration, and project search.
- Add a focused regression test that fails if the timesheet reminder function starts querying or rendering removed job client fields again.

## Root Cause

The timesheet reminder function had reintroduced a `client_name` query/render path even though jobs do not store client metadata. That made the function dependent on a non-existent business field and risked runtime failures when sending reminders.

## Risk Assessment

Risk level: low.

Main risks:
- Removing client display fields could hide previously expected context if some caller still supplied it.
- The regression test is source-level by design, so it guards this exact reintroduction without exercising Deno runtime behavior.

Mitigations:
- The removed fields are not stored in the jobs model.
- CI and local validation passed.
- The affected Supabase function was deployed successfully after validation.

## Impact Checklist

- User-facing UI: pending-task client subtitles and client-derived hoja contacts are removed.
- Edge Functions: `send-timesheet-reminder` no longer queries or renders `client_name`.
- Database migrations: none.
- Supabase production data/schema: no data or schema change.
- Deployment: `send-timesheet-reminder` deployed to production project `syldobdcdsgfgjtbuwxm`.

## Test Evidence

Local:
- `npm install --legacy-peer-deps`
- `npm run lint` passed with existing warnings.
- `npm run test:run` passed: 169 files, 1039 tests.
- `npm run build` passed.

GitHub CI:
- Governance gates passed.
- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run test:critical` passed.
- `npm run test:run` passed.
- `npm run build` passed.
- `npm run test:e2e (smoke)` passed.
- Cloudflare Pages preview deployed successfully.
- CodeRabbit review completed with no actionable comments.

## Rollback Plan

- Revert this PR if the UI needs to temporarily restore the old client display paths.
- Redeploy the previous `send-timesheet-reminder` function version if email sending behavior needs immediate rollback.

## Migration Impact

No database migration is included. No Supabase production `db push` is required.