### PR TITLE
fix: allow spaces in uploaded file names

### DIFF
--- a/src/lib/enhanced-security-config.ts
+++ b/src/lib/enhanced-security-config.ts
@@ -40,8 +40,11 @@ export const ENHANCED_VALIDATION_PATTERNS = {
   // Strong password requirements
   STRONG_PASSWORD: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
   
-  // File name validation (prevent path traversal)
-  SAFE_FILENAME: /^[a-zA-Z0-9._-]+$/,
+  // File name validation (prevent path traversal). Block only path separators
+  // and reserved/control characters; allow spaces, parentheses and accented
+  // letters that legitimately appear in user file names. Mirrors the invalid
+  // character set used by sanitizeFilenamePart in src/utils/fileName.ts.
+  SAFE_FILENAME: /^[^<>:"/\\|?*\u0000-\u001f]+$/,
   
   // URL validation for external links
   SAFE_URL: /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/,


### PR DESCRIPTION
## Problem

All document upload paths were refusing files whose names contained a **space** (also parentheses and accented letters like `á`/`ñ`, common in the Spanish-language UI), failing with *"El nombre del archivo contiene caracteres no permitidos"*.

## Root cause

`validateFileUpload()` in `src/lib/enhanced-security-config.ts` gates every upload path (~14 call sites, via `getDocumentUploadValidationError` in `documentUploadValidation.ts`) on a restrictive whitelist that only allowed `[a-zA-Z0-9._-]`. Any filename with a space failed.

This validator was previously dead code (flagged unused in `.claude/notes/2026-02-01-tech-debt-audit.md`) and was recently wired into all upload UIs, so the symptom surfaced across every upload path at once.

## Fix

Switched the whitelist to a blacklist (`/^[^...]+$/`) that preserves path-traversal protection while allowing legitimate characters. The blocked set is:

- path separators / reserved chars: `< > : " / \ | ? *`
- control characters (``–` `)

Everything else — including **spaces, hyphens, parentheses, and accented letters** — is now permitted. This mirrors the invalid-character set already used by `sanitizeFilenamePart` in `src/utils/fileName.ts`, keeping the two consistent. See the diff for the exact pattern.

## Verification

Regex tested against real-world filenames:

| Filename | Result |
|---|---|
| `My Document.pdf` | ✅ allowed |
| `informe técnico (final).pdf` | ✅ allowed |
| `rider-2024.docx` | ✅ allowed |
| `acentos áéíóú ñ.pdf` | ✅ allowed |
| `a/b.pdf` | ❌ rejected |
| `bad\name.pdf` | ❌ rejected |
| `bad:name.pdf` | ❌ rejected |

Typecheck clean (only a pre-existing `baseUrl` config deprecation warning, unrelated).

## Out of scope

`validateFileUpload` also rejects names with more than one `.` (double-extension `file.txt.exe` guard, e.g. `report v1.2.pdf`). That's a deliberate security check, separate from this spaces regression, and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)