### PR TITLE
UI/UX audit: a11y quick wins, shared primitives, dark-mode fixes & confirm-dialog migration

### DIFF
--- a/docs/UI_UX_AUDIT.md
+++ b/docs/UI_UX_AUDIT.md
@@ -16,7 +16,7 @@ This audit is being actioned on the same branch. Status as of the latest commit:
 | **Phase 0 — Quick wins** | ✅ Done | `lang="es"`; light/dark `theme-color`; global reduced-motion + `:focus-visible` baseline; skip-to-content link; focus-ring token cleanup in `MobileNavBar`. |
 | **Phase 1 — Shared primitives** | ✅ Done | `Loading`/`PageLoading`/`Spinner`, `EmptyState`, `SubmitButton` (a11y-correct, token-themed, unit-tested); adopted in `App.tsx` route fallback. |
 | **C-2 — Dark mode (Auth)** | ✅ Done | Auth signup/recovery view migrated from hardcoded slate/white to semantic tokens. |
-| **M-1 — Native confirm/alert** | 🟡 In progress | `ConfirmDialogProvider` + `useConfirm` added & wired; 4 of 14 sites migrated (Sound/Lights/Video/Dashboard job-delete). Remaining 10 are follow-ups. |
+| **M-1 — Native confirm/alert** | ✅ Done | `ConfirmDialogProvider` + `useConfirm` added & wired; **all** native `window.confirm` sites migrated (14 `.tsx` + 3 `.ts` job-card hooks). A source-scan test (`no-native-confirm.test.ts`) guards against regressions. |
 | **Phase 1 — Toast consolidation (H-2)** | ⬜ Pending | Large mechanical migration (~155 files); recommend a dedicated reviewed pass. |
 | **Phase 1 — ESLint guardrails** | ⬜ Pending | Needs `eslint-plugin-jsx-a11y` + color rules (dependency install). |
 | **Phases 2–5** | ⬜ Pending | See roadmap below. |

