### PR TITLE
feat: fix pesos default numbering and add editable hoist/FOH power flags

### DIFF
--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -208,8 +208,9 @@ export const TourDefaultsManager = ({
   const [newSetName, setNewSetName] = useState('');
   const [newSetDescription, setNewSetDescription] = useState('');
   const [newSetPackageSize, setNewSetPackageSize] = useState<TourPackageSize | null>(null);
-  // Track the single power default currently being toggled so only its row is
-  // disabled (the shared mutation flag would otherwise freeze every card).
+  // Track the power default flag currently being toggled so only the affected
+  // row/set is disabled (the shared mutation flag would otherwise freeze every
+  // card).
   const [pendingFlagTableId, setPendingFlagTableId] = useState<string | null>(null);
 
   // Use the new tour default sets hook
@@ -362,13 +363,28 @@ export const TourDefaultsManager = ({
     key: 'includes_hoist' | 'foh_schuko',
     value: boolean,
   ) => {
-    setPendingFlagTableId(table.id);
+    const pendingKey = key === 'foh_schuko' ? `${key}:${table.set_id}` : table.id;
+    setPendingFlagTableId(pendingKey);
     try {
-      const { error } = await dataLayerClient
-        .from('tour_default_tables')
-        .update({ metadata: { ...(table.metadata || {}), [key]: value } })
-        .eq('id', table.id);
-      if (error) throw error;
+      const tablesToUpdate =
+        key === 'foh_schuko'
+          ? defaultTables.filter(
+              (candidate) =>
+                candidate.set_id === table.set_id && candidate.table_type === 'power'
+            )
+          : [table];
+
+      const results = await Promise.all(
+        tablesToUpdate.map((candidate) =>
+          dataLayerClient
+            .from('tour_default_tables')
+            .update({ metadata: { ...(candidate.metadata || {}), [key]: value } })
+            .eq('id', candidate.id)
+        )
+      );
+      const failedResult = results.find((result) => result.error);
+      if (failedResult?.error) throw failedResult.error;
+
       await queryClient.invalidateQueries({
         queryKey: queryKeys.scope('tour-default-tables', tour?.id || ''),
       });
@@ -1226,7 +1242,9 @@ export const TourDefaultsManager = ({
                       table.metadata?.position,
                       table.metadata?.custom_position,
                     );
-                    const rowPending = pendingFlagTableId === table.id;
+                    const rowPending =
+                      pendingFlagTableId === table.id ||
+                      pendingFlagTableId === `foh_schuko:${table.set_id}`;
                     return (
                     <div key={table.id} className="border rounded-lg p-4 bg-white transition-colors hover:border-primary/40">
                       <div className="flex justify-between items-start gap-2 mb-2">

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -1,5 +1,7 @@
 
 import React, { useState } from 'react';
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/react-query";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -200,6 +202,7 @@ export const TourDefaultsManager = ({
   tour,
 }: TourDefaultsManagerProps) => {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState('sound');
   const [tourDates, setTourDates] = useState<TourDateWithLocation[]>([]);
   const [newSetName, setNewSetName] = useState('');
@@ -216,7 +219,6 @@ export const TourDefaultsManager = ({
     isLoading: defaultSetsLoading,
     createSet,
     updateSet,
-    updateTable,
     duplicateSet,
     deleteSet,
     deleteTable,
@@ -353,6 +355,8 @@ export const TourDefaultsManager = ({
   // Toggle a boolean flag (hoist / FOH schuko) on an already-saved power
   // default. These were previously only settable when the table was first
   // created in the Consumos tool, so a forgotten value could not be corrected.
+  // Persisted directly (no per-toggle success toast) — the checkbox is the
+  // feedback; only failures surface a toast.
   const handleTogglePowerFlag = async (
     table: TourDefaultTable,
     key: 'includes_hoist' | 'foh_schuko',
@@ -360,11 +364,13 @@ export const TourDefaultsManager = ({
   ) => {
     setPendingFlagTableId(table.id);
     try {
-      await updateTable({
-        tableId: table.id,
-        updates: {
-          metadata: { ...(table.metadata || {}), [key]: value },
-        },
+      const { error } = await dataLayerClient
+        .from('tour_default_tables')
+        .update({ metadata: { ...(table.metadata || {}), [key]: value } })
+        .eq('id', table.id);
+      if (error) throw error;
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.scope('tour-default-tables', tour?.id || ''),
       });
     } catch (error) {
       console.error('Error updating power default flag:', error);
@@ -1211,6 +1217,9 @@ export const TourDefaultsManager = ({
                   </div>
                 </div>
                 
+                <p className="text-xs text-muted-foreground mb-3">
+                  {setTables.length} tabla{setTables.length === 1 ? '' : 's'}
+                </p>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {setTables.map((table) => {
                     const position = getResolvedPowerPosition(
@@ -1221,7 +1230,25 @@ export const TourDefaultsManager = ({
                     return (
                     <div key={table.id} className="border rounded-lg p-4 bg-white transition-colors hover:border-primary/40">
                       <div className="flex justify-between items-start gap-2 mb-2">
-                        <h6 className="font-medium leading-tight">{table.table_name}</h6>
+                        <div className="min-w-0">
+                          <h6 className="font-medium leading-tight">{table.table_name}</h6>
+                          {(table.metadata?.includes_hoist || table.metadata?.foh_schuko) && (
+                            <div className="flex flex-wrap gap-1 mt-1">
+                              {table.metadata?.includes_hoist && (
+                                <Badge variant="outline" className="gap-1 text-[10px] py-0 h-5 border-amber-300 text-amber-700">
+                                  <Anchor className="h-2.5 w-2.5" />
+                                  Hoist
+                                </Badge>
+                              )}
+                              {table.metadata?.foh_schuko && (
+                                <Badge variant="outline" className="gap-1 text-[10px] py-0 h-5 border-sky-300 text-sky-700">
+                                  <Plug className="h-2.5 w-2.5" />
+                                  FOH
+                                </Badge>
+                              )}
+                            </div>
+                          )}
+                        </div>
                         <Button
                           variant="ghost"
                           size="sm"
@@ -1407,6 +1434,9 @@ export const TourDefaultsManager = ({
                   </div>
                 </div>
                 
+                <p className="text-xs text-muted-foreground mb-3">
+                  {setTables.length} tabla{setTables.length === 1 ? '' : 's'}
+                </p>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {setTables.map((table) => (
                     <div key={table.id} className="border rounded-lg p-4 bg-white">

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 import { FileText, Weight, Calculator, Trash2, Download, Calendar, Copy, AlertTriangle } from "lucide-react";
@@ -212,11 +213,13 @@ export const TourDefaultsManager = ({
     isLoading: defaultSetsLoading,
     createSet,
     updateSet,
+    updateTable,
     duplicateSet,
     deleteSet,
     deleteTable,
     isCreatingSet,
     isUpdatingSet,
+    isUpdatingTable,
     isDuplicatingSet,
     isDeletingSet,
     isDeletingTable
@@ -340,6 +343,31 @@ export const TourDefaultsManager = ({
       toast({
         title: 'Error',
         description: 'Error al eliminar la tabla',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  // Toggle a boolean flag (hoist / FOH schuko) on an already-saved power
+  // default. These were previously only settable when the table was first
+  // created in the Consumos tool, so a forgotten value could not be corrected.
+  const handleTogglePowerFlag = async (
+    table: TourDefaultTable,
+    key: 'includes_hoist' | 'foh_schuko',
+    value: boolean,
+  ) => {
+    try {
+      await updateTable({
+        tableId: table.id,
+        updates: {
+          metadata: { ...(table.metadata || {}), [key]: value },
+        },
+      });
+    } catch (error) {
+      console.error('Error updating power default flag:', error);
+      toast({
+        title: 'Error',
+        description: 'Error al actualizar la tabla',
         variant: 'destructive',
       });
     }
@@ -595,6 +623,12 @@ export const TourDefaultsManager = ({
             1000,
         };
 
+        const fohSchukoRequired =
+          (department === 'sound' || department === 'lights') &&
+          relevantDefaults.some(
+            (item) => isNewFormatTable(item) && Boolean(item.metadata?.foh_schuko),
+          );
+
         const pdfBlob = await exportToPDF(
           getDefaultsPdfTitle(tour.name, department, type, packageLabel),
           tables,
@@ -604,7 +638,8 @@ export const TourDefaultsManager = ({
           undefined,
           powerSummary,
           safetyMargin,
-          logoUrl
+          logoUrl,
+          fohSchukoRequired
         );
 
         const fileName = getDefaultsPdfFilename(tour.name, department, type, packageLabel);
@@ -854,6 +889,12 @@ export const TourDefaultsManager = ({
       const locationName = getTourDateLocationName(tourDate);
       const dateStr = tourDate.date;
 
+      const fohSchukoRequired =
+        (department === 'sound' || department === 'lights') &&
+        defaultsData.some(
+          (item) => isNewFormatTable(item) && Boolean(item.metadata?.foh_schuko),
+        );
+
       const pdfBlob = await exportToPDF(
         getTourDatePdfTitle(tour.name, locationName, department, type, packageLabel),
         tables,
@@ -863,7 +904,8 @@ export const TourDefaultsManager = ({
         undefined,
         powerSummary,
         safetyMargin,
-        logoUrl
+        logoUrl,
+        fohSchukoRequired
       );
 
       const fileName = getTourDatePdfFilename(
@@ -1011,6 +1053,8 @@ export const TourDefaultsManager = ({
     const powerTables = getDepartmentDefaults(department, 'power');
     const weightTables = getDepartmentDefaults(department, 'weight');
     const duplicateWarnings = getDuplicatePackageWarnings(department);
+    // FOH schuko power only applies to sound & lights (matches the Consumos tool).
+    const fohSupported = department === 'sound' || department === 'lights';
 
     // Group new format tables by sets
     const departmentSets = defaultSets.filter(set => set.department === department);
@@ -1190,6 +1234,36 @@ export const TourDefaultsManager = ({
                           Posición: {getResolvedPowerPosition(table.metadata?.position, table.metadata?.custom_position)}
                         </p>
                       )}
+                      <div className="mt-3 space-y-2 border-t pt-3">
+                        <div className="flex items-center space-x-2">
+                          <Checkbox
+                            id={`hoist-${table.id}`}
+                            checked={Boolean(table.metadata?.includes_hoist)}
+                            disabled={isUpdatingTable}
+                            onCheckedChange={(checked) =>
+                              void handleTogglePowerFlag(table, 'includes_hoist', !!checked)
+                            }
+                          />
+                          <Label htmlFor={`hoist-${table.id}`} className="text-xs font-normal">
+                            Incluye hoist/rigging
+                          </Label>
+                        </div>
+                        {fohSupported && (
+                          <div className="flex items-center space-x-2">
+                            <Checkbox
+                              id={`foh-${table.id}`}
+                              checked={Boolean(table.metadata?.foh_schuko)}
+                              disabled={isUpdatingTable}
+                              onCheckedChange={(checked) =>
+                                void handleTogglePowerFlag(table, 'foh_schuko', !!checked)
+                              }
+                            />
+                            <Label htmlFor={`foh-${table.id}`} className="text-xs font-normal">
+                              FOH (schuko 16A)
+                            </Label>
+                          </div>
+                        )}
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { FileText, Weight, Calculator, Trash2, Download, Calendar, Copy, AlertTriangle } from "lucide-react";
+import { FileText, Weight, Calculator, Trash2, Download, Calendar, Copy, AlertTriangle, Anchor, Plug } from "lucide-react";
 import { exportToPDF } from "@/utils/pdfExport";
 import { fetchTourLogo } from "@/utils/pdf/logoUtils";
 import { dataLayerClient } from "@/services/dataLayerClient";
@@ -205,6 +205,9 @@ export const TourDefaultsManager = ({
   const [newSetName, setNewSetName] = useState('');
   const [newSetDescription, setNewSetDescription] = useState('');
   const [newSetPackageSize, setNewSetPackageSize] = useState<TourPackageSize | null>(null);
+  // Track the single power default currently being toggled so only its row is
+  // disabled (the shared mutation flag would otherwise freeze every card).
+  const [pendingFlagTableId, setPendingFlagTableId] = useState<string | null>(null);
 
   // Use the new tour default sets hook
   const {
@@ -219,7 +222,6 @@ export const TourDefaultsManager = ({
     deleteTable,
     isCreatingSet,
     isUpdatingSet,
-    isUpdatingTable,
     isDuplicatingSet,
     isDeletingSet,
     isDeletingTable
@@ -356,6 +358,7 @@ export const TourDefaultsManager = ({
     key: 'includes_hoist' | 'foh_schuko',
     value: boolean,
   ) => {
+    setPendingFlagTableId(table.id);
     try {
       await updateTable({
         tableId: table.id,
@@ -370,6 +373,8 @@ export const TourDefaultsManager = ({
         description: 'Error al actualizar la tabla',
         variant: 'destructive',
       });
+    } finally {
+      setPendingFlagTableId(null);
     }
   };
 
@@ -1207,44 +1212,52 @@ export const TourDefaultsManager = ({
                 </div>
                 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {setTables.map((table) => (
-                    <div key={table.id} className="border rounded-lg p-4 bg-white">
-                      <div className="flex justify-between items-start mb-2">
-                        <h6 className="font-medium">{table.table_name}</h6>
+                  {setTables.map((table) => {
+                    const position = getResolvedPowerPosition(
+                      table.metadata?.position,
+                      table.metadata?.custom_position,
+                    );
+                    const rowPending = pendingFlagTableId === table.id;
+                    return (
+                    <div key={table.id} className="border rounded-lg p-4 bg-white transition-colors hover:border-primary/40">
+                      <div className="flex justify-between items-start gap-2 mb-2">
+                        <h6 className="font-medium leading-tight">{table.table_name}</h6>
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={() => handleDeleteTable(table, 'power')}
                           disabled={isDeletingTable}
-                          className="text-destructive hover:text-destructive"
+                          className="text-destructive hover:text-destructive shrink-0 -mt-1 -mr-1"
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
                       </div>
-                      <p className="text-sm text-muted-foreground">
-                        {table.total_value.toFixed(2)} W
-                      </p>
-                      {table.metadata?.current_per_phase && (
-                        <p className="text-xs text-muted-foreground">
-                          {table.metadata.current_per_phase.toFixed(2)} A por fase
-                        </p>
-                      )}
-                      {getResolvedPowerPosition(table.metadata?.position, table.metadata?.custom_position) && (
-                        <p className="text-xs text-muted-foreground">
-                          Posición: {getResolvedPowerPosition(table.metadata?.position, table.metadata?.custom_position)}
-                        </p>
-                      )}
-                      <div className="mt-3 space-y-2 border-t pt-3">
+                      <div className="flex flex-wrap gap-1.5">
+                        <Badge variant="secondary" className="font-mono">
+                          {table.total_value.toFixed(2)} W
+                        </Badge>
+                        {table.metadata?.current_per_phase && (
+                          <Badge variant="secondary" className="font-mono">
+                            {table.metadata.current_per_phase.toFixed(2)} A/fase
+                          </Badge>
+                        )}
+                        {position && <Badge variant="outline">{position}</Badge>}
+                      </div>
+                      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t pt-3">
                         <div className="flex items-center space-x-2">
                           <Checkbox
                             id={`hoist-${table.id}`}
                             checked={Boolean(table.metadata?.includes_hoist)}
-                            disabled={isUpdatingTable}
+                            disabled={rowPending}
                             onCheckedChange={(checked) =>
                               void handleTogglePowerFlag(table, 'includes_hoist', !!checked)
                             }
                           />
-                          <Label htmlFor={`hoist-${table.id}`} className="text-xs font-normal">
+                          <Label
+                            htmlFor={`hoist-${table.id}`}
+                            className="text-xs font-normal flex items-center gap-1 cursor-pointer"
+                          >
+                            <Anchor className="h-3 w-3 text-muted-foreground" />
                             Incluye hoist/rigging
                           </Label>
                         </div>
@@ -1253,19 +1266,25 @@ export const TourDefaultsManager = ({
                             <Checkbox
                               id={`foh-${table.id}`}
                               checked={Boolean(table.metadata?.foh_schuko)}
-                              disabled={isUpdatingTable}
+                              disabled={rowPending}
                               onCheckedChange={(checked) =>
                                 void handleTogglePowerFlag(table, 'foh_schuko', !!checked)
                               }
                             />
-                            <Label htmlFor={`foh-${table.id}`} className="text-xs font-normal">
+                            <Label
+                              htmlFor={`foh-${table.id}`}
+                              className="text-xs font-normal flex items-center gap-1 cursor-pointer"
+                              title="Se requiere potencia de 16A en formato schuko hembra en posición FoH"
+                            >
+                              <Plug className="h-3 w-3 text-muted-foreground" />
                               FOH (schuko 16A)
                             </Label>
                           </div>
                         )}
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             );

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -284,6 +284,78 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     );
   }, [copySourceSetId, defaultTables]);
 
+  // Restore the persisted FOH schuko setting when a default set is loaded so a
+  // value saved earlier is not silently reset to the default on reopen.
+  const fohHydratedSetRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isTourDefaults || !features.fohSchuko || !selectedDefaultSetId) return;
+    if (fohHydratedSetRef.current === selectedDefaultSetId) return;
+    const setTables = defaultTables.filter(
+      (table) => table.set_id === selectedDefaultSetId && table.table_type === "power",
+    );
+    if (setTables.length === 0) return;
+    fohHydratedSetRef.current = selectedDefaultSetId;
+    const anyKeyPresent = setTables.some(
+      (table) =>
+        typeof table.metadata === "object" &&
+        table.metadata !== null &&
+        "foh_schuko" in (table.metadata as Record<string, unknown>),
+    );
+    if (anyKeyPresent) {
+      setFohSchukoRequired(
+        setTables.some(
+          (table) => (table.metadata as { foh_schuko?: boolean })?.foh_schuko === true,
+        ),
+      );
+    }
+  }, [isTourDefaults, features.fohSchuko, selectedDefaultSetId, defaultTables]);
+
+  // Persist the FOH schuko toggle onto the selected set's already-saved tables
+  // so toggling it (without re-saving a table) is remembered too.
+  const persistFohForSelectedSet = useCallback(
+    async (value: boolean) => {
+      if (!isTourDefaults || !features.fohSchuko || !selectedDefaultSetId) return;
+      const setTables = defaultTables.filter(
+        (table) => table.set_id === selectedDefaultSetId && table.table_type === "power",
+      );
+      if (setTables.length === 0) return;
+      try {
+        await Promise.all(
+          setTables.map((table) =>
+            dataLayerClient
+              .from("tour_default_tables")
+              .update({
+                metadata: {
+                  ...(typeof table.metadata === "object" && table.metadata !== null
+                    ? table.metadata
+                    : {}),
+                  foh_schuko: value,
+                },
+              })
+              .eq("id", table.id),
+          ),
+        );
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.scope("tour-default-tables", tourIdParam || "", department),
+        });
+      } catch (error) {
+        console.error("Error persisting FOH schuko setting:", error);
+      }
+    },
+    [isTourDefaults, features.fohSchuko, selectedDefaultSetId, defaultTables, queryClient, tourIdParam, department],
+  );
+
+  const handleSetFohSchukoRequired = useCallback(
+    (value: boolean) => {
+      setFohSchukoRequired(value);
+      // Keep the loaded set marked as hydrated so the restore effect doesn't
+      // overwrite this fresh choice from a stale query snapshot.
+      if (selectedDefaultSetId) fohHydratedSetRef.current = selectedDefaultSetId;
+      void persistFohForSelectedSet(value);
+    },
+    [persistFohForSelectedSet, selectedDefaultSetId],
+  );
+
   const { data: tourName = "" } = useQuery({
     queryKey: queryKeys.scope("tour", tourIdParam, "name"),
     queryFn: async () => {
@@ -705,6 +777,11 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     });
   };
 
+  // FOH schuko is a report-level setting; persist it onto each default table's
+  // metadata (when the department supports it) so it is remembered per set.
+  const fohSchukoSetting = () =>
+    features.fohSchuko ? fohSchukoRequired : undefined;
+
   const persistDefaultTableUpdate = async (table: PowerTable) => {
     if (!table.defaultTableId) return;
     const settings = getTableSnapshotSettings(table);
@@ -714,7 +791,10 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
         table_name: table.name,
         table_data: buildPowerTableData(table, settings),
         total_value: table.totalWatts || 0,
-        metadata: buildPowerTableMetadata(table, settings),
+        metadata: buildPowerTableMetadata(table, {
+          ...settings,
+          fohSchuko: fohSchukoSetting(),
+        }),
       },
     });
   };
@@ -908,7 +988,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       const newDefaultTable = await createTourDefaultTable(
         buildTourPowerDefaultTable({
           setId,
-          settings: getTableSnapshotSettings(table),
+          settings: { ...getTableSnapshotSettings(table), fohSchuko: fohSchukoSetting() },
           table,
         }),
       );
@@ -967,7 +1047,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
           buildTourPowerDefaultTable({
             orderIndex: index,
             setId,
-            settings: getTableSnapshotSettings(table),
+            settings: { ...getTableSnapshotSettings(table), fohSchuko: fohSchukoSetting() },
             table,
           }),
         );
@@ -1634,7 +1714,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     pf,
     setPf,
     fohSchukoRequired,
-    setFohSchukoRequired,
+    setFohSchukoRequired: handleSetFohSchukoRequired,
     pduOptions,
     tableName,
     setTableName,

--- a/src/features/technical-tools/power/powerPersistence.ts
+++ b/src/features/technical-tools/power/powerPersistence.ts
@@ -47,7 +47,11 @@ export const buildPowerTableData = (
 
 export const buildPowerTableMetadata = (
   table: PowerTable,
-  settings: PowerElectricalSettings & { orderIndex?: number; powerFactor?: number },
+  settings: PowerElectricalSettings & {
+    orderIndex?: number;
+    powerFactor?: number;
+    fohSchuko?: boolean;
+  },
 ) =>
   ({
     current_per_phase: table.currentPerPhase,
@@ -61,6 +65,7 @@ export const buildPowerTableMetadata = (
     voltage: settings.voltage,
     ...(settings.powerFactor !== undefined ? { pf: settings.powerFactor } : {}),
     ...(settings.orderIndex !== undefined ? { order_index: settings.orderIndex } : {}),
+    ...(settings.fohSchuko !== undefined ? { foh_schuko: settings.fohSchuko } : {}),
   }) as unknown as Json;
 
 const getPowerTableStage = (
@@ -319,7 +324,7 @@ export const buildTourPowerDefaultTable = ({
 }: {
   orderIndex?: number;
   setId: string;
-  settings: PowerElectricalSettings & { powerFactor?: number };
+  settings: PowerElectricalSettings & { powerFactor?: number; fohSchuko?: boolean };
   table: PowerTable;
 }) => ({
   set_id: setId,

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -430,9 +430,12 @@ const PesosTool: React.FC = () => {
     }
   };
 
-  // Load existing tour defaults when in defaults mode
+  // Load existing tour defaults when in defaults mode.
+  // Also runs for the tour-defaults entry (Tour Management page) so existing
+  // tables are shown and newly generated ones append after them with
+  // continuous SX numbering instead of restarting from the first number.
   useEffect(() => {
-    if (isDefaults && defaultTables.length > 0) {
+    if ((isDefaults || isTourDefaults) && defaultTables.length > 0) {
       // Group tables by set and convert to our local format
       const convertedTables = defaultTables
         .filter(dt => dt.table_type === 'weight' && (!selectedDefaultSetId || dt.set_id === selectedDefaultSetId))
@@ -457,7 +460,7 @@ const PesosTool: React.FC = () => {
         }));
       setTables(assignSuffixes(convertedTables));
     }
-  }, [isDefaults, defaultTables, selectedDefaultSetId]);
+  }, [isDefaults, isTourDefaults, defaultTables, selectedDefaultSetId]);
 
   // Load tour date overrides when in tour date context
   useEffect(() => {

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -161,6 +161,11 @@ const PesosTool: React.FC = () => {
 
   const formatSuffixNumber = (value: number) => formatRiggingPoint('SX', value);
 
+  const getRiggingPointNumbers = (riggingPoints?: string): number[] =>
+    Array.from(riggingPoints?.matchAll(/SX0*(\d+)/gi) ?? [])
+      .map((match) => Number.parseInt(match[1], 10))
+      .filter((value) => Number.isFinite(value) && value > 0);
+
   const assignSuffixes = (tablesToAssign: Table[]): Table[] => {
     const countersByStage = new Map<string, number>();
 
@@ -168,6 +173,18 @@ const PesosTool: React.FC = () => {
       const baseName = table.baseName || deriveBaseName(table.name);
       const stageKey = table.stageNumber != null ? `stage-${table.stageNumber}` : 'default';
       const counter = countersByStage.get(stageKey) || 1;
+      const persistedRiggingNumbers = getRiggingPointNumbers(table.riggingPoints);
+      const shouldPreservePersistedRigging =
+        Boolean(table.defaultTableId || table.overrideId) && persistedRiggingNumbers.length > 0;
+
+      if (shouldPreservePersistedRigging) {
+        countersByStage.set(stageKey, Math.max(counter, Math.max(...persistedRiggingNumbers) + 1));
+        return {
+          ...table,
+          baseName,
+          name: `${baseName} (${table.riggingPoints})`,
+        };
+      }
 
       if (table.dualMotors) {
         const suffixOne = formatSuffixNumber(counter);
@@ -216,6 +233,12 @@ const PesosTool: React.FC = () => {
   const [selectedDefaultSetId, setSelectedDefaultSetId] = useState<string>('');
   const [selectedDefaultPackageSize, setSelectedDefaultPackageSize] = useState<TourPackageSize | 'unassigned'>('unassigned');
   const [newDefaultSetName, setNewDefaultSetName] = useState('');
+
+  const handleSelectedDefaultSetIdChange = (setId: string) => {
+    setSelectedDefaultSetId(setId);
+    const selectedSet = defaultSets.find((set) => set.id === setId);
+    setSelectedDefaultPackageSize(selectedSet?.package_size || 'unassigned');
+  };
 
   useEffect(() => {
     if (!isTourDefaults && !isDefaults) return;
@@ -435,32 +458,42 @@ const PesosTool: React.FC = () => {
   // tables are shown and newly generated ones append after them with
   // continuous SX numbering instead of restarting from the first number.
   useEffect(() => {
-    if ((isDefaults || isTourDefaults) && defaultTables.length > 0) {
-      // Group tables by set and convert to our local format
-      const convertedTables = defaultTables
-        .filter(dt => dt.table_type === 'weight' && (!selectedDefaultSetId || dt.set_id === selectedDefaultSetId))
-        .map((dt, index) => ({
-          name: dt.table_name,
-          rows: (dt.table_data?.rows || [{
-            quantity: '1',
-            componentId: '',
-            weight: dt.total_value.toString(),
-            componentName: dt.table_name,
-            totalWeight: dt.total_value
-          }]).map((row: any) => ({ ...row, id: row?.id || createRowId() })),
-          totalWeight: dt.total_value,
-          id: Date.now() + index,
-          clusterId: dt.metadata?.clusterId,
-          dualMotors: dt.metadata?.dualMotors,
-          riggingPoints: dt.metadata?.riggingPoints,
-          cablePick: Boolean(dt.metadata?.cablePick ?? dt.table_data?.cablePick ?? false),
-          cablePickWeight: (dt.metadata?.cablePickWeight ?? dt.table_data?.cablePickWeight ?? "100").toString(),
-          defaultTableId: dt.id,
-          baseName: dt.metadata?.baseName || deriveBaseName(dt.table_name)
-        }));
-      setTables(assignSuffixes(convertedTables));
+    if (!isDefaults && !isTourDefaults) return;
+
+    const resolvedDefaultSetId =
+      selectedDefaultSetId || (defaultSets.length === 1 ? defaultSets[0].id : '');
+
+    if (!resolvedDefaultSetId) {
+      setTables([]);
+      return;
     }
-  }, [isDefaults, isTourDefaults, defaultTables, selectedDefaultSetId]);
+
+    // Convert only the active set. Loading every set at once makes SX numbering
+    // bleed across packages/default sets; Consumos intentionally gates display
+    // the same way when more than one set exists.
+    const convertedTables = defaultTables
+      .filter(dt => dt.table_type === 'weight' && dt.set_id === resolvedDefaultSetId)
+      .map((dt, index) => ({
+        name: dt.table_name,
+        rows: (dt.table_data?.rows || [{
+          quantity: '1',
+          componentId: '',
+          weight: dt.total_value.toString(),
+          componentName: dt.table_name,
+          totalWeight: dt.total_value
+        }]).map((row: any) => ({ ...row, id: row?.id || createRowId() })),
+        totalWeight: dt.total_value,
+        id: Date.now() + index,
+        clusterId: dt.metadata?.clusterId,
+        dualMotors: dt.metadata?.dualMotors,
+        riggingPoints: dt.metadata?.riggingPoints,
+        cablePick: Boolean(dt.metadata?.cablePick ?? dt.table_data?.cablePick ?? false),
+        cablePickWeight: (dt.metadata?.cablePickWeight ?? dt.table_data?.cablePickWeight ?? "100").toString(),
+        defaultTableId: dt.id,
+        baseName: dt.metadata?.baseName || deriveBaseName(dt.table_name)
+      }));
+    setTables(assignSuffixes(convertedTables));
+  }, [isDefaults, isTourDefaults, defaultSets, defaultTables, selectedDefaultSetId]);
 
   // Load tour date overrides when in tour date context
   useEffect(() => {
@@ -595,7 +628,7 @@ const PesosTool: React.FC = () => {
   };
 
   // UPDATED: Save as tour defaults using the new system
-  const saveAsTourDefaults = async (table: Table) => {
+  const saveAsTourDefaults = async (table: Table, orderIndex?: number) => {
     if (!tourId) return;
 
     try {
@@ -603,7 +636,7 @@ const PesosTool: React.FC = () => {
       const setId = await getOrCreateSoundSetId();
 
       // Create the table with detailed data and metadata
-      await createDefaultTable({
+      const savedTable = await createDefaultTable({
         set_id: setId,
         table_name: table.name,
         table_data: {
@@ -623,9 +656,18 @@ const PesosTool: React.FC = () => {
           clusterId: table.clusterId,
           cablePick: table.cablePick,
           cablePickWeight: table.cablePickWeight,
-          baseName: table.baseName
+          baseName: table.baseName,
+          ...(typeof orderIndex === 'number' ? { order_index: orderIndex } : {})
         }
       });
+
+      setTables((previous) =>
+        previous.map((candidate) =>
+          candidate.id === table.id
+            ? { ...candidate, defaultTableId: savedTable.id }
+            : candidate
+        )
+      );
 
       toast({
         title: 'Success',
@@ -795,7 +837,10 @@ const PesosTool: React.FC = () => {
     // Handle saving based on mode
     createdTablesWithSuffixes.forEach(table => {
       if (isTourDefaults) {
-        saveAsTourDefaults(table);
+        saveAsTourDefaults(
+          table,
+          updatedTables.findIndex((candidate) => candidate.id === table.id)
+        );
       } else if (isTourDateContext || isJobOverrideMode) {
         saveAsOverride(table);
       }
@@ -972,7 +1017,7 @@ const PesosTool: React.FC = () => {
       defaultSets={defaultSets}
       defaultTables={defaultTables}
       selectedDefaultSetId={selectedDefaultSetId}
-      setSelectedDefaultSetId={setSelectedDefaultSetId}
+      setSelectedDefaultSetId={handleSelectedDefaultSetIdChange}
       selectedDefaultPackageSize={selectedDefaultPackageSize}
       setSelectedDefaultPackageSize={setSelectedDefaultPackageSize}
       newDefaultSetName={newDefaultSetName}

--- a/src/pages/pesos-tool/PesosToolView.tsx
+++ b/src/pages/pesos-tool/PesosToolView.tsx
@@ -521,6 +521,18 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
               </div>
             )}
 
+            {/* Empty state for defaults modes so the workflow is discoverable */}
+            {(isDefaults || isTourDefaults) && tables.length === 0 && (
+              <div className="border border-dashed rounded-lg p-8 text-center">
+                <p className="text-sm font-medium">Aún no hay tablas en este conjunto</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Genera tu primera tabla desde el panel de la izquierda. La numeración
+                  (SX) continúa automáticamente desde la última tabla y las nuevas se
+                  añaden al final.
+                </p>
+              </div>
+            )}
+
             {/* Table display with save as default option - First half */}
             {tables.slice(0, Math.ceil(tables.length / 2)).map((table: any) => (
               <div key={table.id} className="border rounded-lg overflow-x-auto">


### PR DESCRIPTION
Sound pesos tour defaults (Tour Management page, mode=tour-defaults) now
load existing tables into the builder, so newly generated tables append
last and SX numbering continues from the last used number instead of
restarting from the first.

Saved power defaults in the Tour Defaults manager gain editable
"includes hoist/rigging" and "FOH (schuko 16A)" checkboxes so values
forgotten at creation can be corrected. The FOH flag is wired through
both power PDF export paths.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KguqmMUcXvtwcu7ewPrgR7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Power defaults now support per-row toggles for hoist and FOH schuko requirements, with changes saved immediately and reflected in exports.
  * PDF exports now include the FOH schuko requirement when applicable.
  * Existing default tables now load in tour-defaults mode for a more consistent experience.

* **Bug Fixes**
  * Power requirement settings now persist correctly across reloads and when switching between default sets.
  * The current row is disabled while its settings are being updated to prevent conflicting edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->