### PR TITLE
feat: force techs to send the day they just edited on the timesheet view

### DIFF
--- a/src/components/technician/TimesheetView.tsx
+++ b/src/components/technician/TimesheetView.tsx
@@ -203,13 +203,9 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
         category: isPrepDay ? undefined : formData.category,
       });
       setEditingId(null);
-      // Remember this day and immediately nudge the tech to send it, so a saved
-      // parte doesn't sit forgotten as a draft.
+      // Remember this day so the exit guard can catch it if the tech leaves
+      // without sending. The send nudge itself fires after signing (last step).
       setEditedIds(prev => new Set(prev).add(timesheet.id));
-      const sendableStatuses: Array<Timesheet['status']> = ['draft', 'rejected'];
-      if (!isClosureLocked && sendableStatuses.includes(timesheet.status)) {
-        setSendPromptId(timesheet.id);
-      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Error desconocido';
       toast.error(`No se pudo guardar el parte: ${message}`);
@@ -267,8 +263,17 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
     try {
       const signatureData = signaturePadRef.current.toDataURL();
       await signTimesheet(signingTimesheetId, signatureData);
+      const signedId = signingTimesheetId;
       setSignatureDialogOpen(false);
       setSigningTimesheetId(null);
+      // Signing is the last step before submitting — nudge the tech to send it
+      // now so a signed parte doesn't sit forgotten as a draft.
+      setEditedIds(prev => new Set(prev).add(signedId));
+      const signed = myTimesheets.find(t => t.id === signedId);
+      const sendableStatuses: Array<Timesheet['status']> = ['draft', 'rejected'];
+      if (!isClosureLocked && (!signed || sendableStatuses.includes(signed.status))) {
+        setSendPromptId(signedId);
+      }
     } catch (err) {
       console.error('Error saving signature:', err);
       toast.error('No se pudo guardar la firma');
@@ -805,10 +810,10 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                 <div className="p-2 rounded-full bg-emerald-500/15">
                   <CheckCircle2 size={20} className="text-emerald-500" />
                 </div>
-                <h3 className={`font-bold text-lg ${theme.textMain}`}>Parte guardado</h3>
+                <h3 className={`font-bold text-lg ${theme.textMain}`}>Parte firmado</h3>
               </div>
               <p className={`text-sm ${theme.textMuted} mb-5`}>
-                Tus horas están guardadas pero todavía no se han enviado. Envíalo ahora
+                Has firmado el parte pero todavía no se ha enviado. Envíalo ahora
                 para que pase a aprobación.
               </p>
               <div className="space-y-2">

--- a/src/components/technician/TimesheetView.tsx
+++ b/src/components/technician/TimesheetView.tsx
@@ -123,6 +123,24 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
     return timesheets.filter(t => t.technician_id === userId);
   }, [timesheets, userId]);
 
+  // Days the technician edited & saved in this session. We only force-send the
+  // day(s) they actually touched — never every draft on the job.
+  const [editedIds, setEditedIds] = useState<Set<string>>(new Set());
+
+  // Of those edited days, the ones still saved-but-not-sent (draft/rejected).
+  const editedUnsent = useMemo(() => {
+    if (isClosureLocked) return [];
+    const sendableStatuses: Array<Timesheet['status']> = ['draft', 'rejected'];
+    return myTimesheets.filter(
+      t => editedIds.has(t.id) && sendableStatuses.includes(t.status)
+    );
+  }, [myTimesheets, editedIds, isClosureLocked]);
+
+  // Send prompt (fires right after saving a day) + exit-guard state
+  const [sendPromptId, setSendPromptId] = useState<string | null>(null);
+  const [showExitConfirm, setShowExitConfirm] = useState(false);
+  const [isSendingPrompt, setIsSendingPrompt] = useState(false);
+
   // Editing state
   const [editingId, setEditingId] = useState<string | null>(null);
   const [formData, setFormData] = useState<TimesheetFormData>({
@@ -185,6 +203,13 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
         category: isPrepDay ? undefined : formData.category,
       });
       setEditingId(null);
