### PR TITLE
[codex] Phase 2 staffing message edge hardening

### DIFF
--- a/docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md
+++ b/docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md
@@ -714,10 +714,13 @@ and enforced in CI — Edge Function exposure classification gate,
 SECURITY DEFINER anonymous-grant gate, liveness/diagnostic health split,
 anonymous-reach revoke migration, shared correlation/size-limit/redaction
 primitives, durable service-role public Edge rate limiting for high-risk
-public/token endpoints, and pgTAP authorization regressions. See
+public/token endpoints, and pgTAP authorization regressions. Follow-up handler
+migration has started: user-admin, payout/expense notification, and
+staffing/message delivery slices are now on the shared HTTP/auth/body parsing
+path, and the legacy Edge Function baseline has been ratcheted down. See
 `docs/operations/phase-2-trust-boundary-hardening.md` for the exit-gate mapping
-and remaining follow-up (priority Edge Function handler migration and
-polling-safe wallboard abuse controls).
+and remaining follow-up (Flex/document handler migration and polling-safe
+wallboard abuse controls).
 
 ### Phase 3 — Test and correctness maturity
 

--- a/docs/operations/phase-2-trust-boundary-hardening.md
+++ b/docs/operations/phase-2-trust-boundary-hardening.md
@@ -161,9 +161,19 @@ TV polling behavior needs a separate, polling-safe threshold and rollout plan.
   notification functions (`send-expense-notification`, `send-job-payout-email`,
   `send-payout-override-notification`) were migrated on 2026-06-23 as the next
   follow-up slice, including explicit service-role/privileged-role guards and
-  bounded payload parsing. The duplicated admin/management caller checks across
-  the hardened user-admin, diagnostics, and payout handlers now route through
-  the shared auth helper.
+  bounded payload parsing. Staffing/message delivery functions
+  (`send-staffing-email`, `notify-staffing-cancellation`,
+  `send-tour-availability`, `send-warehouse-message`,
+  `send-job-whatsapp-message`) were migrated on 2026-06-24, reducing the legacy
+  Edge Function baseline from 53 to 48 entries. That slice also corrected the
+  trust-boundary classification for browser-invoked staffing cancellation and
+  staffing send paths: browser callers now require admin/management where the
+  function uses a service-role client, while service-role automation remains
+  explicit for the staffing orchestrator. The staffing send path also stopped
+  logging full request bodies, profile payloads, and generated confirmation
+  links. The duplicated admin/management caller checks across the hardened
+  user-admin, diagnostics, payout, and staffing/message handlers now route
+  through the shared auth helper.
 - Finish the wallboard auth/feed abuse-control design with TV-safe thresholds
   and rollout telemetry; avoid disrupting deployed APK wallboards.
 - Continue ratcheting the `anon`/`PUBLIC` grant baseline downward (trigger

--- a/scripts/governance/edge-function-baseline.json
+++ b/scripts/governance/edge-function-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-06-23T21:57:59.589Z",
+  "generatedAt": "2026-06-24T15:04:03.739Z",
   "note": "Existing manual Edge Functions are grandfathered. New functions must use createHttpHandler or add an explicit reviewed exemption.",
   "manualFunctions": [
     {
@@ -94,11 +94,6 @@
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "get-mapbox-token",
-      "path": "supabase/functions/get-mapbox-token/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "image-proxy",
       "path": "supabase/functions/image-proxy/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
@@ -111,11 +106,6 @@
     {
       "functionName": "manage-flex-crew-assignments",
       "path": "supabase/functions/manage-flex-crew-assignments/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "notify-staffing-cancellation",
-      "path": "supabase/functions/notify-staffing-cancellation/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
@@ -159,11 +149,6 @@
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "send-job-whatsapp-message",
-      "path": "supabase/functions/send-job-whatsapp-message/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "send-onboarding-email",
       "path": "supabase/functions/send-onboarding-email/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
@@ -174,28 +159,13 @@
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "send-staffing-email",
-      "path": "supabase/functions/send-staffing-email/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "send-timesheet-reminder",
       "path": "supabase/functions/send-timesheet-reminder/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "send-tour-availability",
-      "path": "supabase/functions/send-tour-availability/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "send-vacation-decision",
       "path": "supabase/functions/send-vacation-decision/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "send-warehouse-message",
-      "path": "supabase/functions/send-warehouse-message/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {

--- a/scripts/governance/edge-function-exposure.json
+++ b/scripts/governance/edge-function-exposure.json
@@ -35,7 +35,11 @@
     "image-proxy": { "class": "authenticated-user", "verifyJwt": true },
     "import-users": { "class": "privileged-role", "verifyJwt": true },
     "manage-flex-crew-assignments": { "class": "privileged-role", "verifyJwt": true },
-    "notify-staffing-cancellation": { "class": "service-only", "verifyJwt": true },
+    "notify-staffing-cancellation": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; browser callers must be authenticated admin/management, while service-role calls remain available for internal automation."
+    },
     "persist-flex-elements": { "class": "privileged-role", "verifyJwt": true },
     "place-photos": { "class": "authenticated-user", "verifyJwt": true },
     "place-restaurants": { "class": "authenticated-user", "verifyJwt": true },
@@ -55,7 +59,11 @@
       "verifyJwt": true,
       "internalGuard": "Validates the caller JWT with auth.getUser and requires profiles.role to be admin or management before reading payout overrides or sending email."
     },
-    "send-job-whatsapp-message": { "class": "privileged-role", "verifyJwt": true },
+    "send-job-whatsapp-message": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; validates the caller JWT with auth.getUser and requires admin or production department plus a WAHA endpoint before sending."
+    },
     "send-onboarding-email": { "class": "privileged-role", "verifyJwt": true },
     "send-password-reset": { "class": "privileged-role", "verifyJwt": true },
     "send-payout-override-notification": {
@@ -63,11 +71,23 @@
       "verifyJwt": true,
       "internalGuard": "Validates the caller JWT with auth.getUser, requires admin/management, and requires payload actorId to match the authenticated user before any service-role reads."
     },
-    "send-staffing-email": { "class": "service-only", "verifyJwt": true },
+    "send-staffing-email": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; browser callers must be authenticated admin/management, while the staffing orchestrator may call with the service-role key and an audited actor fallback."
+    },
     "send-timesheet-reminder": { "class": "privileged-role", "verifyJwt": true },
