### PR TITLE
feat(security): migrate user admin edge handlers

### DIFF
--- a/docs/operations/phase-2-trust-boundary-hardening.md
+++ b/docs/operations/phase-2-trust-boundary-hardening.md
@@ -110,11 +110,12 @@ These are covered by unit tests in `supabase/functions/_shared/http.test.ts`.
 
 ## Follow-up (not in this change)
 
-- Migrate the priority privileged Edge Functions (user admin, staffing,
-  payouts/expenses, Flex mutations, WhatsApp/email, document access) onto
+- Migrate the priority privileged Edge Functions (staffing, payouts/expenses,
+  Flex mutations, WhatsApp/email, document access) onto
   `createHttpHandler` plus the shared correlation/redaction/size-limit
   primitives. The grandfather baseline in `edge-function-baseline.json` still
-  lists these.
+  lists these. User-admin functions (`create-user`, `delete-user`) were
+  migrated on 2026-06-23 as the first follow-up slice.
 - Add durable, storage-backed rate limiting for public-token endpoints.
 - Continue ratcheting the `anon`/`PUBLIC` grant baseline downward (trigger
   functions can be revoked from `anon` without behavioral impact).

--- a/scripts/governance/edge-function-baseline.json
+++ b/scripts/governance/edge-function-baseline.json
@@ -44,11 +44,6 @@
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "create-user",
-      "path": "supabase/functions/create-user/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "create-whatsapp-group",
       "path": "supabase/functions/create-whatsapp-group/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
@@ -56,11 +51,6 @@
     {
       "functionName": "delete-public-artist-rider",
       "path": "supabase/functions/delete-public-artist-rider/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "delete-user",
-      "path": "supabase/functions/delete-user/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {

--- a/supabase/functions/create-user/index.ts
+++ b/supabase/functions/create-user/index.ts
@@ -1,193 +1,245 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Max-Age': '86400',
+import {
+  correlationHeaders,
+  createHttpHandler,
+  getCorrelationId,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  redactSensitiveValues,
+  requireBearerToken,
+  requireEnvValues,
+} from "../_shared/http.ts";
+
+type CreateUserBody = Record<string, unknown> & {
+  email?: unknown;
+  firstName?: unknown;
+  nickname?: unknown;
+  lastName?: unknown;
+  department?: unknown;
+  phone?: unknown;
+  dni?: unknown;
+  residencia?: unknown;
+  role?: unknown;
+  flex_resource_id?: unknown;
 };
 
-interface CreateUserBody {
-  email: string;
-  firstName: string;
-  nickname?: string;
-  lastName: string;
-  department?: string;
-  phone?: string;
-  dni?: string;
-  residencia?: string;
-  role?: string; // optional; defaults handled by DB
-  flex_resource_id?: string; // optional Flex contact id
+type ErrorLike = {
+  code?: unknown;
+  message?: unknown;
+  status?: unknown;
 }
 
-const jsonResponse = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), {
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-  });
+const MAX_CREATE_USER_BODY_BYTES = 16 * 1024;
+const ADMIN_ROLES = new Set(["admin", "management"]);
 
-const normalizeOptional = (value?: string) => {
-  const normalized = value?.trim();
+const normalizeOptional = (value: unknown) => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim();
   return normalized ? normalized : undefined;
 };
 