+      // Remember this day and immediately nudge the tech to send it, so a saved
+      // parte doesn't sit forgotten as a draft.
+      setEditedIds(prev => new Set(prev).add(timesheet.id));
+      const sendableStatuses: Array<Timesheet['status']> = ['draft', 'rejected'];
+      if (!isClosureLocked && sendableStatuses.includes(timesheet.status)) {
+        setSendPromptId(timesheet.id);
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Error desconocido';
       toast.error(`No se pudo guardar el parte: ${message}`);
@@ -198,6 +223,37 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
       const message = err instanceof Error ? err.message : 'Error desconocido';
       toast.error(`No se pudo enviar el parte: ${message}`);
     }
+  };
+
+  // Send a single day (the one just edited), then optionally leave the view.
+  const sendDay = async (timesheetId: string, { closeAfter = false }: { closeAfter?: boolean } = {}) => {
+    setIsSendingPrompt(true);
+    try {
+      await submitTimesheet(timesheetId);
+      setEditedIds(prev => {
+        const next = new Set(prev);
+        next.delete(timesheetId);
+        return next;
+      });
+      setSendPromptId(null);
+      setShowExitConfirm(false);
+      toast.success('Parte enviado');
+      if (closeAfter) onClose();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Error desconocido';
+      toast.error(`No se pudo enviar el parte: ${message}`);
+    } finally {
+      setIsSendingPrompt(false);
+    }
+  };
+
+  // Guard the exit: if a day was edited but not sent, force a decision first.
+  const handleAttemptClose = () => {
+    if (editedUnsent.length > 0) {
+      setShowExitConfirm(true);
+      return;
+    }
+    onClose();
   };
 
   const openSignatureDialog = (timesheetId: string) => {
@@ -249,7 +305,7 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
         <div className="flex justify-between items-center">
           <div>
             <button
-              onClick={onClose}
+              onClick={handleAttemptClose}
               className={`flex items-center gap-1 text-xs font-bold mb-1 ${theme.textMuted}`}
             >
               <ChevronLeft size={14} /> Volver
@@ -258,6 +314,7 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
           </div>
         </div>
       </div>
+
 
       {/* Content */}
       <ScrollArea className="flex-1">
@@ -738,6 +795,102 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
           )}
         </div>
       </ScrollArea>
