### PR TITLE
[codex] Migrate public token Edge Functions

### DIFF
--- a/docs/operations/phase-2-trust-boundary-hardening.md
+++ b/docs/operations/phase-2-trust-boundary-hardening.md
@@ -178,9 +178,18 @@ TV polling behavior needs a separate, polling-safe threshold and rollout plan.
   unauthenticated `persist-flex-elements` service-role write path, moved Flex
   lookup/proxy handlers onto bounded payload parsing, removed raw Flex lookup
   payloads from client responses, and made authenticated image responses use
-  private cache headers. The duplicated admin/management caller checks across
-  the hardened user-admin, diagnostics, payout, staffing/message, and Flex
-  proxy handlers now route through the shared auth helper.
+  private cache headers. Public token artist/document/calendar handlers
+  (`submit-public-artist-form`, `upload-public-artist-rider`,
+  `delete-public-artist-rider`, `tour-guest-document-url`,
+  `tech-calendar-ics`) were migrated on 2026-06-24, reducing the legacy Edge
+  Function baseline from 43 to 38 entries. That slice moved browser-facing
+  token endpoints behind the shared CORS/method/error wrapper, added bounded
+  JSON parsing where applicable, added a multipart size preflight for public
+  rider uploads, centralized required environment validation, and stopped
+  returning raw database error text from the calendar job-load path. The
+  duplicated admin/management caller checks across the hardened user-admin,
+  diagnostics, payout, staffing/message, and Flex proxy handlers now route
+  through the shared auth helper.
 - Finish the wallboard auth/feed abuse-control design with TV-safe thresholds
   and rollout telemetry; avoid disrupting deployed APK wallboards.
 - Continue ratcheting the `anon`/`PUBLIC` grant baseline downward (trigger

--- a/scripts/governance/edge-function-baseline.json
+++ b/scripts/governance/edge-function-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-06-24T15:24:24.680Z",
+  "generatedAt": "2026-06-24T16:13:10.987Z",
   "note": "Existing manual Edge Functions are grandfathered. New functions must use createHttpHandler or add an explicit reviewed exemption.",
   "manualFunctions": [
     {
@@ -46,11 +46,6 @@
     {
       "functionName": "create-whatsapp-group",
       "path": "supabase/functions/create-whatsapp-group/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "delete-public-artist-rider",
-      "path": "supabase/functions/delete-public-artist-rider/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
@@ -179,28 +174,8 @@
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {
-      "functionName": "submit-public-artist-form",
-      "path": "supabase/functions/submit-public-artist-form/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
       "functionName": "sync-flex-crew-for-job",
       "path": "supabase/functions/sync-flex-crew-for-job/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "tech-calendar-ics",
-      "path": "supabase/functions/tech-calendar-ics/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "tour-guest-document-url",
-      "path": "supabase/functions/tour-guest-document-url/index.ts",
-      "reason": "Legacy entrypoint present before the Edge Function compliance gate."
-    },
-    {
-      "functionName": "upload-public-artist-rider",
-      "path": "supabase/functions/upload-public-artist-rider/index.ts",
       "reason": "Legacy entrypoint present before the Edge Function compliance gate."
     },
     {

--- a/supabase/functions/delete-public-artist-rider/index.ts
+++ b/supabase/functions/delete-public-artist-rider/index.ts
@@ -1,14 +1,19 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
-import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 const INGRESS_RATE_LIMIT_WINDOW_SECONDS = 60;
 const INGRESS_RATE_LIMIT_MAX_REQUESTS = 120;
 const RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
 const RATE_LIMIT_MAX_REQUESTS = 60;
+const MAX_JSON_BODY_BYTES = 32 * 1024;
 
 type DeleteBody = {
   token?: string;
@@ -28,21 +33,14 @@ type RiderFileRow = {
   file_path: string;
 };
 
-serve(async (req) => {
-  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
-    return jsonResponse({ ok: false, error: "server_misconfigured" }, { status: 500 });
-  }
-
-  if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: corsHeaders });
-  }
-
-  if (req.method !== "POST") {
-    return jsonResponse({ ok: false, error: "method_not_allowed" }, { status: 405 });
-  }
-
+serve(createHttpHandler(async (req) => {
   try {
-    const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+    const {
+      SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY,
+    } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const rateLimitSalt = Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SUPABASE_SERVICE_ROLE_KEY;
     const ingressRateLimit = await checkEdgeRateLimit({
       req,
       supabase: supabaseAdmin,
@@ -50,7 +48,7 @@ serve(async (req) => {
       identifierParts: ["json"],
       windowSeconds: INGRESS_RATE_LIMIT_WINDOW_SECONDS,
       maxRequests: INGRESS_RATE_LIMIT_MAX_REQUESTS,
-      salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SERVICE_ROLE_KEY,
+      salt: rateLimitSalt,
     });
 
     if (!ingressRateLimit.allowed) {
@@ -62,9 +60,17 @@ serve(async (req) => {
 
     let body: DeleteBody;
     try {
-      body = (await req.json()) as DeleteBody;
-    } catch {
-      return jsonResponse({ ok: false, error: "invalid_json" }, { status: 400 });
+      body = await readBoundedJsonObject<Record<string, unknown>>(req, {
+        maxBytes: MAX_JSON_BODY_BYTES,
+      }) as DeleteBody;
+    } catch (error) {
+      if (error instanceof HttpError && error.status === 400) {
+        return jsonResponse({ ok: false, error: "invalid_json" }, { status: 400 });
+      }
+      if (error instanceof HttpError && error.status === 413) {
+        return jsonResponse({ ok: false, error: "payload_too_large" }, { status: 413 });
+      }
+      throw error;
     }
 
     const token = String(body?.token ?? "").trim();
@@ -86,7 +92,7 @@ serve(async (req) => {
       maxRequests: RATE_LIMIT_MAX_REQUESTS,
       includeIp: false,
       includeUserAgent: false,
-      salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SERVICE_ROLE_KEY,
+      salt: rateLimitSalt,
     });
 
     if (!rateLimit.allowed) {
@@ -161,7 +167,11 @@ serve(async (req) => {
 
     return jsonResponse({ ok: true, deleted_file_id: fileRow.id }, { status: 200 });
   } catch (error) {
+    if (error instanceof HttpError) throw error;
     console.error("[delete-public-artist-rider] unexpected error", error);
     return jsonResponse({ ok: false, error: "internal_error" }, { status: 500 });
   }
-});
+}, {
+  allowedMethods: ["POST"],
+  methodNotAllowedBody: { ok: false, error: "method_not_allowed" },
+}));

--- a/supabase/functions/submit-public-artist-form/index.ts
+++ b/supabase/functions/submit-public-artist-form/index.ts
@@ -1,14 +1,19 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
-import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 const INGRESS_RATE_LIMIT_WINDOW_SECONDS = 60;
 const INGRESS_RATE_LIMIT_MAX_REQUESTS = 60;
 const RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
 const RATE_LIMIT_MAX_REQUESTS = 20;
+const MAX_JSON_BODY_BYTES = 256 * 1024;
 
 type SubmitBody = {
   token?: string;
@@ -44,21 +49,14 @@ const buildArtistTableUrl = (jobId: string, artistDate?: string | null) => {
   return `/festival-management/${jobId}/artists?date=${encodeURIComponent(normalizedDate)}`;
 };
 
-serve(async (req) => {
-  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
-    return jsonResponse({ ok: false, error: "server_misconfigured" }, { status: 500 });
-  }
-
-  if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: corsHeaders });
-  }
-
-  if (req.method !== "POST") {
-    return jsonResponse({ ok: false, error: "method_not_allowed" }, { status: 405 });
-  }
-
+serve(createHttpHandler(async (req) => {
   try {
-    const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+    const {
+      SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY,
+    } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const rateLimitSalt = Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SUPABASE_SERVICE_ROLE_KEY;
     const ingressRateLimit = await checkEdgeRateLimit({
       req,
       supabase: supabaseAdmin,
@@ -66,7 +64,7 @@ serve(async (req) => {
       identifierParts: ["json"],
       windowSeconds: INGRESS_RATE_LIMIT_WINDOW_SECONDS,
       maxRequests: INGRESS_RATE_LIMIT_MAX_REQUESTS,
-      salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SERVICE_ROLE_KEY,
+      salt: rateLimitSalt,
     });
 
     if (!ingressRateLimit.allowed) {
@@ -78,9 +76,17 @@ serve(async (req) => {
 
     let body: SubmitBody;
     try {
-      body = (await req.json()) as SubmitBody;
-    } catch {
-      return jsonResponse({ ok: false, error: "invalid_json" }, { status: 400 });
+      body = await readBoundedJsonObject<Record<string, unknown>>(req, {
+        maxBytes: MAX_JSON_BODY_BYTES,
+      }) as SubmitBody;
+    } catch (error) {
+      if (error instanceof HttpError && error.status === 400) {
+        return jsonResponse({ ok: false, error: "invalid_json" }, { status: 400 });
+      }
+      if (error instanceof HttpError && error.status === 413) {
+        return jsonResponse({ ok: false, error: "payload_too_large" }, { status: 413 });
+      }
+      throw error;
     }
 
     const token = String(body?.token ?? "").trim();
@@ -103,7 +109,7 @@ serve(async (req) => {
       maxRequests: RATE_LIMIT_MAX_REQUESTS,
       includeIp: false,
       includeUserAgent: false,
-      salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SERVICE_ROLE_KEY,
+      salt: rateLimitSalt,
     });
 
     if (!rateLimit.allowed) {
@@ -187,7 +193,11 @@ serve(async (req) => {
 
     return jsonResponse(submitResult, { status: 200 });
   } catch (error) {
+    if (error instanceof HttpError) throw error;
     console.error("[submit-public-artist-form] unexpected error", error);
     return jsonResponse({ ok: false, error: "internal_error" }, { status: 500 });
   }
-});
+}, {
+  allowedMethods: ["POST"],
+  methodNotAllowedBody: { ok: false, error: "method_not_allowed" },
+}));

--- a/supabase/functions/tech-calendar-ics/index.ts
+++ b/supabase/functions/tech-calendar-ics/index.ts
@@ -1,9 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import { createHttpHandler, requireEnvValues } from "../_shared/http.ts";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
-
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
 type AssignmentRow = {
   job_id: string;
@@ -96,30 +94,19 @@ function replaceIsoDateKeepingTimeAndOffset(iso: string, ymd: string): string {
   return `${ymd}${iso.slice(10)}`;
 }
 
-serve(async (req) => {
-  const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+serve(createHttpHandler(async (req) => {
   const url = new URL(req.url);
-
-  if (req.method === "OPTIONS") {
-    return new Response(null, {
-      headers: {
-        "Access-Control-Allow-Headers":
-          "authorization, x-client-info, apikey, content-type, x-requested-with, accept, prefer, x-supabase-info, x-supabase-api-version, x-supabase-client-platform",
-        "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Max-Age": "86400",
-      },
-      status: 204,
-    });
-  }
 
   if (req.method === 'HEAD') {
     return new Response(null, { status: 204, headers: { 'Content-Type': 'text/calendar; charset=UTF-8', 'Cache-Control': 'public, max-age=900' } });
   }
 
-  if (req.method !== 'GET') {
-    return new Response('Method Not Allowed', { status: 405 });
-  }
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+  const rateLimitSalt = Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SUPABASE_SERVICE_ROLE_KEY;
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
   const tid = url.searchParams.get('tid');
   const token = url.searchParams.get('token');
@@ -133,7 +120,7 @@ serve(async (req) => {
     identifierParts: ["ics"],
     windowSeconds: 60 * 60,
     maxRequests: INGRESS_RATE_LIMIT_PER_HOUR,
-    salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SERVICE_ROLE_KEY,
+    salt: rateLimitSalt,
   });
 
   if (!ingressRateLimit.allowed) {
@@ -153,7 +140,7 @@ serve(async (req) => {
     maxRequests: RATE_LIMIT_PER_HOUR,
     includeIp: false,
     includeUserAgent: false,
-    salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SERVICE_ROLE_KEY,
+    salt: rateLimitSalt,
   });
 
   if (!rateLimit.allowed) {
@@ -200,7 +187,7 @@ serve(async (req) => {
 
     if (jErr) {
       console.error('Jobs query error:', jErr);
-      return new Response(`Failed to load jobs: ${jErr.message}`, { status: 500 });
+      return new Response('Failed to load jobs', { status: 500 });
     }
 
     for (const j of (jobs ?? []) as Array<JobRow & { status?: string; tour_id?: string | null }>) {
@@ -340,7 +327,10 @@ serve(async (req) => {
       'ETag': `W/"${etag}"`,
     },
   });
-});
+}, {
+  allowedMethods: ["GET", "HEAD"],
+  methodNotAllowedBody: { error: "Method not allowed" },
+}));
 
 function buildCalendar(profile: { first_name?: string | null; last_name?: string | null } | null, events: Array<{ uid: string; summary: string; description: string; dtStart: Date; dtEnd: Date }>) {
   const now = new Date();

--- a/supabase/functions/tour-guest-document-url/index.ts
+++ b/supabase/functions/tour-guest-document-url/index.ts
@@ -1,7 +1,13 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
-import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  readBoundedJsonObject,
+  requireEnvValues,
+} from "../_shared/http.ts";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
 
 const SIGNED_URL_TTL_SECONDS = 300;
@@ -9,6 +15,7 @@ const INGRESS_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
 const INGRESS_RATE_LIMIT_MAX_REQUESTS = 300;
 const RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
 const RATE_LIMIT_MAX_REQUESTS = 120;
+const MAX_JSON_BODY_BYTES = 32 * 1024;
 
 const sha256Hex = async (value: string) => {
   const bytes = new TextEncoder().encode(value);
@@ -18,23 +25,14 @@ const sha256Hex = async (value: string) => {
     .join("");
 };
 
-serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
+serve(createHttpHandler(async (req) => {
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+  } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+  const rateLimitSalt = Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SUPABASE_SERVICE_ROLE_KEY;
 
-  if (req.method !== "POST") {
-    return jsonResponse({ error: "Method not allowed" }, { status: 405 });
-  }
-
-  const supabaseUrl = Deno.env.get("SUPABASE_URL");
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-
-  if (!supabaseUrl || !serviceRoleKey) {
-    return jsonResponse({ error: "Missing Supabase configuration" }, { status: 500 });
-  }
-
-  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
     auth: { persistSession: false },
   });
 
@@ -45,7 +43,7 @@ serve(async (req) => {
     identifierParts: ["document"],
     windowSeconds: INGRESS_RATE_LIMIT_WINDOW_SECONDS,
     maxRequests: INGRESS_RATE_LIMIT_MAX_REQUESTS,
-    salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? serviceRoleKey,
+    salt: rateLimitSalt,
   });
 
   if (!ingressRateLimit.allowed) {
@@ -57,9 +55,14 @@ serve(async (req) => {
 
   let body: { token?: unknown; documentId?: unknown };
   try {
-    body = await req.json();
-  } catch {
-    return jsonResponse({ error: "Invalid JSON body" }, { status: 400 });
+    body = await readBoundedJsonObject<Record<string, unknown>>(req, {
+      maxBytes: MAX_JSON_BODY_BYTES,
+    });
+  } catch (error) {
+    if (error instanceof HttpError && error.status === 400) {
+      return jsonResponse({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    throw error;
   }
 
   const token = typeof body.token === "string" ? body.token.trim() : "";
@@ -79,7 +82,7 @@ serve(async (req) => {
     maxRequests: RATE_LIMIT_MAX_REQUESTS,
     includeIp: false,
     includeUserAgent: false,
-    salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? serviceRoleKey,
+    salt: rateLimitSalt,
   });
 
   if (!rateLimit.allowed) {
@@ -135,4 +138,7 @@ serve(async (req) => {
     signedUrl: signed.signedUrl,
     expiresIn: SIGNED_URL_TTL_SECONDS,
   });
-});
+}, {
+  allowedMethods: ["POST"],
+  methodNotAllowedBody: { error: "Method not allowed" },
+}));

--- a/supabase/functions/upload-public-artist-rider/index.ts
+++ b/supabase/functions/upload-public-artist-rider/index.ts
@@ -1,13 +1,16 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
-import { corsHeaders, jsonResponse } from "../_shared/cors.ts";
+import {
+  createHttpHandler,
+  HttpError,
+  jsonResponse,
+  requireEnvValues,
+} from "../_shared/http.ts";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
-
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
 const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
 const MAX_FILES_PER_REQUEST = 10;
+const MAX_MULTIPART_BODY_BYTES = MAX_FILES_PER_REQUEST * MAX_FILE_SIZE_BYTES + 1024 * 1024;
 const INGRESS_RATE_LIMIT_WINDOW_SECONDS = 60;
 const INGRESS_RATE_LIMIT_MAX_REQUESTS = 30;
 const TOKEN_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
@@ -77,24 +80,14 @@ const buildArtistTableUrl = (jobId?: string | null, artistDate?: string | null) 
   return `/festival-management/${normalizedJobId}/artists?date=${encodeURIComponent(normalizedDate)}`;
 };
 
-serve(async (req) => {
-  if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
-    return jsonResponse(
-      { ok: false, error: "server_misconfigured" },
-      { status: 500 },
-    );
-  }
-
-  if (req.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders });
-  }
-
-  if (req.method !== "POST") {
-    return jsonResponse({ ok: false, error: "method_not_allowed" }, { status: 405 });
-  }
-
+serve(createHttpHandler(async (req) => {
   try {
-    const supabaseAdmin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+    const {
+      SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY,
+    } = requireEnvValues(["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const, (name) => Deno.env.get(name));
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const rateLimitSalt = Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SUPABASE_SERVICE_ROLE_KEY;
     const ingressRateLimit = await checkEdgeRateLimit({
       req,
       supabase: supabaseAdmin,
@@ -102,7 +95,7 @@ serve(async (req) => {
       identifierParts: ["multipart"],
       windowSeconds: INGRESS_RATE_LIMIT_WINDOW_SECONDS,
       maxRequests: INGRESS_RATE_LIMIT_MAX_REQUESTS,
-      salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SERVICE_ROLE_KEY,
+      salt: rateLimitSalt,
     });
 
     if (!ingressRateLimit.allowed) {
@@ -112,7 +105,18 @@ serve(async (req) => {
       );
     }
 
-    const formData = await req.formData();
+    const contentLength = Number.parseInt(req.headers.get("content-length") ?? "", 10);
+    if (Number.isFinite(contentLength) && contentLength > MAX_MULTIPART_BODY_BYTES) {
+      return jsonResponse({ ok: false, error: "file_too_large" }, { status: 413 });
+    }
+
+    let formData: FormData;
+    try {
+      formData = await req.formData();
+    } catch {
+      return jsonResponse({ ok: false, error: "invalid_form_data" }, { status: 400 });
+    }
+
     const token = String(formData.get("token") ?? "").trim();
     const fileEntries = extractFiles(formData);
 
@@ -162,7 +166,7 @@ serve(async (req) => {
       maxRequests: TOKEN_RATE_LIMIT_MAX_REQUESTS,
       includeIp: false,
       includeUserAgent: false,
-      salt: Deno.env.get("EDGE_RATE_LIMIT_HASH_SECRET") ?? SERVICE_ROLE_KEY,
+      salt: rateLimitSalt,
     });
 
     if (!tokenRateLimit.allowed) {
@@ -351,7 +355,11 @@ serve(async (req) => {
       { status: 201 },
     );
   } catch (error) {
+    if (error instanceof HttpError) throw error;
     console.error("[upload-public-artist-rider] unexpected error", error);
     return jsonResponse({ ok: false, error: "internal_error" }, { status: 500 });
   }
-});
+}, {
+  allowedMethods: ["POST"],
+  methodNotAllowedBody: { ok: false, error: "method_not_allowed" },
+}));


### PR DESCRIPTION
## Summary

- Migrates the public-token artist form/rider endpoints to the shared `createHttpHandler` boundary.
- Migrates `tour-guest-document-url` and `tech-calendar-ics` to the shared HTTP wrapper while preserving token/rate-limit behavior and calendar `text/calendar` responses.
- Adds bounded JSON parsing for public JSON endpoints, centralized required env validation, multipart size preflight for public rider uploads, and removes raw DB error text from the calendar job-load failure path.
- Updates the Edge Function governance baseline from 43 legacy manual entrypoints to 38 and records the slice in the Phase 2 hardening ledger.

## Validation

- `npm run lint` — passes with existing warning backlog.
- `npm run typecheck` — passes.
- `npm run test:run` — passes, 172 files / 1026 tests.
- `npm run build` — passes with existing Vite chunk warnings.
- `npm run governance` — passes; dependency audit reports the known allowlisted 11 advisories.

No Supabase migrations are included in this PR, so no production database push is required.