### PR TITLE
[codex] Phase 0 enterprise hardening

### DIFF
--- a/docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md
+++ b/docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md
@@ -1,0 +1,915 @@
+# Enterprise Codebase Audit and Roadmap — 2026-06-23
+
+## Audit scope
+
+- Product: Area Tecnica / Sector Pro
+- Audited source: `origin/main`
+- Commit: `e00aa3d77ea8d0a7bceaf565a8f9541c42242239`
+- Production runtime checked: `https://sector-pro.work/` on 2026-06-23
+- Database checked: linked production Supabase project
+- Repository controls checked: `jvhtec/area-tecnica` GitHub rules, Actions, and security settings
+- Previous work reviewed:
+  - `docs/CODEBASE_AUDIT_2026-06-09.md`
+  - `docs/CODEBASE_AUDIT_2026-06-12.md`
+  - `docs/plans/codebase-maintenance-roadmap.md`
+  - `archive/2026-03-repo-cleanup/docs/plans/2026-03-10-enterprise-grade-roadmap.md`
+  - `SECURITY.md`
+  - `ARCHITECTURE.md`
+  - staging, privacy, retention, and monitoring documentation
+
+This was a source, production-control, database, CI/CD, security, testing, architecture, PWA, privacy, and operational-readiness audit. It did not perform destructive exploitation, production data extraction, or external penetration testing.
+
+## Executive verdict
+
+Area Tecnica is a capable production product with a stronger engineering baseline than the earlier audits suggest. Type checking, unit tests, build validation, lazy loading, bundle budgets, migration discipline, and several previously critical security paths have improved materially.
+
+It is **not enterprise grade yet**.
+
+The immediate blockers are not component size or stylistic debt. They are:
+
+1. A confirmed self-service privilege-escalation path through `profiles`.
+2. Backend integration secrets returned to browser code.
+3. Privileged `SECURITY DEFINER` functions executable by inappropriate roles.
+4. Over-permissive availability and vacation RLS.
+5. Production SQL functions that fail live database linting.
+6. Merge, supply-chain, secret-scanning, deployment, observability, recovery, and privacy controls that are documented more strongly than they are enforced.
+
+Recommended classification:
+
+| Domain | Current grade | Enterprise blocker |
+| --- | --- | --- |
+| Authentication and authorization | D | Confirmed role escalation |
+| Secret management | D | Backend credentials delivered to browsers |
+| Database security and integrity | D+ | Unsafe function grants, permissive RLS, live SQL errors |
+| Delivery governance | C- | Zero required approvals; incomplete required checks |
+| Supply-chain security | D+ | No tracked lockfile, no secret scanning, no code scanning |
+| Testing and quality gates | C | Good test count, very low effective coverage |
+| Architecture and maintainability | C+ | Useful foundations, large grandfathered debt |
+| Observability and incident readiness | D | No external error telemetry, alert routing, or SLOs |
+| Backup and disaster recovery | D | No current RPO/RTO or verified restore drill |
+| Privacy and data lifecycle | D+ | Policy/runtime mismatch and no enforced lifecycle |
+| PWA and performance | B- | Good build controls; limited production measurement |
+
+## What is working well
+
+- `npm run typecheck` passes.
+- `npm run test:run` passes: 169 files and 1,034 tests.
+- `npm run build` and the bundle-budget check pass.
+- Production source maps are disabled.
+- Routes are lazy-loaded and heavy map/PDF/spreadsheet dependencies are split.
+- The current build remains inside the committed bundle budget:
+  - total JavaScript gzip: approximately 2.76 MB of a 3.01 MB ceiling
+  - largest entry chunk: approximately 164.6 KB gzip
+- `npm run governance` prevents new violations in selected source boundaries.
+- The latest `origin/main` migration set matches the production migration history; `supabase db push --dry-run` reports the remote database is up to date.
+- Earlier critical findings were genuinely fixed, including broad anonymous sensitive-table reads, image-proxy SSRF, default passwords, wallboard fallback credentials, staffing token logging, Flex retry/idempotency gaps, WhatsApp quotas, and unsanitized payout preview HTML.
+- The repository has a route policy manifest, a unified subscription manager, shared Flex retry logic, shared Brevo mechanics, and an Edge Function HTTP wrapper. These are useful foundations.
+
+## Confirmed findings
+
+### ENT-SEC-01 — Critical — Users can promote their own profile role
+
+**Evidence**
+
+- `supabase/migrations/20260217233500_advisor_security_hardening_phase2_rls.sql:117-132`
+- `supabase/migrations/00000000000000_production_schema.sql:6297-6330`
+- `supabase/migrations/00000000000000_production_schema.sql:10272-10274`
+
+The active `profiles_update` policy permits a user to update their own row. Authenticated users have table-level `UPDATE`, and no later trigger or column-level privilege restriction prevents modification of privileged columns such as:
+
+- `role`
+- `department`
+- `assignable_as_tech`
+- `soundvision_access_enabled`
+- other authorization-relevant flags
+
+An authenticated technician can therefore set their own role to `admin` or `management`. Most RLS policies and Edge Functions trust `profiles.role`, so this is a platform-wide authorization bypass.
+
+**Impact**
+
+- Administrative data access.
+- User, staffing, finance, expense, and payout operations.
+- Access to management-only Edge Functions.
+- Access to the secret-returning function described in ENT-SEC-02.
+- Ability to modify role-gated tables and invoke role-gated RPCs.
+
+**Required remediation**
+
+1. Revoke general user control of authorization columns.
+2. Allow self-service updates only for an explicit safe column set.
+3. Move role/department/privileged-flag changes behind an admin-only RPC or Edge Function.
+4. Add an immutable security audit row for every privilege change.
+5. Add RLS tests proving technicians cannot change any authorization attribute.
+
+**Immediate mitigation**
+
+- Deploy a `BEFORE UPDATE` trigger that restores protected columns unless the actor is service role or an authorized administrator.
+- Review `profiles` audit/history for unexpected role changes.
+
+### ENT-SEC-02 — Critical — Backend integration secrets are returned to browser code
+
+**Evidence**
+
+- `supabase/functions/get-secret/handler.ts:7-8`
+- `supabase/functions/get-secret/handler.ts:128-171`
+- `src/lib/api-service.ts:18-45`
+- `src/components/project-management/apiService.ts:101-128`
+- `src/services/flexPullsheets.ts:33-50`
+- `src/services/flexWorkOrders.ts:15-32`
+- `src/utils/flexUrlResolver.ts:165-225`
+- `src/utils/flex-folders/api.ts:14-54`
+
+`get-secret` returns raw values for:
+
+- `X_AUTH_TOKEN`
+- `OPENAI_API_KEY`
+- `GOOGLE_MAPS_API_KEY`
+
+The Flex token is then cached in browser memory and sent directly from the browser to Flex. Any authorized browser user can retrieve it through DevTools, runtime instrumentation, an XSS payload, or a compromised extension. ENT-SEC-01 makes the management check bypassable by any authenticated user.
+
+`src/lib/api-service.ts` also attaches the retrieved token to a caller-provided URL, increasing accidental or malicious exfiltration risk.
+
+**Impact**
+
+- Direct credential theft and reuse outside Sector Pro.
+- Unauthorized Flex reads and state changes.
+- Potential external API cost or data exposure.
+- Larger impact from any future XSS because Supabase sessions and integration secrets are browser-accessible.
+
+**Required remediation**
+
+1. Stop returning backend secrets to clients.
+2. Route every privileged integration through narrow server-side proxy operations.
+3. Allowlist operation type, upstream host, method, fields, and resource scope.
+4. Rotate exposed integration credentials after migration.
+5. Remove `OPENAI_API_KEY` and server Google credentials from the client-retrievable allowlist immediately.
+
+### ENT-DB-01 — Critical — Privileged SQL functions have unsafe execution grants
+
+**Evidence**
+
+Examples in `supabase/migrations/00000000000000_production_schema.sql`:
+
+- `clear_tour_preset_assignments`: `995-1006`, granted to `anon` at `9679-9681`
+- `get_tour_complete_timeline`: `2349-2392`, granted to `anon` at `9762-9764`
+- `get_tour_date_complete_info`: `2393-2419`, granted to `anon` at `9765-9767`
+- `get_user_job_ids`: `2420-2428`, granted to `anon` at `9768-9770`
+- `invoke_scheduled_push_notification`: `2477-2532`, granted to `anon` at `9782-9784`
+- `log_activity`: `2629-2670`, granted to `anon` at `9804-9806`
+- `log_activity_as`: `2671-2708`, granted to `anon` at `9807-9809`
+- `sync_preset_assignments_for_tour`: `4118-4156`, granted to `anon` at `9882-9884`
+- `upsert_venue`: `4923-4977`, granted to `anon` at `9987-9989`
+
+These functions are `SECURITY DEFINER` and do not consistently enforce caller identity or authorization. Confirmed capabilities include:
+
+- deleting or creating preset assignments
+- spoofing activity actors and audit events
+- invoking scheduled push behavior with a stored service-role credential
+- bypassing table RLS to read tour, travel, accommodation, and assignment-derived data
+- inserting/updating venue data
+
+The schema contains many trigger functions that are harmless when called only by triggers, but broad generated grants make the function surface difficult to reason about. A scan found 41 `SECURITY DEFINER` functions granted to `anon` that either write data or lack an obvious caller-authorization check. Each must be classified rather than assumed safe.
+
+**Required remediation**
+
+1. Default-revoke `EXECUTE` from `PUBLIC` and `anon` for all non-public RPCs.
+2. Maintain an explicit RPC privilege manifest.
+3. Separate trigger-only functions from callable APIs.
+4. Require identity and capability checks inside every privileged callable function.
+5. Add automated schema tests that fail on new unsafe `SECURITY DEFINER` grants.
+
+### ENT-DB-02 — High — Availability and vacation RLS allows cross-user modification
+
+**Evidence**
+
+- `supabase/migrations/00000000000000_production_schema.sql:9416-9419`
+- `supabase/migrations/00000000000000_production_schema.sql:9493-9499`
+
+Every authenticated user can select, insert, update, and delete any row in `technician_availability`. The policies test only that `auth.uid()` is non-null.
+
+The `vacation_requests` insert policy allows broad technician/house-tech/admin/management roles without requiring `technician_id = auth.uid()`. The update policy allows a technician to update their own pending row but does not safely freeze ownership fields.
+
+**Impact**
+
+- One technician can change another technician's availability.
+- Staffing recommendations and scheduling conflicts can be corrupted.
+- Pending vacation ownership can be reassigned.
+
+**Required remediation**
+
+- Self-only insert/update/delete for technicians.
+- Department-scoped management access where required.
+- Protected ownership fields during update.
+- RLS integration tests for every role and operation.
+
+### ENT-DB-03 — High — Job totals RPC trusts a caller-supplied role
+
+**Evidence**
+
+- `supabase/migrations/20260612150000_exclude_voided_timesheets_from_payout_math.sql:126-174`
+
+`get_job_total_amounts(_job_id, _user_role)` uses `_user_role` when supplied. A caller can pass `admin`, `management`, or `logistics`, causing the function to expose all individual payout details for a job.
+
+**Required remediation**
+
+- Remove `_user_role` from the public signature.
+- Derive role exclusively from the authenticated actor.
+- Revoke the old overload explicitly after migrating callers.
+
+### ENT-DB-04 — High — Production database lint reports broken functions
+
+The linked production database reported application-level errors in:
+
+1. `public.auto_complete_past_jobs` — references missing `jobs.updated_at`.
+2. `public.get_timesheet_effective_rate` — references missing `house_tech_rates`.
+3. `public.find_declined_with_active_timesheets` — result type mismatch between assignment status enum/text.
+4. `public.get_job_total_amounts` — ambiguous `job_id`.
+
+These are live schema defects, not only local static warnings. `system-health` calls one of the broken functions, so the health endpoint cannot be trusted as an operational signal.
+
+**Required remediation**
+
+- Correct each function in additive migrations.
+- Add database lint to required CI checks.
+- Execute database function smoke tests against an ephemeral Supabase/Postgres instance.
+
+### ENT-EDGE-01 — High — Public service-role and paid-API endpoints lack consistent protection
+
+**Evidence**
+
+- `supabase/config.toml:19-23`
+- `supabase/config.toml:46-47`
+- `supabase/functions/place-restaurants/index.ts:1-175`
+- `supabase/functions/place-photos/index.ts:10-142`
+- `supabase/functions/cleanup-corporate-email-images/index.ts:32-87`
+
+`place-restaurants`, `place-photos`, and `cleanup-corporate-email-images` have JWT verification disabled. They do not perform equivalent robust authorization internally.
+
+Confirmed risks:
+
+- third parties can consume paid Google APIs through the project
+- request bodies and location data are logged
+- cleanup can be triggered externally using a service-role client
+
+Some other `verify_jwt = false` functions are intentionally public and tokenized. The issue is the absence of one enforced endpoint classification model.
+
+**Required remediation**
+
+- Classify every function as public-token, authenticated-user, privileged-role, or service-only.
+- Enforce that classification in code and `config.toml`.
+- Add durable rate limits for public-token endpoints.
+- Make cleanup functions service-only.
+- Remove unused Google proxy functions if the Mapbox/Wikimedia migration superseded them.
+
+### ENT-EDGE-02 — Medium — Edge Function standardization is mostly a baseline exception
+
+The repository contains 64 Edge Function directories, but only four current entrypoints use the shared `createHttpHandler` pattern. The governance gate permits the other 60 as grandfathered legacy functions.
+
+At least 52 function files define wildcard CORS directly, and the shared CORS helper itself defaults to `Access-Control-Allow-Origin: *`.
+
+Wildcard CORS is not an authorization bypass by itself, but it increases abuse surface and makes endpoint intent unclear. Authentication, authorization, method validation, request-size limits, rate limits, redaction, error shape, and correlation IDs remain inconsistent.
+
+### ENT-WEB-01 — High — Production lacks a CSP and key browser security headers
+
+Production response observed on 2026-06-23:
+
+- present: `X-Content-Type-Options: nosniff`
+- present: `Referrer-Policy: strict-origin-when-cross-origin`
+- absent: Content Security Policy
+- absent: frame protection through CSP `frame-ancestors` or `X-Frame-Options`
+- absent: `Permissions-Policy`
+- absent: cross-origin isolation policies where appropriate
+
+`public/_headers` contains service-worker caching rules but no security-header policy.
+
+Supabase sessions persist in `localStorage` (`src/lib/supabase-client.ts:32-40`). This is common for SPAs, but without a strong CSP any XSS has direct access to the session and to integration secrets exposed by ENT-SEC-02.
+
+**Required remediation**
+
+- Deploy CSP in report-only mode, measure violations, then enforce it.
+- Add `frame-ancestors`, `Permissions-Policy`, and explicit resource origin policies.
+- Define and test a third-party script policy for Cloudflare Analytics.
+- Do not add HSTS without confirming the complete domain/subdomain rollout plan.
+
+### ENT-PWA-01 — Medium — Production service worker logs full push payloads
+
+**Evidence**
+
+- `public/sw.js:226-234`
+
+The service worker is copied as a static asset, so Vite's production console stripping does not remove its logging. Full push payloads and metadata are written to the browser console.
+
+Push payloads should be treated as potentially sensitive operational data. Production logging should include event IDs and delivery outcomes, not content.
+
+### ENT-CI-01 — High — Mainline protection does not require review or all available checks
+
+GitHub ruleset `Protect main and dev` is active, but:
+
+- required approving reviews: `0`
+- code-owner review: disabled
+- last-push approval: disabled
+- required checks:
+  - `npm run lint`
+  - `npm run test:critical`
+  - `npm run test:run`
+  - `npm run build`
+
+The workflow also runs typecheck, governance, and E2E, but those are not required by branch policy. A PR can therefore merge while those checks fail.
+
+**Required remediation**
+
+- Require at least one independent approval; use two for database/security/high-risk changes.
+- Require CODEOWNER review for `supabase/**`, CI, auth, integrations, and security policy.
+- Require typecheck, governance, E2E smoke, database lint, and migration validation.
+- Require approval after the final push for high-risk changes.
+
+### ENT-SUPPLY-01 — High — Builds are not reproducible
+
+The repository intentionally ignores `package-lock.json` and CI runs:
+
+```bash
+npm install --legacy-peer-deps
+```
+
+Most dependencies use caret ranges. The same commit can resolve a different dependency graph on a later day. This weakens:
+
+- reproducibility
+- rollback confidence
+- dependency review
+- software bill of materials generation
+- forensic comparison
+- vulnerability triage
+
+Enterprise remediation requires an approved change to the current repository rule: commit and enforce a lockfile, or adopt another deterministic package-management mechanism.
+
+### ENT-SUPPLY-02 — High — Repository security automation is disabled
+
+The GitHub repository is public. Current settings show:
+
+- Dependabot security updates: disabled
+- secret scanning: disabled
+- secret scanning push protection: disabled
+- code scanning: no analysis configured
+- GitHub Actions SHA pinning: not required
+- actions are referenced by moving tags such as `actions/checkout@v4`
+
+A history scan of 33,995 text-like blobs found JWT-like material in historical `.env` and compiled artifacts, but no high-confidence private key or service-role credential was confirmed by the pattern set. The scan is not a substitute for GitHub secret scanning or a dedicated historical scanner.
+
+**Required remediation**
+
+- Decide explicitly whether a proprietary operations platform should remain public.
+- Enable secret scanning and push protection.
+- Enable CodeQL or equivalent.
+- Enable Dependabot/Renovate with an ownership and rollout policy.
+- Pin third-party Actions by full commit SHA.
+- Generate an SBOM and retain it with releases.
+
+### ENT-TEST-01 — High — Test count is healthy, but effective coverage is low
+
+`npm run test:coverage` fails.
+
+Observed aggregate coverage:
+
+- lines: 15.64%
+- functions: 51.82%
+- branches: 65.29%
+
+Existing focused thresholds also fail for:
+
+- `supabase/functions/_shared/flexFetch.ts`
+- `supabase/functions/_shared/whatsappQuota.ts`
+
+Many business-critical files report 0% coverage, including:
+
+- `supabase/functions/staffing-orchestrator/index.ts`
+- `supabase/functions/send-staffing-email/index.ts`
+- `src/components/jobs/cards/JobCardNew.tsx`
+- `src/features/tour-ops/TourOpsManagementHub.tsx`
+- `supabase/functions/create-whatsapp-group/index.ts`
+
+The Playwright suite uses a mocked Supabase server. It is useful for UI routing and state, but it does not validate production RLS, RPCs, migrations, Realtime, storage policies, or Edge Function authorization.
+
+### ENT-TEST-02 — Medium — E2E has a concurrency flake
+
+The full local E2E run produced two blank-app failures in festival and project management. The same tests passed when rerun with one worker. CI forces one worker, masking the shared-state/concurrency issue.
+
+The suite should either be isolation-safe or declare and document its serialized dependency.
+
+### ENT-CODE-01 — High — Lint is green only because severe rules are warnings
+
+Direct ESLint JSON output reported:
+
+- 2,178 warnings
+- 1,873 `no-explicit-any`
+- 96 `react-hooks/exhaustive-deps`
+- 58 `no-empty`
+- 56 React refresh warnings
+- 5 `react-hooks/rules-of-hooks`
+
+`src/pages/Disponibilidad.tsx:60-81` returns before later hooks execute. This can change the hook order across renders and is a correctness bug, not style debt.
+
+`eslint.config.js:105` explicitly downgrades `react-hooks/rules-of-hooks` to warning, allowing this defect to pass CI.
+
+### ENT-CODE-02 — Medium — Type safety is not at the enterprise target
+
+- `strict: false`
+- `strictNullChecks` is not enabled
+- 329 `as any` occurrences
+- approximately 1,083 explicit `: any` occurrences
+
+`noImplicitAny` is enabled and typecheck passes, which is a meaningful improvement. The next useful ratchet is `strictNullChecks`, domain by domain.
+
+### ENT-ARCH-01 — Medium — The “data layer complete” status is overstated
+
+`src/services/dataLayerClient.ts:4-8` explicitly describes itself as a legacy boundary where UI code still owns query details.
+
+Current baseline:
+
+- 203 UI imports of `dataLayerClient`
+- governance accepts that debt against a fingerprint baseline
+- source-boundary checks stop new violations but do not complete the migration
+
+The result is naming consistency, not a true domain data layer. Query construction, authorization assumptions, error mapping, and cache behavior remain distributed through UI files.
+
+### ENT-ARCH-02 — Medium — Realtime consolidation remains incomplete
+
+Current baseline:
+
+- 36 `.channel(` calls in 20 source files
+- 2 calls belong to the unified manager
+- approximately 34 channels remain outside the manager
+
+The Phase 4 roadmap marked realtime subscription work complete, but the current code still has duplicate lifecycle, invalidation, reconnect, and route-cleanup risks.
+
+### ENT-ARCH-03 — Medium — Large modules remain a change-risk multiplier
+
+Production files above 1,000 lines: 23.
+
+Largest examples:
+
+- `TourOpsManagementHub.tsx`: 2,116
+- `tourSchedulingService.ts`: 1,885
+- `useConsumosTool.ts`: 1,690
+- `send-staffing-email/index.ts`: 1,627
+- `TourDefaultsManager.tsx`: 1,507
+- `JobCardNew.tsx`: 1,422
+- `StaffingCampaignPanel.tsx`: 1,297
+- `SoundVisionInteractiveMap.tsx`: 1,293
+- `TourDateManagementDialog.tsx`: 1,254
+- `rates-pdf-export.ts`: 1,244
+
+File length alone is not a defect. These modules are roadmap targets because they combine data access, policy, state machines, side effects, formatting, and UI, making security review and test isolation harder.
+
+### ENT-OBS-01 — High — There is no enterprise production observability
+
+The repository has:
+
+- browser console logging
+- a narrow `system_errors` table for timesheets and assignments
+- local sessionStorage ErrorBoundary records
+- database health views
+- an in-app subscription diagnostics panel
+
+It does not have evidence of:
+
+- external error aggregation
+- distributed traces
+- correlation IDs across browser, Edge Function, database, and external APIs
+- alert routing
+- on-call ownership
+- SLOs or error budgets
+- release-health comparison
+- synthetic monitoring of critical journeys
+
+`src/lib/errorTracking.ts:22-44` serializes arbitrary context without a sensitive-field denylist. Before expanding this path, add structured redaction.
+
+### ENT-OBS-02 — High — `system-health` is not a safe or reliable health contract
+
+**Evidence**
+
+- `supabase/functions/system-health/index.ts:14-67`
+
+The function:
+
+- uses service role
+- does not perform a role check in its handler
+- returns sample rows from integrity queries
+- exposes internal database error messages
+- depends on a function currently failing database lint
+
+Even if gateway JWT verification is active, every authenticated caller can receive internal health samples unless an upstream policy not represented in code prevents it.
+
+Create two endpoints:
+
+1. A minimal liveness/readiness response with no business data.
+2. A privileged diagnostic endpoint with explicit role checks and audit logging.
+
+### ENT-DR-01 — High — Backup and recovery objectives are not operationalized
+
+The repository has historical backup notes but no current:
+
+- business-approved RPO
+- business-approved RTO
+- production backup inventory
+- point-in-time recovery verification
+- restore runbook
+- recurring restore drill evidence
+- dependency recovery plan for Cloudflare, Supabase, Flex, email, WAHA, or push
+
+Supabase-managed backups may exist, but their configuration and tested recoverability are not evidenced in the repository. Enterprise readiness requires proof, not an assumption based on provider defaults.
+
+### ENT-PRIV-01 — High — Privacy policy and runtime behavior diverge
+
+**Evidence**
+
+- `src/pages/Privacy.tsx:71-90`
+- `src/pages/Profile.tsx:741-780`
+- `supabase/functions/delete-user/index.ts:57`
+
+The privacy page says users can delete their account through Profile and that personal data is deleted immediately. The profile UI instead opens an email request, and the administrative delete function explicitly prevents self-deletion.
+
+The policy does not fully identify:
+
+- legal entity/data controller
+- legal bases by processing purpose
+- processors/subprocessors
+- international transfers
+- complaint authority
+- detailed retention schedule
+- automated decision/profiling status
+- verified deletion/anonymization behavior across audit, payroll, documents, backups, and external integrations
+
+### ENT-PRIV-02 — High — Data-handling policy is not operational
+
+`docs/secure_storage_and_data_handling_policy.md` references:
+
+- `s3://ops-audits-prod`
+- `gs://ops-shared/audit-log.xlsx`
+- `security@company.example`
+
+These appear to be placeholders, and no matching CI or operational integration exists in the repository. The document should not be treated as an implemented control.
+
+### ENT-A11Y-01 — Medium — Accessibility has no automated release gate
+
+No axe, pa11y, or equivalent accessibility test dependency or CI gate is present. The application uses shadcn/Radix primitives in many areas, which helps, but custom mobile workflows, dialogs, maps, tables, and large interactive cards require automated checks plus keyboard/screen-reader testing.
+
+### ENT-DOC-01 — Medium — Security and architecture documentation has material drift
+
+Examples:
+
+- `SECURITY.md` still describes Vitest 2 even though the repository uses Vitest 3.
+- It lists unresolved key-rotation work from February without evidence of closure.
+- It says service-role keys must never be exposed to clients while `get-secret` returns backend credentials to browser code.
+- `ARCHITECTURE.md` has stale migration/function counts and still references removed legacy structure.
+- The maintenance roadmap marks the data-layer and realtime phases complete despite the current baselines above.
+- Previous audits reported lint warning counts that covered only part of the configured lint surface.
+
+Roadmap status must be based on measurable acceptance criteria, not the existence of helper infrastructure.
+
+## Active feature-branch findings
+
+The user's current worktree is on `codex/remove-matrix-unavailable-flag`, behind `origin/main`, with uncommitted matrix changes. Those changes were preserved and not modified.
+
+The new `src/utils/matrixAvailability.ts` currently deletes all legacy `technician_availability` rows for a technician/date when clearing manual unavailability. It should delete only the intended manual `day_off` status. Legacy vacation/travel/sick records are also mapped as clearable.
+
+Before that branch is committed:
+
+- constrain deletion to the manual status/source
+- make only manual entries clearable
+- add regression tests for vacation/travel/sick preservation
+- exclude the modified `supabase/.temp/cli-latest` file
+
+## Reconciliation with previous audits and roadmaps
+
+### March 2026 enterprise roadmap
+
+| Claimed target | Current reality |
+| --- | --- |
+| Required PR review | Ruleset exists, but required approvals are `0` |
+| Required quality checks | Four checks required; typecheck, governance, E2E, DB lint, and migration checks are not |
+| Restore drill and RTO | No current runbook or drill evidence |
+| Secret and code scanning | Disabled |
+| Observability and on-call | Not implemented |
+| SLOs | Not defined |
+
+### May 2026 maintenance roadmap
+
+| Claimed completion | Current reality |
+| --- | --- |
+| Data-layer phase complete | 203 UI `dataLayerClient` imports; UI still owns queries |
+| Realtime phase complete | Approximately 34 unmanaged channels remain |
+| Edge HTTP helper complete | Helper exists, but only 4/64 entrypoints use it |
+| Performance phase complete | Build budgets exist; production RUM and route SLOs do not |
+| Type phase complete | `noImplicitAny` is enabled; `strictNullChecks` and strict mode remain off |
+
+### June 2026 audits
+
+The June audits correctly identified and drove substantial remediation. Their primary weakness was rechecking the prior finding list more deeply than the complete authorization surface. The current privilege escalation, browser secret distribution, broad function grants, and permissive availability RLS were not surfaced.
+
+The June 12 addendum is accurate for the fixes it lists. Those fixes should be retained.
+
+## Enterprise roadmap
+
+The roadmap is ordered by risk reduction and operational dependency. Large refactors should not start before the containment and control-plane work.
+
+### Phase 0 — Containment and incident review
+
+**Target:** 0-72 hours  
+**Estimated effort:** 5-8 engineer-days plus credential coordination
+
+1. Block self-modification of profile authorization fields.
+2. Review profile and security-audit history for unexpected role changes.
+3. Disable browser retrieval of `OPENAI_API_KEY` and server Google credentials.
+4. Begin migration of Flex calls to server-side operation-specific proxies.
+5. Rotate Flex and any other credential that has been returned to browsers.
+6. Revoke `anon`/`PUBLIC` execution from unsafe privileged RPCs.
+7. Fix `technician_availability` and `vacation_requests` RLS.
+8. Remove caller-supplied role trust from `get_job_total_amounts`.
+9. Fix the four live database-lint errors.
+10. Make paid-API proxies authenticated/rate-limited and cleanup functions service-only.
+
+**Exit gates**
+
+- A technician cannot modify role, department, or privileged flags.
+- No backend secret is returned to browser code.
+- No unauthenticated actor can execute a data-changing privileged RPC.
+- Cross-user availability/vacation modification tests fail closed.
+- Production database lint has zero application errors.
+- Credential rotations are recorded with owner and date.
+
+### Phase 1 — Secure delivery control plane
+
+**Target:** Weeks 1-2  
+**Estimated effort:** 5-8 engineer-days
+
+1. Require one independent PR approval; require two for high-risk paths.
+2. Require CODEOWNER review for database, auth, CI, integration, and security changes.
+3. Make all existing CI jobs required:
+   - lint
+   - typecheck
+   - governance
+   - critical tests
+   - full unit tests
+   - build/budget
+   - E2E smoke
+4. Add required database jobs:
+   - migration ordering
+   - `db lint`
+   - ephemeral migration apply
+   - RLS/RPC security tests
+5. Approve and implement deterministic dependency locking; update `AGENTS.md` when the policy changes.
+6. Enable secret scanning, push protection, dependency updates, and CodeQL.
+7. Pin GitHub Actions by full SHA.
+8. Add SBOM generation and retain release artifacts.
+9. Add production security headers, starting with CSP report-only.
+10. Create a release checklist with rollback and post-deploy verification.
+
+**Exit gates**
+
+- No merge to `main` can occur with any quality/security check failing.
+- Every production change has independent review.
+- A commit resolves the same dependency graph locally and in CI.
+- Secret and code scanning run continuously.
+- CSP is enforced without breaking critical routes.
+
+### Phase 2 — Backend trust-boundary hardening
+
+**Target:** Weeks 2-4  
+**Estimated effort:** 10-15 engineer-days
+
+1. Inventory every Edge Function and RPC by exposure class.
+2. Default-revoke SQL function execution and grant explicitly.
+3. Add an automated `SECURITY DEFINER` privilege gate.
+4. Migrate priority Edge Functions to the shared HTTP/auth framework:
+   - user administration
+   - staffing
+   - payouts/expenses
+   - Flex mutations
+   - WhatsApp/email
+   - document access
+5. Add shared:
+   - actor/role authorization
+   - origin policy
+   - request-size limits
+   - structured errors
+   - correlation IDs
+   - sensitive-field redaction
+   - rate limiting
+   - idempotency keys
+6. Separate liveness from privileged diagnostics.
+7. Add abuse tests for public tokenized links and paid API proxies.
+8. Add database policy tests for every role and sensitive table.
+
+**Exit gates**
+
+- 100% of callable privileged RPCs have explicit grants and authorization tests.
+- 100% of service-role Edge Functions have an enforced exposure classification.
+- No health endpoint returns business samples or internal errors to normal users.
+- Public endpoints have durable abuse controls.
+
+### Phase 3 — Test and correctness maturity
+
+**Target:** Weeks 3-6  
+**Estimated effort:** 12-20 engineer-days
+
+1. Fix the Rules-of-Hooks defect and promote `rules-of-hooks` to error.
+2. Add tests for:
+   - staffing orchestrator HTTP/state-machine paths
+   - staffing email orchestration
+   - Flex operation proxies
+   - payout/expense authorization
+   - role change and profile policies
+   - availability/vacation policies
+   - user deletion and privacy workflows
+3. Introduce risk-based coverage gates:
+   - security/finance/staffing/data-integrity modules: at least 90% lines, 80% branches
+   - changed-file coverage gate for all PRs
+   - overall line coverage milestones: 30%, 45%, then 60%
+4. Add integration tests against ephemeral Supabase/Postgres.
+5. Add a small production-like staging E2E suite with isolated test tenants.
+6. Fix or formally serialize the E2E concurrency dependency.
+7. Add accessibility smoke tests for critical routes.
+8. Begin `strictNullChecks` by domain.
+9. Ratchet lint warnings so no PR increases the count.
+
+**Exit gates**
+
+- Coverage command passes.
+- All authorization regressions have negative tests.
+- Critical browser journeys pass against real database policies.
+- Hooks violations and new explicit `any` usage fail CI.
+
+### Phase 4 — Observability, SLOs, and incident operations
+
+**Target:** Weeks 4-8  
+**Estimated effort:** 10-15 engineer-days plus platform configuration
+
+1. Implement external browser and Edge Function error telemetry.
+2. Add trace/correlation IDs through:
+   - browser action
+   - Edge Function
+   - database operation
+   - Flex/email/WhatsApp/push provider
+3. Define redaction rules before sending telemetry.
+4. Establish initial SLOs for:
+   - sign-in/session refresh
+   - dashboard load
+   - assignment mutation
+   - staffing campaign execution
+   - timesheet submission/approval
+   - document access
+   - external notification delivery
+5. Add alerts for error rate, latency, database failures, queue/backlog, quota, and provider failures.
+6. Create on-call ownership, severity definitions, communication templates, and postmortem policy.
+7. Add synthetic checks for the public app, auth, and selected safe APIs.
+8. Add deployment markers and release-health comparison.
+
+**Recommended initial targets**
+
+- critical failure detection: under 5 minutes
+- Sev-1 acknowledgement: under 15 minutes
+- Sev-1 restore/mitigation: under 4 hours
+- critical user-journey availability: 99.9%, then refine with business input
+
+### Phase 5 — Backup, recovery, staging, and release safety
+
+**Target:** Weeks 5-8  
+**Estimated effort:** 6-10 engineer-days plus provider configuration
+
+1. Confirm production backup/PITR capabilities and ownership.
+2. Define business-approved RPO/RTO; recommended starting point:
+   - RPO: no more than 1 hour for core operational data
+   - RTO: no more than 4 hours
+3. Build and test a staging restore runbook.
+4. Run a recorded restore drill.
+5. Verify staging and preview deployments cannot address production Supabase.
+6. Use separate credentials and integration sandboxes where providers support them.
+7. Add post-deploy smoke tests and automated rollback criteria.
+8. Document recovery for Cloudflare, Supabase, Flex, Brevo, WAHA, push, and mobile releases.
+
+**Exit gates**
+
+- Restore drill meets RPO/RTO.
+- Preview builds are technically prevented from writing production.
+- Every release has a tested rollback path and post-deploy verification.
+
+### Phase 6 — Privacy and data governance
+
+**Target:** Weeks 6-10  
+**Estimated effort:** 8-12 engineer-days plus legal/privacy review
+
+1. Build a data inventory and processing map.
+2. Classify data by sensitivity and owner.
+3. Replace placeholder secure-storage policy details with real approved systems and contacts.
+4. Align the privacy notice with actual behavior and legal review.
+5. Implement a verified account/data-subject request workflow.
+6. Define retention by table, storage bucket, audit log, backup, and external processor.
+7. Automate deletion/anonymization where legally permitted.
+8. Record subprocessors, transfer mechanisms, and breach-notification responsibilities.
+9. Run recurring access reviews for production, Supabase, Cloudflare, GitHub, and external providers.
+
+**Exit gates**
+
+- User-facing privacy statements match implemented behavior.
+- Every sensitive dataset has owner, purpose, retention, and deletion rule.
+- Data-subject requests are traceable and testable.
+
+### Phase 7 — Architecture and maintainability convergence
+
+**Target:** Weeks 8-16  
+**Estimated effort:** continuous, 20-35 engineer-days for the first wave
+
+1. Replace the thin `dataLayerClient` alias with domain query/mutation modules.
+2. Reduce UI-owned data queries by at least 25% per sprint until the baseline is zero.
+3. Move all direct Realtime channels behind the manager.
+4. Standardize React Query cache policies by domain.
+5. Split the highest-risk monoliths by state machine, data access, and side effects.
+6. Finish Edge Function handler adoption, prioritized by privilege and external side effects.
+7. Migrate repeated email HTML to tested, render-verified templates.
+8. Reduce lint warnings:
+   - immediate: zero Hooks rule warnings
+   - 30 days: below 1,000
+   - 60 days: below 400
+   - 90 days: below 100
+9. Enable `strictNullChecks`, then broader strict mode.
+10. Keep architecture and roadmap metrics generated from code rather than manually stated.
+
+## Ownership model
+
+| Workstream | Accountable owner |
+| --- | --- |
+| Authorization, RLS, RPC grants | Security/Data owner |
+| Secret migration and integration proxies | Platform/Integration owner |
+| CI, dependency locking, GitHub controls | Platform owner |
+| Test strategy and quality gates | QA/Engineering lead |
+| Browser security and frontend architecture | Frontend owner |
+| Observability and incident response | Platform owner |
+| Recovery and staging isolation | Platform/Data owner |
+| Privacy and retention | Business/privacy owner with engineering |
+
+No critical control should have only one person capable of approving, deploying, or recovering it.
+
+## Weekly enterprise scorecard
+
+Track these metrics from automated sources:
+
+- open critical/high security findings and age
+- percentage of protected branches requiring independent approval
+- percentage of required CI checks enforced by branch rules
+- database lint and migration-test status
+- changed-file and critical-module coverage
+- test flake rate
+- lint warning count by rule/domain
+- unmanaged Realtime channel count
+- browser-owned query count
+- Edge Function standard-handler adoption
+- deployment frequency, change failure rate, rollback rate, MTTR
+- SLO compliance and error-budget consumption
+- dependency and secret-scanning findings
+- restore-drill result and achieved RPO/RTO
+- data-retention/deletion job success
+
+## Enterprise exit criteria
+
+Do not label the platform enterprise grade until all of the following are true:
+
+1. No known critical or unaccepted high-severity security finding remains.
+2. Authorization and RLS have automated negative tests.
+3. No backend credential is delivered to a browser.
+4. Privileged RPC and Edge Function exposure is explicit and least-privilege.
+5. Production database lint and migration validation are clean.
+6. All quality/security checks and independent review are enforced before merge.
+7. Builds are dependency-reproducible and generate an SBOM.
+8. Production errors, latency, and critical workflows are externally monitored with alerts and owners.
+9. RPO/RTO are approved and demonstrated through a restore drill.
+10. Privacy, retention, deletion, and incident-response behavior matches documented policy.
+11. Critical paths meet risk-based coverage targets.
+12. An external penetration test verifies the remediated trust boundaries.
+
+## Validation performed
+
+| Check | Result |
+| --- | --- |
+| Latest `origin/main` isolated audit tree | `e00aa3d7` |
+| `npm run typecheck` | Pass |
+| `npm run lint` | Pass with 2,178 warnings |
+| `npm run governance` | Pass against grandfathered baselines |
+| `npm run test:run` | 169 files / 1,034 tests pass |
+| `npm run test:coverage` | Fail; 15.64% line coverage |
+| `npm run build` | Pass |
+| bundle budget | Pass |
+| Playwright full local run | 18/20 pass; failed tests pass serialized |
+| production migration dry run from latest `origin/main` | Remote database up to date |
+| linked production database lint | Four application function errors |
+| production HTTP header inspection | Missing CSP/frame/permissions policies |
+| GitHub branch/rules/security inspection | Review count 0; scanning controls disabled |
+| Git history pattern scan | 33,995 text-like blobs; no high-confidence private credential confirmed |
+
+## Audit limitations
+
+- No destructive production exploit was executed.
+- No production user records or sensitive function responses were retrieved.
+- Provider dashboards for Supabase backups, Cloudflare build variables, Flex, Brevo, WAHA, Apple, and Google were not available.
+- Historical secret scanning used a local pattern set and should be followed by a dedicated scanner.
+- Legal conclusions require qualified privacy/legal review.
+- External penetration testing remains necessary after Phase 0-2 remediation.