+
+      {/* Post-save nudge — prompt to send the day that was just edited */}
+      {sendPromptId && (
+        <div className={`fixed inset-0 z-[80] flex items-center justify-center ${theme.modalOverlay || 'bg-black/90 backdrop-blur-md'} px-4 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200`}>
+          <div className={`w-full max-w-sm ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${theme.divider} shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200`}>
+            <div className="p-5">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="p-2 rounded-full bg-emerald-500/15">
+                  <CheckCircle2 size={20} className="text-emerald-500" />
+                </div>
+                <h3 className={`font-bold text-lg ${theme.textMain}`}>Parte guardado</h3>
+              </div>
+              <p className={`text-sm ${theme.textMuted} mb-5`}>
+                Tus horas están guardadas pero todavía no se han enviado. Envíalo ahora
+                para que pase a aprobación.
+              </p>
+              <div className="space-y-2">
+                <Button
+                  className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold"
+                  disabled={isSendingPrompt}
+                  onClick={() => sendDay(sendPromptId)}
+                >
+                  {isSendingPrompt ? (
+                    <Loader2 size={16} className="mr-2 animate-spin" />
+                  ) : (
+                    <CheckCircle2 size={16} className="mr-2" />
+                  )}
+                  Enviar parte
+                </Button>
+                <button
+                  className={`w-full text-center text-xs ${theme.textMuted} py-2 disabled:opacity-50`}
+                  disabled={isSendingPrompt}
+                  onClick={() => setSendPromptId(null)}
+                >
+                  Más tarde
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Exit guard — block leaving with an edited-but-unsent day */}
+      {showExitConfirm && editedUnsent.length > 0 && (
+        <div className={`fixed inset-0 z-[80] flex items-center justify-center ${theme.modalOverlay || 'bg-black/90 backdrop-blur-md'} px-4 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200`}>
+          <div className={`w-full max-w-sm ${isDark ? 'bg-[#0f1219]' : 'bg-white'} rounded-2xl border ${theme.divider} shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200`}>
+            <div className="p-5">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="p-2 rounded-full bg-amber-500/15">
+                  <AlertTriangle size={20} className="text-amber-500" />
+                </div>
+                <h3 className={`font-bold text-lg ${theme.textMain}`}>Parte sin enviar</h3>
+              </div>
+              <p className={`text-sm ${theme.textMuted} mb-5`}>
+                Editaste el parte del{' '}
+                <span className={`font-bold ${theme.textMain}`}>
+                  {format(parseISO(editedUnsent[0].date), "d 'de' MMMM", { locale: es })}
+                </span>{' '}
+                pero no lo has enviado. Si sales ahora no pasará a aprobación.
+              </p>
+              <div className="space-y-2">
+                <Button
+                  className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold"
+                  disabled={isSendingPrompt}
+                  onClick={() => sendDay(editedUnsent[0].id, { closeAfter: editedUnsent.length === 1 })}
+                >
+                  {isSendingPrompt ? (
+                    <Loader2 size={16} className="mr-2 animate-spin" />
+                  ) : (
+                    <CheckCircle2 size={16} className="mr-2" />
+                  )}
+                  Enviar parte{editedUnsent.length === 1 ? ' y salir' : ''}
+                </Button>
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  disabled={isSendingPrompt}
+                  onClick={() => setShowExitConfirm(false)}
+                >
+                  Seguir editando
+                </Button>
+                <button
+                  className={`w-full text-center text-xs ${theme.textMuted} py-2 disabled:opacity-50`}
+                  disabled={isSendingPrompt}
+                  onClick={() => {
+                    setShowExitConfirm(false);
+                    onClose();
+                  }}
+                >
+                  Salir sin enviar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Signature Modal - Custom implementation matching incident report */}
       {signatureDialogOpen && (

--- a/src/components/technician/TimesheetView.tsx
+++ b/src/components/technician/TimesheetView.tsx
@@ -98,6 +98,8 @@ const getStatusBadge = (status: string, isDark: boolean) => {
   }
 };
 
+const SENDABLE_TIMESHEET_STATUSES: ReadonlyArray<Timesheet['status']> = ['draft', 'rejected'];
+
 export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }: TimesheetViewProps) => {
   const { user } = useOptimizedAuth();
   const {
@@ -130,9 +132,8 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
   // Of those edited days, the ones still saved-but-not-sent (draft/rejected).
   const editedUnsent = useMemo(() => {
     if (isClosureLocked) return [];
-    const sendableStatuses: Array<Timesheet['status']> = ['draft', 'rejected'];
     return myTimesheets.filter(
-      t => editedIds.has(t.id) && sendableStatuses.includes(t.status)
+      t => editedIds.has(t.id) && SENDABLE_TIMESHEET_STATUSES.includes(t.status)
     );
   }, [myTimesheets, editedIds, isClosureLocked]);
 
@@ -204,8 +205,15 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
       });
       setEditingId(null);
       // Remember this day so the exit guard can catch it if the tech leaves
-      // without sending. The send nudge itself fires after signing (last step).
+      // without sending. If it is already signed, nudge immediately.
       setEditedIds(prev => new Set(prev).add(timesheet.id));
+      if (
+        !isClosureLocked &&
+        timesheet.signature_data &&
+        SENDABLE_TIMESHEET_STATUSES.includes(timesheet.status)
+      ) {
+        setSendPromptId(timesheet.id);
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Error desconocido';
       toast.error(`No se pudo guardar el parte: ${message}`);
@@ -270,8 +278,7 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
       // now so a signed parte doesn't sit forgotten as a draft.
       setEditedIds(prev => new Set(prev).add(signedId));
       const signed = myTimesheets.find(t => t.id === signedId);
-      const sendableStatuses: Array<Timesheet['status']> = ['draft', 'rejected'];
-      if (!isClosureLocked && (!signed || sendableStatuses.includes(signed.status))) {
+      if (!isClosureLocked && (!signed || SENDABLE_TIMESHEET_STATUSES.includes(signed.status))) {
         setSendPromptId(signedId);
       }
     } catch (err) {

--- a/src/components/technician/TimesheetView.tsx
+++ b/src/components/technician/TimesheetView.tsx
@@ -746,24 +746,28 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                                 </Button>
                               )}
 
-                              {/* Sign button */}
+                              {/* Sign button — signing is mandatory before submitting */}
                               {!timesheet.signature_data && canSubmit && (
-                                <Button
-                                  variant="outline"
-                                  className="w-full"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    e.preventDefault();
-                                    openSignatureDialog(timesheet.id);
-                                  }}
-                                >
-                                  <PenTool size={16} className="mr-2" />
-                                  Añadir firma
-                                </Button>
+                                <>
+                                  <Button
+                                    className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      e.preventDefault();
+                                      openSignatureDialog(timesheet.id);
+                                    }}
+                                  >
+                                    <PenTool size={16} className="mr-2" />
+                                    FIRMAR Y ENVIAR
+                                  </Button>
+                                  <p className={`text-center text-[11px] ${theme.textMuted}`}>
+                                    Debes firmar el parte para poder enviarlo.
+                                  </p>
+                                </>
                               )}
 
