### PR TITLE
[codex] fix public wallboard TV frame headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -10,6 +10,12 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), fullscreen=(self), payment=()
 
+# The LG webOS wallboard launcher embeds the public wallboard URL in an iframe.
+# Keep X-Frame-Options locked down globally, but detach it for this read-only
+# tokenized signage route so already-installed TV launchers can load it.
+/wallboard/public/*
+  ! X-Frame-Options
+
 # Prevent service worker caching to ensure users always get the latest version
 /sw.js
   Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0


### PR DESCRIPTION
## Summary

Allow the public wallboard route used by the LG/webOS TV launcher to be embedded again.

## Root cause

The global Cloudflare Pages headers added `X-Frame-Options: DENY` to every route. The `SectorProWallboard` TV launcher loads `/wallboard/public/:token/:presetSlug` inside an iframe, so the production response header blocks the wallboard before the React app can load.

## Change

- Detach `X-Frame-Options` only for `/wallboard/public/*`.
- Keep the global `X-Frame-Options: DENY` header for the rest of the app.

Cloudflare Pages supports detaching inherited headers in `_headers` with `! Header-Name`.

## Validation

- `git diff --check`
- `npm run build`
- Verified production currently sends `X-Frame-Options: DENY` on the TV wallboard URLs; after merge/deploy this route should no longer include that header.
