### PR TITLE
Auto-sync tour package default PDFs

### DIFF
--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -59,42 +59,48 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
   }, [open, artistId]);
 
   const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
+    const selectedFiles = Array.from(event.target.files ?? []);
+    event.target.value = "";
+    if (selectedFiles.length === 0) return;
 
     setIsUploading(true);
     try {
-      const fileExt = file.name.split('.').pop();
-      const filePath = `${artistId}/${crypto.randomUUID()}.${fileExt}`;
+      for (const file of selectedFiles) {
+        const fileExt = file.name.split('.').pop();
+        const filePath = `${artistId}/${crypto.randomUUID()}.${fileExt}`;
 
-      // First upload the file to storage
-      const { error: uploadError } = await dataLayerClient.storage
-        .from('festival_artist_files')
-        .upload(filePath, file);
+        // First upload the file to storage
+        const { error: uploadError } = await dataLayerClient.storage
+          .from('festival_artist_files')
+          .upload(filePath, file);
 
-      if (uploadError) {
-        console.error("Storage upload error:", uploadError);
-        throw uploadError;
-      }
+        if (uploadError) {
+          console.error("Storage upload error:", uploadError);
+          throw uploadError;
+        }
 
-      // Then create the database record
-      const { error: dbError } = await dataLayerClient.from('festival_artist_files')
-        .insert({
-          artist_id: artistId,
-          file_name: file.name,
-          file_path: filePath,
-          file_type: file.type,
-          file_size: file.size,
-        });
+        // Then create the database record
+        const { error: dbError } = await dataLayerClient.from('festival_artist_files')
+          .insert({
+            artist_id: artistId,
+            file_name: file.name,
+            file_path: filePath,
+            file_type: file.type,
+            file_size: file.size,
+          });
 
-      if (dbError) {
-        console.error("Database insert error:", dbError);
-        throw dbError;
+        if (dbError) {
+          console.error("Database insert error:", dbError);
+          throw dbError;
+        }
       }
 
       toast({
         title: "Éxito",
-        description: "Archivo cargado correctamente",
+        description:
+          selectedFiles.length === 1
+            ? "Archivo cargado correctamente"
+            : `${selectedFiles.length} archivos cargados correctamente`,
       });
 
       fetchFiles();
@@ -216,6 +222,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
                 <Input
                   id="file-upload"
                   type="file"
+                  multiple
                   onChange={handleFileUpload}
                   disabled={isUploading}
                   className="cursor-pointer"

--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -8,6 +8,10 @@ import { dataLayerClient } from "@/services/dataLayerClient";
 import { FileText, Loader2, Trash2, Upload, Eye, X } from "lucide-react";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
 import { ViewFileDialog } from "./ViewFileDialog";
+import {
+  DOCUMENT_UPLOAD_ACCEPT,
+  getDocumentUploadValidationError,
+} from "@/utils/documentUploadValidation";
 
 interface ArtistFileDialogProps {
   open: boolean;
@@ -63,6 +67,18 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
     event.target.value = "";
     if (selectedFiles.length === 0) return;
 
+    const validationError = getDocumentUploadValidationError(selectedFiles);
+    if (validationError) {
+      toast({
+        title: "Archivo no permitido",
+        description: validationError,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const uploadedPaths: string[] = [];
+    const insertedIds: string[] = [];
     setIsUploading(true);
     try {
       for (const file of selectedFiles) {
@@ -78,20 +94,27 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
           console.error("Storage upload error:", uploadError);
           throw uploadError;
         }
+        uploadedPaths.push(filePath);
 
         // Then create the database record
-        const { error: dbError } = await dataLayerClient.from('festival_artist_files')
+        const { data: insertedFile, error: dbError } = await dataLayerClient.from('festival_artist_files')
           .insert({
             artist_id: artistId,
             file_name: file.name,
             file_path: filePath,
             file_type: file.type,
             file_size: file.size,
-          });
+          })
+          .select("id")
+          .single();
 
         if (dbError) {
           console.error("Database insert error:", dbError);
           throw dbError;
+        }
+
+        if (insertedFile?.id) {
+          insertedIds.push(insertedFile.id);
         }
       }
 
@@ -106,9 +129,19 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       fetchFiles();
     } catch (error: any) {
       console.error("Error uploading file:", error);
+      try {
+        if (insertedIds.length > 0) {
+          await dataLayerClient.from('festival_artist_files').delete().in('id', insertedIds);
+        }
+        if (uploadedPaths.length > 0) {
+          await dataLayerClient.storage.from('festival_artist_files').remove(uploadedPaths);
+        }
+      } catch (cleanupError) {
+        console.error("Error rolling back artist file upload batch:", cleanupError);
+      }
       toast({
         title: "Error",
-        description: "No se pudo cargar el archivo",
+        description: "No se pudo completar la carga. Se han revertido los archivos de esta tanda.",
         variant: "destructive",
       });
     } finally {
@@ -223,6 +256,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
                   id="file-upload"
                   type="file"
                   multiple
+                  accept={DOCUMENT_UPLOAD_ACCEPT}
                   onChange={handleFileUpload}
                   disabled={isUploading}
                   className="cursor-pointer"

--- a/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
+++ b/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
@@ -35,6 +35,7 @@ import type {
   TechnicalPowerPackState,
 } from "@/components/jobs/cards/job-card-actions/types";
 import { cn } from "@/lib/utils";
+import { DOCUMENT_UPLOAD_ACCEPT } from "@/utils/documentUploadValidation";
 import { hasPrepDayDateType } from "@/utils/timesheetPrepDays";
 import { canSubmitTechnicianIncidentReports } from "@/utils/permissions";
 
@@ -487,6 +488,7 @@ export const JobCardActionButtons = ({
         <input
           type="file"
           multiple
+          accept={DOCUMENT_UPLOAD_ACCEPT}
           aria-label="Subir documento"
           onChange={handleFileUpload}
           className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"

--- a/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
+++ b/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
@@ -486,6 +486,7 @@ export const JobCardActionButtons = ({
       <div className="relative">
         <input
           type="file"
+          multiple
           aria-label="Subir documento"
           onChange={handleFileUpload}
           className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"

--- a/src/components/lights/LightsTaskDialog.tsx
+++ b/src/components/lights/LightsTaskDialog.tsx
@@ -132,25 +132,29 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
     enabled: !!jobId
   });
 
-  const handleFileUpload = async (taskId: string, file: File) => {
+  const handleFileUpload = async (taskId: string, files: File[]) => {
+    if (files.length === 0) return;
+
     try {
       setUploading(true);
-      const filePath = `${taskId}/${crypto.randomUUID()}-${file.name}`;
-      
-      const { error: uploadError } = await dataLayerClient.storage
-        .from('task_documents')
-        .upload(filePath, file);
+      for (const file of files) {
+        const filePath = `${taskId}/${crypto.randomUUID()}-${file.name}`;
+        
+        const { error: uploadError } = await dataLayerClient.storage
+          .from('task_documents')
+          .upload(filePath, file);
 
-      if (uploadError) throw uploadError;
+        if (uploadError) throw uploadError;
 
-      const { error: dbError } = await dataLayerClient.from('task_documents')
-        .insert({
-          lights_task_id: taskId, // Updated to use lights_task_id
-          file_name: file.name,
-          file_path: filePath,
-        });
+        const { error: dbError } = await dataLayerClient.from('task_documents')
+          .insert({
+            lights_task_id: taskId, // Updated to use lights_task_id
+            file_name: file.name,
+            file_path: filePath,
+          });
 
-      if (dbError) throw dbError;
+        if (dbError) throw dbError;
+      }
 
       await dataLayerClient.from('lights_job_tasks')
         .update({ 
@@ -160,8 +164,11 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
         .eq('id', taskId);
 
       toast({
-        title: "File uploaded successfully",
-        description: "The document has been uploaded and task marked as completed.",
+        title: files.length === 1 ? "File uploaded successfully" : "Files uploaded successfully",
+        description:
+          files.length === 1
+            ? "The document has been uploaded and task marked as completed."
+            : `${files.length} documents have been uploaded and the task marked as completed.`,
       });
 
       refetchTasks();
@@ -534,10 +541,12 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                             <div className="relative">
                               <input
                                 type="file"
+                                multiple
                                 className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                                 onChange={(e) => {
-                                  const file = e.target.files?.[0];
-                                  if (file) handleFileUpload(task.id, file);
+                                  const files = Array.from(e.target.files ?? []);
+                                  e.target.value = "";
+                                  if (files.length > 0) handleFileUpload(task.id, files);
                                 }}
                                 disabled={uploading}
                               />

--- a/src/components/lights/LightsTaskDialog.tsx
+++ b/src/components/lights/LightsTaskDialog.tsx
@@ -34,6 +34,10 @@ import {
 
 import { queryKeys } from "@/lib/react-query";
 import type { Database } from "@/integrations/supabase/types";
+import {
+  DOCUMENT_UPLOAD_ACCEPT,
+  getDocumentUploadValidationError,
+} from "@/utils/documentUploadValidation";
 interface LightsTaskDialogProps {
   jobId: string;
   open: boolean;
@@ -135,6 +139,18 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
   const handleFileUpload = async (taskId: string, files: File[]) => {
     if (files.length === 0) return;
 
+    const validationError = getDocumentUploadValidationError(files);
+    if (validationError) {
+      toast({
+        title: "Archivo no permitido",
+        description: validationError,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const uploadedPaths: string[] = [];
+    const insertedIds: string[] = [];
     try {
       setUploading(true);
       for (const file of files) {
@@ -145,37 +161,54 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
           .upload(filePath, file);
 
         if (uploadError) throw uploadError;
+        uploadedPaths.push(filePath);
 
-        const { error: dbError } = await dataLayerClient.from('task_documents')
+        const { data: insertedDocument, error: dbError } = await dataLayerClient.from('task_documents')
           .insert({
             lights_task_id: taskId, // Updated to use lights_task_id
             file_name: file.name,
             file_path: filePath,
-          });
+          })
+          .select('id')
+          .single();
 
         if (dbError) throw dbError;
+        if (insertedDocument?.id) {
+          insertedIds.push(insertedDocument.id);
+        }
       }
 
-      await dataLayerClient.from('lights_job_tasks')
+      const { error: taskUpdateError } = await dataLayerClient.from('lights_job_tasks')
         .update({ 
           status: 'completed',
           progress: 100 
         })
         .eq('id', taskId);
+      if (taskUpdateError) throw taskUpdateError;
 
       toast({
-        title: files.length === 1 ? "File uploaded successfully" : "Files uploaded successfully",
+        title: files.length === 1 ? "Archivo subido correctamente" : "Archivos subidos correctamente",
         description:
           files.length === 1
-            ? "The document has been uploaded and task marked as completed."
-            : `${files.length} documents have been uploaded and the task marked as completed.`,
+            ? "El documento se ha subido y la tarea se ha marcado como completada."
+            : `${files.length} documentos se han subido y la tarea se ha marcado como completada.`,
       });
 
       refetchTasks();
     } catch (error: any) {
+      try {
+        if (insertedIds.length > 0) {
+          await dataLayerClient.from('task_documents').delete().in('id', insertedIds);
+        }
+        if (uploadedPaths.length > 0) {
+          await dataLayerClient.storage.from('task_documents').remove(uploadedPaths);
+        }
+      } catch (cleanupError) {
+        console.error("Error rolling back lights task document upload batch:", cleanupError);
+      }
       toast({
-        title: "Upload failed",
-        description: error.message,
+        title: "Error al subir",
+        description: error.message || "No se pudo completar la subida. Se ha revertido la tanda.",
         variant: "destructive",
       });
     } finally {
@@ -542,6 +575,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                               <input
                                 type="file"
                                 multiple
+                                accept={DOCUMENT_UPLOAD_ACCEPT}
                                 className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                                 onChange={(e) => {
                                   const files = Array.from(e.target.files ?? []);
@@ -557,7 +591,7 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
                                 className="w-[100px]"
                               >
                                 <Upload className="h-3 w-3 mr-1" />
-                                Upload
+                                Subir
                               </Button>
                             </div>
                           )}

--- a/src/components/sound/SoundTaskDialog.tsx
+++ b/src/components/sound/SoundTaskDialog.tsx
@@ -210,29 +210,35 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
     }
   };
 
-  const handleFileUpload = async (taskId: string, file: File) => {
+  const handleFileUpload = async (taskId: string, files: File[]) => {
+    if (files.length === 0) return;
+
     try {
       setUploading(true);
-      const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
-      const timestamp = new Date().getTime();
-      const filePath = `${taskId}/${timestamp}_${sanitizedFileName}`;
+      const { data: authData } = await dataLayerClient.auth.getUser();
+      const uploadedBy = authData.user?.id;
 
-      const { error: uploadError } = await dataLayerClient.storage
-        .from('task_documents')
-        .upload(filePath, file, {
-          cacheControl: '3600',
-          upsert: false
-        });
-      if (uploadError) throw uploadError;
+      for (const file of files) {
+        const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
+        const filePath = `${taskId}/${Date.now()}-${crypto.randomUUID()}_${sanitizedFileName}`;
 
-      const { error: dbError } = await dataLayerClient.from('task_documents')
-        .insert({
-          sound_task_id: taskId,
-          file_name: file.name,
-          file_path: filePath,
-          uploaded_by: (await dataLayerClient.auth.getUser()).data.user?.id
-        });
-      if (dbError) throw dbError;
+        const { error: uploadError } = await dataLayerClient.storage
+          .from('task_documents')
+          .upload(filePath, file, {
+            cacheControl: '3600',
+            upsert: false
+          });
+        if (uploadError) throw uploadError;
+
+        const { error: dbError } = await dataLayerClient.from('task_documents')
+          .insert({
+            sound_task_id: taskId,
+            file_name: file.name,
+            file_path: filePath,
+            uploaded_by: uploadedBy
+          });
+        if (dbError) throw dbError;
+      }
 
       await dataLayerClient.from('sound_job_tasks')
         .update({ 
@@ -243,8 +249,11 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
         .eq('id', taskId);
 
       toast({
-        title: "File uploaded successfully",
-        description: "The document has been uploaded and task marked as completed.",
+        title: files.length === 1 ? "File uploaded successfully" : "Files uploaded successfully",
+        description:
+          files.length === 1
+            ? "The document has been uploaded and task marked as completed."
+            : `${files.length} documents have been uploaded and the task marked as completed.`,
       });
 
       refetchTasks();
@@ -600,10 +609,12 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
                               <div className="relative">
                                 <input
                                   type="file"
+                                  multiple
                                   className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                                   onChange={(e) => {
-                                    const file = e.target.files?.[0];
-                                    if (file) handleFileUpload(task.id, file);
+                                    const files = Array.from(e.target.files ?? []);
+                                    e.target.value = "";
+                                    if (files.length > 0) handleFileUpload(task.id, files);
                                   }}
                                   disabled={uploading}
                                 />

--- a/src/components/sound/SoundTaskDialog.tsx
+++ b/src/components/sound/SoundTaskDialog.tsx
@@ -35,6 +35,10 @@ import {
 
 import { queryKeys } from "@/lib/react-query";
 import type { Database } from "@/integrations/supabase/types";
+import {
+  DOCUMENT_UPLOAD_ACCEPT,
+  getDocumentUploadValidationError,
+} from "@/utils/documentUploadValidation";
 
 type SoundPersonnelUpdate = Database["public"]["Tables"]["sound_job_personnel"]["Update"];
 type SoundPersonnelField = Extract<
@@ -213,6 +217,18 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
   const handleFileUpload = async (taskId: string, files: File[]) => {
     if (files.length === 0) return;
 
+    const validationError = getDocumentUploadValidationError(files);
+    if (validationError) {
+      toast({
+        title: "Archivo no permitido",
+        description: validationError,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const uploadedPaths: string[] = [];
+    const insertedIds: string[] = [];
     try {
       setUploading(true);
       const { data: authData } = await dataLayerClient.auth.getUser();
@@ -229,38 +245,55 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
             upsert: false
           });
         if (uploadError) throw uploadError;
+        uploadedPaths.push(filePath);
 
-        const { error: dbError } = await dataLayerClient.from('task_documents')
+        const { data: insertedDocument, error: dbError } = await dataLayerClient.from('task_documents')
           .insert({
             sound_task_id: taskId,
             file_name: file.name,
             file_path: filePath,
             uploaded_by: uploadedBy
-          });
+          })
+          .select('id')
+          .single();
         if (dbError) throw dbError;
+        if (insertedDocument?.id) {
+          insertedIds.push(insertedDocument.id);
+        }
       }
 
-      await dataLayerClient.from('sound_job_tasks')
+      const { error: taskUpdateError } = await dataLayerClient.from('sound_job_tasks')
         .update({ 
           status: 'completed',
           progress: 100,
           updated_at: new Date().toISOString()
         })
         .eq('id', taskId);
+      if (taskUpdateError) throw taskUpdateError;
 
       toast({
-        title: files.length === 1 ? "File uploaded successfully" : "Files uploaded successfully",
+        title: files.length === 1 ? "Archivo subido correctamente" : "Archivos subidos correctamente",
         description:
           files.length === 1
-            ? "The document has been uploaded and task marked as completed."
-            : `${files.length} documents have been uploaded and the task marked as completed.`,
+            ? "El documento se ha subido y la tarea se ha marcado como completada."
+            : `${files.length} documentos se han subido y la tarea se ha marcado como completada.`,
       });
 
       refetchTasks();
     } catch (error: any) {
+      try {
+        if (insertedIds.length > 0) {
+          await dataLayerClient.from('task_documents').delete().in('id', insertedIds);
+        }
+        if (uploadedPaths.length > 0) {
+          await dataLayerClient.storage.from('task_documents').remove(uploadedPaths);
+        }
+      } catch (cleanupError) {
+        console.error("Error rolling back sound task document upload batch:", cleanupError);
+      }
       toast({
-        title: "Upload failed",
-        description: error.message,
+        title: "Error al subir",
+        description: error.message || "No se pudo completar la subida. Se ha revertido la tanda.",
         variant: "destructive",
       });
     } finally {
@@ -610,6 +643,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
                                 <input
                                   type="file"
                                   multiple
+                                  accept={DOCUMENT_UPLOAD_ACCEPT}
                                   className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                                   onChange={(e) => {
                                     const files = Array.from(e.target.files ?? []);
@@ -625,7 +659,7 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
                                   className="w-[100px]"
                                 >
                                   <Upload className="h-3 w-3 mr-1" />
-                                  Upload
+                                  Subir
                                 </Button>
                               </div>
                             )}

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -12,6 +12,10 @@ import { dataLayerClient } from '@/services/dataLayerClient';
 import { useQuery } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
 import { TASK_TYPES } from '@/constants/taskTypes';
+import {
+  DOCUMENT_UPLOAD_ACCEPT,
+  getDocumentUploadValidationError,
+} from '@/utils/documentUploadValidation';
 
 import { queryKeys } from "@/lib/react-query";
 const DEPARTMENT_NAME: Record<'sound' | 'lights' | 'video', string> = {
@@ -190,17 +194,52 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
 
   const onUpload = async (taskId: string, files: File[]) => {
     if (files.length === 0) return;
-    try {
-      for (const file of files) {
+
+    const validationError = getDocumentUploadValidationError(files);
+    if (validationError) {
+      toast({ title: 'Archivo no permitido', description: validationError, variant: 'destructive' });
+      return;
+    }
+
+    let uploadedCount = 0;
+    const failedMessages: string[] = [];
+
+    for (const file of files) {
+      try {
         await uploadAttachment(taskId, file);
+        uploadedCount += 1;
+      } catch (e: any) {
+        failedMessages.push(`${file.name}: ${e?.message || String(e)}`);
       }
-      toast({
-        title: files.length === 1 ? 'Uploaded' : 'Uploaded files',
-        description: files.length === 1 ? 'Attachment uploaded' : `${files.length} attachments uploaded`,
-      });
+    }
+
+    if (uploadedCount > 0) {
       await refetch();
-    } catch (e: any) {
-      toast({ title: 'Upload failed', description: e?.message || String(e), variant: 'destructive' });
+    }
+
+    if (failedMessages.length === 0) {
+      toast({
+        title: files.length === 1 ? 'Archivo subido' : 'Archivos subidos',
+        description: files.length === 1 ? 'Adjunto subido' : `${files.length} adjuntos subidos`,
+      });
+      return;
+    }
+
+    toast({
+      title: uploadedCount > 0 ? 'Subida parcial' : 'Error al subir',
+      description:
+        uploadedCount > 0
+          ? `${uploadedCount} de ${files.length} adjunto(s) se subieron. ${failedMessages[0]}`
+          : failedMessages[0],
+      variant: 'destructive',
+    });
+
+    if (uploadedCount === 0) {
+      try {
+        await refetch();
+      } catch (e) {
+        console.error('Error refreshing tasks after failed upload:', e);
+      }
     }
   };
 
@@ -348,6 +387,7 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
                     <input
                       type="file"
                       multiple
+                      accept={DOCUMENT_UPLOAD_ACCEPT}
                       className="absolute inset-0 opacity-0 cursor-pointer"
                       onChange={(e) => {
                         const files = Array.from(e.target.files ?? []);
@@ -355,7 +395,7 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
                         onUpload(task.id, files);
                       }}
                     />
-                    <Button size="sm" variant="outline"><Upload className="h-3 w-3 mr-1"/>Upload</Button>
+                    <Button size="sm" variant="outline"><Upload className="h-3 w-3 mr-1"/>Subir</Button>
                   </div>
                   {canEdit && (
                     <Button size="sm" variant="ghost" onClick={() => deleteTask(task.id).then(() => refetch())}>

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -188,11 +188,16 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
     }
   };
 
-  const onUpload = async (taskId: string, file?: File) => {
-    if (!file) return;
+  const onUpload = async (taskId: string, files: File[]) => {
+    if (files.length === 0) return;
     try {
-      await uploadAttachment(taskId, file);
-      toast({ title: 'Uploaded', description: 'Attachment uploaded' });
+      for (const file of files) {
+        await uploadAttachment(taskId, file);
+      }
+      toast({
+        title: files.length === 1 ? 'Uploaded' : 'Uploaded files',
+        description: files.length === 1 ? 'Attachment uploaded' : `${files.length} attachments uploaded`,
+      });
       await refetch();
     } catch (e: any) {
       toast({ title: 'Upload failed', description: e?.message || String(e), variant: 'destructive' });
@@ -340,7 +345,16 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
                 </TableCell>
                 <TableCell className="space-x-2">
                   <div className="relative inline-block">
-                    <input type="file" className="absolute inset-0 opacity-0 cursor-pointer" onChange={(e) => onUpload(task.id, e.target.files?.[0])} />
+                    <input
+                      type="file"
+                      multiple
+                      className="absolute inset-0 opacity-0 cursor-pointer"
+                      onChange={(e) => {
+                        const files = Array.from(e.target.files ?? []);
+                        e.target.value = '';
+                        onUpload(task.id, files);
+                      }}
+                    />
                     <Button size="sm" variant="outline"><Upload className="h-3 w-3 mr-1"/>Upload</Button>
                   </div>
                   {canEdit && (

--- a/src/components/tours/TourDateManagementDialog.tsx
+++ b/src/components/tours/TourDateManagementDialog.tsx
@@ -202,6 +202,33 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
     return matches.length === 1 ? matches[0].id : null;
   };
 
+  const defaultSetMatchesPackageSelection = (
+    setId: string | null,
+    department: PackageDepartment,
+    packageSize: TourPackageSize | null
+  ) => {
+    if (!setId) return false;
+
+    const selectedSet = defaultSets.find((set) => set.id === setId);
+    return Boolean(
+      selectedSet &&
+        selectedSet.department === department &&
+        (!packageSize || !selectedSet.package_size || selectedSet.package_size === packageSize)
+    );
+  };
+
+  const resolveDefaultSetIdForPackageSelection = (
+    department: PackageDepartment,
+    packageSize: TourPackageSize | null,
+    selectedSetId: string | null
+  ) => {
+    if (defaultSetMatchesPackageSelection(selectedSetId, department, packageSize)) {
+      return selectedSetId;
+    }
+
+    return getUniqueDefaultSetId(department, packageSize);
+  };
+
   const buildPackageUpdatePayload = (
     packageSizes: PackageSelectionState,
     defaultSetIds: DefaultSetSelectionState
@@ -210,11 +237,11 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
     lights_package_size: packageSizes.lights,
     video_package_size: packageSizes.video,
     sound_default_set_id:
-      defaultSetIds.sound || getUniqueDefaultSetId("sound", packageSizes.sound),
+      resolveDefaultSetIdForPackageSelection("sound", packageSizes.sound, defaultSetIds.sound),
     lights_default_set_id:
-      defaultSetIds.lights || getUniqueDefaultSetId("lights", packageSizes.lights),
+      resolveDefaultSetIdForPackageSelection("lights", packageSizes.lights, defaultSetIds.lights),
     video_default_set_id:
-      defaultSetIds.video || getUniqueDefaultSetId("video", packageSizes.video),
+      resolveDefaultSetIdForPackageSelection("video", packageSizes.video, defaultSetIds.video),
   });
 
   const invalidateTourDocumentQueries = async () => {
@@ -274,7 +301,11 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
     setPackageSizes((prev) => ({ ...prev, [department]: packageSize }));
     setDefaultSetIds((prev) => ({
       ...prev,
-      [department]: prev[department] && packageSize ? prev[department] : null,
+      [department]: resolveDefaultSetIdForPackageSelection(
+        department,
+        packageSize,
+        prev[department]
+      ),
     }));
   };
 

--- a/src/components/tours/TourDateManagementDialog.tsx
+++ b/src/components/tours/TourDateManagementDialog.tsx
@@ -38,6 +38,10 @@ import { PlaceAutocomplete } from "@/components/maps/PlaceAutocomplete";
 import { TECHNICAL_DEPARTMENTS } from "@/types/department";
 import { syncFlexElementsForTourDateChange } from "@/utils/flex-folders/syncDateChange";
 import {
+  cleanupTourDefaultDocumentsForDate,
+  syncTourDefaultDocuments,
+} from "@/utils/tourDefaultDocumentSync";
+import {
   DateType,
   getDateTypeMeta,
   isSingleDayDateType,
@@ -212,6 +216,42 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
     video_default_set_id:
       defaultSetIds.video || getUniqueDefaultSetId("video", packageSizes.video),
   });
+
+  const invalidateTourDocumentQueries = async () => {
+    if (!tourId) return;
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-documents", tourId) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobcard-tour-documents") }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-documents-for-job") }),
+    ]);
+  };
+
+  const syncTourDefaultDocumentsForDate = async (dateId: string) => {
+    if (!tourId) return;
+
+    try {
+      const result = await syncTourDefaultDocuments({
+        tourId,
+        tourDateIds: [dateId],
+      });
+      await invalidateTourDocumentQueries();
+
+      if (result.errors.length > 0) {
+        toast({
+          title: "Tour date saved with PDF warnings",
+          description: `${result.errors.length} default document(s) could not be refreshed.`,
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      console.error("Error syncing tour default documents:", error);
+      toast({
+        title: "Tour date saved with PDF warnings",
+        description: "Default package PDFs could not be refreshed for this date.",
+        variant: "destructive",
+      });
+    }
+  };
 
   const applyTourPackShortcut = (
     checked: boolean,
@@ -484,6 +524,8 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         queryClient.invalidateQueries({ queryKey: queryKeys.scope("flex-folders-existence") }),
       ]);
 
+      await syncTourDefaultDocumentsForDate(newTourDate.id);
+
       toast({
         title: "Success",
         description: "Tour date and job created successfully",
@@ -690,6 +732,8 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") }),
       ]);
 
+      await syncTourDefaultDocumentsForDate(dateId);
+
       // Only show success toast if flex sync didn't have warnings or errors
       if (!flexSyncHadWarningsOrError) {
         toast({
@@ -874,6 +918,14 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         dataLayerClient.from("tour_date_weight_overrides").delete().eq("tour_date_id", dateId)
       ]);
 
+      if (tourId) {
+        try {
+          await cleanupTourDefaultDocumentsForDate({ tourId, tourDateId: dateId });
+        } catch (cleanupError) {
+          console.error("Error cleaning up tour default documents for deleted date:", cleanupError);
+        }
+      }
+
       // Step 5: Finally delete the tour date itself
       console.log("Deleting tour date...");
       const { error: dateError } = await dataLayerClient.from("tour_dates")
@@ -896,6 +948,7 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") }),
         queryClient.invalidateQueries({ queryKey: queryKeys.scope("flex-folders-existence") }),
       ]);
+      await invalidateTourDocumentQueries();
 
       toast({
         title: "Success",

--- a/src/components/tours/TourDateManagementDialog.tsx
+++ b/src/components/tours/TourDateManagementDialog.tsx
@@ -238,16 +238,16 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
 
       if (result.errors.length > 0) {
         toast({
-          title: "Tour date saved with PDF warnings",
-          description: `${result.errors.length} default document(s) could not be refreshed.`,
+          title: "Fecha de gira guardada con avisos de PDF",
+          description: `${result.errors.length} documento(s) predeterminados no se pudieron actualizar.`,
           variant: "destructive",
         });
       }
     } catch (error) {
       console.error("Error syncing tour default documents:", error);
       toast({
-        title: "Tour date saved with PDF warnings",
-        description: "Default package PDFs could not be refreshed for this date.",
+        title: "Fecha de gira guardada con avisos de PDF",
+        description: "No se pudieron actualizar los PDF del paquete para esta fecha.",
         variant: "destructive",
       });
     }
@@ -918,14 +918,6 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
         dataLayerClient.from("tour_date_weight_overrides").delete().eq("tour_date_id", dateId)
       ]);
 
-      if (tourId) {
-        try {
-          await cleanupTourDefaultDocumentsForDate({ tourId, tourDateId: dateId });
-        } catch (cleanupError) {
-          console.error("Error cleaning up tour default documents for deleted date:", cleanupError);
-        }
-      }
-
       // Step 5: Finally delete the tour date itself
       console.log("Deleting tour date...");
       const { error: dateError } = await dataLayerClient.from("tour_dates")
@@ -935,6 +927,16 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
       if (dateError) {
         console.error("Error deleting tour date:", dateError);
         throw dateError;
+      }
+
+      let defaultDocumentCleanupFailed = false;
+      if (tourId) {
+        try {
+          await cleanupTourDefaultDocumentsForDate({ tourId, tourDateId: dateId });
+        } catch (cleanupError) {
+          defaultDocumentCleanupFailed = true;
+          console.error("Error cleaning up tour default documents for deleted date:", cleanupError);
+        }
       }
 
       console.log("Tour date deletion completed successfully");
@@ -951,15 +953,17 @@ export const TourDateManagementDialog: React.FC<TourDateManagementDialogProps> =
       await invalidateTourDocumentQueries();
 
       toast({
-        title: "Success",
-        description: "Tour date deleted successfully"
+        title: defaultDocumentCleanupFailed ? "Fecha eliminada con avisos" : "Fecha eliminada",
+        description: defaultDocumentCleanupFailed
+          ? "La fecha se eliminó, pero no se pudieron limpiar todos los PDF automáticos."
+          : "La fecha de gira se eliminó correctamente."
       });
 
     } catch (error: any) {
       console.error("Error deleting date:", error);
       toast({
-        title: "Error deleting date",
-        description: error.message || "An unexpected error occurred while deleting the tour date",
+        title: "Error al eliminar la fecha",
+        description: error.message || "Se produjo un error inesperado al eliminar la fecha de gira.",
         variant: "destructive",
       });
     } finally {

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -11,7 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
-import { FileText, Weight, Calculator, Trash2, Download, Calendar, Copy, AlertTriangle, Anchor, Plug } from "lucide-react";
+import { FileText, Weight, Calculator, Trash2, Download, Calendar, Copy, AlertTriangle, Anchor, Plug, UploadCloud } from "lucide-react";
 import { exportToPDF } from "@/utils/pdfExport";
 import { fetchTourLogo } from "@/utils/pdf/logoUtils";
 import { dataLayerClient } from "@/services/dataLayerClient";
@@ -23,6 +23,7 @@ import { buildNormalizedTourPowerTables, computePowerTotalVa } from "@/utils/tou
 import { getDepartmentLabel } from "@/types/department";
 import type { TechnicalPowerDepartment } from "@/utils/technicalPowerTypes";
 import { getResolvedPowerPosition } from "@/utils/powerPositions";
+import { syncTourDefaultDocuments } from "@/utils/tourDefaultDocumentSync";
 import {
   DEPARTMENT_PACKAGE_LABELS,
   TOUR_PACKAGE_LABELS,
@@ -208,6 +209,8 @@ export const TourDefaultsManager = ({
   const [newSetName, setNewSetName] = useState('');
   const [newSetDescription, setNewSetDescription] = useState('');
   const [newSetPackageSize, setNewSetPackageSize] = useState<TourPackageSize | null>(null);
+  const [isSyncingDefaultDocs, setIsSyncingDefaultDocs] = useState(false);
+  const defaultDocumentSyncQueueRef = React.useRef<Promise<void>>(Promise.resolve());
   // Track the power default flag currently being toggled so only the affected
   // row/set is disabled (the shared mutation flag would otherwise freeze every
   // card).
@@ -328,6 +331,61 @@ export const TourDefaultsManager = ({
     }
   };
 
+  const invalidateTourDocumentQueries = async () => {
+    if (!tour?.id) return;
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents', tour.id) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('jobcard-tour-documents') }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents-for-job') }),
+    ]);
+  };
+
+  const syncDefaultDocuments = async ({ silent = false }: { silent?: boolean } = {}) => {
+    if (!tour?.id) return;
+
+    const runSync = async () => {
+      setIsSyncingDefaultDocs(true);
+      try {
+        const result = await syncTourDefaultDocuments({ tourId: tour.id });
+        await invalidateTourDocumentQueries();
+
+        if (result.errors.length > 0) {
+          toast({
+            title: 'PDFs sincronizados con avisos',
+            description: `${result.errors.length} documento(s) no se pudieron refrescar.`,
+            variant: 'destructive',
+          });
+        } else if (!silent) {
+          toast({
+            title: 'PDFs sincronizados',
+            description: `${result.uploaded} documento(s) actualizados y ${result.removed} ruta(s) limpiadas.`,
+          });
+        }
+      } catch (error) {
+        console.error('Error syncing tour default documents:', error);
+        toast({
+          title: 'Error',
+          description: 'No se pudieron sincronizar los PDFs automáticos de fechas.',
+          variant: 'destructive',
+        });
+      } finally {
+        setIsSyncingDefaultDocs(false);
+      }
+    };
+
+    const queuedSync = defaultDocumentSyncQueueRef.current.then(runSync, runSync);
+    defaultDocumentSyncQueueRef.current = queuedSync.catch(() => undefined);
+    await queuedSync;
+  };
+
+  const updateSetAndSync = async ({
+    setId,
+    updates,
+  }: Parameters<typeof updateSet>[0]) => {
+    await updateSet({ setId, updates });
+    await syncDefaultDocuments({ silent: true });
+  };
+
   // Handle deletion based on format type
   const handleDeleteTable = async (table: CombinedDefaultType, type: 'power' | 'weight') => {
     try {
@@ -335,6 +393,7 @@ export const TourDefaultsManager = ({
       if (isNewFormatTable(table)) {
         // New format - use deleteTable from useTourDefaultSets
         await deleteTable(table.id);
+        await syncDefaultDocuments({ silent: true });
       } else {
         // Legacy format - use the old delete functions
         if (type === 'power' && isLegacyPowerDefault(table)) {
@@ -388,6 +447,7 @@ export const TourDefaultsManager = ({
       await queryClient.invalidateQueries({
         queryKey: queryKeys.scope('tour-default-tables', tour?.id || ''),
       });
+      await syncDefaultDocuments({ silent: true });
     } catch (error) {
       console.error('Error updating power default flag:', error);
       toast({
@@ -404,6 +464,7 @@ export const TourDefaultsManager = ({
   const handleDeleteSet = async (setId: string) => {
     try {
       await deleteSet(setId);
+      await syncDefaultDocuments({ silent: true });
     } catch (error) {
       console.error('Error deleting set:', error);
       toast({
@@ -437,6 +498,7 @@ export const TourDefaultsManager = ({
       setNewSetName('');
       setNewSetDescription('');
       setNewSetPackageSize(null);
+      await syncDefaultDocuments({ silent: true });
     } catch (error) {
       console.error('Error creating set:', error);
     }
@@ -453,13 +515,14 @@ export const TourDefaultsManager = ({
         description: sourceSet.description,
         package_size: sourceSet.package_size,
       });
+      await syncDefaultDocuments({ silent: true });
     } catch (error) {
       console.error('Error duplicating set:', error);
     }
   };
 
   const updateSetPackageSize = async (setId: string, value: string) => {
-    await updateSet({
+    await updateSetAndSync({
       setId,
       updates: {
         package_size: value === 'unassigned' ? null : (value as TourPackageSize),
@@ -491,7 +554,7 @@ export const TourDefaultsManager = ({
           onBlur={(event) => {
             const nextName = event.target.value.trim();
             if (nextName && nextName !== set.name) {
-              void updateSet({ setId: set.id, updates: { name: nextName } });
+              void updateSetAndSync({ setId: set.id, updates: { name: nextName } });
             }
           }}
         />
@@ -502,7 +565,7 @@ export const TourDefaultsManager = ({
           onBlur={(event) => {
             const nextDescription = event.target.value.trim() || null;
             if (nextDescription !== (set.description || null)) {
-              void updateSet({ setId: set.id, updates: { description: nextDescription } });
+              void updateSetAndSync({ setId: set.id, updates: { description: nextDescription } });
             }
           }}
         />
@@ -1521,12 +1584,23 @@ export const TourDefaultsManager = ({
     return (
       <div className="space-y-6">
         <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-          <h3 className="text-lg font-semibold flex items-center gap-2 mb-3">
-            <Calendar className="h-5 w-5" />
-            Fechas de Gira ({tourDates.length})
-          </h3>
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between mb-3">
+            <h3 className="text-lg font-semibold flex items-center gap-2">
+              <Calendar className="h-5 w-5" />
+              Fechas de Gira ({tourDates.length})
+            </h3>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => syncDefaultDocuments()}
+              disabled={tourDates.length === 0 || isSyncingDefaultDocs}
+            >
+              <UploadCloud className="h-4 w-4 mr-1" />
+              {isSyncingDefaultDocs ? 'Sincronizando...' : 'Sincronizar PDFs'}
+            </Button>
+          </div>
           <p className="text-sm text-green-700 mb-4">
-            Exporta PDFs individuales para cada fecha de gira, incluyendo valores por defecto y anulaciones.
+            Exporta PDFs individuales para cada fecha de gira, incluyendo valores por defecto y anulaciones. Los PDFs automáticos se suben a documentos de gira y se reemplazan cuando cambian paquetes o valores por defecto.
           </p>
         </div>
 

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -374,7 +374,7 @@ export const TourDefaultsManager = ({
     };
 
     const queuedSync = defaultDocumentSyncQueueRef.current.then(runSync, runSync);
-    defaultDocumentSyncQueueRef.current = queuedSync.catch(() => undefined);
+    defaultDocumentSyncQueueRef.current = queuedSync.catch((): void => undefined);
     await queuedSync;
   };
 

--- a/src/components/tours/TourDocumentUploader.tsx
+++ b/src/components/tours/TourDocumentUploader.tsx
@@ -7,6 +7,10 @@ import { Progress } from "@/components/ui/progress";
 import { Upload, X, FileText } from "lucide-react";
 import { useTourDocuments } from "@/hooks/useTourDocuments";
 import { toast } from "sonner";
+import {
+  DOCUMENT_UPLOAD_ACCEPT,
+  getDocumentUploadValidationError,
+} from "@/utils/documentUploadValidation";
 
 interface TourDocumentUploaderProps {
   tourId: string;
@@ -23,10 +27,16 @@ export const TourDocumentUploader = ({
   const [fileName, setFileName] = useState("");
   const [uploadProgress, setUploadProgress] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { uploadDocument } = useTourDocuments(tourId);
+  const { uploadDocument, refreshDocuments } = useTourDocuments(tourId);
 
   const queueFiles = (files: File[]) => {
     if (files.length === 0) return;
+
+    const validationError = getDocumentUploadValidationError(files);
+    if (validationError) {
+      toast.error("No se pueden añadir archivos", { description: validationError });
+      return;
+    }
 
     setSelectedFiles((currentFiles) => {
       const nextFiles = [...currentFiles, ...files];
@@ -52,26 +62,36 @@ export const TourDocumentUploader = ({
   const handleUpload = async () => {
     if (selectedFiles.length === 0) return;
 
+    const filesToUpload = selectedFiles;
+    const isBatchUpload = filesToUpload.length > 1;
+
     try {
       setUploadProgress(0);
-      for (const [index, file] of selectedFiles.entries()) {
+      for (const [index, file] of filesToUpload.entries()) {
         await uploadDocument.mutateAsync({
           file,
-          fileName: selectedFiles.length === 1 ? fileName.trim() || file.name : file.name,
-          suppressToast: selectedFiles.length > 1
+          fileName: filesToUpload.length === 1 ? fileName.trim() || file.name : file.name,
+          suppressInvalidation: isBatchUpload,
+          suppressToast: isBatchUpload
         });
-        setUploadProgress(Math.round(((index + 1) / selectedFiles.length) * 100));
+        setSelectedFiles((currentFiles) => {
+          const nextFiles = currentFiles.filter((candidate) => candidate !== file);
+          setFileName(nextFiles.length === 1 ? nextFiles[0].name : "");
+          return nextFiles;
+        });
+        setUploadProgress(Math.round(((index + 1) / filesToUpload.length) * 100));
       }
-      if (selectedFiles.length > 1) {
-        toast.success(`${selectedFiles.length} documents uploaded successfully`);
+      if (isBatchUpload) {
+        await refreshDocuments();
+        toast.success(`${filesToUpload.length} documentos subidos correctamente`);
       }
       setUploadProgress(100);
       onSuccess();
     } catch (error) {
       setUploadProgress(0);
       console.error('Upload failed:', error);
-      if (selectedFiles.length > 1) {
-        toast.error('Failed to upload document queue');
+      if (isBatchUpload) {
+        toast.error('No se pudo completar la cola de subida');
       }
     }
   };
@@ -104,7 +124,7 @@ export const TourDocumentUploader = ({
         multiple
         onChange={handleFileSelect}
         className="hidden"
-        accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.jpg,.jpeg,.png,.txt"
+        accept={DOCUMENT_UPLOAD_ACCEPT}
       />
 
       {selectedFiles.length === 0 ? (
@@ -115,9 +135,9 @@ export const TourDocumentUploader = ({
           onClick={() => fileInputRef.current?.click()}
         >
           <Upload className="h-8 w-8 mx-auto mb-4 text-muted-foreground" />
-          <p className="text-lg font-medium mb-2">Drop files here or click to browse</p>
+          <p className="text-lg font-medium mb-2">Suelta archivos aquí o haz clic para seleccionar</p>
           <p className="text-sm text-muted-foreground">
-            Supported formats: PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX, JPG, PNG
+            Formatos admitidos: PDF, DOC, DOCX, JPG, PNG, GIF, TXT
           </p>
         </div>
       ) : (
@@ -125,10 +145,10 @@ export const TourDocumentUploader = ({
           <div className="space-y-2">
             <div className="flex items-center justify-between gap-3">
               <p className="text-sm text-muted-foreground">
-                {selectedFiles.length} file{selectedFiles.length === 1 ? "" : "s"} queued · {totalSizeMb.toFixed(2)} MB
+                {selectedFiles.length} archivo{selectedFiles.length === 1 ? "" : "s"} en cola · {totalSizeMb.toFixed(2)} MB
               </p>
               <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>
-                Add more
+                Añadir más
               </Button>
             </div>
             <div className="max-h-56 space-y-2 overflow-y-auto pr-1">
@@ -151,40 +171,44 @@ export const TourDocumentUploader = ({
 
           {selectedFiles.length === 1 ? (
             <div className="space-y-2">
-              <Label htmlFor="fileName">Document Name (Optional)</Label>
+              <Label htmlFor="fileName">Nombre del documento (opcional)</Label>
               <Input
                 id="fileName"
                 value={fileName}
                 onChange={(e) => setFileName(e.target.value)}
-                placeholder="Enter custom document name"
+                placeholder="Introduce un nombre personalizado"
                 disabled={isUploading}
               />
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">
-              Queued uploads use each file&apos;s original name. Custom naming is available for single-file uploads.
+              Las subidas en cola usan el nombre original de cada archivo. El nombre personalizado solo está disponible para una subida individual.
             </p>
           )}
 
           {uploadProgress > 0 && uploadProgress < 100 && (
             <div className="space-y-2">
-              <Label>Upload Progress</Label>
+              <Label>Progreso de subida</Label>
               <Progress value={uploadProgress} className="w-full" />
             </div>
           )}
 
           <div className="flex gap-2 justify-end">
             <Button variant="outline" onClick={onCancel} disabled={isUploading}>
-              Cancel
+              Cancelar
             </Button>
             <Button variant="ghost" onClick={handleReset} disabled={isUploading}>
-              Clear
+              Limpiar
             </Button>
             <Button 
               onClick={handleUpload}
               disabled={isUploading || selectedFiles.length === 0}
             >
-              {isUploading ? 'Uploading...' : `Upload ${selectedFiles.length === 1 ? 'Document' : `${selectedFiles.length} Documents`}`}
+              {isUploading
+                ? 'Subiendo...'
+                : selectedFiles.length === 1
+                  ? 'Subir documento'
+                  : `Subir ${selectedFiles.length} documentos`}
             </Button>
           </div>
         </div>

--- a/src/components/tours/TourDocumentUploader.tsx
+++ b/src/components/tours/TourDocumentUploader.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { Upload, X, FileText } from "lucide-react";
 import { useTourDocuments } from "@/hooks/useTourDocuments";
+import { toast } from "sonner";
 
 interface TourDocumentUploaderProps {
   tourId: string;
@@ -18,27 +19,30 @@ export const TourDocumentUploader = ({
   onSuccess,
   onCancel
 }: TourDocumentUploaderProps) => {
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [fileName, setFileName] = useState("");
   const [uploadProgress, setUploadProgress] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { uploadDocument } = useTourDocuments(tourId);
 
+  const queueFiles = (files: File[]) => {
+    if (files.length === 0) return;
+
+    setSelectedFiles((currentFiles) => {
+      const nextFiles = [...currentFiles, ...files];
+      setFileName(nextFiles.length === 1 ? nextFiles[0].name : "");
+      return nextFiles;
+    });
+  };
+
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      setSelectedFile(file);
-      setFileName(file.name);
-    }
+    queueFiles(Array.from(event.target.files ?? []));
+    event.target.value = "";
   };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
-    const file = event.dataTransfer.files[0];
-    if (file) {
-      setSelectedFile(file);
-      setFileName(file.name);
-    }
+    queueFiles(Array.from(event.dataTransfer.files));
   };
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
@@ -46,24 +50,34 @@ export const TourDocumentUploader = ({
   };
 
   const handleUpload = async () => {
-    if (!selectedFile) return;
+    if (selectedFiles.length === 0) return;
 
     try {
-      setUploadProgress(25);
-      await uploadDocument.mutateAsync({
-        file: selectedFile,
-        fileName: fileName.trim() || selectedFile.name
-      });
+      setUploadProgress(0);
+      for (const [index, file] of selectedFiles.entries()) {
+        await uploadDocument.mutateAsync({
+          file,
+          fileName: selectedFiles.length === 1 ? fileName.trim() || file.name : file.name,
+          suppressToast: selectedFiles.length > 1
+        });
+        setUploadProgress(Math.round(((index + 1) / selectedFiles.length) * 100));
+      }
+      if (selectedFiles.length > 1) {
+        toast.success(`${selectedFiles.length} documents uploaded successfully`);
+      }
       setUploadProgress(100);
       onSuccess();
     } catch (error) {
       setUploadProgress(0);
       console.error('Upload failed:', error);
+      if (selectedFiles.length > 1) {
+        toast.error('Failed to upload document queue');
+      }
     }
   };
 
   const handleReset = () => {
-    setSelectedFile(null);
+    setSelectedFiles([]);
     setFileName("");
     setUploadProgress(0);
     if (fileInputRef.current) {
@@ -71,9 +85,29 @@ export const TourDocumentUploader = ({
     }
   };
 
+  const handleRemoveFile = (fileIndex: number) => {
+    setSelectedFiles((currentFiles) => {
+      const nextFiles = currentFiles.filter((_, index) => index !== fileIndex);
+      setFileName(nextFiles.length === 1 ? nextFiles[0].name : "");
+      return nextFiles;
+    });
+  };
+
+  const totalSizeMb = selectedFiles.reduce((total, file) => total + file.size, 0) / 1024 / 1024;
+  const isUploading = uploadDocument.isPending || (uploadProgress > 0 && uploadProgress < 100);
+
   return (
     <div className="space-y-4">
-      {!selectedFile ? (
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        onChange={handleFileSelect}
+        className="hidden"
+        accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.jpg,.jpeg,.png,.txt"
+      />
+
+      {selectedFiles.length === 0 ? (
         <div
           className="border-2 border-dashed border-muted-foreground/25 rounded-lg p-8 text-center hover:border-muted-foreground/50 transition-colors cursor-pointer"
           onDrop={handleDrop}
@@ -85,38 +119,52 @@ export const TourDocumentUploader = ({
           <p className="text-sm text-muted-foreground">
             Supported formats: PDF, DOC, DOCX, XLS, XLSX, PPT, PPTX, JPG, PNG
           </p>
-          <input
-            ref={fileInputRef}
-            type="file"
-            onChange={handleFileSelect}
-            className="hidden"
-            accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.jpg,.jpeg,.png,.txt"
-          />
         </div>
       ) : (
         <div className="space-y-4">
-          <div className="flex items-center gap-3 p-4 border rounded-lg">
-            <FileText className="h-6 w-6 text-muted-foreground" />
-            <div className="flex-1">
-              <p className="font-medium">{selectedFile.name}</p>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
               <p className="text-sm text-muted-foreground">
-                {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
+                {selectedFiles.length} file{selectedFiles.length === 1 ? "" : "s"} queued · {totalSizeMb.toFixed(2)} MB
               </p>
+              <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isUploading}>
+                Add more
+              </Button>
             </div>
-            <Button variant="ghost" size="sm" onClick={handleReset}>
-              <X className="h-4 w-4" />
-            </Button>
+            <div className="max-h-56 space-y-2 overflow-y-auto pr-1">
+              {selectedFiles.map((file, index) => (
+                <div key={`${file.name}-${file.size}-${index}`} className="flex items-center gap-3 p-4 border rounded-lg">
+                  <FileText className="h-6 w-6 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-medium">{file.name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {(file.size / 1024 / 1024).toFixed(2)} MB
+                    </p>
+                  </div>
+                  <Button variant="ghost" size="sm" onClick={() => handleRemoveFile(index)} disabled={isUploading}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="fileName">Document Name (Optional)</Label>
-            <Input
-              id="fileName"
-              value={fileName}
-              onChange={(e) => setFileName(e.target.value)}
-              placeholder="Enter custom document name"
-            />
-          </div>
+          {selectedFiles.length === 1 ? (
+            <div className="space-y-2">
+              <Label htmlFor="fileName">Document Name (Optional)</Label>
+              <Input
+                id="fileName"
+                value={fileName}
+                onChange={(e) => setFileName(e.target.value)}
+                placeholder="Enter custom document name"
+                disabled={isUploading}
+              />
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Queued uploads use each file&apos;s original name. Custom naming is available for single-file uploads.
+            </p>
+          )}
 
           {uploadProgress > 0 && uploadProgress < 100 && (
             <div className="space-y-2">
@@ -126,14 +174,17 @@ export const TourDocumentUploader = ({
           )}
 
           <div className="flex gap-2 justify-end">
-            <Button variant="outline" onClick={onCancel}>
+            <Button variant="outline" onClick={onCancel} disabled={isUploading}>
               Cancel
+            </Button>
+            <Button variant="ghost" onClick={handleReset} disabled={isUploading}>
+              Clear
             </Button>
             <Button 
               onClick={handleUpload}
-              disabled={uploadDocument.isPending || uploadProgress > 0}
+              disabled={isUploading || selectedFiles.length === 0}
             >
-              {uploadDocument.isPending ? 'Uploading...' : 'Upload Document'}
+              {isUploading ? 'Uploading...' : `Upload ${selectedFiles.length === 1 ? 'Document' : `${selectedFiles.length} Documents`}`}
             </Button>
           </div>
         </div>

--- a/src/components/video/VideoTaskDialog.tsx
+++ b/src/components/video/VideoTaskDialog.tsx
@@ -133,27 +133,31 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
     enabled: !!jobId
   });
 
-  const handleFileUpload = async (taskId: string, file: File) => {
+  const handleFileUpload = async (taskId: string, files: File[]) => {
+    if (files.length === 0) return;
+
     try {
       setUploading(true);
-      const filePath = `${taskId}/${crypto.randomUUID()}-${file.name}`;
-      
-      const { error: uploadError } = await dataLayerClient.storage
-        .from('task_documents')
-        .upload(filePath, file);
+      for (const file of files) {
+        const filePath = `${taskId}/${crypto.randomUUID()}-${file.name}`;
+        
+        const { error: uploadError } = await dataLayerClient.storage
+          .from('task_documents')
+          .upload(filePath, file);
 
-      if (uploadError) throw uploadError;
+        if (uploadError) throw uploadError;
 
-      const taskDocument: TaskDocumentInsert = {
-          video_task_id: taskId,
-          file_name: file.name,
-          file_path: filePath,
-        };
+        const taskDocument: TaskDocumentInsert = {
+            video_task_id: taskId,
+            file_name: file.name,
+            file_path: filePath,
+          };
 
-      const { error: dbError } = await dataLayerClient.from('task_documents')
-        .insert(taskDocument);
+        const { error: dbError } = await dataLayerClient.from('task_documents')
+          .insert(taskDocument);
 
-      if (dbError) throw dbError;
+        if (dbError) throw dbError;
+      }
 
       await dataLayerClient.from('video_job_tasks')
         .update({ 
@@ -163,8 +167,11 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
         .eq('id', taskId);
 
       toast({
-        title: "File uploaded successfully",
-        description: "The document has been uploaded and task marked as completed.",
+        title: files.length === 1 ? "File uploaded successfully" : "Files uploaded successfully",
+        description:
+          files.length === 1
+            ? "The document has been uploaded and task marked as completed."
+            : `${files.length} documents have been uploaded and the task marked as completed.`,
       });
 
       refetchTasks();
@@ -537,10 +544,12 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                             <div className="relative">
                               <input
                                 type="file"
+                                multiple
                                 className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                                 onChange={(e) => {
-                                  const file = e.target.files?.[0];
-                                  if (file) handleFileUpload(task.id, file);
+                                  const files = Array.from(e.target.files ?? []);
+                                  e.target.value = "";
+                                  if (files.length > 0) handleFileUpload(task.id, files);
                                 }}
                                 disabled={uploading}
                               />

--- a/src/components/video/VideoTaskDialog.tsx
+++ b/src/components/video/VideoTaskDialog.tsx
@@ -34,6 +34,10 @@ import {
 
 import { queryKeys } from "@/lib/react-query";
 import type { Database } from "@/integrations/supabase/types";
+import {
+  DOCUMENT_UPLOAD_ACCEPT,
+  getDocumentUploadValidationError,
+} from "@/utils/documentUploadValidation";
 interface VideoTaskDialogProps {
   jobId: string;
   open: boolean;
@@ -136,6 +140,18 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
   const handleFileUpload = async (taskId: string, files: File[]) => {
     if (files.length === 0) return;
 
+    const validationError = getDocumentUploadValidationError(files);
+    if (validationError) {
+      toast({
+        title: "Archivo no permitido",
+        description: validationError,
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const uploadedPaths: string[] = [];
+    const insertedIds: string[] = [];
     try {
       setUploading(true);
       for (const file of files) {
@@ -146,6 +162,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
           .upload(filePath, file);
 
         if (uploadError) throw uploadError;
+        uploadedPaths.push(filePath);
 
         const taskDocument: TaskDocumentInsert = {
             video_task_id: taskId,
@@ -153,32 +170,48 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
             file_path: filePath,
           };
 
-        const { error: dbError } = await dataLayerClient.from('task_documents')
-          .insert(taskDocument);
+        const { data: insertedDocument, error: dbError } = await dataLayerClient.from('task_documents')
+          .insert(taskDocument)
+          .select('id')
+          .single();
 
         if (dbError) throw dbError;
+        if (insertedDocument?.id) {
+          insertedIds.push(insertedDocument.id);
+        }
       }
 
-      await dataLayerClient.from('video_job_tasks')
+      const { error: taskUpdateError } = await dataLayerClient.from('video_job_tasks')
         .update({ 
           status: 'completed',
           progress: 100 
         })
         .eq('id', taskId);
+      if (taskUpdateError) throw taskUpdateError;
 
       toast({
-        title: files.length === 1 ? "File uploaded successfully" : "Files uploaded successfully",
+        title: files.length === 1 ? "Archivo subido correctamente" : "Archivos subidos correctamente",
         description:
           files.length === 1
-            ? "The document has been uploaded and task marked as completed."
-            : `${files.length} documents have been uploaded and the task marked as completed.`,
+            ? "El documento se ha subido y la tarea se ha marcado como completada."
+            : `${files.length} documentos se han subido y la tarea se ha marcado como completada.`,
       });
 
       refetchTasks();
     } catch (error: any) {
+      try {
+        if (insertedIds.length > 0) {
+          await dataLayerClient.from('task_documents').delete().in('id', insertedIds);
+        }
+        if (uploadedPaths.length > 0) {
+          await dataLayerClient.storage.from('task_documents').remove(uploadedPaths);
+        }
+      } catch (cleanupError) {
+        console.error("Error rolling back video task document upload batch:", cleanupError);
+      }
       toast({
-        title: "Upload failed",
-        description: error.message,
+        title: "Error al subir",
+        description: error.message || "No se pudo completar la subida. Se ha revertido la tanda.",
         variant: "destructive",
       });
     } finally {
@@ -545,6 +578,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                               <input
                                 type="file"
                                 multiple
+                                accept={DOCUMENT_UPLOAD_ACCEPT}
                                 className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                                 onChange={(e) => {
                                   const files = Array.from(e.target.files ?? []);
@@ -560,7 +594,7 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
                                 className="w-[100px]"
                               >
                                 <Upload className="h-3 w-3 mr-1" />
-                                Upload
+                                Subir
                               </Button>
                             </div>
                           )}

--- a/src/features/festival-management/hooks/useFestivalDocuments.ts
+++ b/src/features/festival-management/hooks/useFestivalDocuments.ts
@@ -21,6 +21,11 @@ const EMPTY_JOB_DOCUMENTS: JobDocumentEntry[] = [];
 
 const getErrorMessage = (error: unknown, fallback: string) => (error instanceof Error ? error.message : fallback);
 
+type UploadFestivalDocumentVariables = {
+  file: File;
+  suppressToast?: boolean;
+};
+
 export const useFestivalDocuments = ({ jobId, toast }: { jobId?: string; toast: ToastFn }) => {
   const queryClient = useQueryClient();
   const documentsQueryKey = useMemo(() => queryKeys.scope("festival-documents", jobId ?? "none"), [jobId]);
@@ -65,27 +70,31 @@ export const useFestivalDocuments = ({ jobId, toast }: { jobId?: string; toast: 
   }, [documentsQueryKey, jobId, queryClient, refetchDocuments]);
 
   const { isPending: isUploadingDocument, mutateAsync: uploadDocument } = useMutation({
-    mutationFn: (file: File) => {
+    mutationFn: ({ file }: UploadFestivalDocumentVariables) => {
       if (!jobId) {
         throw new Error("No se encontró el trabajo.");
       }
 
       return uploadJobDocument({ file, jobId });
     },
-    onSuccess: async () => {
-      toast({
-        title: "Éxito",
-        description: "Documento subido exitosamente",
-      });
+    onSuccess: async (_data, variables) => {
+      if (!variables.suppressToast) {
+        toast({
+          title: "Éxito",
+          description: "Documento subido exitosamente",
+        });
+      }
       await queryClient.invalidateQueries({ queryKey: documentsQueryKey });
     },
-    onError: (error) => {
+    onError: (error, variables) => {
       console.error("Error uploading document:", error);
-      toast({
-        title: "Error al subir",
-        description: getErrorMessage(error, "Error al subir documento"),
-        variant: "destructive",
-      });
+      if (!variables?.suppressToast) {
+        toast({
+          title: "Error al subir",
+          description: getErrorMessage(error, "Error al subir documento"),
+          variant: "destructive",
+        });
+      }
     },
   });
 
@@ -166,19 +175,35 @@ export const useFestivalDocuments = ({ jobId, toast }: { jobId?: string; toast: 
 
   const handleDocumentUpload = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      if (!file || !jobId) {
+      const files = Array.from(event.target.files ?? []);
+      if (files.length === 0 || !jobId) {
         event.target.value = "";
         return;
       }
 
       try {
-        await uploadDocument(file);
+        for (const file of files) {
+          await uploadDocument({ file, suppressToast: files.length > 1 });
+        }
+        if (files.length > 1) {
+          toast({
+            title: "Éxito",
+            description: `${files.length} documentos subidos exitosamente`,
+          });
+        }
+      } catch (error) {
+        if (files.length > 1) {
+          toast({
+            title: "Error al subir",
+            description: getErrorMessage(error, "Error al subir documentos"),
+            variant: "destructive",
+          });
+        }
       } finally {
         event.target.value = "";
       }
     },
-    [jobId, uploadDocument],
+    [jobId, toast, uploadDocument],
   );
 
   const groupedRiderFiles = useMemo(() => groupFestivalRiderFiles(artistRiderFiles), [artistRiderFiles]);

--- a/src/features/festival-management/hooks/useFestivalDocuments.ts
+++ b/src/features/festival-management/hooks/useFestivalDocuments.ts
@@ -13,6 +13,7 @@ import { fetchFestivalDocuments } from "@/features/festival-management/queries";
 import { formatFestivalDateLabel, groupFestivalRiderFiles } from "@/features/festival-management/selectors";
 import type { ArtistRiderFile, JobDocumentEntry } from "@/features/festival-management/types";
 import { queryKeys } from "@/lib/react-query";
+import { getDocumentUploadValidationError } from "@/utils/documentUploadValidation";
 
 type ToastFn = (props: { description?: string; title: string; variant?: "destructive" }) => void;
 
@@ -23,6 +24,7 @@ const getErrorMessage = (error: unknown, fallback: string) => (error instanceof 
 
 type UploadFestivalDocumentVariables = {
   file: File;
+  suppressInvalidation?: boolean;
   suppressToast?: boolean;
 };
 
@@ -84,7 +86,9 @@ export const useFestivalDocuments = ({ jobId, toast }: { jobId?: string; toast: 
           description: "Documento subido exitosamente",
         });
       }
-      await queryClient.invalidateQueries({ queryKey: documentsQueryKey });
+      if (!variables.suppressInvalidation) {
+        await queryClient.invalidateQueries({ queryKey: documentsQueryKey });
+      }
     },
     onError: (error, variables) => {
       console.error("Error uploading document:", error);
@@ -182,10 +186,26 @@ export const useFestivalDocuments = ({ jobId, toast }: { jobId?: string; toast: 
       }
 
       try {
-        for (const file of files) {
-          await uploadDocument({ file, suppressToast: files.length > 1 });
+        const validationError = getDocumentUploadValidationError(files);
+        if (validationError) {
+          toast({
+            title: "Archivo no permitido",
+            description: validationError,
+            variant: "destructive",
+          });
+          return;
         }
-        if (files.length > 1) {
+
+        const isBatchUpload = files.length > 1;
+        for (const file of files) {
+          await uploadDocument({
+            file,
+            suppressInvalidation: isBatchUpload,
+            suppressToast: isBatchUpload,
+          });
+        }
+        if (isBatchUpload) {
+          await queryClient.invalidateQueries({ queryKey: documentsQueryKey });
           toast({
             title: "Éxito",
             description: `${files.length} documentos subidos exitosamente`,
@@ -203,7 +223,7 @@ export const useFestivalDocuments = ({ jobId, toast }: { jobId?: string; toast: 
         event.target.value = "";
       }
     },
-    [jobId, toast, uploadDocument],
+    [documentsQueryKey, jobId, queryClient, toast, uploadDocument],
   );
 
   const groupedRiderFiles = useMemo(() => groupFestivalRiderFiles(artistRiderFiles), [artistRiderFiles]);

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -349,7 +349,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       );
       if (setTables.length === 0) return;
       try {
-        await Promise.all(
+        const results = await Promise.all(
           setTables.map((table) =>
             dataLayerClient
               .from("tour_default_tables")
@@ -364,7 +364,10 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
               .eq("id", table.id),
           ),
         );
-        queryClient.invalidateQueries({
+        const failedResult = results.find((result) => result.error);
+        if (failedResult?.error) throw failedResult.error;
+
+        await queryClient.invalidateQueries({
           queryKey: queryKeys.scope("tour-default-tables", tourIdParam || "", department),
         });
         await syncDefaultDocumentsAfterMutation();

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -12,6 +12,7 @@ import type { TourPackageSize } from "@/utils/tourPackages";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { queryKeys } from "@/lib/react-query";
 import { exportToPDF } from "@/utils/pdfExport";
+import { syncTourDefaultDocuments } from "@/utils/tourDefaultDocumentSync";
 import {
   CUSTOM_POWER_POSITION_VALUE,
   NO_POWER_POSITION_VALUE,
@@ -243,6 +244,34 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     [defaultSets, selectedDefaultSetId],
   );
 
+  const syncDefaultDocumentsAfterMutation = useCallback(async () => {
+    if (!isTourDefaults || !tourIdParam) return;
+
+    try {
+      const result = await syncTourDefaultDocuments({ tourId: tourIdParam });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-documents", tourIdParam) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobcard-tour-documents") }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-documents-for-job") }),
+      ]);
+
+      if (result.errors.length > 0) {
+        toast({
+          title: labels.toastError,
+          description: `${result.errors.length} default document(s) could not be refreshed.`,
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      console.error("Error syncing tour default documents:", error);
+      toast({
+        title: labels.toastError,
+        description: "Default package PDFs could not be refreshed.",
+        variant: "destructive",
+      });
+    }
+  }, [isTourDefaults, tourIdParam, queryClient, toast, labels.toastError]);
+
   useEffect(() => {
     if (
       !isTourDefaults ||
@@ -338,11 +367,21 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
         queryClient.invalidateQueries({
           queryKey: queryKeys.scope("tour-default-tables", tourIdParam || "", department),
         });
+        await syncDefaultDocumentsAfterMutation();
       } catch (error) {
         console.error("Error persisting FOH schuko setting:", error);
       }
     },
-    [isTourDefaults, features.fohSchuko, selectedDefaultSetId, defaultTables, queryClient, tourIdParam, department],
+    [
+      isTourDefaults,
+      features.fohSchuko,
+      selectedDefaultSetId,
+      defaultTables,
+      queryClient,
+      tourIdParam,
+      department,
+      syncDefaultDocumentsAfterMutation,
+    ],
   );
 
   const handleSetFohSchukoRequired = useCallback(
@@ -797,6 +836,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
         }),
       },
     });
+    await syncDefaultDocumentsAfterMutation();
   };
 
   const generateTable = async () => {
@@ -971,6 +1011,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
   const createEmptyDefaultSet = async () => {
     try {
       await getOrCreateDefaultSetId();
+      await syncDefaultDocumentsAfterMutation();
     } catch (error: unknown) {
       console.error("Error creating default set:", error);
       toast({
@@ -1006,6 +1047,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
             : candidate,
         ),
       );
+      await syncDefaultDocumentsAfterMutation();
       toast({ title: labels.toastSuccess, description: labels.toastDefaultSaved });
     } catch (error: unknown) {
       console.error("Error saving tour default:", error);
@@ -1069,6 +1111,9 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       }
     }
     const saved = unsaved.length - failed.length;
+    if (saved > 0) {
+      await syncDefaultDocumentsAfterMutation();
+    }
     if (failed.length === 0) {
       toast({ title: labels.toastSuccess, description: labels.toastDefaultsSaved(saved) });
     } else if (saved > 0) {
@@ -1092,6 +1137,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       if (editing?.kind === "default" && editing.id === defaultTableId) {
         resetCurrentTable();
       }
+      await syncDefaultDocumentsAfterMutation();
     } catch (error) {
       console.error("Error deleting default table:", error);
       toast({
@@ -1227,6 +1273,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       setSelectedCopyTableIds([]);
       setSelectedDefaultSetId(targetSetId);
       setIsCreatingDefaultSet(false);
+      await syncDefaultDocumentsAfterMutation();
     } catch (error: unknown) {
       console.error("Error copying default tables:", error);
       toast({

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -10,7 +10,7 @@ import { useTourDateOverrides } from "@/hooks/useTourDateOverrides";
 import { useTourOverrideMode } from "@/hooks/useTourOverrideMode";
 import type { TourPackageSize } from "@/utils/tourPackages";
 import { dataLayerClient } from "@/services/dataLayerClient";
-import { queryKeys } from "@/lib/react-query";
+import { optimizedInvalidation, queryKeys } from "@/lib/react-query";
 import { exportToPDF } from "@/utils/pdfExport";
 import { syncTourDefaultDocuments } from "@/utils/tourDefaultDocumentSync";
 import {
@@ -249,16 +249,16 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
 
     try {
       const result = await syncTourDefaultDocuments({ tourId: tourIdParam });
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-documents", tourIdParam) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobcard-tour-documents") }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.scope("tour-documents-for-job") }),
+      optimizedInvalidation.invalidateQueryKeys(queryClient, [
+        queryKeys.scope("tour-documents", tourIdParam),
+        queryKeys.scope("jobcard-tour-documents"),
+        queryKeys.scope("tour-documents-for-job"),
       ]);
 
       if (result.errors.length > 0) {
         toast({
           title: labels.toastError,
-          description: `${result.errors.length} default document(s) could not be refreshed.`,
+          description: `${result.errors.length} documento(s) predeterminados no se pudieron actualizar.`,
           variant: "destructive",
         });
       }
@@ -266,7 +266,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       console.error("Error syncing tour default documents:", error);
       toast({
         title: labels.toastError,
-        description: "Default package PDFs could not be refreshed.",
+        description: "No se pudieron actualizar los PDF predeterminados del paquete.",
         variant: "destructive",
       });
     }

--- a/src/hooks/useGlobalTaskMutations.ts
+++ b/src/hooks/useGlobalTaskMutations.ts
@@ -3,6 +3,7 @@ import { completeTask, revertTask, Department } from '@/services/taskCompletion'
 import type { Database } from '@/integrations/supabase/types';
 import { type Dept } from '@/utils/tasks';
 import { isTaskAssigneeUniqueConflict } from '@/utils/taskAssignment';
+import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
 
 type SoundTaskUpdate = Database['public']['Tables']['sound_job_tasks']['Update'];
 type LightsTaskUpdate = Database['public']['Tables']['lights_job_tasks']['Update'];
@@ -724,6 +725,9 @@ export function useGlobalTaskMutations(department: Dept) {
     file: File,
     context?: { jobId?: string | null; tourId?: string | null },
   ) => {
+    const validationError = getDocumentUploadValidationError([file]);
+    if (validationError) throw new Error(validationError);
+
     const { data: authData } = await supabase.auth.getUser();
     const uploaderId = authData?.user?.id;
     if (!uploaderId) throw new Error('User must be authenticated to upload attachments');
@@ -747,7 +751,13 @@ export function useGlobalTaskMutations(department: Dept) {
     taskDocumentInsert[docFk] = taskId;
 
     const { error: insErr } = await supabase.from('task_documents').insert(taskDocumentInsert);
-    if (insErr) throw insErr;
+    if (insErr) {
+      const { error: cleanupError } = await supabase.storage.from('task_documents').remove([taskKey]);
+      if (cleanupError) {
+        console.error('Storage cleanup after failed task document insert failed:', cleanupError);
+      }
+      throw insErr;
+    }
 
     // 2. Mirror to job bucket if linked (idempotent: delete-before-insert)
     if (jobId) {

--- a/src/hooks/useJobCard.ts
+++ b/src/hooks/useJobCard.ts
@@ -13,6 +13,7 @@ import {
   canManageFestivalArtists,
   canUploadDocuments as canUploadDocumentsForRole,
 } from '@/utils/permissions';
+import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -175,8 +176,17 @@ export const useJobCard = (job: any, department: Department, userRole: string | 
     e.target.value = "";
     if (files.length === 0 || !department) return;
 
-    try {
-      for (const file of files) {
+    const validationError = getDocumentUploadValidationError(files);
+    if (validationError) {
+      toast({ title: "Archivo no permitido", description: validationError, variant: "destructive" });
+      return;
+    }
+
+    let uploadedCount = 0;
+    const failedMessages: string[] = [];
+
+    for (const file of files) {
+      try {
         const fileExt = file.name.split(".").pop();
         const filePath = `${department}/${job.id}/${crypto.randomUUID()}.${fileExt}`;
 
@@ -195,7 +205,14 @@ export const useJobCard = (job: any, department: Department, userRole: string | 
             file_size: file.size,
             original_type: null
           });
-        if (dbError) throw dbError;
+        if (dbError) {
+          const { error: cleanupError } = await supabase.storage.from("job_documents").remove([filePath]);
+          if (cleanupError) {
+            console.error("Storage cleanup after failed job document insert failed:", cleanupError);
+          }
+          throw dbError;
+        }
+        uploadedCount += 1;
 
         // Broadcast push: new document uploaded
         try {
@@ -203,25 +220,33 @@ export const useJobCard = (job: any, department: Department, userRole: string | 
             body: { action: 'broadcast', type: 'document.uploaded', job_id: job.id, file_name: file.name }
           });
         } catch {}
+      } catch (err: any) {
+        failedMessages.push(`${file.name}: ${err?.message || String(err)}`);
       }
+    }
 
-      queryClient.invalidateQueries({ queryKey: queryKeys.scope("optimized-jobs") });
-      queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope("optimized-jobs") });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") });
 
+    if (failedMessages.length === 0) {
       toast({
-        title: files.length === 1 ? "Document uploaded" : "Documents uploaded",
+        title: files.length === 1 ? "Documento subido" : "Documentos subidos",
         description:
           files.length === 1
-            ? "The document has been successfully uploaded."
-            : `${files.length} documents have been successfully uploaded.`
+            ? "El documento se ha subido correctamente."
+            : `${files.length} documentos se han subido correctamente.`
       });
-    } catch (err: any) {
-      toast({
-        title: "Upload failed",
-        description: err.message,
-        variant: "destructive"
-      });
+      return;
     }
+
+    toast({
+      title: uploadedCount > 0 ? "Subida parcial" : "Error al subir",
+      description:
+        uploadedCount > 0
+          ? `${uploadedCount} de ${files.length} documento(s) se subieron. ${failedMessages[0]}`
+          : failedMessages[0],
+      variant: "destructive"
+    });
   };
 
   const handleDeleteDocument = async (doc: JobDocument) => {

--- a/src/hooks/useJobCard.ts
+++ b/src/hooks/useJobCard.ts
@@ -171,43 +171,49 @@ export const useJobCard = (job: any, department: Department, userRole: string | 
 
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
-    const file = e.target.files?.[0];
-    if (!file || !department) return;
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = "";
+    if (files.length === 0 || !department) return;
 
     try {
-      const fileExt = file.name.split(".").pop();
-      const filePath = `${department}/${job.id}/${crypto.randomUUID()}.${fileExt}`;
+      for (const file of files) {
+        const fileExt = file.name.split(".").pop();
+        const filePath = `${department}/${job.id}/${crypto.randomUUID()}.${fileExt}`;
 
-      const { error: uploadError } = await supabase.storage
-        .from("job_documents")
-        .upload(filePath, file);
-      if (uploadError) throw uploadError;
+        const { error: uploadError } = await supabase.storage
+          .from("job_documents")
+          .upload(filePath, file);
+        if (uploadError) throw uploadError;
 
-      const { error: dbError } = await supabase
-        .from("job_documents")
-        .insert({
-          job_id: job.id,
-          file_name: file.name,
-          file_path: filePath,
-          file_type: file.type,
-          file_size: file.size,
-          original_type: null
-        });
-      if (dbError) throw dbError;
+        const { error: dbError } = await supabase
+          .from("job_documents")
+          .insert({
+            job_id: job.id,
+            file_name: file.name,
+            file_path: filePath,
+            file_type: file.type,
+            file_size: file.size,
+            original_type: null
+          });
+        if (dbError) throw dbError;
 
-      // Broadcast push: new document uploaded
-      try {
-        void supabase.functions.invoke('push', {
-          body: { action: 'broadcast', type: 'document.uploaded', job_id: job.id, file_name: file.name }
-        });
-      } catch {}
+        // Broadcast push: new document uploaded
+        try {
+          void supabase.functions.invoke('push', {
+            body: { action: 'broadcast', type: 'document.uploaded', job_id: job.id, file_name: file.name }
+          });
+        } catch {}
+      }
 
       queryClient.invalidateQueries({ queryKey: queryKeys.scope("optimized-jobs") });
       queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") });
 
       toast({
-        title: "Document uploaded",
-        description: "The document has been successfully uploaded."
+        title: files.length === 1 ? "Document uploaded" : "Documents uploaded",
+        description:
+          files.length === 1
+            ? "The document has been successfully uploaded."
+            : `${files.length} documents have been successfully uploaded.`
       });
     } catch (err: any) {
       toast({

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -3,6 +3,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { supabase } from '@/lib/supabase';
 import { useTheme } from 'next-themes';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@/hooks/use-toast';
 import { createQueryKey } from '@/lib/optimized-react-query';
 import { useRequiredRoleSummary } from '@/hooks/useJobRequiredRoles';
 import { resolveJobDocLocation } from '@/utils/jobDocuments';
@@ -13,6 +14,7 @@ import {
   canManageFestivalArtists,
   canUploadDocuments as canUploadDocumentsForRole,
 } from '@/utils/permissions';
+import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -41,6 +43,7 @@ export const useOptimizedJobCard = (
 ) => {
   const { theme } = useTheme();
   const queryClient = useQueryClient();
+  const { toast } = useToast();
   const enableRoleSummary = options?.enableRoleSummary ?? true;
   const enableSoundTasks = options?.enableSoundTasks ?? true;
   const refreshAssignmentsOnMount = options?.refreshAssignmentsOnMount ?? false;
@@ -357,10 +360,17 @@ export const useOptimizedJobCard = (
     e.target.value = "";
     if (files.length === 0 || !department) return;
 
-    try {
-      const insertedDocuments: JobDocumentRow[] = [];
+    const validationError = getDocumentUploadValidationError(files);
+    if (validationError) {
+      toast({ title: 'Archivo no permitido', description: validationError, variant: 'destructive' });
+      return;
+    }
 
-      for (const file of files) {
+    const insertedDocuments: JobDocumentRow[] = [];
+    const failedMessages: string[] = [];
+
+    for (const file of files) {
+      try {
         const fileExt = file.name.split('.').pop();
         const filePath = `${department}/${job.id}/${crypto.randomUUID()}.${fileExt}`;
 
@@ -381,7 +391,13 @@ export const useOptimizedJobCard = (
           })
           .select('*')
           .single();
-        if (dbError) throw dbError;
+        if (dbError) {
+          const { error: cleanupError } = await supabase.storage.from('job_documents').remove([filePath]);
+          if (cleanupError) {
+            console.error('Storage cleanup after failed job document insert failed:', cleanupError);
+          }
+          throw dbError;
+        }
 
         if (inserted) {
           insertedDocuments.push(inserted as JobDocumentRow);
@@ -393,16 +409,31 @@ export const useOptimizedJobCard = (
             body: { action: 'broadcast', type: 'document.uploaded', job_id: job.id, file_name: file.name }
           });
         } catch {}
+      } catch (err: any) {
+        failedMessages.push(`${file.name}: ${err?.message || String(err)}`);
       }
-
-      // Update local documents state immediately
-      if (insertedDocuments.length > 0) {
-        setDocuments((prev) => Array.isArray(prev) ? [...prev, ...insertedDocuments] : insertedDocuments);
-      }
-    } catch (err: any) {
-      console.error('Upload error:', err);
     }
-  }, [job.id, department]);
+
+    // Update local documents state immediately
+    if (insertedDocuments.length > 0) {
+      setDocuments((prev) => Array.isArray(prev) ? [...prev, ...insertedDocuments] : insertedDocuments);
+    }
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope("optimized-jobs") });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope("jobs") });
+
+    if (failedMessages.length === 0) {
+      return;
+    }
+
+    toast({
+      title: insertedDocuments.length > 0 ? 'Subida parcial' : 'Error al subir',
+      description:
+        insertedDocuments.length > 0
+          ? `${insertedDocuments.length} de ${files.length} documento(s) se subieron. ${failedMessages[0]}`
+          : failedMessages[0],
+      variant: 'destructive',
+    });
+  }, [job.id, department, queryClient, toast]);
 
   const handleDeleteDocument = useCallback(async (doc: any) => {
     if (doc?.read_only) {

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -353,43 +353,52 @@ export const useOptimizedJobCard = (
 
   const handleFileUpload = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
-    const file = e.target.files?.[0];
-    if (!file || !department) return;
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = "";
+    if (files.length === 0 || !department) return;
 
     try {
-      const fileExt = file.name.split('.').pop();
-      const filePath = `${department}/${job.id}/${crypto.randomUUID()}.${fileExt}`;
+      const insertedDocuments: JobDocumentRow[] = [];
 
-      const { error: uploadError } = await supabase.storage
-        .from('job_documents')
-        .upload(filePath, file);
-      if (uploadError) throw uploadError;
+      for (const file of files) {
+        const fileExt = file.name.split('.').pop();
+        const filePath = `${department}/${job.id}/${crypto.randomUUID()}.${fileExt}`;
 
-      const { data: inserted, error: dbError } = await supabase
-        .from('job_documents')
-        .insert({
-          job_id: job.id,
-          file_name: file.name,
-          file_path: filePath,
-          file_type: file.type,
-          file_size: file.size,
-          original_type: null
-        })
-        .select('*')
-        .single();
-      if (dbError) throw dbError;
+        const { error: uploadError } = await supabase.storage
+          .from('job_documents')
+          .upload(filePath, file);
+        if (uploadError) throw uploadError;
 
-      // Update local documents state immediately
-      if (inserted) {
-        setDocuments((prev) => Array.isArray(prev) ? [...prev, inserted as JobDocumentRow] : [inserted as JobDocumentRow]);
+        const { data: inserted, error: dbError } = await supabase
+          .from('job_documents')
+          .insert({
+            job_id: job.id,
+            file_name: file.name,
+            file_path: filePath,
+            file_type: file.type,
+            file_size: file.size,
+            original_type: null
+          })
+          .select('*')
+          .single();
+        if (dbError) throw dbError;
+
+        if (inserted) {
+          insertedDocuments.push(inserted as JobDocumentRow);
+        }
+
+        // Broadcast push: new document uploaded
+        try {
+          void supabase.functions.invoke('push', {
+            body: { action: 'broadcast', type: 'document.uploaded', job_id: job.id, file_name: file.name }
+          });
+        } catch {}
       }
 
-      // Broadcast push: new document uploaded
-      try {
-        void supabase.functions.invoke('push', {
-          body: { action: 'broadcast', type: 'document.uploaded', job_id: job.id, file_name: file.name }
-        });
-      } catch {}
+      // Update local documents state immediately
+      if (insertedDocuments.length > 0) {
+        setDocuments((prev) => Array.isArray(prev) ? [...prev, ...insertedDocuments] : insertedDocuments);
+      }
     } catch (err: any) {
       console.error('Upload error:', err);
     }

--- a/src/hooks/useTaskMutations.ts
+++ b/src/hooks/useTaskMutations.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib/supabase';
 import { completeTask, revertTask, Department } from '@/services/taskCompletion';
+import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
 
 type Dept = 'sound'|'lights'|'video';
 
@@ -323,12 +324,21 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
   };
 
   const uploadAttachment = async (taskId: string, file: File) => {
+    const validationError = getDocumentUploadValidationError([file]);
+    if (validationError) throw new Error(validationError);
+
     const sanitized = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
     const key = `${taskId}/${Date.now()}_${sanitized}`;
     const { error: upErr } = await supabase.storage.from('task_documents').upload(key, file, { upsert: false });
     if (upErr) throw upErr;
     const { error: insErr } = await supabase.from('task_documents').insert({ [docFk]: taskId, file_name: file.name, file_path: key });
-    if (insErr) throw insErr;
+    if (insErr) {
+      const { error: cleanupError } = await supabase.storage.from('task_documents').remove([key]);
+      if (cleanupError) {
+        console.error('Storage cleanup after failed task document insert failed:', cleanupError);
+      }
+      throw insErr;
+    }
     // Do not auto-complete; leave explicit status control in UI
   };
 

--- a/src/hooks/useTourDocuments.ts
+++ b/src/hooks/useTourDocuments.ts
@@ -28,6 +28,7 @@ export interface TourDocument {
 type UploadTourDocumentVariables = {
   file: File;
   fileName?: string;
+  suppressInvalidation?: boolean;
   suppressToast?: boolean;
 };
 
@@ -101,6 +102,10 @@ export const useTourDocuments = (tourId: string) => {
 
       if (dbError) {
         console.error('Database insert error:', dbError);
+        const { error: cleanupError } = await supabase.storage.from('tour-documents').remove([filePath]);
+        if (cleanupError) {
+          console.error('Storage cleanup after failed document insert failed:', cleanupError);
+        }
         throw dbError;
       }
 
@@ -108,18 +113,23 @@ export const useTourDocuments = (tourId: string) => {
       return data;
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents', tourId) });
+      if (!variables.suppressInvalidation) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents', tourId) });
+      }
       if (!variables.suppressToast) {
-        toast.success('Document uploaded successfully');
+        toast.success('Documento subido correctamente');
       }
     },
     onError: (error: any, variables) => {
       console.error('Upload error:', error);
       if (!variables?.suppressToast) {
-        toast.error('Failed to upload document');
+        toast.error('No se pudo subir el documento');
       }
     }
   });
+
+  const refreshDocuments = () =>
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents', tourId) });
 
   const updateVisibility = useMutation({
     mutationFn: async ({ documentId, visibleToTech }: { documentId: string; visibleToTech: boolean }) => {
@@ -257,6 +267,7 @@ export const useTourDocuments = (tourId: string) => {
     isLoading,
     error,
     uploadDocument,
+    refreshDocuments,
     updateVisibility,
     updateGuestVisibility,
     deleteDocument,

--- a/src/hooks/useTourDocuments.ts
+++ b/src/hooks/useTourDocuments.ts
@@ -25,6 +25,12 @@ export interface TourDocument {
   visible_to_guest?: boolean;
 }
 
+type UploadTourDocumentVariables = {
+  file: File;
+  fileName?: string;
+  suppressToast?: boolean;
+};
+
 export const useTourDocuments = (tourId: string) => {
   const { user, userRole } = useOptimizedAuth();
   const queryClient = useQueryClient();
@@ -54,7 +60,7 @@ export const useTourDocuments = (tourId: string) => {
   });
 
   const uploadDocument = useMutation({
-    mutationFn: async ({ file, fileName }: { file: File; fileName?: string }) => {
+    mutationFn: async ({ file, fileName }: UploadTourDocumentVariables) => {
       if (!user?.id) throw new Error("User not authenticated");
       if (!canUploadTourDocuments(userRole)) throw new Error("Not allowed");
 
@@ -101,13 +107,17 @@ export const useTourDocuments = (tourId: string) => {
       console.log('Document uploaded successfully:', data);
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents', tourId) });
-      toast.success('Document uploaded successfully');
+      if (!variables.suppressToast) {
+        toast.success('Document uploaded successfully');
+      }
     },
-    onError: (error: any) => {
+    onError: (error: any, variables) => {
       console.error('Upload error:', error);
-      toast.error('Failed to upload document');
+      if (!variables?.suppressToast) {
+        toast.error('Failed to upload document');
+      }
     }
   });
 

--- a/src/lib/enhanced-security-config.ts
+++ b/src/lib/enhanced-security-config.ts
@@ -165,18 +165,18 @@ export function validateFileUpload(file: File): {
   
   // Check file size
   if (file.size > ENHANCED_RATE_LIMITS.MAX_DOCUMENT_SIZE) {
-    errors.push(`File size exceeds ${ENHANCED_RATE_LIMITS.MAX_DOCUMENT_SIZE / 1024 / 1024}MB limit`);
+    errors.push(`El archivo supera el límite de ${ENHANCED_RATE_LIMITS.MAX_DOCUMENT_SIZE / 1024 / 1024} MB`);
   }
   
   // Check filename
   if (!ENHANCED_VALIDATION_PATTERNS.SAFE_FILENAME.test(file.name)) {
-    errors.push('File name contains invalid characters');
+    errors.push('El nombre del archivo contiene caracteres no permitidos');
   }
   
   // Check for double extensions (e.g., file.txt.exe)
   const nameParts = file.name.split('.');
   if (nameParts.length > 2) {
-    errors.push('File name cannot contain multiple extensions');
+    errors.push('El nombre del archivo no puede contener múltiples extensiones');
   }
   
   // Allowed file types
@@ -191,7 +191,7 @@ export function validateFileUpload(file: File): {
   ];
   
   if (!allowedTypes.includes(file.type)) {
-    errors.push('File type not allowed');
+    errors.push('Tipo de archivo no permitido');
   }
   
   return {

--- a/src/pages/GlobalTasks.tsx
+++ b/src/pages/GlobalTasks.tsx
@@ -42,6 +42,10 @@ import {
   localInputToUTC,
 } from '@/utils/timezoneUtils';
 import { getErrorMessage } from '@/utils/errorMessage';
+import {
+  DOCUMENT_UPLOAD_ACCEPT,
+  getDocumentUploadValidationError,
+} from '@/utils/documentUploadValidation';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -234,21 +238,48 @@ export default function GlobalTasks() {
 
   const onUpload = async (task: GlobalTask, files: File[]) => {
     if (files.length === 0) return;
-    try {
-      for (const file of files) {
+
+    const validationError = getDocumentUploadValidationError(files);
+    if (validationError) {
+      toast({ title: 'Archivo no permitido', description: validationError, variant: 'destructive' });
+      return;
+    }
+
+    let uploadedCount = 0;
+    const failedMessages: string[] = [];
+
+    for (const file of files) {
+      try {
         await mutations.uploadAttachment(task.id, file, {
           jobId: task.job_id,
           tourId: task.tour_id,
         });
+        uploadedCount += 1;
+      } catch (err: unknown) {
+        failedMessages.push(`${file.name}: ${getErrorMessage(err)}`);
       }
+    }
+
+    if (uploadedCount > 0 || failedMessages.length > 0) {
+      await refetch();
+    }
+
+    if (failedMessages.length === 0) {
       toast({
         title: files.length === 1 ? 'Archivo subido' : 'Archivos subidos',
         description: files.length === 1 ? undefined : `${files.length} archivos adjuntados`,
       });
-      await refetch();
-    } catch (err: unknown) {
-      toast({ title: 'Error', description: getErrorMessage(err), variant: 'destructive' });
+      return;
     }
+
+    toast({
+      title: uploadedCount > 0 ? 'Subida parcial' : 'Error',
+      description:
+        uploadedCount > 0
+          ? `${uploadedCount} de ${files.length} archivo(s) se subieron. ${failedMessages[0]}`
+          : failedMessages[0],
+      variant: 'destructive',
+    });
   };
 
   const onDeleteAttachment = async (task: GlobalTask, docId: string, filePath: string) => {
@@ -779,6 +810,7 @@ export default function GlobalTasks() {
                           <input
                             type="file"
                             multiple
+                            accept={DOCUMENT_UPLOAD_ACCEPT}
                             className="absolute inset-0 opacity-0 cursor-pointer w-full h-full"
                             onChange={(e) => {
                               const files = Array.from(e.target.files ?? []);

--- a/src/pages/GlobalTasks.tsx
+++ b/src/pages/GlobalTasks.tsx
@@ -232,14 +232,19 @@ export default function GlobalTasks() {
     completed: tasks.filter((t) => t.status === 'completed').length,
   }), [tasks]);
 
-  const onUpload = async (task: GlobalTask, file?: File) => {
-    if (!file) return;
+  const onUpload = async (task: GlobalTask, files: File[]) => {
+    if (files.length === 0) return;
     try {
-      await mutations.uploadAttachment(task.id, file, {
-        jobId: task.job_id,
-        tourId: task.tour_id,
+      for (const file of files) {
+        await mutations.uploadAttachment(task.id, file, {
+          jobId: task.job_id,
+          tourId: task.tour_id,
+        });
+      }
+      toast({
+        title: files.length === 1 ? 'Archivo subido' : 'Archivos subidos',
+        description: files.length === 1 ? undefined : `${files.length} archivos adjuntados`,
       });
-      toast({ title: 'Archivo subido' });
       await refetch();
     } catch (err: unknown) {
       toast({ title: 'Error', description: getErrorMessage(err), variant: 'destructive' });
@@ -773,11 +778,12 @@ export default function GlobalTasks() {
                         <div className="relative inline-block">
                           <input
                             type="file"
+                            multiple
                             className="absolute inset-0 opacity-0 cursor-pointer w-full h-full"
                             onChange={(e) => {
-                              const file = e.target.files?.[0];
+                              const files = Array.from(e.target.files ?? []);
                               e.target.value = ''; // Clear so same file can be re-selected
-                              onUpload(task, file);
+                              onUpload(task, files);
                             }}
                           />
                           <Button size="sm" variant="ghost" className="h-7 w-7 p-0">

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { exportToPDF } from '@/utils/pdfExport';
 import { useJobSelection, JobSelection } from '@/hooks/useJobSelection';
 import { useToast } from '@/hooks/use-toast';
@@ -23,6 +24,8 @@ import type { TechnicalStage } from '@/features/technical-tools/stage/stageUtils
 import { CopyToStageMenu } from '@/features/technical-tools/table-presets/CopyToStageMenu';
 import { QuickPresetsMenu } from '@/features/technical-tools/table-presets/QuickPresetsMenu';
 import type { TourPackageSize } from '@/utils/tourPackages';
+import { queryKeys } from '@/lib/react-query';
+import { syncTourDefaultDocuments } from '@/utils/tourDefaultDocumentSync';
 import {
   cloneTablesToStage,
   remapClusterIds,
@@ -113,6 +116,7 @@ interface SummaryRow {
 const PesosTool: React.FC = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const { data: jobs } = useJobSelection();
   const [searchParams] = useSearchParams();
   const jobIdFromUrl = searchParams.get('jobId');
@@ -254,6 +258,34 @@ const PesosTool: React.FC = () => {
     isLoading: overridesLoading
   } = useTourDateOverrides(tourDateId || '', 'weight');
 
+  const syncDefaultDocumentsAfterMutation = async () => {
+    if (!isTourDefaults || !tourId) return;
+
+    try {
+      const result = await syncTourDefaultDocuments({ tourId });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents', tourId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('jobcard-tour-documents') }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents-for-job') }),
+      ]);
+
+      if (result.errors.length > 0) {
+        toast({
+          title: 'PDF sync warning',
+          description: `${result.errors.length} default document(s) could not be refreshed.`,
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      console.error('Error syncing tour default documents:', error);
+      toast({
+        title: 'PDF sync warning',
+        description: 'Default package PDFs could not be refreshed.',
+        variant: 'destructive',
+      });
+    }
+  };
+
   // Get tour name for display
   const [tourName, setTourName] = useState<string>('');
   const [tourDateInfo, setTourDateInfo] = useState<{ date: string; location: string } | null>(null);
@@ -371,6 +403,11 @@ const PesosTool: React.FC = () => {
     setSelectedDefaultSetId(newSet.id);
     setNewDefaultSetName('');
     return newSet.id;
+  };
+
+  const deleteSetAndSync = async (setId: string) => {
+    await deleteSet(setId);
+    await syncDefaultDocumentsAfterMutation();
   };
 
   // Detect job-based override mode
@@ -608,6 +645,8 @@ const PesosTool: React.FC = () => {
         });
       }
 
+      await syncDefaultDocumentsAfterMutation();
+
       toast({
         title: 'Success',
         description: `Default set "${currentSetName}" saved successfully`,
@@ -628,7 +667,11 @@ const PesosTool: React.FC = () => {
   };
 
   // UPDATED: Save as tour defaults using the new system
-  const saveAsTourDefaults = async (table: Table, orderIndex?: number) => {
+  const saveAsTourDefaults = async (
+    table: Table,
+    orderIndex?: number,
+    options: { syncAfterSave?: boolean } = {}
+  ) => {
     if (!tourId) return;
 
     try {
@@ -673,6 +716,9 @@ const PesosTool: React.FC = () => {
         title: 'Success',
         description: 'Tour default saved successfully',
       });
+      if (options.syncAfterSave !== false) {
+        await syncDefaultDocumentsAfterMutation();
+      }
     } catch (error: any) {
       console.error('Error saving tour default:', error);
       toast({
@@ -749,7 +795,7 @@ const PesosTool: React.FC = () => {
     }
   };
 
-  const generateTable = () => {
+  const generateTable = async () => {
     if (!tableName) {
       toast({
         title: 'Missing table name',
@@ -835,17 +881,23 @@ const PesosTool: React.FC = () => {
     );
 
     // Handle saving based on mode
-    createdTablesWithSuffixes.forEach(table => {
-      if (isTourDefaults) {
-        saveAsTourDefaults(
+    if (isTourDefaults) {
+      for (const table of createdTablesWithSuffixes) {
+        await saveAsTourDefaults(
           table,
-          updatedTables.findIndex((candidate) => candidate.id === table.id)
+          updatedTables.findIndex((candidate) => candidate.id === table.id),
+          { syncAfterSave: false }
         );
-      } else if (isTourDateContext || isJobOverrideMode) {
-        saveAsOverride(table);
       }
-      // For regular defaults mode, tables are just saved to local state
-    });
+      await syncDefaultDocumentsAfterMutation();
+    } else {
+      createdTablesWithSuffixes.forEach(table => {
+        if (isTourDateContext || isJobOverrideMode) {
+          saveAsOverride(table);
+        }
+        // For regular defaults mode, tables are just saved to local state
+      });
+    }
 
     resetCurrentTable();
     setUseDualMotors(false);
@@ -1022,7 +1074,7 @@ const PesosTool: React.FC = () => {
       setSelectedDefaultPackageSize={setSelectedDefaultPackageSize}
       newDefaultSetName={newDefaultSetName}
       setNewDefaultSetName={setNewDefaultSetName}
-      deleteSet={deleteSet}
+      deleteSet={deleteSetAndSync}
       weightOverrides={weightOverrides}
       deleteOverride={deleteOverride}
       saveAsDefaultSet={saveAsDefaultSet}

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -919,7 +919,24 @@ const PesosTool: React.FC = () => {
     setTableName('');
   };
 
-  const removeTable = (tableId: number) => {
+  const removeTable = async (tableId: number) => {
+    const tableToRemove = tables.find((table) => table.id === tableId);
+
+    if (tableToRemove?.defaultTableId) {
+      try {
+        await deleteDefaultTable(tableToRemove.defaultTableId);
+        await syncDefaultDocumentsAfterMutation();
+      } catch (error) {
+        console.error('Error deleting default weight table:', error);
+        toast({
+          title: 'Error',
+          description: 'No se pudo eliminar la tabla predeterminada.',
+          variant: 'destructive',
+        });
+        return;
+      }
+    }
+
     updateTablesState((prev) => prev.filter((table) => table.id !== tableId));
   };
 

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -950,11 +950,18 @@ const PesosTool: React.FC = () => {
       return;
     }
 
+    const getMotorCountLabel = (table: Table) => {
+      const motorCount = getRiggingPointNumbers(table.riggingPoints).length;
+      if (motorCount > 0) return String(motorCount);
+      if (table.dualMotors) return '2';
+      return table.totalWeight > 0 ? '1' : 'N/A';
+    };
+
     const summaryRows: SummaryRow[] = activeTables.map((table) => {
       const cleanName = table.name.split('(')[0].trim();
       return {
         clusterName: cleanName,
-        riggingPoints: table.riggingPoints || '',
+        riggingPoints: getMotorCountLabel(table),
         clusterWeight: table.totalWeight || 0,
       };
     });
@@ -978,7 +985,7 @@ const PesosTool: React.FC = () => {
       cablePickCounter += 1;
       summaryRows.push({
         clusterName: 'CABLE PICK',
-        riggingPoints: `CP${String(cablePickCounter).padStart(2, "0")}`,
+        riggingPoints: '—',
         clusterWeight: parseFloat(tableWithCablePick.cablePickWeight || "0") || 0,
       });
     });

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -24,7 +24,7 @@ import type { TechnicalStage } from '@/features/technical-tools/stage/stageUtils
 import { CopyToStageMenu } from '@/features/technical-tools/table-presets/CopyToStageMenu';
 import { QuickPresetsMenu } from '@/features/technical-tools/table-presets/QuickPresetsMenu';
 import type { TourPackageSize } from '@/utils/tourPackages';
-import { queryKeys } from '@/lib/react-query';
+import { optimizedInvalidation, queryKeys } from '@/lib/react-query';
 import { syncTourDefaultDocuments } from '@/utils/tourDefaultDocumentSync';
 import {
   cloneTablesToStage,
@@ -259,28 +259,28 @@ const PesosTool: React.FC = () => {
   } = useTourDateOverrides(tourDateId || '', 'weight');
 
   const syncDefaultDocumentsAfterMutation = async () => {
-    if (!isTourDefaults || !tourId) return;
+    if ((!isTourDefaults && !isDefaults) || !tourId) return;
 
     try {
       const result = await syncTourDefaultDocuments({ tourId });
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents', tourId) }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.scope('jobcard-tour-documents') }),
-        queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-documents-for-job') }),
+      optimizedInvalidation.invalidateQueryKeys(queryClient, [
+        queryKeys.scope('tour-documents', tourId),
+        queryKeys.scope('jobcard-tour-documents'),
+        queryKeys.scope('tour-documents-for-job'),
       ]);
 
       if (result.errors.length > 0) {
         toast({
-          title: 'PDF sync warning',
-          description: `${result.errors.length} default document(s) could not be refreshed.`,
+          title: 'Aviso de sincronización de PDF',
+          description: `${result.errors.length} documento(s) predeterminados no se pudieron actualizar.`,
           variant: 'destructive',
         });
       }
     } catch (error) {
       console.error('Error syncing tour default documents:', error);
       toast({
-        title: 'PDF sync warning',
-        description: 'Default package PDFs could not be refreshed.',
+        title: 'Aviso de sincronización de PDF',
+        description: 'No se pudieron actualizar los PDF predeterminados del paquete.',
         variant: 'destructive',
       });
     }
@@ -671,8 +671,8 @@ const PesosTool: React.FC = () => {
     table: Table,
     orderIndex?: number,
     options: { syncAfterSave?: boolean } = {}
-  ) => {
-    if (!tourId) return;
+  ): Promise<boolean> => {
+    if (!tourId) return false;
 
     try {
       // Get or create the sound set ID
@@ -714,18 +714,20 @@ const PesosTool: React.FC = () => {
 
       toast({
         title: 'Success',
-        description: 'Tour default saved successfully',
+        description: 'Predeterminado de gira guardado correctamente',
       });
       if (options.syncAfterSave !== false) {
         await syncDefaultDocumentsAfterMutation();
       }
+      return true;
     } catch (error: any) {
       console.error('Error saving tour default:', error);
       toast({
         title: 'Error',
-        description: 'Failed to save tour default',
+        description: 'No se pudo guardar el predeterminado de gira',
         variant: 'destructive',
       });
+      return false;
     }
   };
 
@@ -882,14 +884,19 @@ const PesosTool: React.FC = () => {
 
     // Handle saving based on mode
     if (isTourDefaults) {
+      let savedCount = 0;
       for (const table of createdTablesWithSuffixes) {
-        await saveAsTourDefaults(
+        if (await saveAsTourDefaults(
           table,
           updatedTables.findIndex((candidate) => candidate.id === table.id),
           { syncAfterSave: false }
-        );
+        )) {
+          savedCount += 1;
+        }
       }
-      await syncDefaultDocumentsAfterMutation();
+      if (savedCount > 0) {
+        await syncDefaultDocumentsAfterMutation();
+      }
     } else {
       createdTablesWithSuffixes.forEach(table => {
         if (isTourDateContext || isJobOverrideMode) {

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -534,6 +534,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                     <div className="relative">
                       <input
                         type="file"
+                        multiple
                         onChange={handleDocumentUpload}
                         className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-10"
                         disabled={isUploadingDocument}
@@ -545,7 +546,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                             Subiendo...
                           </>
                         ) : (
-                          "Elegir Archivo"
+                          "Elegir Archivo(s)"
                         )}
                       </Button>
                     </div>

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -35,6 +35,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { FestivalManagementVm } from "@/features/festival-management/types";
 import type { Department } from "@/types/department";
+import { DOCUMENT_UPLOAD_ACCEPT } from "@/utils/documentUploadValidation";
 import { canSubmitTechnicianIncidentReports, isDepartmentManagementRole, isManagementRole } from "@/utils/permissions";
 
 import { FestivalManagementDialogs } from "./FestivalManagementDialogs";
@@ -535,6 +536,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                       <input
                         type="file"
                         multiple
+                        accept={DOCUMENT_UPLOAD_ACCEPT}
                         onChange={handleDocumentUpload}
                         className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-10"
                         disabled={isUploadingDocument}

--- a/src/utils/__tests__/pdfExport.test.ts
+++ b/src/utils/__tests__/pdfExport.test.ts
@@ -98,6 +98,7 @@ describe('exportToPDF', () => {
       pdf,
       expect.objectContaining({
         head: [['Truss', 'Motores', 'Peso Total (kg)']],
+        body: [['Main PA', '2', '250.00']],
       })
     );
   });

--- a/src/utils/__tests__/pdfExport.test.ts
+++ b/src/utils/__tests__/pdfExport.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pdfMocks = vi.hoisted(() => {
+  const autoTable = vi.fn();
+  const loadPdfLibs = vi.fn();
+
+  return { autoTable, loadPdfLibs };
+});
+
+vi.mock('@/utils/pdf/lazyPdf', () => ({
+  loadPdfLibs: pdfMocks.loadPdfLibs,
+}));
+
+vi.mock('@/utils/pdf/powerStagePlotPdf', () => ({
+  drawPowerStagePlot: vi.fn((_doc, _plot, options) => options.startY + 10),
+}));
+
+import { exportToPDF } from '@/utils/pdfExport';
+
+type MockPdf = ReturnType<typeof makePdf>;
+
+const makePdf = () => {
+  const pdf = {
+    internal: {
+      pageSize: {
+        width: 210,
+        height: 297,
+      },
+      pages: [null, {}],
+    },
+    addImage: vi.fn(),
+    addPage: vi.fn(() => {
+      pdf.internal.pages.push({});
+    }),
+    output: vi.fn(() => new Blob(['pdf'], { type: 'application/pdf' })),
+    rect: vi.fn(),
+    setFillColor: vi.fn(),
+    setFont: vi.fn(),
+    setFontSize: vi.fn(),
+    setPage: vi.fn(),
+    setTextColor: vi.fn(),
+    text: vi.fn(),
+    lastAutoTable: {
+      finalY: 80,
+    },
+  };
+
+  return pdf;
+};
+
+class FailingImage {
+  crossOrigin = '';
+  height = 1;
+  width = 1;
+  onerror: (() => void) | null = null;
+  onload: (() => void) | null = null;
+
+  set src(_value: string) {
+    queueMicrotask(() => this.onerror?.());
+  }
+}
+
+describe('exportToPDF', () => {
+  let pdf: MockPdf;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pdf = makePdf();
+    vi.stubGlobal('Image', FailingImage);
+    pdfMocks.loadPdfLibs.mockResolvedValue({
+      jsPDF: vi.fn(() => pdf),
+      autoTable: pdfMocks.autoTable,
+    });
+    pdfMocks.autoTable.mockImplementation((doc, options) => {
+      doc.lastAutoTable = { finalY: (options.startY || 70) + 20 };
+      options.didDrawPage?.({ cursor: { y: doc.lastAutoTable.finalY } });
+    });
+  });
+
+  it('labels weight summary rigging points as motors', async () => {
+    await exportToPDF(
+      'Peso XL',
+      [
+        {
+          name: 'Main PA',
+          rows: [],
+          totalWeight: 250,
+          riggingPoint: 'SX01, SX02',
+          toolType: 'pesos',
+        },
+      ],
+      'weight',
+      'Tour',
+      '2026-07-10'
+    );
+
+    expect(pdfMocks.autoTable).toHaveBeenCalledWith(
+      pdf,
+      expect.objectContaining({
+        head: [['Truss', 'Motores', 'Peso Total (kg)']],
+      })
+    );
+  });
+
+  it('prints the FOH schuko note on power summaries when requested', async () => {
+    await exportToPDF(
+      'Potencia XL',
+      [
+        {
+          name: 'FoH',
+          rows: [
+            {
+              quantity: '1',
+              componentName: 'Control',
+              watts: '100',
+              totalWatts: 100,
+            },
+          ],
+          totalWatts: 100,
+          currentPerPhase: 1,
+          pduType: 'Schuko 16A',
+          position: 'FOH',
+          toolType: 'consumos',
+        },
+      ],
+      'power',
+      'Tour',
+      '2026-07-10',
+      undefined,
+      { totalSystemWatts: 100, totalSystemAmps: 1, totalSystemKva: 0.1 },
+      0,
+      undefined,
+      true
+    );
+
+    expect(pdf.text).toHaveBeenCalledWith(
+      expect.stringContaining('formato schuko hembra'),
+      14,
+      expect.any(Number)
+    );
+  });
+});

--- a/src/utils/__tests__/tourDefaultDocumentSync.test.ts
+++ b/src/utils/__tests__/tourDefaultDocumentSync.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTourDefaultDocumentPlan,
+  getTourDefaultDocumentObjectPath,
+  type TourDefaultDocumentSyncData,
+} from "@/utils/tourDefaultDocumentSync";
+
+const baseDate = {
+  created_at: "2026-06-01T00:00:00Z",
+  date: "2026-07-10",
+  end_date: "2026-07-10",
+  flex_folders_created: false,
+  id: "date-1",
+  is_tour_pack_only: null,
+  lights_default_set_id: null,
+  lights_package_size: null,
+  location_id: "loc-1",
+  rehearsal_days: 1,
+  sound_default_set_id: null,
+  sound_package_size: "s" as const,
+  start_date: "2026-07-10",
+  tour_date_type: "show" as const,
+  tour_id: "tour-1",
+  video_default_set_id: null,
+  video_package_size: null,
+  locations: { name: "Madrid" },
+};
+
+const buildSet = (overrides: Partial<TourDefaultDocumentSyncData["defaultSets"][number]>) => ({
+  created_at: "2026-06-01T00:00:00Z",
+  department: "sound",
+  description: null,
+  id: "set-s",
+  name: "Small",
+  package_size: "s" as const,
+  tour_id: "tour-1",
+  updated_at: "2026-06-01T00:00:00Z",
+  ...overrides,
+});
+
+const buildTable = (
+  overrides: Partial<TourDefaultDocumentSyncData["defaultTables"][number]>
+) => ({
+  created_at: "2026-06-01T00:00:00Z",
+  id: "table-1",
+  metadata: { order_index: 0 },
+  set_id: "set-s",
+  table_data: {
+    rows: [{ quantity: "1", componentName: "K1", weight: "106", totalWeight: 106 }],
+  },
+  table_name: "Main PA",
+  table_type: "weight",
+  total_value: 106,
+  updated_at: "2026-06-01T00:00:00Z",
+  ...overrides,
+});
+
+const buildData = (
+  overrides: Partial<TourDefaultDocumentSyncData> = {}
+): TourDefaultDocumentSyncData => ({
+  tour: { id: "tour-1", name: "Enterprise Tour" },
+  tourDates: [baseDate],
+  defaultSets: [buildSet({})],
+  defaultTables: [buildTable({})],
+  powerOverrides: [],
+  weightOverrides: [],
+  ...overrides,
+});
+
+describe("tour default document sync planning", () => {
+  it("uploads the resolved package PDF and cleans unrelated date/dept/type slots", () => {
+    const plan = buildTourDefaultDocumentPlan(buildData());
+
+    const soundWeightUpload = plan.find(
+      (item) =>
+        item.action === "upload" &&
+        item.department === "sound" &&
+        item.type === "weight"
+    );
+    expect(soundWeightUpload).toMatchObject({
+      action: "upload",
+      objectPath: "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight.pdf",
+      fileName: "Enterprise Tour - 2026-07-10 - Madrid - Sound S - Small peso.pdf",
+    });
+
+    expect(
+      plan.some(
+        (item) =>
+          item.action === "cleanup" &&
+          item.department === "sound" &&
+          item.type === "power" &&
+          item.reason === "no_tables"
+      )
+    ).toBe(true);
+    expect(plan).toHaveLength(6);
+  });
+
+  it("keeps the same object path when a date switches package size", () => {
+    const sPlan = buildTourDefaultDocumentPlan(buildData());
+    const mPlan = buildTourDefaultDocumentPlan(
+      buildData({
+        tourDates: [{ ...baseDate, sound_package_size: "m" }],
+        defaultSets: [buildSet({ id: "set-m", name: "Medium", package_size: "m" })],
+        defaultTables: [buildTable({ id: "table-m", set_id: "set-m" })],
+      })
+    );
+
+    const sUpload = sPlan.find(
+      (item) => item.action === "upload" && item.department === "sound" && item.type === "weight"
+    );
+    const mUpload = mPlan.find(
+      (item) => item.action === "upload" && item.department === "sound" && item.type === "weight"
+    );
+
+    expect(sUpload?.objectPath).toBe(mUpload?.objectPath);
+    expect(sUpload?.fileName).toContain("Sound S - Small");
+    expect(mUpload?.fileName).toContain("Sound M - Medium");
+  });
+
+  it("cleans the stable slot instead of leaving stale files when package resolution is ambiguous", () => {
+    const plan = buildTourDefaultDocumentPlan(
+      buildData({
+        defaultSets: [
+          buildSet({ id: "set-s-a", name: "Small A" }),
+          buildSet({ id: "set-s-b", name: "Small B" }),
+        ],
+        defaultTables: [
+          buildTable({ id: "table-a", set_id: "set-s-a" }),
+          buildTable({ id: "table-b", set_id: "set-s-b" }),
+        ],
+      })
+    );
+
+    expect(
+      plan.find(
+        (item) =>
+          item.action === "cleanup" &&
+          item.department === "sound" &&
+          item.type === "weight"
+      )
+    ).toMatchObject({
+      objectPath: getTourDefaultDocumentObjectPath({
+        tourId: "tour-1",
+        tourDateId: "date-1",
+        department: "sound",
+        type: "weight",
+      }),
+      reason: "ambiguous_default_set",
+    });
+  });
+
+  it("cleans the stable slot when a resolved set has no tables for that PDF type", () => {
+    const plan = buildTourDefaultDocumentPlan(buildData({ defaultTables: [] }));
+
+    expect(
+      plan.find(
+        (item) =>
+          item.action === "cleanup" &&
+          item.department === "sound" &&
+          item.type === "weight"
+      )
+    ).toMatchObject({
+      reason: "no_tables",
+      objectPath: "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight.pdf",
+    });
+  });
+});

--- a/src/utils/__tests__/tourDefaultDocumentSync.test.ts
+++ b/src/utils/__tests__/tourDefaultDocumentSync.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from "vitest";
 import {
   buildTourDefaultDocumentPlan,
   getTourDefaultDocumentObjectPath,
+  type TourDefaultDocumentPlanItem,
   type TourDefaultDocumentSyncData,
 } from "@/utils/tourDefaultDocumentSync";
 
-const baseDate = {
+type SyncTourDate = TourDefaultDocumentSyncData["tourDates"][number];
+type SyncDefaultSet = TourDefaultDocumentSyncData["defaultSets"][number];
+type SyncDefaultTable = TourDefaultDocumentSyncData["defaultTables"][number];
+type UploadPlanItem = Extract<TourDefaultDocumentPlanItem, { action: "upload" }>;
+
+const baseDate: SyncTourDate = {
   created_at: "2026-06-01T00:00:00Z",
   date: "2026-07-10",
   end_date: "2026-07-10",
@@ -26,7 +32,7 @@ const baseDate = {
   locations: { name: "Madrid" },
 };
 
-const buildSet = (overrides: Partial<TourDefaultDocumentSyncData["defaultSets"][number]>) => ({
+const buildSet = (overrides: Partial<SyncDefaultSet>): SyncDefaultSet => ({
   created_at: "2026-06-01T00:00:00Z",
   department: "sound",
   description: null,
@@ -39,8 +45,8 @@ const buildSet = (overrides: Partial<TourDefaultDocumentSyncData["defaultSets"][
 });
 
 const buildTable = (
-  overrides: Partial<TourDefaultDocumentSyncData["defaultTables"][number]>
-) => ({
+  overrides: Partial<SyncDefaultTable>
+): SyncDefaultTable => ({
   created_at: "2026-06-01T00:00:00Z",
   id: "table-1",
   metadata: { order_index: 0 },
@@ -54,6 +60,20 @@ const buildTable = (
   updated_at: "2026-06-01T00:00:00Z",
   ...overrides,
 });
+
+const findUploadPlanItem = (
+  plan: TourDefaultDocumentPlanItem[],
+  department: UploadPlanItem["department"] = "sound",
+  type: UploadPlanItem["type"] = "weight"
+): UploadPlanItem | undefined => {
+  const item = plan.find(
+    (candidate) =>
+      candidate.action === "upload" &&
+      candidate.department === department &&
+      candidate.type === type
+  );
+  return item?.action === "upload" ? item : undefined;
+};
 
 const buildData = (
   overrides: Partial<TourDefaultDocumentSyncData> = {}
@@ -71,12 +91,7 @@ describe("tour default document sync planning", () => {
   it("uploads the resolved package PDF and cleans unrelated date/dept/type slots", () => {
     const plan = buildTourDefaultDocumentPlan(buildData());
 
-    const soundWeightUpload = plan.find(
-      (item) =>
-        item.action === "upload" &&
-        item.department === "sound" &&
-        item.type === "weight"
-    );
+    const soundWeightUpload = findUploadPlanItem(plan);
     expect(soundWeightUpload).toMatchObject({
       action: "upload",
       objectPath: "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight.pdf",
@@ -105,12 +120,8 @@ describe("tour default document sync planning", () => {
       })
     );
 
-    const sUpload = sPlan.find(
-      (item) => item.action === "upload" && item.department === "sound" && item.type === "weight"
-    );
-    const mUpload = mPlan.find(
-      (item) => item.action === "upload" && item.department === "sound" && item.type === "weight"
-    );
+    const sUpload = findUploadPlanItem(sPlan);
+    const mUpload = findUploadPlanItem(mPlan);
 
     expect(sUpload?.objectPath).toBe(mUpload?.objectPath);
     expect(sUpload?.fileName).toContain("Sound S - Small");

--- a/src/utils/__tests__/tourDefaultDocumentSync.test.ts
+++ b/src/utils/__tests__/tourDefaultDocumentSync.test.ts
@@ -128,6 +128,36 @@ describe("tour default document sync planning", () => {
     expect(mUpload?.fileName).toContain("Sound M - Medium");
   });
 
+  it("uses the current package size when a date still has a stale explicit default set id", () => {
+    const plan = buildTourDefaultDocumentPlan(
+      buildData({
+        tourDates: [
+          {
+            ...baseDate,
+            sound_package_size: "xl",
+            sound_default_set_id: "set-l",
+          },
+        ],
+        defaultSets: [
+          buildSet({ id: "set-l", name: "Large", package_size: "l" }),
+          buildSet({ id: "set-xl", name: "Extra Large", package_size: "xl" }),
+        ],
+        defaultTables: [
+          buildTable({ id: "table-l", set_id: "set-l" }),
+          buildTable({ id: "table-xl", set_id: "set-xl" }),
+        ],
+      })
+    );
+
+    const soundWeightUpload = findUploadPlanItem(plan);
+
+    expect(soundWeightUpload).toMatchObject({
+      action: "upload",
+      objectPath: "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight.pdf",
+      fileName: "Enterprise Tour - 2026-07-10 - Madrid - Sound XL - Extra Large peso.pdf",
+    });
+  });
+
   it("cleans the stable slot instead of leaving stale files when package resolution is ambiguous", () => {
     const plan = buildTourDefaultDocumentPlan(
       buildData({

--- a/src/utils/__tests__/tourPowerTables.test.ts
+++ b/src/utils/__tests__/tourPowerTables.test.ts
@@ -84,6 +84,29 @@ describe('tourPowerTables', () => {
     expect(normalized.totalVa).toBe(1200);
   });
 
+  it('preserves the persisted FOH schuko flag on normalized tour default tables', () => {
+    const normalized = normalizeTourDefaultPowerTable(
+      {
+        id: 'default-foh',
+        set_id: 'set-1',
+        table_name: 'FoH',
+        table_type: 'power',
+        total_value: 950,
+        metadata: {
+          current_per_phase: 5,
+          pdu_type: '32A',
+          foh_schuko: true,
+        },
+        table_data: { rows: [] },
+        created_at: '2026-04-08T10:00:00.000Z',
+        updated_at: '2026-04-08T10:00:00.000Z',
+      } as any,
+      'sound'
+    );
+
+    expect(normalized.fohSchukoRequired).toBe(true);
+  });
+
   it('normalizes custom positions from legacy defaults and overrides', () => {
     const legacy = normalizeLegacyTourPowerDefault(
       {

--- a/src/utils/documentUploadValidation.ts
+++ b/src/utils/documentUploadValidation.ts
@@ -1,0 +1,14 @@
+import { validateFileUpload } from "@/lib/enhanced-security-config";
+
+export const DOCUMENT_UPLOAD_ACCEPT = ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.txt";
+
+export const getDocumentUploadValidationError = (files: File[]) => {
+  for (const file of files) {
+    const validation = validateFileUpload(file);
+    if (!validation.isValid) {
+      return `${file.name}: ${validation.errors.join(", ")}`;
+    }
+  }
+
+  return null;
+};

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -47,6 +47,16 @@ export interface SummaryRow {
   clusterWeight: number;
 }
 
+const getMotorCountLabel = (table: ExportTable) => {
+  if (table.riggingPoint) {
+    const motorCount = table.riggingPoint.split(',').filter((point) => point.trim().length > 0).length;
+    if (motorCount > 0) return String(motorCount);
+  }
+
+  if (table.dualMotors) return '2';
+  return table.totalWeight && table.totalWeight > 0 ? '1' : 'N/A';
+};
+
 export const exportToPDF = async (
   projectName: string,
   tables: ExportTable[],
@@ -324,7 +334,7 @@ export const exportToPDF = async (
       if (type === 'weight') {
         generatedSummaryRows = tables.map((table) => ({
           clusterName: table.name,
-          riggingPoints: table.riggingPoint || 'N/A',
+          riggingPoints: getMotorCountLabel(table),
           clusterWeight: table.totalWeight || 0
         }));
       }
@@ -463,10 +473,9 @@ export const exportToPDF = async (
           yPosition += 6;
 
           const summaryData = finalSummaryRows.map((row) => [row.clusterName, row.riggingPoints, row.clusterWeight.toFixed(2)]);
-          const riggingColumnLabel = type === 'weight' ? 'Motores' : 'Puntos de Montaje';
 
           autoTable(doc, {
-            head: [['Truss', riggingColumnLabel, 'Peso Total (kg)']],
+            head: [['Truss', 'Motores', 'Peso Total (kg)']],
             body: summaryData,
             startY: yPosition,
             theme: 'grid',

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -463,9 +463,10 @@ export const exportToPDF = async (
           yPosition += 6;
 
           const summaryData = finalSummaryRows.map((row) => [row.clusterName, row.riggingPoints, row.clusterWeight.toFixed(2)]);
+          const riggingColumnLabel = type === 'weight' ? 'Motores' : 'Puntos de Montaje';
 
           autoTable(doc, {
-            head: [['Truss', 'Puntos de Montaje', 'Peso Total (kg)']],
+            head: [['Truss', riggingColumnLabel, 'Peso Total (kg)']],
             body: summaryData,
             startY: yPosition,
             theme: 'grid',

--- a/src/utils/tourDefaultDocumentSync.ts
+++ b/src/utils/tourDefaultDocumentSync.ts
@@ -1,8 +1,9 @@
-import { supabase } from "@/lib/supabase";
+import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
 import { exportToPDF } from "@/utils/pdfExport";
 import { fetchTourLogo } from "@/utils/pdf/logoUtils";
 import { getDepartmentLabel } from "@/types/department";
+import { toJobTimezone } from "@/utils/timezoneUtils";
 import {
   PACKAGE_DEPARTMENTS,
   getPackageSetLabel,
@@ -193,7 +194,7 @@ const sortTourDefaultTables = (tables: TourDefaultTableRow[]) =>
     const leftOrder = getNumber(getRecord(left.metadata).order_index) ?? 999;
     const rightOrder = getNumber(getRecord(right.metadata).order_index) ?? 999;
     if (leftOrder !== rightOrder) return leftOrder - rightOrder;
-    return new Date(left.created_at).getTime() - new Date(right.created_at).getTime();
+    return toJobTimezone(left.created_at).getTime() - toJobTimezone(right.created_at).getTime();
   });
 
 const getTableRiggingPoint = (metadata: unknown) => {
@@ -206,7 +207,7 @@ const buildWeightPdfTables = (item: Extract<TourDefaultDocumentPlanItem, { actio
     return item.weightOverrides.map((override): PdfTable => ({
       name: override.item_name || "Anulación",
       rows: getRowsFromJson(override.override_data),
-      totalWeight: (override.weight_kg || 0) * (override.quantity || 1),
+      totalWeight: (override.weight_kg ?? 0) * (override.quantity ?? 1),
       toolType: "pesos",
     }));
   }
@@ -527,7 +528,11 @@ const cleanupTourDefaultDocument = async ({
   tourId: string;
   objectPath: string;
 }) => {
-  await client.storage.from(TOUR_DOCUMENTS_BUCKET).remove([objectPath]).catch(() => {});
+  const { error: storageError } = await client.storage
+    .from(TOUR_DOCUMENTS_BUCKET)
+    .remove([objectPath]);
+
+  if (storageError) throw storageError;
 
   const { error } = await client
     .from("tour_documents")
@@ -600,7 +605,17 @@ const uploadTourDefaultDocument = async ({
     visible_to_guest: false,
   });
 
-  if (insertError) throw insertError;
+  if (insertError) {
+    const { error: cleanupError } = await client.storage
+      .from(TOUR_DOCUMENTS_BUCKET)
+      .remove([objectPath]);
+
+    if (cleanupError) {
+      console.error("Error removing uploaded tour default document after insert failure:", cleanupError);
+    }
+
+    throw insertError;
+  }
 };
 
 const generateTourDefaultDocumentPdf = async ({

--- a/src/utils/tourDefaultDocumentSync.ts
+++ b/src/utils/tourDefaultDocumentSync.ts
@@ -254,7 +254,7 @@ const buildPowerPdfPayload = (
 
   const fohSchukoRequired =
     (item.department === "sound" || item.department === "lights") &&
-    item.defaultTables.some((table) => getBoolean(getRecord(table.metadata).foh_schuko));
+    tables.some((table) => table.fohSchukoRequired);
 
   return {
     tables: tables as PdfTables,

--- a/src/utils/tourDefaultDocumentSync.ts
+++ b/src/utils/tourDefaultDocumentSync.ts
@@ -203,8 +203,7 @@ const getTableRiggingPoint = (metadata: unknown) => {
 
 const buildWeightPdfTables = (item: Extract<TourDefaultDocumentPlanItem, { action: "upload" }>): PdfTables => {
   if (item.weightOverrides.length > 0) {
-    return item.weightOverrides.map((override, index): PdfTable => ({
-      id: index + 1,
+    return item.weightOverrides.map((override): PdfTable => ({
       name: override.item_name || "Anulación",
       rows: getRowsFromJson(override.override_data),
       totalWeight: (override.weight_kg || 0) * (override.quantity || 1),
@@ -212,8 +211,7 @@ const buildWeightPdfTables = (item: Extract<TourDefaultDocumentPlanItem, { actio
     }));
   }
 
-  return sortTourDefaultTables(item.defaultTables).map((defaultTable, index): PdfTable => ({
-    id: index + 1,
+  return sortTourDefaultTables(item.defaultTables).map((defaultTable): PdfTable => ({
     name: defaultTable.table_name || "Unnamed",
     rows: getRowsFromJson(defaultTable.table_data),
     totalWeight: defaultTable.total_value || 0,

--- a/src/utils/tourDefaultDocumentSync.ts
+++ b/src/utils/tourDefaultDocumentSync.ts
@@ -1,0 +1,704 @@
+import { supabase } from "@/lib/supabase";
+import type { Database } from "@/integrations/supabase/types";
+import { exportToPDF } from "@/utils/pdfExport";
+import { fetchTourLogo } from "@/utils/pdf/logoUtils";
+import { getDepartmentLabel } from "@/types/department";
+import {
+  PACKAGE_DEPARTMENTS,
+  getPackageSetLabel,
+  resolveDefaultSetForTourDate,
+  type PackageDepartment,
+} from "@/utils/tourPackages";
+import { buildNormalizedTourPowerTables } from "@/utils/tourPowerTables";
+
+const TOUR_DOCUMENTS_BUCKET = "tour-documents";
+const AUTO_DEFAULT_DOCUMENT_ROOT = "auto-generated/default-pdfs";
+const TOUR_DEFAULT_DOCUMENT_TYPES = ["power", "weight"] as const;
+const UNKNOWN_LOCATION_LABEL = "Ubicación desconocida";
+
+type Tables = Database["public"]["Tables"];
+type TourRow = Pick<Tables["tours"]["Row"], "id" | "name">;
+type TourDateRow = Tables["tour_dates"]["Row"] & {
+  locations?: { name: string | null } | Array<{ name: string | null }> | null;
+  location?: { name: string | null } | Array<{ name: string | null }> | null;
+};
+type TourDefaultSetRow = Tables["tour_default_sets"]["Row"];
+type TourDefaultTableRow = Tables["tour_default_tables"]["Row"];
+type TourDatePowerOverrideRow = Tables["tour_date_power_overrides"]["Row"];
+type TourDateWeightOverrideRow = Tables["tour_date_weight_overrides"]["Row"];
+type TourDefaultDocumentType = (typeof TOUR_DEFAULT_DOCUMENT_TYPES)[number];
+type JsonRecord = Record<string, unknown>;
+type PdfTables = Parameters<typeof exportToPDF>[1];
+type PdfTable = PdfTables[number];
+type PdfTableRow = PdfTable["rows"][number];
+
+type SupabaseClientLike = typeof supabase;
+
+export interface TourDefaultDocumentSyncData {
+  tour: TourRow;
+  tourDates: TourDateRow[];
+  defaultSets: TourDefaultSetRow[];
+  defaultTables: TourDefaultTableRow[];
+  powerOverrides?: TourDatePowerOverrideRow[];
+  weightOverrides?: TourDateWeightOverrideRow[];
+}
+
+export type TourDefaultDocumentPlanItem =
+  | {
+      action: "upload";
+      tour: TourRow;
+      tourDate: TourDateRow;
+      department: PackageDepartment;
+      type: TourDefaultDocumentType;
+      defaultSet: TourDefaultSetRow;
+      defaultTables: TourDefaultTableRow[];
+      powerOverrides: TourDatePowerOverrideRow[];
+      weightOverrides: TourDateWeightOverrideRow[];
+      packageLabel: string;
+      objectPath: string;
+      fileName: string;
+      title: string;
+      jobName: string;
+      jobDate: string;
+    }
+  | {
+      action: "cleanup";
+      tourDate: TourDateRow;
+      department: PackageDepartment;
+      type: TourDefaultDocumentType;
+      objectPath: string;
+      reason: "missing_default_set" | "ambiguous_default_set" | "invalid_default_set" | "no_tables";
+    };
+
+export interface SyncTourDefaultDocumentsResult {
+  uploaded: number;
+  removed: number;
+  skipped: number;
+  errors: Array<{
+    objectPath: string;
+    message: string;
+  }>;
+}
+
+export interface SyncTourDefaultDocumentsOptions {
+  tourId: string;
+  tourDateIds?: string[];
+  client?: SupabaseClientLike;
+  logoUrl?: string;
+  fetchLogo?: (tourId: string) => Promise<string | undefined>;
+  exportPdf?: typeof exportToPDF;
+}
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const getString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0 ? value : undefined;
+
+const getBoolean = (value: unknown): boolean | undefined =>
+  typeof value === "boolean" ? value : undefined;
+
+const getRecord = (value: unknown): JsonRecord =>
+  isRecord(value) ? value : {};
+
+const getRowsFromJson = (value: unknown): PdfTableRow[] => {
+  if (!isRecord(value)) return [];
+
+  if (Array.isArray(value.rows)) {
+    return value.rows.filter(isRecord) as PdfTableRow[];
+  }
+
+  if (isRecord(value.tableData) && Array.isArray(value.tableData.rows)) {
+    return value.tableData.rows.filter(isRecord) as PdfTableRow[];
+  }
+
+  return [];
+};
+
+const getSafetyMarginFromJson = (value: unknown): number => {
+  if (!isRecord(value)) return 0;
+  const direct = getNumber(value.safetyMargin);
+  if (direct !== undefined) return direct;
+  return isRecord(value.tableData) ? getNumber(value.tableData.safetyMargin) ?? 0 : 0;
+};
+
+const getTourDateLocationName = (tourDate: TourDateRow): string => {
+  const locationSource = tourDate.locations ?? tourDate.location;
+  const location = Array.isArray(locationSource) ? locationSource[0] : locationSource;
+  return location?.name || UNKNOWN_LOCATION_LABEL;
+};
+
+const getPdfTypeLabel = (type: TourDefaultDocumentType) =>
+  type === "power" ? "potencia" : "peso";
+
+const cleanDisplayFilePart = (value: string): string =>
+  value.replace(/[\\/\r\n]+/g, " ").replace(/\s+/g, " ").trim();
+
+export const getTourDefaultDocumentObjectPath = ({
+  tourId,
+  tourDateId,
+  department,
+  type,
+}: {
+  tourId: string;
+  tourDateId: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+}) =>
+  `tours/${tourId}/${AUTO_DEFAULT_DOCUMENT_ROOT}/${tourDateId}/${department}-${type}.pdf`;
+
+export const getTourDefaultDocumentFileName = ({
+  tourName,
+  date,
+  locationName,
+  department,
+  type,
+  packageLabel,
+}: {
+  tourName: string;
+  date: string;
+  locationName: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+  packageLabel?: string;
+}) =>
+  cleanDisplayFilePart(
+    `${tourName} - ${date} - ${locationName} - ${
+      packageLabel || getDepartmentLabel(department)
+    } ${getPdfTypeLabel(type)}.pdf`
+  );
+
+const getTourDefaultDocumentTitle = ({
+  tourName,
+  locationName,
+  department,
+  type,
+  packageLabel,
+}: {
+  tourName: string;
+  locationName: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+  packageLabel?: string;
+}) =>
+  `${tourName} - ${locationName} - ${
+    packageLabel || getDepartmentLabel(department)
+  } ${getPdfTypeLabel(type)}`;
+
+const sortTourDefaultTables = (tables: TourDefaultTableRow[]) =>
+  [...tables].sort((left, right) => {
+    const leftOrder = getNumber(getRecord(left.metadata).order_index) ?? 999;
+    const rightOrder = getNumber(getRecord(right.metadata).order_index) ?? 999;
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+    return new Date(left.created_at).getTime() - new Date(right.created_at).getTime();
+  });
+
+const getTableRiggingPoint = (metadata: unknown) => {
+  const record = getRecord(metadata);
+  return getString(record.riggingPoint) || getString(record.riggingPoints);
+};
+
+const buildWeightPdfTables = (item: Extract<TourDefaultDocumentPlanItem, { action: "upload" }>): PdfTables => {
+  if (item.weightOverrides.length > 0) {
+    return item.weightOverrides.map((override, index): PdfTable => ({
+      id: index + 1,
+      name: override.item_name || "Anulación",
+      rows: getRowsFromJson(override.override_data),
+      totalWeight: (override.weight_kg || 0) * (override.quantity || 1),
+      toolType: "pesos",
+    }));
+  }
+
+  return sortTourDefaultTables(item.defaultTables).map((defaultTable, index): PdfTable => ({
+    id: index + 1,
+    name: defaultTable.table_name || "Unnamed",
+    rows: getRowsFromJson(defaultTable.table_data),
+    totalWeight: defaultTable.total_value || 0,
+    dualMotors: getBoolean(getRecord(defaultTable.metadata).dualMotors) || false,
+    riggingPoint: getTableRiggingPoint(defaultTable.metadata),
+    toolType: "pesos",
+  }));
+};
+
+const buildWeightSafetyMargin = (
+  item: Extract<TourDefaultDocumentPlanItem, { action: "upload" }>
+): number => {
+  if (item.weightOverrides.length > 0) {
+    return getSafetyMarginFromJson(item.weightOverrides[0]?.override_data);
+  }
+
+  const firstDefault = sortTourDefaultTables(item.defaultTables)[0];
+  if (!firstDefault) return 0;
+  const metadataMargin = getNumber(getRecord(firstDefault.metadata).safetyMargin);
+  return metadataMargin ?? getSafetyMarginFromJson(firstDefault.table_data);
+};
+
+const buildPowerPdfPayload = (
+  item: Extract<TourDefaultDocumentPlanItem, { action: "upload" }>
+) => {
+  const { tables, safetyMargin } = buildNormalizedTourPowerTables({
+    department: item.department,
+    overrides: item.powerOverrides,
+    defaultTables: item.defaultTables,
+  });
+
+  const powerSummary = {
+    totalSystemWatts: tables.reduce((sum, table) => sum + (table.totalWatts || 0), 0),
+    totalSystemAmps: tables.reduce((sum, table) => sum + (table.currentPerPhase || 0), 0),
+    totalSystemKva:
+      tables.reduce((sum, table) => sum + (table.totalVa || table.totalWatts || 0), 0) /
+      1000,
+  };
+
+  const fohSchukoRequired =
+    (item.department === "sound" || item.department === "lights") &&
+    item.defaultTables.some((table) => getBoolean(getRecord(table.metadata).foh_schuko));
+
+  return {
+    tables: tables as PdfTables,
+    powerSummary,
+    safetyMargin,
+    fohSchukoRequired,
+  };
+};
+
+const buildUploadPlanItem = ({
+  tour,
+  tourDate,
+  department,
+  type,
+  defaultSet,
+  defaultTables,
+  powerOverrides,
+  weightOverrides,
+  packageLabel,
+}: {
+  tour: TourRow;
+  tourDate: TourDateRow;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+  defaultSet: TourDefaultSetRow;
+  defaultTables: TourDefaultTableRow[];
+  powerOverrides: TourDatePowerOverrideRow[];
+  weightOverrides: TourDateWeightOverrideRow[];
+  packageLabel: string;
+}): Extract<TourDefaultDocumentPlanItem, { action: "upload" }> => {
+  const locationName = getTourDateLocationName(tourDate);
+  const jobDate = tourDate.date || tourDate.start_date;
+
+  return {
+    action: "upload",
+    tour,
+    tourDate,
+    department,
+    type,
+    defaultSet,
+    defaultTables,
+    powerOverrides,
+    weightOverrides,
+    packageLabel,
+    objectPath: getTourDefaultDocumentObjectPath({
+      tourId: tour.id,
+      tourDateId: tourDate.id,
+      department,
+      type,
+    }),
+    fileName: getTourDefaultDocumentFileName({
+      tourName: tour.name,
+      date: jobDate,
+      locationName,
+      department,
+      type,
+      packageLabel,
+    }),
+    title: getTourDefaultDocumentTitle({
+      tourName: tour.name,
+      locationName,
+      department,
+      type,
+      packageLabel,
+    }),
+    jobName: `${tour.name} - ${locationName}`,
+    jobDate,
+  };
+};
+
+export const buildTourDefaultDocumentPlan = ({
+  tour,
+  tourDates,
+  defaultSets,
+  defaultTables,
+  powerOverrides = [],
+  weightOverrides = [],
+}: TourDefaultDocumentSyncData): TourDefaultDocumentPlanItem[] => {
+  const plan: TourDefaultDocumentPlanItem[] = [];
+
+  for (const tourDate of tourDates) {
+    for (const department of PACKAGE_DEPARTMENTS) {
+      const resolution = resolveDefaultSetForTourDate({
+        tourDate,
+        department,
+        defaultSets,
+      });
+
+      for (const type of TOUR_DEFAULT_DOCUMENT_TYPES) {
+        const objectPath = getTourDefaultDocumentObjectPath({
+          tourId: tour.id,
+          tourDateId: tourDate.id,
+          department,
+          type,
+        });
+
+        if (resolution.status !== "resolved") {
+          plan.push({
+            action: "cleanup",
+            tourDate,
+            department,
+            type,
+            objectPath,
+            reason:
+              resolution.status === "ambiguous"
+                ? "ambiguous_default_set"
+                : resolution.status === "invalid_explicit"
+                  ? "invalid_default_set"
+                  : "missing_default_set",
+          });
+          continue;
+        }
+
+        const tablesForType = defaultTables.filter(
+          (table) => table.set_id === resolution.set.id && table.table_type === type
+        );
+        const powerOverridesForDate =
+          type === "power"
+            ? powerOverrides.filter(
+                (override) =>
+                  override.tour_date_id === tourDate.id && override.department === department
+              )
+            : [];
+        const weightOverridesForDate =
+          type === "weight"
+            ? weightOverrides.filter(
+                (override) =>
+                  override.tour_date_id === tourDate.id && override.department === department
+              )
+            : [];
+
+        if (
+          tablesForType.length === 0 &&
+          powerOverridesForDate.length === 0 &&
+          weightOverridesForDate.length === 0
+        ) {
+          plan.push({
+            action: "cleanup",
+            tourDate,
+            department,
+            type,
+            objectPath,
+            reason: "no_tables",
+          });
+          continue;
+        }
+
+        plan.push(
+          buildUploadPlanItem({
+            tour,
+            tourDate,
+            department,
+            type,
+            defaultSet: resolution.set,
+            defaultTables: tablesForType,
+            powerOverrides: powerOverridesForDate,
+            weightOverrides: weightOverridesForDate,
+            packageLabel: getPackageSetLabel(department, resolution.packageSize, resolution.set),
+          })
+        );
+      }
+    }
+  }
+
+  return plan;
+};
+
+const loadTourDefaultDocumentSyncData = async ({
+  client,
+  tourId,
+  tourDateIds,
+}: {
+  client: SupabaseClientLike;
+  tourId: string;
+  tourDateIds?: string[];
+}): Promise<TourDefaultDocumentSyncData> => {
+  const { data: tour, error: tourError } = await client
+    .from("tours")
+    .select("id, name")
+    .eq("id", tourId)
+    .single();
+
+  if (tourError) throw tourError;
+  if (!tour) throw new Error("Tour not found");
+
+  let datesQuery = client
+    .from("tour_dates")
+    .select(
+      `
+        id,
+        tour_id,
+        date,
+        start_date,
+        end_date,
+        is_tour_pack_only,
+        sound_package_size,
+        lights_package_size,
+        video_package_size,
+        sound_default_set_id,
+        lights_default_set_id,
+        video_default_set_id,
+        locations (
+          name
+        )
+      `
+    )
+    .eq("tour_id", tourId)
+    .order("date", { ascending: true });
+
+  if (tourDateIds?.length) {
+    datesQuery = datesQuery.in("id", tourDateIds);
+  }
+
+  const { data: tourDates, error: datesError } = await datesQuery;
+  if (datesError) throw datesError;
+
+  const { data: defaultSets, error: setsError } = await client
+    .from("tour_default_sets")
+    .select("*")
+    .eq("tour_id", tourId)
+    .order("created_at", { ascending: true });
+
+  if (setsError) throw setsError;
+
+  const setIds = (defaultSets || []).map((set) => set.id);
+  const dateIds = (tourDates || []).map((tourDate) => tourDate.id);
+
+  const [{ data: defaultTables, error: tablesError }, powerResult, weightResult] =
+    await Promise.all([
+      setIds.length
+        ? client
+            .from("tour_default_tables")
+            .select("*")
+            .in("set_id", setIds)
+            .order("created_at", { ascending: true })
+        : Promise.resolve({ data: [], error: null }),
+      dateIds.length
+        ? client
+            .from("tour_date_power_overrides")
+            .select("*")
+            .in("tour_date_id", dateIds)
+        : Promise.resolve({ data: [], error: null }),
+      dateIds.length
+        ? client
+            .from("tour_date_weight_overrides")
+            .select("*")
+            .in("tour_date_id", dateIds)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
+
+  if (tablesError) throw tablesError;
+  if (powerResult.error) throw powerResult.error;
+  if (weightResult.error) throw weightResult.error;
+
+  return {
+    tour: tour as TourRow,
+    tourDates: (tourDates || []) as TourDateRow[],
+    defaultSets: (defaultSets || []) as TourDefaultSetRow[],
+    defaultTables: (defaultTables || []) as TourDefaultTableRow[],
+    powerOverrides: (powerResult.data || []) as TourDatePowerOverrideRow[],
+    weightOverrides: (weightResult.data || []) as TourDateWeightOverrideRow[],
+  };
+};
+
+const cleanupTourDefaultDocument = async ({
+  client,
+  tourId,
+  objectPath,
+}: {
+  client: SupabaseClientLike;
+  tourId: string;
+  objectPath: string;
+}) => {
+  await client.storage.from(TOUR_DOCUMENTS_BUCKET).remove([objectPath]).catch(() => {});
+
+  const { error } = await client
+    .from("tour_documents")
+    .delete()
+    .eq("tour_id", tourId)
+    .eq("file_path", objectPath);
+
+  if (error) throw error;
+};
+
+export const cleanupTourDefaultDocumentsForDate = async ({
+  tourId,
+  tourDateId,
+  client = supabase,
+}: {
+  tourId: string;
+  tourDateId: string;
+  client?: SupabaseClientLike;
+}) => {
+  for (const department of PACKAGE_DEPARTMENTS) {
+    for (const type of TOUR_DEFAULT_DOCUMENT_TYPES) {
+      await cleanupTourDefaultDocument({
+        client,
+        tourId,
+        objectPath: getTourDefaultDocumentObjectPath({
+          tourId,
+          tourDateId,
+          department,
+          type,
+        }),
+      });
+    }
+  }
+};
+
+const uploadTourDefaultDocument = async ({
+  client,
+  tourId,
+  objectPath,
+  fileName,
+  pdfBlob,
+}: {
+  client: SupabaseClientLike;
+  tourId: string;
+  objectPath: string;
+  fileName: string;
+  pdfBlob: Blob;
+}) => {
+  await cleanupTourDefaultDocument({ client, tourId, objectPath });
+
+  const { error: uploadError } = await client.storage
+    .from(TOUR_DOCUMENTS_BUCKET)
+    .upload(objectPath, pdfBlob, {
+      cacheControl: "3600",
+      upsert: false,
+      contentType: "application/pdf",
+    });
+
+  if (uploadError) throw uploadError;
+
+  const { data: userResult } = await client.auth.getUser();
+  const { error: insertError } = await client.from("tour_documents").insert({
+    tour_id: tourId,
+    file_name: fileName,
+    file_path: objectPath,
+    file_type: "application/pdf",
+    file_size: pdfBlob.size,
+    uploaded_by: userResult?.user?.id || null,
+    visible_to_tech: true,
+    visible_to_guest: false,
+  });
+
+  if (insertError) throw insertError;
+};
+
+const generateTourDefaultDocumentPdf = async ({
+  item,
+  logoUrl,
+  exportPdf,
+}: {
+  item: Extract<TourDefaultDocumentPlanItem, { action: "upload" }>;
+  logoUrl?: string;
+  exportPdf: typeof exportToPDF;
+}) => {
+  if (item.type === "power") {
+    const { tables, powerSummary, safetyMargin, fohSchukoRequired } = buildPowerPdfPayload(item);
+    return exportPdf(
+      item.title,
+      tables,
+      item.type,
+      item.jobName,
+      item.jobDate,
+      undefined,
+      powerSummary,
+      safetyMargin,
+      logoUrl,
+      fohSchukoRequired
+    );
+  }
+
+  const tables = buildWeightPdfTables(item);
+  return exportPdf(
+    item.title,
+    tables,
+    item.type,
+    item.jobName,
+    item.jobDate,
+    undefined,
+    undefined,
+    buildWeightSafetyMargin(item),
+    logoUrl
+  );
+};
+
+export const syncTourDefaultDocuments = async ({
+  tourId,
+  tourDateIds,
+  client = supabase,
+  logoUrl,
+  fetchLogo = fetchTourLogo,
+  exportPdf = exportToPDF,
+}: SyncTourDefaultDocumentsOptions): Promise<SyncTourDefaultDocumentsResult> => {
+  const data = await loadTourDefaultDocumentSyncData({ client, tourId, tourDateIds });
+  const plan = buildTourDefaultDocumentPlan(data);
+  const result: SyncTourDefaultDocumentsResult = {
+    uploaded: 0,
+    removed: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  let resolvedLogoUrl = logoUrl;
+  if (resolvedLogoUrl === undefined) {
+    try {
+      resolvedLogoUrl = await fetchLogo(tourId);
+    } catch (error) {
+      console.error("Error fetching tour logo for default document sync:", error);
+    }
+  }
+
+  for (const item of plan) {
+    try {
+      if (item.action === "cleanup") {
+        await cleanupTourDefaultDocument({ client, tourId, objectPath: item.objectPath });
+        result.removed += 1;
+        if (item.reason !== "no_tables") result.skipped += 1;
+        continue;
+      }
+
+      const pdfBlob = await generateTourDefaultDocumentPdf({
+        item,
+        logoUrl: resolvedLogoUrl,
+        exportPdf,
+      });
+      await uploadTourDefaultDocument({
+        client,
+        tourId,
+        objectPath: item.objectPath,
+        fileName: item.fileName,
+        pdfBlob,
+      });
+      result.uploaded += 1;
+    } catch (error) {
+      result.errors.push({
+        objectPath: item.objectPath,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return result;
+};

--- a/src/utils/tourDefaultDocumentSync.ts
+++ b/src/utils/tourDefaultDocumentSync.ts
@@ -254,7 +254,8 @@ const buildPowerPdfPayload = (
 
   const fohSchukoRequired =
     (item.department === "sound" || item.department === "lights") &&
-    tables.some((table) => table.fohSchukoRequired);
+    (tables.some((table) => table.fohSchukoRequired) ||
+      item.defaultTables.some((table) => getBoolean(getRecord(table.metadata).foh_schuko) ?? false));
 
   return {
     tables: tables as PdfTables,

--- a/src/utils/tourPackages.ts
+++ b/src/utils/tourPackages.ts
@@ -166,6 +166,9 @@ export const resolveDefaultSetForTourDate = <TSet extends TourDefaultSetLike>({
   const explicitPackageSize = getExplicitDepartmentPackageSize(tourDate, department);
   const packageSize = getDepartmentPackageSize(tourDate, department);
   const explicitSetId = getDepartmentDefaultSetId(tourDate, department);
+  const departmentSets = defaultSets.filter(
+    (set) => setMatchesTour(tourDate, set) && setMatchesDepartment(set, department)
+  );
 
   if (explicitSetId) {
     const explicitSet = defaultSets.find((set) => set.id === explicitSetId);
@@ -206,6 +209,29 @@ export const resolveDefaultSetForTourDate = <TSet extends TourDefaultSetLike>({
       explicitSet.package_size &&
       explicitSet.package_size !== explicitPackageSize
     ) {
+      const packageMatches = departmentSets.filter(
+        (set) => set.package_size === explicitPackageSize
+      );
+
+      if (packageMatches.length === 1) {
+        return {
+          status: "resolved",
+          set: packageMatches[0],
+          source: "package_size",
+          packageSize,
+          department,
+        };
+      }
+
+      if (packageMatches.length > 1) {
+        return {
+          status: "ambiguous",
+          packageSize,
+          department,
+          matches: packageMatches,
+        };
+      }
+
       return {
         status: "invalid_explicit",
         packageSize,
@@ -224,10 +250,6 @@ export const resolveDefaultSetForTourDate = <TSet extends TourDefaultSetLike>({
       department,
     };
   }
-
-  const departmentSets = defaultSets.filter(
-    (set) => setMatchesTour(tourDate, set) && setMatchesDepartment(set, department)
-  );
 
   if (packageSize) {
     const matches = departmentSets.filter((set) => set.package_size === packageSize);

--- a/src/utils/tourPowerTables.ts
+++ b/src/utils/tourPowerTables.ts
@@ -25,6 +25,7 @@ export interface NormalizedTourPowerTable {
   position?: string;
   customPosition?: string;
   includesHoist: boolean;
+  fohSchukoRequired: boolean;
   toolType: 'consumos';
   source: 'tour-default' | 'tour-override' | 'legacy-tour-default';
 }
@@ -140,6 +141,7 @@ export const normalizeTourDefaultPowerTable = (
     position: position || undefined,
     customPosition: customPosition || undefined,
     includesHoist: getBoolean(metadata.includes_hoist) ?? false,
+    fohSchukoRequired: getBoolean(metadata.foh_schuko) ?? false,
     toolType: 'consumos',
     source: 'tour-default',
   };
@@ -167,6 +169,7 @@ export const normalizeLegacyTourPowerDefault = (
   position: table.position || undefined,
   customPosition: table.custom_position || undefined,
   includesHoist: table.includes_hoist || false,
+  fohSchukoRequired: false,
   toolType: 'consumos',
   source: 'legacy-tour-default',
 });
@@ -190,6 +193,7 @@ export const normalizeTourPowerOverride = (
   position: override.position || undefined,
   customPosition: override.custom_position || undefined,
   includesHoist: override.includes_hoist || false,
+  fohSchukoRequired: false,
   toolType: 'consumos',
   source: 'tour-override',
 });


### PR DESCRIPTION
## Summary
- Add deterministic auto-generated tour default PDF sync for date/package documents.
- Regenerate/upload PDFs when tour dates, default sets, Consumos defaults, or Pesos defaults change.
- Clean stale auto-generated PDFs when dates are deleted, package resolution becomes invalid/ambiguous, or matching tables disappear.
- Allow queued multi-file document uploads across job, tour, festival, artist, and task document upload flows.
- Address CodeRabbit data-integrity feedback for cleanup order, storage rollback, explicit zero quantities, Spanish warning copy, and consolidated sync gating.

## Risk Assessment
- Medium: touches shared document upload flows and tour default PDF synchronization.
- Main risks are duplicate/partial document uploads and stale generated PDFs; mitigated by sequential upload queues, stable generated object paths, cleanup-on-invalid-plan behavior, and local validation.
- No destructive schema changes and no broad dependency/build pipeline changes.

## Impact Checklist
- [x] Tour default package PDFs stay current when relevant defaults or tour dates change.
- [x] Stale generated PDF slots are cleaned when package resolution or source tables are no longer valid.
- [x] Document upload UIs can select/drop multiple files or queue selected files.
- [x] Existing single-slot asset uploads such as logos/profile pictures/stage plots remain single-file.
- [x] No Supabase migrations included.
- [x] No dependency changes included.

## Rollback Plan
- Revert this PR to restore previous manual/single-file document behavior.
- Because generated PDFs use deterministic storage paths under `tours/<tourId>/auto-generated/default-pdfs/...`, stale files can be safely regenerated by re-running the sync after rollback/reapply.
- No database rollback is required because this PR does not add migrations.

## Migration Impact
- No Supabase migration in this PR.
- No production `supabase db push` is required; merging `main` is the production deploy path.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`

## CODEOWNER / Approval Notes
- Solo-dev workflow; no separate approval gate required beyond clean CI and review feedback resolution.
- CodeRabbit actionable review feedback has been addressed in follow-up commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading multiple files in one action across several document and task upload screens.
  * Added a manual “Sync PDFs” option for tour dates to refresh generated documents.

* **Bug Fixes**
  * Tour document PDFs now stay in sync automatically after creating, editing, or deleting tour dates and related tour-default changes.
  * Improved default-set selection so the chosen package size and department stay consistent.
  * PDF summaries now show clearer rigging/power labels and preserve expected power requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->