-                              {/* Submit button */}
-                              {canSubmit && (
+                              {/* Submit button — only once the parte is signed */}
+                              {timesheet.signature_data && canSubmit && (
                                 <Button
                                   className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold"
                                   onClick={(e) => {
@@ -859,20 +863,35 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
                   {format(parseISO(editedUnsent[0].date), "d 'de' MMMM", { locale: es })}
                 </span>{' '}
                 pero no lo has enviado. Si sales ahora no pasará a aprobación.
+                {!editedUnsent[0].signature_data && ' Debes firmarlo para poder enviarlo.'}
               </p>
               <div className="space-y-2">
-                <Button
-                  className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold"
-                  disabled={isSendingPrompt}
-                  onClick={() => sendDay(editedUnsent[0].id, { closeAfter: editedUnsent.length === 1 })}
-                >
-                  {isSendingPrompt ? (
-                    <Loader2 size={16} className="mr-2 animate-spin" />
-                  ) : (
-                    <CheckCircle2 size={16} className="mr-2" />
-                  )}
-                  Enviar parte{editedUnsent.length === 1 ? ' y salir' : ''}
-                </Button>
+                {editedUnsent[0].signature_data ? (
+                  <Button
+                    className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold"
+                    disabled={isSendingPrompt}
+                    onClick={() => sendDay(editedUnsent[0].id, { closeAfter: editedUnsent.length === 1 })}
+                  >
+                    {isSendingPrompt ? (
+                      <Loader2 size={16} className="mr-2 animate-spin" />
+                    ) : (
+                      <CheckCircle2 size={16} className="mr-2" />
+                    )}
+                    Enviar parte{editedUnsent.length === 1 ? ' y salir' : ''}
+                  </Button>
+                ) : (
+                  <Button
+                    className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold"
+                    disabled={isSendingPrompt}
+                    onClick={() => {
+                      setShowExitConfirm(false);
+                      openSignatureDialog(editedUnsent[0].id);
+                    }}
+                  >
+                    <PenTool size={16} className="mr-2" />
+                    Firmar y enviar
+                  </Button>
+                )}
                 <Button
                   variant="outline"
                   className="w-full"

--- a/src/components/technician/__tests__/TimesheetView.test.tsx
+++ b/src/components/technician/__tests__/TimesheetView.test.tsx
@@ -231,7 +231,14 @@ describe("TimesheetView", () => {
       expect(signTimesheet).toHaveBeenCalledWith("mine", "data:image/png;base64,signature");
     });
 
-    await user.click(screen.getByRole("button", { name: /enviar parte/i }));
+    // Signing is the last step before submitting, so the send nudge pops.
+    expect(await screen.findByText(/parte firmado/i)).toBeInTheDocument();
+
+    // The prompt's button is "Enviar parte"; the card's is "ENVIAR PARTE".
+    // Match the prompt one case-sensitively to disambiguate.
+    await user.click(
+      screen.getByRole("button", { name: (name) => name === "Enviar parte" }),
+    );
 
     expect(submitTimesheet).toHaveBeenCalledWith("mine");
   });

--- a/src/components/technician/__tests__/TimesheetView.test.tsx
+++ b/src/components/technician/__tests__/TimesheetView.test.tsx
@@ -222,7 +222,13 @@ describe("TimesheetView", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /añadir firma/i }));
+    // Signing is mandatory: an unsigned parte exposes no submit button.
+    expect(
+      screen.queryByRole("button", { name: (name) => name === "ENVIAR PARTE" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/debes firmar el parte para poder enviarlo/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /firmar y enviar/i }));
     expect(screen.getByTestId("signature-pad")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /^guardar$/i }));