--- a/docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md
+++ b/docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md
@@ -53,7 +53,8 @@ Recommended classification:
 ## What is working well
 
 - `npm run typecheck` passes.
-- `npm run test:run` passes: 169 files and 1,034 tests.
+- At the audit baseline `e00aa3d7`, `npm run test:run` passed: 169 files and 1,034 tests.
+- At the Phase 0 implementation commit `5ab97b6`, `npm run test:run` passed: 169 files and 997 tests. The lower test count is from consolidating Flex-secret delivery tests around the new proxy contract.
 - `npm run build` and the bundle-budget check pass.
 - Production source maps are disabled.
 - Routes are lazy-loaded and heavy map/PDF/spreadsheet dependencies are split.
@@ -892,9 +893,11 @@ Do not label the platform enterprise grade until all of the following are true:
 | --- | --- |
 | Latest `origin/main` isolated audit tree | `e00aa3d7` |
 | `npm run typecheck` | Pass |
-| `npm run lint` | Pass with 2,178 warnings |
+| `npm run lint` at audit baseline `e00aa3d7` | Pass with 2,178 warnings |
+| `npm run lint` at Phase 0 implementation `5ab97b6` | Pass with 405 warnings |
 | `npm run governance` | Pass against grandfathered baselines |
-| `npm run test:run` | 169 files / 1,034 tests pass |
+| `npm run test:run` at audit baseline `e00aa3d7` | 169 files / 1,034 tests pass |
+| `npm run test:run` at Phase 0 implementation `5ab97b6` | 169 files / 997 tests pass |
 | `npm run test:coverage` | Fail; 15.64% line coverage |
 | `npm run build` | Pass |
 | bundle budget | Pass |

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.0.0"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.1"),
         .package(name: "CapacitorPushNotifications", path: "../../../node_modules/@capacitor/push-notifications")
     ],
     targets: [

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.1"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.0.0"),
         .package(name: "CapacitorPushNotifications", path: "../../../node_modules/@capacitor/push-notifications")
     ],
     targets: [

--- a/src/components/project-management/apiService.test.ts
+++ b/src/components/project-management/apiService.test.ts
@@ -1,292 +1,82 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getElementTree, ElementTreeNode } from "./apiService";
-import { dataLayerClient } from "@/services/dataLayerClient";
-vi.mock("@/services/dataLayerClient", () => ({
-  dataLayerClient: {
-    functions: {
-      invoke: vi.fn(),
-    },
-  },
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { flexApiFetch } from "@/lib/flex-api-client";
+import { getElementTree, type ElementTreeNode } from "./apiService";
+
+vi.mock("@/lib/flex-api-client", () => ({
+  flexApiFetch: vi.fn(),
 }));
 
-global.fetch = vi.fn();
+function proxyResponse(options: {
+  ok: boolean;
+  status?: number;
+  statusText?: string;
+  data?: unknown;
+}) {
+  return {
+    ok: options.ok,
+    status: options.status ?? 200,
+    statusText: options.statusText ?? "",
+    headers: new Headers(),
+    json: vi.fn().mockResolvedValue(options.data),
+    text: vi.fn().mockResolvedValue(""),
+  };
+}
 
 describe("getElementTree", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("should throw error when auth token retrieval fails", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValueOnce({
-      data: { X_AUTH_TOKEN: null },
-      error: { message: "Failed to get secret" } as any,
-    } as any);
-
-    await expect(getElementTree("test-element-id")).rejects.toThrow(
-      "Failed to get auth token"
-    );
-  });
-
-  it("should fetch element tree successfully with happy path data", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    const mockTreeData: ElementTreeNode[] = [
-      {
-        nodeId: "1",
-        name: "Root Element",
-        displayName: "Root Element",
-        documentNumber: "DOC-001",
-        parentId: null,
-        iconUrl: "https://example.com/icon.png",
-        leaf: false,
-        children: [
-          {
-            nodeId: "1.1",
-            name: "Child Element",
-            displayName: "Child Element",
-            documentNumber: "DOC-002",
-            parentId: "1",
-            iconUrl: "https://example.com/child-icon.png",
-            leaf: true,
-          },
-        ],
-      },
-    ];
-
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => mockTreeData,
-    } as Response);
-
-    const result = await getElementTree("test-element-id");
-
-    expect(result).toEqual(mockTreeData);
-    expect(fetch).toHaveBeenCalledWith(
-      "https://sectorpro.flexrentalsolutions.com/f5/api/element/test-element-id/tree",
-      {
-        headers: {
-          "Content-Type": "application/json",
-          "X-Auth-Token": "test-token",
-          "apikey": "test-token",
-        },
-      }
-    );
-  });
-
-  it("should return empty array when API returns non-array data", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    
-    const mockNonArrayData = {
-      message: "Unexpected format",
-    };
-
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => mockNonArrayData,
-    } as Response);
-
-    const result = await getElementTree("test-element-id");
-
-    expect(result).toEqual([]);
-  });
-
-  it("should handle empty tree response", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => [],
-    } as Response);
-
-    const result = await getElementTree("test-element-id");
-
-    expect(result).toEqual([]);
-  });
-
-  it("should throw error on 404 response", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-      json: async () => ({}),
-    } as Response);
-
-    await expect(getElementTree("invalid-element-id")).rejects.toThrow(
-      "Failed to fetch element tree for element ID invalid-element-id: Not Found (404)"
-    );
-  });
-
-  it("should throw error on 500 response", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-      json: async () => ({}),
-    } as Response);
-
-    await expect(getElementTree("test-element-id")).rejects.toThrow(
-      "Failed to fetch element tree for element ID test-element-id: Internal Server Error (500)"
-    );
-  });
-
-  it("should throw error on 401 unauthorized response", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: false,
-      status: 401,
-      statusText: "Unauthorized",
-      json: async () => ({}),
-    } as Response);
-
-    await expect(getElementTree("test-element-id")).rejects.toThrow(
-      "Failed to fetch element tree for element ID test-element-id: Unauthorized (401)"
-    );
-  });
-
-  it("should handle network errors gracefully", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    
-    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
-
-    await expect(getElementTree("test-element-id")).rejects.toThrow(
-      "Network error"
-    );
-  });
-
-  it("should handle complex nested tree structures", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    
-    const mockComplexTree: ElementTreeNode[] = [
+  it("fetches an element tree through the server-side proxy", async () => {
+    const tree: ElementTreeNode[] = [
       {
         nodeId: "root",
         name: "Root",
-        displayName: "Root Element",
-        documentNumber: "ROOT-001",
-        parentId: null,
+        displayName: "Root",
         leaf: false,
-        children: [
-          {
-            nodeId: "child1",
-            name: "Child 1",
-            displayName: "Child 1",
-            documentNumber: "CHILD-001",
-            parentId: "root",
-            leaf: false,
-            children: [
-              {
-                nodeId: "grandchild1",
-                name: "Grandchild 1",
-                displayName: "Grandchild 1",
-                documentNumber: "GC-001",
-                parentId: "child1",
-                leaf: true,
-              },
-            ],
-          },
-          {
-            nodeId: "child2",
-            name: "Child 2",
-            displayName: "Child 2",
-            documentNumber: "CHILD-002",
-            parentId: "root",
-            leaf: true,
-          },
-        ],
+        children: [],
       },
     ];
+    vi.mocked(flexApiFetch).mockResolvedValue(
+      proxyResponse({ ok: true, data: tree }),
+    );
 
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => mockComplexTree,
-    } as Response);
-
-    const result = await getElementTree("root-element-id");
-
-    expect(result).toEqual(mockComplexTree);
-    expect(result[0].children).toHaveLength(2);
-    expect(result[0].children![0].children).toHaveLength(1);
+    await expect(getElementTree("test-element-id")).resolves.toEqual(tree);
+    expect(flexApiFetch).toHaveBeenCalledWith(
+      "/element/test-element-id/tree",
+      { headers: { "Content-Type": "application/json" } },
+    );
   });
 
-  it("should make multiple fetch calls with the same auth token", async () => {
-    vi.mocked(dataLayerClient.functions.invoke).mockResolvedValue({
-      data: { X_AUTH_TOKEN: "test-token" },
-      error: null,
-    });
-    
-    const mockTreeData: ElementTreeNode[] = [
-      {
-        nodeId: "1",
-        name: "Element",
-        displayName: "Element",
-        leaf: true,
-      },
-    ];
-
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => mockTreeData,
-    } as Response);
-
-    const result1 = await getElementTree("element-1");
-    const result2 = await getElementTree("element-2");
-
-    expect(result1).toEqual(mockTreeData);
-    expect(result2).toEqual(mockTreeData);
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).toHaveBeenCalledWith(
-      "https://sectorpro.flexrentalsolutions.com/f5/api/element/element-1/tree",
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          "X-Auth-Token": "test-token",
-          "apikey": "test-token",
-        }),
-      })
+  it("returns an empty array for an unexpected payload", async () => {
+    vi.mocked(flexApiFetch).mockResolvedValue(
+      proxyResponse({ ok: true, data: { unexpected: true } }),
     );
-    expect(fetch).toHaveBeenCalledWith(
-      "https://sectorpro.flexrentalsolutions.com/f5/api/element/element-2/tree",
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          "X-Auth-Token": "test-token",
-          "apikey": "test-token",
-        }),
-      })
+
+    await expect(getElementTree("test-element-id")).resolves.toEqual([]);
+  });
+
+  it("surfaces an upstream error without exposing credentials", async () => {
+    vi.mocked(flexApiFetch).mockResolvedValue(
+      proxyResponse({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        data: {},
+      }),
+    );
+
+    await expect(getElementTree("missing")).rejects.toThrow(
+      "Failed to fetch element tree for element ID missing: Not Found (404)",
+    );
+  });
+
+  it("surfaces proxy network errors", async () => {
+    vi.mocked(flexApiFetch).mockRejectedValue(new Error("Network error"));
+
+    await expect(getElementTree("test-element-id")).rejects.toThrow(
+      "Network error",
     );
   });
 });