-const getErrorStatus = (error: unknown) => {
-  const status = Number((error as { status?: number })?.status);
-  return Number.isInteger(status) && status >= 400 && status < 600 ? status : 400;
+const requireText = (value: unknown) => normalizeOptional(value);
+
+const getErrorObject = (error: unknown): ErrorLike =>
+  error && typeof error === "object" ? error as ErrorLike : {};
+
+const getErrorStatus = (error: unknown, fallbackStatus = 502) => {
+  const status = Number(getErrorObject(error).status);
+  return Number.isInteger(status) && status >= 400 && status < 600 ? status : fallbackStatus;
+};
+
+const getErrorCode = (error: unknown) => {
+  const code = getErrorObject(error).code;
+  return typeof code === "string" && code.trim() ? code.trim() : undefined;
+};
+
+const getErrorMessage = (error: unknown) => {
+  const message = getErrorObject(error).message;
+  return typeof message === "string" && message.trim() ? message.trim() : undefined;
 };
 
 const isEmailExistsError = (error: unknown) => {
-  const candidate = error as { code?: string; message?: string; status?: number };
-  const message = candidate?.message?.toLowerCase() ?? '';
+  const candidate = getErrorObject(error);
+  const message = typeof candidate.message === "string" ? candidate.message.toLowerCase() : "";
   return (
-    candidate?.code === 'email_exists' ||
-    (candidate?.status === 422 && message.includes('already') && message.includes('registered')) ||
-    (message.includes('email') && (message.includes('already') || message.includes('exists')))
+    candidate.code === "email_exists" ||
+    (candidate.status === 422 && message.includes("already") && message.includes("registered")) ||
+    (message.includes("email") && (message.includes("already") || message.includes("exists")))
   );
 };
 
-const duplicateEmailResponse = () =>
+const duplicateEmailResponse = (headers: Record<string, string>) =>
   jsonResponse(
     {
-      error: 'A user with this email address has already been registered',
-      code: 'email_exists',
+      error: "A user with this email address has already been registered",
+      code: "email_exists",
     },
-    409,
+    { status: 409, headers },
   );
 
-serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+const failAuthLookup = () => {
+  throw new HttpError(500, "Authorization lookup failed", {
+    code: "authorization_lookup_failed",
+    exposeDetails: false,
+  });
+};
 
-  if (req.method !== 'POST') {
-    return jsonResponse({ error: 'Method not allowed' }, 405);
-  }
+serve(createHttpHandler(async (req) => {
+  const correlationId = getCorrelationId(req);
+  const headers = correlationHeaders(correlationId);
+  const respond = (body: unknown, status = 200) => jsonResponse(body, { status, headers });
 
-  try {
-    let body: CreateUserBody;
-    try {
-      body = await req.json() as CreateUserBody;
-    } catch {
-      return jsonResponse({ error: 'Invalid JSON body' }, 400);
-    }
+  const body = await readBoundedJsonObject<CreateUserBody>(req, {
+    maxBytes: MAX_CREATE_USER_BODY_BYTES,
+  });
 
-    const email = body?.email?.trim().toLowerCase();
-    const firstName = body?.firstName?.trim();
-    const lastName = body?.lastName?.trim();
+  const email = requireText(body.email)?.toLowerCase();
+  const firstName = requireText(body.firstName);
+  const lastName = requireText(body.lastName);
 
-    if (!email || !firstName || !lastName) {
-      return jsonResponse({ error: 'Missing required fields' }, 400);
-    }
-
-    const supabaseAdmin = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-    );
-
-    // AuthN of requester
-    const authHeader = req.headers.get('Authorization') ?? req.headers.get('authorization');
-    if (!authHeader) {
-      return jsonResponse({ error: 'Unauthorized' }, 401);
-    }
-
-    const token = authHeader.replace('Bearer ', '').trim();
-    const { data: { user: requestingUser } } = await supabaseAdmin.auth.getUser(
-      token
-    );
-
-    if (!requestingUser) {
-      return jsonResponse({ error: 'Unauthorized' }, 401);
-    }
-
-    // AuthZ: require admin or management
-    const { data: requesterProfile, error: profileErr } = await supabaseAdmin
-      .from('profiles')
-      .select('role')
-      .eq('id', requestingUser.id)
-      .maybeSingle();
-
-    if (profileErr) throw profileErr;
-    if (!requesterProfile || !['admin', 'management'].includes(requesterProfile.role)) {
-      return jsonResponse({ error: 'Unauthorized' }, 403);
-    }
-
-    const { data: existingProfile, error: existingProfileErr } = await supabaseAdmin
-      .from('profiles')
-      .select('id')
-      .eq('email', email)
-      .maybeSingle();
-
-    if (existingProfileErr) throw existingProfileErr;
-    if (existingProfile) {
-      return duplicateEmailResponse();
-    }
-
-    const role = normalizeOptional(body.role) ?? 'technician';
-    const nickname = normalizeOptional(body.nickname);
-    const department = normalizeOptional(body.department);
-    const phone = normalizeOptional(body.phone);
-    const dni = normalizeOptional(body.dni);
-    const residencia = normalizeOptional(body.residencia);
-    const flexResourceId = normalizeOptional(body.flex_resource_id);
-
-    // Create auth user with a random throwaway password. It is never disclosed:
-    // the user sets their real password via the "Olvidé mi contraseña" reset flow.
-    const tempPassword = crypto.randomUUID();
-    const { data: authData, error: authError } = await supabaseAdmin.auth.admin.createUser({
-      email,
-      password: tempPassword,
-      email_confirm: true,
-      user_metadata: {
-        first_name: firstName,
-        nickname,
-        last_name: lastName,
-        phone,
-        department,
-        dni,
-        residencia,
-        needs_password_change: true,
-      },
+  if (!email || !firstName || !lastName) {
+    throw new HttpError(400, "Missing required fields", {
+      code: "missing_required_fields",
     });
-
-    if (authError) {
-      if (isEmailExistsError(authError)) {
-        return duplicateEmailResponse();
-      }
-      throw authError;
-    }
-
-    const { error: profileUpsertErr } = await supabaseAdmin
-      .from('profiles')
-      .upsert({
-        id: authData.user.id,
-        email,
-        first_name: firstName,
-        last_name: lastName,
-        phone,
-        department,
-        dni,
-        residencia,
-        role,
-        nickname,
-        flex_resource_id: flexResourceId,
-      }, { onConflict: 'id' });
-
-    if (profileUpsertErr) {
-      const { error: rollbackErr } = await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
-      if (rollbackErr) {
-        console.error('create-user rollback error:', rollbackErr);
-      }
-      throw profileUpsertErr;
-    }
-
-    return jsonResponse({ id: authData.user.id, email: authData.user.email });
-  } catch (error) {
-    console.error('create-user error:', error);
-    return jsonResponse({
-      error: (error as any).message ?? 'Unexpected error',
-      code: (error as any).code,
-    }, getErrorStatus(error));
   }
-});
+
+  const {
+    SUPABASE_URL: supabaseUrl,
+    SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+  const token = requireBearerToken(req);
+  const { data: { user: requestingUser }, error: userError } = await supabaseAdmin.auth.getUser(token);
+
+  if (userError || !requestingUser) {
+    throw new HttpError(401, "Unauthorized", { code: "invalid_authorization" });
+  }
+
+  const { data: requesterProfile, error: profileErr } = await supabaseAdmin
+    .from("profiles")
+    .select("role")
+    .eq("id", requestingUser.id)
+    .maybeSingle();
+
+  if (profileErr) {
+    failAuthLookup();
+  }
+
+  const requesterRole = typeof requesterProfile?.role === "string"
+    ? requesterProfile.role.toLowerCase()
+    : "";
+
+  if (!ADMIN_ROLES.has(requesterRole)) {
+    throw new HttpError(403, "Unauthorized", { code: "insufficient_role" });
+  }
+
+  const { data: existingProfile, error: existingProfileErr } = await supabaseAdmin
+    .from("profiles")
+    .select("id")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (existingProfileErr) {
+    throw new HttpError(500, "User lookup failed", {
+      code: "user_lookup_failed",
+      exposeDetails: false,
+    });
+  }
+
+  if (existingProfile) {
+    return duplicateEmailResponse(headers);
+  }
+
+  const role = normalizeOptional(body.role) ?? "technician";
+  const nickname = normalizeOptional(body.nickname);
+  const department = normalizeOptional(body.department);
+  const phone = normalizeOptional(body.phone);
+  const dni = normalizeOptional(body.dni);
+  const residencia = normalizeOptional(body.residencia);
+  const flexResourceId = normalizeOptional(body.flex_resource_id);
+
+  // Create auth user with a random throwaway password. It is never disclosed:
+  // the user sets their real password via the "Olvidé mi contraseña" reset flow.
+  const tempPassword = crypto.randomUUID();
+  const { data: authData, error: authError } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password: tempPassword,
+    email_confirm: true,
+    user_metadata: {
+      first_name: firstName,
+      nickname,
+      last_name: lastName,
+      phone,
+      department,
+      dni,
+      residencia,
+      needs_password_change: true,
+    },
+  });
+
+  if (authError) {
+    if (isEmailExistsError(authError)) {
+      return duplicateEmailResponse(headers);
+    }
+
+    const status = getErrorStatus(authError);
+    throw new HttpError(status, status < 500 ? getErrorMessage(authError) ?? "Failed to create user" : "Failed to create user", {
+      code: getErrorCode(authError) ?? "create_user_failed",
+      exposeDetails: status < 500,
+    });
+  }
+
+  if (!authData.user?.id) {
+    throw new HttpError(502, "Failed to create user", {
+      code: "missing_created_user",
+      exposeDetails: false,
+    });
+  }
+
+  const { error: profileUpsertErr } = await supabaseAdmin
+    .from("profiles")
+    .upsert({
+      id: authData.user.id,
+      email,
+      first_name: firstName,
+      last_name: lastName,
+      phone,
+      department,
+      dni,
+      residencia,
+      role,
+      nickname,
+      flex_resource_id: flexResourceId,
+    }, { onConflict: "id" });
+
+  if (profileUpsertErr) {
+    const { error: rollbackErr } = await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+    if (rollbackErr) {
+      console.error("create-user rollback error:", redactSensitiveValues({ correlationId, error: rollbackErr }));
+    }
+
+    throw new HttpError(500, "Failed to create profile", {
+      code: "profile_upsert_failed",
+      exposeDetails: false,
+    });
+  }
+
+  return respond({ id: authData.user.id, email: authData.user.email });
+}, {
+  allowedMethods: ["POST"],
+  internalErrorMessage: "Unexpected error",
+  onError: (error, req) => {
+    console.error("create-user error:", redactSensitiveValues({
+      correlationId: getCorrelationId(req),
+      error,
+    }));
+  },
+}));

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,97 +1,118 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
-import { corsHeaders, jsonResponse } from "../_shared/http.ts";
+import {
+  correlationHeaders,
+  createHttpHandler,
+  getCorrelationId,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  redactSensitiveValues,
+  requireBearerToken,
+  requireEnvValues,
+} from "../_shared/http.ts";
 
-serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
+type DeleteUserBody = Record<string, unknown> & {
+  userId?: unknown;
+};
+
+const MAX_DELETE_USER_BODY_BYTES = 8 * 1024;
+const ADMIN_ROLES = new Set(["admin", "management"]);
+
+const normalizeRequiredText = (value: unknown) => {
+  if (typeof value !== "string") {
+    return undefined;
   }
 
-  if (req.method !== 'POST') {
-    return jsonResponse({ error: 'Method not allowed' }, 405);
+  const normalized = value.trim();
+  return normalized ? normalized : undefined;
+};
+
+serve(createHttpHandler(async (req) => {
+  const correlationId = getCorrelationId(req);
+  const headers = correlationHeaders(correlationId);
+  const respond = (body: unknown, status = 200) => jsonResponse(body, { status, headers });
+
+  const { userId: rawUserId } = await readBoundedJsonObject<DeleteUserBody>(req, {
+    maxBytes: MAX_DELETE_USER_BODY_BYTES,
+  });
+  const userId = normalizeRequiredText(rawUserId);
+
+  if (!userId) {
+    throw new HttpError(400, "User ID is required", { code: "missing_user_id" });
   }
 
-  try {
-    let userId: string | undefined;
-    try {
-      ({ userId } = await req.json());
-    } catch {
-      return jsonResponse({ error: 'Invalid JSON body' }, 400);
-    }
+  const {
+    SUPABASE_URL: supabaseUrl,
+    SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
 
-    if (!userId) {
-      return jsonResponse({ error: 'User ID is required' }, 400);
-    }
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 
-    const supabaseAdmin = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
-    );
-
-    // AuthN of requester
-    const authHeader = req.headers.get('Authorization') ?? req.headers.get('authorization');
-    if (!authHeader) {
-      return jsonResponse({ error: 'Unauthorized' }, 401);
-    }
-
-    const token = authHeader.replace('Bearer ', '').trim();
-    const { data: { user: requestingUser } } = await supabaseAdmin.auth.getUser(token);
-    if (!requestingUser) {
-      return jsonResponse({ error: 'Unauthorized' }, 401);
-    }
-
-    // AuthZ: require admin or management
-    const { data: requesterProfile, error: profileErr } = await supabaseAdmin
-      .from('profiles')
-      .select('role')
-      .eq('id', requestingUser.id)
-      .maybeSingle();
-
-    if (profileErr) throw profileErr;
-    if (!requesterProfile || !['admin', 'management'].includes(requesterProfile.role)) {
-      return jsonResponse({ error: 'Unauthorized - admin or management role required' }, 403);
-    }
-
-    // Guard against self-deletion (would orphan the requester's own session/audit trail)
-    if (userId === requestingUser.id) {
-      return jsonResponse({ error: 'You cannot delete your own account' }, 400);
-    }
-
-    // Confirm the target exists for a clear 404 instead of a silent success
-    const { data: targetUser, error: getErr } = await supabaseAdmin.auth.admin.getUserById(userId);
-    if (getErr || !targetUser?.user) {
-      return jsonResponse({ error: 'User not found' }, 404);
-    }
-
-    console.log('Deleting user:', userId, 'requested by:', requestingUser.id);
-
-    // Deleting from auth.users cascades to profiles and, via the normalized
-    // ON DELETE rules, to all dependent records.
-    const { error: deleteError } = await supabaseAdmin.auth.admin.deleteUser(userId);
-
-    if (deleteError) {
-      console.error('Error deleting user:', deleteError);
-      // Surface the underlying reason (e.g. a foreign-key still blocking the
-      // delete) rather than a generic 400, so it is actionable.
-      return jsonResponse(
-        {
-          error: 'Failed to delete user',
-          details: deleteError.message,
-          code: (deleteError as { code?: string }).code,
-        },
-        502,
-      );
-    }
-
-    return jsonResponse({ message: 'User deleted successfully' });
-  } catch (error) {
-    console.error('Error in delete-user function:', error);
-    return jsonResponse(
-      {
-        error: 'Unexpected error',
-        details: (error as Error).message,
-      },
-      500,
-    );
+  const token = requireBearerToken(req);
+  const { data: { user: requestingUser }, error: userError } = await supabaseAdmin.auth.getUser(token);
+  if (userError || !requestingUser) {
+    throw new HttpError(401, "Unauthorized", { code: "invalid_authorization" });
   }
-});
+
+  const { data: requesterProfile, error: profileErr } = await supabaseAdmin
+    .from("profiles")
+    .select("role")
+    .eq("id", requestingUser.id)
+    .maybeSingle();
+
+  if (profileErr) {
+    throw new HttpError(500, "Authorization lookup failed", {
+      code: "authorization_lookup_failed",
+      exposeDetails: false,
+    });
+  }
+
+  const requesterRole = typeof requesterProfile?.role === "string"
+    ? requesterProfile.role.toLowerCase()
+    : "";
+
+  if (!ADMIN_ROLES.has(requesterRole)) {
+    throw new HttpError(403, "Unauthorized - admin or management role required", {
+      code: "insufficient_role",
+    });
+  }
+
+  // Guard against self-deletion (would orphan the requester's own session/audit trail).
+  if (userId === requestingUser.id) {
+    throw new HttpError(400, "You cannot delete your own account", {
+      code: "self_delete_blocked",
+    });
+  }
+
+  // Confirm the target exists for a clear 404 instead of a silent success.
+  const { data: targetUser, error: getErr } = await supabaseAdmin.auth.admin.getUserById(userId);
+  if (getErr || !targetUser?.user) {
+    throw new HttpError(404, "User not found", { code: "user_not_found" });
+  }
+
+  console.log("Deleting user:", redactSensitiveValues({ correlationId, userId, requestedBy: requestingUser.id }));
+
+  // Deleting from auth.users cascades to profiles and, via the normalized
+  // ON DELETE rules, to all dependent records.
+  const { error: deleteError } = await supabaseAdmin.auth.admin.deleteUser(userId);
+
+  if (deleteError) {
+    console.error("Error deleting user:", redactSensitiveValues({ correlationId, error: deleteError }));
+    throw new HttpError(502, "Failed to delete user", {
+      code: "delete_user_failed",
+      exposeDetails: false,
+    });
+  }
+
+  return respond({ message: "User deleted successfully" });
+}, {
+  allowedMethods: ["POST"],
+  internalErrorMessage: "Unexpected error",
+  onError: (error, req) => {
+    console.error("delete-user error:", redactSensitiveValues({
+      correlationId: getCorrelationId(req),
+      error,
+    }));
+  },
+}));


### PR DESCRIPTION
## Summary
- migrate `create-user` and `delete-user` to `createHttpHandler`
- add shared bounded JSON parsing, bearer token extraction, env validation, correlation headers, structured errors, and redacted error logs
- remove both functions from the legacy Edge Function baseline
- update the Phase 2 operations note with this first follow-up slice

## Validation
- `npm run governance:functions`
- `npm run governance:exposure`
- `npm run governance`
- `npm run lint:functions` (403 warnings, 0 errors; existing baseline reduced by 2)
- `npm run lint` (existing warnings, 0 errors)
- `npm run typecheck`
- `npm run test:run` (169 files / 1002 tests)
- `npm run build`

## Deployment notes
- No Supabase migration in this PR.
- If merged, deploy Edge Functions `create-user` and `delete-user` so production receives the new handler bundles.