--- a/docs/UI_UX_AUDIT.md
+++ b/docs/UI_UX_AUDIT.md
@@ -1,0 +1,230 @@
+# UI/UX Audit — Area Tecnica (Sector Pro)
+
+**Date:** 2026-06-25
+**Scope:** Whole codebase — web (desktop) and mobile/PWA (Capacitor + responsive web)
+**Branch:** `claude/ui-ux-audit-321wc9`
+**Method:** Static analysis of `src/` (638 `.tsx` files), design-system review (`tailwind.config.ts`, `src/index.css`, `src/components/ui/`), layout/navigation review, and pattern sampling of representative pages.
+
+---
+
+## 1. Executive Summary
+
+Sector Pro is a large, mature, mobile-first PWA with a genuinely solid foundation: a token-based design system (HSL CSS variables + shadcn/ui), a shared `ViewportProvider` with consistent breakpoints, safe-area-aware mobile chrome, route-aware code-splitting, and an `ErrorBoundary` with chunk-recovery. The bones are good.
+
+The problems are **consistency and accessibility debt accumulated across many parallel features**, not a broken architecture. The single most damaging theme: **two competing styling philosophies coexist** — the canonical CSS-variable token system *and* a sprawl of ad-hoc hardcoded palette colors / per-page `isDark` maps. This produces visible dark-mode breakage, inconsistent surfaces, and high maintenance cost. Accessibility is the second systemic gap: the app is functionally usable but fails several WCAG basics (wrong document language, no reduced-motion support, thin ARIA/live-region coverage).
+
+**Severity tally (issue groups):** 4 Critical · 7 High · 8 Medium · 5 Low
+
+### Headline metrics
+
+| Signal | Count | Why it matters |
+|---|---:|---|
+| Hardcoded Tailwind palette classes (`text-gray-*`, `bg-white`, `text-red-*`, …) in TSX | **768** | Bypasses the theme token system; breaks dark mode & rebranding |
+| Hardcoded hex colors in TSX | **252** | Same as above; not theme- or contrast-managed |
+| `bg-white` with **no** `dark:` variant | **143** | White surfaces persist in dark mode → contrast/glare bugs |
+| `text-black` with no `dark:` variant | **29** | Invisible/low-contrast text in dark mode |
+| Files using **both** toast systems app-wide | Sonner **49** + shadcn `useToast` **155** | Two visually different notification UIs |
+| Spinner-based loading (`animate-spin`/`Loader2`/`PageLoader`) | **151 files** | vs only **11** files using `Skeleton` → layout shift, jank |
+| `aria-live` / `role="status"` / `role="alert"` regions | **5** | 1,076 loading strings + 174 async buttons go unannounced |
+| `prefers-reduced-motion` / `motion-reduce` handling | **0** | 393 animation usages; no vestibular-safety escape hatch |
+| Skip-to-content link | **0** | Keyboard users must tab through full nav every page |
+| Tiny fixed fonts (`text-[8–11px]`) | **204** | Below legible/accessible minimums, esp. mobile |
+| Fixed pixel widths (`w-[≥100px]`, `min-w-[≥100px]`) | **160 + 53** | Horizontal-overflow risk on small screens |
+| Hardcoded loading/UI strings (`Cargando`, `Loading…`) | **1,076** | No i18n layer; inconsistent copy |
+
+> Counts are static-grep heuristics meant to size each problem, not exact defect lists. Treat them as prioritization signal.
+
+---
+
+## 2. What's Working Well (Keep / Build On)
+
+- **Token foundation exists** — `src/index.css` defines a complete light/dark HSL variable palette wired into `tailwind.config.ts` (`primary`, `muted`, `card`, `sidebar`, etc.). When components use it, theming "just works."
+- **Unified responsive system** — `ViewportProvider` / `useViewport` / `useIsMobile` share one breakpoint scale aligned with Tailwind `screens`. No competing `window.innerWidth` checks scattered around.
+- **Mobile chrome is thoughtfully built** — `MobileNavBar` handles `visualViewport` keyboard/browser-UI shifts, `env(safe-area-inset-*)`, `role="navigation"`, `aria-label`, and `aria-current`. Tailwind has dedicated `safe-*` spacing tokens.
+- **Fluid typography** — `clamp()`-based `--text-*` scale on `body`/`h1–h4` adapts to viewport.
+- **Resilience** — global `ErrorBoundary` + chunk-load auto-recovery; lazy routes with `Suspense` fallbacks.
+- **Mature primitive library** — 61 shadcn/ui components already in place (dialog, drawer, sheet, command, sidebar, etc.).
+
+---
+
+## 3. Detailed Findings
+
+Severity: **Critical** (broken/blocking for a user segment) · **High** (frequent friction or a11y failure) · **Medium** (inconsistency / polish) · **Low** (hygiene).
+
+### 3.1 Theming & Dark Mode
+
+**[CRITICAL] C-1 — Two competing theming systems.**
+The canonical path is next-themes (`class` strategy) + CSS variable tokens. But several high-traffic pages reimplement theming by hand with `isDark` ternaries and hardcoded hex:
+- `src/pages/TechnicianDashboard.tsx` — `nav/card/input/cluster` maps using `bg-[#0f1219]`, `bg-[#0a0c10]`, `bg-white`, `text-black`.
+- `src/pages/TechnicianSuperApp.tsx` — same pattern (lines ~98–109, 412).
+- `src/pages/SoundVisionFiles.tsx` — same pattern (lines ~87–98).
+
+`isDark`/`useTheme`/`ThemeContext` is referenced in **54 files**. Two systems means a theme/brand change must be made twice, and the hand-rolled pages can drift out of sync with the token palette.
+
+**[CRITICAL] C-2 — Dark mode visibly breaks on non-token surfaces.**
+**143** `bg-white` and **29** `text-black` usages have **no** `dark:` variant. Concrete example: `src/pages/Auth.tsx` signup/recovery view uses `bg-slate-50`, `bg-white`, `text-slate-900` unconditionally — it renders as a light card even when the user's theme is dark. Multiply across 143 surfaces for the systemic glare/contrast problem.
+
+**[HIGH] H-1 — Palette-class sprawl.**
+**768** hardcoded `text-gray-*`/`bg-gray-*`/`text-red-*`/`bg-blue-*`-style classes and **252** raw hex values sit outside the token system. Even where a `dark:` pair exists, these encode color decisions inline instead of via semantic tokens (`muted-foreground`, `destructive`, `primary`), so contrast and brand are unmanaged.
+
+### 3.2 Notifications / Toasts
+
+**[HIGH] H-2 — Two toast systems mounted simultaneously.**
+`src/routes/RouteAwareAppEffects.tsx` mounts **both** the shadcn `Toaster` and the Sonner `Toaster` (`top-right`). Components inconsistently call shadcn `useToast` (**155 files**) or Sonner `toast()` (**49 files**). Users see two different toast visual languages, positions, and stacking behaviors depending on which code path fired. Pick one (recommend Sonner for ergonomics) and migrate.
+
+**[MEDIUM] M-1 — Native `window.confirm/alert` in UI.**
+**14** usages of `window.confirm`/`window.alert` — unstyled, un-themeable, blocking dialogs that break the design language. Replace with `AlertDialog`.
+
+### 3.3 Accessibility (WCAG)
+
+**[CRITICAL] C-3 — Wrong document language.**
+`index.html` declares `<html lang="en">` while UI/content is primarily Spanish. Screen readers will use the wrong pronunciation/voice. One-line fix (`lang="es"`), high impact. (WCAG 3.1.1)
+
+**[HIGH] H-3 — No reduced-motion support.**
+**0** occurrences of `prefers-reduced-motion`/`motion-reduce` against **393** animation usages, including infinite loops (`animate-pulse`, `animate-spin`, the `alien-flicker` keyframes, Auth blob `float`/`pulse`, celebration/confetti). Users with vestibular sensitivity have no escape hatch. (WCAG 2.3.3 / 2.2.2)
+
+**[HIGH] H-4 — Thin live-region / status coverage.**
+Only **5** `aria-live`/`role="status"`/`role="alert"` regions exist, yet there are **1,076** loading strings and **174** async-disabled buttons. Async state changes (saving, loading, errors) are largely silent to assistive tech. (WCAG 4.1.3)
+
+**[HIGH] H-5 — No skip-to-content link.**
+Keyboard and screen-reader users must traverse the entire sidebar/nav on every route. Add a visually-hidden, focus-revealed "Saltar al contenido" anchor in `Layout`. (WCAG 2.4.1)
+
+**[MEDIUM] M-2 — Inconsistent focus styling.**
+Focus rings split between `focus-visible:ring-ring` (token, 17) and `focus-visible:ring-blue-500` (hardcoded, e.g. `MobileNavBar`). No global `:focus-visible` baseline in `index.css`. Custom clickable elements may have weak/absent focus indication. (WCAG 2.4.7)
+
+**[MEDIUM] M-3 — Images missing alt text.**
+~**55** `<img>` lines without an `alt` attribute. Decorative images should have `alt=""`; informational ones need descriptions. (WCAG 1.1.1)
+
+**[MEDIUM] M-4 — Custom interactive elements lack keyboard semantics.**
+**1,664** `onClick` handlers but only **21** `onKeyDown`/`onKeyPress` and **5** `tabIndex`. The good news: only **4** are on `<div>`/`<span>` directly — most ride on `Button`/`Card`. Audit clickable `Card`s (job cards, list rows) for keyboard operability and `role`/`tabIndex`.
+
+### 3.4 Loading & Feedback States
+
+**[HIGH] H-6 — Spinner-heavy, skeleton-light.**
+**151** files use spinners vs **11** using `Skeleton`. Full-screen/section spinners cause layout shift (CLS) and feel slower than skeletons that preserve layout. Standardize on skeletons for content regions, reserve spinners for inline button/action states.
+
+**[MEDIUM] M-5 — Inconsistent loading copy.**
+**1,076** ad-hoc "Cargando…"/"Loading…" strings with no shared component. Centralize via a `<Loading label>` / `<PageLoader>` pattern so copy, spacing, and a11y (`role="status"`) are uniform.
+
+### 3.5 Mobile & Responsive
+
+**[HIGH] H-7 — Horizontal-overflow risk from fixed widths.**
+**160** `w-[≥100px]` and **53** `min-w-[≥100px]` fixed pixel widths. On 360px viewports these are prime suspects for horizontal scroll/cut-off. Audit against the `xs` (360px) breakpoint; prefer `max-w`, `w-full`, fluid grids.
+
+**[MEDIUM] M-6 — Wide tables on mobile.**
+**36** files render `<table>`/`<Table>`; **68** `overflow-x-auto` usages suggest the wrapper pattern exists but isn't universal. Tables that don't reflow to cards on mobile produce pinch-zoom/scroll friction. Adopt a consistent responsive-table or card-list strategy.
+
+**[MEDIUM] M-7 — Very large page components.**
+Several pages exceed maintainable size: `PayoutsDueFortnights.tsx` (1,225), `PesosTool.tsx` (1,150), `TourManagement.tsx` (1,118), `GlobalTasks.tsx` (887). Oversized components make consistent responsive/a11y treatment harder and invite divergence. Decompose into sections + hooks.
+
+### 3.6 Ergonomics & Touch Targets
+
+**[MEDIUM] M-8 — Touch targets below 44px.**
+`button.tsx`: default `h-10` (40px), `sm` `h-9` (36px), `icon` `h-10 w-10` (40px). All below the 44×44px (iOS HIG) / 48px (Material) minimum. On a mobile-first product this matters; bump mobile sizes or add a touch-target-safe `icon` variant.
+
+**[LOW] L-1 — Tiny fonts.**
+**204** uses of `text-[8px]`–`text-[11px]`. Some are legitimately dense data views, but sub-12px text is hard to read and fails comfortable-reading guidance, especially on mobile/wallboard-at-distance.
+
+### 3.7 Forms, Errors & Empty States
+
+**[MEDIUM] M-9 — Validation/empty-state consistency.**
+The app standardizes on react-hook-form + zod + shadcn `Form` (good), but error presentation and **empty states** ("no hay resultados") aren't centralized. Establish a shared `<EmptyState>` and verify every list/table has loading / empty / error / success states.
+
+**[LOW] L-2 — Disabled-during-async is partial.**
+**174** buttons disable on `isLoading`/`isPending`, but this isn't universal — double-submit is possible on un-guarded mutations. Standardize a `<SubmitButton loading>` that disables + shows a spinner + sets `aria-busy`.
+
+### 3.8 Hygiene & PWA Polish
+
+**[LOW] L-3 — Console noise.**
+**2,770** `console.*` calls in `src/`. Stripped in prod builds via esbuild, but they clutter dev and risk leaking data in non-prod. Route through a `logger` with levels.
+
+**[LOW] L-4 — Missing `theme-color` meta.**
+`index.html` has rich PWA/OG meta but no `<meta name="theme-color">` (ideally light/dark via `media`). Affects mobile browser chrome color.
+
+**[LOW] L-5 — Legacy "Alien terminal" CSS.**
+`src/index.css` ships `--alien-*` variables, scanlines, vignette, and `alien-flicker` keyframes. If still used (wallboard?), confirm intentional and reduced-motion-guarded; otherwise prune dead CSS.
+
+---
+
+## 4. Remediation Plan
+
+Grouped by effort. **Effort:** S = <½ day · M = 1–3 days · L = 1–2 weeks · XL = multi-sprint.
+
+| ID | Issue | Sev | Effort | Action |
+|----|-------|-----|:---:|--------|
+| C-3 | Wrong `lang` | Crit | S | `index.html` → `lang="es"`. |
+| H-5 | Skip link | High | S | Add focus-revealed skip anchor + `id="main"` in `Layout`. |
+| L-4 | theme-color | Low | S | Add `<meta name="theme-color">` (light/dark via `media`). |
+| H-3 | Reduced motion | High | S→M | Global `@media (prefers-reduced-motion: reduce){ *{animation/transition minimized} }` in `index.css`; guard confetti/flicker. |
+| M-2 | Focus baseline | Med | S | Add global `:focus-visible` ring in `index.css`; replace `ring-blue-500` with `ring-ring`. |
+| H-2 | Dual toasts | High | M | Choose one (rec. Sonner); codemod `useToast`→`toast`; unmount the other; keep one provider. |
+| M-1 | Native confirm/alert | Med | M | Replace 14 `window.confirm/alert` with `AlertDialog`/`useConfirm` hook. |
+| C-1/C-2/H-1 | Theming unification | Crit | L→XL | (1) Lint rule banning raw palette/hex + `bg-white`/`text-black` without `dark:`; (2) migrate the 3 `isDark` pages to tokens; (3) burn down `bg-white`/`text-black` sites; (4) sweep 768 palette classes → semantic tokens. |
+| H-6/M-5 | Loading standardization | High | M→L | Shared `<Loading>`/skeleton components; convert section spinners to skeletons; one copy source. |
+| H-4 | Live regions | High | M | Add `role="status"`/`aria-live` to page loaders, toasts already covered, and form submit feedback; `aria-busy` on async buttons. |
+| H-7/M-6 | Mobile overflow & tables | High | L | Audit 213 fixed-width sites at 360px; responsive-table/card wrapper standard. |
+| M-3/M-4 | Img alt & keyboard | Med | M | Add `alt`; audit clickable `Card`s for `role`/`tabIndex`/`onKeyDown`. |
+| M-8/L-1 | Touch targets & fonts | Med | M | Raise mobile button/icon sizes to ≥44px; lift sub-12px fonts where not data-dense. |
+| M-9/L-2 | Empty states & submit guard | Med | M | `<EmptyState>` + `<SubmitButton loading>` primitives; adopt across lists/forms. |
+| M-7 | Component decomposition | Med | XL | Incrementally split 800+ line pages as they're touched. |
+| L-3/L-5 | Console & dead CSS | Low | S→M | `logger` wrapper; verify/prune `alien-*` CSS. |
+
+---
+
+## 5. Roadmap
+
+### Phase 0 — Quick Wins (≈1 day, ship immediately)
+High-impact, low-risk, mostly one-liners. Establishes a11y baseline.
+- C-3 `lang="es"` · L-4 theme-color · H-5 skip link · H-3 reduced-motion media query · M-2 global focus-visible baseline.
+- **Exit:** Lighthouse a11y score jumps; reduced-motion respected app-wide.
+
+### Phase 1 — Consistency Foundations (Sprint 1)
+Stop the bleeding before mass migration.
+- H-2 consolidate to one toast system.
+- Add ESLint/Tailwind guardrails: ban raw hex & non-`dark:` `bg-white`/`text-black`; warn on palette classes (prevents *new* debt).
+- Ship shared primitives: `<Loading>`, `<EmptyState>`, `<SubmitButton>`, `useConfirm`.
+- **Exit:** New code can't reintroduce the top offenders; one notification language.
+
+### Phase 2 — Dark Mode & Theming Cleanup (Sprints 2–3)
+- C-1 migrate `TechnicianDashboard`, `TechnicianSuperApp`, `SoundVisionFiles`, `Auth` off `isDark`/hardcoded surfaces to tokens.
+- C-2 burn down 143 `bg-white` + 29 `text-black` non-`dark:` sites.
+- H-1 sweep highest-traffic palette-class files → semantic tokens.
+- **Exit:** Dark mode visually correct on all primary routes; theme/brand change is single-source.
+
+### Phase 3 — Accessibility Hardening (Sprint 4)
+- H-4 live regions · M-3 alt text · M-4 keyboard operability for custom interactives · M-8 touch targets.
+- Bring in `eslint-plugin-jsx-a11y`; add an axe-core pass to Playwright smoke tests.
+- **Exit:** WCAG 2.1 AA on core flows (auth, dashboard, assignments, timesheets); automated a11y gate in CI.
+
+### Phase 4 — Mobile & Loading Polish (Sprint 5)
+- H-6/M-5 skeletons everywhere · H-7/M-6 mobile overflow + responsive tables · L-1 fonts.
+- Device-matrix QA at 360px (`xs`).
+- **Exit:** No horizontal scroll on small screens; smooth perceived-performance loading.
+
+### Phase 5 — Continuous (ongoing)
+- M-7 decompose oversized pages opportunistically · M-9 empty-state coverage · L-2 submit guards · L-3/L-5 hygiene.
+- Document the design system (token usage, do/don't) so the patterns above are discoverable.
+
+---
+
+## 6. Suggested Guardrails (prevent regression)
+
+1. **Tailwind/ESLint rule** — disallow raw hex in `className`, and `bg-white`/`text-black` without a `dark:` counterpart.
+2. **`eslint-plugin-jsx-a11y`** in the lint job (alt text, click-events-have-key-events, no-static-element-interactions).
+3. **axe-core in Playwright** smoke tests for the critical routes.
+4. **One toast import** — lint-ban the deprecated toast path post-migration.
+5. **Design-system doc** in `docs/` describing semantic tokens and the loading/empty/submit primitives.
+
+---
+
+## 7. Appendix — Evidence Index
+
+Representative locations cited above:
+- Hand-rolled theming: `src/pages/TechnicianDashboard.tsx:79–90,415`, `src/pages/TechnicianSuperApp.tsx:98–109,412`, `src/pages/SoundVisionFiles.tsx:87–98`, `src/pages/Auth.tsx:163–183`.
+- Dual toasts mounted: `src/routes/RouteAwareAppEffects.tsx:42–49,108–109`.
+- Document language: `index.html:2`.
+- Design tokens (source of truth): `src/index.css` (`:root` / `.dark`), `tailwind.config.ts`.
+- Mobile chrome (good reference): `src/components/layout/MobileNavBar.tsx`, `src/hooks/use-mobile.tsx`.
+- Button sizing: `src/components/ui/button.tsx`.
+
+*All counts produced via repo-wide static grep over `src/` on 2026-06-25; they size each problem class for prioritization rather than enumerate exact defects.*

--- a/docs/UI_UX_AUDIT.md
+++ b/docs/UI_UX_AUDIT.md
@@ -7,6 +7,24 @@
 
 ---
 
+## 0. Implementation Progress
+
+This audit is being actioned on the same branch. Status as of the latest commit:
+
+| Phase / Item | Status | Notes |
+|---|---|---|
+| **Phase 0 — Quick wins** | ✅ Done | `lang="es"`; light/dark `theme-color`; global reduced-motion + `:focus-visible` baseline; skip-to-content link; focus-ring token cleanup in `MobileNavBar`. |
+| **Phase 1 — Shared primitives** | ✅ Done | `Loading`/`PageLoading`/`Spinner`, `EmptyState`, `SubmitButton` (a11y-correct, token-themed, unit-tested); adopted in `App.tsx` route fallback. |
+| **C-2 — Dark mode (Auth)** | ✅ Done | Auth signup/recovery view migrated from hardcoded slate/white to semantic tokens. |
+| **M-1 — Native confirm/alert** | 🟡 In progress | `ConfirmDialogProvider` + `useConfirm` added & wired; 4 of 14 sites migrated (Sound/Lights/Video/Dashboard job-delete). Remaining 10 are follow-ups. |
+| **Phase 1 — Toast consolidation (H-2)** | ⬜ Pending | Large mechanical migration (~155 files); recommend a dedicated reviewed pass. |
+| **Phase 1 — ESLint guardrails** | ⬜ Pending | Needs `eslint-plugin-jsx-a11y` + color rules (dependency install). |
+| **Phases 2–5** | ⬜ Pending | See roadmap below. |
+
+All shipped changes verified with `vite build` and `vitest` (no regressions across 78 existing touched-area tests + 11 new primitive/confirm tests).
+
+---
+
 ## 1. Executive Summary
 
 Sector Pro is a large, mature, mobile-first PWA with a genuinely solid foundation: a token-based design system (HSL CSS variables + shadcn/ui), a shared `ViewportProvider` with consistent breakpoints, safe-area-aware mobile chrome, route-aware code-splitting, and an `ErrorBoundary` with chunk-recovery. The bones are good.

--- a/docs/UI_UX_AUDIT.md
+++ b/docs/UI_UX_AUDIT.md
@@ -15,7 +15,7 @@ This audit is being actioned on the same branch. Status as of the latest commit:
 |---|---|---|
 | **Phase 0 — Quick wins** | ✅ Done | `lang="es"`; light/dark `theme-color`; global reduced-motion + `:focus-visible` baseline; skip-to-content link; focus-ring token cleanup in `MobileNavBar`. |
 | **Phase 1 — Shared primitives** | ✅ Done | `Loading`/`PageLoading`/`Spinner`, `EmptyState`, `SubmitButton` (a11y-correct, token-themed, unit-tested); adopted in `App.tsx` route fallback. |
-| **C-2 — Dark mode (Auth)** | ✅ Done | Auth signup/recovery view migrated from hardcoded slate/white to semantic tokens. |
+| **C-2 — Dark mode (Auth)** | 🟡 Partial | The Auth **signup/recovery** view is migrated from hardcoded slate/white to semantic tokens (shipped). The **primary login** screen in `Auth.tsx` is *not* token-migrated — it's an intentional dark-branded glassmorphic hero (animated gradient mesh + `BRAND_CONFIG` blob colors), so a full semantic-token migration of `Auth.tsx` is deliberately deferred, not complete. Don't read Auth as fully migrated. |
 | **M-1 — Native confirm/alert** | ✅ Done | `ConfirmDialogProvider` + `useConfirm` added & wired; **all** native `window.confirm` sites migrated (14 `.tsx` + 3 `.ts` job-card hooks). A source-scan test (`no-native-confirm.test.ts`) guards against regressions. |
 | **Phase 1 — Toast consolidation (H-2)** | ⬜ Pending | Large mechanical migration (~155 files); recommend a dedicated reviewed pass. |
 | **Phase 1 — ESLint guardrails** | ⬜ Pending | Needs `eslint-plugin-jsx-a11y` + color rules (dependency install). |
@@ -31,7 +31,7 @@ Sector Pro is a large, mature, mobile-first PWA with a genuinely solid foundatio
 
 The problems are **consistency and accessibility debt accumulated across many parallel features**, not a broken architecture. The single most damaging theme: **two competing styling philosophies coexist** — the canonical CSS-variable token system *and* a sprawl of ad-hoc hardcoded palette colors / per-page `isDark` maps. This produces visible dark-mode breakage, inconsistent surfaces, and high maintenance cost. Accessibility is the second systemic gap: the app is functionally usable but fails several WCAG basics (wrong document language, no reduced-motion support, thin ARIA/live-region coverage).
 
-**Severity tally (issue groups):** 4 Critical · 7 High · 8 Medium · 5 Low
+**Severity tally (issue groups):** 3 Critical · 7 High · 9 Medium · 5 Low
 
 ### Headline metrics
 
@@ -204,7 +204,7 @@ Stop the bleeding before mass migration.
 - **Exit:** New code can't reintroduce the top offenders; one notification language.
 
 ### Phase 2 — Dark Mode & Theming Cleanup (Sprints 2–3)
-- C-1 migrate `TechnicianDashboard`, `TechnicianSuperApp`, `SoundVisionFiles`, `Auth` off `isDark`/hardcoded surfaces to tokens.
+- C-1 migrate `TechnicianDashboard`, `TechnicianSuperApp`, `SoundVisionFiles` off `isDark`/hardcoded surfaces to tokens. (Auth: only the signup/recovery view is tokenized; the primary login is an intentional dark-branded hero — exclude unless a fully theme-aware login is explicitly wanted.)
 - C-2 burn down 143 `bg-white` + 29 `text-black` non-`dark:` sites.
 - H-1 sweep highest-traffic palette-class files → semantic tokens.
 - **Exit:** Dark mode visually correct on all primary routes; theme/brand change is single-source.

--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
   <meta name="description" content="Sector Pro - Area Tecnica">
   <meta name="author" content="Sector Pro" />
 
-  <!-- Browser UI / status bar color (light + dark) -->
-  <meta name="theme-color" content="#eceef2" media="(prefers-color-scheme: light)" />
-  <meta name="theme-color" content="#07090d" media="(prefers-color-scheme: dark)" />
+  <!-- Browser UI / status bar color. Default for first paint; kept in sync with
+       the active app theme at runtime by <ThemeColorMeta>. -->
+  <meta name="theme-color" content="#07090d" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 
 <head>
   <meta charset="UTF-8" />
@@ -8,6 +8,10 @@
   <title>Sector Pro</title>
   <meta name="description" content="Sector Pro - Area Tecnica">
   <meta name="author" content="Sector Pro" />
+
+  <!-- Browser UI / status bar color (light + dark) -->
+  <meta name="theme-color" content="#eceef2" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#07090d" media="(prefers-color-scheme: dark)" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { ConfirmDialogProvider } from "@/components/ui/confirm-dialog";
 import { PageLoading } from "@/components/ui/loading";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ViewportProvider } from "@/hooks/use-mobile";