-    "send-tour-availability": { "class": "privileged-role", "verifyJwt": true },
+    "send-tour-availability": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper, bounded JSON parsing, and shared admin/management role guard before signing documents or sending email/WhatsApp availability requests."
+    },
     "send-vacation-decision": { "class": "privileged-role", "verifyJwt": true },
-    "send-warehouse-message": { "class": "authenticated-user", "verifyJwt": true },
+    "send-warehouse-message": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper, bounded JSON parsing, and shared admin/management role guard; also requires the caller profile to have a WAHA endpoint before sending warehouse WhatsApp messages."
+    },
     "set-job-preventive-resource": { "class": "privileged-role", "verifyJwt": true, "internalGuard": "ALLOWED_ROLES set restricts callers to admin/management/logistics." },
     "staffing-click": { "class": "public-token", "verifyJwt": false, "internalGuard": "Opaque per-invitation action token has durable ingress and per-link rate limits, then is validated against the campaign before any state transition." },
     "staffing-orchestrator": { "class": "service-only", "verifyJwt": false, "internalGuard": "Service-role/internal campaign execution; validates caller secret/service role before mutating campaign state." },

--- a/supabase/functions/_shared/auth.test.ts
+++ b/supabase/functions/_shared/auth.test.ts
@@ -2,8 +2,10 @@ import { type SupabaseClient, type User } from "npm:@supabase/supabase-js@2";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  isServiceRoleRequest,
   requireAdminOrManagement,
   requireAuthenticatedRole,
+  requireServiceRoleRequest,
 } from "./auth.ts";
 
 type ProfileError = {
@@ -131,5 +133,33 @@ describe("shared Edge Function auth helpers", () => {
     })).resolves.toMatchObject({
       role: "logistics",
     });
