### PR TITLE
[codex] centralize edge function role auth

### DIFF
--- a/docs/operations/phase-2-trust-boundary-hardening.md
+++ b/docs/operations/phase-2-trust-boundary-hardening.md
@@ -89,6 +89,19 @@ priority-function migration:
 
 These are covered by unit tests in `supabase/functions/_shared/http.test.ts`.
 
+`supabase/functions/_shared/auth.ts` centralizes authenticated role checks for
+privileged Edge Functions:
+
+- `requireAuthenticatedRole` verifies the bearer token, resolves
+  `profiles.role`, enforces an allowlist, and returns a normalized caller
+  context plus the original authorization header for safe nested function calls.
+- `requireAdminOrManagement` is the default admin/management guard used by the
+  hardened user-admin, diagnostics, and payout notification handlers.
+- Callers can preserve endpoint-specific error messages and run denial hooks
+  such as `system-health` security audit logging without copying auth logic.
+
+This helper is covered by unit tests in `supabase/functions/_shared/auth.test.ts`.
+
 ### 5. Database authorization regression tests
 
 `supabase/tests/database/phase2_trust_boundary.sql` (pgTAP, run by the required
@@ -119,7 +132,9 @@ These are covered by unit tests in `supabase/functions/_shared/http.test.ts`.
   notification functions (`send-expense-notification`, `send-job-payout-email`,
   `send-payout-override-notification`) were migrated on 2026-06-23 as the next
   follow-up slice, including explicit service-role/privileged-role guards and
-  bounded payload parsing.
+  bounded payload parsing. The duplicated admin/management caller checks across
+  the hardened user-admin, diagnostics, and payout handlers now route through
+  the shared auth helper.
 - Add durable, storage-backed rate limiting for public-token endpoints.
 - Continue ratcheting the `anon`/`PUBLIC` grant baseline downward (trigger
   functions can be revoked from `anon` without behavioral impact).

--- a/supabase/functions/_shared/auth.test.ts
+++ b/supabase/functions/_shared/auth.test.ts
@@ -1,0 +1,135 @@
+import { type SupabaseClient, type User } from "npm:@supabase/supabase-js@2";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  requireAdminOrManagement,
+  requireAuthenticatedRole,
+} from "./auth.ts";
+
+type ProfileError = {
+  message: string;
+};
+
+function requestWithToken(token = "token-1") {
+  return new Request("https://example.com", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+function createSupabaseStub(options: {
+  user?: User | null;
+  authError?: ProfileError | null;
+  role?: string | null;
+  profileError?: ProfileError | null;
+}) {
+  const user = typeof options.user === "undefined"
+    ? ({ id: "user-1" } as User)
+    : options.user;
+  const authError = options.authError ?? null;
+  const profileError = options.profileError ?? null;
+  const maybeSingle = vi.fn(async () => ({
+    data: profileError ? null : { role: options.role ?? "admin" },
+    error: profileError,
+  }));
+  const eq = vi.fn(() => ({ maybeSingle }));
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ select }));
+  const getUser = vi.fn(async () => ({
+    data: { user },
+    error: authError,
+  }));
+
+  return {
+    supabase: {
+      auth: { getUser },
+      from,
+    } as unknown as SupabaseClient,
+    getUser,
+    from,
+    select,
+    eq,
+    maybeSingle,
+  };
+}
+
+describe("shared Edge Function auth helpers", () => {
+  it("returns a normalized privileged caller for admin or management roles", async () => {
+    const { supabase } = createSupabaseStub({ role: "Management" });
+
+    await expect(requireAdminOrManagement(supabase, requestWithToken("jwt-1"))).resolves.toMatchObject({
+      userId: "user-1",
+      role: "management",
+      token: "jwt-1",
+      authorizationHeader: "Bearer jwt-1",
+    });
+  });
+
+  it("rejects missing and invalid bearer tokens", async () => {
+    const missing = createSupabaseStub({});
+    await expect(requireAdminOrManagement(missing.supabase, new Request("https://example.com"))).rejects.toMatchObject({
+      status: 401,
+      code: "missing_authorization",
+    });
+    expect(missing.getUser).not.toHaveBeenCalled();
+
+    const invalid = createSupabaseStub({
+      user: null,
+      authError: { message: "expired" },
+    });
+    await expect(requireAdminOrManagement(invalid.supabase, requestWithToken())).rejects.toMatchObject({
+      status: 401,
+      code: "invalid_authorization",
+    });
+  });
+
+  it("rejects callers outside the allowed roles", async () => {
+    const onForbidden = vi.fn();
+    const { supabase } = createSupabaseStub({ role: "technician" });
+
+    await expect(requireAdminOrManagement(supabase, requestWithToken(), { onForbidden })).rejects.toMatchObject({
+      status: 403,
+      code: "insufficient_role",
+    });
+    expect(onForbidden).toHaveBeenCalledWith(expect.objectContaining({
+      userId: "user-1",
+      role: "technician",
+    }));
+  });
+
+  it("keeps denial hook failures from masking the authorization rejection", async () => {
+    const onForbidden = vi.fn(async () => {
+      throw new Error("audit write failed");
+    });
+    const { supabase } = createSupabaseStub({ role: "technician" });
+
+    await expect(requireAdminOrManagement(supabase, requestWithToken(), {
+      onForbidden,
+    })).rejects.toMatchObject({
+      status: 403,
+      code: "insufficient_role",
+    });
+    expect(onForbidden).toHaveBeenCalledOnce();
+  });
+
+  it("keeps profile lookup failures opaque to clients", async () => {
+    const { supabase } = createSupabaseStub({
+      profileError: { message: "database password leaked" },
+    });
+
+    await expect(requireAdminOrManagement(supabase, requestWithToken())).rejects.toMatchObject({
+      status: 500,
+      code: "authorization_lookup_failed",
+      exposeDetails: false,
+    });
+  });
+
+  it("supports custom role sets for non-admin privileged functions", async () => {
+    const { supabase } = createSupabaseStub({ role: "Logistics" });
+
+    await expect(requireAuthenticatedRole(supabase, requestWithToken(), {
+      allowedRoles: new Set(["ADMIN", "MANAGEMENT", "LOGISTICS"]),
+    })).resolves.toMatchObject({
+      role: "logistics",
+    });
+  });
+});

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,118 @@
+import { type SupabaseClient, type User } from "npm:@supabase/supabase-js@2";
+
+import { HttpError, requireBearerToken } from "./http.ts";
+
+export const ADMIN_MANAGEMENT_ROLES = new Set(["admin", "management"]);
+
+export interface AuthenticatedRoleCaller {
+  userId: string;
+  role: string;
+  token: string;
+  authorizationHeader: string;
+  user: User;
+}
+
+export interface ForbiddenRoleContext {
+  userId: string;
+  role: string;
+  user: User;
+}
+
+export interface RequireAuthenticatedRoleOptions {
+  allowedRoles?: ReadonlySet<string> | readonly string[];
+  logContext?: string;
+  missingMessage?: string;
+  missingCode?: string;
+  invalidMessage?: string;
+  invalidCode?: string;
+  forbiddenMessage?: string;
+  forbiddenCode?: string;
+  onForbidden?: (context: ForbiddenRoleContext) => void | Promise<void>;
+}
+
+type ProfileRoleRow = {
+  role?: unknown;
+} | null;
+
+const roleSet = (roles: ReadonlySet<string> | readonly string[]) =>
+  new Set(Array.from(roles, (role) => role.toLowerCase()));
+
+const normalizeRole = (role: unknown) =>
+  typeof role === "string" ? role.toLowerCase() : "";
+
+export async function requireAuthenticatedRole(
+  supabase: SupabaseClient,
+  req: Request,
+  options: RequireAuthenticatedRoleOptions = {},
+): Promise<AuthenticatedRoleCaller> {
+  const token = requireBearerToken(req, {
+    message: options.missingMessage ?? "Missing or malformed authorization header",
+    code: options.missingCode ?? "missing_authorization",
+  });
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) {
+    if (options.logContext) {
+      console.error(`[${options.logContext}] Token verification failed:`, authError?.message);
+    }
+
+    throw new HttpError(401, options.invalidMessage ?? "Invalid or expired token", {
+      code: options.invalidCode ?? "invalid_authorization",
+    });
+  }
+
+  const { data: callerProfile, error: profileError } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    if (options.logContext) {
+      console.error(`[${options.logContext}] Profile lookup failed:`, profileError.message);
+    }
+
+    throw new HttpError(500, "Authorization lookup failed", {
+      code: "authorization_lookup_failed",
+      exposeDetails: false,
+    });
+  }
+
+  const role = normalizeRole((callerProfile as ProfileRoleRow)?.role);
+  const allowedRoles = roleSet(options.allowedRoles ?? ADMIN_MANAGEMENT_ROLES);
+
+  if (!allowedRoles.has(role)) {
+    if (options.logContext) {
+      console.warn(`[${options.logContext}] Forbidden: user`, user.id, "role:", role || "<missing>");
+    }
+
+    try {
+      await options.onForbidden?.({ userId: user.id, role, user });
+    } catch (hookError) {
+      if (options.logContext) {
+        console.error(`[${options.logContext}] Forbidden hook failed:`, hookError);
+      }
+    }
+
+    throw new HttpError(403, options.forbiddenMessage ?? "Forbidden: insufficient permissions", {
+      code: options.forbiddenCode ?? "insufficient_role",
+    });
+  }
+
+  return {
+    userId: user.id,
+    role,
+    token,
+    authorizationHeader: `Bearer ${token}`,
+    user,
+  };
+}
+
+export const requireAdminOrManagement = (
+  supabase: SupabaseClient,
+  req: Request,
+  options: Omit<RequireAuthenticatedRoleOptions, "allowedRoles"> = {},
+) => requireAuthenticatedRole(supabase, req, {
+  ...options,
+  allowedRoles: ADMIN_MANAGEMENT_ROLES,
+});