@@ -57,22 +58,24 @@ export default function App() {
             <AppBadgeProvider>
               <Router>
                 <OptimizedAuthProvider>
-                  <AppRuntimeCoordinator />
-                  <RouteAwareGlobalInitializers />
-                  <div className="app">
-                    <Suspense fallback={<PageLoader />}>
-                      <Routes>
-                        {publicRoutes.map(renderRoute)}
-                        <Route element={<AuthenticatedShell />}>
-                          {fullscreenRoutes.map(renderRoute)}
-                          <Route element={<Layout />}>
-                            {appShellRoutes.map(renderRoute)}
+                  <ConfirmDialogProvider>
+                    <AppRuntimeCoordinator />
+                    <RouteAwareGlobalInitializers />
+                    <div className="app">
+                      <Suspense fallback={<PageLoader />}>
+                        <Routes>
+                          {publicRoutes.map(renderRoute)}
+                          <Route element={<AuthenticatedShell />}>
+                            {fullscreenRoutes.map(renderRoute)}
+                            <Route element={<Layout />}>
+                              {appShellRoutes.map(renderRoute)}
+                            </Route>
                           </Route>
-                        </Route>
-                      </Routes>
-                    </Suspense>
-                    <RouteAwareGlobalOverlays />
-                  </div>
+                        </Routes>
+                      </Suspense>
+                      <RouteAwareGlobalOverlays />
+                    </div>
+                  </ConfirmDialogProvider>
                 </OptimizedAuthProvider>
               </Router>
             </AppBadgeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { ThemeColorMeta } from "@/components/ThemeColorMeta";
 import { ConfirmDialogProvider } from "@/components/ui/confirm-dialog";
 import { PageLoading } from "@/components/ui/loading";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -55,6 +56,7 @@ export default function App() {
       <QueryClientProvider client={queryClient}>
         <ViewportProvider>
           <ThemeProvider defaultTheme="system" storageKey="sector-pro-theme" attribute="class">
+            <ThemeColorMeta />
             <AppBadgeProvider>
               <Router>
                 <OptimizedAuthProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import React, { Suspense, lazy } from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
 
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { PageLoading } from "@/components/ui/loading";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ViewportProvider } from "@/hooks/use-mobile";
 import { OptimizedAuthProvider } from "@/hooks/useOptimizedAuth";
@@ -34,11 +34,7 @@ const ReactQueryDevtoolsLazy = import.meta.env.DEV
 const Layout = lazy(() => import("@/components/layout/Layout"));
 const AuthenticatedShell = lazy(() => import("@/routes/AuthenticatedShell"));
 
-const PageLoader = () => (
-  <div className="flex min-h-[50vh] items-center justify-center">
-    <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-  </div>
-);
+const PageLoader = () => <PageLoading />;
 
 const renderRoute = (route: AppRoute) => (
   <Route key={route.id} path={route.path} element={createRouteElement(route)} />

--- a/src/components/ThemeColorMeta.tsx
+++ b/src/components/ThemeColorMeta.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react"
+import { useTheme } from "next-themes"
+
+/**
+ * Keeps the browser chrome color (<meta name="theme-color">) in sync with the
+ * *active app theme* selected via ThemeProvider, rather than only the OS
+ * `prefers-color-scheme` (see docs/UI_UX_AUDIT.md, theme-color nitpick).
+ *
+ * `resolvedTheme` from next-themes already accounts for both an explicit
+ * light/dark override and the "system" default, so a manual theme switch is
+ * reflected immediately.
+ */
+const THEME_COLORS = {
+  light: "#eceef2", // --background (light)
+  dark: "#07090d", // --background (dark)
+} as const
+
+export function ThemeColorMeta(): null {
+  const { resolvedTheme } = useTheme()
+
+  useEffect(() => {
+    const color = resolvedTheme === "dark" ? THEME_COLORS.dark : THEME_COLORS.light
+    let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+    if (!meta) {
+      meta = document.createElement("meta")
+      meta.setAttribute("name", "theme-color")
+      document.head.appendChild(meta)
+    }
+    meta.setAttribute("content", color)
+  }, [resolvedTheme])
+
+  return null
+}

--- a/src/components/ThemeColorMeta.tsx
+++ b/src/components/ThemeColorMeta.tsx
@@ -19,6 +19,9 @@ export function ThemeColorMeta(): null {
   const { resolvedTheme } = useTheme()
 
   useEffect(() => {
+    // Exit early if theme is not yet resolved
+    if (!resolvedTheme) return
+
     const color = resolvedTheme === "dark" ? THEME_COLORS.dark : THEME_COLORS.light
     let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
     if (!meta) {

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, type ChangeEvent, type ClipboardEvent as ReactClipboardEvent } from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Pencil, Trash2, FileText, Loader2, Mic, Link, ExternalLink, Printer, ImagePlus, ImageOff, Receipt } from "lucide-react";
 import { format, parseISO, isAfter, setHours, setMinutes } from "date-fns";
@@ -144,6 +145,7 @@ export const ArtistTable = ({
   selectedDate,
   onArtistStagePlotUpdated
 }: ArtistTableProps) => {
+  const confirm = useConfirm();
   const { createExtrasPresupuesto, isCreatingExtrasFor } = useCreateExtrasPresupuesto(jobId);
   const [deletingArtistId, setDeletingArtistId] = useState<string | null>(null);
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
@@ -446,7 +448,13 @@ export const ArtistTable = ({
   const handleDeleteStagePlot = async (artist: Artist) => {
     if (!artist.stage_plot_file_path) return;
 
-    if (!window.confirm(`¿Eliminar el stage plot de ${artist.name}?`)) {
+    const confirmed = await confirm({
+      title: "Eliminar stage plot",
+      description: `¿Eliminar el stage plot de ${artist.name}?`,
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (!confirmed) {
       return;
     }
 
@@ -542,7 +550,13 @@ export const ArtistTable = ({
   const sortedFilteredArtists = sortArtistsChronologically(filteredArtists as any) as Artist[];
   const hasArtistSubmittedData = sortedFilteredArtists.some((artist) => artist.artist_submitted);
   const handleDeleteClick = async (artist: Artist) => {
-    if (window.confirm(`¿Estás seguro de que quieres eliminar ${artist.name}?`)) {
+    const confirmed = await confirm({
+      title: "Eliminar artista",
+      description: `¿Estás seguro de que quieres eliminar ${artist.name}?`,
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (confirmed) {
       setDeletingArtistId(artist.id);
       await onDeleteArtist(artist);
       setDeletingArtistId(null);

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -25,6 +25,7 @@ import { JobCardNewDetailsOnly } from "./job-card-new/JobCardNewDetailsOnly";
 import { JobCardNewView } from "./job-card-new/JobCardNewView";
 import { loadHojaDeRutaPdfData } from "@/utils/hoja-de-ruta/load-hoja-de-ruta-pdf-data";
 import { useToast } from "@/hooks/use-toast";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CreateFoldersOptions } from "@/utils/flex-folders";
 import { isFestivalLikeJobType } from "@/utils/jobType";
@@ -211,6 +212,7 @@ function JobCardNewFull({
 }: JobCardNewProps) {
   const navigate = useNavigate();
   const { toast } = useToast();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const { addDeletingJob, removeDeletingJob, isDeletingJob } = useDeletionState();
 
@@ -670,7 +672,15 @@ function JobCardNewFull({
         return;
       }
       if (missing.length > 0) {
-        const proceed = window.confirm(`Faltan teléfonos para ${missing.length} técnico(s):\n- ${missing.slice(0, 5).join('\n- ')}${missing.length > 5 ? '\n...' : ''}\n\n¿Crear el grupo igualmente?`);
+        const proceed = await confirm({
+          title: 'Crear grupo de WhatsApp',
+          description: (
+            <span className="whitespace-pre-line">
+              {`Faltan teléfonos para ${missing.length} técnico(s):\n- ${missing.slice(0, 5).join('\n- ')}${missing.length > 5 ? '\n...' : ''}\n\n¿Crear el grupo igualmente?`}
+            </span>
+          ),
+          confirmText: 'Crear grupo',
+        });
         if (!proceed) return;
       }
 
@@ -883,7 +893,13 @@ function JobCardNewFull({
       return;
     }
 
-    if (!window.confirm('Are you sure you want to delete this job? This action cannot be undone and will remove all related data.')) {
+    const confirmedDelete = await confirm({
+      title: 'Eliminar trabajo',
+      description: '¿Seguro que quieres eliminar este trabajo? Esta acción no se puede deshacer y eliminará todos los datos relacionados.',
+      confirmText: 'Eliminar',
+      destructive: true,
+    });
+    if (!confirmedDelete) {
       return;
     }
 

--- a/src/components/layout/AboutCard.tsx
+++ b/src/components/layout/AboutCard.tsx
@@ -5,6 +5,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card"
 import { Button } from "@/components/ui/button"
+import { useConfirm } from "@/components/ui/confirm-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Info, Edit3, Save, X, Clock, Plus, Trash2, Bell } from "lucide-react"
@@ -91,6 +92,7 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
   const [sendBroadcast, setSendBroadcast] = useState(false)
   const [hasRecentUpdate, setHasRecentUpdate] = useState(false)
   const { toast } = useToast()
+  const confirm = useConfirm()
 
   // Allow editing for management/admin or Javier by email
   const canDeleteChangelog = isAdminRole(userRole)
@@ -210,7 +212,12 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
 
   const deleteEntry = async (id: string) => {
     if (!id) return
-    const proceed = window.confirm('Delete this changelog entry?')
+    const proceed = await confirm({
+      title: 'Eliminar entrada',
+      description: '¿Eliminar esta entrada del changelog?',
+      confirmText: 'Eliminar',
+      destructive: true,
+    })
     if (!proceed) return
     try {
       const { error } = await dataLayerClient.from('app_changelog')

--- a/src/components/layout/AboutCard.tsx
+++ b/src/components/layout/AboutCard.tsx
@@ -231,9 +231,9 @@ export const AboutCard = ({ userRole, userEmail, autoOpen, onAutoOpenHandled }: 
         setEditVersion('')
         setEditDate('')
       }
-      toast({ title: 'Entry deleted' })
+      toast({ title: 'Entrada eliminada' })
     } catch (e: any) {
-      toast({ title: 'Failed to delete', description: e?.message || String(e), variant: 'destructive' })
+      toast({ title: 'No se pudo eliminar', description: e?.message || String(e), variant: 'destructive' })
     }
   }
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -518,7 +518,7 @@ const Layout = () => {
             id="main-content"
             tabIndex={-1}
             className={cn(
-              "flex-1 min-w-0 w-full overflow-y-auto px-3 pt-4 sm:px-6 sm:pt-6 focus:outline-none",
+              "flex-1 min-w-0 w-full overflow-y-auto px-3 pt-4 sm:px-6 sm:pt-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
               suppressChrome || mobileFullscreenRoutes
                 ? "pb-6"
                 : isMobile

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -428,6 +428,12 @@ const Layout = () => {
 
   return (
     <SidebarProvider defaultOpen={showSidebar}>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        Saltar al contenido
+      </a>
       <div className="flex min-h-screen w-full bg-background">
         {showSidebar && (
           <Sidebar className="border-r border-border/50 bg-sidebar text-sidebar-foreground">
@@ -509,8 +515,10 @@ const Layout = () => {
             </header>
           )}
           <main
+            id="main-content"
+            tabIndex={-1}
             className={cn(
-              "flex-1 min-w-0 w-full overflow-y-auto px-3 pt-4 sm:px-6 sm:pt-6",
+              "flex-1 min-w-0 w-full overflow-y-auto px-3 pt-4 sm:px-6 sm:pt-6 focus:outline-none",
               suppressChrome || mobileFullscreenRoutes
                 ? "pb-6"
                 : isMobile

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -116,7 +116,7 @@ export const MobileNavBar = ({
               aria-label={item.label}
               aria-current={isActive ? "page" : undefined}
               className={cn(
-                "flex min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-2 text-[11px] font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                "flex min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-2 text-[11px] font-semibold tracking-tight transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 isActive
                   ? "bg-blue-600/20 text-blue-400"
                   : "text-muted-foreground hover:text-foreground hover:bg-accent",
@@ -140,7 +140,7 @@ export const MobileNavBar = ({
                 type="button"
                 aria-label="Más opciones"
                 className={cn(
-                  "flex min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-2 text-[11px] font-semibold text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:text-foreground hover:bg-accent",
+                  "flex min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-3 py-2 text-[11px] font-semibold text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:text-foreground hover:bg-accent",
                   (open || activeInTray) && "bg-blue-600/20 text-blue-400",
                 )}
               >

--- a/src/components/messages/DirectMessageCard.tsx
+++ b/src/components/messages/DirectMessageCard.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { CheckCircle, MessageSquare, Trash2 } from "lucide-react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
@@ -35,6 +36,7 @@ export const DirectMessageCard = ({
   theme,
   isDark = false
 }: DirectMessageCardProps) => {
+  const confirm = useConfirm();
   const isRecipient = message.recipient_id === currentUserId;
   const showMarkAsRead = isRecipient && message.status === 'unread';
 
@@ -55,8 +57,14 @@ export const DirectMessageCard = ({
     cluster: isDark ? "bg-white text-black" : "bg-slate-900 text-white"
   };
 
-  const handleDelete = () => {
-    if (window.confirm('¿Seguro que deseas eliminar este mensaje de forma permanente?')) {
+  const handleDelete = async () => {
+    const confirmed = await confirm({
+      title: "Eliminar mensaje",
+      description: "¿Seguro que deseas eliminar este mensaje de forma permanente?",
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (confirmed) {
       onDelete(message.id);
     }
   };

--- a/src/components/messages/__tests__/DirectMessageCard.confirm.test.tsx
+++ b/src/components/messages/__tests__/DirectMessageCard.confirm.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import React from "react"
+import { act, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ConfirmDialogProvider } from "@/components/ui/confirm-dialog"
+import { DirectMessageCard } from "@/components/messages/DirectMessageCard"
+import type { DirectMessage } from "@/components/messages/types"
+
+const message: DirectMessage = {
+  id: "msg-1",
+  content: "Hola equipo",
+  created_at: new Date("2026-06-01T10:00:00Z").toISOString(),
+  status: "read",
+  sender: { id: "u-sender", first_name: "Ana", last_name: "García" },
+  recipient: { id: "u-me", first_name: "Yo", last_name: "Mismo" },
+  sender_id: "u-sender",
+  recipient_id: "u-me",
+}
+
+function renderCard(onDelete: (id: string) => void) {
+  return render(
+    <ConfirmDialogProvider>
+      <DirectMessageCard
+        message={message}
+        currentUserId="u-me"
+        onDelete={onDelete}
+        onMarkAsRead={() => {}}
+      />
+    </ConfirmDialogProvider>,
+  )
+}
+
+describe("DirectMessageCard delete confirmation (useConfirm migration)", () => {
+  it("does not delete until the themed dialog is confirmed", async () => {
+    const onDelete = vi.fn()
+    renderCard(onDelete)
+
+    // No native confirm should be involved.
+    const nativeConfirm = vi.spyOn(window, "confirm")
+
+    act(() => {
+      screen.getByTitle("Eliminar mensaje").click()
+    })
+
+    // The AlertDialog appears with our copy; nothing deleted yet.
+    expect(await screen.findByText("Eliminar mensaje")).toBeInTheDocument()
+    expect(
+      screen.getByText("¿Seguro que deseas eliminar este mensaje de forma permanente?"),
+    ).toBeInTheDocument()
+    expect(onDelete).not.toHaveBeenCalled()
+
+    const confirmBtn = screen.getByRole("button", { name: "Eliminar" })
+    await act(async () => {
+      confirmBtn.click()
+    })
+
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    expect(onDelete).toHaveBeenCalledWith("msg-1")
+    expect(nativeConfirm).not.toHaveBeenCalled()
+  })
+
+  it("does not delete when the dialog is cancelled", async () => {
+    const onDelete = vi.fn()
+    renderCard(onDelete)
+
+    act(() => {
+      screen.getByTitle("Eliminar mensaje").click()
+    })
+
+    const cancelBtn = await screen.findByRole("button", { name: "Cancelar" })
+    await act(async () => {
+      cancelBtn.click()
+    })
+
+    expect(onDelete).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -11,6 +11,7 @@ import { Upload, Download, Trash2, Plus } from 'lucide-react';
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useQuery } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
+import { useConfirm } from '@/components/ui/confirm-dialog';
 import { TASK_TYPES } from '@/constants/taskTypes';
 import {
   DOCUMENT_UPLOAD_ACCEPT,
@@ -56,6 +57,7 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
   const [newAssignee, setNewAssignee] = React.useState<string | undefined>(undefined);
   const [bulkDeleteMode, setBulkDeleteMode] = React.useState<'all' | 'unassigned'>('all');
   const { toast } = useToast();
+  const confirm = useConfirm();
   const [currentUserId, setCurrentUserId] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -175,9 +177,12 @@ export const TaskList: React.FC<TaskListProps> = ({ jobId, tourId, department, c
     }
 
     const scopeLabel = bulkDeleteMode === 'unassigned' ? 'sin asignar' : 'todas';
-    const confirmed = window.confirm(
-      `Vas a borrar ${ids.length} tarea(s) ${scopeLabel} de tipo "${newType}". Esta acción no se puede deshacer.`
-    );
+    const confirmed = await confirm({
+      title: 'Borrado masivo',
+      description: `Vas a borrar ${ids.length} tarea(s) ${scopeLabel} de tipo "${newType}". Esta acción no se puede deshacer.`,
+      confirmText: 'Borrar',
+      destructive: true,
+    });
     if (!confirmed) return;
 
     try {

--- a/src/components/ui/__tests__/confirm-dialog.test.tsx
+++ b/src/components/ui/__tests__/confirm-dialog.test.tsx
@@ -62,7 +62,7 @@ describe("ConfirmDialogProvider / useConfirm", () => {
   })
 
   it("throws when used outside the provider", () => {
-    const Bare = () => {
+    const Bare = (): null => {
       useConfirm()
       return null
     }

--- a/src/components/ui/__tests__/confirm-dialog.test.tsx
+++ b/src/components/ui/__tests__/confirm-dialog.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import React from "react"
+import { act, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ConfirmDialogProvider, useConfirm } from "@/components/ui/confirm-dialog"
+
+function Harness({ onResult }: { onResult: (value: boolean) => void }) {
+  const confirm = useConfirm()
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        const result = await confirm({ description: "¿Eliminar?", confirmText: "Eliminar" })
+        onResult(result)
+      }}
+    >
+      Abrir
+    </button>
+  )
+}
+
+describe("ConfirmDialogProvider / useConfirm", () => {
+  it("resolves true when the confirm action is clicked", async () => {
+    const results: boolean[] = []
+    render(
+      <ConfirmDialogProvider>
+        <Harness onResult={(v) => results.push(v)} />
+      </ConfirmDialogProvider>,
+    )
+
+    act(() => {
+      screen.getByRole("button", { name: "Abrir" }).click()
+    })
+
+    const confirmBtn = await screen.findByRole("button", { name: "Eliminar" })
+    await act(async () => {
+      confirmBtn.click()
+    })
+
+    expect(results).toEqual([true])
+  })
+
+  it("resolves false when the cancel action is clicked", async () => {
+    const results: boolean[] = []
+    render(
+      <ConfirmDialogProvider>
+        <Harness onResult={(v) => results.push(v)} />
+      </ConfirmDialogProvider>,
+    )
+
+    act(() => {
+      screen.getByRole("button", { name: "Abrir" }).click()
+    })
+
+    const cancelBtn = await screen.findByRole("button", { name: "Cancelar" })
+    await act(async () => {
+      cancelBtn.click()
+    })
+
+    expect(results).toEqual([false])
+  })
+
+  it("throws when used outside the provider", () => {
+    const Bare = () => {
+      useConfirm()
+      return null
+    }
+    // Silence the expected React error log from the throwing render.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    expect(() => render(<Bare />)).toThrow(/ConfirmDialogProvider/)
+    spy.mockRestore()
+  })
+})

--- a/src/components/ui/__tests__/no-native-confirm.test.ts
+++ b/src/components/ui/__tests__/no-native-confirm.test.ts
@@ -14,7 +14,14 @@ const SRC_DIR = join(process.cwd(), "src")
 // The confirm-dialog implementation references the pattern in its JSDoc only.
 const ALLOWLIST = new Set(["components/ui/confirm-dialog.tsx"])
 
-const NATIVE_DIALOG = /\bwindow\.(confirm|alert)\s*\(/
+// Intentionally scoped to the explicit `window.` member form — i.e. exactly what
+// the M-1 migration removed and the most likely reintroduction. Matching a *bare*
+// `confirm(` is not safe with a text scan: the migrated code uses a local binding
+// `const confirm = useConfirm()` and calls `confirm(...)`, so it would false-positive
+// across the whole migration. Bare `alert(`/`prompt(` also have pre-existing,
+// out-of-scope usages (e.g. JobCardDocuments, SoundVisionFileUploader). Catching
+// those correctly needs scope-aware AST analysis, which is overkill for a guard test.
+const NATIVE_DIALOG = /\bwindow\.(confirm|alert|prompt)\s*\(/
 
 function collectSourceFiles(dir: string, acc: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {

--- a/src/components/ui/__tests__/no-native-confirm.test.ts
+++ b/src/components/ui/__tests__/no-native-confirm.test.ts
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Regression guard for docs/UI_UX_AUDIT.md M-1: blocking, unstyled
+ * `window.confirm` / `window.alert` dialogs are replaced by the themed
+ * `useConfirm` dialog. This test fails if a new native dialog sneaks back in,
+ * so the migration stays complete.
+ */
+
+const SRC_DIR = join(process.cwd(), "src")
+
+// The confirm-dialog implementation references the pattern in its JSDoc only.
+const ALLOWLIST = new Set(["components/ui/confirm-dialog.tsx"])
+
+const NATIVE_DIALOG = /\bwindow\.(confirm|alert)\s*\(/
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stats = statSync(full)
+    if (stats.isDirectory()) {
+      if (entry === "__tests__" || entry === "node_modules") continue
+      collectSourceFiles(full, acc)
+    } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      acc.push(full)
+    }
+  }
+  return acc
+}
+
+describe("no native window.confirm/alert in app source", () => {
+  it("uses the themed useConfirm dialog everywhere", () => {
+    const offenders: string[] = []
+    for (const file of collectSourceFiles(SRC_DIR)) {
+      const rel = file.slice(SRC_DIR.length + 1).replace(/\\/g, "/")
+      if (ALLOWLIST.has(rel)) continue
+      if (NATIVE_DIALOG.test(readFileSync(file, "utf8"))) {
+        offenders.push(rel)
+      }
+    }
+
+    expect(offenders, `Use useConfirm() instead of window.confirm/alert in: ${offenders.join(", ")}`).toEqual([])
+  })
+})

--- a/src/components/ui/__tests__/no-native-confirm.test.ts
+++ b/src/components/ui/__tests__/no-native-confirm.test.ts
@@ -23,7 +23,7 @@ function collectSourceFiles(dir: string, acc: string[] = []): string[] {
     if (stats.isDirectory()) {
       if (entry === "__tests__" || entry === "node_modules") continue
       collectSourceFiles(full, acc)
-    } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+    } else if (/\.(tsx?|jsx?)$/.test(entry) && !/\.test\.(tsx?|jsx?)$/.test(entry)) {
       acc.push(full)
     }
   }

--- a/src/components/ui/__tests__/primitives.test.tsx
+++ b/src/components/ui/__tests__/primitives.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { Inbox } from "lucide-react"
+import { describe, expect, it, vi } from "vitest"
+
+import { Loading, PageLoading, Spinner } from "@/components/ui/loading"
+import { EmptyState } from "@/components/ui/empty-state"
+import { SubmitButton } from "@/components/ui/submit-button"
+
+describe("Loading", () => {
+  it("exposes an accessible polite status with the default Spanish label", () => {
+    render(<Loading />)
+    const status = screen.getByRole("status")
+    expect(status).toHaveAttribute("aria-live", "polite")
+    expect(status).toHaveAttribute("aria-busy", "true")
+    expect(status).toHaveTextContent("Cargando…")
+  })
+
+  it("keeps the label announced but visually hidden when hideLabel is set", () => {
+    render(<Loading label="Cargando trabajos…" hideLabel />)
+    const label = screen.getByText("Cargando trabajos…")
+    expect(label).toHaveClass("sr-only")
+  })
+
+  it("PageLoading renders a status region", () => {
+    render(<PageLoading label="Cargando datos…" />)
+    expect(screen.getByRole("status")).toHaveTextContent("Cargando datos…")
+  })
+
+  it("Spinner is decorative (aria-hidden icon)", () => {
+    const { container } = render(<Spinner />)
+    expect(container.querySelector("[aria-hidden='true']")).toBeTruthy()
+  })
+})
+
+describe("EmptyState", () => {
+  it("renders title, description and action", () => {
+    render(
+      <EmptyState
+        icon={Inbox}
+        title="No hay trabajos"
+        description="Aparecerán aquí."
+        action={<button type="button">Crear</button>}
+      />,
+    )
+    expect(screen.getByRole("heading", { name: "No hay trabajos" })).toBeInTheDocument()
+    expect(screen.getByText("Aparecerán aquí.")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Crear" })).toBeInTheDocument()
+  })
+})
+
+describe("SubmitButton", () => {
+  it("disables and marks aria-busy while loading", () => {
+    render(<SubmitButton loading>Guardar</SubmitButton>)
+    const button = screen.getByRole("button")
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute("aria-busy", "true")
+  })
+
+  it("shows loadingText while loading and children otherwise", () => {
+    const { rerender } = render(
+      <SubmitButton loading loadingText="Guardando…">
+        Guardar
+      </SubmitButton>,
+    )
+    expect(screen.getByRole("button")).toHaveTextContent("Guardando…")
+
+    rerender(<SubmitButton loadingText="Guardando…">Guardar</SubmitButton>)
+    expect(screen.getByRole("button")).toHaveTextContent("Guardar")
+  })
+
+  it("is not disabled and forwards clicks when not loading", () => {
+    const onClick = vi.fn()
+    render(<SubmitButton onClick={onClick}>Guardar</SubmitButton>)
+    const button = screen.getByRole("button")
+    expect(button).not.toBeDisabled()
+    button.click()
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,110 @@
+import * as React from "react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+/**
+ * Promise-based confirmation dialog.
+ *
+ * Replaces blocking, unstyled `window.confirm` calls (see docs/UI_UX_AUDIT.md,
+ * M-1) with a themed, accessible AlertDialog while keeping call sites nearly
+ * identical:
+ *
+ *   if (!window.confirm("¿Eliminar?")) return
+ *   // becomes
+ *   if (!(await confirm({ description: "¿Eliminar?" }))) return
+ *
+ * Mount <ConfirmDialogProvider> once near the app root, then call useConfirm().
+ */
+
+export interface ConfirmOptions {
+  title?: React.ReactNode
+  description?: React.ReactNode
+  confirmText?: string
+  cancelText?: string
+  /** Style the confirm action as destructive (red). */
+  destructive?: boolean
+}
+
+type ConfirmFn = (options?: ConfirmOptions) => Promise<boolean>
+
+const ConfirmContext = React.createContext<ConfirmFn | null>(null)
+
+interface PendingState extends ConfirmOptions {
+  resolve: (value: boolean) => void
+}
+
+export function ConfirmDialogProvider({ children }: { children: React.ReactNode }) {
+  const [pending, setPending] = React.useState<PendingState | null>(null)
+
+  const confirm = React.useCallback<ConfirmFn>((options) => {
+    return new Promise<boolean>((resolve) => {
+      setPending({ ...options, resolve })
+    })
+  }, [])
+
+  const settle = React.useCallback(
+    (value: boolean) => {
+      setPending((current) => {
+        current?.resolve(value)
+        return null
+      })
+    },
+    [],
+  )
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <AlertDialog
+        open={pending !== null}
+        onOpenChange={(open) => {
+          // Closing via overlay/escape counts as a cancel.
+          if (!open) settle(false)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{pending?.title ?? "¿Confirmar acción?"}</AlertDialogTitle>
+            {pending?.description && (
+              <AlertDialogDescription>{pending.description}</AlertDialogDescription>
+            )}
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => settle(false)}>
+              {pending?.cancelText ?? "Cancelar"}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className={cn(pending?.destructive && buttonVariants({ variant: "destructive" }))}
+              onClick={() => settle(true)}
+            >
+              {pending?.confirmText ?? "Confirmar"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </ConfirmContext.Provider>
+  )
+}
+
+/**
+ * Returns an async `confirm(options)` that resolves to true/false.
+ * Throws if used outside <ConfirmDialogProvider>.
+ */
+export function useConfirm(): ConfirmFn {
+  const ctx = React.useContext(ConfirmContext)
+  if (!ctx) {
+    throw new Error("useConfirm must be used within a ConfirmDialogProvider")
+  }
+  return ctx
+}

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -46,22 +46,29 @@ interface PendingState extends ConfirmOptions {
 
 export function ConfirmDialogProvider({ children }: { children: React.ReactNode }) {
   const [pending, setPending] = React.useState<PendingState | null>(null)
+  // Mirror of `pending` for reading the in-flight request synchronously without
+  // adding it to callback deps (which would churn the context value identity).
+  const pendingRef = React.useRef<PendingState | null>(null)
+
+  const settle = React.useCallback((value: boolean) => {
+    const current = pendingRef.current
+    pendingRef.current = null
+    setPending(null)
+    // Resolve outside the state updater so the promise settles as a plain
+    // side effect rather than during render (StrictMode-safe).
+    current?.resolve(value)
+  }, [])
 
   const confirm = React.useCallback<ConfirmFn>((options) => {
     return new Promise<boolean>((resolve) => {
-      setPending({ ...options, resolve })
+      // If a request is already in flight, settle it as a cancel first so its
+      // promise never leaks unresolved when a new confirm() overwrites it.
+      pendingRef.current?.resolve(false)
+      const next: PendingState = { ...options, resolve }
+      pendingRef.current = next
+      setPending(next)
     })
   }, [])
-
-  const settle = React.useCallback(
-    (value: boolean) => {
-      setPending((current) => {
-        current?.resolve(value)
-        return null
-      })
-    },
-    [],
-  )
 
   return (
     <ConfirmContext.Provider value={confirm}>

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils"
  *   action={<Button onClick={onCreate}>Crear trabajo</Button>}
  * />
  */
-export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface EmptyStateProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   icon?: LucideIcon
   title: React.ReactNode
   description?: React.ReactNode

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+import type { LucideIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Shared empty-state primitive.
+ *
+ * Standardizes the "no hay resultados" / "sin datos" treatment that is
+ * currently reimplemented ad hoc across lists and tables
+ * (see docs/UI_UX_AUDIT.md, M-9). Pairs an optional icon, a title, an optional
+ * description, and an optional call-to-action in a consistent, token-themed
+ * layout that works in light and dark mode.
+ *
+ * @example
+ * <EmptyState
+ *   icon={Inbox}
+ *   title="No hay trabajos"
+ *   description="Cuando se creen trabajos aparecerán aquí."
+ *   action={<Button onClick={onCreate}>Crear trabajo</Button>}
+ * />
+ */
+export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
+  icon?: LucideIcon
+  title: React.ReactNode
+  description?: React.ReactNode
+  action?: React.ReactNode
+}
+
+export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
+  ({ icon: Icon, title, description, action, className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border bg-muted/30 px-6 py-12 text-center",
+        className,
+      )}
+      {...props}
+    >
+      {Icon && (
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Icon className="h-6 w-6" aria-hidden="true" />
+        </div>
+      )}
+      <div className="space-y-1">
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        {description && (
+          <p className="mx-auto max-w-sm text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  ),
+)
+EmptyState.displayName = "EmptyState"

--- a/src/components/ui/loading.tsx
+++ b/src/components/ui/loading.tsx
@@ -1,0 +1,88 @@
+import * as React from "react"
+import { Loader2 } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Shared loading primitives.
+ *
+ * Replaces the ad-hoc `<Loader2 className="animate-spin" />` spinners scattered
+ * across the app (see docs/UI_UX_AUDIT.md, H-6 / M-5). All variants expose an
+ * accessible status region so screen readers announce loading transitions
+ * (WCAG 4.1.3), and the spinner is paused under `prefers-reduced-motion` via the
+ * global rule in index.css.
+ */
+
+const spinnerSizes = {
+  sm: "h-4 w-4",
+  md: "h-6 w-6",
+  lg: "h-8 w-8",
+  xl: "h-12 w-12",
+} as const
+
+export type SpinnerSize = keyof typeof spinnerSizes
+
+export interface SpinnerProps extends React.HTMLAttributes<HTMLSpanElement> {
+  size?: SpinnerSize
+}
+
+/** Bare animated spinner. Prefer <Loading> when there is a status to announce. */
+export const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
+  ({ size = "md", className, ...props }, ref) => (
+    <span ref={ref} className={cn("inline-flex", className)} {...props}>
+      <Loader2 className={cn("animate-spin text-muted-foreground", spinnerSizes[size])} aria-hidden="true" />
+    </span>
+  ),
+)
+Spinner.displayName = "Spinner"
+
+export interface LoadingProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Accessible + visible label. Defaults to the Spanish "Cargando…". */
+  label?: string
+  /** Hide the visible label but keep it announced to assistive tech. */
+  hideLabel?: boolean
+  size?: SpinnerSize
+}
+
+/**
+ * Inline loading indicator with an accessible status label.
+ *
+ * @example
+ * <Loading label="Cargando trabajos…" />
+ */
+export const Loading = React.forwardRef<HTMLDivElement, LoadingProps>(
+  ({ label = "Cargando…", hideLabel = false, size = "md", className, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      className={cn("flex items-center justify-center gap-2 text-sm text-muted-foreground", className)}
+      {...props}
+    >
+      <Spinner size={size} />
+      <span className={cn(hideLabel && "sr-only")}>{label}</span>
+    </div>
+  ),
+)
+Loading.displayName = "Loading"
+
+export interface PageLoadingProps extends Omit<LoadingProps, "size"> {
+  /** Minimum vertical space the loader fills. Defaults to 50vh. */
+  minHeightClassName?: string
+}
+
+/**
+ * Full-section loading state for route/page fallbacks.
+ *
+ * @example
+ * <Suspense fallback={<PageLoading />}>…</Suspense>
+ */
+export const PageLoading = React.forwardRef<HTMLDivElement, PageLoadingProps>(
+  ({ label = "Cargando…", minHeightClassName = "min-h-[50vh]", className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex w-full items-center justify-center", minHeightClassName, className)}>
+      <Loading label={label} size="lg" {...props} />
+    </div>
+  ),
+)
+PageLoading.displayName = "PageLoading"

--- a/src/components/ui/loading.tsx
+++ b/src/components/ui/loading.tsx
@@ -80,8 +80,10 @@ export interface PageLoadingProps extends Omit<LoadingProps, "size"> {
  */
 export const PageLoading = React.forwardRef<HTMLDivElement, PageLoadingProps>(
   ({ label = "Cargando…", minHeightClassName = "min-h-[50vh]", className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex w-full items-center justify-center", minHeightClassName, className)}>
-      <Loading label={label} size="lg" {...props} />
+    // Wrapper carries only layout styling; the forwarded ref and ...props
+    // (id, data-*, ARIA, handlers) land together on the inner status element.
+    <div className={cn("flex w-full items-center justify-center", minHeightClassName, className)}>
+      <Loading ref={ref} label={label} size="lg" {...props} />
     </div>
   ),
 )

--- a/src/components/ui/submit-button.tsx
+++ b/src/components/ui/submit-button.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+import { Loader2 } from "lucide-react"
+
+import { Button, type ButtonProps } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+/**
+ * Submit/action button with a built-in async guard.
+ *
+ * Prevents double-submit and gives consistent loading feedback for the many
+ * mutations that currently wire `disabled={isPending}` by hand or not at all
+ * (see docs/UI_UX_AUDIT.md, L-2 / H-4). While `loading` is true the button is
+ * disabled, shows a spinner, and sets `aria-busy` so assistive tech is informed.
+ *
+ * @example
+ * <SubmitButton loading={mutation.isPending} loadingText="Guardando…">
+ *   Guardar
+ * </SubmitButton>
+ */
+export interface SubmitButtonProps extends ButtonProps {
+  loading?: boolean
+  /** Optional text shown while loading. Falls back to the button's children. */
+  loadingText?: React.ReactNode
+}
+
+export const SubmitButton = React.forwardRef<HTMLButtonElement, SubmitButtonProps>(
+  ({ loading = false, loadingText, disabled, children, className, ...props }, ref) => (
+    <Button
+      ref={ref}
+      className={cn(className)}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      {...props}
+    >
+      {loading && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+      {loading && loadingText ? loadingText : children}
+    </Button>
+  ),
+)
+SubmitButton.displayName = "SubmitButton"

--- a/src/hooks/useJobActions.ts
+++ b/src/hooks/useJobActions.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useToast } from "@/hooks/use-toast";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { useDeletionState } from "@/hooks/useDeletionState";
 import { deleteJobOptimistically } from "@/services/optimisticJobDeletionService";
@@ -13,6 +14,7 @@ import { canUseCustomFolderStructure, isManagementRole } from "@/utils/permissio
 import { queryKeys } from "@/lib/react-query";
 export const useJobActions = (job: any, userRole: string | null, onDeleteClick?: (jobId: string) => void) => {
   const { toast } = useToast();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const { addDeletingJob, removeDeletingJob, isDeletingJob } = useDeletionState();
   
@@ -38,7 +40,13 @@ export const useJobActions = (job: any, userRole: string | null, onDeleteClick?:
       return;
     }
 
-    if (!window.confirm('Are you sure you want to delete this job? This action cannot be undone and will remove all related data.')) {
+    const confirmed = await confirm({
+      title: "Eliminar trabajo",
+      description: "¿Seguro que quieres eliminar este trabajo? Esta acción no se puede deshacer y eliminará todos los datos relacionados.",
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (!confirmed) {
       return;
     }
 

--- a/src/hooks/useJobCard.ts
+++ b/src/hooks/useJobCard.ts
@@ -3,6 +3,7 @@ import { useTheme } from 'next-themes';
 import { useQueryClient, useMutation, useQuery } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
 import { useToast } from '@/hooks/use-toast';
+import { useConfirm } from '@/components/ui/confirm-dialog';
 import { JobDocument } from '@/components/jobs/cards/JobCardDocuments';
 import { Department } from '@/types/department';
 import { useDeletionState } from './useDeletionState';
@@ -19,6 +20,7 @@ import { getDocumentUploadValidationError } from '@/utils/documentUploadValidati
 import { queryKeys } from "@/lib/react-query";
 export const useJobCard = (job: any, department: Department, userRole: string | null, onEditClick?: (job: any) => void, onDeleteClick?: (jobId: string) => void, onJobClick?: (jobId: string) => void) => {
   const { toast } = useToast();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const { theme } = useTheme();
   const isDark = theme === "dark";
@@ -259,7 +261,13 @@ export const useJobCard = (job: any, department: Department, userRole: string | 
       return;
     }
 
-    if (!window.confirm("Are you sure you want to delete this document?")) return;
+    const confirmed = await confirm({
+      title: "Eliminar documento",
+      description: "¿Seguro que quieres eliminar este documento?",
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (!confirmed) return;
     try {
       console.log("useJobCard: Starting document deletion:", doc);
       const { bucket, path } = resolveJobDocLocation(doc.file_path);

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -4,6 +4,7 @@ import { supabase } from '@/lib/supabase';
 import { useTheme } from 'next-themes';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/hooks/use-toast';
+import { useConfirm } from '@/components/ui/confirm-dialog';
 import { createQueryKey } from '@/lib/optimized-react-query';
 import { useRequiredRoleSummary } from '@/hooks/useJobRequiredRoles';
 import { resolveJobDocLocation } from '@/utils/jobDocuments';
@@ -44,6 +45,7 @@ export const useOptimizedJobCard = (
   const { theme } = useTheme();
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const confirm = useConfirm();
   const enableRoleSummary = options?.enableRoleSummary ?? true;
   const enableSoundTasks = options?.enableSoundTasks ?? true;
   const refreshAssignmentsOnMount = options?.refreshAssignmentsOnMount ?? false;
@@ -440,7 +442,13 @@ export const useOptimizedJobCard = (
       console.error('Attempted to delete read-only document', doc);
       return;
     }
-    if (!window.confirm('Are you sure you want to delete this document?')) return;
+    const confirmed = await confirm({
+      title: 'Eliminar documento',
+      description: '¿Seguro que quieres eliminar este documento?',
+      confirmText: 'Eliminar',
+      destructive: true,
+    });
+    if (!confirmed) return;
 
     try {
       const { bucket, path } = resolveJobDocLocation(doc.file_path);
@@ -469,7 +477,7 @@ export const useOptimizedJobCard = (
     } catch (err: any) {
       console.error('Delete error:', err);
     }
-  }, [job.id]);
+  }, [job.id, confirm]);
 
   const refreshData = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,28 @@
   h3 { font-size: var(--text-xl); line-height: 1.3; }
   h4 { font-size: var(--text-lg); line-height: 1.35; }
   small { font-size: var(--text-xs); }
+
+  /* Consistent, token-based keyboard focus indicator for any focusable
+     element that doesn't already define its own focus-visible treatment. */
+  :focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+}
+
+/* Respect users who prefer reduced motion (WCAG 2.3.3 / 2.2.2).
+   Near-instant animations/transitions and disabled smooth scroll, while
+   preserving final visual state. Components needing motion can opt back in
+   with a `motion-safe:` variant. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* Custom scrollbar styles */

--- a/src/index.css
+++ b/src/index.css
@@ -179,8 +179,10 @@
   *::before,
   *::after {
     animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -160,13 +160,13 @@ const Auth = () => {
   // Show legacy forms for signup/recovery
   if (showSignUp || showForgotPassword || isRecovery) {
     return (
-      <div className="auth-no-oauth min-h-screen flex flex-col px-4 py-8 pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] md:py-12 bg-slate-50">
+      <div className="auth-no-oauth min-h-screen flex flex-col px-4 py-8 pt-[max(2rem,env(safe-area-inset-top))] pb-[max(2rem,env(safe-area-inset-bottom))] md:py-12 bg-background">
         <div className="container max-w-lg mx-auto flex-1 flex flex-col">
           <div className="text-center mb-8">
-            <h1 className="text-4xl font-bold mb-2 text-slate-900">Bienvenido</h1>
-            <p className="text-lg text-slate-500">al Área Técnica Sector-Pro</p>
+            <h1 className="text-4xl font-bold mb-2 text-foreground">Bienvenido</h1>
+            <p className="text-lg text-muted-foreground">al Área Técnica Sector-Pro</p>
           </div>
-          <div className="bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+          <div className="bg-card text-card-foreground p-6 rounded-xl shadow-lg border border-border">
             {isRecovery ? (
               <ResetPasswordForm onSuccess={() => { }} />
             ) : showForgotPassword ? (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import { MessageSquare, Mail, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { isJobOnDate } from "@/utils/timezoneUtils";
 import { useToast } from "@/hooks/use-toast";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { deleteJobOptimistically } from "@/services/optimisticJobDeletionService";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -95,6 +96,7 @@ const Dashboard = () => {
   const jobsRangeEnd = addDays(endOfMonth(monthAnchor), 14);
   const { data: jobs = [], isLoading } = useOptimizedJobs(undefined, jobsRangeStart, jobsRangeEnd);
   const { toast } = useToast();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
 
   const { data: pendingExpensesSummary, isLoading: isLoadingPendingExpenses } = useQuery({
@@ -165,7 +167,13 @@ const Dashboard = () => {
       return;
     }
 
-    if (!window.confirm("Are you sure you want to delete this job? This action cannot be undone and will remove all related data.")) return;
+    const confirmed = await confirm({
+      title: "Eliminar trabajo",
+      description: "¿Seguro que quieres eliminar este trabajo? Esta acción no se puede deshacer y eliminará todos los datos relacionados.",
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (!confirmed) return;
 
     try {
       // Call optimistic deletion service
@@ -190,7 +198,7 @@ const Dashboard = () => {
         variant: "destructive"
       });
     }
-  }, [queryClient, toast, userRole]);
+  }, [queryClient, toast, userRole, confirm]);
 
   const handleDateTypeChange = useCallback(() => {}, []);
 

--- a/src/pages/GlobalTasks.tsx
+++ b/src/pages/GlobalTasks.tsx
@@ -6,6 +6,7 @@ import { canAssignTasks, canCreateTasks, canEditTasks, normalizeDept, type Dept 
 import { CreateGlobalTaskDialog } from '@/components/tasks/CreateGlobalTaskDialog';
 import { LinkJobDialog } from '@/components/tasks/LinkJobDialog';
 import { Button } from '@/components/ui/button';
+import { useConfirm } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -158,6 +159,7 @@ export default function GlobalTasks() {
   const canCreate = canCreateTasks(userRole) || isProductionDepartmentUser;
   const canAssign = canAssignTasks(userRole) || isProductionDepartmentUser;
   const { toast } = useToast();
+  const confirm = useConfirm();
 
   // Filters
   const [statusFilter, setStatusFilter] = React.useState<string>('active');
@@ -336,9 +338,12 @@ export default function GlobalTasks() {
     }
 
     const scopeLabel = bulkDeleteScope === 'unassigned' ? 'sin asignar' : 'todas';
-    const confirmed = window.confirm(
-      `Vas a borrar ${candidates.length} tarea(s) ${scopeLabel} de tipo "${bulkDeleteType}". Esta acción no se puede deshacer.`
-    );
+    const confirmed = await confirm({
+      title: 'Borrado masivo',
+      description: `Vas a borrar ${candidates.length} tarea(s) ${scopeLabel} de tipo "${bulkDeleteType}". Esta acción no se puede deshacer.`,
+      confirmText: 'Borrar',
+      destructive: true,
+    });
     if (!confirmed) return;
 
     const results = await Promise.allSettled(candidates.map((task) => mutations.deleteTask(task.id)));
@@ -827,8 +832,14 @@ export default function GlobalTasks() {
                             size="sm"
                             variant="ghost"
                             className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                            onClick={() => {
-                              if (window.confirm('¿Eliminar esta tarea? Esta acción no se puede deshacer.')) {
+                            onClick={async () => {
+                              const confirmed = await confirm({
+                                title: 'Eliminar tarea',
+                                description: '¿Eliminar esta tarea? Esta acción no se puede deshacer.',
+                                confirmText: 'Eliminar',
+                                destructive: true,
+                              });
+                              if (confirmed) {
                                 mutations
                                   .deleteTask(task.id)
                                   .then(() => {

--- a/src/pages/Lights.tsx
+++ b/src/pages/Lights.tsx
@@ -121,7 +121,7 @@ const Lights = () => {
 
     const confirmed = await confirm({
       title: "Eliminar trabajo",
-      description: "¿Está seguro de que desea eliminar este trabajo?",
+      description: "¿Seguro que quieres eliminar este trabajo? Esta acción no se puede deshacer y eliminará todos los datos relacionados.",
       confirmText: "Eliminar",
       destructive: true,
     });

--- a/src/pages/Lights.tsx
+++ b/src/pages/Lights.tsx
@@ -7,6 +7,7 @@ import { addDays, endOfMonth, format, startOfMonth, subDays } from "date-fns";
 import { JobAssignmentDialog } from "@/components/jobs/JobAssignmentDialog";
 import { EditJobDialog } from "@/components/jobs/EditJobDialog";
 import { useToast } from "@/hooks/use-toast";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useQueryClient } from "@tanstack/react-query";
 import { LightsHeader } from "@/components/lights/LightsHeader";
@@ -51,6 +52,7 @@ const Lights = () => {
   const jobsRangeEnd = addDays(endOfMonth(monthAnchor), 14);
   const { data: jobs, isLoading } = useOptimizedJobs(currentDepartment as any, jobsRangeStart, jobsRangeEnd);
   const { toast } = useToast();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
 
   // Keyboard shortcut: Cmd/Ctrl+N to open (disable plain 'c')
@@ -117,7 +119,13 @@ const Lights = () => {
       return;
     }
 
-    if (!window.confirm("¿Está seguro de que desea eliminar este trabajo?")) return;
+    const confirmed = await confirm({
+      title: "Eliminar trabajo",
+      description: "¿Está seguro de que desea eliminar este trabajo?",
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (!confirmed) return;
 
     try {
       console.log("Lights page: Starting optimistic job deletion for:", jobId);
@@ -144,7 +152,7 @@ const Lights = () => {
           variant: "destructive"
         });
       }
-  }, [canManageJobs, queryClient, toast]);
+  }, [canManageJobs, queryClient, toast, confirm]);
 
   const handleAssignmentDialogClose = useCallback(() => {
     setIsAssignmentDialogOpen(false);

--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -4,6 +4,7 @@ import { useJobs } from "@/hooks/useJobs";
 import { JobAssignmentDialog } from "@/components/jobs/JobAssignmentDialog";
 import { EditJobDialog } from "@/components/jobs/EditJobDialog";
 import { useToast } from "@/hooks/use-toast";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useQueryClient } from "@tanstack/react-query";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { LightsHeader } from "@/components/lights/LightsHeader";
@@ -62,6 +63,7 @@ const Sound = () => {
   const currentDepartment = "sound";
   const { data: jobs } = useJobs();
   const { toast } = useToast();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const { user, userRole, hasSoundVisionAccess, userDepartment, isLoading: authLoading } = useOptimizedAuth();
   const canManageJobs = isManagementRole(userRole);
@@ -222,7 +224,13 @@ const Sound = () => {
       return;
     }
 
-    if (!window.confirm("¿Seguro que quieres eliminar este trabajo? Esta acción no se puede deshacer y eliminará todos los datos relacionados.")) return;
+    const confirmed = await confirm({
+      title: "Eliminar trabajo",
+      description: "¿Seguro que quieres eliminar este trabajo? Esta acción no se puede deshacer y eliminará todos los datos relacionados.",
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (!confirmed) return;
 
     try {
       const result = await deleteJobOptimistically(jobId);

--- a/src/pages/Video.tsx
+++ b/src/pages/Video.tsx
@@ -8,6 +8,7 @@ import { addDays, endOfMonth, format, startOfMonth, subDays } from "date-fns";
 import { JobAssignmentDialog } from "@/components/jobs/JobAssignmentDialog";
 import { EditJobDialog } from "@/components/jobs/EditJobDialog";
 import { useToast } from "@/hooks/use-toast";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { useQueryClient } from "@tanstack/react-query";
@@ -49,6 +50,7 @@ const Video = () => {
   
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const confirm = useConfirm();
   
   useTabVisibility(['optimized-jobs']);
 
@@ -121,7 +123,13 @@ const Video = () => {
       return;
     }
 
-    if (!window.confirm("Are you sure you want to delete this job?")) return;
+    const confirmed = await confirm({
+      title: "Eliminar trabajo",
+      description: "¿Seguro que quieres eliminar este trabajo?",
+      confirmText: "Eliminar",
+      destructive: true,
+    });
+    if (!confirmed) return;
 
     try {
       const { error } = await dataLayerClient.from('jobs')
@@ -142,7 +150,7 @@ const Video = () => {
         variant: "destructive",
       });
     }
-  }, [canManageJobs, queryClient, toast]);
+  }, [canManageJobs, queryClient, toast, confirm]);
 
   const handleAssignmentDialogClose = useCallback(() => {
     setIsAssignmentDialogOpen(false);

--- a/src/pages/WallboardPresets.tsx
+++ b/src/pages/WallboardPresets.tsx
@@ -3,6 +3,7 @@ import { dataLayerClient } from '@/services/dataLayerClient';
 import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { MANAGEMENT_ALLOWED_ROLES } from '@/utils/permissions';
 import { Button } from '@/components/ui/button';
+import { useConfirm } from '@/components/ui/confirm-dialog';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -77,6 +78,7 @@ function getPublicDisplayUrl(value?: string, slug?: string): string {
 export default function WallboardPresets() {
   useRoleGuard(MANAGEMENT_ALLOWED_ROLES);
   const { toast } = useToast();
+  const confirm = useConfirm();
 
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -368,12 +370,13 @@ export default function WallboardPresets() {
   };
 
   const deletePreset = async (preset: WallboardPresetRow) => {
-    if (typeof window !== 'undefined') {
-      const confirmed = window.confirm(
-        `¿Eliminar wallboard "${preset.name}"? Esta acción no se puede deshacer y cualquier pantalla que lo use dejará de actualizarse.`
-      );
-      if (!confirmed) return;
-    }
+    const confirmed = await confirm({
+      title: 'Eliminar wallboard',
+      description: `¿Eliminar wallboard "${preset.name}"? Esta acción no se puede deshacer y cualquier pantalla que lo use dejará de actualizarse.`,
+      confirmText: 'Eliminar',
+      destructive: true,
+    });
+    if (!confirmed) return;
 
     setDeletingId(preset.id);
     try {


### PR DESCRIPTION
## Summary

Lands the full UI/UX audit work stream into `main`, including the **`window.confirm` → `useConfirm` migration (M-1)** (originally PR #738, merged into this integration branch). The migration can't be cherry-picked alone — it shares the `useConfirm` provider and `App.tsx` wiring with the rest of the audit work — so the whole reviewed stream lands together.

`main` has been merged into this branch and the one conflict (`App.tsx`) resolved, so the PR is up to date and conflict-free.

## What's included

- **Audit doc** — `docs/UI_UX_AUDIT.md`: findings, severity, remediation plan, 6-phase roadmap, live progress table.
- **Phase 0 a11y quick wins** — `lang="es"`, light/dark `theme-color`, global `prefers-reduced-motion` + `:focus-visible` baseline, skip-to-content link, focus-ring token cleanup.
- **Shared primitives** — `Loading`/`PageLoading`/`Spinner`, `EmptyState`, `SubmitButton` (a11y-correct, token-themed, unit-tested); adopted in the route fallback.
- **Dark-mode fixes** — Auth signup/recovery migrated to semantic tokens; `ThemeColorMeta` syncs browser chrome to the active app theme.
- **M-1 confirm migration** — every native `window.confirm`/`alert` replaced with the themed, accessible `useConfirm` dialog (components, pages, and 3 job-card hooks), guarded by a source-scan regression test (`no-native-confirm.test.ts`).

## Conflict resolution (`App.tsx`)

`main` independently added theme handling (`ThemePreferenceSync`, `APP_THEME_STORAGE_KEY`). The merge combines both, dropping nothing:
- kept `main`'s `storageKey={APP_THEME_STORAGE_KEY}` and the `<ThemePreferenceSync />` mount;
- kept this branch's `<ThemeColorMeta />`, `<ConfirmDialogProvider>` wrapping, and `PageLoading` fallback.

## Validation (post-merge)

- `tsc -p tsconfig.app.json` — no new errors (only the pre-existing `baseUrl` deprecation).
- `vitest` — primitive/confirm/scan suites pass (14 tests); earlier touched-area runs (130 tests) green.
- `vite build` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent in-app confirmation dialog for destructive actions, replacing browser prompts.
  * Introduced shared loading, empty-state, and submit-button states with clearer feedback.
  * Added a skip-to-content link and improved theme-aware browser color handling.

* **Bug Fixes**
  * Improved accessibility with better focus styling, live loading regions, and reduced-motion support.
  * Updated several screens to use theme-consistent colors in light and dark modes.

* **Tests**
  * Added coverage for confirmation flows and shared UI states, plus a regression check against native dialogs.

* **Documentation**
  * Expanded the UI/UX audit notes with findings, verification, and a remediation roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->