### PR TITLE
[codex] Phase 2 Flex proxy edge hardening

### DIFF
--- a/docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md
+++ b/docs/ENTERPRISE_CODEBASE_AUDIT_2026-06-23.md
@@ -715,12 +715,13 @@ SECURITY DEFINER anonymous-grant gate, liveness/diagnostic health split,
 anonymous-reach revoke migration, shared correlation/size-limit/redaction
 primitives, durable service-role public Edge rate limiting for high-risk
 public/token endpoints, and pgTAP authorization regressions. Follow-up handler
-migration has started: user-admin, payout/expense notification, and
-staffing/message delivery slices are now on the shared HTTP/auth/body parsing
-path, and the legacy Edge Function baseline has been ratcheted down. See
+migration has started: user-admin, payout/expense notification,
+staffing/message delivery, and Flex proxy/support slices are now on the shared
+HTTP/auth/body parsing path, and the legacy Edge Function baseline has been
+ratcheted down. See
 `docs/operations/phase-2-trust-boundary-hardening.md` for the exit-gate mapping
-and remaining follow-up (Flex/document handler migration and polling-safe
-wallboard abuse controls).
+and remaining follow-up (larger Flex/document generation/mutation handlers and
+polling-safe wallboard abuse controls).
 
 ### Phase 3 — Test and correctness maturity
 

--- a/docs/operations/phase-2-trust-boundary-hardening.md
+++ b/docs/operations/phase-2-trust-boundary-hardening.md
@@ -171,9 +171,16 @@ TV polling behavior needs a separate, polling-safe threshold and rollout plan.
   function uses a service-role client, while service-role automation remains
   explicit for the staffing orchestrator. The staffing send path also stopped
   logging full request bodies, profile payloads, and generated confirmation
-  links. The duplicated admin/management caller checks across the hardened
-  user-admin, diagnostics, payout, and staffing/message handlers now route
-  through the shared auth helper.
+  links. Flex proxy/support handlers (`secure-flex-api`,
+  `fetch-flex-contact-info`, `fetch-flex-inventory-model`, `fetch-flex-image`,
+  `persist-flex-elements`) were migrated on 2026-06-24, reducing the legacy
+  Edge Function baseline from 48 to 43 entries. That slice closed the
+  unauthenticated `persist-flex-elements` service-role write path, moved Flex
+  lookup/proxy handlers onto bounded payload parsing, removed raw Flex lookup
+  payloads from client responses, and made authenticated image responses use
+  private cache headers. The duplicated admin/management caller checks across
+  the hardened user-admin, diagnostics, payout, staffing/message, and Flex
+  proxy handlers now route through the shared auth helper.
 - Finish the wallboard auth/feed abuse-control design with TV-safe thresholds
   and rollout telemetry; avoid disrupting deployed APK wallboards.
 - Continue ratcheting the `anon`/`PUBLIC` grant baseline downward (trigger

--- a/scripts/governance/edge-function-baseline.json
+++ b/scripts/governance/edge-function-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-06-24T15:04:03.739Z",
+  "generatedAt": "2026-06-24T15:24:24.680Z",
   "note": "Existing manual Edge Functions are grandfathered. New functions must use createHttpHandler or add an explicit reviewed exemption.",
   "manualFunctions": [
     {
@@ -59,21 +59,6 @@
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "fetch-flex-contact-info",
-      "path": "supabase/functions/fetch-flex-contact-info/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "fetch-flex-image",
-      "path": "supabase/functions/fetch-flex-image/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "fetch-flex-inventory-model",
-      "path": "supabase/functions/fetch-flex-inventory-model/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "generate-lights-memoria-tecnica",
       "path": "supabase/functions/generate-lights-memoria-tecnica/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
@@ -109,11 +94,6 @@
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "persist-flex-elements",
-      "path": "supabase/functions/persist-flex-elements/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "place-photos",
       "path": "supabase/functions/place-photos/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
@@ -126,11 +106,6 @@
     {
       "functionName": "recalc-timesheet-amount",
       "path": "supabase/functions/recalc-timesheet-amount/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "secure-flex-api",
-      "path": "supabase/functions/secure-flex-api/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {

--- a/scripts/governance/edge-function-exposure.json
+++ b/scripts/governance/edge-function-exposure.json
@@ -22,9 +22,21 @@
     "delete-public-artist-rider": { "class": "public-token", "verifyJwt": false, "internalGuard": "Festival artist form access token validated against the submission before any storage delete; guarded by durable ingress and token/document scoped rate limits." },
     "delete-user": { "class": "privileged-role", "verifyJwt": true },
     "evaluate-achievements": { "class": "service-only", "verifyJwt": true },
-    "fetch-flex-contact-info": { "class": "privileged-role", "verifyJwt": true },
-    "fetch-flex-image": { "class": "authenticated-user", "verifyJwt": true },
-    "fetch-flex-inventory-model": { "class": "privileged-role", "verifyJwt": true },
+    "fetch-flex-contact-info": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; validates the caller JWT and requires admin/management before fetching Flex contact key-info."
+    },
+    "fetch-flex-image": {
+      "class": "authenticated-user",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper; validates the caller JWT before proxying allowlisted Flex image IDs and returns authenticated-user private cache headers."
+    },
+    "fetch-flex-inventory-model": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; validates the caller JWT and requires admin/management before fetching Flex inventory model details."
+    },
     "generate-lights-memoria-tecnica": { "class": "authenticated-user", "verifyJwt": true },
     "generate-memoria-tecnica": { "class": "authenticated-user", "verifyJwt": true },
     "generate-sv-report": { "class": "authenticated-user", "verifyJwt": true },
@@ -40,12 +52,20 @@
       "verifyJwt": true,
       "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; browser callers must be authenticated admin/management, while service-role calls remain available for internal automation."
     },
-    "persist-flex-elements": { "class": "privileged-role", "verifyJwt": true },
+    "persist-flex-elements": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; validates the caller JWT, requires admin/management, and validates created Flex element records before service-role persistence."
+    },
     "place-photos": { "class": "authenticated-user", "verifyJwt": true },
     "place-restaurants": { "class": "authenticated-user", "verifyJwt": true },
     "push": { "class": "authenticated-user", "verifyJwt": true },
     "recalc-timesheet-amount": { "class": "service-only", "verifyJwt": true },