--- a/supabase/functions/create-user/index.ts
+++ b/supabase/functions/create-user/index.ts
@@ -9,9 +9,9 @@ import {
   jsonResponse,
   readBoundedJsonObject,
   redactSensitiveValues,
-  requireBearerToken,
   requireEnvValues,
 } from "../_shared/http.ts";
+import { requireAdminOrManagement } from "../_shared/auth.ts";
 
 type CreateUserBody = Record<string, unknown> & {
   email?: unknown;
@@ -33,7 +33,6 @@ type ErrorLike = {
 }
 
 const MAX_CREATE_USER_BODY_BYTES = 16 * 1024;
-const ADMIN_ROLES = new Set(["admin", "management"]);
 
 const normalizeOptional = (value: unknown) => {
   if (typeof value !== "string") {
@@ -83,13 +82,6 @@ const duplicateEmailResponse = (headers: Record<string, string>) =>
     { status: 409, headers },
   );
 
-const failAuthLookup = () => {
-  throw new HttpError(500, "Authorization lookup failed", {
-    code: "authorization_lookup_failed",
-    exposeDetails: false,
-  });
-};
-
 serve(createHttpHandler(async (req) => {
   const correlationId = getCorrelationId(req);
   const headers = correlationHeaders(correlationId);
@@ -116,30 +108,11 @@ serve(createHttpHandler(async (req) => {
 
   const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 
-  const token = requireBearerToken(req);
-  const { data: { user: requestingUser }, error: userError } = await supabaseAdmin.auth.getUser(token);
-
-  if (userError || !requestingUser) {
-    throw new HttpError(401, "Unauthorized", { code: "invalid_authorization" });
-  }
-
-  const { data: requesterProfile, error: profileErr } = await supabaseAdmin
-    .from("profiles")
-    .select("role")
-    .eq("id", requestingUser.id)
-    .maybeSingle();
-
-  if (profileErr) {
-    failAuthLookup();
-  }
-
-  const requesterRole = typeof requesterProfile?.role === "string"
-    ? requesterProfile.role.toLowerCase()
-    : "";
-
-  if (!ADMIN_ROLES.has(requesterRole)) {
-    throw new HttpError(403, "Unauthorized", { code: "insufficient_role" });
-  }
+  await requireAdminOrManagement(supabaseAdmin, req, {
+    missingMessage: "Unauthorized",
+    invalidMessage: "Unauthorized",
+    forbiddenMessage: "Unauthorized",
+  });
 
   const { data: existingProfile, error: existingProfileErr } = await supabaseAdmin
     .from("profiles")
@@ -236,6 +209,7 @@ serve(createHttpHandler(async (req) => {
 }, {
   allowedMethods: ["POST"],
   internalErrorMessage: "Unexpected error",
+  errorHeaders: (req) => correlationHeaders(getCorrelationId(req)),
   onError: (error, req) => {
     console.error("create-user error:", redactSensitiveValues({
       correlationId: getCorrelationId(req),

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -8,16 +8,15 @@ import {
   jsonResponse,
   readBoundedJsonObject,
   redactSensitiveValues,
-  requireBearerToken,
   requireEnvValues,
 } from "../_shared/http.ts";
+import { requireAdminOrManagement } from "../_shared/auth.ts";
 
 type DeleteUserBody = Record<string, unknown> & {
   userId?: unknown;
 };
 
 const MAX_DELETE_USER_BODY_BYTES = 8 * 1024;
-const ADMIN_ROLES = new Set(["admin", "management"]);
 
 const normalizeRequiredText = (value: unknown) => {
   if (typeof value !== "string") {
@@ -49,37 +48,14 @@ serve(createHttpHandler(async (req) => {
 
   const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 
-  const token = requireBearerToken(req);
-  const { data: { user: requestingUser }, error: userError } = await supabaseAdmin.auth.getUser(token);
-  if (userError || !requestingUser) {
-    throw new HttpError(401, "Unauthorized", { code: "invalid_authorization" });
-  }
-
-  const { data: requesterProfile, error: profileErr } = await supabaseAdmin
-    .from("profiles")
-    .select("role")
-    .eq("id", requestingUser.id)
-    .maybeSingle();
-
-  if (profileErr) {
-    throw new HttpError(500, "Authorization lookup failed", {
-      code: "authorization_lookup_failed",
-      exposeDetails: false,
-    });
-  }
-
-  const requesterRole = typeof requesterProfile?.role === "string"
-    ? requesterProfile.role.toLowerCase()
-    : "";
-
-  if (!ADMIN_ROLES.has(requesterRole)) {
-    throw new HttpError(403, "Unauthorized - admin or management role required", {
-      code: "insufficient_role",
-    });
-  }
+  const caller = await requireAdminOrManagement(supabaseAdmin, req, {
+    missingMessage: "Unauthorized",
+    invalidMessage: "Unauthorized",
+    forbiddenMessage: "Unauthorized - admin or management role required",
+  });
 
   // Guard against self-deletion (would orphan the requester's own session/audit trail).
-  if (userId === requestingUser.id) {
+  if (userId === caller.userId) {
     throw new HttpError(400, "You cannot delete your own account", {
       code: "self_delete_blocked",
     });
@@ -91,7 +67,7 @@ serve(createHttpHandler(async (req) => {
     throw new HttpError(404, "User not found", { code: "user_not_found" });
   }
 
-  console.log("Deleting user:", redactSensitiveValues({ correlationId, userId, requestedBy: requestingUser.id }));
+  console.log("Deleting user:", redactSensitiveValues({ correlationId, userId, requestedBy: caller.userId }));
 
   // Deleting from auth.users cascades to profiles and, via the normalized
   // ON DELETE rules, to all dependent records.
@@ -109,6 +85,7 @@ serve(createHttpHandler(async (req) => {
 }, {
   allowedMethods: ["POST"],
   internalErrorMessage: "Unexpected error",
+  errorHeaders: (req) => correlationHeaders(getCorrelationId(req)),
   onError: (error, req) => {
     console.error("delete-user error:", redactSensitiveValues({
       correlationId: getCorrelationId(req),

--- a/supabase/functions/send-job-payout-email/index.ts
+++ b/supabase/functions/send-job-payout-email/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { addDays, getDaysInMonth } from "npm:date-fns@3.6.0";
 import { formatInTimeZone, fromZonedTime } from "npm:date-fns-tz@3.2.0";
 
@@ -11,9 +11,9 @@ import {
   jsonResponse,
   readBoundedJsonObject,
   redactSensitiveValues,
-  requireBearerToken,
   requireEnvValues,
 } from "../_shared/http.ts";
+import { requireAdminOrManagement } from "../_shared/auth.ts";
 import { getInvoicingCompanyDetails } from "../_shared/invoicing-company-data.ts";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
 
@@ -21,7 +21,6 @@ const INVOICE_SUBMISSION_EMAIL = "administracion@sector-pro.com";
 const MADRID_TIMEZONE = "Europe/Madrid";
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_PAYOUT_EMAIL_BODY_BYTES = 25 * 1024 * 1024;
-const ADMIN_ROLES = new Set(["admin", "management"]);
 
 interface JobMetadata {
   id: string;
@@ -68,49 +67,6 @@ interface JobPayoutRequestBody extends Record<string, unknown> {
   technicians?: TechnicianPayload[];
   missing_emails?: string[];
   requested_at?: string;
-}
-
-async function requireAdminOrManagement(
-  supabaseAdmin: SupabaseClient,
-  req: Request,
-): Promise<{ userId: string; role: string }> {
-  const token = requireBearerToken(req, {
-    message: "Missing or malformed authorization header",
-    code: "missing_authorization",
-  });
-
-  const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token);
-  if (authError || !user) {
-    console.error("[send-job-payout-email] Token verification failed:", authError?.message);
-    throw new HttpError(401, "Invalid or expired token", { code: "invalid_authorization" });
-  }
-
-  const { data: callerProfile, error: profileError } = await supabaseAdmin
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (profileError) {
-    console.error("[send-job-payout-email] Profile lookup failed:", profileError.message);
-    throw new HttpError(500, "Authorization lookup failed", {
-      code: "authorization_lookup_failed",
-      exposeDetails: false,
-    });
-  }
-
-  const role = typeof callerProfile?.role === "string"
-    ? callerProfile.role.toLowerCase()
-    : "";
-
-  if (!ADMIN_ROLES.has(role)) {
-    console.warn("[send-job-payout-email] Forbidden: user", user.id, "role:", role || "<missing>");
-    throw new HttpError(403, "Forbidden: insufficient permissions", {
-      code: "insufficient_role",
-    });
-  }
-
-  return { userId: user.id, role };
 }
 
 async function mapWithConcurrency<T, R>(
@@ -281,7 +237,9 @@ serve(createHttpHandler(async (req) => {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const caller = await requireAdminOrManagement(supabaseAdmin, req);
+  const caller = await requireAdminOrManagement(supabaseAdmin, req, {
+    logContext: "send-job-payout-email",
+  });
   const body = await readBoundedJsonObject<JobPayoutRequestBody>(req, {
     maxBytes: MAX_PAYOUT_EMAIL_BODY_BYTES,
   });

--- a/supabase/functions/send-payout-override-notification/index.ts
+++ b/supabase/functions/send-payout-override-notification/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
 import {
   correlationHeaders,
@@ -9,12 +9,11 @@ import {
   jsonResponse,
   readBoundedJsonObject,
   redactSensitiveValues,
-  requireBearerToken,
   requireEnvValues,
 } from "../_shared/http.ts";
+import { requireAdminOrManagement } from "../_shared/auth.ts";
 
 const MAX_PAYOUT_OVERRIDE_BODY_BYTES = 16 * 1024;
-const ADMIN_ROLES = new Set(["admin", "management"]);
 
 /**
  * Escapes HTML special characters to prevent XSS injection in email templates.
@@ -44,53 +43,6 @@ interface PayoutOverrideNotificationRequest extends Record<string, unknown> {
   calculatedTotal: number;
 }
 
-async function requireAdminOrManagement(
-  supabase: SupabaseClient,
-  req: Request,
-): Promise<{ userId: string; role: string; authorizationHeader: string }> {
-  const token = requireBearerToken(req, {
-    message: "Missing or malformed authorization header",
-    code: "missing_authorization",
-  });
-
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    console.error("[send-payout-override-notification] Token verification failed:", authError?.message);
-    throw new HttpError(401, "Invalid or expired token", { code: "invalid_authorization" });
-  }
-
-  const { data: callerProfile, error: profileError } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (profileError) {
-    console.error("[send-payout-override-notification] Profile lookup failed:", profileError.message);
-    throw new HttpError(500, "Authorization lookup failed", {
-      code: "authorization_lookup_failed",
-      exposeDetails: false,
-    });
-  }
-
-  const role = typeof callerProfile?.role === "string"
-    ? callerProfile.role.toLowerCase()
-    : "";
-
-  if (!ADMIN_ROLES.has(role)) {
-    console.warn("[send-payout-override-notification] Forbidden: user", user.id, "role:", role || "<missing>");
-    throw new HttpError(403, "Forbidden: insufficient permissions", {
-      code: "insufficient_role",
-    });
-  }
-
-  return {
-    userId: user.id,
-    role,
-    authorizationHeader: `Bearer ${token}`,
-  };
-}
-
 serve(createHttpHandler(async (req) => {
   const correlationId = getCorrelationId(req);
   const responseHeaders = correlationHeaders(correlationId);
@@ -108,7 +60,9 @@ serve(createHttpHandler(async (req) => {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const caller = await requireAdminOrManagement(supabase, req);
+  const caller = await requireAdminOrManagement(supabase, req, {
+    logContext: "send-payout-override-notification",
+  });
 
   // Parse request body
   const payload = await readBoundedJsonObject<PayoutOverrideNotificationRequest>(req, {

--- a/supabase/functions/system-health/index.ts
+++ b/supabase/functions/system-health/index.ts
@@ -5,9 +5,9 @@ import {
   createHttpHandler,
   HttpError,
   jsonResponse,
-  requireBearerToken,
   requireEnvValues,
 } from "../_shared/http.ts";
+import { requireAdminOrManagement } from "../_shared/auth.ts";
 import { persistSecurityAuditLog } from "../_shared/securityAudit.ts";
 
 // Privileged integrity diagnostics (ENT-OBS-02).
@@ -21,8 +21,6 @@ import { persistSecurityAuditLog } from "../_shared/securityAudit.ts";
 //   * audited on every access.
 //
 // Unauthenticated liveness lives in the separate `health` function.
-
-const PRIVILEGED_ROLES = new Set(["admin", "management"]);
 
 type CheckStatus = "ok" | "warning" | "critical" | "error";
 
@@ -58,46 +56,25 @@ serve(createHttpHandler(async (req) => {
     (name) => Deno.env.get(name),
   );
 
-  const accessToken = requireBearerToken(req);
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const { data: authData, error: authError } = await supabase.auth.getUser(accessToken);
-  const user = authData?.user ?? null;
-
-  if (authError || !user) {
-    throw new HttpError(401, "Unauthorized", { code: "invalid_token" });
-  }
-
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (profileError) {
-    // Do not mistake an upstream lookup failure for an authorization denial.
-    console.error("system-health profile lookup failed", profileError?.message);
-    throw new HttpError(500, "Authorization lookup failed", {
-      code: "authorization_lookup_failed",
-      exposeDetails: false,
-    });
-  }
-
-  const role = typeof profile?.role === "string" ? profile.role.toLowerCase() : "";
-
-  if (!PRIVILEGED_ROLES.has(role)) {
-    await persistSecurityAuditLog(req, supabase, {
-      user_id: user.id,
-      action: "system_health_access_denied",
-      resource: "edge.system-health",
-      severity: "medium",
-      metadata: { role: role || null },
-    }).catch((error) => console.error("system-health audit (denied) failed", error));
-
-    throw new HttpError(403, "Forbidden", { code: "insufficient_role" });
-  }
+  const caller = await requireAdminOrManagement(supabase, req, {
+    logContext: "system-health",
+    missingMessage: "Unauthorized",
+    invalidMessage: "Unauthorized",
+    invalidCode: "invalid_token",
+    forbiddenMessage: "Forbidden",
+    onForbidden: ({ userId, role }) =>
+      persistSecurityAuditLog(req, supabase, {
+        user_id: userId,
+        action: "system_health_access_denied",
+        resource: "edge.system-health",
+        severity: "medium",
+        metadata: { role: role || null },
+      }).catch((error) => console.error("system-health audit (denied) failed", error)),
+  });
 
   const [orphanedResult, doubleBookingResult, declinedResult] = await Promise.all([
     supabase.rpc("find_orphaned_timesheets"),
@@ -132,7 +109,7 @@ serve(createHttpHandler(async (req) => {
         : "ok";
 
   await persistSecurityAuditLog(req, supabase, {
-    user_id: user.id,
+    user_id: caller.userId,
     action: "system_health_viewed",
     resource: "edge.system-health",
     severity: "low",


### PR DESCRIPTION
## Summary
- Add a shared Edge Function auth helper for bearer-token verification, profile role lookup, allowlist enforcement, normalized caller context, and forbidden hooks.
- Migrate privileged user-admin, diagnostics, and payout notification handlers to the shared admin/management guard.
- Preserve endpoint-specific auth error messages/codes and correlation headers while reducing duplicated role-check logic.
- Document the Phase 2 follow-up in the trust-boundary hardening notes.

## Validation
- npm run lint
- npm run lint:functions
- npm run typecheck
- npm run test:run
- npm run test:run -- supabase/functions/_shared/auth.test.ts supabase/functions/_shared/http.test.ts
- npm run build
- npm run governance
- git diff --check
- ./scripts/check-staged-secrets.sh

## Deployment notes
No database migrations. After CI and CodeRabbit are clean, deploy the changed Supabase functions: create-user, delete-user, system-health, send-job-payout-email, send-payout-override-notification.