+  });
+
+  it("detects service-role requests from bearer or apikey headers without exposing partial matches", () => {
+    const serviceRoleKey = "service-role-secret";
+
+    expect(isServiceRoleRequest(new Request("https://example.com", {
+      headers: { Authorization: `Bearer ${serviceRoleKey}` },
+    }), serviceRoleKey)).toBe(true);
+
+    expect(isServiceRoleRequest(new Request("https://example.com", {
+      headers: { apikey: serviceRoleKey },
+    }), serviceRoleKey)).toBe(true);
+
+    expect(isServiceRoleRequest(new Request("https://example.com", {
+      headers: { Authorization: "Bearer service-role" },
+    }), serviceRoleKey)).toBe(false);
+  });
+
+  it("throws a structured forbidden error when service-role authorization is absent", () => {
+    try {
+      requireServiceRoleRequest(new Request("https://example.com"), "service-role-secret");
+      throw new Error("expected requireServiceRoleRequest to throw");
+    } catch (error) {
+      expect(error).toMatchObject({
+        status: 403,
+        code: "service_role_required",
+      });
+    }
   });
 });

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -34,6 +34,37 @@ type ProfileRoleRow = {
   role?: unknown;
 } | null;
 
+function timingSafeEqual(left: string, right: string): boolean {
+  const maxLength = Math.max(left.length, right.length);
+  let mismatch = left.length ^ right.length;
+
+  for (let index = 0; index < maxLength; index += 1) {
+    mismatch |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+  }
+
+  return mismatch === 0;
+}
+
+function extractBearerValue(req: Request): string {
+  const authorization = req.headers.get("authorization") ?? "";
+  return authorization.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? "";
+}
+
+export function isServiceRoleRequest(req: Request, serviceRoleKey: string): boolean {
+  if (!serviceRoleKey) return false;
+
+  const bearer = extractBearerValue(req);
+  const apikey = req.headers.get("apikey")?.trim() ?? "";
+
+  return timingSafeEqual(bearer, serviceRoleKey) || timingSafeEqual(apikey, serviceRoleKey);
+}
+
+export function requireServiceRoleRequest(req: Request, serviceRoleKey: string): void {
+  if (!isServiceRoleRequest(req, serviceRoleKey)) {
+    throw new HttpError(403, "Forbidden", { code: "service_role_required" });
+  }
+}
+
 const roleSet = (roles: ReadonlySet<string> | readonly string[]) =>
   new Set(Array.from(roles, (role) => role.toLowerCase()));
 

