### PR TITLE
[codex] fix wallboard feed cors

### DIFF
--- a/supabase/functions/wallboard-feed/index.ts
+++ b/supabase/functions/wallboard-feed/index.ts
@@ -41,8 +41,8 @@ function corsHeaders() {
   return {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-wallboard-jwt, x-wallboard-token, x-wallboard-shared-token, x-wallboard-shared",
-    "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Max-Age": "86400",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Max-Age": "86400",
   } as Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary

Fixes the production wallboard feed CORS preflight by allowing the POST method used by `supabase.functions.invoke`.

## Root cause

`wallboard-feed` accepted Supabase client invoke requests server-side, but its CORS response advertised only `GET, OPTIONS`. Browser preflight for the app's `POST` request with `authorization`, `content-type`, and `x-wallboard-jwt` headers was therefore rejected before the request reached the function.

## Production mitigation

The updated `wallboard-feed` Edge Function has already been deployed to project `syldobdcdsgfgjtbuwxm` to restore production wallboard access. This PR keeps source control aligned with the deployed function.

## Validation

- `git diff --check`
- `npm run lint:functions` (passes with existing warnings)
- Verified live preflight now returns `Access-Control-Allow-Methods: GET, POST, OPTIONS` for `https://sector-pro.work`.
