### PR TITLE
feat: render breadcrumb navigation across app pages

### DIFF
--- a/src/components/layout/AppBreadcrumbs.tsx
+++ b/src/components/layout/AppBreadcrumbs.tsx
@@ -1,0 +1,90 @@
+import { Fragment, useMemo } from "react"
+import { Link, useLocation } from "react-router-dom"
+import { Home } from "lucide-react"
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth"
+import { getBreadcrumbsForPathname } from "@/routes/app-route-manifest"
+import { getDashboardPath } from "@/utils/roleBasedRouting"
+import type { UserRole } from "@/types/user"
+import { cn } from "@/lib/utils"
+
+type Crumb = { label: string; path: string }
+
+/**
+ * Renders the breadcrumb trail for the active route, driven entirely by the
+ * `breadcrumb` config on the route manifest. A role-aware "home" crumb is
+ * prepended so every page exposes a working path back up the hierarchy instead
+ * of relying on per-page back buttons (which were inconsistent or absent).
+ */
+export const AppBreadcrumbs = ({ className }: { className?: string }) => {
+  const location = useLocation()
+  const { userRole } = useOptimizedAuth()
+
+  const crumbs = useMemo<Crumb[]>(() => {
+    const routeCrumbs = getBreadcrumbsForPathname(location.pathname)
+
+    if (routeCrumbs.length === 0) {
+      return []
+    }
+
+    const homePath = getDashboardPath((userRole as UserRole | null) ?? null)
+    const home: Crumb = { label: "Inicio", path: homePath }
+
+    // Avoid a duplicate home link when the route already roots at the dashboard.
+    const trail =
+      routeCrumbs[0]?.path === homePath ? routeCrumbs : [home, ...routeCrumbs]
+
+    return trail
+  }, [location.pathname, userRole])
+
+  // Nothing useful to show for a lone crumb (e.g. the dashboard itself).
+  if (crumbs.length <= 1) {
+    return null
+  }
+
+  return (
+    <Breadcrumb className={cn("min-w-0", className)}>
+      <BreadcrumbList className="flex-nowrap overflow-x-auto">
+        {crumbs.map((crumb, index) => {
+          const isLast = index === crumbs.length - 1
+          const isHome = index === 0
+
+          return (
+            <Fragment key={`${crumb.path}-${index}`}>
+              <BreadcrumbItem className="shrink-0">
+                {isLast ? (
+                  <BreadcrumbPage className="max-w-[40vw] truncate sm:max-w-none">
+                    {crumb.label}
+                  </BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink asChild>
+                    <Link
+                      to={crumb.path}
+                      className="inline-flex items-center gap-1 whitespace-nowrap"
+                    >
+                      {isHome && <Home className="h-3.5 w-3.5" aria-hidden="true" />}
+                      <span className="max-w-[28vw] truncate sm:max-w-none">
+                        {crumb.label}
+                      </span>
+                    </Link>
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+              {!isLast && <BreadcrumbSeparator className="shrink-0" />}
+            </Fragment>
+          )
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}
+
+export default AppBreadcrumbs

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -36,6 +36,7 @@ import {
 
 import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { AboutCard } from "./AboutCard"
+import { AppBreadcrumbs } from "./AppBreadcrumbs"
 import { HelpButton } from "./HelpButton"
 import { MobileNavBar } from "./MobileNavBar"
 import { NotificationBadge } from "./NotificationBadge"
@@ -504,6 +505,7 @@ const Layout = () => {
                   <HelpButton />
                 </div>
               </div>
+              <AppBreadcrumbs className="mt-2" />
             </header>
           )}
           <main

--- a/src/routes/__tests__/app-route-manifest.test.ts
+++ b/src/routes/__tests__/app-route-manifest.test.ts
@@ -83,10 +83,29 @@ describe("app route manifest", () => {
     expect(isMobileFullscreenRoutePath("/sound/consumos")).toBe(true);
   });
 
-  it("resolves breadcrumb metadata from the manifest", () => {
+  it("resolves a multi-level breadcrumb trail, substituting route params into parent links", () => {
     expect(getBreadcrumbsForPathname("/festival-management/job-1/gear")).toEqual([
       { label: "Festivales", path: "/festivals" },
+      { label: "Festival", path: "/festival-management/job-1" },
       { label: "Equipamiento", path: "/festival-management/job-1/gear" },
     ]);
+  });
+
+  it("nests tour tool routes under the tour management hub", () => {
+    expect(getBreadcrumbsForPathname("/tours/tour-9/sound/pesos")).toEqual([
+      { label: "Giras", path: "/tours" },
+      { label: "Gestión de gira", path: "/tour-management/tour-9" },
+      { label: "Pesos", path: "/tours/tour-9/sound/pesos" },
+    ]);
+  });
+
+  it("returns a single crumb for a top-level route without a parent", () => {
+    expect(getBreadcrumbsForPathname("/festivals")).toEqual([
+      { label: "Festivales", path: "/festivals" },
+    ]);
+  });
+
+  it("returns no breadcrumbs for an unknown path", () => {
+    expect(getBreadcrumbsForPathname("/this-route-does-not-exist")).toEqual([]);
   });
 });

--- a/src/routes/app-route-manifest.tsx
+++ b/src/routes/app-route-manifest.tsx
@@ -1,5 +1,5 @@
 import React, { lazy } from "react";
-import { Navigate, matchPath } from "react-router-dom";
+import { Navigate, generatePath, matchPath } from "react-router-dom";
 
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
@@ -959,7 +959,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "tours",
     subscriptionRouteKey: "/tours",
-    breadcrumb: { label: "Pesos", parentPath: "/tours" },
+    breadcrumb: { label: "Pesos", parentPath: "/tour-management/:tourId" },
   },
   {
     id: "tourSoundConsumos",
@@ -969,7 +969,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "tours",
     subscriptionRouteKey: "/tours",
-    breadcrumb: { label: "Consumos", parentPath: "/tours" },
+    breadcrumb: { label: "Consumos", parentPath: "/tour-management/:tourId" },
   },
   {
     id: "tourLightsPesos",
@@ -979,7 +979,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "tours",
     subscriptionRouteKey: "/tours",
-    breadcrumb: { label: "Pesos luces", parentPath: "/tours" },
+    breadcrumb: { label: "Pesos luces", parentPath: "/tour-management/:tourId" },
   },
   {
     id: "tourLightsConsumos",
@@ -989,7 +989,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "tours",
     subscriptionRouteKey: "/tours",
-    breadcrumb: { label: "Consumos luces", parentPath: "/tours" },
+    breadcrumb: { label: "Consumos luces", parentPath: "/tour-management/:tourId" },
   },
   {
     id: "tourVideoPesos",
@@ -999,7 +999,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "tours",
     subscriptionRouteKey: "/tours",
-    breadcrumb: { label: "Pesos vídeo", parentPath: "/tours" },
+    breadcrumb: { label: "Pesos vídeo", parentPath: "/tour-management/:tourId" },
   },
   {
     id: "tourVideoConsumos",
@@ -1009,7 +1009,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "tours",
     subscriptionRouteKey: "/tours",
-    breadcrumb: { label: "Consumos vídeo", parentPath: "/tours" },
+    breadcrumb: { label: "Consumos vídeo", parentPath: "/tour-management/:tourId" },
   },
   {
     id: "tourDateSoundPesos",
@@ -1085,7 +1085,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "festivalManagementArtists",
     subscriptionRouteKey: "/festival-management/artists",
-    breadcrumb: { label: "Artistas", parentPath: "/festivals" },
+    breadcrumb: { label: "Artistas", parentPath: "/festival-management/:jobId" },
   },
   {
     id: "festivalManagementGear",
@@ -1095,7 +1095,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "festivalManagementGear",
     subscriptionRouteKey: "/festival-management/gear",
-    breadcrumb: { label: "Equipamiento", parentPath: "/festivals" },
+    breadcrumb: { label: "Equipamiento", parentPath: "/festival-management/:jobId" },
   },
   {
     id: "festivalManagementScheduling",
@@ -1105,7 +1105,7 @@ export const appRoutes: readonly AppRoute[] = [
     access: "managementAndHouseTech",
     subscriptions: "festivalManagementScheduling",
     subscriptionRouteKey: "/festival-management/scheduling",
-    breadcrumb: { label: "Programación", parentPath: "/festivals" },
+    breadcrumb: { label: "Programación", parentPath: "/festival-management/:jobId" },
   },
 ];
 
@@ -1211,6 +1211,28 @@ export const getSubscriptionConfigForPathname = (
   };
 };
 
+// Substitute the dynamic params resolved from the active pathname into an
+// ancestor route's path template (e.g. "/festival-management/:jobId" -> the
+// concrete URL) so breadcrumb parent links actually navigate somewhere valid.
+const resolveAncestorPath = (
+  pathTemplate: string,
+  params: Record<string, string | undefined>,
+): string => {
+  if (!pathTemplate.includes(":")) {
+    return pathTemplate;
+  }
+
+  try {
+    return generatePath(pathTemplate, params);
+  } catch {
+    // Missing param for this template — fall back to the raw template so the
+    // crumb still renders (it just won't be a working link in that edge case).
+    return pathTemplate;
+  }
+};
+
+const MAX_BREADCRUMB_DEPTH = 10;
+
 export const getBreadcrumbsForPathname = (
   pathname: string,
 ): Array<{ label: string; path: string }> => {
@@ -1220,19 +1242,39 @@ export const getBreadcrumbsForPathname = (
     return [];
   }
 
-  const breadcrumbs: Array<{ label: string; path: string }> = [];
-  if (route.breadcrumb.parentPath) {
-    const parent = matchAppRoute(route.breadcrumb.parentPath);
-    breadcrumbs.push({
-      label: parent?.breadcrumb?.label ?? route.breadcrumb.parentPath,
-      path: route.breadcrumb.parentPath,
+  // Resolve the params for the active route once; ancestor templates reuse the
+  // same param names (e.g. :jobId / :tourId) so they can be substituted too.
+  const match = matchPath({ path: route.path, end: true }, pathname);
+  const params = (match?.params ?? {}) as Record<string, string | undefined>;
+
+  // Walk up the parentPath chain, building the trail from the current page
+  // upward, then reverse so it reads root -> current.
+  const reversed: Array<{ label: string; path: string }> = [
+    { label: route.breadcrumb.label, path: pathname },
+  ];
+
+  let parentPath = route.breadcrumb.parentPath;
+  const visited = new Set<string>([route.path]);
+
+  while (parentPath && reversed.length < MAX_BREADCRUMB_DEPTH) {
+    const parentRoute = appRoutes.find((candidate) => candidate.path === parentPath);
+
+    if (!parentRoute || visited.has(parentRoute.path)) {
+      // Unknown or cyclic parent — still emit a best-effort crumb and stop.
+      reversed.push({
+        label: parentRoute?.breadcrumb?.label ?? parentPath,
+        path: resolveAncestorPath(parentPath, params),
+      });
+      break;
+    }
+
+    visited.add(parentRoute.path);
+    reversed.push({
+      label: parentRoute.breadcrumb?.label ?? parentPath,
+      path: resolveAncestorPath(parentPath, params),
     });
+    parentPath = parentRoute.breadcrumb?.parentPath;
   }
 
-  breadcrumbs.push({
-    label: route.breadcrumb.label,
-    path: pathname,
-  });
-
-  return breadcrumbs;
+  return reversed.reverse();
 };


### PR DESCRIPTION
Activate the existing-but-unused breadcrumb data layer and surface it as a
global breadcrumb bar in the app header so every page exposes a working path
back up the hierarchy, instead of relying on inconsistent (or absent) per-page
back buttons that jumped straight to the dashboard.

- AppBreadcrumbs component rendered in the Layout header, with a role-aware
  "Inicio" home crumb prepended.
- getBreadcrumbsForPathname now walks multi-level parent chains and substitutes
  dynamic route params (:jobId, :tourId) into ancestor links.
- Festival sub-pages and tour tool pages now nest under their real parent
  (the festival / tour hub) rather than flat to the list page.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WdXpM7HvBCbP2mqgsR4Uzq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb navigation to page layouts, including a home item based on the current user role.
  * Breadcrumbs now support deeper route hierarchies and dynamic page paths.

* **Bug Fixes**
  * Improved breadcrumb links for tour and festival management pages.
  * Unknown or circular routes now fail gracefully instead of breaking navigation.

* **Tests**
  * Expanded breadcrumb route coverage for nested paths, top-level pages, and missing routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->