### PR TITLE
feat(security): migrate payout edge handlers

### DIFF
--- a/docs/operations/phase-2-trust-boundary-hardening.md
+++ b/docs/operations/phase-2-trust-boundary-hardening.md
@@ -115,7 +115,11 @@ These are covered by unit tests in `supabase/functions/_shared/http.test.ts`.
   `createHttpHandler` plus the shared correlation/redaction/size-limit
   primitives. The grandfather baseline in `edge-function-baseline.json` still
   lists these. User-admin functions (`create-user`, `delete-user`) were
-  migrated on 2026-06-23 as the first follow-up slice.
+  migrated on 2026-06-23 as the first follow-up slice. Payout/expense
+  notification functions (`send-expense-notification`, `send-job-payout-email`,
+  `send-payout-override-notification`) were migrated on 2026-06-23 as the next
+  follow-up slice, including explicit service-role/privileged-role guards and
+  bounded payload parsing.
 - Add durable, storage-backed rate limiting for public-token endpoints.
 - Continue ratcheting the `anon`/`PUBLIC` grant baseline downward (trigger
   functions can be revoked from `anon` without behavioral impact).

--- a/scripts/governance/edge-function-baseline.json
+++ b/scripts/governance/edge-function-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-06-04T17:55:51.218Z",
+  "generatedAt": "2026-06-23T21:57:59.589Z",
   "note": "Existing manual Edge Functions are grandfathered. New functions must use createHttpHandler or add an explicit reviewed exemption.",
   "manualFunctions": [
     {
@@ -159,16 +159,6 @@
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "send-expense-notification",
-      "path": "supabase/functions/send-expense-notification/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "send-job-payout-email",
-      "path": "supabase/functions/send-job-payout-email/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "send-job-whatsapp-message",
       "path": "supabase/functions/send-job-whatsapp-message/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
@@ -181,11 +171,6 @@
     {
       "functionName": "send-password-reset",
       "path": "supabase/functions/send-password-reset/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "send-payout-override-notification",
-      "path": "supabase/functions/send-payout-override-notification/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
@@ -256,11 +241,6 @@
     {
       "functionName": "sync-flex-crew-for-job",
       "path": "supabase/functions/sync-flex-crew-for-job/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "system-health",
-      "path": "supabase/functions/system-health/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {

--- a/scripts/governance/edge-function-exposure.json
+++ b/scripts/governance/edge-function-exposure.json
@@ -45,12 +45,24 @@
     "security-audit": { "class": "privileged-role", "verifyJwt": true },
     "send-bug-resolution-email": { "class": "privileged-role", "verifyJwt": true },
     "send-corporate-email": { "class": "privileged-role", "verifyJwt": true },
-    "send-expense-notification": { "class": "privileged-role", "verifyJwt": true },
-    "send-job-payout-email": { "class": "privileged-role", "verifyJwt": true },
+    "send-expense-notification": {
+      "class": "service-only",
+      "verifyJwt": true,
+      "internalGuard": "Database trigger invokes with the service-role bearer token; function performs a timing-safe compare against SUPABASE_SERVICE_ROLE_KEY before sending."
+    },
+    "send-job-payout-email": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Validates the caller JWT with auth.getUser and requires profiles.role to be admin or management before reading payout overrides or sending email."
+    },
     "send-job-whatsapp-message": { "class": "privileged-role", "verifyJwt": true },
     "send-onboarding-email": { "class": "privileged-role", "verifyJwt": true },
     "send-password-reset": { "class": "privileged-role", "verifyJwt": true },
-    "send-payout-override-notification": { "class": "privileged-role", "verifyJwt": true },
+    "send-payout-override-notification": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Validates the caller JWT with auth.getUser, requires admin/management, and requires payload actorId to match the authenticated user before any service-role reads."
+    },
     "send-staffing-email": { "class": "service-only", "verifyJwt": true },
     "send-timesheet-reminder": { "class": "privileged-role", "verifyJwt": true },
     "send-tour-availability": { "class": "privileged-role", "verifyJwt": true },

--- a/supabase/functions/_shared/http.test.ts
+++ b/supabase/functions/_shared/http.test.ts
@@ -116,6 +116,26 @@ describe("shared Edge Function HTTP helpers", () => {
     }
   });
 
+  it("attaches configured headers to handled error responses", async () => {
+    const wrapped = createHttpHandler(
+      async () => {
+        throw new HttpError(400, "bad request", { code: "bad_request" });
+      },
+      {
+        errorHeaders: (req) => correlationHeaders(getCorrelationId(req)),
+      },
+    );
+
+    const response = await wrapped(new Request("https://example.com", {
+      method: "POST",
+      headers: { "x-correlation-id": "trace-12345" },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("x-correlation-id")).toBe("trace-12345");
+    await expect(response.json()).resolves.toEqual({ error: "bad request", code: "bad_request" });
+  });
+
   it("reuses a well-formed inbound correlation id and generates otherwise", () => {
     const withHeader = new Request("https://example.com", {
       headers: { "x-correlation-id": "abc12345-trace-id" },
@@ -128,6 +148,7 @@ describe("shared Edge Function HTTP helpers", () => {
     const generated = getCorrelationId(malformed);
     expect(generated).not.toBe("bad id!");
     expect(generated.length).toBeGreaterThanOrEqual(8);
+    expect(getCorrelationId(malformed)).toBe(generated);
 
     expect(correlationHeaders("trace-123")).toEqual({ "x-correlation-id": "trace-123" });
   });

--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -126,6 +126,7 @@ export const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
 
 const CORRELATION_HEADER = "x-correlation-id";
 const CORRELATION_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+const generatedCorrelationIds = new WeakMap<Request, string>();
 
 /**
  * Returns a stable correlation id for a request: the inbound `x-correlation-id`
@@ -139,7 +140,14 @@ export function getCorrelationId(req: Request): string {
     return inbound;
   }
 
-  return crypto.randomUUID();
+  const existing = generatedCorrelationIds.get(req);
+  if (existing) {
+    return existing;
+  }
+
+  const generated = crypto.randomUUID();
+  generatedCorrelationIds.set(req, generated);
+  return generated;
 }
 
 /** Returns response headers carrying the correlation id. */
@@ -388,6 +396,7 @@ export function errorResponse(
     fallbackMessage?: string;
     includeDetails?: boolean;
     fallbackStatus?: number;
+    headers?: Record<string, string>;
   } = {},
 ) {
   return jsonResponse(
@@ -395,7 +404,10 @@ export function errorResponse(
       fallbackMessage: options.fallbackMessage,
       includeDetails: options.includeDetails,
     }),
-    { status: getErrorStatus(error, options.fallbackStatus ?? 500) },
+    {
+      status: getErrorStatus(error, options.fallbackStatus ?? 500),
+      headers: options.headers,
+    },
   );
 }
 
@@ -438,6 +450,7 @@ export function createHttpHandler(
     methodNotAllowedStatus?: number;
     methodNotAllowedBody?: unknown;
     onError?: (error: unknown, req: Request) => void;
+    errorHeaders?: (req: Request, error: unknown) => Record<string, string>;
     includeErrorDetails?: boolean;
     internalErrorMessage?: string;
   } = {},
@@ -469,9 +482,17 @@ export function createHttpHandler(
         console.error("createHttpHandler onError callback failed", onErrorFailure);
       }
 
+      let headers: Record<string, string> | undefined;
+      try {
+        headers = options.errorHeaders?.(req, error);
+      } catch (errorHeadersFailure) {
+        console.error("createHttpHandler errorHeaders callback failed", errorHeadersFailure);
+      }
+
       return errorResponse(error, {
         fallbackMessage: options.internalErrorMessage,
         includeDetails: options.includeErrorDetails,
+        headers,
       });
     }
   };

--- a/supabase/functions/send-expense-notification/index.ts
+++ b/supabase/functions/send-expense-notification/index.ts
@@ -115,7 +115,8 @@ serve(createHttpHandler(async (req) => {
   const categoryLabel = typeof payload.category_label === "string" ? payload.category_label.trim() : "";
   const expenseDate = typeof payload.expense_date === "string" ? payload.expense_date : "";
   const status = typeof payload.status === "string" ? payload.status : "updated";
-  const amountEur = Number(payload.amount_eur ?? 0);
+  const parsedAmountEur = Number(payload.amount_eur ?? 0);
+  const amountEur = Number.isFinite(parsedAmountEur) ? parsedAmountEur : 0;
 
   console.log("[send-expense-notification] Incoming payload", JSON.stringify(redactSensitiveValues({
     correlationId,
@@ -290,6 +291,7 @@ serve(createHttpHandler(async (req) => {
 }, {
   allowedMethods: ["POST"],
   internalErrorMessage: "Expense notification failed",
+  errorHeaders: (req) => correlationHeaders(getCorrelationId(req)),
   onError(error, req) {
     console.error("[send-expense-notification] Request failed", JSON.stringify(redactSensitiveValues({
       correlationId: getCorrelationId(req),

--- a/supabase/functions/send-expense-notification/index.ts
+++ b/supabase/functions/send-expense-notification/index.ts
@@ -1,18 +1,21 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+import {
+  correlationHeaders,
+  createHttpHandler,
+  getCorrelationId,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  redactSensitiveValues,
+  requireBearerToken,
+  requireEnvValues,
+} from "../_shared/http.ts";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
 
-const corsHeaders: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-};
+const MAX_EXPENSE_NOTIFICATION_BODY_BYTES = 16 * 1024;
 
-const BREVO_KEY = Deno.env.get("BREVO_API_KEY") ?? "";
-const BREVO_FROM = Deno.env.get("BREVO_FROM") ?? "";
-const EXPENSE_NOTIFICATION_BCC = Deno.env.get("EXPENSE_NOTIFICATION_BCC") ?? "";
-
-interface ExpenseNotificationPayload {
+interface ExpenseNotificationPayload extends Record<string, unknown> {
   expense_id: string;
   job_id: string;
   job_title: string;
@@ -21,14 +24,56 @@ interface ExpenseNotificationPayload {
   category_label: string;
   amount_eur: number;
   expense_date: string;
-  status: 'submitted' | 'approved' | 'rejected';
+  status: "submitted" | "approved" | "rejected" | string;
   rejection_reason?: string;
 }
 
+function timingSafeEqual(left: string, right: string): boolean {
+  const maxLength = Math.max(left.length, right.length);
+  let mismatch = left.length ^ right.length;
+
+  for (let index = 0; index < maxLength; index += 1) {
+    mismatch |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+  }
+
+  return mismatch === 0;
+}
+
+function requireServiceRoleRequest(req: Request, serviceRoleKey: string) {
+  const token = requireBearerToken(req, {
+    message: "Missing service authorization",
+    code: "missing_service_authorization",
+  });
+
+  if (!timingSafeEqual(token, serviceRoleKey)) {
+    throw new HttpError(403, "Forbidden", { code: "service_role_required" });
+  }
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new HttpError(400, "Missing required fields", {
+      code: "missing_required_fields",
+      details: { field: fieldName },
+    });
+  }
+
+  return value.trim();
+}
+
 function formatCurrency(amount: number) {
-  return new Intl.NumberFormat('es-ES', {
-    style: 'currency',
-    currency: 'EUR',
+  return new Intl.NumberFormat("es-ES", {
+    style: "currency",
+    currency: "EUR",
     minimumFractionDigits: 2,
   }).format(amount);
 }
@@ -37,99 +82,93 @@ function formatDate(dateStr: string) {
   try {
     const parsed = new Date(dateStr);
     if (Number.isNaN(parsed.getTime())) return dateStr;
-    return new Intl.DateTimeFormat('es-ES', { dateStyle: 'long' }).format(parsed);
+    return new Intl.DateTimeFormat("es-ES", { dateStyle: "long" }).format(parsed);
   } catch {
     return dateStr;
   }
 }
 
-serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
+serve(createHttpHandler(async (req) => {
+  const correlationId = getCorrelationId(req);
+  const responseHeaders = correlationHeaders(correlationId);
+  const respond = (body: unknown, status = 200) => jsonResponse(body, { status, headers: responseHeaders });
+
+  const {
+    BREVO_API_KEY: brevoKey,
+    BREVO_FROM: brevoFrom,
+    SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+  } = requireEnvValues(
+    ["BREVO_API_KEY", "BREVO_FROM", "SUPABASE_SERVICE_ROLE_KEY"] as const,
+    (name) => Deno.env.get(name),
+  );
+
+  requireServiceRoleRequest(req, serviceRoleKey);
+
+  const payload = await readBoundedJsonObject<ExpenseNotificationPayload>(req, {
+    maxBytes: MAX_EXPENSE_NOTIFICATION_BODY_BYTES,
+  });
+
+  const expenseId = requireString(payload.expense_id, "expense_id");
+  const jobTitle = requireString(payload.job_title, "job_title");
+  const technicianEmail = requireString(payload.technician_email, "technician_email");
+  const technicianName = typeof payload.technician_name === "string" ? payload.technician_name.trim() : "";
+  const categoryLabel = typeof payload.category_label === "string" ? payload.category_label.trim() : "";
+  const expenseDate = typeof payload.expense_date === "string" ? payload.expense_date : "";
+  const status = typeof payload.status === "string" ? payload.status : "updated";
+  const amountEur = Number(payload.amount_eur ?? 0);
+
+  console.log("[send-expense-notification] Incoming payload", JSON.stringify(redactSensitiveValues({
+    correlationId,
+    expense_id: expenseId,
+    job_id: payload.job_id,
+    status,
+  })));
+
+  // Corporate assets
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") || "";
+  const companyLogoUrl = Deno.env.get("COMPANY_LOGO_URL_W") ||
+    (supabaseUrl ? `${supabaseUrl}/storage/v1/object/public/company-assets/sectorlogow.png` : "");
+  const areaTecnicaLogoUrl = Deno.env.get("AT_LOGO_URL") ||
+    (supabaseUrl ? `${supabaseUrl}/storage/v1/object/public/company-assets/area-tecnica-logo.png` : "");
+
+  let subject: string;
+  let statusText: string;
+  let statusColor: string;
+  let messageText: string;
+
+  switch (status) {
+    case "submitted":
+      subject = `Gasto enviado para aprobación · ${jobTitle}`;
+      statusText = "Enviado para Aprobación";
+      statusColor = "#3b82f6";
+      messageText = "Tu gasto ha sido enviado correctamente y está pendiente de revisión por parte de administración.";
+      break;
+    case "approved":
+      subject = `Gasto aprobado · ${jobTitle}`;
+      statusText = "Aprobado";
+      statusColor = "#10b981";
+      messageText = "Tu gasto ha sido aprobado y se incluirá en el próximo pago.";
+      break;
+    case "rejected":
+      subject = `Gasto rechazado · ${jobTitle}`;
+      statusText = "Rechazado";
+      statusColor = "#ef4444";
+      messageText =
+        "Tu gasto ha sido rechazado. Por favor, revisa el motivo a continuación y contacta con administración si tienes dudas.";
+      break;
+    default:
+      subject = `Actualización de gasto · ${jobTitle}`;
+      statusText = status;
+      statusColor = "#6b7280";
+      messageText = "El estado de tu gasto ha sido actualizado.";
   }
 
-  if (req.method !== 'POST') {
-    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
-  }
-
-  if (!BREVO_KEY || !BREVO_FROM) {
-    return new Response(
-      JSON.stringify({
-        success: false,
-        error: 'Email channel not configured',
-        missing_env: [
-          ...(BREVO_KEY ? [] : ['BREVO_API_KEY']),
-          ...(BREVO_FROM ? [] : ['BREVO_FROM']),
-        ],
-      }),
-      {
-        status: 500,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
-    );
-  }
-
-  try {
-    const payload = (await req.json()) as ExpenseNotificationPayload;
-    console.log('[send-expense-notification] Incoming payload', JSON.stringify(payload, null, 2));
-
-    if (!payload || !payload.expense_id || !payload.technician_email) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'Missing required fields' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const trimmedEmail = payload.technician_email.trim();
-    if (!trimmedEmail) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'Invalid email address' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    // Corporate assets
-    const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || '';
-    const COMPANY_LOGO_URL = Deno.env.get('COMPANY_LOGO_URL_W') || (SUPABASE_URL ? `${SUPABASE_URL}/storage/v1/object/public/company-assets/sectorlogow.png` : '');
-    const AT_LOGO_URL = Deno.env.get('AT_LOGO_URL') || (SUPABASE_URL ? `${SUPABASE_URL}/storage/v1/object/public/company-assets/area-tecnica-logo.png` : '');
-
-    let subject: string;
-    let statusText: string;
-    let statusColor: string;
-    let messageText: string;
-
-    switch (payload.status) {
-      case 'submitted':
-        subject = `Gasto enviado para aprobación · ${payload.job_title}`;
-        statusText = 'Enviado para Aprobación';
-        statusColor = '#3b82f6';
-        messageText = 'Tu gasto ha sido enviado correctamente y está pendiente de revisión por parte de administración.';
-        break;
-      case 'approved':
-        subject = `Gasto aprobado · ${payload.job_title}`;
-        statusText = 'Aprobado';
-        statusColor = '#10b981';
-        messageText = 'Tu gasto ha sido aprobado y se incluirá en el próximo pago.';
-        break;
-      case 'rejected':
-        subject = `Gasto rechazado · ${payload.job_title}`;
-        statusText = 'Rechazado';
-        statusColor = '#ef4444';
-        messageText = 'Tu gasto ha sido rechazado. Por favor, revisa el motivo a continuación y contacta con administración si tienes dudas.';
-        break;
-      default:
-        subject = `Actualización de gasto · ${payload.job_title}`;
-        statusText = payload.status;
-        statusColor = '#6b7280';
-        messageText = 'El estado de tu gasto ha sido actualizado.';
-    }
-
-    const htmlContent = `<!DOCTYPE html>
+  const htmlContent = `<!DOCTYPE html>
     <html lang="es">
     <head>
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>${subject}</title>
+      <title>${escapeHtml(subject)}</title>
     </head>
     <body style="margin:0;padding:0;background:#f5f7fb;font-family:Arial,Helvetica,sans-serif;color:#111827;">
       <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f5f7fb;padding:24px;">
@@ -141,10 +180,10 @@ serve(async (req) => {
                   <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
                     <tr>
                       <td align="left" style="vertical-align:middle;">
-                        ${COMPANY_LOGO_URL ? `<img src="${COMPANY_LOGO_URL}" alt="Sector Pro" height="36" style="display:block;border:0;max-height:36px" />` : ''}
+                        ${companyLogoUrl ? `<img src="${escapeHtml(companyLogoUrl)}" alt="Sector Pro" height="36" style="display:block;border:0;max-height:36px" />` : ""}
                       </td>
                       <td align="right" style="vertical-align:middle;">
-                        ${AT_LOGO_URL ? `<img src="${AT_LOGO_URL}" alt="Área Técnica" height="36" style="display:block;border:0;max-height:36px" />` : ''}
+                        ${areaTecnicaLogoUrl ? `<img src="${escapeHtml(areaTecnicaLogoUrl)}" alt="Área Técnica" height="36" style="display:block;border:0;max-height:36px" />` : ""}
                       </td>
                     </tr>
                   </table>
@@ -152,9 +191,9 @@ serve(async (req) => {
               </tr>
               <tr>
                 <td style="padding:24px 24px 8px 24px;">
-                  <h2 style="margin:0 0 8px 0;font-size:20px;color:#111827;">Hola ${payload.technician_name || 'equipo'},</h2>
+                  <h2 style="margin:0 0 8px 0;font-size:20px;color:#111827;">Hola ${escapeHtml(technicianName || "equipo")},</h2>
                   <p style="margin:0;color:#374151;line-height:1.55;">
-                    ${messageText}
+                    ${escapeHtml(messageText)}
                   </p>
                 </td>
               </tr>
@@ -165,22 +204,22 @@ serve(async (req) => {
                       <tr>
                         <td style="vertical-align:middle;padding-right:8px;"><b>Estado:</b></td>
                         <td style="vertical-align:middle;">
-                          <span style="display:inline-block;background:${statusColor};color:white;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">${statusText}</span>
+                          <span style="display:inline-block;background:${statusColor};color:white;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:600;">${escapeHtml(statusText)}</span>
                         </td>
                       </tr>
                     </table>
                     <ul style="margin:10px 0 0 18px;padding:0;line-height:1.55;">
-                      <li><b>Trabajo:</b> ${payload.job_title}</li>
-                      <li><b>Categoría:</b> ${payload.category_label}</li>
-                      <li><b>Fecha del gasto:</b> ${formatDate(payload.expense_date)}</li>
-                      <li><b>Importe:</b> ${formatCurrency(payload.amount_eur)}</li>
+                      <li><b>Trabajo:</b> ${escapeHtml(jobTitle)}</li>
+                      <li><b>Categoría:</b> ${escapeHtml(categoryLabel)}</li>
+                      <li><b>Fecha del gasto:</b> ${escapeHtml(formatDate(expenseDate))}</li>
+                      <li><b>Importe:</b> ${escapeHtml(formatCurrency(amountEur))}</li>
                     </ul>
-                    ${payload.status === 'rejected' && payload.rejection_reason ? `
+                    ${status === "rejected" && payload.rejection_reason ? `
                     <div style="margin-top:12px;padding-top:12px;border-top:1px solid #e5e7eb;">
                       <b>Motivo del rechazo:</b><br/>
-                      <span style="color:#ef4444;">${payload.rejection_reason}</span>
+                      <span style="color:#ef4444;">${escapeHtml(payload.rejection_reason)}</span>
                     </div>
-                    ` : ''}
+                    ` : ""}
                   </div>
                 </td>
               </tr>
@@ -209,48 +248,52 @@ serve(async (req) => {
     </body>
     </html>`;
 
-    const emailPayload: Record<string, unknown> = {
-      sender: { email: BREVO_FROM, name: 'Área Técnica' },
-      to: [{ email: trimmedEmail, name: payload.technician_name || undefined }],
-      subject,
-      htmlContent,
-    };
+  const emailPayload: Record<string, unknown> = {
+    sender: { email: brevoFrom, name: "Área Técnica" },
+    to: [{ email: technicianEmail, name: technicianName || undefined }],
+    subject,
+    htmlContent,
+  };
 
-    // Add BCC for admin/finanzas shadow notification
-    if (EXPENSE_NOTIFICATION_BCC) {
-      emailPayload['bcc'] = [{ email: EXPENSE_NOTIFICATION_BCC }];
-    }
-
-    const sendRes = await sendBrevoEmail(BREVO_KEY, emailPayload);
-
-    if (!sendRes.ok) {
-      const errText = await sendRes.text();
-      console.error('[send-expense-notification] Brevo error', sendRes.status, errText);
-      return new Response(
-        JSON.stringify({ success: false, error: errText || sendRes.statusText }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    console.log('[send-expense-notification] Email sent successfully', payload.expense_id);
-    return new Response(
-      JSON.stringify({
-        success: true,
-        expense_id: payload.expense_id,
-        status: payload.status,
-        sent_to: trimmedEmail,
-        bcc_sent: !!EXPENSE_NOTIFICATION_BCC,
-      }),
-      {
-        status: 200,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
-    );
-  } catch (err) {
-    console.error('[send-expense-notification] Unexpected error', err);
-    return new Response(
-      JSON.stringify({ success: false, error: (err as Error).message }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+  const expenseNotificationBcc = Deno.env.get("EXPENSE_NOTIFICATION_BCC") ?? "";
+  if (expenseNotificationBcc) {
+    emailPayload.bcc = [{ email: expenseNotificationBcc }];
   }
-});
+
+  const sendRes = await sendBrevoEmail(brevoKey, emailPayload);
+
+  if (!sendRes.ok) {
+    const errText = await sendRes.text();
+    console.error("[send-expense-notification] Brevo error", JSON.stringify(redactSensitiveValues({
+      correlationId,
+      status: sendRes.status,
+      error: errText || sendRes.statusText,
+    })));
+    throw new HttpError(502, "Email provider rejected the message", {
+      code: "email_provider_error",
+      exposeDetails: false,
+    });
+  }
+
+  console.log("[send-expense-notification] Email sent successfully", JSON.stringify({
+    correlationId,
+    expense_id: expenseId,
+  }));
+
+  return respond({
+    success: true,
+    expense_id: expenseId,
+    status,
+    sent_to: technicianEmail,
+    bcc_sent: !!expenseNotificationBcc,
+  });
+}, {
+  allowedMethods: ["POST"],
+  internalErrorMessage: "Expense notification failed",
+  onError(error, req) {
+    console.error("[send-expense-notification] Request failed", JSON.stringify(redactSensitiveValues({
+      correlationId: getCorrelationId(req),
+      error: error instanceof Error ? { name: error.name, message: error.message } : error,
+    })));
+  },
+}));

--- a/supabase/functions/send-job-payout-email/index.ts
+++ b/supabase/functions/send-job-payout-email/index.ts
@@ -584,6 +584,7 @@ serve(createHttpHandler(async (req) => {
 }, {
   allowedMethods: ["POST"],
   internalErrorMessage: "Payout email request failed",
+  errorHeaders: (req) => correlationHeaders(getCorrelationId(req)),
   onError(error, req) {
     console.error("[send-job-payout-email] Request failed", JSON.stringify(redactSensitiveValues({
       correlationId: getCorrelationId(req),

--- a/supabase/functions/send-job-payout-email/index.ts
+++ b/supabase/functions/send-job-payout-email/index.ts
@@ -1,32 +1,27 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { addDays, getDaysInMonth } from "npm:date-fns@3.6.0";
 import { formatInTimeZone, fromZonedTime } from "npm:date-fns-tz@3.2.0";
+
+import {
+  correlationHeaders,
+  createHttpHandler,
+  getCorrelationId,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  redactSensitiveValues,
+  requireBearerToken,
+  requireEnvValues,
+} from "../_shared/http.ts";
 import { getInvoicingCompanyDetails } from "../_shared/invoicing-company-data.ts";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-
-if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
-  throw new Error(
-    "Missing required environment variables: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY"
-  );
-}
-
-const corsHeaders: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-};
-
-const BREVO_KEY = Deno.env.get("BREVO_API_KEY") ?? "";
-const BREVO_FROM = Deno.env.get("BREVO_FROM") ?? "";
-const ADMIN_BCC = Deno.env.get("PAYOUT_EMAIL_BCC") ?? "";
 const INVOICE_SUBMISSION_EMAIL = "administracion@sector-pro.com";
 const MADRID_TIMEZONE = "Europe/Madrid";
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_PAYOUT_EMAIL_BODY_BYTES = 25 * 1024 * 1024;
+const ADMIN_ROLES = new Set(["admin", "management"]);
 
 interface JobMetadata {
   id: string;
@@ -68,11 +63,54 @@ interface PayoutEmailResult {
   error?: string;
 }
 
-interface JobPayoutRequestBody {
+interface JobPayoutRequestBody extends Record<string, unknown> {
   job?: JobMetadata;
   technicians?: TechnicianPayload[];
   missing_emails?: string[];
   requested_at?: string;
+}
+
+async function requireAdminOrManagement(
+  supabaseAdmin: SupabaseClient,
+  req: Request,
+): Promise<{ userId: string; role: string }> {
+  const token = requireBearerToken(req, {
+    message: "Missing or malformed authorization header",
+    code: "missing_authorization",
+  });
+
+  const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
+  if (authError || !user) {
+    console.error("[send-job-payout-email] Token verification failed:", authError?.message);
+    throw new HttpError(401, "Invalid or expired token", { code: "invalid_authorization" });
+  }
+
+  const { data: callerProfile, error: profileError } = await supabaseAdmin
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    console.error("[send-job-payout-email] Profile lookup failed:", profileError.message);
+    throw new HttpError(500, "Authorization lookup failed", {
+      code: "authorization_lookup_failed",
+      exposeDetails: false,
+    });
+  }
+
+  const role = typeof callerProfile?.role === "string"
+    ? callerProfile.role.toLowerCase()
+    : "";
+
+  if (!ADMIN_ROLES.has(role)) {
+    console.warn("[send-job-payout-email] Forbidden: user", user.id, "role:", role || "<missing>");
+    throw new HttpError(403, "Forbidden: insufficient permissions", {
+      code: "insufficient_role",
+    });
+  }
+
+  return { userId: user.id, role };
 }
 
 async function mapWithConcurrency<T, R>(
@@ -223,80 +261,36 @@ function formatLongDate(date: Date): string {
   return new Intl.DateTimeFormat('es-ES', { dateStyle: 'long', timeZone: MADRID_TIMEZONE }).format(date);
 }
 
-serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
-  }
+serve(createHttpHandler(async (req) => {
+  const correlationId = getCorrelationId(req);
+  const responseHeaders = correlationHeaders(correlationId);
+  const respond = (body: unknown, status = 200) => jsonResponse(body, { status, headers: responseHeaders });
 
-  if (req.method !== 'POST') {
-    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
-  }
+  const {
+    SUPABASE_URL: supabaseUrl,
+    SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+    BREVO_API_KEY: brevoKey,
+    BREVO_FROM: brevoFrom,
+  } = requireEnvValues(
+    ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "BREVO_API_KEY", "BREVO_FROM"] as const,
+    (name) => Deno.env.get(name),
+  );
 
-  if (!BREVO_KEY || !BREVO_FROM) {
-    return new Response(
-      JSON.stringify({
-        success: false,
-        error: 'Email channel not configured',
-        missing_env: [
-          ...(BREVO_KEY ? [] : ['BREVO_API_KEY']),
-          ...(BREVO_FROM ? [] : ['BREVO_FROM']),
-        ],
-      }),
-      {
-        status: 500,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
-    );
-  }
+  // Service-role client for DB queries (bypasses RLS)
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
 
-  try {
-    // Service-role client for DB queries (bypasses RLS)
-    const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
-      auth: { persistSession: false, autoRefreshToken: false },
-    });
-
-    // ── Authorization: verify caller is admin or management ──
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'Missing or malformed authorization header' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const token = authHeader.replace('Bearer ', '');
-    const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
-    if (authError || !user) {
-      console.error('[send-job-payout-email] Token verification failed:', authError?.message);
-      return new Response(
-        JSON.stringify({ success: false, error: 'Invalid or expired token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const { data: callerProfile, error: profileError } = await supabaseAdmin
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .single();
-
-    if (profileError) {
-      console.error('[send-job-payout-email] Profile lookup failed:', profileError.message);
-    }
-
-    if (!callerProfile || !['admin', 'management'].includes(callerProfile.role)) {
-      console.warn('[send-job-payout-email] Forbidden: user', user.id, 'role:', callerProfile?.role);
-      return new Response(
-        JSON.stringify({ success: false, error: 'Forbidden: insufficient permissions' }),
-        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const body = (await req.json()) as JobPayoutRequestBody;
-    const DEBUG = Deno.env.get('DEBUG_PAYOUT_EMAILS') === 'true';
+  const caller = await requireAdminOrManagement(supabaseAdmin, req);
+  const body = await readBoundedJsonObject<JobPayoutRequestBody>(req, {
+    maxBytes: MAX_PAYOUT_EMAIL_BODY_BYTES,
+  });
+  const DEBUG = Deno.env.get('DEBUG_PAYOUT_EMAILS') === 'true';
 
     // Avoid dumping base64 PDFs / PII into logs.
-    console.log('[send-job-payout-email] Incoming payload', JSON.stringify({
+    console.log('[send-job-payout-email] Incoming payload', JSON.stringify(redactSensitiveValues({
+      correlationId,
+      actor_id: caller.userId,
       job: { id: body.job?.id, title: body.job?.title },
       technicians: body.technicians?.map(t => ({
         technician_id: t.technician_id,
@@ -304,7 +298,7 @@ serve(async (req) => {
         pdf_length: t.pdf_base64?.length ?? 0,
       })),
       technicians_count: body.technicians?.length ?? 0,
-    }));
+    })));
 
     if (DEBUG) {
       console.log('[send-job-payout-email][debug] Incoming payload (full)', {
@@ -314,17 +308,11 @@ serve(async (req) => {
     }
 
     if (!body || !body.job || !body.job.id) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'Missing job metadata' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
+      return respond({ success: false, error: 'Missing job metadata' }, 400);
     }
 
     if (!Array.isArray(body.technicians) || body.technicians.length === 0) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'No technician payloads received' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
+      return respond({ success: false, error: 'No technician payloads received' }, 400);
     }
 
     const job = body.job;
@@ -352,8 +340,8 @@ serve(async (req) => {
     }
 
     // Corporate assets (logos)
-    const COMPANY_LOGO_URL = Deno.env.get('COMPANY_LOGO_URL_W') || `${SUPABASE_URL}/storage/v1/object/public/company-assets/sectorlogow.png`;
-    const AT_LOGO_URL = Deno.env.get('AT_LOGO_URL') || `${SUPABASE_URL}/storage/v1/object/public/company-assets/area-tecnica-logo.png`;
+    const COMPANY_LOGO_URL = Deno.env.get('COMPANY_LOGO_URL_W') || `${supabaseUrl}/storage/v1/object/public/company-assets/sectorlogow.png`;
+    const AT_LOGO_URL = Deno.env.get('AT_LOGO_URL') || `${supabaseUrl}/storage/v1/object/public/company-assets/area-tecnica-logo.png`;
     const todayEstimate = calculateEstimatedPayoutRange([new Date()]);
     const todayEstimateText = escapeHtml(`a partir del ${formatLongDate(todayEstimate.fromDate)}`);
 
@@ -544,7 +532,7 @@ serve(async (req) => {
       </html>`;
 
       const emailPayload: Record<string, unknown> = {
-        sender: { email: BREVO_FROM, name: 'Área Técnica' },
+        sender: { email: brevoFrom, name: 'Área Técnica' },
         to: [{ email: trimmedEmail, name: tech.full_name || undefined }],
         subject,
         htmlContent,
@@ -568,7 +556,7 @@ serve(async (req) => {
       }
 
       try {
-        const sendRes = await sendBrevoEmail(BREVO_KEY, emailPayload, { timeoutMs: 10000 });
+        const sendRes = await sendBrevoEmail(brevoKey, emailPayload, { timeoutMs: 10000 });
 
         if (!sendRes.ok) {
           const errText = await sendRes.text();
@@ -584,24 +572,22 @@ serve(async (req) => {
     );
 
     const success = results.every((r) => r.sent);
-    return new Response(
-      JSON.stringify({
+    return respond(
+      {
         success,
         results,
         job,
         missing_emails: body.missing_emails || [],
         requested_at: body.requested_at || new Date().toISOString(),
-      }),
-      {
-        status: 200,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
+      },
     );
-  } catch (err) {
-    console.error('[send-job-payout-email] Unexpected error', err);
-    return new Response(
-      JSON.stringify({ success: false, error: (err as Error).message }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
-  }
-});
+}, {
+  allowedMethods: ["POST"],
+  internalErrorMessage: "Payout email request failed",
+  onError(error, req) {
+    console.error("[send-job-payout-email] Request failed", JSON.stringify(redactSensitiveValues({
+      correlationId: getCorrelationId(req),
+      error: error instanceof Error ? { name: error.name, message: error.message } : error,
+    })));
+  },
+}));

--- a/supabase/functions/send-payout-override-notification/index.ts
+++ b/supabase/functions/send-payout-override-notification/index.ts
@@ -528,7 +528,10 @@ serve(createHttpHandler(async (req) => {
         correlationId,
         error: sendError,
       })));
-      // Don't fail the whole operation, just log it
+      throw new HttpError(502, "Notification email delivery failed", {
+        code: "notification_delivery_failed",
+        exposeDetails: false,
+      });
     }
 
     return respond({
@@ -538,6 +541,7 @@ serve(createHttpHandler(async (req) => {
 }, {
   allowedMethods: ["POST"],
   internalErrorMessage: "Payout override notification failed",
+  errorHeaders: (req) => correlationHeaders(getCorrelationId(req)),
   onError(error, req) {
     console.error("[send-payout-override-notification] Request failed", JSON.stringify(redactSensitiveValues({
       correlationId: getCorrelationId(req),

--- a/supabase/functions/send-payout-override-notification/index.ts
+++ b/supabase/functions/send-payout-override-notification/index.ts
@@ -1,19 +1,20 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "npm:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+import {
+  correlationHeaders,
+  createHttpHandler,
+  getCorrelationId,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  redactSensitiveValues,
+  requireBearerToken,
+  requireEnvValues,
+} from "../_shared/http.ts";
 
-if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
-  throw new Error("Missing required environment variables: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
-};
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-};
+const MAX_PAYOUT_OVERRIDE_BODY_BYTES = 16 * 1024;
+const ADMIN_ROLES = new Set(["admin", "management"]);
 
 /**
  * Escapes HTML special characters to prevent XSS injection in email templates.
@@ -29,7 +30,7 @@ function escapeHtml(value: string | null | undefined): string {
     .replace(/'/g, "&#39;");
 }
 
-interface PayoutOverrideNotificationRequest {
+interface PayoutOverrideNotificationRequest extends Record<string, unknown> {
   jobId: string;
   jobTitle: string;
   jobStartTime: string;
@@ -43,24 +44,80 @@ interface PayoutOverrideNotificationRequest {
   calculatedTotal: number;
 }
 
-serve(async (req) => {
-  // Handle CORS preflight
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+async function requireAdminOrManagement(
+  supabase: SupabaseClient,
+  req: Request,
+): Promise<{ userId: string; role: string; authorizationHeader: string }> {
+  const token = requireBearerToken(req, {
+    message: "Missing or malformed authorization header",
+    code: "missing_authorization",
+  });
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) {
+    console.error("[send-payout-override-notification] Token verification failed:", authError?.message);
+    throw new HttpError(401, "Invalid or expired token", { code: "invalid_authorization" });
   }
 
-  try {
-    const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+  const { data: callerProfile, error: profileError } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
 
-    // Parse request body
-    const payload: PayoutOverrideNotificationRequest = await req.json();
+  if (profileError) {
+    console.error("[send-payout-override-notification] Profile lookup failed:", profileError.message);
+    throw new HttpError(500, "Authorization lookup failed", {
+      code: "authorization_lookup_failed",
+      exposeDetails: false,
+    });
+  }
+
+  const role = typeof callerProfile?.role === "string"
+    ? callerProfile.role.toLowerCase()
+    : "";
+
+  if (!ADMIN_ROLES.has(role)) {
+    console.warn("[send-payout-override-notification] Forbidden: user", user.id, "role:", role || "<missing>");
+    throw new HttpError(403, "Forbidden: insufficient permissions", {
+      code: "insufficient_role",
+    });
+  }
+
+  return {
+    userId: user.id,
+    role,
+    authorizationHeader: `Bearer ${token}`,
+  };
+}
+
+serve(createHttpHandler(async (req) => {
+  const correlationId = getCorrelationId(req);
+  const responseHeaders = correlationHeaders(correlationId);
+  const respond = (body: unknown, status = 200) => jsonResponse(body, { status, headers: responseHeaders });
+
+  const {
+    SUPABASE_URL: supabaseUrl,
+    SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+  } = requireEnvValues(
+    ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const,
+    (name) => Deno.env.get(name),
+  );
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const caller = await requireAdminOrManagement(supabase, req);
+
+  // Parse request body
+  const payload = await readBoundedJsonObject<PayoutOverrideNotificationRequest>(req, {
+    maxBytes: MAX_PAYOUT_OVERRIDE_BODY_BYTES,
+  });
 
     // Validate required fields
     if (!payload.jobId || !payload.technicianId || !payload.actorId) {
-      return new Response(
-        JSON.stringify({ error: "Missing required fields: jobId, technicianId, actorId" }),
-        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-      );
+      return respond({ error: "Missing required fields: jobId, technicianId, actorId" }, 400);
     }
 
     const {
@@ -76,6 +133,24 @@ serve(async (req) => {
       newOverrideAmountEur,
       calculatedTotal,
     } = payload;
+
+    if (actorId !== caller.userId) {
+      console.warn("[send-payout-override-notification] Actor mismatch", JSON.stringify(redactSensitiveValues({
+        correlationId,
+        caller_id: caller.userId,
+        payload_actor_id: actorId,
+      })));
+      throw new HttpError(403, "Forbidden: actor mismatch", { code: "actor_mismatch" });
+    }
+
+    console.log("[send-payout-override-notification] Incoming payload", JSON.stringify(redactSensitiveValues({
+      correlationId,
+      actor_id: caller.userId,
+      role: caller.role,
+      job_id: jobId,
+      technician_id: technicianId,
+      has_override: newOverrideAmountEur !== null,
+    })));
 
     let resolvedJobType = jobType?.toLowerCase()?.trim() || null;
     if (!resolvedJobType && jobId) {
@@ -93,15 +168,10 @@ serve(async (req) => {
     }
 
     if (resolvedJobType === "ciclo") {
-      return new Response(
-        JSON.stringify({
-          success: true,
-          message: "Notification skipped for ciclo job type",
-        }),
-        {
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
+      return respond({
+        success: true,
+        message: "Notification skipped for ciclo job type",
+      });
     }
 
     // Get actor information
@@ -113,10 +183,10 @@ serve(async (req) => {
 
     if (actorError || !actorProfile) {
       console.error("[send-payout-override-notification] Error fetching actor profile:", actorError);
-      return new Response(
-        JSON.stringify({ error: "Failed to fetch actor information" }),
-        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-      );
+      throw new HttpError(500, "Failed to fetch actor information", {
+        code: "actor_lookup_failed",
+        exposeDetails: false,
+      });
     }
 
     const actorName = `${actorProfile.first_name || ""} ${actorProfile.last_name || ""}`.trim() || "Unknown User";
@@ -419,8 +489,7 @@ serve(async (req) => {
       console.warn("[send-payout-override-notification] finanzas@sector-pro.com profile not found");
     }
 
-    // Forward caller auth to preserve actor identity/permissions in nested function call.
-    const authHeader = req.headers.get("Authorization");
+    // Forward verified caller auth to preserve actor identity/permissions in nested function call.
     const corporateEmailInvokeOptions: {
       body: {
         subject: string;
@@ -444,13 +513,9 @@ serve(async (req) => {
       },
     };
 
-    if (authHeader) {
-      corporateEmailInvokeOptions.headers = {
-        Authorization: authHeader,
-      };
-    } else {
-      console.warn("[send-payout-override-notification] Missing Authorization header for nested corporate email call");
-    }
+    corporateEmailInvokeOptions.headers = {
+      Authorization: caller.authorizationHeader,
+    };
 
     // Send email via corporate email function to admins and finanzas
     const { error: sendError } = await supabase.functions.invoke(
@@ -459,29 +524,24 @@ serve(async (req) => {
     );
 
     if (sendError) {
-      console.error("[send-payout-override-notification] Error calling send-corporate-email:", sendError);
+      console.error("[send-payout-override-notification] Error calling send-corporate-email:", JSON.stringify(redactSensitiveValues({
+        correlationId,
+        error: sendError,
+      })));
       // Don't fail the whole operation, just log it
     }
 
-    return new Response(
-      JSON.stringify({
-        success: true,
-        message: "Notification emails sent",
-      }),
-      {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      }
-    );
-  } catch (error) {
-    console.error("[send-payout-override-notification] Error:", error);
-    return new Response(
-      JSON.stringify({
-        error: error instanceof Error ? error.message : "Unknown error",
-      }),
-      {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      }
-    );
-  }
-});
+    return respond({
+      success: true,
+      message: "Notification emails sent",
+    });
+}, {
+  allowedMethods: ["POST"],
+  internalErrorMessage: "Payout override notification failed",
+  onError(error, req) {
+    console.error("[send-payout-override-notification] Request failed", JSON.stringify(redactSensitiveValues({
+      correlationId: getCorrelationId(req),
+      error: error instanceof Error ? { name: error.name, message: error.message } : error,
+    })));
+  },
+}));


### PR DESCRIPTION
## Summary
- migrate `send-expense-notification`, `send-job-payout-email`, and `send-payout-override-notification` onto `createHttpHandler`
- add bounded JSON parsing, correlation headers, redacted logging, and request-time env validation for the payout/expense notification cluster
- enforce explicit trust boundaries: service-role-only expense trigger endpoint, admin/management payout sender, and admin/management + actorId/JWT binding for payout override notifications
- address review follow-ups: finite expense amount formatting, correlation headers on handled error responses, and observable failure when nested payout override email delivery fails
- keep the Edge Function governance gate at 54 current legacy manual entrypoints; the regenerated baseline also removes a stale `system-health` exemption while the three touched functions move to `createHttpHandler`

## Validation
- `npm install --legacy-peer-deps --package-lock=false`
- `npm run governance:functions`
- `npm run governance:exposure`
- `npm run lint:functions` (403 warnings, 0 errors)
- `npm run governance`
- `npm run lint` (warnings only, 0 errors)
- `npm run typecheck`
- `npm run test:run -- supabase/functions/_shared/http.test.ts` (13 tests)
- `npm run test:run` (169 files, 1003 tests)
- `npm run build`
- `git diff --check`
- `./scripts/check-staged-secrets.sh`

Note: direct `deno check` was attempted for the edited Edge Function entrypoints, but `deno` is not installed on the local PATH.