--- a/src/components/technician/__tests__/TimesheetView.test.tsx
+++ b/src/components/technician/__tests__/TimesheetView.test.tsx
@@ -249,6 +249,58 @@ describe("TimesheetView", () => {
     expect(submitTimesheet).toHaveBeenCalledWith("mine");
   });
 
+  it("prompts to send immediately after saving an already-signed draft", async () => {
+    const user = userEvent.setup();
+    const updateTimesheet = vi.fn().mockResolvedValue(undefined);
+    const submitTimesheet = vi.fn().mockResolvedValue(undefined);
+
+    useTimesheetsMock.mockReturnValue({
+      ...baseHookValue(),
+      updateTimesheet,
+      submitTimesheet,
+      timesheets: [
+        createTimesheet({
+          id: "mine",
+          technician_id: "tech-1",
+          date: "2026-03-10",
+          start_time: "09:00",
+          end_time: "17:00",
+          status: "draft",
+          signature_data: "data:image/png;base64,existing-signature",
+        }),
+      ],
+    });
+
+    renderWithProviders(
+      <TimesheetView
+        theme={theme}
+        isDark
+        job={createJob({ id: "job-1", title: "Job 1" }) as any}
+        onClose={vi.fn()}
+        userRole="technician"
+        userId="tech-1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /editar horario/i }));
+    await user.click(screen.getByRole("button", { name: /guardar/i }));
+
+    await waitFor(() => {
+      expect(updateTimesheet).toHaveBeenCalledWith(
+        "mine",
+        expect.objectContaining({ start_time: "09:00", end_time: "17:00" }),
+      );
+    });
+
+    expect(await screen.findByText(/parte firmado/i)).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: (name) => name === "Enviar parte" }),
+    );
+
+    expect(submitTimesheet).toHaveBeenCalledWith("mine");
+  });
+
   it("hides technician totals until rates are approved and locks actions after closure", () => {
     useJobRatesApprovalMock.mockReturnValue({ data: { rates_approved: false } });
     isJobPastClosureWindowMock.mockReturnValue(true);

--- a/tests/timesheets/critical-paths.test.ts
+++ b/tests/timesheets/critical-paths.test.ts
@@ -196,6 +196,7 @@ describe("Timesheets Critical Paths", () => {
       status: "rejected",
       rejection_reason: "Faltan notas",
       technician_id: "tech-1",
+      signature_data: "data:image/png;base64,existing-signature",
     });
 
     renderTimesheetView({ timesheets: [timesheet] });
@@ -223,7 +224,7 @@ describe("Timesheets Critical Paths", () => {
 
     renderTimesheetView({ timesheets: [timesheet] });
 
-    await user.click(screen.getByRole("button", { name: /añadir firma/i }));
+    await user.click(screen.getByRole("button", { name: /firmar y enviar/i }));
 
     expect(screen.getByText(/firma digital/i)).toBeInTheDocument();
     expect(screen.getByTestId("signature-pad")).toBeInTheDocument();


### PR DESCRIPTION
Techs frequently saved their hours but forgot the separate "ENVIAR PARTE"
step, leaving the parte stuck as a draft that never reached approval.

- After saving an edited day, immediately prompt to send that specific day
- Guard the "Volver" exit: if a day was edited but not sent, block leaving
  and offer to send it (or seguir editando / salir sin enviar)
- Scope is per edited day only — never a blanket "send all drafts"

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EfTAeVxoeu4pMDZbJUY62w