-    "secure-flex-api": { "class": "privileged-role", "verifyJwt": true },
+    "secure-flex-api": {
+      "class": "privileged-role",
+      "verifyJwt": true,
+      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; validates the caller JWT, requires admin/management, and preserves the Flex endpoint/method/header allowlists before proxying."
+    },
     "security-audit": { "class": "privileged-role", "verifyJwt": true },
     "send-bug-resolution-email": { "class": "privileged-role", "verifyJwt": true },
     "send-corporate-email": { "class": "privileged-role", "verifyJwt": true },

--- a/supabase/functions/fetch-flex-contact-info/index.ts
+++ b/supabase/functions/fetch-flex-contact-info/index.ts
@@ -1,13 +1,19 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import { requireAdminOrManagement } from "../_shared/auth.ts";
 import { fetchWithRetry } from "../_shared/flexFetch.ts";
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-};
+interface FetchFlexContactBody extends Record<string, unknown> {
+  contact_id?: unknown;
+  url?: unknown;
+}
 
 function extractUuid(input: string): string | null {
   const uuidRe = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/;
@@ -15,72 +21,73 @@ function extractUuid(input: string): string | null {
   return m?.[0] || null;
 }
 
-serve(async (req: Request) => {
-  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: corsHeaders });
+serve(createHttpHandler(async (req: Request) => {
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+  const flexAuthToken =
+    Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
 
-  try {
-    const body = await req.json() as { contact_id?: string; url?: string };
-    const supabase = createClient(
-      Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
-    );
-
-    // AuthZ: require admin or management
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    const { data: { user } } = await supabase.auth.getUser(authHeader.replace('Bearer ', ''));
-    if (!user) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    const { data: profile } = await supabase.from('profiles').select('role').eq('id', user.id).maybeSingle();
-    if (!profile || !['admin','management'].includes(profile.role)) {
-      return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
-
-    // Parse contact id
-    const cid = body.contact_id || (body.url ? extractUuid(body.url) : null);
-    if (!cid) return new Response(JSON.stringify({ error: 'Missing contact_id or url' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-
-    const flexAuthToken =
-      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
-    if (!flexAuthToken) return new Response(JSON.stringify({ error: 'Flex auth not configured' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-
-    // Call Flex key-info
-    const qs = new URLSearchParams();
-    qs.set('_dc', String(Date.now()));
-    const url = `https://sectorpro.flexrentalsolutions.com/f5/api/contact/${encodeURIComponent(cid)}/key-info/?${qs.toString()}`;
-    const res = await fetchWithRetry(url, { headers: { 'X-Auth-Token': flexAuthToken, 'apikey': flexAuthToken, 'X-Requested-With': 'XMLHttpRequest' } });
-    if (!res.ok) {
-      const text = await res.text();
-      return new Response(JSON.stringify({ error: `Flex error ${res.status}`, details: text }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
-    const info = await res.json();
-
-    // Map to our profile fields
-    const firstName = info?.firstName || '';
-    const lastName = info?.lastName || '';
-    const email = info?.defaultEmail?.url || '';
-    const dial = info?.defaultPhone?.dialNumber || '';
-    const cc = info?.defaultPhone?.countryCode || '';
-    const phone = [cc ? `+${cc}` : '', dial].filter(Boolean).join(' ');
-    const residencia = info?.homeBaseLocation?.preferredDisplayString || info?.homeBaseLocation?.name || '';
-    const dni = info?.assignedNumber || '';
-    const contactTypeName = Array.isArray(info?.contactTypes) && info.contactTypes.length ? String(info.contactTypes[0]?.name || '') : '';
-    const dept = (() => {
-      const s = contactTypeName.toLowerCase();
-      if (/sonido|sound/.test(s)) return 'sound';
-      if (/luz|luces|light/.test(s)) return 'lights';
-      if (/video/.test(s)) return 'video';
-      return null;
-    })();
-
-    return new Response(JSON.stringify({
-      ok: true,
-      contact_id: cid,
-      mapped: { firstName, lastName, email, phone, residencia, dni, department: dept },
-      raw: info
-    }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-  } catch (e) {
-    const msg = (e as any)?.message || String(e);
-    return new Response(JSON.stringify({ error: msg }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  if (!flexAuthToken) {
+    throw new HttpError(503, "Flex auth not configured", {
+      code: "flex_auth_missing",
+      exposeDetails: false,
+    });
   }
-});
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  await requireAdminOrManagement(supabase, req, {
+    logContext: "fetch-flex-contact-info",
+  });
+
+  const body = await readBoundedJsonObject<FetchFlexContactBody>(req, { maxBytes: 16 * 1024 });
+
+  // Parse contact id
+  const contactInput = typeof body.contact_id === "string" ? body.contact_id : "";
+  const urlInput = typeof body.url === "string" ? body.url : "";
+  const cid = extractUuid(contactInput) || extractUuid(urlInput);
+  if (!cid) {
+    throw new HttpError(400, "Missing contact_id or url", {
+      code: "missing_flex_contact_id",
+    });
+  }
+
+  // Call Flex key-info
+  const qs = new URLSearchParams();
+  qs.set('_dc', String(Date.now()));
+  const url = `https://sectorpro.flexrentalsolutions.com/f5/api/contact/${encodeURIComponent(cid)}/key-info/?${qs.toString()}`;
+  const res = await fetchWithRetry(url, { headers: { 'X-Auth-Token': flexAuthToken, 'apikey': flexAuthToken, 'X-Requested-With': 'XMLHttpRequest' } });
+  if (!res.ok) {
+    throw new HttpError(502, `Flex error ${res.status}`, {
+      code: "flex_upstream_error",
+    });
+  }
+  const info = await res.json();
+
+  // Map to our profile fields
+  const firstName = info?.firstName || '';
+  const lastName = info?.lastName || '';
+  const email = info?.defaultEmail?.url || '';
+  const dial = info?.defaultPhone?.dialNumber || '';
+  const cc = info?.defaultPhone?.countryCode || '';
+  const phone = [cc ? `+${cc}` : '', dial].filter(Boolean).join(' ');
+  const residencia = info?.homeBaseLocation?.preferredDisplayString || info?.homeBaseLocation?.name || '';
+  const dni = info?.assignedNumber || '';
+  const contactTypeName = Array.isArray(info?.contactTypes) && info.contactTypes.length ? String(info.contactTypes[0]?.name || '') : '';
+  const dept = (() => {
+    const s = contactTypeName.toLowerCase();
+    if (/sonido|sound/.test(s)) return 'sound';
+    if (/luz|luces|light/.test(s)) return 'lights';
+    if (/video/.test(s)) return 'video';
+    return null;
+  })();
+
+  return jsonResponse({
+    ok: true,
+    contact_id: cid,
+    mapped: { firstName, lastName, email, phone, residencia, dni, department: dept },
+  });
+}, {
+  allowedMethods: ["POST"],
+}));

--- a/supabase/functions/fetch-flex-image/index.ts
+++ b/supabase/functions/fetch-flex-image/index.ts
@@ -1,140 +1,114 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { fetchWithRetry } from "../_shared/flexFetch.ts";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-};
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  requireBearerToken,
+  requireEnvValues,
+} from "../_shared/http.ts";
 
 // Valid image ID pattern (UUID or Flex-specific ID)
 const IMAGE_ID_PATTERN = /^[a-zA-Z0-9-]{1,100}$/;
 
-serve(async (req: Request) => {
-  // Handle CORS preflight
-  if (req.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders });
+interface FetchFlexImageBody extends Record<string, unknown> {
+  imageId?: unknown;
+  size?: unknown;
+}
+
+serve(createHttpHandler(async (req: Request) => {
+  let imageId: string | null = null;
+  let size: "thumb" | "full" = "thumb";
+
+  // Support both GET (query params) and POST (JSON body)
+  if (req.method === "GET") {
+    const url = new URL(req.url);
+    imageId = url.searchParams.get("imageId");
+    const sizeParam = url.searchParams.get("size");
+    if (sizeParam === "full") size = "full";
+  } else {
+    const body = await readBoundedJsonObject<FetchFlexImageBody>(req, { maxBytes: 4 * 1024 });
+    imageId = typeof body.imageId === "string" ? body.imageId : null;
+    if (body.size === "full") size = "full";
   }
 
-  try {
-    let imageId: string | null = null;
-    let size: "thumb" | "full" = "thumb";
-
-    // Support both GET (query params) and POST (JSON body)
-    if (req.method === "GET") {
-      const url = new URL(req.url);
-      imageId = url.searchParams.get("imageId");
-      const sizeParam = url.searchParams.get("size");
-      if (sizeParam === "full") size = "full";
-    } else if (req.method === "POST") {
-      const body = await req.json() as { imageId?: string; size?: string };
-      imageId = body.imageId || null;
-      if (body.size === "full") size = "full";
-    } else {
-      return new Response("Method Not Allowed", {
-        status: 405,
-        headers: corsHeaders
-      });
-    }
-
-    // Validate imageId
-    if (!imageId) {
-      return new Response(JSON.stringify({ error: "imageId is required" }), {
-        status: 400,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    if (!IMAGE_ID_PATTERN.test(imageId)) {
-      return new Response(JSON.stringify({ error: "Invalid imageId format" }), {
-        status: 400,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    // Initialize Supabase client
-    const supabase = createClient(
-      Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
-    );
-
-    // AuthZ: Require authenticated user (any role can view equipment images)
-    const authHeader = req.headers.get("Authorization");
-    if (!authHeader) {
-      return new Response(JSON.stringify({ error: "Unauthorized" }), {
-        status: 401,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    const { data: { user } } = await supabase.auth.getUser(
-      authHeader.replace("Bearer ", "")
-    );
-    if (!user) {
-      return new Response(JSON.stringify({ error: "Unauthorized" }), {
-        status: 401,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    const flexAuthToken =
-      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
-
-    if (!flexAuthToken) {
-      return new Response(JSON.stringify({ error: "Flex auth not configured" }), {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    // Fetch image from Flex API
-    const flexUrl = `https://sectorpro.flexrentalsolutions.com/f5/api/image/${encodeURIComponent(imageId)}/${size}`;
-
-    const flexResponse = await fetchWithRetry(flexUrl, {
-      headers: {
-        "X-Auth-Token": flexAuthToken,
-        "apikey": flexAuthToken,
-        "X-Requested-With": "XMLHttpRequest",
-      },
-    });
-
-    if (!flexResponse.ok) {
-      // Return a transparent 1x1 pixel for missing images (graceful degradation)
-      if (flexResponse.status === 404) {
-        return new Response(null, {
-          status: 404,
-          headers: { ...corsHeaders },
-        });
-      }
-      return new Response(JSON.stringify({
-        error: `Flex API error: ${flexResponse.status}`
-      }), {
-        status: 502,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    // Get the image content
-    const imageBlob = await flexResponse.blob();
-    const contentType = flexResponse.headers.get("Content-Type") || "image/jpeg";
-
-    // Return the image with appropriate caching headers
-    return new Response(imageBlob, {
-      status: 200,
-      headers: {
-        ...corsHeaders,
-        "Content-Type": contentType,
-        "Cache-Control": "public, max-age=3600", // Cache for 1 hour
-      },
-    });
-
-  } catch (e) {
-    const msg = (e as Error)?.message || String(e);
-    return new Response(JSON.stringify({ error: msg }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
+  // Validate imageId
+  if (!imageId) {
+    throw new HttpError(400, "imageId is required", {
+      code: "missing_image_id",
     });
   }
-});
+
+  if (!IMAGE_ID_PATTERN.test(imageId)) {
+    throw new HttpError(400, "Invalid imageId format", {
+      code: "invalid_image_id",
+    });
+  }
+
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+
+  // AuthZ: Require authenticated user (any role can view equipment images)
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const token = requireBearerToken(req);
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) {
+    throw new HttpError(401, "Unauthorized", {
+      code: "invalid_authorization",
+    });
+  }
+
+  const flexAuthToken =
+    Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
+
+  if (!flexAuthToken) {
+    throw new HttpError(503, "Flex auth not configured", {
+      code: "flex_auth_missing",
+      exposeDetails: false,
+    });
+  }
+
+  // Fetch image from Flex API
+  const flexUrl = `https://sectorpro.flexrentalsolutions.com/f5/api/image/${encodeURIComponent(imageId)}/${size}`;
+
+  const flexResponse = await fetchWithRetry(flexUrl, {
+    headers: {
+      "X-Auth-Token": flexAuthToken,
+      "apikey": flexAuthToken,
+      "X-Requested-With": "XMLHttpRequest",
+    },
+  });
+
+  if (!flexResponse.ok) {
+    // Return 404 directly for missing images (graceful degradation)
+    if (flexResponse.status === 404) {
+      return new Response(null, { status: 404 });
+    }
+    return jsonResponse({
+      error: `Flex API error: ${flexResponse.status}`
+    }, { status: 502 });
+  }
+
+  // Get the image content
+  const imageBlob = await flexResponse.blob();
+  const contentType = flexResponse.headers.get("Content-Type") || "image/jpeg";
+
+  if (!contentType.toLowerCase().startsWith("image/")) {
+    throw new HttpError(502, "Flex image response had an invalid content type", {
+      code: "invalid_flex_image_response",
+    });
+  }
+
+  // Return the image with authenticated-user-safe caching headers
+  return new Response(imageBlob, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "private, max-age=3600", // Cache for 1 hour in the user's browser only
+    },
+  });
+}, { allowedMethods: ["GET", "POST"] }));

--- a/supabase/functions/fetch-flex-inventory-model/index.ts
+++ b/supabase/functions/fetch-flex-inventory-model/index.ts
@@ -1,13 +1,19 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import { requireAdminOrManagement } from "../_shared/auth.ts";
 import { fetchWithRetry } from "../_shared/flexFetch.ts";
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-};
+interface FetchFlexInventoryModelBody extends Record<string, unknown> {
+  model_id?: unknown;
+  url?: unknown;
+}
 
 // Expected structure from Flex API inventory-model endpoint
 interface FlexInventoryModelResponse {
@@ -72,66 +78,66 @@ function validateFlexResponse(data: unknown): ValidatedEquipmentData {
   };
 }
 
-serve(async (req: Request) => {
-  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: corsHeaders });
+serve(createHttpHandler(async (req: Request) => {
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+  const flexAuthToken =
+    Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
 
-  try {
-    const body = await req.json() as { model_id?: string; url?: string };
-    const supabase = createClient(
-      Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
-    );
-
-    // AuthZ: require admin or management
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    const { data: { user } } = await supabase.auth.getUser(authHeader.replace('Bearer ', ''));
-    if (!user) return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    const { data: profile } = await supabase.from('profiles').select('role').eq('id', user.id).maybeSingle();
-    if (!profile || !['admin','management'].includes(profile.role)) {
-      return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
-
-    // Parse model id
-    const modelId = body.model_id || (body.url ? extractUuid(body.url) : null);
-    if (!modelId) return new Response(JSON.stringify({ error: 'Missing model_id or url' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-
-    const flexAuthToken =
-      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN") || "";
-    if (!flexAuthToken) return new Response(JSON.stringify({ error: 'Flex auth not configured' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-
-    // Call Flex inventory-model API
-    const qs = new URLSearchParams();
-    qs.set('_dc', String(Date.now()));
-    const url = `https://sectorpro.flexrentalsolutions.com/f5/api/inventory-model/${encodeURIComponent(modelId)}?${qs.toString()}`;
-    const res = await fetchWithRetry(url, { headers: { 'X-Auth-Token': flexAuthToken, 'apikey': flexAuthToken, 'X-Requested-With': 'XMLHttpRequest' } });
-    if (!res.ok) {
-      const text = await res.text();
-      return new Response(JSON.stringify({ error: `Flex error ${res.status}`, details: text }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
-    const rawResponse = await res.json();
-
-    // Validate and sanitize the Flex API response
-    let mapped: ValidatedEquipmentData;
-    try {
-      mapped = validateFlexResponse(rawResponse);
-    } catch (validationError) {
-      return new Response(JSON.stringify({
-        error: 'Invalid response from Flex API',
-        details: (validationError as Error).message
-      }), { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-    }
-
-    return new Response(JSON.stringify({
-      ok: true,
-      model_id: modelId,
-      mapped,
-      // Only include raw in development for debugging - sanitized fields are authoritative
-      raw: rawResponse
-    }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
-  } catch (e) {
-    const msg = (e as any)?.message || String(e);
-    return new Response(JSON.stringify({ error: msg }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  if (!flexAuthToken) {
+    throw new HttpError(503, "Flex auth not configured", {
+      code: "flex_auth_missing",
+      exposeDetails: false,
+    });
   }
-});
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  await requireAdminOrManagement(supabase, req, {
+    logContext: "fetch-flex-inventory-model",
+  });
+
+  const body = await readBoundedJsonObject<FetchFlexInventoryModelBody>(req, { maxBytes: 16 * 1024 });
+
+  // Parse model id
+  const modelInput = typeof body.model_id === "string" ? body.model_id : "";
+  const urlInput = typeof body.url === "string" ? body.url : "";
+  const modelId = extractUuid(modelInput) || extractUuid(urlInput);
+  if (!modelId) {
+    throw new HttpError(400, "Missing model_id or url", {
+      code: "missing_flex_model_id",
+    });
+  }
+
+  // Call Flex inventory-model API
+  const qs = new URLSearchParams();
+  qs.set('_dc', String(Date.now()));
+  const url = `https://sectorpro.flexrentalsolutions.com/f5/api/inventory-model/${encodeURIComponent(modelId)}?${qs.toString()}`;
+  const res = await fetchWithRetry(url, { headers: { 'X-Auth-Token': flexAuthToken, 'apikey': flexAuthToken, 'X-Requested-With': 'XMLHttpRequest' } });
+  if (!res.ok) {
+    throw new HttpError(502, `Flex error ${res.status}`, {
+      code: "flex_upstream_error",
+    });
+  }
+  const rawResponse = await res.json();
+
+  // Validate and sanitize the Flex API response
+  let mapped: ValidatedEquipmentData;
+  try {
+    mapped = validateFlexResponse(rawResponse);
+  } catch (validationError) {
+    throw new HttpError(502, "Invalid response from Flex API", {
+      code: "invalid_flex_response",
+      details: validationError instanceof Error ? validationError.message : undefined,
+    });
+  }
+
+  return jsonResponse({
+    ok: true,
+    model_id: modelId,
+    mapped,
+  });
+}, {
+  allowedMethods: ["POST"],
+}));

--- a/supabase/functions/persist-flex-elements/index.ts
+++ b/supabase/functions/persist-flex-elements/index.ts
@@ -1,6 +1,15 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
+import { requireAdminOrManagement } from "../_shared/auth.ts";
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
+
 type Dept = "sound" | "lights" | "video" | "production" | "personnel" | "comercial";
 type Kind =
   | "job_root_folder"
@@ -24,142 +33,219 @@ interface CreatedItem {
   parentElementId?: string;
 }
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
-const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+interface PersistFlexElementsBody extends Record<string, unknown> {
+  created?: unknown;
+}
 
-serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response(null, {
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-        "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-      },
+const VALID_KINDS = new Set<string>([
+  "job_root_folder",
+  "job_department_folder",
+  "tour_date_folder",
+  "crew_call",
+  "pull_sheet",
+  "doc_tecnica",
+  "hoja_gastos",
+  "hoja_info_sx",
+  "hoja_info_lx",
+  "hoja_info_vx",
+]);
+
+const VALID_DEPARTMENTS = new Set<string>([
+  "sound",
+  "lights",
+  "video",
+  "production",
+  "personnel",
+  "comercial",
+]);
+const VALID_CREW_CALL_DEPARTMENTS = new Set(["sound", "lights"]);
+
+const MAX_CREATED_ITEMS = 500;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function optionalString(value: unknown, maxLength = 128): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed && trimmed.length <= maxLength ? trimmed : undefined;
+}
+
+function normalizeCreatedItem(value: unknown, index: number): CreatedItem {
+  if (!isRecord(value)) {
+    throw new HttpError(400, `Invalid created item at index ${index}`, {
+      code: "invalid_created_item",
     });
   }
 
-  if (req.method !== "POST") {
-    return new Response("Method Not Allowed", { status: 405 });
+  const kind = optionalString(value.kind, 64);
+  const elementId = optionalString(value.elementId, 256);
+  if (!kind || !VALID_KINDS.has(kind) || !elementId) {
+    throw new HttpError(400, `Invalid created item at index ${index}`, {
+      code: "invalid_created_item",
+    });
   }
 
-  try {
-    const { created } = (await req.json()) as { created: CreatedItem[] };
-    if (!Array.isArray(created)) {
-      throw new Error("Invalid payload: created must be an array");
-    }
+  const department = optionalString(value.department, 32);
+  if (department && !VALID_DEPARTMENTS.has(department)) {
+    throw new HttpError(400, `Invalid created item department at index ${index}`, {
+      code: "invalid_created_item_department",
+    });
+  }
 
-    const sb = createClient(SUPABASE_URL, SERVICE_ROLE);
+  if (
+    kind === "crew_call" &&
+    (!optionalString(value.jobId) || !department || !VALID_CREW_CALL_DEPARTMENTS.has(department))
+  ) {
+    throw new HttpError(400, `Invalid crew_call item at index ${index}`, {
+      code: "invalid_crew_call_item",
+    });
+  }
 
-    // Helper to resolve parent row id by element id
-    const parentCache = new Map<string, string | null>();
-    async function getParentRowIdByElementId(elementId?: string): Promise<string | null> {
-      if (!elementId) return null;
-      if (parentCache.has(elementId)) return parentCache.get(elementId)!;
-      const { data } = await sb
-        .from("flex_folders")
-        .select("id")
-        .eq("element_id", elementId)
-        .limit(1)
-        .maybeSingle();
-      const id = data?.id ?? null;
-      parentCache.set(elementId, id);
-      return id;
-    }
+  return {
+    kind: kind as Kind,
+    elementId,
+    jobId: optionalString(value.jobId),
+    tourId: optionalString(value.tourId),
+    tourDateId: optionalString(value.tourDateId),
+    department: department as Dept | undefined,
+    parentElementId: optionalString(value.parentElementId, 256),
+  };
+}
 
-    for (const c of created) {
-      try {
-        switch (c.kind) {
-          case "crew_call": {
-            if (!c.jobId || !c.department || !c.elementId) break;
-            // Upsert by (job_id, department)
-            const { data: existing } = await sb
-              .from("flex_crew_calls")
-              .select("id, flex_element_id")
-              .eq("job_id", c.jobId)
-              .eq("department", c.department)
-              .maybeSingle();
-            if (existing) {
-              if (existing.flex_element_id !== c.elementId) {
-                await sb
-                  .from("flex_crew_calls")
-                  .update({ flex_element_id: c.elementId })
-                  .eq("id", existing.id);
-              }
-            } else {
-              await sb.from("flex_crew_calls").insert({
-                job_id: c.jobId,
-                department: c.department,
-                flex_element_id: c.elementId,
-              });
+serve(createHttpHandler(async (req) => {
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+
+  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  await requireAdminOrManagement(sb, req, {
+    logContext: "persist-flex-elements",
+  });
+
+  const { created } = await readBoundedJsonObject<PersistFlexElementsBody>(req, { maxBytes: 256 * 1024 });
+  if (!Array.isArray(created)) {
+    throw new HttpError(400, "Invalid payload: created must be an array", {
+      code: "invalid_created_payload",
+    });
+  }
+  if (created.length > MAX_CREATED_ITEMS) {
+    throw new HttpError(413, "Too many created items", {
+      code: "too_many_created_items",
+    });
+  }
+  const createdItems = created.map((item, index) => normalizeCreatedItem(item, index));
+
+  // Helper to resolve parent row id by element id
+  const parentCache = new Map<string, string | null>();
+  async function getParentRowIdByElementId(elementId?: string): Promise<string | null> {
+    if (!elementId) return null;
+    if (parentCache.has(elementId)) return parentCache.get(elementId)!;
+    const { data } = await sb
+      .from("flex_folders")
+      .select("id")
+      .eq("element_id", elementId)
+      .limit(1)
+      .maybeSingle();
+    const id = data?.id ?? null;
+    parentCache.set(elementId, id);
+    return id;
+  }
+
+  for (const c of createdItems) {
+    try {
+      switch (c.kind) {
+        case "crew_call": {
+          if (!c.jobId || !c.department || !c.elementId) break;
+          // Upsert by (job_id, department)
+          const { data: existing } = await sb
+            .from("flex_crew_calls")
+            .select("id, flex_element_id")
+            .eq("job_id", c.jobId)
+            .eq("department", c.department)
+            .maybeSingle();
+          if (existing) {
+            if (existing.flex_element_id !== c.elementId) {
+              await sb
+                .from("flex_crew_calls")
+                .update({ flex_element_id: c.elementId })
+                .eq("id", existing.id);
             }
-            break;
-          }
-
-          case "job_root_folder":
-          case "job_department_folder":
-          case "tour_date_folder":
-          case "pull_sheet":
-          case "doc_tecnica":
-          case "hoja_gastos":
-          case "hoja_info_sx":
-          case "hoja_info_lx":
-          case "hoja_info_vx": {
-            // Avoid duplicates: skip if element_id already present
-            const { data: exists } = await sb
-              .from("flex_folders")
-              .select("id")
-              .eq("element_id", c.elementId)
-              .limit(1)
-              .maybeSingle();
-            if (exists) break;
-
-            // Map folder_type
-            const folderTypeMap: Record<Kind, string> = {
-              job_root_folder: "main_event",
-              job_department_folder: "department",
-              tour_date_folder: "tourdate",
-              pull_sheet: "pull_sheet",
-              doc_tecnica: "doc_tecnica",
-              hoja_gastos: "hoja_gastos",
-              hoja_info_sx: "hoja_info_sx",
-              hoja_info_lx: "hoja_info_lx",
-              hoja_info_vx: "hoja_info_vx",
-              crew_call: "crew_call",
-            };
-
-            const parent_id = await getParentRowIdByElementId(c.parentElementId);
-
-            await sb.from("flex_folders").insert({
-              job_id: c.jobId ?? null,
-              tour_date_id: c.tourDateId ?? null,
-              parent_id,
-              element_id: c.elementId,
-              folder_type: folderTypeMap[c.kind],
-              department: c.department ?? null,
+          } else {
+            await sb.from("flex_crew_calls").insert({
+              job_id: c.jobId,
+              department: c.department,
+              flex_element_id: c.elementId,
             });
-
-            // Mark job as created when root captured
-            if (c.kind === "job_root_folder" && c.jobId) {
-              await sb.from("jobs").update({ flex_folders_created: true }).eq("id", c.jobId);
-            }
-            break;
           }
+          break;
         }
-      } catch (innerErr) {
-        console.warn("[persist-flex-elements] Skipping item due to error", c, innerErr);
-        continue;
-      }
-    }
 
-    return new Response(JSON.stringify({ ok: true }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
-  } catch (e: any) {
-    return new Response(JSON.stringify({ ok: false, error: e?.message ?? String(e) }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+        case "job_root_folder":
+        case "job_department_folder":
+        case "tour_date_folder":
+        case "pull_sheet":
+        case "doc_tecnica":
+        case "hoja_gastos":
+        case "hoja_info_sx":
+        case "hoja_info_lx":
+        case "hoja_info_vx": {
+          // Avoid duplicates: skip if element_id already present
+          const { data: exists } = await sb
+            .from("flex_folders")
+            .select("id")
+            .eq("element_id", c.elementId)
+            .limit(1)
+            .maybeSingle();
+          if (exists) break;
+
+          // Map folder_type
+          const folderTypeMap: Record<Kind, string> = {
+            job_root_folder: "main_event",
+            job_department_folder: "department",
+            tour_date_folder: "tourdate",
+            pull_sheet: "pull_sheet",
+            doc_tecnica: "doc_tecnica",
+            hoja_gastos: "hoja_gastos",
+            hoja_info_sx: "hoja_info_sx",
+            hoja_info_lx: "hoja_info_lx",
+            hoja_info_vx: "hoja_info_vx",
+            crew_call: "crew_call",
+          };
+
+          const parent_id = await getParentRowIdByElementId(c.parentElementId);
+
+          await sb.from("flex_folders").insert({
+            job_id: c.jobId ?? null,
+            tour_date_id: c.tourDateId ?? null,
+            parent_id,
+            element_id: c.elementId,
+            folder_type: folderTypeMap[c.kind],
+            department: c.department ?? null,
+          });
+
+          // Mark job as created when root captured
+          if (c.kind === "job_root_folder" && c.jobId) {
+            await sb.from("jobs").update({ flex_folders_created: true }).eq("id", c.jobId);
+          }
+          break;
+        }
+      }
+    } catch (innerErr) {
+      console.warn("[persist-flex-elements] Skipping item due to error", {
+        kind: c.kind,
+        elementId: c.elementId,
+      }, innerErr);
+      continue;
+    }
   }
-});
+
+  return jsonResponse({ ok: true });
+}, {
+  allowedMethods: ["POST"],
+  onError(error) {
+    console.error("persist-flex-elements request failed", error);
+  },
+}));

--- a/supabase/functions/secure-flex-api/index.ts
+++ b/supabase/functions/secure-flex-api/index.ts
@@ -1,15 +1,15 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
+import { requireAdminOrManagement } from "../_shared/auth.ts";
 import { fetchWithRetry } from "../_shared/flexFetch.ts";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Max-Age": "86400",
-};
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
 
 const FLEX_API_BASE_URL =
   Deno.env.get("FLEX_API_BASE_URL") ||
@@ -29,16 +29,18 @@ const ALLOWED_FORWARD_HEADERS = new Set([
 const MAX_ENDPOINT_LENGTH = 2_048;
 const MAX_BODY_LENGTH = 1_000_000;
 
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
-  });
+interface FlexProxyRequest extends Record<string, unknown> {
+  method?: unknown;
+  endpoint?: unknown;
+  body?: unknown;
+  headers?: unknown;
 }
 
 function validateEndpoint(endpoint: unknown): URL {
   if (typeof endpoint !== "string" || !endpoint.startsWith("/")) {
-    throw new Error("Endpoint must be a relative Flex API path");
+    throw new HttpError(400, "Endpoint must be a relative Flex API path", {
+      code: "invalid_flex_endpoint",
+    });
   }
   if (
     endpoint.length > MAX_ENDPOINT_LENGTH ||
@@ -46,7 +48,9 @@ function validateEndpoint(endpoint: unknown): URL {
     endpoint.includes("\\") ||
     /[\u0000-\u001f\u007f]/.test(endpoint)
   ) {
-    throw new Error("Invalid Flex API endpoint");
+    throw new HttpError(400, "Invalid Flex API endpoint", {
+      code: "invalid_flex_endpoint",
+    });
   }
 
   const baseUrl = new URL(FLEX_API_BASE_URL);
@@ -57,7 +61,9 @@ function validateEndpoint(endpoint: unknown): URL {
     target.origin !== baseUrl.origin ||
     !target.pathname.startsWith(`${basePath}/`)
   ) {
-    throw new Error("Flex API endpoint escaped the configured base path");
+    throw new HttpError(400, "Flex API endpoint escaped the configured base path", {
+      code: "invalid_flex_endpoint",
+    });
   }
 
   const relativePath = target.pathname.slice(basePath.length);
@@ -66,7 +72,9 @@ function validateEndpoint(endpoint: unknown): URL {
       (prefix) => relativePath === prefix || relativePath.startsWith(`${prefix}/`),
     )
   ) {
-    throw new Error("Flex API endpoint is not allowlisted");
+    throw new HttpError(400, "Flex API endpoint is not allowlisted", {
+      code: "flex_endpoint_not_allowed",
+    });
   }
 
   return target;
@@ -91,150 +99,126 @@ function sanitizeHeaders(input: unknown): Headers {
   return output;
 }
 
-serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders });
-  }
+serve(createHttpHandler(async (req) => {
+  const {
+    SUPABASE_URL: supabaseUrl,
+    SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+  } = requireEnvValues(
+    ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const,
+    (name) => Deno.env.get(name),
+  );
+  const flexAuthToken =
+    Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN");
 
-  if (req.method !== "POST") {
-    return jsonResponse({ success: false, error: "Method not allowed" }, 405);
-  }
-
-  try {
-    const supabaseUrl = Deno.env.get("SUPABASE_URL");
-    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-    const flexAuthToken =
-      Deno.env.get("X_AUTH_TOKEN") || Deno.env.get("FLEX_X_AUTH_TOKEN");
-
-    if (!supabaseUrl || !serviceRoleKey || !flexAuthToken) {
-      console.error("secure-flex-api is missing required environment variables");
-      return jsonResponse({ success: false, error: "Service unavailable" }, 503);
-    }
-
-    const authHeader = req.headers.get("authorization");
-    if (!authHeader?.startsWith("Bearer ")) {
-      return jsonResponse({ success: false, error: "Authentication required" }, 401);
-    }
-
-    const supabase = createClient(supabaseUrl, serviceRoleKey, {
-      auth: { persistSession: false, autoRefreshToken: false },
+  if (!flexAuthToken) {
+    console.error("secure-flex-api is missing required Flex auth token");
+    throw new HttpError(503, "Service unavailable", {
+      code: "flex_auth_missing",
+      exposeDetails: false,
     });
-    const accessToken = authHeader.slice("Bearer ".length);
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser(accessToken);
+  }
 
-    if (authError || !user) {
-      return jsonResponse({ success: false, error: "Invalid authentication" }, 401);
-    }
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const caller = await requireAdminOrManagement(supabase, req, {
+    logContext: "secure-flex-api",
+    missingMessage: "Authentication required",
+    invalidMessage: "Invalid authentication",
+    forbiddenMessage: "Insufficient permissions",
+  });
 
-    const { data: profile, error: profileError } = await supabase
-      .from("profiles")
-      .select("role")
-      .eq("id", user.id)
-      .maybeSingle();
+  const requestBody = await readBoundedJsonObject<FlexProxyRequest>(req, {
+    maxBytes: MAX_BODY_LENGTH + 16 * 1024,
+  });
 
-    if (profileError) {
-      console.error("secure-flex-api profile lookup failed", profileError);
-      return jsonResponse({ success: false, error: "Authorization check failed" }, 500);
-    }
-    if (!profile || !["admin", "management"].includes(profile.role)) {
-      return jsonResponse({ success: false, error: "Insufficient permissions" }, 403);
-    }
+  const method = String(requestBody.method || "GET").toUpperCase();
+  if (!ALLOWED_METHODS.has(method)) {
+    throw new HttpError(400, "Flex API method is not allowed", {
+      code: "flex_method_not_allowed",
+    });
+  }
 
-    const requestBody = await req.json().catch(() => null);
-    if (!requestBody || typeof requestBody !== "object") {
-      return jsonResponse({ success: false, error: "Invalid request body" }, 400);
-    }
+  const target = validateEndpoint(requestBody.endpoint);
+  const body = requestBody.body;
+  if (body !== undefined && typeof body !== "string") {
+    throw new HttpError(400, "Flex API body must be a string", {
+      code: "invalid_flex_body",
+    });
+  }
+  if (typeof body === "string" && body.length > MAX_BODY_LENGTH) {
+    throw new HttpError(413, "Flex API body is too large", {
+      code: "flex_body_too_large",
+    });
+  }
+  if (["GET", "DELETE"].includes(method) && body) {
+    throw new HttpError(400, `${method} requests may not include a body`, {
+      code: "invalid_flex_body",
+    });
+  }
 
-    const method = String(requestBody.method || "GET").toUpperCase();
-    if (!ALLOWED_METHODS.has(method)) {
-      return jsonResponse({ success: false, error: "Flex API method is not allowed" }, 400);
-    }
+  const headers = sanitizeHeaders(requestBody.headers);
+  headers.set("X-Auth-Token", flexAuthToken);
+  headers.set("apikey", flexAuthToken);
 
-    const target = validateEndpoint(requestBody.endpoint);
-    const body = requestBody.body;
-    if (body !== undefined && typeof body !== "string") {
-      return jsonResponse({ success: false, error: "Flex API body must be a string" }, 400);
-    }
-    if (typeof body === "string" && body.length > MAX_BODY_LENGTH) {
-      return jsonResponse({ success: false, error: "Flex API body is too large" }, 413);
-    }
-    if (["GET", "DELETE"].includes(method) && body) {
-      return jsonResponse(
-        { success: false, error: `${method} requests may not include a body` },
-        400,
-      );
-    }
+  const shouldRetry = method === "GET";
+  const response = await fetchWithRetry(
+    target.toString(),
+    {
+      method,
+      headers,
+      body: body || undefined,
+    },
+    {
+      attempts: shouldRetry ? 3 : 1,
+      retryOnTimeout: shouldRetry,
+    },
+  );
 
-    const headers = sanitizeHeaders(requestBody.headers);
-    headers.set("X-Auth-Token", flexAuthToken);
-    headers.set("apikey", flexAuthToken);
+  const contentType = response.headers.get("content-type") || "";
+  const rawBody = await response.text();
+  let data: unknown;
 
-    const shouldRetry = method === "GET";
-    const response = await fetchWithRetry(
-      target.toString(),
-      {
+  if (rawBody && contentType.includes("json")) {
+    try {
+      data = JSON.parse(rawBody);
+    } catch (parseError) {
+      console.warn("secure-flex-api upstream returned invalid JSON", parseError);
+      data = rawBody;
+    }
+  }
+
+  if (method !== "GET" || !response.ok) {
+    const { error: auditError } = await supabase.from("security_audit_log").insert({
+      user_id: caller.userId,
+      action: "flex_api_proxy",
+      resource: `flex:${target.pathname.slice(0, 240)}`,
+      severity: response.ok ? "low" : "medium",
+      metadata: {
         method,
-        headers,
-        body: body || undefined,
+        status: response.status,
+        success: response.ok,
       },
-      {
-        attempts: shouldRetry ? 3 : 1,
-        retryOnTimeout: shouldRetry,
-      },
-    );
-
-    const contentType = response.headers.get("content-type") || "";
-    const rawBody = await response.text();
-    let data: unknown;
-
-    if (rawBody && contentType.includes("json")) {
-      try {
-        data = JSON.parse(rawBody);
-      } catch (parseError) {
-        console.warn("secure-flex-api upstream returned invalid JSON", parseError);
-        data = rawBody;
-      }
-    }
-
-    if (method !== "GET" || !response.ok) {
-      const { error: auditError } = await supabase.from("security_audit_log").insert({
-        user_id: user.id,
-        action: "flex_api_proxy",
-        resource: `flex:${target.pathname.slice(0, 240)}`,
-        severity: response.ok ? "low" : "medium",
-        metadata: {
-          method,
-          status: response.status,
-          success: response.ok,
-        },
-      });
-      if (auditError) {
-        console.error("secure-flex-api audit write failed", auditError);
-      }
-    }
-
-    return jsonResponse({
-      success: response.ok,
-      status: response.status,
-      statusText: response.statusText,
-      contentType,
-      data,
-      rawBody: data === undefined ? rawBody : undefined,
-      error: response.ok
-        ? undefined
-        : (
-          data && typeof data === "object" &&
-            "exceptionMessage" in data
-            ? String((data as { exceptionMessage?: unknown }).exceptionMessage)
-            : `Flex API returned ${response.status}`
-        ),
     });
-  } catch (error) {
-    console.error("secure-flex-api request failed", error);
-    const message = error instanceof Error ? error.message : "Invalid request";
-    return jsonResponse({ success: false, error: message }, 400);
+    if (auditError) {
+      console.error("secure-flex-api audit write failed", auditError);
+    }
   }
-});
+
+  return jsonResponse({
+    success: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    contentType,
+    data,
+    rawBody: data === undefined ? rawBody : undefined,
+    error: response.ok
+      ? undefined
+      : `Flex API returned ${response.status}`,
+  });
+}, {
+  allowedMethods: ["POST"],
+  onError(error) {
+    console.error("secure-flex-api request failed", error);
+  },
+}));


### PR DESCRIPTION
## Summary

- Migrates five Flex proxy/support Edge handlers onto the shared HTTP wrapper and bounded body parsing path:
  - `secure-flex-api`
  - `fetch-flex-contact-info`
  - `fetch-flex-inventory-model`
  - `fetch-flex-image`
  - `persist-flex-elements`
- Closes the unauthenticated `persist-flex-elements` service-role write path by requiring admin/management auth and validating created Flex element payloads before persistence.
- Preserves the `secure-flex-api` method/path/header allowlists while moving auth/env/error handling to shared helpers.
- Removes raw Flex lookup payloads from contact/inventory lookup responses and changes authenticated image proxy caching from public to private.
- Ratchets the Edge Function compliance baseline from 48 to 43 legacy manual handlers and updates Phase 2 docs/exposure metadata.

## Impact

Flex lookup/proxy writes now consistently enforce their intended trust boundary before service-role operations. Current app callers only consume sanitized mapped lookup data, so removing raw Flex payloads should not affect UI behavior.

No Supabase migrations are included in this PR.

## Validation

- `npm run lint` — 0 errors; existing warnings remain
- `npm run test:run` — 171 files / 1020 tests passed
- `npm run build`
- `npm run governance`
- `npm run typecheck`
- `npm run lint:functions` — 0 errors; existing warnings remain
- `npm run governance:functions`
- `npm run governance:exposure`
- `git diff --check`