--- a/supabase/functions/notify-staffing-cancellation/index.ts
+++ b/supabase/functions/notify-staffing-cancellation/index.ts
@@ -1,6 +1,13 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
+import { isServiceRoleRequest, requireAdminOrManagement } from "../_shared/auth.ts";
+import {
+  corsHeaders,
+  createHttpHandler,
+  HttpError,
+  readBoundedJsonObject,
+} from "../_shared/http.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -11,35 +18,23 @@ const COMPANY_TZ = Deno.env.get('COMPANY_TZ') || 'Europe/Madrid';
 const COMPANY_LOGO_URL = Deno.env.get("COMPANY_LOGO_URL_W") || `${SUPABASE_URL}/storage/v1/object/public/company-assets/sectorlogow.png`;
 const AT_LOGO_URL = Deno.env.get("AT_LOGO_URL") || `${SUPABASE_URL}/storage/v1/object/public/company-assets/area-tecnica-logo.png`;
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Max-Age': '86400',
-};
-
-async function resolveActorId(supabase: ReturnType<typeof createClient>, req: Request): Promise<string | null> {
-  const authHeader = req.headers.get('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  const token = authHeader.replace('Bearer ', '').trim();
-  if (!token) return null;
-  try {
-    const { data, error } = await supabase.auth.getUser(token);
-    if (error) return null;
-    return data.user?.id ?? null;
-  } catch {
-    return null;
-  }
+type CancellationBody = {
+  job_id?: string;
+  profile_id?: string;
+  phase?: 'availability' | 'offer';
+  actor_id?: string;
 }
 
-serve(async (req) => {
-  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
-  if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
-
+serve(createHttpHandler(async (req) => {
   try {
     const supabase = createClient(SUPABASE_URL, SERVICE_ROLE);
-    const actorId = await resolveActorId(supabase, req);
-    const body = await req.json();
+    const body = await readBoundedJsonObject<Record<string, unknown>>(req, { maxBytes: 16 * 1024 }) as CancellationBody;
+    const serviceRequest = isServiceRoleRequest(req, SERVICE_ROLE);
+    const actorId = serviceRequest
+      ? (typeof body.actor_id === 'string' ? body.actor_id : null)
+      : (await requireAdminOrManagement(supabase, req, {
+        logContext: "notify-staffing-cancellation",
+      })).userId;
     const { job_id, profile_id, phase } = body as { job_id: string, profile_id: string, phase: 'availability'|'offer' };
 
     if (!job_id || !profile_id || !['availability','offer'].includes(phase)) {
@@ -259,7 +254,8 @@ serve(async (req) => {
     }
 
   } catch (error) {
+    if (error instanceof HttpError) throw error;
     console.error('notify-staffing-cancellation error:', error);
     return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   }
-});
+}, { allowedMethods: ["POST"] }));

--- a/supabase/functions/send-job-whatsapp-message/index.ts
+++ b/supabase/functions/send-job-whatsapp-message/index.ts
@@ -1,7 +1,12 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
-import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+} from "../_shared/http.ts";
 import { checkAndRecordWhatsappQuota } from "../_shared/whatsappQuota.ts";
 
 /** Request payload for sending a WhatsApp message to multiple assigned users. */
@@ -297,13 +302,7 @@ function logRejection(
   console.warn("send-job-whatsapp-message rejected", { reason, ...details });
 }
 
-serve(async (req: Request) => {
-  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
-  if (req.method !== "POST") {
-    logRejection("method_not_allowed", { method: req.method });
-    return jsonResponse({ error: "Method Not Allowed" }, { status: 405 });
-  }
-
+serve(createHttpHandler(async (req: Request) => {
   try {
     const supabaseAdmin = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
@@ -347,7 +346,7 @@ serve(async (req: Request) => {
       return jsonResponse({ error: "Forbidden", reason: "User not authorized for WhatsApp operations" }, { status: 403 });
     }
 
-    const body = (await req.json().catch(() => ({}))) as SendRequest;
+    const body = await readBoundedJsonObject<Record<string, unknown>>(req, { maxBytes: 64 * 1024 }) as SendRequest;
     const message = (body.message || "").toString().trim();
     const recipientIds = Array.isArray(body.recipient_ids) ? body.recipient_ids.filter(Boolean) : [];
     const dedupedRecipientIds = Array.from(new Set(recipientIds));
@@ -633,7 +632,8 @@ serve(async (req: Request) => {
       { status: 200 },
     );
   } catch (err) {
+    if (err instanceof HttpError) throw err;
     console.error("send-job-whatsapp-message error:", err);
     return jsonResponse({ error: "Internal Server Error" }, { status: 500 });
   }
-});
+}, { allowedMethods: ["POST"] }));

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -7,6 +7,13 @@ import {
   normalizeStaffingConfirmBase,
 } from "./messageUtils.ts";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
+import { isServiceRoleRequest, requireAdminOrManagement } from "../_shared/auth.ts";
+import {
+  corsHeaders,
+  createHttpHandler,
+  HttpError,
+  readBoundedJsonObject,
+} from "../_shared/http.ts";
 
 // Inlined from roles.ts for dashboard deployment compatibility
 const CODE_TO_LABEL: Record<string, string> = {
@@ -118,45 +125,6 @@ const DAILY_CAP = parseInt(Deno.env.get("STAFFING_DAILY_CAP") ?? "100", 10);
 const COMPANY_TZ = Deno.env.get('COMPANY_TZ') || 'Europe/Madrid';
 const STAFFING_SYSTEM_ACTOR_ID = Deno.env.get('STAFFING_SYSTEM_ACTOR_ID') || null;
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Max-Age': '86400',
-};
-
-async function resolveActorId(supabase: ReturnType<typeof createClient>, req: Request): Promise<string | null> {
-  const authHeader = req.headers.get('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return null;
-  }
-
-  const token = authHeader.replace('Bearer ', '').trim();
-  if (!token) return null;
-
-  try {
-    const { data, error } = await supabase.auth.getUser(token);
-    if (error) {
-      console.warn('[send-staffing-email] Unable to resolve actor id:', error);
-      return null;
-    }
-    return data.user?.id ?? null;
-  } catch (err) {
-    console.warn('[send-staffing-email] Error resolving actor id', err);
-    return null;
-  }
-}
-
-function isServiceRoleRequest(req: Request): boolean {
-  const authHeader = req.headers.get('Authorization') || '';
-  const apikey = req.headers.get('apikey') || '';
-  const token = authHeader.startsWith('Bearer ')
-    ? authHeader.slice('Bearer '.length).trim()
-    : '';
-
-  return token === SERVICE_ROLE || apikey === SERVICE_ROLE;
-}
-
 function b64url(u8: Uint8Array) {
   return btoa(String.fromCharCode(...u8)).replace(/\+/g,"-").replace(/\//g,"_").replace(/=+$/,"");
 }
@@ -247,25 +215,31 @@ function emitStaffingPush(params: {
   }
 }
 
-serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
-
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: corsHeaders });
-  
+serve(createHttpHandler(async (req) => {
   try {
     const supabase = createClient(SUPABASE_URL, SERVICE_ROLE);
-    let actorId = await resolveActorId(supabase, req);
-    const body = await req.json();
-    if (!actorId && isServiceRoleRequest(req) && typeof body?.actor_id === 'string') {
+    const body = await readBoundedJsonObject<Record<string, any>>(req, { maxBytes: 128 * 1024 });
+    const serviceRequest = isServiceRoleRequest(req, SERVICE_ROLE);
+    let actorId: string | null = null;
+
+    if (serviceRequest && typeof body?.actor_id === 'string') {
       actorId = body.actor_id;
     }
-    if (!actorId && isServiceRoleRequest(req) && isUuid(STAFFING_SYSTEM_ACTOR_ID)) {
+
+    if (!serviceRequest) {
+      actorId = (await requireAdminOrManagement(supabase, req, {
+        logContext: "send-staffing-email",
+      })).userId;
+    }
+
+    if (!actorId && serviceRequest && isUuid(STAFFING_SYSTEM_ACTOR_ID)) {
       actorId = STAFFING_SYSTEM_ACTOR_ID;
     }
-    console.log('📥 RECEIVED PAYLOAD:', JSON.stringify(body, null, 2));
+    console.log('📥 RECEIVED STAFFING REQUEST:', {
+      serviceRequest,
+      hasActor: Boolean(actorId),
+      fields: Object.keys(body).sort(),
+    });
 
     const { job_id, profile_id, phase, role, message, channel, tour_pdf_path, target_date, single_day, override_conflicts, require_no_conflicts, idempotency_key, request_origin, campaign_id, department } = body;
     const roleCode = typeof role === 'string' && role.trim().length > 0 ? role.trim() : null;
@@ -302,12 +276,12 @@ serve(async (req) => {
       profile_id: { value: profile_id, type: typeof profile_id, isValid: !!profile_id },
       phase: { value: phase, type: typeof phase, isValidPhase: ["availability","offer"].includes(phase) },
       role: { value: role ?? null, normalized: roleCode },
-      message: { value: message ?? null },
+      message: { present: typeof message === 'string' && message.trim().length > 0, length: typeof message === 'string' ? message.length : 0 },
       target_date: { value: target_date ?? null, normalized: normalizedTargetDate },
       single_day: { value: single_day ?? null, effective: isSingleDayRequest },
       dates: normalizedDates,
       require_no_conflicts: shouldRequireNoConflicts,
-      idempotency_key: { value: idempotency_key ?? null }
+      idempotency_key: { present: typeof idempotency_key === 'string' && idempotency_key.length > 0 }
     });
     
     if (!job_id || !profile_id || !["availability","offer"].includes(phase)) {
@@ -466,9 +440,11 @@ serve(async (req) => {
         jobDepartmentsPromise,
       ]);
       
-      console.log('📋 JOB RESULT:', { data: jobResult.data, error: jobResult.error });
+      console.log('📋 JOB RESULT:', { found: Boolean(jobResult.data), error: jobResult.error });
       console.log('👤 PROFILE RESULT:', { 
-        data: techResult.data ? { ...techResult.data, email: techResult.data.email ? '***@***.***' : null } : null, 
+        found: Boolean(techResult.data),
+        has_email: Boolean(techResult.data?.email),
+        has_phone: Boolean(techResult.data?.phone),
         error: techResult.error 
       });
       if (roleDepartmentResult.error) {
@@ -1328,11 +1304,10 @@ serve(async (req) => {
       </html>`;
 
       // Step 6: Deliver via chosen channel
-      console.log('🔗 CONFIRM LINKS:', {
-        emailConfirmUrl,
-        emailDeclineUrl,
-        whatsappConfirmUrl,
-        whatsappDeclineUrl,
+      console.log('🔗 CONFIRM LINKS GENERATED:', {
+        email: desiredChannel === 'email',
+        whatsapp: desiredChannel === 'whatsapp',
+        expires_at: new Date(exp * 1000).toISOString(),
       });
       if (desiredChannel === 'whatsapp') {
         const text = buildWhatsAppStaffingMessage({
@@ -1611,17 +1586,15 @@ serve(async (req) => {
 
     } catch (operationError) {
       console.error('❌ OPERATION ERROR:', operationError);
-      return new Response(JSON.stringify({ 
-        error: "Internal server error", 
-        details: { message: operationError.message, stack: operationError.stack }
-      }), { 
+      return new Response(JSON.stringify({ error: "Internal server error" }), {
         status: 500, 
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       });
     }
 
   } catch (error) {
+    if (error instanceof HttpError) throw error;
     console.error("Server error:", error);
     return new Response("Server error", { status: 500, headers: corsHeaders });
   }
-});
+}, { allowedMethods: ["POST"] }));

--- a/supabase/functions/send-tour-availability/index.ts
+++ b/supabase/functions/send-tour-availability/index.ts
@@ -1,46 +1,42 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
+import { requireAdminOrManagement } from "../_shared/auth.ts";
+import {
+  corsHeaders,
+  createHttpHandler,
+  HttpError,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Max-Age': '86400',
-};
-
-serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
-  if (req.method !== 'POST') {
-    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
-  }
-
+serve(createHttpHandler(async (req) => {
   try {
-    const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
-    const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
-    const BREVO_KEY = Deno.env.get('BREVO_API_KEY')!;
-    const BREVO_FROM = Deno.env.get('BREVO_FROM')!;
+    const {
+      SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY: SERVICE_ROLE,
+    } = requireEnvValues(
+      ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const,
+      (name) => Deno.env.get(name),
+    );
+    const BREVO_KEY = Deno.env.get('BREVO_API_KEY') || '';
+    const BREVO_FROM = Deno.env.get('BREVO_FROM') || '';
     const COMPANY_LOGO_URL = Deno.env.get('COMPANY_LOGO_URL_W') || `${SUPABASE_URL}/storage/v1/object/public/company-assets/sectorlogow.png`;
     const AT_LOGO_URL = Deno.env.get('AT_LOGO_URL') || `${SUPABASE_URL}/storage/v1/object/public/company-assets/area-tecnica-logo.png`;
 
     const supabase = createClient(SUPABASE_URL, SERVICE_ROLE);
 
     // AuthN: require logged-in admin/management
-    const authHeader = req.headers.get('authorization') || req.headers.get('Authorization');
-    if (!authHeader) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
-    const token = authHeader.replace('Bearer ', '').trim();
-    const { data: userRes } = await supabase.auth.getUser(token);
-    const requester = userRes?.user;
-    if (!requester) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
-    const { data: requesterProfile } = await supabase.from('profiles').select('role,waha_endpoint').eq('id', requester.id).maybeSingle();
-    const requesterRole = (requesterProfile as any)?.role;
-    if (!['admin','management'].includes(requesterRole || '')) {
-      return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
-    }
+    const requester = await requireAdminOrManagement(supabase, req, {
+      logContext: "send-tour-availability",
+    });
+    const { data: requesterProfile } = await supabase
+      .from('profiles')
+      .select('waha_endpoint')
+      .eq('id', requester.userId)
+      .maybeSingle();
 
-    const body = await req.json();
+    const body = await readBoundedJsonObject(req, { maxBytes: 64 * 1024 });
     const { tour_id, profile_id, channel, message, tour_pdf_path } = body || {};
     const desiredChannel: 'email'|'whatsapp' = (String(channel || '').toLowerCase() === 'whatsapp') ? 'whatsapp' : 'email';
 
@@ -210,7 +206,8 @@ serve(async (req) => {
     }
     return new Response(JSON.stringify({ success: true, channel: 'email' }), { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
   } catch (err) {
+    if (err instanceof HttpError) throw err;
     console.error('[send-tour-availability] error:', err);
     return new Response('Server error', { status: 500, headers: corsHeaders });
   }
-});
+}, { allowedMethods: ["POST"] }));

--- a/supabase/functions/send-warehouse-message/index.ts
+++ b/supabase/functions/send-warehouse-message/index.ts
@@ -1,12 +1,14 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-};
+import { requireAdminOrManagement } from "../_shared/auth.ts";
+import {
+  corsHeaders,
+  createHttpHandler,
+  HttpError,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
 
 interface SendRequest {
   message?: string;
@@ -16,48 +18,34 @@ interface SendRequest {
 
 const WAREHOUSE_SOUND_GROUP = "120363042398076348@g.us"; // "Almacén sonido"
 
-serve(async (req: Request) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
-  if (req.method !== 'POST') {
-    return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
-  }
-
+serve(createHttpHandler(async (req: Request) => {
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
   const supabaseAdmin = createClient(
-    Deno.env.get('SUPABASE_URL') ?? '',
-    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
   );
 
   try {
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
-      return new Response(JSON.stringify({ error: 'Unauthorized', reason: 'Missing Authorization header' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
-    const token = authHeader.replace('Bearer ', '').trim();
-
-    const { data: userData } = await supabaseAdmin.auth.getUser(token);
-    const actorId = userData?.user?.id || null;
-    if (!actorId) {
-      return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
+    const caller = await requireAdminOrManagement(supabaseAdmin, req, {
+      logContext: "send-warehouse-message",
+    });
+    const actorId = caller.userId;
 
     // Load actor profile to read role and WAHA endpoint
     const { data: profile } = await supabaseAdmin
       .from('profiles')
-      .select('id, role, waha_endpoint')
+      .select('id, waha_endpoint')
       .eq('id', actorId)
       .maybeSingle();
 
-    const role = (profile?.role || '').toLowerCase();
-    if (!['admin', 'management'].includes(role)) {
-      return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
     if (!profile?.waha_endpoint) {
       return new Response(JSON.stringify({ error: 'Forbidden', reason: 'User not authorized for WhatsApp operations' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    const body = (await req.json().catch(() => ({}))) as SendRequest;
+    const body = await readBoundedJsonObject<Record<string, unknown>>(req, { maxBytes: 32 * 1024 }) as SendRequest;
     let msg = (body.message || '').toString().trim();
 
     // Fetch job title early if available (to detect default message and build fallback)
@@ -292,7 +280,8 @@ serve(async (req: Request) => {
 
     return new Response(JSON.stringify({ success: true }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   } catch (err) {
+    if (err instanceof HttpError) throw err;
     console.error('send-warehouse-message error:', err);
     return new Response(JSON.stringify({ error: 'Unexpected error' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   }
-});
+}, { allowedMethods: ["POST"] }));


### PR DESCRIPTION
## Summary

- Migrates five staffing/message Edge handlers onto the shared HTTP wrapper and bounded JSON parsing path:
  - `send-staffing-email`
  - `notify-staffing-cancellation`
  - `send-tour-availability`
  - `send-warehouse-message`
  - `send-job-whatsapp-message`
- Adds shared service-role request detection/guard helpers with tests.
- Corrects governance exposure classifications for browser-invoked service-role-client handlers and ratchets the legacy Edge Function baseline down to 48 manual entrypoints.
- Tightens `send-staffing-email` logging so full request bodies, profile payloads, generated confirmation URLs, and internal stack traces are not returned/logged.

## Impact

Browser callers for staffing/message delivery paths now require the intended privileged role checks before service-role reads/writes or WhatsApp/email dispatch. Internal service-role staffing automation remains explicitly supported where required.

No Supabase migrations are included in this PR.

## Validation

Final tree:
- `npm run governance`
- `npm run lint:functions` — 0 errors; existing warnings remain
- `npm run typecheck`
- `npx vitest run supabase/functions/_shared/auth.test.ts`
- `git diff --check`

Broader gates also run for this slice before the final log-scrub/doc note:
- `npm run lint` — 0 errors; existing warnings remain
- `npm run test:run`
- `npm run build`