--- a/src/components/project-management/apiService.test.ts
+++ b/src/components/project-management/apiService.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { flexApiFetch } from "@/lib/flex-api-client";
-import { getElementTree, type ElementTreeNode } from "./apiService";
+import { getElementTree, type ElementTreeNode } from "@/components/project-management/apiService";
 
 vi.mock("@/lib/flex-api-client", () => ({
   flexApiFetch: vi.fn(),

--- a/src/components/project-management/apiService.ts
+++ b/src/components/project-management/apiService.ts
@@ -1,4 +1,4 @@
-import { dataLayerClient } from "@/services/dataLayerClient";
+import { flexApiFetch } from "@/lib/flex-api-client";
 export interface CreateLaborPORequest {
   name: string;
   plannedStartDate: string;
@@ -98,32 +98,12 @@ interface ProjectHeaderResponse {
   customerPO: FlexField<string>;
 }
 
-let cachedToken: string | null = null;
-
-const getAuthToken = async () => {
-  if (cachedToken) return cachedToken;
-  
-  const { data: { X_AUTH_TOKEN }, error } = await dataLayerClient.functions.invoke('get-secret', {
-      body: { secretName: 'X_AUTH_TOKEN' }
-    });
-    
-  if (error) {
-    throw new Error('Failed to get auth token');
-  }
-  
-  cachedToken = X_AUTH_TOKEN;
-  return X_AUTH_TOKEN;
-};
-
 export const getProjectDetails = async (searchText: string): Promise<ProjectDetails[]> => {
-  const token = await getAuthToken();
-  const url = `https://sectorpro.flexrentalsolutions.com/f5/api/element/search?searchText=${searchText}`;
+  const url = `/element/search?searchText=${encodeURIComponent(searchText)}`;
   
-  const response = await fetch(url, {
+  const response = await flexApiFetch(url, {
     headers: {
       'Content-Type': 'application/json',
-      'X-Auth-Token': token,
-      'apikey': token,
     },
   });
 
@@ -135,15 +115,11 @@ export const getProjectDetails = async (searchText: string): Promise<ProjectDeta
 };
 
 export const getProjectHeader = async (projectId: string): Promise<ProjectHeader> => {
-  const token = await getAuthToken();
-  const timestamp = new Date().getTime();
-  const url = `https://sectorpro.flexrentalsolutions.com/f5/api/element/${projectId}/key-info/?_dc=1737066549442`;
+  const url = `/element/${encodeURIComponent(projectId)}/key-info/`;
   
-  const response = await fetch(url, {
+  const response = await flexApiFetch(url, {
     headers: {
       'Content-Type': 'application/json',
-      'X-Auth-Token': token,
-      'apikey': token,
     },
   });
 
@@ -151,7 +127,7 @@ export const getProjectHeader = async (projectId: string): Promise<ProjectHeader
     throw new Error(`Failed to fetch project header: ${response.statusText}`);
   }
 
-  const data: ProjectHeaderResponse = await response.json();
+  const data = await response.json<ProjectHeaderResponse>();
   
   return {
     documentName: data.documentName.data || '',
@@ -164,16 +140,13 @@ export const getProjectHeader = async (projectId: string): Promise<ProjectHeader
 };
 
 export const createLaborPO = async (data: CreateLaborPORequest): Promise<CreateLaborPOResponse> => {
-  const token = await getAuthToken();
-  const url = 'https://sectorpro.flexrentalsolutions.com/f5/api/element';
+  const url = '/element';
 
-  const response = await fetch(url, {
+  const response = await flexApiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       accept: '*/*',
-      'X-Auth-Token': token,
-      'apikey': token,
     },
     body: JSON.stringify({
       definitionId: 'labor-po-definition-id',
@@ -194,7 +167,7 @@ export const createLaborPO = async (data: CreateLaborPORequest): Promise<CreateL
     throw new Error(`Failed to create Labor PO: ${response.statusText}`);
   }
 
-  const responseData = await response.json();
+  const responseData = await response.json<CreateLaborPOResponse>();
   return {
     id: responseData.id,
     name: responseData.name,
@@ -204,15 +177,17 @@ export const createLaborPO = async (data: CreateLaborPORequest): Promise<CreateL
 export const addResourceLineItem = async (
   data: AddResourceLineItemRequest
 ): Promise<AddResourceLineItemResponse> => {
-  const token = await getAuthToken();
-  const url = `https://sectorpro.flexrentalsolutions.com/f5/api/financial-document-line-item/${data.documentId}/add-resource/${data.resourceId}?resourceParentId=${data.resourceParentId}&managedResourceLineItemType=${data.managedResourceLineItemType}&quantity=${data.quantity}`;
+  const query = new URLSearchParams({
+    resourceParentId: data.resourceParentId,
+    managedResourceLineItemType: data.managedResourceLineItemType,
+    quantity: String(data.quantity),
+  });
+  const url = `/financial-document-line-item/${encodeURIComponent(data.documentId)}/add-resource/${encodeURIComponent(data.resourceId)}?${query}`;
 
-  const response = await fetch(url, {
+  const response = await flexApiFetch(url, {
     method: 'POST',
     headers: {
       accept: '*/*',
-      'X-Auth-Token': token,
-      'apikey': token,
     },
   });
 
@@ -220,14 +195,13 @@ export const addResourceLineItem = async (
     throw new Error(`Failed to add resource line item: ${response.statusText}`);
   }
 
-  return response.json();
+  return response.json<AddResourceLineItemResponse>();
 };
 
 export const updateLineItemDates = async (
   data: UpdateLineItemDatesRequest
 ): Promise<UpdateLineItemDatesResponse> => {
-  const token = await getAuthToken();
-  const url = `https://sectorpro.flexrentalsolutions.com/f5/api/financial-document-line-item/${data.documentId}/bulk-update`;
+  const url = `/financial-document-line-item/${encodeURIComponent(data.documentId)}/bulk-update`;
 
   const payload = {
     bulkData: [
@@ -239,13 +213,11 @@ export const updateLineItemDates = async (
     ],
   };
 
-  const response = await fetch(url, {
+  const response = await flexApiFetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       accept: '*/*',
-      'X-Auth-Token': token,
-      'apikey': token,
     },
     body: JSON.stringify(payload),
   });
@@ -269,16 +241,13 @@ export interface ElementTreeNode {
 }
 
 export const getElementTree = async (elementId: string): Promise<ElementTreeNode[]> => {
-  const token = await getAuthToken();
-  const url = `https://sectorpro.flexrentalsolutions.com/f5/api/element/${elementId}/tree`;
+  const url = `/element/${encodeURIComponent(elementId)}/tree`;
 
   console.log(`Fetching element tree for element ID: ${elementId}`);
 
-  const response = await fetch(url, {
+  const response = await flexApiFetch(url, {
     headers: {
       'Content-Type': 'application/json',
-      'X-Auth-Token': token,
-      'apikey': token,
     },
   });
 
@@ -288,7 +257,7 @@ export const getElementTree = async (elementId: string): Promise<ElementTreeNode
     throw new Error(errorMessage);
   }
 
-  const data = await response.json();
+  const data = await response.json<ElementTreeNode[] | unknown>();
   console.log(`Successfully fetched element tree for element ID: ${elementId}`, data);
 
   return Array.isArray(data) ? data : [];

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -10604,7 +10604,7 @@ export type Database = {
         }[]
       }
       get_job_total_amounts: {
-        Args: { _job_id: string; _user_role?: string }
+        Args: { _job_id: string }
         Returns: {
           breakdown_by_category: Json
           expenses_breakdown: Json

--- a/src/lib/api-service.ts
+++ b/src/lib/api-service.ts
@@ -1,10 +1,7 @@
 
-import { supabase } from "@/lib/supabase";
-
 // Singleton API Service class
 export class ApiService {
   private static instance: ApiService;
-  private token: string | null = null;
   
   private constructor() {}
   
@@ -15,33 +12,11 @@ export class ApiService {
     return ApiService.instance;
   }
   
-  async getToken(): Promise<string> {
-    if (this.token) return this.token;
-    
-    try {
-      // Fetch token from secure source
-      const { data, error } = await supabase.functions.invoke('get-secret', {
-        body: { secretName: 'X_AUTH_TOKEN' }
-      });
-      
-      if (error) throw new Error('Failed to get auth token');
-      
-      this.token = data.X_AUTH_TOKEN;
-      return this.token;
-    } catch (error) {
-      console.error('Error getting auth token:', error);
-      throw error;
-    }
-  }
-  
   async get<T>(url: string): Promise<T> {
     try {
-      const token = await this.getToken();
       const response = await fetch(url, {
         headers: {
           'Content-Type': 'application/json',
-          'X-Auth-Token': token,
-          'apikey': token,
         },
       });
       
@@ -58,13 +33,10 @@ export class ApiService {
   
   async post<T>(url: string, data: any): Promise<T> {
     try {
-      const token = await this.getToken();
       const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-Auth-Token': token,
-          'apikey': token,
         },
         body: JSON.stringify(data),
       });
@@ -82,13 +54,10 @@ export class ApiService {
   
   async put<T>(url: string, data: any): Promise<T> {
     try {
-      const token = await this.getToken();
       const response = await fetch(url, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          'X-Auth-Token': token,
-          'apikey': token,
         },
         body: JSON.stringify(data),
       });
@@ -106,13 +75,10 @@ export class ApiService {
   
   async delete<T>(url: string): Promise<T> {
     try {
-      const token = await this.getToken();
       const response = await fetch(url, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
-          'X-Auth-Token': token,
-          'apikey': token,
         },
       });
       

--- a/src/lib/flex-api-client.ts
+++ b/src/lib/flex-api-client.ts
@@ -1,0 +1,128 @@
+import { FLEX_API_BASE_URL } from "@/lib/api-config";
+import { supabase } from "@/lib/supabase";
+
+interface FlexProxyEnvelope {
+  success: boolean;
+  status: number;
+  statusText?: string;
+  contentType?: string;
+  data?: unknown;
+  rawBody?: string;
+  error?: string;
+}
+
+export interface FlexApiResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Headers;
+  json: <T = unknown>() => Promise<T>;
+  text: () => Promise<string>;
+}
+
+function normalizeFlexEndpoint(input: string): string {
+  if (input.startsWith(FLEX_API_BASE_URL)) {
+    return input.slice(FLEX_API_BASE_URL.length) || "/";
+  }
+
+  if (/^https?:\/\//i.test(input)) {
+    throw new Error("Only the configured Flex API origin may be proxied");
+  }
+
+  return input.startsWith("/") ? input : `/${input}`;
+}
+
+function serializeHeaders(input?: HeadersInit): Record<string, string> {
+  const source = new Headers(input);
+  const allowed = new Set([
+    "accept",
+    "content-type",
+    "x-api-client",
+    "x-requested-with",
+  ]);
+  const result: Record<string, string> = {};
+
+  source.forEach((value, key) => {
+    if (allowed.has(key.toLowerCase())) {
+      result[key] = value;
+    }
+  });
+
+  return result;
+}
+
+export async function flexApiFetch(
+  endpoint: string,
+  init: RequestInit = {},
+): Promise<FlexApiResponse> {
+  const method = (init.method || "GET").toUpperCase();
+  const headers = serializeHeaders(init.headers);
+  const body = typeof init.body === "string" ? init.body : undefined;
+
+  if (init.body && typeof init.body !== "string") {
+    throw new Error("Flex proxy requests must use a string body");
+  }
+
+  const invocation = supabase.functions.invoke<FlexProxyEnvelope>("secure-flex-api", {
+    body: {
+      endpoint: normalizeFlexEndpoint(endpoint),
+      method,
+      headers,
+      body,
+    },
+  });
+
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = globalThis.setTimeout(
+      () => reject(new DOMException("Flex API request timed out", "AbortError")),
+      15_000,
+    );
+  });
+
+  let result: Awaited<typeof invocation>;
+  try {
+    result = await Promise.race([invocation, timeout]);
+  } finally {
+    if (timeoutId !== undefined) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  }
+
+  const { data, error } = result;
+
+  if (error) {
+    throw new Error(error.message || "Flex API proxy request failed");
+  }
+
+  if (!data || typeof data.status !== "number") {
+    throw new Error("Flex API proxy returned an invalid response");
+  }
+
+  const responseHeaders = new Headers();
+  if (data.contentType) {
+    responseHeaders.set("content-type", data.contentType);
+  }
+
+  return {
+    ok: data.success,
+    status: data.status,
+    statusText: data.statusText || data.error || "",
+    headers: responseHeaders,
+    json: async <T>() => {
+      if (data.data !== undefined) {
+        return data.data as T;
+      }
+      if (data.rawBody) {
+        return JSON.parse(data.rawBody) as T;
+      }
+      return null as T;
+    },
+    text: async () => {
+      if (data.rawBody !== undefined) {
+        return data.rawBody;
+      }
+      return data.data === undefined ? "" : JSON.stringify(data.data);
+    },
+  };
+}

--- a/src/lib/flex-api-client.ts
+++ b/src/lib/flex-api-client.ts
@@ -1,5 +1,5 @@
 import { FLEX_API_BASE_URL } from "@/lib/api-config";
-import { supabase } from "@/lib/supabase";
+import { supabase } from "@/integrations/supabase/client";
 
 interface FlexProxyEnvelope {
   success: boolean;
@@ -72,17 +72,21 @@ export async function flexApiFetch(
     },
   });
 
+  const canTimeoutLocally = method === "GET" || method === "HEAD";
   let timeoutId: ReturnType<typeof globalThis.setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timeoutId = globalThis.setTimeout(
-      () => reject(new DOMException("Flex API request timed out", "AbortError")),
-      15_000,
-    );
-  });
-
+  const timeout = canTimeoutLocally
+    ? new Promise<never>((_, reject) => {
+        timeoutId = globalThis.setTimeout(
+          () => reject(new DOMException("Flex API request timed out", "AbortError")),
+          15_000,
+        );
+      })
+    : undefined;
   let result: Awaited<typeof invocation>;
   try {
-    result = await Promise.race([invocation, timeout]);
+    result = timeout
+      ? await Promise.race([invocation, timeout])
+      : await invocation;
   } finally {
     if (timeoutId !== undefined) {
       globalThis.clearTimeout(timeoutId);

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -6,9 +6,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Department, ALL_DEPARTMENTS, DEPARTMENT_LABELS, getDepartmentLabel } from "@/types/department";
+import { getDepartmentLabel } from "@/types/department";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Loader2, Save, UserCircle, AlertTriangle, Calendar as CalendarIcon, CalendarCheck, RefreshCcw, Shield, ExternalLink, Trophy } from "lucide-react";
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from "@/lib/api-config";
@@ -25,7 +24,6 @@ import {
   canUseTechnicianSelfTools,
   canViewAchievements,
   canViewProfilePushControls,
-  isManagementRole,
 } from "@/utils/permissions";
 
 export const Profile = () => {
@@ -114,7 +112,6 @@ export const Profile = () => {
           nickname: profile.nickname,
           last_name: profile.last_name,
           phone: profile.phone,
-          department: profile.department,
           dni: profile.dni,
           residencia: profile.residencia,
           home_latitude: profile.home_latitude,
@@ -334,30 +331,12 @@ export const Profile = () => {
 
                   <div className="space-y-2">
                     <Label htmlFor="department">Departamento</Label>
-                    {isManagementRole(profile.role) || profile.role === 'super_admin' ? (
-                      <Select
-                        value={profile.department || ''}
-                        onValueChange={(value) => setProfile({ ...profile, department: value as Department })}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Selecciona un departamento" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {ALL_DEPARTMENTS.map((dept) => (
-                            <SelectItem key={dept} value={dept}>
-                              {DEPARTMENT_LABELS[dept]}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        id="department"
-                        value={getDepartmentLabel(profile.department)}
-                        disabled
-                        className="bg-muted"
-                      />
-                    )}
+                    <Input
+                      id="department"
+                      value={getDepartmentLabel(profile.department)}
+                      disabled
+                      className="bg-muted"
+                    />
                   </div>
 
                   <div className="space-y-2">

--- a/src/services/flexPullsheets.ts
+++ b/src/services/flexPullsheets.ts
@@ -1,8 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
-import { FLEX_API_BASE_URL } from '@/lib/api-config';
+import { flexApiFetch } from '@/lib/flex-api-client';
 import type { PresetSubsystem } from '@/types/equipment';
-
-let cachedFlexToken: string | null = null;
 
 // Material de sonido is a root-only grouping in Flex and intentionally omitted here.
 export const FLEX_CATEGORY_MAP = new Map<string, string>([
@@ -30,42 +28,19 @@ const SUBSYSTEM_TO_FLEX_CATEGORY: Record<PresetSubsystem, string> = {
   amplification: 'pa_amp',
 };
 
-async function getFlexAuthToken(): Promise<string> {
-  if (cachedFlexToken) return cachedFlexToken;
-
-  const { data, error } = await supabase.functions.invoke('get-secret', {
-    body: { secretName: 'X_AUTH_TOKEN' },
-  });
-
-  if (error) {
-    throw new Error(error.message || 'Failed to resolve Flex auth token');
-  }
-
-  const token = (data as { X_AUTH_TOKEN?: string } | null)?.X_AUTH_TOKEN;
-  if (!token) {
-    throw new Error('Flex auth token response missing X_AUTH_TOKEN');
-  }
-
-  cachedFlexToken = token;
-  return token;
-}
-
 async function addResourceLineItem(options: {
   documentId: string;
   resourceId: string;
   quantity: number;
   parentLineItemId?: string;
   nextSiblingId?: string;
-  token: string;
 }): Promise<{ success: boolean; error?: string; lineItemId?: string }> {
-  const { documentId, resourceId, quantity, parentLineItemId = '', nextSiblingId = '', token } = options;
-  const baseUrl = `${FLEX_API_BASE_URL}/line-item/${encodeURIComponent(documentId)}/add-resource/${encodeURIComponent(resourceId)}`;
+  const { documentId, resourceId, quantity, parentLineItemId = '', nextSiblingId = '' } = options;
+  const endpoint = `/line-item/${encodeURIComponent(documentId)}/add-resource/${encodeURIComponent(resourceId)}`;
 
   const headers = {
     accept: '*/*',
     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-    'X-Auth-Token': token,
-    'apikey': token,
   };
 
   const form = new URLSearchParams({
@@ -77,7 +52,7 @@ async function addResourceLineItem(options: {
   });
 
   try {
-    const res = await fetch(baseUrl, {
+    const res = await flexApiFetch(endpoint, {
       method: 'POST',
       headers,
       body: form.toString(),
@@ -178,20 +153,6 @@ export async function pushEquipmentToPullsheet(
     failed: [],
   };
 
-  // Get auth token
-  let token: string;
-  try {
-    token = await getFlexAuthToken();
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-    console.error('[FlexPullsheets] Failed to get auth token:', errorMessage);
-    // Mark all items as failed
-    equipment.forEach(item => {
-      result.failed.push({ name: item.name, error: 'Authentication failed' });
-    });
-    return result;
-  }
-
   const normalizedItems = normalizeEquipmentItems(equipment);
 
   console.log('[FlexPullsheets] Using category headers:', Array.from(FLEX_CATEGORY_MAP.entries()));
@@ -221,7 +182,6 @@ export async function pushEquipmentToPullsheet(
         documentId: pullsheetElementId,
         resourceId: categoryResourceId,
         quantity: 1,
-        token,
       });
 
       if (categoryResponse.success && categoryResponse.lineItemId) {
@@ -241,7 +201,6 @@ export async function pushEquipmentToPullsheet(
         resourceId: item.resourceId,
         quantity: item.quantity,
         parentLineItemId: parentLineItemId,
-        token,
       });
 
       if (response.success) {
@@ -342,27 +301,17 @@ export async function getJobPullsheetsWithFlexApi(jobId: string): Promise<JobPul
       return dbPullsheets;
     }
 
-    // Fetch Flex tree with timeout
-    const token = await getFlexAuthToken();
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
-
     let treeData;
     try {
-      const response = await fetch(
-        `${FLEX_API_BASE_URL}/element/${mainFolder.element_id}/tree`,
+      const response = await flexApiFetch(
+        `/element/${encodeURIComponent(mainFolder.element_id)}/tree`,
         {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
-            'X-Auth-Token': token,
-            'apikey': token,
           },
-          signal: controller.signal,
         }
       );
-
-      clearTimeout(timeoutId);
 
       if (!response.ok) {
         console.warn('[FlexPullsheets] Failed to fetch Flex tree, returning DB results only');
@@ -371,13 +320,12 @@ export async function getJobPullsheetsWithFlexApi(jobId: string): Promise<JobPul
 
       // Parse JSON inside try-catch to handle parsing errors
       try {
-        treeData = await response.json();
+        treeData = await response.json<FlexTreeNode | FlexTreeNode[]>();
       } catch (jsonError) {
         console.warn('[FlexPullsheets] Failed to parse Flex tree JSON, returning DB results only:', jsonError);
         return dbPullsheets;
       }
     } catch (fetchError) {
-      clearTimeout(timeoutId);
       if (fetchError instanceof Error && fetchError.name === 'AbortError') {
         console.warn('[FlexPullsheets] Flex API request timed out, returning DB results only');
       } else {

--- a/src/services/flexWorkOrders.ts
+++ b/src/services/flexWorkOrders.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
 import { FLEX_API_BASE_URL } from '@/lib/api-config';
+import { flexApiFetch } from '@/lib/flex-api-client';
 import { FLEX_FOLDER_IDS, RESPONSIBLE_PERSON_IDS, DEPARTMENT_SUFFIXES } from '@/utils/flex-folders/constants';
 import { resourceIdForRole, EXTRA_RESOURCE_IDS } from '@/utils/flex-labor-resources';
 
@@ -9,28 +10,6 @@ const PERSONNEL_RESPONSIBLE_ID = RESPONSIBLE_PERSON_IDS.personnel;
 const CURRENCY_EUR_ID = 'd3d53320-6926-11ea-9bb5-2a0a4490a7fb';
 const PRICING_MODEL_BASE_2025_ID = 'a4307bf9-cd39-4df1-9d6d-48932120c4bd';
 const PRICING_MODEL_DIA_TOUR_ID = '04c62780-c51d-11ea-a087-2a0a4490a7fb';
-
-let cachedFlexToken: string | null = null;
-
-async function getFlexAuthToken(): Promise<string> {
-  if (cachedFlexToken) return cachedFlexToken;
-
-  const { data, error } = await supabase.functions.invoke('get-secret', {
-    body: { secretName: 'X_AUTH_TOKEN' },
-  });
-
-  if (error) {
-    throw new Error(error.message || 'Failed to resolve Flex auth token');
-  }
-
-  const token = (data as { X_AUTH_TOKEN?: string } | null)?.X_AUTH_TOKEN;
-  if (!token) {
-    throw new Error('Flex auth token response missing X_AUTH_TOKEN');
-  }
-
-  cachedFlexToken = token;
-  return token;
-}
 
 function formatDate(value: string | null | undefined): string | null {
   if (!value) return null;
@@ -54,10 +33,9 @@ async function createWorkOrderElement(options: {
   job: { id: string; title: string; start_time: string; end_time: string; location_id: string | null };
   technicianName: string;
   vendorId: string;
-  token: string;
 }): Promise<{ documentId: string; raw: any }>
 {
-  const { parentElementId, job, technicianName, vendorId, token } = options;
+  const { parentElementId, job, technicianName, vendorId } = options;
   const plannedStartDate = formatDate(job.start_time) ?? new Date().toISOString().slice(0, 10);
   const plannedEndDate = formatDate(job.end_time) ?? plannedStartDate;
 
@@ -72,24 +50,24 @@ async function createWorkOrderElement(options: {
     currencyId: CURRENCY_EUR_ID,
   };
 
-  const response = await fetch(`${FLEX_API_BASE_URL}/element`, {
+  const response = await flexApiFetch(`${FLEX_API_BASE_URL}/element`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       accept: 'application/json',
-      'X-Auth-Token': token,
-      'apikey': token,
     },
     body: JSON.stringify(payload),
   });
 
   if (!response.ok) {
-    const errorPayload = await response.json().catch((): null => null);
+    const errorPayload = await response.json<{ exceptionMessage?: string }>().catch((): null => null);
     const message = errorPayload?.exceptionMessage || response.statusText || 'Failed to create work order';
     throw new Error(message);
   }
 
-  const raw = await response.json().catch(() => ({}));
+  const raw: Record<string, any> = await response
+    .json<Record<string, any>>()
+    .catch((): Record<string, any> => ({}));
   const documentId =
     raw?.id || raw?.elementId || raw?.data?.id || raw?.data?.elementId || raw?.element?.id || null;
   const documentNumber = raw?.documentNumber || raw?.elementNumber || raw?.number || raw?.data?.documentNumber || null;
@@ -101,10 +79,10 @@ async function createWorkOrderElement(options: {
   return { documentId, raw: { ...raw, documentNumber } };
 }
 
-async function fetchDocumentNumber(documentId: string, token: string): Promise<string | null> {
+async function fetchDocumentNumber(documentId: string): Promise<string | null> {
   const url = `${FLEX_API_BASE_URL}/element/${encodeURIComponent(documentId)}/key-info/`;
   try {
-    const res = await fetch(url, { headers: { 'Content-Type': 'application/json', 'X-Auth-Token': token, 'apikey': token } });
+    const res = await flexApiFetch(url, { headers: { 'Content-Type': 'application/json' } });
     if (!res.ok) return null;
     const j = await res.json().catch((): null => null) as any;
     const docNum = j?.documentNumber?.data || j?.documentNumber || null;
@@ -119,11 +97,10 @@ async function addResourceLineItem(options: {
   parentElementId: string;
   resourceId: string;
   quantity?: number;
-  token: string;
   managedResourceLineItemType?: string;
   parentLineItemId?: string;
 }): Promise<string | null> {
-  const { documentId, parentElementId, resourceId, quantity = 1, token, managedResourceLineItemType = 'service-offering', parentLineItemId } = options;
+  const { documentId, parentElementId, resourceId, quantity = 1, managedResourceLineItemType = 'service-offering', parentLineItemId } = options;
   const baseUrl = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/add-resource/${encodeURIComponent(resourceId)}`;
   const query = new URLSearchParams({
     resourceParentId: parentElementId,
@@ -133,7 +110,7 @@ async function addResourceLineItem(options: {
 
   const tryRequest = async (init: RequestInit): Promise<any | null> => {
     try {
-      const res = await fetch(`${baseUrl}?${query.toString()}`, init);
+      const res = await flexApiFetch(`${baseUrl}?${query.toString()}`, init);
       if (!res.ok) return null;
       return await res.json().catch((): null => null);
     } catch (err) {
@@ -142,7 +119,7 @@ async function addResourceLineItem(options: {
     }
   };
 
-  const headers = { accept: '*/*', 'X-Auth-Token': token, 'apikey': token } as Record<string, string>;
+  const headers = { accept: '*/*' } as Record<string, string>;
   let payload: any | null = null;
   if (!parentLineItemId) {
     // Try JSON path first when not nesting under a parent line
@@ -178,18 +155,15 @@ async function updateLineItemDates(options: {
   lineItemId: string;
   pickupDate: string; // YYYY-MM-DD
   returnDate: string; // YYYY-MM-DD
-  token: string;
 }): Promise<boolean> {
-  const { documentId, lineItemId, pickupDate, returnDate, token } = options;
+  const { documentId, lineItemId, pickupDate, returnDate } = options;
   const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
   try {
-    const res = await fetch(url, {
+    const res = await flexApiFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         accept: '*/*',
-        'X-Auth-Token': token,
-        'apikey': token,
       },
       body: JSON.stringify({
         bulkData: [{ itemId: lineItemId, alternatePickupDate: pickupDate, alternateReturnDate: returnDate }],
@@ -206,25 +180,22 @@ async function setLineItemPricingModel(options: {
   documentId: string;
   lineItemId: string;
   pricingModelId: string;
-  token: string;
 }): Promise<boolean> {
-  const { documentId, lineItemId, pricingModelId, token } = options;
+  const { documentId, lineItemId, pricingModelId } = options;
   const rowDataUrl = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
   try {
     const headers = {
       'Content-Type': 'application/json',
       accept: 'application/json',
-      'X-Auth-Token': token,
-      'apikey': token,
       'X-Requested-With': 'XMLHttpRequest',
       'X-API-Client': 'flex5-desktop',
     } as Record<string,string>;
     // First try dedicated update endpoint with camelCase field (per working example)
-    const ok = await updateLineItemField({ documentId, lineItemId, fieldType: 'pricingModel', payloadValue: pricingModelId, token });
+    const ok = await updateLineItemField({ documentId, lineItemId, fieldType: 'pricingModel', payloadValue: pricingModelId });
     if (ok) return true;
 
     // Fallback to row-data camelCase
-    let res = await fetch(rowDataUrl, {
+    let res = await flexApiFetch(rowDataUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({ lineItemId, fieldType: 'pricingModel', payloadValue: pricingModelId }),
@@ -232,7 +203,7 @@ async function setLineItemPricingModel(options: {
     if (res.ok) return true;
 
     // Fallback to kebab-case on row-data
-    res = await fetch(rowDataUrl, {
+    res = await flexApiFetch(rowDataUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({ lineItemId, fieldType: 'pricing-model', payloadValue: pricingModelId }),
@@ -248,24 +219,21 @@ async function setLineItemTimeQty(options: {
   documentId: string;
   lineItemId: string;
   timeQty: number;
-  token: string;
 }): Promise<boolean> {
-  const { documentId, lineItemId, timeQty, token } = options;
+  const { documentId, lineItemId, timeQty } = options;
   const rowDataUrl = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
   try {
     const headers = {
       'Content-Type': 'application/json',
       accept: 'application/json',
-      'X-Auth-Token': token,
-      'apikey': token,
       'X-Requested-With': 'XMLHttpRequest',
       'X-API-Client': 'flex5-desktop',
     } as Record<string,string>;
     // Try dedicated update endpoint first (as per working payload)
-    const ok = await updateLineItemField({ documentId, lineItemId, fieldType: 'timeQty', payloadValue: timeQty, token });
+    const ok = await updateLineItemField({ documentId, lineItemId, fieldType: 'timeQty', payloadValue: timeQty });
     if (ok) return true;
     // Try canonical camelCase key first (as seen in Flex payloads)
-    let res = await fetch(rowDataUrl, {
+    let res = await flexApiFetch(rowDataUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({ lineItemId, fieldType: 'timeQty', payloadValue: timeQty }),
@@ -273,7 +241,7 @@ async function setLineItemTimeQty(options: {
     if (res.ok) return true;
 
     // Fallback to kebab-case variant some environments expect
-    res = await fetch(rowDataUrl, {
+    res = await flexApiFetch(rowDataUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({ lineItemId, fieldType: 'time-qty', payloadValue: timeQty }),
@@ -281,7 +249,7 @@ async function setLineItemTimeQty(options: {
     if (res.ok) return true;
 
     // Last fallback: send as string payload
-    res = await fetch(rowDataUrl, {
+    res = await flexApiFetch(rowDataUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({ lineItemId, fieldType: 'timeQty', payloadValue: String(timeQty) }),
@@ -297,18 +265,15 @@ async function setLineItemTimeQtyBulk(options: {
   documentId: string;
   lineItemId: string;
   timeQty: number;
-  token: string;
 }): Promise<boolean> {
-  const { documentId, lineItemId, timeQty, token } = options;
+  const { documentId, lineItemId, timeQty } = options;
   const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
   try {
-    const res = await fetch(url, {
+    const res = await flexApiFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         accept: '*/*',
-        'X-Auth-Token': token,
-        'apikey': token,
         'X-Requested-With': 'XMLHttpRequest',
         'X-API-Client': 'flex5-desktop',
       },
@@ -326,18 +291,15 @@ async function updateLineItemField(options: {
   lineItemId: string;
   fieldType: string;
   payloadValue: string | number;
-  token: string;
 }): Promise<boolean> {
-  const { documentId, lineItemId, fieldType, payloadValue, token } = options;
+  const { documentId, lineItemId, fieldType, payloadValue } = options;
   const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/update`;
   try {
-    const res = await fetch(url, {
+    const res = await flexApiFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         accept: 'application/json',
-        'X-Auth-Token': token,
-        'apikey': token,
         'X-Requested-With': 'XMLHttpRequest',
         'X-API-Client': 'flex5-desktop',
       },
@@ -354,29 +316,26 @@ async function setLineItemQuantityRow(options: {
   documentId: string;
   lineItemId: string;
   quantity: number;
-  token: string;
 }): Promise<boolean> {
-  const { documentId, lineItemId, quantity, token } = options;
+  const { documentId, lineItemId, quantity } = options;
   const rowDataUrl = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
   try {
     const headers = {
       'Content-Type': 'application/json',
       accept: 'application/json',
-      'X-Auth-Token': token,
-      'apikey': token,
       'X-Requested-With': 'XMLHttpRequest',
       'X-API-Client': 'flex5-desktop',
     } as Record<string,string>;
     // Try dedicated update endpoint first
-    const ok = await updateLineItemField({ documentId, lineItemId, fieldType: 'quantity', payloadValue: quantity, token });
+    const ok = await updateLineItemField({ documentId, lineItemId, fieldType: 'quantity', payloadValue: quantity });
     if (ok) return true;
-    let res = await fetch(rowDataUrl, {
+    let res = await flexApiFetch(rowDataUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({ lineItemId, fieldType: 'quantity', payloadValue: quantity }),
     });
     if (res.ok) return true;
-    res = await fetch(rowDataUrl, {
+    res = await flexApiFetch(rowDataUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({ lineItemId, fieldType: 'quantity', payloadValue: String(quantity) }),
@@ -392,18 +351,15 @@ async function setLineItemQuantityBulk(options: {
   documentId: string;
   lineItemId: string;
   quantity: number;
-  token: string;
 }): Promise<boolean> {
-  const { documentId, lineItemId, quantity, token } = options;
+  const { documentId, lineItemId, quantity } = options;
   const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
   try {
-    const res = await fetch(url, {
+    const res = await flexApiFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         accept: '*/*',
-        'X-Auth-Token': token,
-        'apikey': token,
         'X-Requested-With': 'XMLHttpRequest',
         'X-API-Client': 'flex5-desktop',
       },
@@ -419,20 +375,17 @@ async function setLineItemQuantityBulk(options: {
 async function addExtraNoteLineItem(options: {
   documentId: string;
   note: string;
-  token: string;
 }): Promise<void> {
-  const { documentId, note, token } = options;
+  const { documentId, note } = options;
   const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/add-note`;
 
   const tryJson = async () => {
     try {
-      const res = await fetch(url, {
+      const res = await flexApiFetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           accept: 'application/json',
-          'X-Auth-Token': token,
-          'apikey': token,
         },
         body: JSON.stringify({ note }),
       });
@@ -447,13 +400,11 @@ async function addExtraNoteLineItem(options: {
   if (ok) return;
 
   try {
-    const res = await fetch(url, {
+    const res = await flexApiFetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
         accept: '*/*',
-        'X-Auth-Token': token,
-        'apikey': token,
       },
       body: new URLSearchParams({ note }).toString(),
     });
@@ -531,8 +482,6 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
   const errors: string[] = [];
   let created = 0;
   let skipped = 0;
-
-  const token = await getFlexAuthToken();
 
   const [{ data: job, error: jobError }] = await Promise.all([
     supabase
@@ -626,23 +575,21 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
       name: `Órdenes de Trabajo - ${job.title} [${plannedStartDate} – ${plannedEndDate}]`,
     };
     
-    const flexResponse = await fetch(`${FLEX_API_BASE_URL}/element`, {
+    const flexResponse = await flexApiFetch(`${FLEX_API_BASE_URL}/element`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         accept: 'application/json',
-        'X-Auth-Token': token,
-        'apikey': token,
       },
       body: JSON.stringify(workOrderPayload),
     });
     
     if (!flexResponse.ok) {
-      const errorData = await flexResponse.json().catch((): null => null);
+      const errorData = await flexResponse.json<{ exceptionMessage?: string }>().catch((): null => null);
       throw new Error(`Failed to create work orders folder in Flex: ${errorData?.exceptionMessage || flexResponse.statusText}`);
     }
     
-    const flexData = await flexResponse.json();
+    const flexData = await flexResponse.json<Record<string, any>>();
     const newElementId = flexData?.id || flexData?.elementId || flexData?.data?.id;
     
     if (!newElementId) {
@@ -734,11 +681,10 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
         job,
         technicianName,
         vendorId: flexResourceId,
-        token,
       });
       let createdNumber: string | null = (createdRaw && (createdRaw.documentNumber || createdRaw.elementNumber || createdRaw.number)) || null;
       if (!createdNumber) {
-        createdNumber = await fetchDocumentNumber(documentId, token);
+        createdNumber = await fetchDocumentNumber(documentId);
       }
 
       // Build role line items for SOUND and LIGHTS only (skip VIDEO)
@@ -758,7 +704,6 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
           parentElementId: parentFolder.element_id,
           resourceId: laborResourceId,
           quantity: roleQty,
-          token,
           managedResourceLineItemType: 'service-offering',
         });
         if (!lineItemId) {
@@ -766,12 +711,12 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
         }
         // Apply pricing model to main role line and set quantities
         if (lineItemId) {
-          await setLineItemPricingModel({ documentId, lineItemId, pricingModelId, token });
+          await setLineItemPricingModel({ documentId, lineItemId, pricingModelId });
           // Update both quantity and timeQty via row-data and bulk for reliability
-          await setLineItemQuantityRow({ documentId, lineItemId, quantity: roleQty, token });
-          await setLineItemQuantityBulk({ documentId, lineItemId, quantity: roleQty, token });
-          await setLineItemTimeQty({ documentId, lineItemId, timeQty: roleQty, token });
-          await setLineItemTimeQtyBulk({ documentId, lineItemId, timeQty: roleQty, token });
+          await setLineItemQuantityRow({ documentId, lineItemId, quantity: roleQty });
+          await setLineItemQuantityBulk({ documentId, lineItemId, quantity: roleQty });
+          await setLineItemTimeQty({ documentId, lineItemId, timeQty: roleQty });
+          await setLineItemTimeQtyBulk({ documentId, lineItemId, timeQty: roleQty });
         }
         // For single/festival jobs with overtime, add child lines under SOUND and LIGHTS roles
         if (lineItemId && job.job_type && (job.job_type === 'single' || job.job_type === 'festival' || job.job_type === 'ciclo') && (r.dept === 'sound' || r.dept === 'lights')) {
@@ -781,7 +726,6 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
             parentElementId: parentFolder.element_id,
             resourceId: '14b84b51-2a96-4afd-a384-f86f18f039da',
             quantity: 0,
-            token,
             managedResourceLineItemType: 'service-offering',
             parentLineItemId: lineItemId,
           });
@@ -791,15 +735,14 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
             parentElementId: parentFolder.element_id,
             resourceId: '7d5eaf16-4499-45e1-b705-b5f1513ea71f',
             quantity: 0,
-            token,
             managedResourceLineItemType: 'service-offering',
             parentLineItemId: lineItemId,
           });
           if (child1) {
-            await setLineItemPricingModel({ documentId, lineItemId: child1, pricingModelId, token });
+            await setLineItemPricingModel({ documentId, lineItemId: child1, pricingModelId });
           }
           if (child2) {
-            await setLineItemPricingModel({ documentId, lineItemId: child2, pricingModelId, token });
+            await setLineItemPricingModel({ documentId, lineItemId: child2, pricingModelId });
           }
         }
       }
@@ -822,7 +765,6 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
             parentElementId: parentFolder.element_id,
             resourceId: EXTRA_RESOURCE_IDS.transit,
             quantity: transitUnits,
-            token,
             managedResourceLineItemType: 'service-offering',
           });
         }
@@ -832,7 +774,6 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
             parentElementId: parentFolder.element_id,
             resourceId: EXTRA_RESOURCE_IDS.dayOff,
             quantity: dayOff,
-            token,
             managedResourceLineItemType: 'service-offering',
           });
         }

--- a/src/services/flexWorkOrders.ts
+++ b/src/services/flexWorkOrders.ts
@@ -1,5 +1,4 @@
 import { supabase } from '@/integrations/supabase/client';
-import { FLEX_API_BASE_URL } from '@/lib/api-config';
 import { flexApiFetch } from '@/lib/flex-api-client';
 import { FLEX_FOLDER_IDS, RESPONSIBLE_PERSON_IDS, DEPARTMENT_SUFFIXES } from '@/utils/flex-folders/constants';
 import { resourceIdForRole, EXTRA_RESOURCE_IDS } from '@/utils/flex-labor-resources';
@@ -50,7 +49,7 @@ async function createWorkOrderElement(options: {
     currencyId: CURRENCY_EUR_ID,
   };
 
-  const response = await flexApiFetch(`${FLEX_API_BASE_URL}/element`, {
+  const response = await flexApiFetch('/element', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -80,7 +79,7 @@ async function createWorkOrderElement(options: {
 }
 
 async function fetchDocumentNumber(documentId: string): Promise<string | null> {
-  const url = `${FLEX_API_BASE_URL}/element/${encodeURIComponent(documentId)}/key-info/`;
+  const url = `/element/${encodeURIComponent(documentId)}/key-info/`;
   try {
     const res = await flexApiFetch(url, { headers: { 'Content-Type': 'application/json' } });
     if (!res.ok) return null;
@@ -101,7 +100,7 @@ async function addResourceLineItem(options: {
   parentLineItemId?: string;
 }): Promise<string | null> {
   const { documentId, parentElementId, resourceId, quantity = 1, managedResourceLineItemType = 'service-offering', parentLineItemId } = options;
-  const baseUrl = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/add-resource/${encodeURIComponent(resourceId)}`;
+  const baseUrl = `/financial-document-line-item/${encodeURIComponent(documentId)}/add-resource/${encodeURIComponent(resourceId)}`;
   const query = new URLSearchParams({
     resourceParentId: parentElementId,
     managedResourceLineItemType,
@@ -157,7 +156,7 @@ async function updateLineItemDates(options: {
   returnDate: string; // YYYY-MM-DD
 }): Promise<boolean> {
   const { documentId, lineItemId, pickupDate, returnDate } = options;
-  const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
+  const url = `/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
   try {
     const res = await flexApiFetch(url, {
       method: 'POST',
@@ -182,7 +181,7 @@ async function setLineItemPricingModel(options: {
   pricingModelId: string;
 }): Promise<boolean> {
   const { documentId, lineItemId, pricingModelId } = options;
-  const rowDataUrl = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
+  const rowDataUrl = `/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
   try {
     const headers = {
       'Content-Type': 'application/json',
@@ -221,7 +220,7 @@ async function setLineItemTimeQty(options: {
   timeQty: number;
 }): Promise<boolean> {
   const { documentId, lineItemId, timeQty } = options;
-  const rowDataUrl = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
+  const rowDataUrl = `/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
   try {
     const headers = {
       'Content-Type': 'application/json',
@@ -267,7 +266,7 @@ async function setLineItemTimeQtyBulk(options: {
   timeQty: number;
 }): Promise<boolean> {
   const { documentId, lineItemId, timeQty } = options;
-  const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
+  const url = `/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
   try {
     const res = await flexApiFetch(url, {
       method: 'POST',
@@ -293,7 +292,7 @@ async function updateLineItemField(options: {
   payloadValue: string | number;
 }): Promise<boolean> {
   const { documentId, lineItemId, fieldType, payloadValue } = options;
-  const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/update`;
+  const url = `/financial-document-line-item/${encodeURIComponent(documentId)}/update`;
   try {
     const res = await flexApiFetch(url, {
       method: 'POST',
@@ -318,7 +317,7 @@ async function setLineItemQuantityRow(options: {
   quantity: number;
 }): Promise<boolean> {
   const { documentId, lineItemId, quantity } = options;
-  const rowDataUrl = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
+  const rowDataUrl = `/financial-document-line-item/${encodeURIComponent(documentId)}/row-data/`;
   try {
     const headers = {
       'Content-Type': 'application/json',
@@ -353,7 +352,7 @@ async function setLineItemQuantityBulk(options: {
   quantity: number;
 }): Promise<boolean> {
   const { documentId, lineItemId, quantity } = options;
-  const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
+  const url = `/financial-document-line-item/${encodeURIComponent(documentId)}/bulk-update`;
   try {
     const res = await flexApiFetch(url, {
       method: 'POST',
@@ -377,7 +376,7 @@ async function addExtraNoteLineItem(options: {
   note: string;
 }): Promise<void> {
   const { documentId, note } = options;
-  const url = `${FLEX_API_BASE_URL}/financial-document-line-item/${encodeURIComponent(documentId)}/add-note`;
+  const url = `/financial-document-line-item/${encodeURIComponent(documentId)}/add-note`;
 
   const tryJson = async () => {
     try {
@@ -575,7 +574,7 @@ export async function syncFlexWorkOrdersForJob(jobId: string): Promise<FlexWorkO
       name: `Órdenes de Trabajo - ${job.title} [${plannedStartDate} – ${plannedEndDate}]`,
     };
     
-    const flexResponse = await flexApiFetch(`${FLEX_API_BASE_URL}/element`, {
+    const flexResponse = await flexApiFetch('/element', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
+++ b/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
@@ -7,9 +7,9 @@ import {
   getElementDetails,
   isFinancialDocument,
   isSimpleFolder,
-} from "../buildFlexUrl";
-import { FLEX_FOLDER_IDS } from "../constants";
-import { FLEX_CONFIG } from "../config";
+} from "@/utils/flex-folders/buildFlexUrl";
+import { FLEX_FOLDER_IDS } from "@/utils/flex-folders/constants";
+import { FLEX_CONFIG } from "@/utils/flex-folders/config";
 
 vi.mock("@/lib/flex-api-client", () => ({
   flexApiFetch: vi.fn(),

--- a/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
+++ b/src/utils/flex-folders/__tests__/buildFlexUrl.test.ts
@@ -1,352 +1,147 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { flexApiFetch } from "@/lib/flex-api-client";
 import {
   buildFlexUrl,
   buildFlexUrlWithTypeDetection,
+  getElementDetails,
   isFinancialDocument,
   isSimpleFolder,
-  getElementDetails,
-} from '../buildFlexUrl';
-import { FLEX_FOLDER_IDS } from '../constants';
-import { FLEX_CONFIG } from '../config';
+} from "../buildFlexUrl";
+import { FLEX_FOLDER_IDS } from "../constants";
+import { FLEX_CONFIG } from "../config";
 
-// Mock fetch globally
-global.fetch = vi.fn();
+vi.mock("@/lib/flex-api-client", () => ({
+  flexApiFetch: vi.fn(),
+}));
 
-describe('buildFlexUrl', () => {
-  it('should build financial document URL for presupuesto', () => {
-    const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.presupuesto);
-    expect(url).toContain(
-      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/detail`
+function proxyResponse(ok: boolean, data: unknown, statusText = "") {
+  return {
+    ok,
+    status: ok ? 200 : 404,
+    statusText,
+    headers: new Headers(),
+    json: vi.fn().mockResolvedValue(data),
+    text: vi.fn().mockResolvedValue(""),
+  };
+}
+
+describe("buildFlexUrl", () => {
+  it("builds financial document URLs", () => {
+    expect(buildFlexUrl("id", FLEX_FOLDER_IDS.presupuesto)).toContain(
+      `#fin-doc/id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/detail`,
     );
-    expect(url).toContain('/detail');
-  });
-
-  it('should build financial document URL for presupuestoDryHire', () => {
-    const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.presupuestoDryHire);
-    expect(url).toContain(
-      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.presupuesto}/detail`
-    );
-    expect(url).toContain('/detail');
-  });
-
-  it('should build financial document URL for hojaGastos', () => {
-    const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.hojaGastos);
-    expect(url).toContain(
-      `#fin-doc/test-element-id/doc-view/${FLEX_CONFIG.viewIds.expenseSheet}/detail`
+    expect(buildFlexUrl("id", FLEX_FOLDER_IDS.hojaGastos)).toContain(
+      `#fin-doc/id/doc-view/${FLEX_CONFIG.viewIds.expenseSheet}/detail`,
     );
   });
 
-  it('should build contact-list URL for crewCall', () => {
-    const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.crewCall);
-    expect(url).toContain(`#contact-list/test-element-id/view/${FLEX_CONFIG.viewIds.crewCall}/detail`);
+  it("builds crew, equipment and simple element URLs", () => {
+    expect(buildFlexUrl("id", FLEX_FOLDER_IDS.crewCall)).toContain(
+      `#contact-list/id/view/${FLEX_CONFIG.viewIds.crewCall}/detail`,
+    );
+    expect(buildFlexUrl("id", FLEX_FOLDER_IDS.pullSheet)).toContain(
+      "#element/id/view/equipment-list/detail",
+    );
+    expect(buildFlexUrl("id", FLEX_FOLDER_IDS.mainFolder)).toContain(
+      "#element/id/view/simple-element/detail",
+    );
   });
 
-  it('should build equipment-list URL for pullSheet', () => {
-    const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.pullSheet);
-    expect(url).toContain('#element/test-element-id/view/equipment-list/detail');
-  });
-
-  it('should build simple element URL for mainFolder', () => {
-    const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.mainFolder);
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-  });
-
-  it('should build simple element URL for subFolder', () => {
-    const url = buildFlexUrl('test-element-id', FLEX_FOLDER_IDS.subFolder);
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-  });
-
-  it('should build simple element URL when no definitionId provided', () => {
-    const url = buildFlexUrl('test-element-id');
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-  });
-
-  it('should build simple element URL for unknown definitionId', () => {
-    const url = buildFlexUrl('test-element-id', 'unknown-definition-id');
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-  });
-
-  it('should throw error for empty elementId', () => {
-    expect(() => buildFlexUrl('', FLEX_FOLDER_IDS.presupuesto)).toThrow('Invalid elementId');
-  });
-
-  it('should throw error for null elementId', () => {
-    expect(() => buildFlexUrl(null as unknown as string, FLEX_FOLDER_IDS.presupuesto)).toThrow('Invalid elementId');
-  });
-
-  it('should throw error for undefined elementId', () => {
-    expect(() => buildFlexUrl(undefined as unknown as string, FLEX_FOLDER_IDS.presupuesto)).toThrow('Invalid elementId');
-  });
-
-  it('should throw error for whitespace-only elementId', () => {
-    expect(() => buildFlexUrl('   ', FLEX_FOLDER_IDS.presupuesto)).toThrow('Invalid elementId');
-  });
+  it.each([[""], ["   "], [null], [undefined]])(
+    "rejects invalid element IDs",
+    (elementId) => {
+      expect(() => buildFlexUrl(elementId as string)).toThrow("Invalid elementId");
+    },
+  );
 });
 
-describe('isFinancialDocument', () => {
-  it('should return true for presupuesto', () => {
+describe("intent helpers", () => {
+  it("classifies financial documents", () => {
     expect(isFinancialDocument(FLEX_FOLDER_IDS.presupuesto)).toBe(true);
-  });
-
-  it('should return true for presupuestoDryHire', () => {
-    expect(isFinancialDocument(FLEX_FOLDER_IDS.presupuestoDryHire)).toBe(true);
-  });
-
-  it('should return true for hojaGastos', () => {
-    expect(isFinancialDocument(FLEX_FOLDER_IDS.hojaGastos)).toBe(true);
-  });
-
-  it('should return false for mainFolder', () => {
     expect(isFinancialDocument(FLEX_FOLDER_IDS.mainFolder)).toBe(false);
-  });
-
-  it('should return false for subFolder', () => {
-    expect(isFinancialDocument(FLEX_FOLDER_IDS.subFolder)).toBe(false);
-  });
-
-  it('should return false for undefined', () => {
     expect(isFinancialDocument(undefined)).toBe(false);
   });
-});
 
-describe('isSimpleFolder', () => {
-  it('should return true for mainFolder', () => {
+  it("classifies simple folders", () => {
     expect(isSimpleFolder(FLEX_FOLDER_IDS.mainFolder)).toBe(true);
-  });
-
-  it('should return true for subFolder', () => {
-    expect(isSimpleFolder(FLEX_FOLDER_IDS.subFolder)).toBe(true);
-  });
-
-  it('should return false for presupuesto', () => {
     expect(isSimpleFolder(FLEX_FOLDER_IDS.presupuesto)).toBe(false);
-  });
-
-  it('should return false for undefined', () => {
     expect(isSimpleFolder(undefined)).toBe(false);
   });
 });
 
-describe('getElementDetails', () => {
+describe("server-side type detection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should fetch element details successfully', async () => {
-    const mockResponse = {
-      elementDefinitionId: { data: 'test-definition-id' },
-      name: { data: 'Test Element' },
-      documentNumber: { data: 'DOC-123' },
-    };
+  it("fetches element metadata through the Flex proxy", async () => {
+    vi.mocked(flexApiFetch).mockResolvedValue(
+      proxyResponse(true, {
+        elementDefinitionId: { data: "definition-id" },
+        name: { data: "Test Element" },
+        documentNumber: { data: "DOC-123" },
+      }),
+    );
 
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockResponse,
-    } as unknown as Response);
-
-    const details = await getElementDetails('test-element-id', 'test-token');
-
-    expect(details).toEqual({
-      elementId: 'test-element-id',
-      definitionId: 'test-definition-id',
-      name: 'Test Element',
-      documentNumber: 'DOC-123',
+    await expect(getElementDetails("element-id")).resolves.toEqual({
+      elementId: "element-id",
+      definitionId: "definition-id",
+      name: "Test Element",
+      documentNumber: "DOC-123",
     });
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://sectorpro.flexrentalsolutions.com/f5/api/element/test-element-id/key-info/',
+    expect(flexApiFetch).toHaveBeenCalledWith(
+      "/element/element-id/key-info/",
       {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Auth-Token': 'test-token',
-          'apikey': 'test-token',
-        },
-      }
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      },
     );
   });
 
-  it('should handle fetch failure gracefully', async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: false,
-      statusText: 'Not Found',
-    } as unknown as Response);
-
-    const details = await getElementDetails('test-element-id', 'test-token');
-
-    expect(details).toEqual({
-      elementId: 'test-element-id',
+  it("falls back safely when metadata cannot be fetched", async () => {
+    vi.mocked(flexApiFetch).mockRejectedValue(new Error("proxy unavailable"));
+    await expect(getElementDetails("element-id")).resolves.toEqual({
+      elementId: "element-id",
     });
   });
 
-  it('should handle network error gracefully', async () => {
-    vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network error'));
-
-    const details = await getElementDetails('test-element-id', 'test-token');
-
-    expect(details).toEqual({
-      elementId: 'test-element-id',
-    });
-  });
-});
-
-describe('buildFlexUrlWithTypeDetection', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('should use definitionId from context if provided', async () => {
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {
-      definitionId: FLEX_FOLDER_IDS.presupuesto,
-    });
-
-    expect(url).toContain('#fin-doc/test-element-id/doc-view/');
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it('should use simple-element URL for dryhire folderType', async () => {
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {
-      folderType: 'dryhire',
-    });
-
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it('should use simple-element URL for tourdate folderType', async () => {
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {
-      folderType: 'tourdate',
-    });
-
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it('should use simple-element URL for dryhire jobType', async () => {
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {
-      jobType: 'dryhire',
-    });
-
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it('should use simple-element URL for tourdate jobType', async () => {
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {
-      jobType: 'tourdate',
-    });
-
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it('should fetch element details when no context provided', async () => {
-    const mockResponse = {
-      elementDefinitionId: { data: FLEX_FOLDER_IDS.presupuesto },
-    };
-
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockResponse,
-    } as unknown as Response);
-
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token');
-
-    expect(url).toContain('#fin-doc/test-element-id/doc-view/');
-    expect(global.fetch).toHaveBeenCalled();
-  });
-
-  it('should fallback to simple-element URL when API call fails', async () => {
-    vi.mocked(global.fetch).mockRejectedValueOnce(new Error('API error'));
-
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token');
-
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-  });
-
-  it('should not fetch when no context is provided that enables optimization', async () => {
-    const mockResponse = {
-      elementDefinitionId: { data: FLEX_FOLDER_IDS.mainFolder },
-    };
-
-    vi.mocked(global.fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockResponse,
-    } as unknown as Response);
-
-    // When no context that enables optimization is provided, fetch should be called
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {});
-
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-    expect(global.fetch).toHaveBeenCalled();
-  });
-
-  it('should throw error for empty elementId in buildFlexUrlWithTypeDetection', async () => {
+  it("uses strong local context without a network call", async () => {
     await expect(
-      buildFlexUrlWithTypeDetection('', 'test-token')
-    ).rejects.toThrow('Invalid elementId');
-  });
+      buildFlexUrlWithTypeDetection("element-id", {
+        definitionId: FLEX_FOLDER_IDS.presupuesto,
+      }),
+    ).resolves.toContain("#fin-doc/element-id/doc-view/");
 
-  it('should throw error for null elementId in buildFlexUrlWithTypeDetection', async () => {
     await expect(
-      buildFlexUrlWithTypeDetection(null as unknown as string, 'test-token')
-    ).rejects.toThrow('Invalid elementId');
-  });
+      buildFlexUrlWithTypeDetection("element-id", { jobType: "dryhire" }),
+    ).resolves.toContain("#element/element-id/view/simple-element/detail");
 
-  it('should throw error for undefined elementId in buildFlexUrlWithTypeDetection', async () => {
     await expect(
-      buildFlexUrlWithTypeDetection(undefined as unknown as string, 'test-token')
-    ).rejects.toThrow('Invalid elementId');
+      buildFlexUrlWithTypeDetection("element-id", {
+        viewHint: "equipment-list",
+      }),
+    ).resolves.toContain("#element/element-id/view/equipment-list/detail");
+
+    expect(flexApiFetch).not.toHaveBeenCalled();
   });
 
-  it('should throw error for whitespace-only elementId in buildFlexUrlWithTypeDetection', async () => {
+  it("uses proxied metadata when context is ambiguous", async () => {
+    vi.mocked(flexApiFetch).mockResolvedValue(
+      proxyResponse(true, {
+        elementDefinitionId: { data: FLEX_FOLDER_IDS.presupuesto },
+      }),
+    );
+
     await expect(
-      buildFlexUrlWithTypeDetection('   ', 'test-token')
-    ).rejects.toThrow('Invalid elementId');
+      buildFlexUrlWithTypeDetection("element-id"),
+    ).resolves.toContain("#fin-doc/element-id/doc-view/");
   });
 
-  it('should handle empty authToken gracefully with context optimization', async () => {
-    // With context optimization, should not need authToken
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', '', {
-      jobType: 'dryhire',
-    });
-
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it('should use fallback when authToken is empty and no context', async () => {
-    vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Unauthorized'));
-
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', '');
-
-    expect(url).toContain('#element/test-element-id/view/simple-element/detail');
-  });
-
-  it('should use viewHint when provided in context', async () => {
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {
-      viewHint: 'contact-list',
-    });
-
-    expect(url).toContain('#contact-list/test-element-id/view/');
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it('should use equipment-list URL when viewHint is equipment-list', async () => {
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {
-      viewHint: 'equipment-list',
-    });
-
-    expect(url).toContain('#element/test-element-id/view/equipment-list/detail');
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it('should use remote-file-list URL when viewHint is remote-file-list', async () => {
-    const url = await buildFlexUrlWithTypeDetection('test-element-id', 'test-token', {
-      viewHint: 'remote-file-list',
-    });
-
-    expect(url).toContain('#element/test-element-id/view/remote-file-list/detail');
-    expect(global.fetch).not.toHaveBeenCalled();
+  it("rejects invalid IDs before making a request", async () => {
+    await expect(buildFlexUrlWithTypeDetection("")).rejects.toThrow(
+      "Invalid elementId",
+    );
+    expect(flexApiFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/flex-folders/__tests__/flexUrlResolver.test.ts
+++ b/src/utils/flex-folders/__tests__/flexUrlResolver.test.ts
@@ -6,29 +6,19 @@ import {
   __resetFlexAuthCacheForTests,
   type FlexTreeNode,
 } from '../../flexUrlResolver';
+import { flexApiFetch } from '@/lib/flex-api-client';
 import { FLEX_FOLDER_IDS } from '../constants';
-import { supabase } from '@/lib/supabase';
 
-vi.mock('@/lib/supabase', () => ({
-  supabase: {
-    functions: {
-      invoke: vi.fn(),
-    },
-  },
+vi.mock('@/lib/flex-api-client', () => ({
+  flexApiFetch: vi.fn(),
 }));
 
 describe('resolveFlexUrl', () => {
-  const invokeMock = () => supabase.functions.invoke as unknown as ReturnType<typeof vi.fn>;
-  const getFetchMock = () => globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+  const getProxyMock = () => flexApiFetch as unknown as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     __resetFlexAuthCacheForTests();
     vi.clearAllMocks();
-    invokeMock().mockResolvedValue({
-      data: { X_AUTH_TOKEN: 'test-token' },
-      error: null,
-    });
-    globalThis.fetch = vi.fn() as any;
   });
 
   it('resolves simple element URL for simple project element domain', async () => {
@@ -42,8 +32,7 @@ describe('resolveFlexUrl', () => {
     expect(url).toBe(
       `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('simple-id')}/view/simple-element/header`
     );
-    expect(invokeMock()).not.toHaveBeenCalled();
-    expect(getFetchMock()).not.toHaveBeenCalled();
+    expect(getProxyMock()).not.toHaveBeenCalled();
   });
 
   it('resolves financial document URL for fin-doc domain', async () => {
@@ -122,7 +111,7 @@ describe('resolveFlexUrl', () => {
     expect(url).toBe(
       `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('dryhire-folder-id')}/view/simple-element/header`
     );
-    expect(getFetchMock()).not.toHaveBeenCalled();
+    expect(getProxyMock()).not.toHaveBeenCalled();
   });
 
   it('falls back to simple element for tourdate job with tourdate hint', async () => {
@@ -136,7 +125,7 @@ describe('resolveFlexUrl', () => {
     expect(url).toBe(
       `${FLEX_UI_BASE_URL}#element/${encodeURIComponent('tourdate-folder-id')}/view/simple-element/header`
     );
-    expect(getFetchMock()).not.toHaveBeenCalled();
+    expect(getProxyMock()).not.toHaveBeenCalled();
   });
 
   it('fetches metadata when schema cannot be determined and applies headers', async () => {
@@ -144,19 +133,17 @@ describe('resolveFlexUrl', () => {
       nodeId: 'metadata-id',
     };
 
-    __resetFlexAuthCacheForTests();
-    invokeMock().mockResolvedValue({
-      data: { X_AUTH_TOKEN: 'metadata-token' },
-      error: null,
-    });
-
-    getFetchMock().mockResolvedValueOnce({
+    getProxyMock().mockResolvedValueOnce({
       ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
       json: async () => ({
         domainId: { data: 'fin-doc' },
         elementDefinitionId: { data: FLEX_FOLDER_IDS.presupuesto },
       }),
-    } as unknown as Response);
+      text: async () => '',
+    });
 
     const url = await resolveFlexUrl(node);
 
@@ -164,13 +151,10 @@ describe('resolveFlexUrl', () => {
       `${FLEX_UI_BASE_URL}#fin-doc/${encodeURIComponent('metadata-id')}/doc-view/${FLEX_VIEW_IDS.FIN_DOC}/header`
     );
 
-    expect(invokeMock()).toHaveBeenCalledTimes(1);
-    expect(getFetchMock()).toHaveBeenCalledTimes(1);
-
-    const [, init] = getFetchMock().mock.calls[0] as [RequestInfo, RequestInit];
-    const headers = init.headers as Headers;
-    expect(headers.get('X-Auth-Token')).toBe('metadata-token');
-    expect(headers.get('apikey')).toBe('metadata-token');
+    expect(getProxyMock()).toHaveBeenCalledWith(
+      '/element/metadata-id/key-info/',
+      { method: 'GET' },
+    );
   });
 
   it('returns null when schema cannot be determined even after metadata fetch', async () => {
@@ -178,18 +162,14 @@ describe('resolveFlexUrl', () => {
       nodeId: 'unknown-id',
     };
 
-    __resetFlexAuthCacheForTests();
-    invokeMock().mockResolvedValue({
-      data: { X_AUTH_TOKEN: 'fail-token' },
-      error: null,
-    });
-
-    getFetchMock().mockResolvedValueOnce({
+    getProxyMock().mockResolvedValueOnce({
       ok: false,
       status: 500,
       statusText: 'Server Error',
+      headers: new Headers(),
       json: async () => ({}),
-    } as unknown as Response);
+      text: async () => '',
+    });
 
     const url = await resolveFlexUrl(node, { jobType: 'single' });
 

--- a/src/utils/flex-folders/__tests__/flexUrlResolver.test.ts
+++ b/src/utils/flex-folders/__tests__/flexUrlResolver.test.ts
@@ -5,9 +5,9 @@ import {
   FLEX_VIEW_IDS,
   __resetFlexAuthCacheForTests,
   type FlexTreeNode,
-} from '../../flexUrlResolver';
+} from '@/utils/flexUrlResolver';
 import { flexApiFetch } from '@/lib/flex-api-client';
-import { FLEX_FOLDER_IDS } from '../constants';
+import { FLEX_FOLDER_IDS } from '@/utils/flex-folders/constants';
 
 vi.mock('@/lib/flex-api-client', () => ({
   flexApiFetch: vi.fn(),

--- a/src/utils/flex-folders/__tests__/resolveFlexUrl.test.ts
+++ b/src/utils/flex-folders/__tests__/resolveFlexUrl.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flexApiFetch } from '@/lib/flex-api-client';
-import { resolveFlexUrl } from '../resolveFlexUrl';
+import { resolveFlexUrl } from '@/utils/flex-folders/resolveFlexUrl';
 
 vi.mock('@/lib/flex-api-client', () => ({
   flexApiFetch: vi.fn(),

--- a/src/utils/flex-folders/__tests__/resolveFlexUrl.test.ts
+++ b/src/utils/flex-folders/__tests__/resolveFlexUrl.test.ts
@@ -1,22 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flexApiFetch } from '@/lib/flex-api-client';
 import { resolveFlexUrl } from '../resolveFlexUrl';
-import { supabase } from '@/lib/supabase';
 
-vi.mock('@/lib/supabase', () => ({
-  supabase: {
-    functions: {
-      invoke: vi.fn(),
-    },
-  },
+vi.mock('@/lib/flex-api-client', () => ({
+  flexApiFetch: vi.fn(),
 }));
 
 describe('resolveFlexUrl (schema hints)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (supabase.functions.invoke as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: { X_AUTH_TOKEN: 'token' },
-      error: null,
-    });
   });
 
   it('bypasses Supabase when schemaId provides a strong hint', async () => {
@@ -28,6 +20,6 @@ describe('resolveFlexUrl (schema hints)', () => {
     });
 
     expect(url).toContain('#fin-doc/');
-    expect(supabase.functions.invoke).not.toHaveBeenCalled();
+    expect(flexApiFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/flex-folders/api.ts
+++ b/src/utils/flex-folders/api.ts
@@ -25,7 +25,9 @@ export async function createFlexFolder(payload: FlexFolderPayload): Promise<Flex
   });
 
   if (!response.ok) {
-    const errorData = await response.json<FlexApiError>();
+    const errorData = await response
+      .json<FlexApiError>()
+      .catch((): FlexApiError => ({}));
     console.error("Flex folder creation error:", errorData);
     throw new Error(errorData.exceptionMessage || "Failed to create folder in Flex");
   }

--- a/src/utils/flex-folders/api.ts
+++ b/src/utils/flex-folders/api.ts
@@ -1,37 +1,11 @@
-import { supabase } from "@/integrations/supabase/client";
+import { flexApiFetch } from "@/lib/flex-api-client";
 import { FlexFolderPayload, FlexFolderResponse } from "./types";
-import { getFlexApiBaseUrl } from "./config";
 
 /**
  * Error response from Flex API
  */
 interface FlexApiError {
   exceptionMessage?: string;
-}
-
-let cachedFlexToken: string | null = null;
-
-/**
- * Gets the Flex authentication token from Supabase secrets
- */
-async function getFlexAuthToken(): Promise<string> {
-  if (cachedFlexToken) return cachedFlexToken;
-
-  const { data, error } = await supabase.functions.invoke('get-secret', {
-    body: { secretName: 'X_AUTH_TOKEN' },
-  });
-
-  if (error) {
-    throw new Error(error.message || 'Failed to resolve Flex auth token');
-  }
-
-  const token = (data as { X_AUTH_TOKEN?: string } | null)?.X_AUTH_TOKEN;
-  if (!token) {
-    throw new Error('Flex auth token response missing X_AUTH_TOKEN');
-  }
-
-  cachedFlexToken = token;
-  return token;
 }
 
 /**
@@ -42,40 +16,28 @@ async function getFlexAuthToken(): Promise<string> {
 export async function createFlexFolder(payload: FlexFolderPayload): Promise<FlexFolderResponse> {
   console.log("Creating Flex folder with payload:", payload);
   
-  const token = await getFlexAuthToken();
-  const apiBaseUrl = getFlexApiBaseUrl();
-
-  const response = await fetch(`${apiBaseUrl}/element`, {
+  const response = await flexApiFetch("/element", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Auth-Token": token,
-      "apikey": token,
     },
     body: JSON.stringify(payload)
   });
 
   if (!response.ok) {
-    const errorData = await response.json();
+    const errorData = await response.json<FlexApiError>();
     console.error("Flex folder creation error:", errorData);
     throw new Error(errorData.exceptionMessage || "Failed to create folder in Flex");
   }
 
-  const data = await response.json();
+  const data = await response.json<FlexFolderResponse>();
   console.log("Created Flex folder:", data);
   return data;
 }
 
 export async function deleteFlexFolder(elementId: string): Promise<void> {
-  const token = await getFlexAuthToken();
-  const apiBaseUrl = getFlexApiBaseUrl();
-
-  const response = await fetch(`${apiBaseUrl}/element/${encodeURIComponent(elementId)}`, {
+  const response = await flexApiFetch(`/element/${encodeURIComponent(elementId)}`, {
     method: "DELETE",
-    headers: {
-      "X-Auth-Token": token,
-      "apikey": token,
-    },
   });
 
   if (!response.ok) {
@@ -101,16 +63,12 @@ export async function updateFlexElementHeader(
   fieldType: string,
   value: string
 ): Promise<void> {
-  const token = await getFlexAuthToken();
-  const apiBaseUrl = getFlexApiBaseUrl();
-
-  const response = await fetch(
-    `${apiBaseUrl}/element/${encodeURIComponent(elementId)}/header-update`,
+  const response = await flexApiFetch(
+    `/element/${encodeURIComponent(elementId)}/header-update`,
     {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Auth-Token": token,
         "X-Api-Client": "flex5-desktop",
         "X-Requested-With": "XMLHttpRequest",
       },

--- a/src/utils/flex-folders/buildFlexUrl.ts
+++ b/src/utils/flex-folders/buildFlexUrl.ts
@@ -1,4 +1,4 @@
-import { getFlexApiBaseUrl } from './config';
+import { flexApiFetch } from '@/lib/flex-api-client';
 import {
   detectFlexLinkIntent,
   IntentDetectionContext,
@@ -18,25 +18,20 @@ export interface ElementDetails {
 /**
  * Fetches element details from Flex API to get definitionId
  * @param elementId - The element ID to fetch
- * @param authToken - Flex API authentication token
  * @returns Element details including definitionId
  */
 export async function getElementDetails(
-  elementId: string,
-  authToken: string
+  elementId: string
 ): Promise<ElementDetails> {
   try {
     console.log(`[buildFlexUrl] Fetching element details for ${elementId}`);
     
-    const apiBaseUrl = getFlexApiBaseUrl();
-    const response = await fetch(
-      `${apiBaseUrl}/element/${elementId}/key-info/`,
+    const response = await flexApiFetch(
+      `/element/${encodeURIComponent(elementId)}/key-info/`,
       {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'X-Auth-Token': authToken,
-          'apikey': authToken,
         },
       }
     );
@@ -46,7 +41,7 @@ export async function getElementDetails(
       return { elementId };
     }
 
-    const data = await response.json();
+    const data = await response.json<Record<string, any>>();
     
     // Extract definitionId from the response
     // The response structure has fields wrapped in objects with data property
@@ -137,7 +132,6 @@ export type ElementContext = IntentDetectionContext;
  * Fetches element details if needed to determine the correct URL format
  * 
  * @param elementId - The element ID to open
- * @param authToken - Flex API authentication token
  * @param context - Optional context about the element to avoid extra API calls
  * @returns Promise with the formatted Flex URL
  * 
@@ -154,7 +148,6 @@ export type ElementContext = IntentDetectionContext;
  */
 export async function buildFlexUrlWithTypeDetection(
   elementId: string,
-  authToken: string,
   context?: ElementContext
 ): Promise<string> {
   console.log('[buildFlexUrl] Starting type detection', {
@@ -166,8 +159,6 @@ export async function buildFlexUrlWithTypeDetection(
     elementIdEmpty: elementId === '',
     elementIdValid: !!elementId && elementId.trim().length > 0,
     elementIdLength: elementId?.length || 0,
-    hasAuthToken: !!authToken,
-    authTokenLength: authToken?.length || 0,
     hasContext: !!context,
     context,
   });
@@ -185,13 +176,6 @@ export async function buildFlexUrlWithTypeDetection(
     throw new Error(error);
   }
 
-  if (!authToken || typeof authToken !== 'string' || authToken.trim().length === 0) {
-    console.warn('[buildFlexUrl] Invalid authToken, will attempt to build URL without API call', {
-      hasAuthToken: !!authToken,
-      authTokenType: typeof authToken,
-    });
-  }
-  
   // If context provides strong, unambiguous information for intent detection, use it
   const hasStrongDefinition = !!context?.definitionId;
   const isExplicitView = !!(context?.viewHint && context.viewHint !== 'auto');
@@ -241,9 +225,8 @@ export async function buildFlexUrlWithTypeDetection(
   try {
     console.log('[buildFlexUrl] No context optimization available, fetching element details from API', {
       elementId,
-      hasAuthToken: !!authToken,
     });
-    const details = await getElementDetails(elementId, authToken);
+    const details = await getElementDetails(elementId);
     console.log('[buildFlexUrl] Element details fetched from API:', {
       elementId,
       definitionId: details.definitionId,

--- a/src/utils/flex-folders/getElementTree.ts
+++ b/src/utils/flex-folders/getElementTree.ts
@@ -1,4 +1,4 @@
-import { supabase } from "@/integrations/supabase/client";
+import { flexApiFetch } from "@/lib/flex-api-client";
 
 /**
  * Types for Flex element tree structure
@@ -27,31 +27,6 @@ export interface FlatElementNode {
   depth: number;
 }
 
-let cachedFlexToken: string | null = null;
-
-/**
- * Gets the Flex authentication token from Supabase secrets
- */
-async function getFlexAuthToken(): Promise<string> {
-  if (cachedFlexToken) return cachedFlexToken;
-
-  const { data, error } = await supabase.functions.invoke('get-secret', {
-    body: { secretName: 'X_AUTH_TOKEN' },
-  });
-
-  if (error) {
-    throw new Error(error.message || 'Failed to resolve Flex auth token');
-  }
-
-  const token = (data as { X_AUTH_TOKEN?: string } | null)?.X_AUTH_TOKEN;
-  if (!token) {
-    throw new Error('Flex auth token response missing X_AUTH_TOKEN');
-  }
-
-  cachedFlexToken = token;
-  return token;
-}
-
 /**
  * Fetches the element tree from Flex API starting from a given main element
  * @param mainElementId The root element ID to fetch the tree from
@@ -61,29 +36,27 @@ export async function getElementTree(
   mainElementId: string
 ): Promise<FlexElementNode[]> {
   try {
-    const token = await getFlexAuthToken();
-
-    const response = await fetch(
-      `https://sectorpro.flexrentalsolutions.com/f5/api/element/${mainElementId}/tree`,
+    const response = await flexApiFetch(
+      `/element/${encodeURIComponent(mainElementId)}/tree`,
       {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
-          "X-Auth-Token": token,
-          "apikey": token,
         },
       }
     );
 
     if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}));
+      const errorData: { exceptionMessage?: string } = await response
+        .json<{ exceptionMessage?: string }>()
+        .catch(() => ({}));
       console.error("Flex element tree fetch error:", errorData);
       throw new Error(
         errorData.exceptionMessage || "Failed to fetch element tree from Flex"
       );
     }
 
-    const data = await response.json();
+    const data = await response.json<unknown>();
     console.log("Fetched Flex element tree:", data);
 
     // Transform API response to our format

--- a/src/utils/flex-folders/resolveFlexUrl.ts
+++ b/src/utils/flex-folders/resolveFlexUrl.ts
@@ -1,5 +1,4 @@
 import { buildFlexUrl, buildFlexUrlWithTypeDetection, ElementContext } from './buildFlexUrl';
-import { supabase } from '@/lib/supabase';
 import {
   detectFlexLinkIntent,
   intentFromSchemaId,
@@ -117,28 +116,7 @@ export async function resolveFlexUrl(options: ResolveFlexUrlOptions): Promise<st
       return url;
     }
 
-    // Fetch auth token via Supabase Function
-    const { data, error } = await supabase.functions.invoke('get-secret', {
-      body: { secretName: 'X_AUTH_TOKEN' },
-    });
-
-    if (error) {
-      console.warn('[resolveFlexUrl] Failed to fetch auth token, using fallback simple-element URL:', error);
-      // Fallback: simple-element URL
-      const fallbackUrl = buildFlexUrl(elementId);
-      return fallbackUrl;
-    }
-
-    const X_AUTH_TOKEN = (data as { X_AUTH_TOKEN?: string } | null)?.X_AUTH_TOKEN || '';
-
-    // If token is missing, fallback to simple-element URL
-    if (!X_AUTH_TOKEN) {
-      console.warn('[resolveFlexUrl] Missing auth token, using fallback simple-element URL');
-      return buildFlexUrl(elementId);
-    }
-
-    // Use the async type detection when token is available
-    const url = await buildFlexUrlWithTypeDetection(elementId, X_AUTH_TOKEN, context);
+    const url = await buildFlexUrlWithTypeDetection(elementId, context);
     console.log('[resolveFlexUrl] Resolved URL via API detection:', {
       url,
       elementId,

--- a/src/utils/flexUrlResolver.ts
+++ b/src/utils/flexUrlResolver.ts
@@ -1,5 +1,4 @@
-import { supabase } from '@/lib/supabase';
-import { FLEX_API_BASE_URL } from '@/lib/api-config';
+import { flexApiFetch as proxyFlexApiFetch } from '@/lib/flex-api-client';
 import { FLEX_FOLDER_IDS } from './flex-folders/constants';
 
 export const FLEX_UI_BASE_URL = 'https://sectorpro.flexrentalsolutions.com/f5/ui/?desktop';
@@ -122,9 +121,6 @@ interface SchemaResolution {
   reason?: string;
 }
 
-let cachedFlexToken: string | null = null;
-let pendingTokenPromise: Promise<string> | null = null;
-
 function coerceString(value: unknown): string | undefined {
   if (typeof value === 'string') {
     const trimmed = value.trim();
@@ -162,68 +158,7 @@ function pickPrimaryElementId(node: FlexTreeNode): string | null {
   return null;
 }
 
-async function getFlexAuthToken(): Promise<string> {
-  if (cachedFlexToken) {
-    return cachedFlexToken;
-  }
-
-  if (pendingTokenPromise) {
-    return pendingTokenPromise;
-  }
-
-  pendingTokenPromise = (async () => {
-    console.log('[flexUrlResolver] Fetching Flex auth token');
-    const { data, error } = await supabase.functions.invoke('get-secret', {
-      body: { secretName: 'X_AUTH_TOKEN' },
-    });
-
-    if (error) {
-      pendingTokenPromise = null;
-      throw new Error(error.message || 'Failed to resolve Flex auth token');
-    }
-
-    const token = (data as { X_AUTH_TOKEN?: string } | null)?.X_AUTH_TOKEN;
-    if (!token) {
-      pendingTokenPromise = null;
-      throw new Error('Flex auth token response missing X_AUTH_TOKEN');
-    }
-
-    cachedFlexToken = token;
-    pendingTokenPromise = null;
-    return token;
-  })();
-
-  try {
-    return await pendingTokenPromise;
-  } catch (error) {
-    cachedFlexToken = null;
-    throw error;
-  }
-}
-
-async function flexApiFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  const token = await getFlexAuthToken();
-  const headers = new Headers(init.headers || {});
-
-  if (!headers.has('X-Auth-Token')) {
-    headers.set('X-Auth-Token', token);
-  }
-  if (!headers.has('apikey')) {
-    headers.set('apikey', token);
-  }
-  if (!headers.has('Accept')) {
-    headers.set('Accept', 'application/json');
-  }
-
-  const url = path.startsWith('http')
-    ? path
-    : `${FLEX_API_BASE_URL}${path.startsWith('/') ? '' : '/'}${path}`;
-
-  return fetch(url, {
-    ...init,
-    headers,
-  });
-}
+const flexApiFetch = proxyFlexApiFetch;
 
 function extractFlexField(value: unknown): string | undefined {
   if (!value || typeof value === 'string') {
@@ -530,6 +465,6 @@ export async function resolveFlexUrl(
 }
 
 export function __resetFlexAuthCacheForTests(): void {
-  cachedFlexToken = null;
-  pendingTokenPromise = null;
+  // Retained as a no-op for backward-compatible test helpers. Credentials are
+  // no longer cached in the browser.
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -17,10 +17,10 @@ verify_jwt = false
 verify_jwt = false
 
 [functions.place-photos]
-verify_jwt = false
+verify_jwt = true
 
 [functions.place-restaurants]
-verify_jwt = false
+verify_jwt = true
 
 [functions.staffing-click]
 verify_jwt = false

--- a/supabase/functions/apply-flex-status/index.ts
+++ b/supabase/functions/apply-flex-status/index.ts
@@ -200,19 +200,8 @@ serve(async (req) => {
     const type: 'master'|'sub' = isMaster ? 'master' : 'sub';
     const workflowActionId = workflowActions[type][status];
 
-    // Resolve Flex auth token: prefer env, else fetch via get-secret using caller's auth
-    let flexAuthToken = Deno.env.get('X_AUTH_TOKEN') || Deno.env.get('FLEX_X_AUTH_TOKEN') || '';
-    if (!flexAuthToken) {
-      try {
-        const { data: secretData, error: secretError } = await supabase.functions.invoke('get-secret', {
-          body: { secretName: 'X_AUTH_TOKEN' },
-          headers: authHeader ? { authorization: authHeader } : undefined,
-        });
-        if (!secretError && secretData?.X_AUTH_TOKEN) {
-          flexAuthToken = secretData.X_AUTH_TOKEN as string;
-        }
-      } catch {}
-    }
+    const flexAuthToken =
+      Deno.env.get('X_AUTH_TOKEN') || Deno.env.get('FLEX_X_AUTH_TOKEN') || '';
     if (!flexAuthToken) {
       return new Response(JSON.stringify({ success: false, error: 'Flex authentication token missing' }), { status: 503, headers: { ...corsHeaders, 'Content-Type': 'application/json' }});
     }

--- a/supabase/functions/cleanup-corporate-email-images/index.ts
+++ b/supabase/functions/cleanup-corporate-email-images/index.ts
@@ -29,6 +29,28 @@ interface OrphanCleanupSummary {
   errors: string[];
 }
 
+function timingSafeEqual(left: string, right: string): boolean {
+  const maxLength = Math.max(left.length, right.length);
+  let mismatch = left.length ^ right.length;
+  for (let index = 0; index < maxLength; index += 1) {
+    mismatch |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+  }
+  return mismatch === 0;
+}
+
+function isServiceRoleRequest(req: Request): boolean {
+  if (!SERVICE_ROLE_KEY) return false;
+  const authorization = req.headers.get("authorization") || "";
+  const bearer = authorization.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length)
+    : "";
+  const apiKey = req.headers.get("apikey") || "";
+  return (
+    timingSafeEqual(bearer, SERVICE_ROLE_KEY) ||
+    timingSafeEqual(apiKey, SERVICE_ROLE_KEY)
+  );
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
@@ -42,6 +64,13 @@ serve(async (req) => {
   }
 
   try {
+    if (!isServiceRoleRequest(req)) {
+      return new Response(JSON.stringify({ success: false, error: "Forbidden" }), {
+        status: 403,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
     if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
       throw new Error("Missing Supabase configuration");
     }

--- a/supabase/functions/fetch-flex-contact-info/index.ts
+++ b/supabase/functions/fetch-flex-contact-info/index.ts
@@ -40,17 +40,8 @@ serve(async (req: Request) => {
     const cid = body.contact_id || (body.url ? extractUuid(body.url) : null);
     if (!cid) return new Response(JSON.stringify({ error: 'Missing contact_id or url' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
-    // Resolve Flex auth token
-    let flexAuthToken = Deno.env.get("X_AUTH_TOKEN") || "";
-    if (!flexAuthToken) {
-      try {
-        const { data: secretData } = await supabase.functions.invoke('get-secret', {
-          body: { secretName: 'X_AUTH_TOKEN' },
-          headers: { Authorization: authHeader }
-        });
-        if (secretData?.X_AUTH_TOKEN) flexAuthToken = secretData.X_AUTH_TOKEN as string;
-      } catch (_) {}
-    }
+    const flexAuthToken =
+      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
     if (!flexAuthToken) return new Response(JSON.stringify({ error: 'Flex auth not configured' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     // Call Flex key-info

--- a/supabase/functions/fetch-flex-image/index.ts
+++ b/supabase/functions/fetch-flex-image/index.ts
@@ -79,21 +79,8 @@ serve(async (req: Request) => {
       });
     }
 
-    // Resolve Flex auth token
-    let flexAuthToken = Deno.env.get("X_AUTH_TOKEN") || "";
-    if (!flexAuthToken) {
-      try {
-        const { data: secretData } = await supabase.functions.invoke("get-secret", {
-          body: { secretName: "X_AUTH_TOKEN" },
-          headers: { Authorization: authHeader },
-        });
-        if (secretData?.X_AUTH_TOKEN) {
-          flexAuthToken = secretData.X_AUTH_TOKEN as string;
-        }
-      } catch (_) {
-        // Ignore secret fetch errors
-      }
-    }
+    const flexAuthToken =
+      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
 
     if (!flexAuthToken) {
       return new Response(JSON.stringify({ error: "Flex auth not configured" }), {

--- a/supabase/functions/fetch-flex-inventory-model/index.ts
+++ b/supabase/functions/fetch-flex-inventory-model/index.ts
@@ -97,17 +97,8 @@ serve(async (req: Request) => {
     const modelId = body.model_id || (body.url ? extractUuid(body.url) : null);
     if (!modelId) return new Response(JSON.stringify({ error: 'Missing model_id or url' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
-    // Resolve Flex auth token
-    let flexAuthToken = Deno.env.get("X_AUTH_TOKEN") || "";
-    if (!flexAuthToken) {
-      try {
-        const { data: secretData } = await supabase.functions.invoke('get-secret', {
-          body: { secretName: 'X_AUTH_TOKEN' },
-          headers: { Authorization: authHeader }
-        });
-        if (secretData?.X_AUTH_TOKEN) flexAuthToken = secretData.X_AUTH_TOKEN as string;
-      } catch (_) {}
-    }
+    const flexAuthToken =
+      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
     if (!flexAuthToken) return new Response(JSON.stringify({ error: 'Flex auth not configured' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
     // Call Flex inventory-model API

--- a/supabase/functions/get-secret/__tests__/handler.test.ts
+++ b/supabase/functions/get-secret/__tests__/handler.test.ts
@@ -2,232 +2,103 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { handleGetSecretRequest } from "../handler";
 
-function createProfilesBuilder(result: { data: { role: string | null } | null; error: unknown }) {
-  const builder = {
-    eq: vi.fn(() => ({
-      single: vi.fn().mockResolvedValue(result),
-    })),
-  };
-
-  return {
-    select: vi.fn(() => builder),
-  };
-}
-
 describe("handleGetSecretRequest", () => {
   const getUser = vi.fn();
   const auditInsert = vi.fn();
+  const supabase = {
+    auth: { getUser },
+    from: vi.fn(() => ({
+      insert: auditInsert,
+    })),
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
     getUser.mockResolvedValue({
-      data: {
-        user: {
-          id: "user-1",
-        },
-      },
+      data: { user: { id: "user-1" } },
       error: null,
     });
     auditInsert.mockResolvedValue({ error: null });
   });
 
-  it("returns the secret and writes a success audit row", async () => {
-    const profiles = createProfilesBuilder({ data: { role: "management" }, error: null });
-    const supabase = {
-      auth: { getUser },
-      from: vi.fn((table: string) => {
-        if (table === "profiles") {
-          return profiles;
-        }
-
-        return {
-          insert: auditInsert,
-        };
-      }),
-    };
-
+  it("never returns a secret to an authenticated caller", async () => {
     const response = await handleGetSecretRequest(
       new Request("https://example.com/get-secret", {
         method: "POST",
-        headers: {
-          authorization: "Bearer token-1",
-          "user-agent": "Vitest",
-        },
-        body: JSON.stringify({ secretName: "OPENAI_API_KEY" }),
+        headers: { authorization: "Bearer token-1" },
+        body: JSON.stringify({ secretName: "X_AUTH_TOKEN" }),
       }),
-      {
-        supabase,
-        getEnv: (name) => (name === "OPENAI_API_KEY" ? "super-secret-value" : undefined),
-      },
+      { supabase },
     );
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ OPENAI_API_KEY: "super-secret-value" });
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "Direct secret delivery is disabled. Use an approved server-side operation.",
+    });
     expect(auditInsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        action: "secret_access",
-        resource: "secret:OPENAI_API_KEY",
-        metadata: expect.objectContaining({
-          success: true,
-          secret_name: "OPENAI_API_KEY",
-        }),
-      }),
-    );
-    expect(auditInsert.mock.calls[0][0].metadata).not.toHaveProperty("secret_value");
-  });
-
-  it("writes an audit row when the caller lacks permission", async () => {
-    const profiles = createProfilesBuilder({ data: { role: "technician" }, error: null });
-    const supabase = {
-      auth: { getUser },
-      from: vi.fn((table: string) => {
-        if (table === "profiles") {
-          return profiles;
-        }
-
-        return {
-          insert: auditInsert,
-        };
-      }),
-    };
-
-    const response = await handleGetSecretRequest(
-      new Request("https://example.com/get-secret", {
-        method: "POST",
-        headers: {
-          authorization: "Bearer token-1",
-        },
-        body: JSON.stringify({ secretName: "OPENAI_API_KEY" }),
-      }),
-      {
-        supabase,
-        getEnv: () => "super-secret-value",
-      },
-    );
-
-    expect(response.status).toBe(403);
-    expect(auditInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
+        action: "secret_access_blocked",
+        resource: "secret:X_AUTH_TOKEN",
+        severity: "high",
         metadata: expect.objectContaining({
           success: false,
-          outcome: "insufficient_permissions",
-          role: "technician",
+          outcome: "direct_secret_delivery_disabled",
         }),
       }),
     );
   });
 
-  it("returns 500 when the profile lookup fails with a database error", async () => {
-    const profiles = createProfilesBuilder({ data: null, error: new Error("db failed") });
-    const supabase = {
-      auth: { getUser },
-      from: vi.fn((table: string) => {
-        if (table === "profiles") {
-          return profiles;
-        }
-
-        return {
-          insert: auditInsert,
-        };
+  it("requires authentication", async () => {
+    const response = await handleGetSecretRequest(
+      new Request("https://example.com/get-secret", {
+        method: "POST",
+        body: JSON.stringify({ secretName: "OPENAI_API_KEY" }),
       }),
-    };
+      { supabase },
+    );
+
+    expect(response.status).toBe(401);
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid authentication", async () => {
+    getUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error("invalid"),
+    });
 
     const response = await handleGetSecretRequest(
       new Request("https://example.com/get-secret", {
         method: "POST",
-        headers: {
-          authorization: "Bearer token-1",
-        },
-        body: JSON.stringify({ secretName: "OPENAI_API_KEY" }),
+        headers: { authorization: "Bearer invalid" },
+        body: JSON.stringify({ secretName: "GOOGLE_MAPS_API_KEY" }),
       }),
-      {
-        supabase,
-        getEnv: () => "super-secret-value",
-      },
+      { supabase },
     );
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(401);
     expect(auditInsert).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.objectContaining({
-          outcome: "db_error",
+          outcome: "invalid_authentication",
         }),
       }),
     );
   });
 
-  it("fails closed when the success audit write fails", async () => {
-    const profiles = createProfilesBuilder({ data: { role: "management" }, error: null });
-    const supabase = {
-      auth: { getUser },
-      from: vi.fn((table: string) => {
-        if (table === "profiles") {
-          return profiles;
-        }
-
-        return {
-          insert: vi.fn().mockResolvedValue({ error: new Error("audit failed") }),
-        };
-      }),
-    };
+  it("fails closed when the audit write fails", async () => {
+    auditInsert.mockResolvedValue({ error: new Error("audit failed") });
 
     await expect(
       handleGetSecretRequest(
         new Request("https://example.com/get-secret", {
           method: "POST",
-          headers: {
-            authorization: "Bearer token-1",
-          },
-          body: JSON.stringify({ secretName: "OPENAI_API_KEY" }),
+          headers: { authorization: "Bearer token-1" },
+          body: JSON.stringify({ secretName: "X_AUTH_TOKEN" }),
         }),
-        {
-          supabase,
-          getEnv: () => "super-secret-value",
-        },
+        { supabase },
       ),
     ).rejects.toThrow("Failed to persist security audit log");
-  });
-
-  it("truncates oversized secret names in the audit resource", async () => {
-    const profiles = createProfilesBuilder({ data: { role: "technician" }, error: null });
-    const supabase = {
-      auth: { getUser },
-      from: vi.fn((table: string) => {
-        if (table === "profiles") {
-          return profiles;
-        }
-
-        return {
-          insert: auditInsert,
-        };
-      }),
-    };
-    const oversizedSecretName = "A".repeat(400);
-
-    const response = await handleGetSecretRequest(
-      new Request("https://example.com/get-secret", {
-        method: "POST",
-        headers: {
-          authorization: "Bearer token-1",
-        },
-        body: JSON.stringify({ secretName: oversizedSecretName }),
-      }),
-      {
-        supabase,
-        getEnv: () => "super-secret-value",
-      },
-    );
-
-    expect(response.status).toBe(403);
-    expect(auditInsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resource: expect.any(String),
-        metadata: expect.objectContaining({
-          secret_name: oversizedSecretName,
-          secret_name_truncated: true,
-        }),
-      }),
-    );
-    expect(auditInsert.mock.calls[0][0].resource.length).toBeLessThanOrEqual(255);
   });
 });

--- a/supabase/functions/get-secret/handler.ts
+++ b/supabase/functions/get-secret/handler.ts
@@ -4,15 +4,10 @@ import {
   persistSecurityAuditLog,
 } from "../_shared/securityAudit.ts";
 
-const ALLOWED_SECRET_NAMES = ["X_AUTH_TOKEN", "OPENAI_API_KEY", "GOOGLE_MAPS_API_KEY"];
-const MANAGEMENT_ROLES = new Set(["admin", "management"]);
 const SECRET_RESOURCE_PREFIX = "secret:";
 const MAX_AUDIT_RESOURCE_LENGTH = 255;
-const MAX_AUDIT_SECRET_NAME_LENGTH = MAX_AUDIT_RESOURCE_LENGTH - SECRET_RESOURCE_PREFIX.length;
-
-interface ProfileRecord {
-  role: string | null;
-}
+const MAX_AUDIT_SECRET_NAME_LENGTH =
+  MAX_AUDIT_RESOURCE_LENGTH - SECRET_RESOURCE_PREFIX.length;
 
 interface GetSecretDeps {
   supabase: {
@@ -22,41 +17,36 @@ interface GetSecretDeps {
       ) => Promise<{ data: { user: { id: string } | null }; error: unknown }>;
     };
     from: (table: string) => {
-      select: (columns: string) => {
-        eq: (column: string, value: string) => {
-          single: () => Promise<{ data: ProfileRecord | null; error: unknown }>;
-        };
-      };
       insert: (payload: Record<string, unknown>) => Promise<{ error: unknown }>;
     };
   };
-  getEnv: (name: string) => string | undefined;
 }
 
-async function auditSecretAccess(
+async function auditBlockedSecretAccess(
   req: Request,
   deps: GetSecretDeps,
   details: {
     userId?: string | null;
     secretName?: string | null;
-    success: boolean;
     outcome: string;
-    role?: string | null;
   },
 ): Promise<void> {
-  const normalizedSecretName = (details.secretName ?? "unknown").slice(0, MAX_AUDIT_SECRET_NAME_LENGTH);
+  const normalizedSecretName = (details.secretName ?? "unknown").slice(
+    0,
+    MAX_AUDIT_SECRET_NAME_LENGTH,
+  );
 
   await persistSecurityAuditLog(req, deps.supabase, {
     user_id: details.userId ?? null,
-    action: "secret_access",
+    action: "secret_access_blocked",
     resource: `${SECRET_RESOURCE_PREFIX}${normalizedSecretName}`,
-    severity: details.success ? "low" : "high",
+    severity: "high",
     metadata: {
-      success: details.success,
+      success: false,
       outcome: details.outcome,
-      role: details.role ?? null,
       secret_name: details.secretName ?? null,
-      secret_name_truncated: normalizedSecretName !== (details.secretName ?? "unknown"),
+      secret_name_truncated:
+        normalizedSecretName !== (details.secretName ?? "unknown"),
     },
   });
 }
@@ -66,23 +56,21 @@ export async function handleGetSecretRequest(
   deps: GetSecretDeps,
 ): Promise<Response> {
   const body = await req.json().catch(() => null);
-  const secretName = typeof body?.secretName === "string" ? body.secretName.trim() : "";
+  const secretName =
+    typeof body?.secretName === "string" ? body.secretName.trim() : "";
 
   if (!secretName) {
-    await auditSecretAccess(req, deps, {
+    await auditBlockedSecretAccess(req, deps, {
       secretName: null,
-      success: false,
       outcome: "invalid_request",
     });
     return jsonResponse({ error: "secretName is required" }, { status: 400 });
   }
 
   const accessToken = extractBearerToken(req);
-
   if (!accessToken) {
-    await auditSecretAccess(req, deps, {
+    await auditBlockedSecretAccess(req, deps, {
       secretName,
-      success: false,
       outcome: "missing_authorization",
     });
     return jsonResponse({ error: "Authorization header required" }, { status: 401 });
@@ -94,79 +82,24 @@ export async function handleGetSecretRequest(
   } = await deps.supabase.auth.getUser(accessToken);
 
   if (authError || !user) {
-    await auditSecretAccess(req, deps, {
+    await auditBlockedSecretAccess(req, deps, {
       secretName,
-      success: false,
       outcome: "invalid_authentication",
     });
     return jsonResponse({ error: "Invalid authentication" }, { status: 401 });
   }
 
-  const profileQuery = deps.supabase.from("profiles").select("role");
-  const { data: profile, error: profileError } = await profileQuery.eq("id", user.id).single();
-
-  if (profileError) {
-    await auditSecretAccess(req, deps, {
-      userId: user.id,
-      secretName,
-      success: false,
-      outcome: "db_error",
-    });
-    return jsonResponse({ error: "Failed to load user profile" }, { status: 500 });
-  }
-
-  if (!profile) {
-    await auditSecretAccess(req, deps, {
-      userId: user.id,
-      secretName,
-      success: false,
-      outcome: "profile_not_found",
-    });
-    return jsonResponse({ error: "User profile not found" }, { status: 403 });
-  }
-
-  if (!MANAGEMENT_ROLES.has(profile.role ?? "")) {
-    await auditSecretAccess(req, deps, {
-      userId: user.id,
-      secretName,
-      success: false,
-      outcome: "insufficient_permissions",
-      role: profile.role,
-    });
-    return jsonResponse({ error: "Insufficient permissions" }, { status: 403 });
-  }
-
-  if (!ALLOWED_SECRET_NAMES.includes(secretName)) {
-    await auditSecretAccess(req, deps, {
-      userId: user.id,
-      secretName,
-      success: false,
-      outcome: "secret_not_allowed",
-      role: profile.role,
-    });
-    return jsonResponse({ error: `Secret ${secretName} not allowed` }, { status: 403 });
-  }
-
-  const secretValue = deps.getEnv(secretName);
-
-  if (!secretValue) {
-    await auditSecretAccess(req, deps, {
-      userId: user.id,
-      secretName,
-      success: false,
-      outcome: "secret_not_configured",
-      role: profile.role,
-    });
-    return jsonResponse({ error: `Secret ${secretName} not found` }, { status: 404 });
-  }
-
-  await auditSecretAccess(req, deps, {
+  await auditBlockedSecretAccess(req, deps, {
     userId: user.id,
     secretName,
-    success: true,
-    outcome: "allowed",
-    role: profile.role,
+    outcome: "direct_secret_delivery_disabled",
   });
 
-  return jsonResponse({ [secretName]: secretValue }, { status: 200 });
+  return jsonResponse(
+    {
+      error:
+        "Direct secret delivery is disabled. Use an approved server-side operation.",
+    },
+    { status: 410 },
+  );
 }

--- a/supabase/functions/get-secret/index.ts
+++ b/supabase/functions/get-secret/index.ts
@@ -19,7 +19,6 @@ serve(createHttpHandler(async (req) => {
 
   return await handleGetSecretRequest(req, {
     supabase,
-    getEnv: (name) => Deno.env.get(name),
   });
 }, {
   allowedMethods: ["POST"],

--- a/supabase/functions/place-photos/index.ts
+++ b/supabase/functions/place-photos/index.ts
@@ -160,6 +160,22 @@ Deno.serve(async (req) => {
       )
     }
     const supabase = createClient(supabaseUrl, serviceRoleKey)
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader?.startsWith('Bearer ')) {
+      return new Response(
+        JSON.stringify({ error: 'Authentication required', photos: [] }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      )
+    }
+    const { data: { user }, error: authError } = await supabase.auth.getUser(
+      authHeader.slice('Bearer '.length),
+    )
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid authentication', photos: [] }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      )
+    }
 
     let body: Partial<PhotoRequest>
     try {

--- a/supabase/functions/place-restaurants/index.ts
+++ b/supabase/functions/place-restaurants/index.ts
@@ -55,31 +55,21 @@ async function consumePaidApiQuota(
   supabase: ReturnType<typeof createClient>,
   userId: string,
 ): Promise<boolean> {
-  const { data: userAllowed, error: userQuotaError } = await supabase.rpc(
-    'consume_external_api_quota',
+  const { data: allowed, error: quotaError } = await supabase.rpc(
+    'consume_external_api_dual_quota',
     {
-      p_actor_id: userId,
-      p_service: 'google_places',
-      p_daily_limit: USER_DAILY_PAID_API_LIMIT,
+      p_user_actor_id: userId,
+      p_user_service: 'google_places',
+      p_user_daily_limit: USER_DAILY_PAID_API_LIMIT,
+      p_global_actor_id: GLOBAL_QUOTA_ACTOR_ID,
+      p_global_service: 'google_places_global',
+      p_global_daily_limit: GLOBAL_DAILY_PAID_API_LIMIT,
     },
   );
-  if (userQuotaError || userAllowed !== true) {
-    if (userQuotaError) console.error('place-restaurants: user quota check failed', userQuotaError);
-    return false;
+  if (quotaError) {
+    console.error('place-restaurants: quota check failed', quotaError);
   }
-
-  const { data: globalAllowed, error: globalQuotaError } = await supabase.rpc(
-    'consume_external_api_quota',
-    {
-      p_actor_id: GLOBAL_QUOTA_ACTOR_ID,
-      p_service: 'google_places_global',
-      p_daily_limit: GLOBAL_DAILY_PAID_API_LIMIT,
-    },
-  );
-  if (globalQuotaError) {
-    console.error('place-restaurants: global quota check failed', globalQuotaError);
-  }
-  return !globalQuotaError && globalAllowed === true;
+  return !quotaError && allowed === true;
 }
 
 Deno.serve(async (req) => {

--- a/supabase/functions/place-restaurants/index.ts
+++ b/supabase/functions/place-restaurants/index.ts
@@ -20,6 +20,9 @@ const RESTAURANT_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 const DEFAULT_RADIUS_METERS = 2000;
 const MAX_RADIUS_METERS = 10000;
 const DEFAULT_MAX_RESULTS = 20;
+const USER_DAILY_PAID_API_LIMIT = 100;
+const GLOBAL_DAILY_PAID_API_LIMIT = 1000;
+const GLOBAL_QUOTA_ACTOR_ID = '00000000-0000-0000-0000-000000000000';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object';
@@ -48,6 +51,37 @@ function normalizePositiveInteger(value: unknown, fallback: number, max: number)
   return Math.min(Math.floor(value), max);
 }
 
+async function consumePaidApiQuota(
+  supabase: ReturnType<typeof createClient>,
+  userId: string,
+): Promise<boolean> {
+  const { data: userAllowed, error: userQuotaError } = await supabase.rpc(
+    'consume_external_api_quota',
+    {
+      p_actor_id: userId,
+      p_service: 'google_places',
+      p_daily_limit: USER_DAILY_PAID_API_LIMIT,
+    },
+  );
+  if (userQuotaError || userAllowed !== true) {
+    if (userQuotaError) console.error('place-restaurants: user quota check failed', userQuotaError);
+    return false;
+  }
+
+  const { data: globalAllowed, error: globalQuotaError } = await supabase.rpc(
+    'consume_external_api_quota',
+    {
+      p_actor_id: GLOBAL_QUOTA_ACTOR_ID,
+      p_service: 'google_places_global',
+      p_daily_limit: GLOBAL_DAILY_PAID_API_LIMIT,
+    },
+  );
+  if (globalQuotaError) {
+    console.error('place-restaurants: global quota check failed', globalQuotaError);
+  }
+  return !globalQuotaError && globalAllowed === true;
+}
+
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
@@ -70,6 +104,20 @@ Deno.serve(async (req) => {
       });
     }
     const supabase = createClient(supabaseUrl, serviceRoleKey);
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return new Response(JSON.stringify({ error: 'Authentication required' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+    const { data: { user }, error: authError } = await supabase.auth.getUser(
+      authHeader.slice('Bearer '.length),
+    );
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: 'Invalid authentication' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
 
     let body: Record<string, unknown>;
     try {
@@ -115,6 +163,12 @@ Deno.serve(async (req) => {
       if (cachedDetails?.restaurant) {
         return new Response(JSON.stringify({ restaurant: cachedDetails.restaurant, cached: true }), {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        });
+      }
+
+      if (!(await consumePaidApiQuota(supabase, user.id))) {
+        return new Response(JSON.stringify({ error: 'Daily Places API quota exceeded' }), {
+          status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         });
       }
 
@@ -183,6 +237,12 @@ Deno.serve(async (req) => {
     if (cachedSearch?.restaurants) {
       return new Response(JSON.stringify({ restaurants: cachedSearch.restaurants, cached: true }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    if (!(await consumePaidApiQuota(supabase, user.id))) {
+      return new Response(JSON.stringify({ error: 'Daily Places API quota exceeded' }), {
+        status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
 

--- a/supabase/functions/secure-flex-api/index.ts
+++ b/supabase/functions/secure-flex-api/index.ts
@@ -172,6 +172,7 @@ serve(async (req) => {
     headers.set("X-Auth-Token", flexAuthToken);
     headers.set("apikey", flexAuthToken);
 
+    const shouldRetry = method === "GET";
     const response = await fetchWithRetry(
       target.toString(),
       {
@@ -180,7 +181,8 @@ serve(async (req) => {
         body: body || undefined,
       },
       {
-        retryOnTimeout: method === "GET",
+        attempts: shouldRetry ? 3 : 1,
+        retryOnTimeout: shouldRetry,
       },
     );
 
@@ -189,7 +191,12 @@ serve(async (req) => {
     let data: unknown;
 
     if (rawBody && contentType.includes("json")) {
-      data = JSON.parse(rawBody);
+      try {
+        data = JSON.parse(rawBody);
+      } catch (parseError) {
+        console.warn("secure-flex-api upstream returned invalid JSON", parseError);
+        data = rawBody;
+      }
     }
 
     if (method !== "GET" || !response.ok) {

--- a/supabase/functions/secure-flex-api/index.ts
+++ b/supabase/functions/secure-flex-api/index.ts
@@ -1,130 +1,233 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts"
-import { createClient } from 'npm:@supabase/supabase-js@2'
 import { fetchWithRetry } from "../_shared/flexFetch.ts";
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Max-Age': '86400',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Max-Age": "86400",
+};
+
+const FLEX_API_BASE_URL =
+  Deno.env.get("FLEX_API_BASE_URL") ||
+  "https://sectorpro.flexrentalsolutions.com/f5/api";
+const ALLOWED_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+const ALLOWED_PATH_PREFIXES = [
+  "/element",
+  "/line-item",
+  "/financial-document-line-item",
+];
+const ALLOWED_FORWARD_HEADERS = new Set([
+  "accept",
+  "content-type",
+  "x-api-client",
+  "x-requested-with",
+]);
+const MAX_ENDPOINT_LENGTH = 2_048;
+const MAX_BODY_LENGTH = 1_000_000;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
 }
 
-const FLEX_API_BASE_URL = Deno.env.get('FLEX_API_BASE_URL') || 'https://sectorpro.flexrentalsolutions.com/f5/api';
+function validateEndpoint(endpoint: unknown): URL {
+  if (typeof endpoint !== "string" || !endpoint.startsWith("/")) {
+    throw new Error("Endpoint must be a relative Flex API path");
+  }
+  if (
+    endpoint.length > MAX_ENDPOINT_LENGTH ||
+    endpoint.startsWith("//") ||
+    endpoint.includes("\\") ||
+    /[\u0000-\u001f\u007f]/.test(endpoint)
+  ) {
+    throw new Error("Invalid Flex API endpoint");
+  }
+
+  const baseUrl = new URL(FLEX_API_BASE_URL);
+  const basePath = baseUrl.pathname.replace(/\/$/, "");
+  const target = new URL(`${basePath}${endpoint}`, baseUrl.origin);
+
+  if (
+    target.origin !== baseUrl.origin ||
+    !target.pathname.startsWith(`${basePath}/`)
+  ) {
+    throw new Error("Flex API endpoint escaped the configured base path");
+  }
+
+  const relativePath = target.pathname.slice(basePath.length);
+  if (
+    !ALLOWED_PATH_PREFIXES.some(
+      (prefix) => relativePath === prefix || relativePath.startsWith(`${prefix}/`),
+    )
+  ) {
+    throw new Error("Flex API endpoint is not allowlisted");
+  }
+
+  return target;
+}
+
+function sanitizeHeaders(input: unknown): Headers {
+  const output = new Headers();
+
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    for (const [key, value] of Object.entries(input)) {
+      const normalized = key.toLowerCase();
+      if (ALLOWED_FORWARD_HEADERS.has(normalized) && typeof value === "string") {
+        output.set(key, value.slice(0, 1_000));
+      }
+    }
+  }
+
+  if (!output.has("Accept")) {
+    output.set("Accept", "application/json");
+  }
+
+  return output;
+}
 
 serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders })
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return jsonResponse({ success: false, error: "Method not allowed" }, 405);
   }
 
   try {
-    // Initialize Supabase client for authentication
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')
-    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
-    const authToken = Deno.env.get('X_AUTH_TOKEN')
-    
-    if (!supabaseUrl || !supabaseKey || !authToken) {
-      throw new Error('Missing required environment variables')
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    const flexAuthToken =
+      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN");
+
+    if (!supabaseUrl || !serviceRoleKey || !flexAuthToken) {
+      console.error("secure-flex-api is missing required environment variables");
+      return jsonResponse({ success: false, error: "Service unavailable" }, 503);
     }
 
-    const supabase = createClient(supabaseUrl, supabaseKey)
-
-    // Verify user authentication
-    const authHeader = req.headers.get('authorization')
-    if (!authHeader) {
-      throw new Error('Authorization header required')
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return jsonResponse({ success: false, error: "Authentication required" }, 401);
     }
 
-    const { data: { user }, error: authError } = await supabase.auth.getUser(
-      authHeader.replace('Bearer ', '')
-    )
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const accessToken = authHeader.slice("Bearer ".length);
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser(accessToken);
 
     if (authError || !user) {
-      throw new Error('Invalid authentication')
+      return jsonResponse({ success: false, error: "Invalid authentication" }, 401);
     }
 
-    // Authorization: only admin/management may proxy Flex API calls
     const { data: profile, error: profileError } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .maybeSingle()
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle();
 
     if (profileError) {
-      throw new Error('Could not verify authorization')
+      console.error("secure-flex-api profile lookup failed", profileError);
+      return jsonResponse({ success: false, error: "Authorization check failed" }, 500);
     }
-    if (!profile || !['admin', 'management'].includes(profile.role)) {
-      throw new Error('Forbidden - admin or management role required')
-    }
-
-    // Parse request body
-    const { endpoint, method = 'POST', payload } = await req.json()
-    
-    if (!endpoint) {
-      throw new Error('Endpoint is required')
+    if (!profile || !["admin", "management"].includes(profile.role)) {
+      return jsonResponse({ success: false, error: "Insufficient permissions" }, 403);
     }
 
-    // Validate endpoint (security measure)
-    const allowedEndpoints = ['/element']
-    if (!allowedEndpoints.some(allowed => endpoint.startsWith(allowed))) {
-      throw new Error('Endpoint not allowed')
+    const requestBody = await req.json().catch(() => null);
+    if (!requestBody || typeof requestBody !== "object") {
+      return jsonResponse({ success: false, error: "Invalid request body" }, 400);
     }
 
-    // Sanitize logging - don't expose sensitive data
-    console.log(`Making ${method} request to Flex endpoint: ${endpoint} by user: ${user.id}`);
-
-    // Make secure API call to Flex
-    const flexUrl = `${FLEX_API_BASE_URL}${endpoint}`
-    
-    const response = await fetchWithRetry(flexUrl, {
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Auth-Token': authToken,
-        'apikey': authToken,
-      },
-      body: payload ? JSON.stringify(payload) : undefined
-    }, {
-      // A timed-out mutation may have been applied by Flex; only GETs are
-      // safe to replay after a timeout.
-      retryOnTimeout: String(method).toUpperCase() === 'GET',
-    });
-
-    console.log('Flex API response status:', response.status);
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}))
-      console.error("Flex API error response:", errorData);
-      throw new Error(errorData.exceptionMessage || `Flex API error: ${response.status}`)
+    const method = String(requestBody.method || "GET").toUpperCase();
+    if (!ALLOWED_METHODS.has(method)) {
+      return jsonResponse({ success: false, error: "Flex API method is not allowed" }, 400);
     }
 
-    const data = await response.json()
-    console.log("Flex API success response:", data)
+    const target = validateEndpoint(requestBody.endpoint);
+    const body = requestBody.body;
+    if (body !== undefined && typeof body !== "string") {
+      return jsonResponse({ success: false, error: "Flex API body must be a string" }, 400);
+    }
+    if (typeof body === "string" && body.length > MAX_BODY_LENGTH) {
+      return jsonResponse({ success: false, error: "Flex API body is too large" }, 413);
+    }
+    if (["GET", "DELETE"].includes(method) && body) {
+      return jsonResponse(
+        { success: false, error: `${method} requests may not include a body` },
+        400,
+      );
+    }
 
-    return new Response(
-      JSON.stringify({ success: true, data }),
-      { 
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 200,
-      },
-    )
-  } catch (error) {
-    console.error("Error in secure-flex-api:", error)
-    const message = error instanceof Error ? error.message : 'Internal server error'
-    const status = message.includes('authentication') || message.includes('Authorization header')
-      ? 401
-      : message.includes('Forbidden')
-        ? 403
-        : message.includes('Could not verify') || message.includes('Missing required environment')
-          ? 500
-          : 400
-    return new Response(
-      JSON.stringify({ success: false, error: message }),
+    const headers = sanitizeHeaders(requestBody.headers);
+    headers.set("X-Auth-Token", flexAuthToken);
+    headers.set("apikey", flexAuthToken);
+
+    const response = await fetchWithRetry(
+      target.toString(),
       {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status,
+        method,
+        headers,
+        body: body || undefined,
       },
-    )
+      {
+        retryOnTimeout: method === "GET",
+      },
+    );
+
+    const contentType = response.headers.get("content-type") || "";
+    const rawBody = await response.text();
+    let data: unknown;
+
+    if (rawBody && contentType.includes("json")) {
+      data = JSON.parse(rawBody);
+    }
+
+    if (method !== "GET" || !response.ok) {
+      const { error: auditError } = await supabase.from("security_audit_log").insert({
+        user_id: user.id,
+        action: "flex_api_proxy",
+        resource: `flex:${target.pathname.slice(0, 240)}`,
+        severity: response.ok ? "low" : "medium",
+        metadata: {
+          method,
+          status: response.status,
+          success: response.ok,
+        },
+      });
+      if (auditError) {
+        console.error("secure-flex-api audit write failed", auditError);
+      }
+    }
+
+    return jsonResponse({
+      success: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      contentType,
+      data,
+      rawBody: data === undefined ? rawBody : undefined,
+      error: response.ok
+        ? undefined
+        : (
+          data && typeof data === "object" &&
+            "exceptionMessage" in data
+            ? String((data as { exceptionMessage?: unknown }).exceptionMessage)
+            : `Flex API returned ${response.status}`
+        ),
+    });
+  } catch (error) {
+    console.error("secure-flex-api request failed", error);
+    const message = error instanceof Error ? error.message : "Invalid request";
+    return jsonResponse({ success: false, error: message }, 400);
   }
-})
+});

--- a/supabase/functions/sync-flex-crew-for-job/index.ts
+++ b/supabase/functions/sync-flex-crew-for-job/index.ts
@@ -30,23 +30,8 @@ serve(async (req: Request) => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
     );
 
-    // Auth token
-    let flexAuthToken = Deno.env.get("X_AUTH_TOKEN") || "";
-    if (!flexAuthToken) {
-      try {
-        const res = await fetch(new URL(req.url).origin + "/functions/v1/get-secret", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ key: "X_AUTH_TOKEN" })
-        });
-        if (res.ok) {
-          const j = await res.json();
-          flexAuthToken = (j as any)?.X_AUTH_TOKEN || flexAuthToken;
-        }
-      } catch (_) {
-        // ignore
-      }
-    }
+    const flexAuthToken =
+      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
 
     if (!flexAuthToken) {
       return new Response(JSON.stringify({ error: "X_AUTH_TOKEN not configured" }), {

--- a/supabase/migrations/20260623160000_phase0_authorization_hardening.sql
+++ b/supabase/migrations/20260623160000_phase0_authorization_hardening.sql
@@ -1,0 +1,922 @@
+-- Phase 0 enterprise hardening:
+--   * prevent profile privilege escalation
+--   * scope availability and vacation writes
+--   * remove caller-controlled payout authorization
+--   * close unsafe SECURITY DEFINER grants
+--   * fix the four application errors reported by `supabase db lint --linked`
+
+-- ---------------------------------------------------------------------------
+-- Profile privilege boundary
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.enforce_profile_privilege_changes()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_actor_department text;
+  v_changed_fields text[] := ARRAY[]::text[];
+BEGIN
+  IF auth.role() = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Authentication required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF OLD.email IS DISTINCT FROM NEW.email THEN
+    v_changed_fields := array_append(v_changed_fields, 'email');
+  END IF;
+  IF OLD.role IS DISTINCT FROM NEW.role THEN
+    v_changed_fields := array_append(v_changed_fields, 'role');
+  END IF;
+  IF OLD.department IS DISTINCT FROM NEW.department THEN
+    v_changed_fields := array_append(v_changed_fields, 'department');
+  END IF;
+  IF OLD.assignable_as_tech IS DISTINCT FROM NEW.assignable_as_tech THEN
+    v_changed_fields := array_append(v_changed_fields, 'assignable_as_tech');
+  END IF;
+  IF OLD.default_timesheet_category IS DISTINCT FROM NEW.default_timesheet_category THEN
+    v_changed_fields := array_append(v_changed_fields, 'default_timesheet_category');
+  END IF;
+  IF OLD.soundvision_access_enabled IS DISTINCT FROM NEW.soundvision_access_enabled THEN
+    v_changed_fields := array_append(v_changed_fields, 'soundvision_access_enabled');
+  END IF;
+  IF OLD.autonomo IS DISTINCT FROM NEW.autonomo THEN
+    v_changed_fields := array_append(v_changed_fields, 'autonomo');
+  END IF;
+  IF OLD.warehouse_duty_exempt IS DISTINCT FROM NEW.warehouse_duty_exempt THEN
+    v_changed_fields := array_append(v_changed_fields, 'warehouse_duty_exempt');
+  END IF;
+  IF OLD.flex_user_id IS DISTINCT FROM NEW.flex_user_id THEN
+    v_changed_fields := array_append(v_changed_fields, 'flex_user_id');
+  END IF;
+  IF OLD.flex_id IS DISTINCT FROM NEW.flex_id THEN
+    v_changed_fields := array_append(v_changed_fields, 'flex_id');
+  END IF;
+  IF OLD.flex_resource_id IS DISTINCT FROM NEW.flex_resource_id THEN
+    v_changed_fields := array_append(v_changed_fields, 'flex_resource_id');
+  END IF;
+  IF OLD.waha_endpoint IS DISTINCT FROM NEW.waha_endpoint THEN
+    v_changed_fields := array_append(v_changed_fields, 'waha_endpoint');
+  END IF;
+
+  IF cardinality(v_changed_fields) = 0 THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT p.role::text, p.department
+  INTO v_actor_role, v_actor_department
+  FROM public.profiles p
+  WHERE p.id = v_actor;
+
+  IF v_actor = OLD.id THEN
+    RAISE EXCEPTION 'Privileged profile fields cannot be changed on your own account'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_actor_role NOT IN ('admin', 'management') THEN
+    RAISE EXCEPTION 'Only administrators and management may change privileged profile fields'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_actor_role = 'management' THEN
+    IF OLD.department IS DISTINCT FROM v_actor_department THEN
+      RAISE EXCEPTION 'Management may only change profiles in their department'
+        USING ERRCODE = '42501';
+    END IF;
+
+    IF OLD.role::text IN ('admin', 'management')
+       OR NEW.role::text IN ('admin', 'management') THEN
+      RAISE EXCEPTION 'Management may not assign or modify administrative roles'
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  INSERT INTO public.security_audit_log (
+    user_id,
+    action,
+    resource,
+    severity,
+    metadata
+  )
+  VALUES (
+    v_actor,
+    'profile_privilege_change',
+    'profile:' || OLD.id::text,
+    CASE WHEN 'role' = ANY(v_changed_fields) THEN 'critical' ELSE 'high' END,
+    jsonb_build_object(
+      'changed_fields', to_jsonb(v_changed_fields),
+      'actor_role', v_actor_role,
+      'old_role', OLD.role::text,
+      'new_role', NEW.role::text,
+      'old_department', OLD.department,
+      'new_department', NEW.department
+    )
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_profile_privilege_changes ON public.profiles;
+CREATE TRIGGER enforce_profile_privilege_changes
+BEFORE UPDATE ON public.profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_profile_privilege_changes();
+
+REVOKE ALL ON FUNCTION public.enforce_profile_privilege_changes() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enforce_profile_privilege_changes() TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Department-scoped technician management helper
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.can_manage_technician(p_technician_id text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT
+    auth.role() = 'service_role'
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles actor
+      JOIN public.profiles target ON target.id::text = p_technician_id
+      WHERE actor.id = auth.uid()
+        AND (
+          actor.role = 'admin'::public.user_role
+          OR (
+            actor.role = 'management'::public.user_role
+            AND actor.department IS NOT DISTINCT FROM target.department
+          )
+        )
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.can_manage_technician(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.can_manage_technician(text) TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- Availability and vacation RLS
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "p_technician_availability_public_delete_ce70b4" ON public.technician_availability;
+DROP POLICY IF EXISTS "p_technician_availability_public_insert_46f742" ON public.technician_availability;
+DROP POLICY IF EXISTS "p_technician_availability_public_select_cfa90a" ON public.technician_availability;
+DROP POLICY IF EXISTS "p_technician_availability_public_update_c42e80" ON public.technician_availability;
+
+CREATE POLICY technician_availability_select_scoped
+ON public.technician_availability
+FOR SELECT
+TO authenticated
+USING (
+  technician_id = auth.uid()::text
+  OR public.can_manage_technician(technician_id)
+);
+
+CREATE POLICY technician_availability_insert_scoped
+ON public.technician_availability
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  technician_id = auth.uid()::text
+  OR public.can_manage_technician(technician_id)
+);
+
+CREATE POLICY technician_availability_update_scoped
+ON public.technician_availability
+FOR UPDATE
+TO authenticated
+USING (
+  technician_id = auth.uid()::text
+  OR public.can_manage_technician(technician_id)
+)
+WITH CHECK (
+  technician_id = auth.uid()::text
+  OR public.can_manage_technician(technician_id)
+);
+
+CREATE POLICY technician_availability_delete_scoped
+ON public.technician_availability
+FOR DELETE
+TO authenticated
+USING (
+  technician_id = auth.uid()::text
+  OR public.can_manage_technician(technician_id)
+);
+
+REVOKE ALL ON TABLE public.technician_availability FROM anon;
+REVOKE ALL ON SEQUENCE public.technician_availability_id_seq FROM anon;
+
+CREATE OR REPLACE FUNCTION public.enforce_vacation_request_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+BEGIN
+  IF auth.role() = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Authentication required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF OLD.technician_id = v_actor THEN
+    IF OLD.status <> 'pending'
+       OR NEW.status <> 'pending'
+       OR NEW.technician_id IS DISTINCT FROM OLD.technician_id
+       OR NEW.approved_by IS DISTINCT FROM OLD.approved_by
+       OR NEW.approved_at IS DISTINCT FROM OLD.approved_at
+       OR NEW.rejection_reason IS DISTINCT FROM OLD.rejection_reason
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+      RAISE EXCEPTION 'Pending vacation owners may only change dates and reason'
+        USING ERRCODE = '42501';
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF NOT public.can_manage_technician(OLD.technician_id::text)
+     OR NEW.technician_id IS DISTINCT FROM OLD.technician_id THEN
+    RAISE EXCEPTION 'Not authorized to update this vacation request'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_vacation_request_update ON public.vacation_requests;
+CREATE TRIGGER enforce_vacation_request_update
+BEFORE UPDATE ON public.vacation_requests
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_vacation_request_update();
+
+REVOKE ALL ON FUNCTION public.enforce_vacation_request_update() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enforce_vacation_request_update() TO service_role;
+
+DROP POLICY IF EXISTS "p_vacation_requests_public_delete_553dfc" ON public.vacation_requests;
+DROP POLICY IF EXISTS "p_vacation_requests_public_insert_7548f9" ON public.vacation_requests;
+DROP POLICY IF EXISTS "p_vacation_requests_public_select_69263e" ON public.vacation_requests;
+DROP POLICY IF EXISTS "p_vacation_requests_public_update_1af407" ON public.vacation_requests;
+
+CREATE POLICY vacation_requests_select_scoped
+ON public.vacation_requests
+FOR SELECT
+TO authenticated
+USING (
+  technician_id = auth.uid()
+  OR public.can_manage_technician(technician_id::text)
+);
+
+CREATE POLICY vacation_requests_insert_scoped
+ON public.vacation_requests
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  technician_id = auth.uid()
+  OR public.can_manage_technician(technician_id::text)
+);
+
+CREATE POLICY vacation_requests_update_scoped
+ON public.vacation_requests
+FOR UPDATE
+TO authenticated
+USING (
+  (technician_id = auth.uid() AND status = 'pending')
+  OR public.can_manage_technician(technician_id::text)
+)
+WITH CHECK (
+  technician_id = auth.uid()
+  OR public.can_manage_technician(technician_id::text)
+);
+
+CREATE POLICY vacation_requests_delete_scoped
+ON public.vacation_requests
+FOR DELETE
+TO authenticated
+USING (
+  (technician_id = auth.uid() AND status = 'pending')
+  OR public.can_manage_technician(technician_id::text)
+);
+
+REVOKE ALL ON TABLE public.vacation_requests FROM anon;
+
+-- ---------------------------------------------------------------------------
+-- External API quota ledger (service-role only)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.external_api_usage (
+  id bigint GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+  actor_id uuid NOT NULL,
+  service text NOT NULL,
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  request_date date NOT NULL DEFAULT ((now() AT TIME ZONE 'UTC')::date),
+  CONSTRAINT external_api_usage_service_check
+    CHECK (char_length(service) BETWEEN 1 AND 80)
+);
+
+CREATE INDEX IF NOT EXISTS external_api_usage_actor_service_date_idx
+ON public.external_api_usage (actor_id, service, request_date);
+
+ALTER TABLE public.external_api_usage ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.external_api_usage FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.external_api_usage TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE public.external_api_usage_id_seq TO service_role;
+
+CREATE POLICY external_api_usage_service_role_all
+ON public.external_api_usage
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE OR REPLACE FUNCTION public.consume_external_api_quota(
+  p_actor_id uuid,
+  p_service text,
+  p_daily_limit integer
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_usage_count integer;
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_actor_id IS NULL
+     OR NULLIF(trim(p_service), '') IS NULL
+     OR p_daily_limit < 1 THEN
+    RAISE EXCEPTION 'Invalid external API quota request';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(p_actor_id::text || ':' || p_service, 0)
+  );
+
+  SELECT count(*)::integer
+  INTO v_usage_count
+  FROM public.external_api_usage usage
+  WHERE usage.actor_id = p_actor_id
+    AND usage.service = p_service
+    AND usage.request_date = (now() AT TIME ZONE 'UTC')::date;
+
+  IF v_usage_count >= p_daily_limit THEN
+    RETURN false;
+  END IF;
+
+  INSERT INTO public.external_api_usage (actor_id, service)
+  VALUES (p_actor_id, p_service);
+
+  RETURN true;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.consume_external_api_quota(uuid, text, integer)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.consume_external_api_quota(uuid, text, integer)
+TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Remove caller-controlled payout authorization and qualify every identifier.
+-- ---------------------------------------------------------------------------
+
+DROP FUNCTION IF EXISTS public.get_job_total_amounts(uuid, text);
+
+CREATE OR REPLACE FUNCTION public.get_job_total_amounts(_job_id uuid)
+RETURNS TABLE(
+  job_id uuid,
+  total_approved_eur numeric,
+  total_pending_eur numeric,
+  pending_item_count integer,
+  breakdown_by_category json,
+  individual_amounts json,
+  user_can_see_all boolean,
+  expenses_total_eur numeric,
+  expenses_pending_eur numeric,
+  expenses_breakdown json
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_role text;
+  v_user_can_see_all boolean := false;
+  v_can_view boolean := false;
+  v_timesheets_pending_count integer := 0;
+  v_timesheets_pending_amount numeric := 0;
+  v_timesheets_total numeric := 0;
+  v_extras_total numeric := 0;
+  v_expenses_total numeric := 0;
+  v_expenses_pending_amount numeric := 0;
+  v_expenses_pending_count integer := 0;
+  v_breakdown jsonb := '{}'::jsonb;
+  v_individual jsonb := '[]'::jsonb;
+  v_expense_breakdown jsonb := '[]'::jsonb;
+BEGIN
+  IF _job_id IS NULL THEN
+    RAISE EXCEPTION 'Job id is required';
+  END IF;
+
+  IF auth.role() = 'service_role' THEN
+    v_role := 'admin';
+  ELSE
+    IF v_actor IS NULL THEN
+      RAISE EXCEPTION 'Authentication required to view job totals'
+        USING ERRCODE = '42501';
+    END IF;
+
+    SELECT lower(p.role::text)
+    INTO v_role
+    FROM public.profiles p
+    WHERE p.id = v_actor;
+  END IF;
+
+  v_user_can_see_all := v_role IN ('admin', 'management', 'logistics');
+  v_can_view := v_user_can_see_all OR EXISTS (
+    SELECT 1
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id
+      AND ja.technician_id = v_actor
+  );
+
+  IF NOT v_can_view THEN
+    RAISE EXCEPTION 'Not authorized to view totals for job %', _job_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT
+    COALESCE(SUM(payout.timesheets_total_eur), 0),
+    COALESCE(SUM(payout.extras_total_eur), 0),
+    COALESCE(SUM(payout.expenses_total_eur), 0),
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'technician_id', payout.technician_id,
+          'expenses_breakdown', payout.expenses_breakdown
+        )
+      ),
+      '[]'::jsonb
+    )
+  INTO v_timesheets_total, v_extras_total, v_expenses_total, v_expense_breakdown
+  FROM public.v_job_tech_payout_2025 payout
+  WHERE payout.job_id = _job_id
+    AND (v_user_can_see_all OR payout.technician_id = v_actor);
+
+  SELECT
+    COALESCE(SUM(CASE WHEN t.status = 'submitted' THEN t.amount_eur ELSE 0 END), 0),
+    COUNT(*) FILTER (WHERE t.status = 'submitted')
+  INTO v_timesheets_pending_amount, v_timesheets_pending_count
+  FROM public.timesheets t
+  WHERE t.job_id = _job_id
+    AND COALESCE(t.is_active, true)
+    AND (v_user_can_see_all OR t.technician_id = v_actor);
+
+  SELECT jsonb_object_agg(categories.cat, jsonb_build_object(
+    'count', categories.cnt,
+    'total_eur', categories.total
+  ))
+  INTO v_breakdown
+  FROM (
+    SELECT
+      COALESCE(t.category, 'uncategorized') AS cat,
+      COUNT(*) AS cnt,
+      COALESCE(SUM(t.amount_eur), 0) AS total
+    FROM public.timesheets t
+    WHERE t.job_id = _job_id
+      AND t.status = 'approved'
+      AND COALESCE(t.is_active, true)
+      AND (v_user_can_see_all OR t.technician_id = v_actor)
+    GROUP BY COALESCE(t.category, 'uncategorized')
+  ) AS categories;
+
+  IF v_user_can_see_all THEN
+    SELECT COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'technician_name', COALESCE(
+            NULLIF(trim(COALESCE(p.first_name || ' ' || p.last_name, '')), ''),
+            p.nickname,
+            p.email,
+            'Sin nombre'
+          ),
+          'category', COALESCE(t.category, 'uncategorized'),
+          'amount_eur', COALESCE(t.amount_eur, 0),
+          'date', t.date
+        )
+        ORDER BY t.date DESC
+      ),
+      '[]'::jsonb
+    )
+    INTO v_individual
+    FROM public.timesheets t
+    LEFT JOIN public.profiles p ON p.id = t.technician_id
+    WHERE t.job_id = _job_id
+      AND t.status = 'approved'
+      AND COALESCE(t.is_active, true);
+  END IF;
+
+  SELECT
+    COALESCE(SUM(expenses.submitted_total_eur), 0),
+    COALESCE(SUM((expenses.status_counts->>'submitted')::int), 0)
+  INTO v_expenses_pending_amount, v_expenses_pending_count
+  FROM public.v_job_expense_summary expenses
+  WHERE expenses.job_id = _job_id
+    AND (v_user_can_see_all OR expenses.technician_id = v_actor);
+
+  RETURN QUERY
+  SELECT
+    _job_id,
+    ROUND(v_timesheets_total + v_extras_total + v_expenses_total, 2),
+    ROUND(v_timesheets_pending_amount + v_expenses_pending_amount, 2),
+    v_timesheets_pending_count + v_expenses_pending_count,
+    COALESCE(v_breakdown, '{}'::jsonb)::json,
+    COALESCE(v_individual, '[]'::jsonb)::json,
+    v_user_can_see_all,
+    ROUND(v_expenses_total, 2),
+    ROUND(v_expenses_pending_amount, 2),
+    COALESCE(v_expense_breakdown, '[]'::jsonb)::json;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_job_total_amounts(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_job_total_amounts(uuid) TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- Production database lint repairs
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.auto_complete_past_jobs()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  updated_count integer;
+  job_ids uuid[];
+  ts_ids uuid[];
+  ts_id uuid;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  WITH updated AS (
+    UPDATE public.jobs j
+    SET status = 'Completado'::public.job_status
+    WHERE now() >= (
+            date_trunc(
+              'day',
+              (j.end_time AT TIME ZONE COALESCE(j.timezone, 'Europe/Madrid'))
+              + interval '7 days'
+            ) AT TIME ZONE COALESCE(j.timezone, 'Europe/Madrid')
+          )
+      AND j.status NOT IN (
+        'Cancelado'::public.job_status,
+        'Completado'::public.job_status
+      )
+    RETURNING j.id
+  )
+  SELECT array_agg(updated.id), count(*)::integer
+  INTO job_ids, updated_count
+  FROM updated;
+
+  IF job_ids IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  SELECT array_agg(updated_timesheets.id)
+  INTO ts_ids
+  FROM (
+    UPDATE public.timesheets t
+    SET start_time = COALESCE(t.start_time, '09:00'::time),
+        end_time = COALESCE(t.end_time, '17:00'::time),
+        break_minutes = COALESCE(t.break_minutes, 0),
+        ends_next_day = COALESCE(t.ends_next_day, false)
+    WHERE t.job_id = ANY(job_ids)
+      AND t.is_active = true
+      AND (
+        t.start_time IS NULL
+        OR t.end_time IS NULL
+        OR t.break_minutes IS NULL
+        OR t.ends_next_day IS NULL
+      )
+    RETURNING t.id
+  ) updated_timesheets;
+
+  IF ts_ids IS NOT NULL THEN
+    FOREACH ts_id IN ARRAY ts_ids LOOP
+      PERFORM public.compute_timesheet_amount_2025(ts_id, true);
+    END LOOP;
+  END IF;
+
+  RETURN updated_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.auto_complete_past_jobs() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.auto_complete_past_jobs() TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.get_timesheet_effective_rate(_timesheet_id uuid)
+RETURNS TABLE(
+  timesheet_id uuid,
+  category text,
+  technician_id uuid,
+  base_day_default numeric,
+  plus_10_12_default numeric,
+  overtime_default numeric,
+  base_day_override numeric,
+  plus_10_12_override numeric,
+  overtime_override numeric
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF auth.role() <> 'service_role'
+     AND NOT public.is_admin_or_management()
+     AND NOT EXISTS (
+       SELECT 1
+       FROM public.timesheets owned
+       WHERE owned.id = _timesheet_id
+         AND owned.technician_id = auth.uid()
+     ) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    t.id,
+    t.category,
+    t.technician_id,
+    rc.base_day_eur,
+    rc.plus_10_12_eur,
+    rc.overtime_hour_eur,
+    CASE
+      WHEN t.category = 'responsable' THEN COALESCE(
+        ctr.base_day_responsable_eur,
+        ctr.base_day_especialista_eur,
+        ctr.base_day_eur
+      )
+      WHEN t.category = 'especialista' THEN COALESCE(
+        ctr.base_day_especialista_eur,
+        ctr.base_day_eur
+      )
+      ELSE ctr.base_day_eur
+    END,
+    ctr.plus_10_12_eur,
+    CASE
+      WHEN t.category = 'responsable' THEN COALESCE(
+        ctr.overtime_hour_responsable_eur,
+        ctr.overtime_hour_especialista_eur,
+        ctr.overtime_hour_eur
+      )
+      WHEN t.category = 'especialista' THEN COALESCE(
+        ctr.overtime_hour_especialista_eur,
+        ctr.overtime_hour_eur
+      )
+      ELSE ctr.overtime_hour_eur
+    END
+  FROM public.timesheets t
+  LEFT JOIN public.rate_cards_2025 rc ON rc.category = t.category
+  LEFT JOIN public.custom_tech_rates ctr ON ctr.profile_id = t.technician_id
+  WHERE t.id = _timesheet_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_timesheet_effective_rate(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_timesheet_effective_rate(uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.find_declined_with_active_timesheets()
+RETURNS TABLE(
+  job_id uuid,
+  technician_id uuid,
+  assignment_status text,
+  active_timesheet_count bigint
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF auth.role() <> 'service_role' AND NOT public.is_admin_or_management() THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    ja.job_id,
+    ja.technician_id,
+    ja.status::text,
+    COUNT(ts.date)::bigint
+  FROM public.job_assignments ja
+  JOIN public.timesheets ts
+    ON ts.job_id = ja.job_id
+   AND ts.technician_id = ja.technician_id
+  WHERE ja.status::text = 'declined'
+    AND ts.is_active = true
+  GROUP BY ja.job_id, ja.technician_id, ja.status;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.find_declined_with_active_timesheets() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.find_declined_with_active_timesheets() TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- SECURITY DEFINER execution grants
+-- ---------------------------------------------------------------------------
+
+REVOKE ALL ON FUNCTION public.log_activity_as(
+  uuid, text, uuid, text, text, jsonb, public.activity_visibility
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.log_activity_as(
+  uuid, text, uuid, text, text, jsonb, public.activity_visibility
+) TO service_role;
+
+REVOKE ALL ON FUNCTION public.log_activity(
+  text, uuid, text, text, jsonb, public.activity_visibility
+) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.log_activity(
+  text, uuid, text, text, jsonb, public.activity_visibility
+) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.clear_tour_preset_assignments(uuid, uuid)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.clear_tour_preset_assignments(uuid, uuid)
+TO service_role;
+
+REVOKE ALL ON FUNCTION public.sync_preset_assignments_for_tour(uuid, uuid)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sync_preset_assignments_for_tour(uuid, uuid)
+TO service_role;
+
+REVOKE ALL ON FUNCTION public.invoke_scheduled_push_notification(text)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.invoke_scheduled_push_notification(text)
+TO service_role;
+
+REVOKE ALL ON FUNCTION public.get_tour_complete_timeline(uuid)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_tour_complete_timeline(uuid)
+TO service_role;
+
+REVOKE ALL ON FUNCTION public.get_tour_date_complete_info(uuid)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_tour_date_complete_info(uuid)
+TO service_role;
+
+CREATE OR REPLACE FUNCTION public.get_user_job_ids(user_uuid uuid)
+RETURNS TABLE(job_id uuid)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT DISTINCT ja.job_id
+  FROM public.job_assignments ja
+  WHERE ja.technician_id = user_uuid
+    AND (
+      auth.role() = 'service_role'
+      OR user_uuid = auth.uid()
+      OR public.is_admin_or_management()
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.get_user_job_ids(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_user_job_ids(uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.upsert_venue(
+  p_name text,
+  p_google_place_id text,
+  p_city text,
+  p_state_region text,
+  p_country text,
+  p_full_address text DEFAULT NULL,
+  p_coordinates jsonb DEFAULT NULL,
+  p_capacity integer DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_venue_id uuid;
+  v_role text;
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    SELECT p.role::text
+    INTO v_role
+    FROM public.profiles p
+    WHERE p.id = auth.uid();
+
+    IF v_role NOT IN ('admin', 'management', 'house_tech', 'technician', 'logistics') THEN
+      RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF NULLIF(trim(p_name), '') IS NULL
+     OR NULLIF(trim(p_city), '') IS NULL
+     OR NULLIF(trim(p_country), '') IS NULL THEN
+    RAISE EXCEPTION 'Venue name, city and country are required';
+  END IF;
+
+  IF p_google_place_id IS NOT NULL THEN
+    SELECT v.id
+    INTO v_venue_id
+    FROM public.venues v
+    WHERE v.google_place_id = p_google_place_id;
+  END IF;
+
+  IF v_venue_id IS NOT NULL THEN
+    UPDATE public.venues v
+    SET name = p_name,
+        city = p_city,
+        state_region = p_state_region,
+        country = p_country,
+        full_address = COALESCE(p_full_address, v.full_address),
+        coordinates = COALESCE(p_coordinates, v.coordinates),
+        capacity = COALESCE(p_capacity, v.capacity),
+        updated_at = now()
+    WHERE v.id = v_venue_id;
+  ELSE
+    INSERT INTO public.venues (
+      name,
+      google_place_id,
+      city,
+      state_region,
+      country,
+      full_address,
+      coordinates,
+      capacity
+    )
+    VALUES (
+      p_name,
+      p_google_place_id,
+      p_city,
+      p_state_region,
+      p_country,
+      p_full_address,
+      p_coordinates,
+      p_capacity
+    )
+    RETURNING id INTO v_venue_id;
+  END IF;
+
+  RETURN v_venue_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.upsert_venue(
+  text, text, text, text, text, text, jsonb, integer
+) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.upsert_venue(
+  text, text, text, text, text, text, jsonb, integer
+) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.set_expense_permission(
+  uuid, uuid, text, date, date, numeric, numeric, text
+) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.set_expense_permission(
+  uuid, uuid, text, date, date, numeric, numeric, text
+) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.submit_job_expense(
+  uuid, text, date, numeric, text, numeric, text, text, uuid
+) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.submit_job_expense(
+  uuid, text, date, numeric, text, numeric, text, text, uuid
+) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.set_technician_payout_override(uuid, uuid, numeric)
+FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.set_technician_payout_override(uuid, uuid, numeric)
+TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.remove_technician_payout_override(uuid, uuid)
+FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.remove_technician_payout_override(uuid, uuid)
+TO authenticated, service_role;

--- a/supabase/migrations/20260623160000_phase0_authorization_hardening.sql
+++ b/supabase/migrations/20260623160000_phase0_authorization_hardening.sql
@@ -81,7 +81,7 @@ BEGIN
       USING ERRCODE = '42501';
   END IF;
 
-  IF v_actor_role NOT IN ('admin', 'management') THEN
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('admin', 'management') THEN
     RAISE EXCEPTION 'Only administrators and management may change privileged profile fields'
       USING ERRCODE = '42501';
   END IF;
@@ -395,6 +395,86 @@ FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.consume_external_api_quota(uuid, text, integer)
 TO service_role;
 
+CREATE OR REPLACE FUNCTION public.consume_external_api_dual_quota(
+  p_user_actor_id uuid,
+  p_user_service text,
+  p_user_daily_limit integer,
+  p_global_actor_id uuid,
+  p_global_service text,
+  p_global_daily_limit integer
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_user_usage_count integer;
+  v_global_usage_count integer;
+  v_user_lock bigint;
+  v_global_lock bigint;
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_user_actor_id IS NULL
+     OR p_global_actor_id IS NULL
+     OR NULLIF(trim(p_user_service), '') IS NULL
+     OR NULLIF(trim(p_global_service), '') IS NULL
+     OR p_user_daily_limit < 1
+     OR p_global_daily_limit < 1 THEN
+    RAISE EXCEPTION 'Invalid external API quota request';
+  END IF;
+
+  v_user_lock := hashtextextended(p_user_actor_id::text || ':' || p_user_service, 0);
+  v_global_lock := hashtextextended(p_global_actor_id::text || ':' || p_global_service, 0);
+
+  IF v_user_lock <= v_global_lock THEN
+    PERFORM pg_advisory_xact_lock(v_user_lock);
+    PERFORM pg_advisory_xact_lock(v_global_lock);
+  ELSE
+    PERFORM pg_advisory_xact_lock(v_global_lock);
+    PERFORM pg_advisory_xact_lock(v_user_lock);
+  END IF;
+
+  SELECT count(*)::integer
+  INTO v_user_usage_count
+  FROM public.external_api_usage usage
+  WHERE usage.actor_id = p_user_actor_id
+    AND usage.service = p_user_service
+    AND usage.request_date = (now() AT TIME ZONE 'UTC')::date;
+
+  SELECT count(*)::integer
+  INTO v_global_usage_count
+  FROM public.external_api_usage usage
+  WHERE usage.actor_id = p_global_actor_id
+    AND usage.service = p_global_service
+    AND usage.request_date = (now() AT TIME ZONE 'UTC')::date;
+
+  IF v_user_usage_count >= p_user_daily_limit
+     OR v_global_usage_count >= p_global_daily_limit THEN
+    RETURN false;
+  END IF;
+
+  INSERT INTO public.external_api_usage (actor_id, service)
+  VALUES
+    (p_user_actor_id, p_user_service),
+    (p_global_actor_id, p_global_service);
+
+  RETURN true;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.consume_external_api_dual_quota(
+  uuid, text, integer, uuid, text, integer
+)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.consume_external_api_dual_quota(
+  uuid, text, integer, uuid, text, integer
+)
+TO service_role;
+
 -- ---------------------------------------------------------------------------
 -- Remove caller-controlled payout authorization and qualify every identifier.
 -- ---------------------------------------------------------------------------
@@ -606,9 +686,7 @@ BEGIN
     RETURN 0;
   END IF;
 
-  SELECT array_agg(updated_timesheets.id)
-  INTO ts_ids
-  FROM (
+  WITH updated_timesheets AS (
     UPDATE public.timesheets t
     SET start_time = COALESCE(t.start_time, '09:00'::time),
         end_time = COALESCE(t.end_time, '17:00'::time),
@@ -623,7 +701,10 @@ BEGIN
         OR t.ends_next_day IS NULL
       )
     RETURNING t.id
-  ) updated_timesheets;
+  )
+  SELECT array_agg(updated_timesheets.id)
+  INTO ts_ids
+  FROM updated_timesheets;
 
   IF ts_ids IS NOT NULL THEN
     FOREACH ts_id IN ARRAY ts_ids LOOP


### PR DESCRIPTION
## Summary

Implements Phase 0 from the enterprise re-audit: closes the confirmed authorization and secret-management blockers, hardens public/service Edge Function exposure, and adds the full enterprise audit + roadmap for follow-up phases.

## What changed

- Added `docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md` with the deep re-audit findings, enterprise-grade exit criteria, ownership model, and phased roadmap.
- Added a Supabase hardening migration that:
  - blocks self-service privilege changes on `profiles` and audits privileged profile changes;
  - scopes technician availability and vacation-request RLS;
  - locks external API quota tracking behind service role, including an atomic user/global quota RPC for Google Places paid calls;
  - derives sensitive job-total authorization from the authenticated session instead of caller-supplied role text;
  - fixes live database lint errors in SQL functions;
  - revokes unsafe `SECURITY DEFINER` function grants.
- Removed browser access to backend Flex credentials by routing Flex reads/mutations through `secure-flex-api`.
- Retired `get-secret` as a browser secret delivery path; it now returns `410` and audits blocked attempts.
- Hardened Google Places functions and corporate-email image cleanup with explicit authentication/service-role checks.
- Made profile department read-only in self-service profile UI.
- Updated related tests, Supabase config/types, and Flex proxy callers.
- Addressed CodeRabbit feedback around non-idempotent Flex write retries, malformed upstream JSON handling, quota atomicity, SQL syntax, NULL-role authorization, canonical imports, and audit metric clarity.

## Validation

- `npm install --legacy-peer-deps`
- `npm run typecheck`
- `npm run lint` — pass with existing 405-warning baseline
- `npm run test:run` — 169 files / 997 tests pass
- `npm run build`
- `npm run cap:sync`
- `npm run lint:functions`
- `npx vitest run supabase/functions/get-secret/__tests__/handler.test.ts src/components/project-management/apiService.test.ts src/utils/flex-folders/__tests__/buildFlexUrl.test.ts src/utils/flex-folders/__tests__/resolveFlexUrl.test.ts src/utils/flex-folders/__tests__/flexUrlResolver.test.ts` — 5 files / 32 tests pass
- `supabase db push --linked --dry-run` — pending migration detected as expected
- `git diff --check`
- Browser-side grep for `get-secret` / Flex secret delivery — clean; remaining Flex token reads are server-side Edge Functions only

## Deployment note

This PR includes `supabase/migrations/20260623160000_phase0_authorization_hardening.sql`. Per the production workflow, apply the linked production Supabase migration after CI and CodeRabbit are clean and before merging.
