### PR TITLE
[codex] Add stable Hoja de Ruta job message links

### DIFF
--- a/scripts/governance/edge-function-exposure.json
+++ b/scripts/governance/edge-function-exposure.json
@@ -46,6 +46,11 @@
     "get-secret": { "class": "privileged-role", "verifyJwt": true, "internalGuard": "Management role check; only client-safe allowlisted keys are returned (see ENT-SEC-02 remediation)." },
     "image-proxy": { "class": "authenticated-user", "verifyJwt": true },
     "import-users": { "class": "privileged-role", "verifyJwt": true },
+    "job-hoja-de-ruta-link": {
+      "class": "public-token",
+      "verifyJwt": false,
+      "internalGuard": "HMAC-signed job-scoped links expire, pass durable ingress and token-scoped rate limits, then resolve the latest Hoja de Ruta and redirect only to a short-lived storage signed URL."
+    },
     "manage-flex-crew-assignments": { "class": "privileged-role", "verifyJwt": true },
     "notify-staffing-cancellation": {
       "class": "privileged-role",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -67,6 +67,9 @@ verify_jwt = false
 [functions.tour-guest-document-url]
 verify_jwt = false
 
+[functions.job-hoja-de-ruta-link]
+verify_jwt = false
+
 # Browser-posted CSP reports carry no credentials, so the gateway JWT check must
 # be disabled. The function reads a size-bounded body and writes only normalized
 # reports via the service role (see check-edge-function-exposure.mjs).

--- a/supabase/functions/_shared/hojaAttachment.ts
+++ b/supabase/functions/_shared/hojaAttachment.ts
@@ -1,0 +1,228 @@
+import { type SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+type SupabaseAdminClient = SupabaseClient;
+
+type HojaDocumentRow = {
+  id?: string;
+  job_id?: string | null;
+  file_name?: string | null;
+  file_path?: string | null;
+  file_type?: string | null;
+  uploaded_at?: string | null;
+};
+
+export type HojaAttachment = {
+  source: "job_documents" | "tour_documents";
+  bucket: "job-documents" | "job_documents" | "tour-documents";
+  path: string;
+  filename: string;
+};
+
+const DEPT_PREFIXES = new Set(["sound", "lights", "video", "production", "logistics", "administrative"]);
+
+const normalizeObjectPath = (value: string | null | undefined) => (value || "").replace(/^\/+/, "");
+
+const normalizeText = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+const hasHojaDeRutaText = (doc: HojaDocumentRow) => {
+  const text = normalizeText(`${doc.file_name || ""} ${doc.file_path || ""}`);
+  return text.includes("hoja") && (text.includes("ruta") || text.includes("route"));
+};
+
+const isPdfDocument = (doc: HojaDocumentRow) => {
+  const mimeType = (doc.file_type || "").split(";")[0].trim().toLowerCase();
+  if (mimeType === "application/pdf") return true;
+
+  return [doc.file_name, doc.file_path].some((value) =>
+    /\.pdf$/i.test(normalizeObjectPath(value))
+  );
+};
+
+const uploadedAtMs = (doc: HojaDocumentRow) => {
+  const value = doc.uploaded_at ? Date.parse(doc.uploaded_at) : NaN;
+  return Number.isFinite(value) ? value : 0;
+};
+
+const byNewestUpload = (a: HojaDocumentRow, b: HojaDocumentRow) =>
+  uploadedAtMs(b) - uploadedAtMs(a);
+
+function resolveJobDocumentBucket(filePath: string): "job-documents" | "job_documents" {
+  const first = normalizeObjectPath(filePath).split("/")[0] || "";
+  return DEPT_PREFIXES.has(first) ? "job_documents" : "job-documents";
+}
+
+function isJobHojaDeRutaDocument(doc: HojaDocumentRow, jobId: string): boolean {
+  const path = normalizeObjectPath(doc.file_path);
+  if (!path) return false;
+  if (!isPdfDocument(doc)) return false;
+  if (path.startsWith(`hojas-de-ruta/${jobId}/`)) return true;
+  if (path.startsWith("hojas-de-ruta/") && hasHojaDeRutaText(doc)) return true;
+  if (path.startsWith(`${jobId}/`) && hasHojaDeRutaText(doc)) return true;
+  return hasHojaDeRutaText(doc);
+}
+
+function isTourHojaDeRutaDocument(doc: HojaDocumentRow): boolean {
+  const path = normalizeObjectPath(doc.file_path);
+  if (!path) return false;
+  if (!isPdfDocument(doc)) return false;
+  if (path.startsWith("hojas-de-ruta/")) return true;
+  return hasHojaDeRutaText(doc);
+}
+
+function toHojaAttachment(
+  source: HojaAttachment["source"],
+  doc: HojaDocumentRow,
+  bucket: HojaAttachment["bucket"],
+): HojaAttachment | null {
+  const path = normalizeObjectPath(doc.file_path);
+  if (!path) return null;
+  return {
+    source,
+    bucket,
+    path,
+    filename: (doc.file_name || "Hoja de Ruta.pdf").toString(),
+  };
+}
+
+async function findLatestJobHojaAttachment(
+  supabaseAdmin: SupabaseAdminClient,
+  jobId: string,
+): Promise<HojaAttachment | null> {
+  const { data, error } = await supabaseAdmin
+    .from("job_documents")
+    .select("id, file_name, file_path, file_type, uploaded_at")
+    .eq("job_id", jobId)
+    .order("uploaded_at", { ascending: false })
+    .limit(25);
+
+  if (error) throw error;
+
+  const doc = ((data || []) as HojaDocumentRow[])
+    .filter((row) => isJobHojaDeRutaDocument(row, jobId))
+    .sort(byNewestUpload)[0];
+  if (!doc?.file_path) return null;
+  return toHojaAttachment("job_documents", doc, resolveJobDocumentBucket(doc.file_path));
+}
+
+async function findLatestLinkedJobHojaAttachment(
+  supabaseAdmin: SupabaseAdminClient,
+  linkedJobIds: string[],
+): Promise<HojaAttachment | null> {
+  if (linkedJobIds.length === 0) return null;
+
+  const { data, error } = await supabaseAdmin
+    .from("job_documents")
+    .select("id, job_id, file_name, file_path, file_type, uploaded_at")
+    .in("job_id", linkedJobIds)
+    .order("uploaded_at", { ascending: false });
+
+  if (error) throw error;
+
+  const linkedJobIdSet = new Set(linkedJobIds);
+  const doc = ((data || []) as HojaDocumentRow[])
+    .filter((row) => {
+      const rowJobId = row.job_id || null;
+      return Boolean(rowJobId && linkedJobIdSet.has(rowJobId) && isJobHojaDeRutaDocument(row, rowJobId));
+    })
+    .sort(byNewestUpload)[0];
+
+  if (!doc?.file_path) return null;
+  return toHojaAttachment("job_documents", doc, resolveJobDocumentBucket(doc.file_path));
+}
+
+async function findLinkedHojaJobIdsForTourDate(
+  supabaseAdmin: SupabaseAdminClient,
+  tourDateId: string,
+  currentJobId: string,
+): Promise<string[]> {
+  const { data, error } = await supabaseAdmin
+    .from("hoja_de_ruta")
+    .select("job_id")
+    .eq("tour_date_id", tourDateId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  return Array.from(new Set(
+    ((data || []) as Array<{ job_id?: string | null }>)
+      .map((row) => row.job_id)
+      .filter((id): id is string => Boolean(id && id !== currentJobId))
+  ));
+}
+
+async function resolveTourIdFromTourDate(
+  supabaseAdmin: SupabaseAdminClient,
+  tourDateId: string | null,
+): Promise<string | null> {
+  if (!tourDateId) return null;
+
+  const { data, error } = await supabaseAdmin
+    .from("tour_dates")
+    .select("tour_id")
+    .eq("id", tourDateId)
+    .maybeSingle();
+
+  if (error) throw error;
+  const tourId = (data as { tour_id?: string | null } | null)?.tour_id;
+  return typeof tourId === "string" && tourId ? tourId : null;
+}
+
+async function findLatestTourHojaAttachment(
+  supabaseAdmin: SupabaseAdminClient,
+  tourId: string,
+): Promise<HojaAttachment | null> {
+  const { data, error } = await supabaseAdmin
+    .from("tour_documents")
+    .select("id, file_name, file_path, file_type, uploaded_at")
+    .eq("tour_id", tourId)
+    .order("uploaded_at", { ascending: false })
+    .limit(25);
+
+  if (error) throw error;
+
+  const doc = ((data || []) as HojaDocumentRow[])
+    .filter(isTourHojaDeRutaDocument)
+    .sort(byNewestUpload)[0];
+  return doc ? toHojaAttachment("tour_documents", doc, "tour-documents") : null;
+}
+
+/**
+ * Resolve the latest Hoja de Ruta PDF visible from a job context.
+ *
+ * Lookup order intentionally mirrors the existing job-message behavior:
+ * direct job document, linked job document for the same tour date, then tour document.
+ */
+export async function resolveHojaAttachment(
+  supabaseAdmin: SupabaseAdminClient,
+  jobId: string,
+): Promise<HojaAttachment | null> {
+  const directJobDoc = await findLatestJobHojaAttachment(supabaseAdmin, jobId);
+  if (directJobDoc) return directJobDoc;
+
+  const { data: jobRow, error: jobErr } = await supabaseAdmin
+    .from("jobs")
+    .select("id, tour_id, tour_date_id")
+    .eq("id", jobId)
+    .maybeSingle();
+
+  if (jobErr) throw jobErr;
+
+  const jobContext = (jobRow || {}) as { tour_id?: string | null; tour_date_id?: string | null };
+  const tourDateId = typeof jobContext.tour_date_id === "string" ? jobContext.tour_date_id : null;
+
+  if (tourDateId) {
+    const linkedJobIds = await findLinkedHojaJobIdsForTourDate(supabaseAdmin, tourDateId, jobId);
+    const linkedJobDoc = await findLatestLinkedJobHojaAttachment(supabaseAdmin, linkedJobIds);
+    if (linkedJobDoc) return linkedJobDoc;
+  }
+
+  const tourId = typeof jobContext.tour_id === "string" && jobContext.tour_id
+    ? jobContext.tour_id
+    : await resolveTourIdFromTourDate(supabaseAdmin, tourDateId);
+
+  return tourId ? findLatestTourHojaAttachment(supabaseAdmin, tourId) : null;
+}

--- a/supabase/functions/_shared/hojaAttachment.ts
+++ b/supabase/functions/_shared/hojaAttachment.ts
@@ -96,8 +96,7 @@ async function findLatestJobHojaAttachment(
     .from("job_documents")
     .select("id, file_name, file_path, file_type, uploaded_at")
     .eq("job_id", jobId)
-    .order("uploaded_at", { ascending: false })
-    .limit(25);
+    .order("uploaded_at", { ascending: false });
 
   if (error) throw error;
 
@@ -179,8 +178,7 @@ async function findLatestTourHojaAttachment(
     .from("tour_documents")
     .select("id, file_name, file_path, file_type, uploaded_at")
     .eq("tour_id", tourId)
-    .order("uploaded_at", { ascending: false })
-    .limit(25);
+    .order("uploaded_at", { ascending: false });
 
   if (error) throw error;
 

--- a/supabase/functions/_shared/hojaLinkToken.test.ts
+++ b/supabase/functions/_shared/hojaLinkToken.test.ts
@@ -74,6 +74,19 @@ describe("Hoja de Ruta stable link tokens", () => {
     );
   });
 
+  it("builds the resolver as a sibling when the source function URL has a trailing slash", () => {
+    const url = buildJobHojaLinkUrl({
+      requestUrl: "https://project.supabase.co/functions/v1/send-job-whatsapp-message/",
+      jobId: "job-1",
+      expiresAt: 1_800_000_000,
+      token: "token-1",
+    });
+
+    expect(url).toBe(
+      "https://project.supabase.co/functions/v1/job-hoja-de-ruta-link?job_id=job-1&exp=1800000000&t=token-1",
+    );
+  });
+
   it("uses a long-lived but bounded default ttl that can be configured", () => {
     expect(computeJobHojaLinkExpiry(100, 60)).toBe(160);
     expect(resolveJobHojaLinkTtlSeconds(() => undefined)).toBe(60 * 60 * 24 * 365);

--- a/supabase/functions/_shared/hojaLinkToken.test.ts
+++ b/supabase/functions/_shared/hojaLinkToken.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildJobHojaLinkUrl,
+  computeJobHojaLinkExpiry,
+  getJobHojaLinkSecret,
+  resolveJobHojaLinkTtlSeconds,
+  signJobHojaLink,
+  verifyJobHojaLink,
+} from "./hojaLinkToken.ts";
+
+describe("Hoja de Ruta stable link tokens", () => {
+  it("signs and verifies a job-scoped expiring link token", async () => {
+    const expiresAt = 1_800_000_000;
+    const token = await signJobHojaLink({
+      jobId: "job-1",
+      expiresAt,
+      secret: "secret-1",
+    });
+
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    await expect(verifyJobHojaLink({
+      jobId: "job-1",
+      expiresAt,
+      token,
+      secret: "secret-1",
+      nowSeconds: expiresAt - 60,
+    })).resolves.toBe(true);
+  });
+
+  it("rejects tampered, expired, and unsigned link tokens", async () => {
+    const expiresAt = 1_800_000_000;
+    const token = await signJobHojaLink({
+      jobId: "job-1",
+      expiresAt,
+      secret: "secret-1",
+    });
+
+    await expect(verifyJobHojaLink({
+      jobId: "job-2",
+      expiresAt,
+      token,
+      secret: "secret-1",
+      nowSeconds: expiresAt - 60,
+    })).resolves.toBe(false);
+
+    await expect(verifyJobHojaLink({
+      jobId: "job-1",
+      expiresAt,
+      token,
+      secret: "secret-1",
+      nowSeconds: expiresAt,
+    })).resolves.toBe(false);
+
+    await expect(verifyJobHojaLink({
+      jobId: "job-1",
+      expiresAt,
+      token,
+      secret: "",
+      nowSeconds: expiresAt - 60,
+    })).resolves.toBe(false);
+  });
+
+  it("builds a sibling Edge Function URL without preserving stale query state", async () => {
+    const url = buildJobHojaLinkUrl({
+      requestUrl: "https://project.supabase.co/functions/v1/send-job-whatsapp-message?old=true",
+      jobId: " job-1 ",
+      expiresAt: 1_800_000_000,
+      token: "token-1",
+    });
+
+    expect(url).toBe(
+      "https://project.supabase.co/functions/v1/job-hoja-de-ruta-link?job_id=job-1&exp=1800000000&t=token-1",
+    );
+  });
+
+  it("uses a long-lived but bounded default ttl that can be configured", () => {
+    expect(computeJobHojaLinkExpiry(100, 60)).toBe(160);
+    expect(resolveJobHojaLinkTtlSeconds(() => undefined)).toBe(60 * 60 * 24 * 365);
+    expect(resolveJobHojaLinkTtlSeconds((name) => name === "JOB_HOJA_LINK_TTL_SECONDS" ? "3600" : undefined)).toBe(3600);
+    expect(resolveJobHojaLinkTtlSeconds((name) => name === "JOB_HOJA_LINK_TTL_SECONDS" ? "10" : undefined)).toBe(60);
+  });
+
+  it("prefers explicit Hoja link secrets before falling back to service role", () => {
+    expect(getJobHojaLinkSecret((name) => ({
+      JOB_HOJA_LINK_SECRET: "job-secret",
+      HOJA_DE_RUTA_LINK_SECRET: "hoja-secret",
+      SUPABASE_SERVICE_ROLE_KEY: "service-secret",
+    })[name])).toBe("job-secret");
+
+    expect(getJobHojaLinkSecret((name) => ({
+      SUPABASE_SERVICE_ROLE_KEY: "service-secret",
+    })[name])).toBe("service-secret");
+  });
+});

--- a/supabase/functions/_shared/hojaLinkToken.ts
+++ b/supabase/functions/_shared/hojaLinkToken.ts
@@ -1,0 +1,128 @@
+const encoder = new TextEncoder();
+
+export const DEFAULT_JOB_HOJA_LINK_TTL_SECONDS = 60 * 60 * 24 * 365;
+const MAX_JOB_HOJA_LINK_TTL_SECONDS = 60 * 60 * 24 * 365 * 5;
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  const maxLength = Math.max(left.length, right.length);
+  let mismatch = left.length ^ right.length;
+
+  for (let index = 0; index < maxLength; index += 1) {
+    mismatch |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+  }
+
+  return mismatch === 0;
+}
+
+function normalizeJobId(jobId: string): string {
+  return jobId.trim();
+}
+
+function payloadFor(jobId: string, expiresAt: number): string {
+  return `${normalizeJobId(jobId)}.${Math.trunc(expiresAt)}`;
+}
+
+export function getJobHojaLinkSecret(getEnv: (name: string) => string | undefined): string {
+  return (
+    getEnv("JOB_HOJA_LINK_SECRET") ||
+    getEnv("HOJA_DE_RUTA_LINK_SECRET") ||
+    getEnv("SUPABASE_SERVICE_ROLE_KEY") ||
+    ""
+  );
+}
+
+export function resolveJobHojaLinkTtlSeconds(
+  getEnv: (name: string) => string | undefined,
+  fallback = DEFAULT_JOB_HOJA_LINK_TTL_SECONDS,
+): number {
+  const raw = getEnv("JOB_HOJA_LINK_TTL_SECONDS");
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  const ttl = Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  return Math.min(Math.max(60, ttl), MAX_JOB_HOJA_LINK_TTL_SECONDS);
+}
+
+export function computeJobHojaLinkExpiry(
+  nowSeconds = Math.floor(Date.now() / 1000),
+  ttlSeconds = DEFAULT_JOB_HOJA_LINK_TTL_SECONDS,
+): number {
+  return Math.trunc(nowSeconds) + Math.trunc(ttlSeconds);
+}
+
+export async function signJobHojaLink(args: {
+  jobId: string;
+  expiresAt: number;
+  secret: string;
+}): Promise<string> {
+  const jobId = normalizeJobId(args.jobId);
+  const expiresAt = Math.trunc(args.expiresAt);
+
+  if (!jobId || !Number.isFinite(expiresAt) || !args.secret) {
+    return "";
+  }
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(args.secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(payloadFor(jobId, expiresAt)));
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+export async function verifyJobHojaLink(args: {
+  jobId: string;
+  expiresAt: number;
+  token: string;
+  secret: string;
+  nowSeconds?: number;
+}): Promise<boolean> {
+  const jobId = normalizeJobId(args.jobId);
+  const expiresAt = Math.trunc(args.expiresAt);
+  const token = args.token.trim();
+  const nowSeconds = Math.trunc(args.nowSeconds ?? Date.now() / 1000);
+
+  if (!jobId || !token || !args.secret || !Number.isFinite(expiresAt)) {
+    return false;
+  }
+
+  if (expiresAt <= nowSeconds) {
+    return false;
+  }
+
+  const expected = await signJobHojaLink({
+    jobId,
+    expiresAt,
+    secret: args.secret,
+  });
+
+  return expected ? timingSafeEqual(token, expected) : false;
+}
+
+export function buildJobHojaLinkUrl(args: {
+  requestUrl: string;
+  jobId: string;
+  expiresAt: number;
+  token: string;
+}): string {
+  const url = new URL(args.requestUrl);
+  const pathParts = url.pathname.split("/");
+  pathParts[pathParts.length - 1] = "job-hoja-de-ruta-link";
+  url.pathname = pathParts.join("/") || "/job-hoja-de-ruta-link";
+  url.search = "";
+  url.hash = "";
+  url.searchParams.set("job_id", normalizeJobId(args.jobId));
+  url.searchParams.set("exp", String(Math.trunc(args.expiresAt)));
+  url.searchParams.set("t", args.token);
+  return url.toString();
+}

--- a/supabase/functions/_shared/hojaLinkToken.ts
+++ b/supabase/functions/_shared/hojaLinkToken.ts
@@ -116,7 +116,7 @@ export function buildJobHojaLinkUrl(args: {
   token: string;
 }): string {
   const url = new URL(args.requestUrl);
-  const pathParts = url.pathname.split("/");
+  const pathParts = url.pathname.replace(/\/+$/, "").split("/");
   pathParts[pathParts.length - 1] = "job-hoja-de-ruta-link";
   url.pathname = pathParts.join("/") || "/job-hoja-de-ruta-link";
   url.search = "";

--- a/supabase/functions/job-hoja-de-ruta-link/index.ts
+++ b/supabase/functions/job-hoja-de-ruta-link/index.ts
@@ -1,0 +1,122 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+import {
+  corsHeaders,
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  requireEnvValues,
+} from "../_shared/http.ts";
+import { resolveHojaAttachment } from "../_shared/hojaAttachment.ts";
+import {
+  getJobHojaLinkSecret,
+  verifyJobHojaLink,
+} from "../_shared/hojaLinkToken.ts";
+import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
+
+const SIGNED_URL_TTL_SECONDS = 5 * 60;
+const INGRESS_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
+const INGRESS_RATE_LIMIT_MAX_REQUESTS = 300;
+const TOKEN_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
+const TOKEN_RATE_LIMIT_MAX_REQUESTS = 120;
+
+function parseExpiresAt(value: string | null): number {
+  if (!value || !/^\d+$/.test(value)) return NaN;
+  return Number.parseInt(value, 10);
+}
+
+serve(createHttpHandler(async (req: Request) => {
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, Deno.env.get);
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
+  const rateLimitSalt = Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SUPABASE_SERVICE_ROLE_KEY;
+
+  const ingressRateLimit = await checkEdgeRateLimit({
+    req,
+    supabase,
+    scope: "job-hoja-de-ruta-link.ingress",
+    identifierParts: ["document"],
+    windowSeconds: INGRESS_RATE_LIMIT_WINDOW_SECONDS,
+    maxRequests: INGRESS_RATE_LIMIT_MAX_REQUESTS,
+    salt: rateLimitSalt,
+  });
+
+  if (!ingressRateLimit.allowed) {
+    return jsonResponse(
+      { error: "rate_limited" },
+      { status: 429, headers: rateLimitHeaders(ingressRateLimit) },
+    );
+  }
+
+  const url = new URL(req.url);
+  const jobId = (url.searchParams.get("job_id") || "").trim();
+  const expiresAt = parseExpiresAt(url.searchParams.get("exp"));
+  const token = (url.searchParams.get("t") || "").trim();
+
+  if (!jobId || !Number.isFinite(expiresAt) || !token) {
+    throw new HttpError(400, "Invalid Hoja de Ruta link", { code: "invalid_hoja_link" });
+  }
+
+  const secret = getJobHojaLinkSecret(Deno.env.get);
+  const valid = await verifyJobHojaLink({
+    jobId,
+    expiresAt,
+    token,
+    secret,
+  });
+
+  if (!valid) {
+    throw new HttpError(404, "Hoja de Ruta link not found or expired", { code: "hoja_link_not_found" });
+  }
+
+  const tokenRateLimit = await checkEdgeRateLimit({
+    req,
+    supabase,
+    scope: "job-hoja-de-ruta-link",
+    identifierParts: [jobId, token],
+    windowSeconds: TOKEN_RATE_LIMIT_WINDOW_SECONDS,
+    maxRequests: TOKEN_RATE_LIMIT_MAX_REQUESTS,
+    includeIp: false,
+    includeUserAgent: false,
+    salt: rateLimitSalt,
+  });
+
+  if (!tokenRateLimit.allowed) {
+    return jsonResponse(
+      { error: "rate_limited" },
+      { status: 429, headers: rateLimitHeaders(tokenRateLimit) },
+    );
+  }
+
+  const doc = await resolveHojaAttachment(supabase, jobId);
+  if (!doc) {
+    throw new HttpError(404, "Hoja de Ruta not found", { code: "hoja_de_ruta_not_found" });
+  }
+
+  const { data: signed, error: signError } = await supabase.storage
+    .from(doc.bucket)
+    .createSignedUrl(doc.path, SIGNED_URL_TTL_SECONDS);
+
+  if (signError || !signed?.signedUrl) {
+    console.error("Failed to sign latest Hoja de Ruta URL:", signError);
+    throw new HttpError(500, "Unable to create Hoja de Ruta link", {
+      code: "hoja_de_ruta_sign_failed",
+      exposeDetails: false,
+    });
+  }
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      ...corsHeaders,
+      "Cache-Control": "no-store",
+      Location: signed.signedUrl,
+    },
+  });
+}, { allowedMethods: ["GET"] }));

--- a/supabase/functions/send-job-whatsapp-message/index.ts
+++ b/supabase/functions/send-job-whatsapp-message/index.ts
@@ -7,6 +7,14 @@ import {
   jsonResponse,
   readBoundedJsonObject,
 } from "../_shared/http.ts";
+import { resolveHojaAttachment } from "../_shared/hojaAttachment.ts";
+import {
+  buildJobHojaLinkUrl,
+  computeJobHojaLinkExpiry,
+  getJobHojaLinkSecret,
+  resolveJobHojaLinkTtlSeconds,
+  signJobHojaLink,
+} from "../_shared/hojaLinkToken.ts";
 import { checkAndRecordWhatsappQuota } from "../_shared/whatsappQuota.ts";
 
 /** Request payload for sending a WhatsApp message to multiple assigned users. */
@@ -72,227 +80,6 @@ async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: numbe
   } finally {
     clearTimeout(id);
   }
-}
-
-type SupabaseAdminClient = ReturnType<typeof createClient>;
-
-type HojaDocumentRow = {
-  id?: string;
-  job_id?: string | null;
-  file_name?: string | null;
-  file_path?: string | null;
-  file_type?: string | null;
-  uploaded_at?: string | null;
-};
-
-type HojaAttachment = {
-  source: "job_documents" | "tour_documents";
-  bucket: "job-documents" | "job_documents" | "tour-documents";
-  path: string;
-  filename: string;
-};
-
-const DEPT_PREFIXES = new Set(["sound", "lights", "video", "production", "logistics", "administrative"]);
-
-const normalizeObjectPath = (value: string | null | undefined) => (value || "").replace(/^\/+/, "");
-
-const normalizeText = (value: string) =>
-  value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase();
-
-const hasHojaDeRutaText = (doc: HojaDocumentRow) => {
-  const text = normalizeText(`${doc.file_name || ""} ${doc.file_path || ""}`);
-  return text.includes("hoja") && (text.includes("ruta") || text.includes("route"));
-};
-
-const isPdfDocument = (doc: HojaDocumentRow) => {
-  const mimeType = (doc.file_type || "").split(";")[0].trim().toLowerCase();
-  if (mimeType === "application/pdf") return true;
-
-  return [doc.file_name, doc.file_path].some((value) =>
-    /\.pdf$/i.test(normalizeObjectPath(value))
-  );
-};
-
-const uploadedAtMs = (doc: HojaDocumentRow) => {
-  const value = doc.uploaded_at ? Date.parse(doc.uploaded_at) : NaN;
-  return Number.isFinite(value) ? value : 0;
-};
-
-const byNewestUpload = (a: HojaDocumentRow, b: HojaDocumentRow) =>
-  uploadedAtMs(b) - uploadedAtMs(a);
-
-function resolveJobDocumentBucket(filePath: string): "job-documents" | "job_documents" {
-  const first = normalizeObjectPath(filePath).split("/")[0] || "";
-  return DEPT_PREFIXES.has(first) ? "job_documents" : "job-documents";
-}
-
-function isJobHojaDeRutaDocument(doc: HojaDocumentRow, jobId: string): boolean {
-  const path = normalizeObjectPath(doc.file_path);
-  if (!path) return false;
-  if (!isPdfDocument(doc)) return false;
-  if (path.startsWith(`hojas-de-ruta/${jobId}/`)) return true;
-  if (path.startsWith("hojas-de-ruta/") && hasHojaDeRutaText(doc)) return true;
-  if (path.startsWith(`${jobId}/`) && hasHojaDeRutaText(doc)) return true;
-  return hasHojaDeRutaText(doc);
-}
-
-function isTourHojaDeRutaDocument(doc: HojaDocumentRow): boolean {
-  const path = normalizeObjectPath(doc.file_path);
-  if (!path) return false;
-  if (!isPdfDocument(doc)) return false;
-  if (path.startsWith("hojas-de-ruta/")) return true;
-  return hasHojaDeRutaText(doc);
-}
-
-function toHojaAttachment(
-  source: HojaAttachment["source"],
-  doc: HojaDocumentRow,
-  bucket: HojaAttachment["bucket"],
-): HojaAttachment | null {
-  const path = normalizeObjectPath(doc.file_path);
-  if (!path) return null;
-  return {
-    source,
-    bucket,
-    path,
-    filename: (doc.file_name || "Hoja de Ruta.pdf").toString(),
-  };
-}
-
-async function findLatestJobHojaAttachment(
-  supabaseAdmin: SupabaseAdminClient,
-  jobId: string,
-): Promise<HojaAttachment | null> {
-  const { data, error } = await supabaseAdmin
-    .from("job_documents")
-    .select("id, file_name, file_path, file_type, uploaded_at")
-    .eq("job_id", jobId)
-    .order("uploaded_at", { ascending: false })
-    .limit(25);
-
-  if (error) throw error;
-
-  const doc = ((data || []) as HojaDocumentRow[])
-    .filter((row) => isJobHojaDeRutaDocument(row, jobId))
-    .sort(byNewestUpload)[0];
-  if (!doc?.file_path) return null;
-  return toHojaAttachment("job_documents", doc, resolveJobDocumentBucket(doc.file_path));
-}
-
-async function findLatestLinkedJobHojaAttachment(
-  supabaseAdmin: SupabaseAdminClient,
-  linkedJobIds: string[],
-): Promise<HojaAttachment | null> {
-  if (linkedJobIds.length === 0) return null;
-
-  const { data, error } = await supabaseAdmin
-    .from("job_documents")
-    .select("id, job_id, file_name, file_path, file_type, uploaded_at")
-    .in("job_id", linkedJobIds)
-    .order("uploaded_at", { ascending: false });
-
-  if (error) throw error;
-
-  const linkedJobIdSet = new Set(linkedJobIds);
-  const doc = ((data || []) as HojaDocumentRow[])
-    .filter((row) => {
-      const rowJobId = row.job_id || null;
-      return Boolean(rowJobId && linkedJobIdSet.has(rowJobId) && isJobHojaDeRutaDocument(row, rowJobId));
-    })
-    .sort(byNewestUpload)[0];
-
-  if (!doc?.file_path) return null;
-  return toHojaAttachment("job_documents", doc, resolveJobDocumentBucket(doc.file_path));
-}
-
-async function findLinkedHojaJobIdsForTourDate(
-  supabaseAdmin: SupabaseAdminClient,
-  tourDateId: string,
-  currentJobId: string,
-): Promise<string[]> {
-  const { data, error } = await supabaseAdmin
-    .from("hoja_de_ruta")
-    .select("job_id")
-    .eq("tour_date_id", tourDateId)
-    .order("created_at", { ascending: false });
-
-  if (error) throw error;
-
-  return Array.from(new Set(
-    ((data || []) as Array<{ job_id?: string | null }>)
-      .map((row) => row.job_id)
-      .filter((id): id is string => Boolean(id && id !== currentJobId))
-  ));
-}
-
-async function resolveTourIdFromTourDate(
-  supabaseAdmin: SupabaseAdminClient,
-  tourDateId: string | null,
-): Promise<string | null> {
-  if (!tourDateId) return null;
-
-  const { data, error } = await supabaseAdmin
-    .from("tour_dates")
-    .select("tour_id")
-    .eq("id", tourDateId)
-    .maybeSingle();
-
-  if (error) throw error;
-  const tourId = (data as { tour_id?: string | null } | null)?.tour_id;
-  return typeof tourId === "string" && tourId ? tourId : null;
-}
-
-async function findLatestTourHojaAttachment(
-  supabaseAdmin: SupabaseAdminClient,
-  tourId: string,
-): Promise<HojaAttachment | null> {
-  const { data, error } = await supabaseAdmin
-    .from("tour_documents")
-    .select("id, file_name, file_path, file_type, uploaded_at")
-    .eq("tour_id", tourId)
-    .order("uploaded_at", { ascending: false })
-    .limit(25);
-
-  if (error) throw error;
-
-  const doc = ((data || []) as HojaDocumentRow[])
-    .filter(isTourHojaDeRutaDocument)
-    .sort(byNewestUpload)[0];
-  return doc ? toHojaAttachment("tour_documents", doc, "tour-documents") : null;
-}
-
-async function resolveHojaAttachment(
-  supabaseAdmin: SupabaseAdminClient,
-  jobId: string,
-): Promise<HojaAttachment | null> {
-  const directJobDoc = await findLatestJobHojaAttachment(supabaseAdmin, jobId);
-  if (directJobDoc) return directJobDoc;
-
-  const { data: jobRow, error: jobErr } = await supabaseAdmin
-    .from("jobs")
-    .select("id, tour_id, tour_date_id")
-    .eq("id", jobId)
-    .maybeSingle();
-
-  if (jobErr) throw jobErr;
-
-  const jobContext = (jobRow || {}) as { tour_id?: string | null; tour_date_id?: string | null };
-  const tourDateId = typeof jobContext.tour_date_id === "string" ? jobContext.tour_date_id : null;
-
-  if (tourDateId) {
-    const linkedJobIds = await findLinkedHojaJobIdsForTourDate(supabaseAdmin, tourDateId, jobId);
-    const linkedJobDoc = await findLatestLinkedJobHojaAttachment(supabaseAdmin, linkedJobIds);
-    if (linkedJobDoc) return linkedJobDoc;
-  }
-
-  const tourId = typeof jobContext.tour_id === "string" && jobContext.tour_id
-    ? jobContext.tour_id
-    : await resolveTourIdFromTourDate(supabaseAdmin, tourDateId);
-
-  return tourId ? findLatestTourHojaAttachment(supabaseAdmin, tourId) : null;
 }
 
 function logRejection(
@@ -383,19 +170,23 @@ serve(createHttpHandler(async (req: Request) => {
         return jsonResponse({ error: "Bad Request", reason: "hoja_de_ruta_not_found" }, { status: 400 });
       }
 
-      // 7 days: the link must stay alive in the chat, not just survive the send.
-      // (Used both by sendFile and by the WAHA Core text-link fallback.)
-      const { data: signed, error: signErr } = await supabaseAdmin.storage
-        .from(doc.bucket)
-        .createSignedUrl(doc.path, 60 * 60 * 24 * 7);
+      const secret = getJobHojaLinkSecret(Deno.env.get);
+      const ttlSeconds = resolveJobHojaLinkTtlSeconds(Deno.env.get);
+      const expiresAt = computeJobHojaLinkExpiry(Math.floor(Date.now() / 1000), ttlSeconds);
+      const token = await signJobHojaLink({ jobId, expiresAt, secret });
 
-      if (signErr || !signed?.signedUrl) {
-        console.error("Failed to sign Hoja de Ruta URL:", signErr);
-        return jsonResponse({ error: "Internal Server Error", reason: "hoja_de_ruta_sign_failed" }, { status: 500 });
+      if (!token) {
+        console.error("Failed to sign stable Hoja de Ruta link: missing signing secret");
+        return jsonResponse({ error: "Internal Server Error", reason: "hoja_de_ruta_link_sign_failed" }, { status: 500 });
       }
 
       attachment = {
-        url: signed.signedUrl,
+        url: buildJobHojaLinkUrl({
+          requestUrl: req.url,
+          jobId,
+          expiresAt,
+          token,
+        }),
         filename: doc.filename,
       };
     }
@@ -511,9 +302,10 @@ serve(createHttpHandler(async (req: Request) => {
     ] as const;
 
     // WAHA Core fallback: sending files is a Plus feature, so when sendFile is
-    // unavailable we deliver the PDF as a signed download link via plain text.
+    // unavailable we deliver a stable resolver link via plain text. The resolver
+    // always signs the latest available Hoja de Ruta at click time.
     const linkAttemptsFor = (chatId: string, file: { url: string; filename: string }) => {
-      const text = `📄 Hoja de Ruta: ${file.filename}\n${file.url}\n(Enlace de descarga válido durante 7 días)`;
+      const text = `📄 Hoja de Ruta actualizada\n${file.url}\n(El enlace abre la última versión disponible)`;
       return [
         {
           url: `${base}/api/${encodeURIComponent(session)}/sendText`,


### PR DESCRIPTION
## Summary

This PR fixes stale Hoja de Ruta links in job WhatsApp messages by replacing direct long-lived storage signed URLs with a stable, tokenized resolver URL.

## Root cause

`send-job-whatsapp-message` selected the current Hoja de Ruta PDF and embedded a 7-day Supabase Storage signed URL. If a newer Hoja de Ruta was uploaded after the WhatsApp message was sent, the chat link still pointed at the older storage object.

## What changed

- Extracted the latest Hoja de Ruta attachment lookup into a shared Edge Function helper.
- Added `job-hoja-de-ruta-link`, a public token-protected Edge Function that:
  - validates an HMAC-signed, job-scoped expiring link;
  - applies durable ingress and token-scoped rate limits;
  - resolves the latest Hoja de Ruta at click time;
  - redirects to a fresh short-lived storage signed URL.
- Updated `send-job-whatsapp-message` to attach the stable resolver URL instead of a direct storage signed URL.
- Added token helper coverage and Edge Function exposure/config governance entries.

## Impact

WhatsApp Hoja de Ruta links now open the latest available PDF for the job context instead of going stale when the Hoja de Ruta is regenerated or replaced. Existing security posture is preserved with expiring signed links, HMAC validation, short-lived storage redirects, and rate limits.

No database migrations are included.

## Validation

- `npm install --legacy-peer-deps`
- `npx vitest run supabase/functions/_shared/hojaLinkToken.test.ts`
- `npm run governance:functions`
- `npm run governance:exposure`
- `npm run lint:functions`
- `npx tsc --noEmit`
- `npx eslint supabase/functions/send-job-whatsapp-message/index.ts supabase/functions/job-hoja-de-ruta-link/index.ts supabase/functions/_shared/hojaAttachment.ts supabase/functions/_shared/hojaLinkToken.ts supabase/functions/_shared/hojaLinkToken.test.ts`
- `npm run test:run`
- `npm run build`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new stable link flow for Hoja de Ruta documents, including secure link generation, verification, and redirect handling.
  - WhatsApp messages can now share a link to the latest available Hoja de Ruta version instead of a short-lived download link.

- **Bug Fixes**
  - Improved attachment resolution so the latest matching document is found more reliably across related job and tour records.
  - Added stricter validation for expired or invalid links, with safer failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->