### PR TITLE
fix: stabilize persisted theme preference

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -52,6 +52,10 @@ vi.mock("@/components/theme-provider", () => ({
   ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("@/components/ThemePreferenceSync", () => ({
+  ThemePreferenceSync: (): null => null,
+}));
+
 vi.mock("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,13 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { ThemePreferenceSync } from "@/components/ThemePreferenceSync";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ViewportProvider } from "@/hooks/use-mobile";
 import { OptimizedAuthProvider } from "@/hooks/useOptimizedAuth";
 import { MultiTabCoordinator } from "@/lib/multitab-coordinator";
 import { queryClient } from "@/lib/react-query";
+import { APP_THEME_STORAGE_KEY } from "@/lib/theme";
 import { AppBadgeProvider } from "@/providers/AppBadgeProvider";
 import { AppRuntimeCoordinator } from "@/runtime/AppRuntimeCoordinator";
 import {
@@ -57,10 +59,11 @@ export default function App() {
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <ViewportProvider>
-          <ThemeProvider defaultTheme="system" storageKey="sector-pro-theme" attribute="class">
+          <ThemeProvider defaultTheme="system" storageKey={APP_THEME_STORAGE_KEY} attribute="class">
             <AppBadgeProvider>
               <Router>
                 <OptimizedAuthProvider>
+                  <ThemePreferenceSync />
                   <AppRuntimeCoordinator />
                   <RouteAwareGlobalInitializers />
                   <div className="app">

--- a/src/components/ThemePreferenceSync.tsx
+++ b/src/components/ThemePreferenceSync.tsx
@@ -1,0 +1,7 @@
+import { useThemePreferenceSync } from "@/hooks/useThemePreferenceSync";
+
+export const ThemePreferenceSync = (): null => {
+  useThemePreferenceSync();
+
+  return null;
+};

--- a/src/components/__tests__/ThemePreferenceSync.test.tsx
+++ b/src/components/__tests__/ThemePreferenceSync.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+import { APP_THEME_STORAGE_KEY, LEGACY_THEME_STORAGE_KEY } from "@/lib/theme";
+
+const { authStateMock, fromMock, setThemeMock } = vi.hoisted(() => ({
+  authStateMock: vi.fn(),
+  fromMock: vi.fn(),
+  setThemeMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/useOptimizedAuth", () => ({
+  useOptimizedAuth: () => authStateMock(),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ setTheme: setThemeMock }),
+}));
+
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: {
+    from: (...args: unknown[]) => fromMock(...args),
+  },
+}));
+
+import { ThemePreferenceSync } from "@/components/ThemePreferenceSync";
+
+const createProfileQuery = (darkMode: boolean | null) => {
+  const query = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: { dark_mode: darkMode },
+      error: null,
+    }),
+  };
+
+  return query;
+};
+
+describe("ThemePreferenceSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    authStateMock.mockReturnValue({
+      user: { id: "user-1" },
+      isLoading: false,
+    });
+  });
+
+  it("keeps a local persisted theme instead of reading the database fallback", async () => {
+    window.localStorage.setItem(APP_THEME_STORAGE_KEY, "dark");
+
+    render(<ThemePreferenceSync />);
+
+    await waitFor(() => {
+      expect(setThemeMock).toHaveBeenCalledWith("dark");
+    });
+
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the database preference only when there is no local theme", async () => {
+    fromMock.mockReturnValue(createProfileQuery(true));
+
+    render(<ThemePreferenceSync />);
+
+    await waitFor(() => {
+      expect(setThemeMock).toHaveBeenCalledWith("dark");
+    });
+
+    expect(window.localStorage.getItem(APP_THEME_STORAGE_KEY)).toBe("dark");
+    expect(window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY)).toBe("dark");
+  });
+});

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
 
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import { persistExplicitThemePreference } from "@/lib/theme"
 import { useUserPreferences } from "@/hooks/useUserPreferences"
 
 interface ThemeToggleProps {
@@ -18,35 +19,20 @@ export const ThemeToggle = ({
   ariaLabel,
 }: ThemeToggleProps = {}) => {
   const { resolvedTheme, setTheme } = useTheme()
-  const { preferences, updatePreferences } = useUserPreferences()
+  const { updatePreferences } = useUserPreferences()
   const [mounted, setMounted] = useState(false)
-  const hasManuallyToggled = useRef(false)
 
   useEffect(() => setMounted(true), [])
-
-  // Sync with database preferences on initial load only
-  useEffect(() => {
-    if (hasManuallyToggled.current) return
-    if (preferences?.dark_mode !== undefined) {
-      const preferred = preferences.dark_mode ? 'dark' : 'light'
-      setTheme(preferred)
-      // Keep legacy key in sync for backward compat with useTechnicianTheme
-      localStorage.setItem('theme-preference', preferred)
-    }
-  }, [preferences, setTheme])
 
   const isDarkMode = mounted ? resolvedTheme === 'dark' : true
 
   const toggleDarkMode = useCallback(() => {
-    hasManuallyToggled.current = true
     const newTheme = isDarkMode ? 'light' : 'dark'
+    persistExplicitThemePreference(newTheme)
     setTheme(newTheme)
 
-    // Keep legacy key in sync for backward compat with useTechnicianTheme
-    localStorage.setItem('theme-preference', newTheme)
-
     // Update database in background
-    updatePreferences({ dark_mode: !isDarkMode })
+    updatePreferences({ dark_mode: newTheme === 'dark' })
   }, [isDarkMode, setTheme, updatePreferences])
 
   // Global keyboard shortcut: Ctrl+Shift+D (Cmd+Shift+D on Mac)

--- a/src/components/layout/__tests__/ThemeToggle.test.tsx
+++ b/src/components/layout/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { APP_THEME_STORAGE_KEY, LEGACY_THEME_STORAGE_KEY } from "@/lib/theme";
+
+const { setThemeMock, updatePreferencesMock, useThemeMock } = vi.hoisted(() => ({
+  setThemeMock: vi.fn(),
+  updatePreferencesMock: vi.fn(),
+  useThemeMock: vi.fn(),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => useThemeMock(),
+}));
+
+vi.mock("@/hooks/useUserPreferences", () => ({
+  useUserPreferences: () => ({
+    updatePreferences: updatePreferencesMock,
+  }),
+}));
+
+import { ThemeToggle } from "@/components/layout/ThemeToggle";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    useThemeMock.mockReturnValue({
+      resolvedTheme: "light",
+      setTheme: setThemeMock,
+    });
+  });
+
+  it("does not overwrite the current theme when mounted", async () => {
+    window.localStorage.setItem(APP_THEME_STORAGE_KEY, "dark");
+
+    render(<ThemeToggle />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Modo claro")).toBeInTheDocument();
+    });
+
+    expect(setThemeMock).not.toHaveBeenCalled();
+  });
+
+  it("persists explicit toggles to both current and legacy storage keys", async () => {
+    const user = userEvent.setup();
+
+    render(<ThemeToggle />);
+
+    await screen.findByText("Modo claro");
+    await user.click(screen.getByRole("button", { name: /modo claro/i }));
+
+    expect(setThemeMock).toHaveBeenCalledWith("dark");
+    expect(updatePreferencesMock).toHaveBeenCalledWith({ dark_mode: true });
+    expect(window.localStorage.getItem(APP_THEME_STORAGE_KEY)).toBe("dark");
+    expect(window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY)).toBe("dark");
+  });
+});

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -4,6 +4,12 @@ import * as React from "react"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
 import { type ThemeProviderProps } from "next-themes/dist/types"
 
+import { APP_THEME_STORAGE_KEY, migrateLegacyThemePreference } from "@/lib/theme"
+
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  if (props.storageKey === APP_THEME_STORAGE_KEY) {
+    migrateLegacyThemePreference()
+  }
+
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>
 }

--- a/src/hooks/useTechnicianTheme.ts
+++ b/src/hooks/useTechnicianTheme.ts
@@ -1,18 +1,22 @@
 import { useEffect, useState } from 'react';
 import { Theme } from '@/components/technician/types';
 import { useUserPreferences } from './useUserPreferences';
+import {
+  explicitPreferenceFromDarkMode,
+  getStoredThemePreference,
+  isDarkThemePreference,
+} from '@/lib/theme';
 
 export const useTechnicianTheme = () => {
   const { preferences } = useUserPreferences();
 
   // Get initial theme from localStorage (synchronous, no flash!)
   const getInitialDarkMode = () => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('theme-preference');
-      if (stored !== null) {
-        return stored === 'dark';
-      }
+    const storedPreference = getStoredThemePreference();
+    if (storedPreference) {
+      return isDarkThemePreference(storedPreference);
     }
+
     // Fallback to document class or system preference
     if (typeof document !== 'undefined' && document.documentElement.classList.contains('dark')) {
       return true;
@@ -27,9 +31,17 @@ export const useTechnicianTheme = () => {
 
   // Sync with user preferences when they load from database
   useEffect(() => {
-    if (preferences?.dark_mode !== undefined) {
-      setIsDark(preferences.dark_mode);
+    if (typeof preferences?.dark_mode !== 'boolean') {
+      return;
     }
+
+    const storedPreference = getStoredThemePreference();
+    if (storedPreference) {
+      setIsDark(isDarkThemePreference(storedPreference));
+      return;
+    }
+
+    setIsDark(explicitPreferenceFromDarkMode(preferences.dark_mode) === 'dark');
   }, [preferences]);
 
   const theme: Theme = {

--- a/src/hooks/useThemePreferenceSync.ts
+++ b/src/hooks/useThemePreferenceSync.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { useTheme } from "next-themes";
+
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
+import {
+  explicitPreferenceFromDarkMode,
+  getStoredThemePreference,
+  migrateLegacyThemePreference,
+  persistExplicitThemePreference,
+} from "@/lib/theme";
+import { dataLayerClient } from "@/services/dataLayerClient";
+
+export const useThemePreferenceSync = () => {
+  const { user, isLoading } = useOptimizedAuth();
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    if (isLoading || !user?.id) {
+      return;
+    }
+
+    const localPreference = migrateLegacyThemePreference();
+    if (localPreference) {
+      setTheme(localPreference);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadDatabaseFallback = async () => {
+      const { data, error } = await dataLayerClient
+        .from("profiles")
+        .select("dark_mode")
+        .eq("id", user.id)
+        .maybeSingle();
+
+      if (cancelled || error || typeof data?.dark_mode !== "boolean") {
+        return;
+      }
+
+      if (getStoredThemePreference()) {
+        return;
+      }
+
+      const preference = explicitPreferenceFromDarkMode(data.dark_mode);
+      persistExplicitThemePreference(preference);
+      setTheme(preference);
+    };
+
+    loadDatabaseFallback();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoading, setTheme, user?.id]);
+};

--- a/src/hooks/useUserPreferences.ts
+++ b/src/hooks/useUserPreferences.ts
@@ -91,13 +91,6 @@ export const useUserPreferences = () => {
         if (data) {
           console.log('Preferences loaded:', data);
           setPreferences(data);
-          
-          // Apply dark mode if saved
-          if (data.dark_mode) {
-            document.documentElement.classList.add('dark');
-          } else {
-            document.documentElement.classList.remove('dark');
-          }
         }
       } catch (error) {
         console.error('Error loading preferences:', error);

--- a/src/lib/__tests__/theme.test.ts
+++ b/src/lib/__tests__/theme.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  APP_THEME_STORAGE_KEY,
+  LEGACY_THEME_STORAGE_KEY,
+  getStoredThemePreference,
+  migrateLegacyThemePreference,
+  persistExplicitThemePreference,
+} from "@/lib/theme";
+
+describe("theme storage helpers", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("prefers the app theme key over the legacy key", () => {
+    window.localStorage.setItem(APP_THEME_STORAGE_KEY, "dark");
+    window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, "light");
+
+    expect(getStoredThemePreference()).toBe("dark");
+  });
+
+  it("migrates a valid legacy theme into the app theme key", () => {
+    window.localStorage.setItem(LEGACY_THEME_STORAGE_KEY, "light");
+
+    expect(migrateLegacyThemePreference()).toBe("light");
+    expect(window.localStorage.getItem(APP_THEME_STORAGE_KEY)).toBe("light");
+    expect(window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY)).toBe("light");
+  });
+
+  it("persists explicit theme choices to both current and legacy keys", () => {
+    persistExplicitThemePreference("dark");
+
+    expect(window.localStorage.getItem(APP_THEME_STORAGE_KEY)).toBe("dark");
+    expect(window.localStorage.getItem(LEGACY_THEME_STORAGE_KEY)).toBe("dark");
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,100 @@
+export const APP_THEME_STORAGE_KEY = "sector-pro-theme";
+export const LEGACY_THEME_STORAGE_KEY = "theme-preference";
+
+export type StoredThemePreference = "light" | "dark" | "system";
+export type ExplicitThemePreference = "light" | "dark";
+
+const isStoredThemePreference = (value: string | null): value is StoredThemePreference =>
+  value === "light" || value === "dark" || value === "system";
+
+export const isExplicitThemePreference = (value: string | null): value is ExplicitThemePreference =>
+  value === "light" || value === "dark";
+
+const readStorageValue = (key: string): string | null => {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const writeStorageValue = (key: string, value: string) => {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Storage can be unavailable in private browsing or embedded webviews.
+  }
+};
+
+const removeStorageValue = (key: string) => {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Storage can be unavailable in private browsing or embedded webviews.
+  }
+};
+
+export const getStoredThemePreference = (): StoredThemePreference | null => {
+  const appPreference = readStorageValue(APP_THEME_STORAGE_KEY);
+  if (isStoredThemePreference(appPreference)) {
+    return appPreference;
+  }
+
+  const legacyPreference = readStorageValue(LEGACY_THEME_STORAGE_KEY);
+  return isExplicitThemePreference(legacyPreference) ? legacyPreference : null;
+};
+
+export const getStoredExplicitThemePreference = (): ExplicitThemePreference | null => {
+  const preference = getStoredThemePreference();
+  return isExplicitThemePreference(preference) ? preference : null;
+};
+
+export const persistThemePreference = (preference: StoredThemePreference) => {
+  writeStorageValue(APP_THEME_STORAGE_KEY, preference);
+
+  if (isExplicitThemePreference(preference)) {
+    writeStorageValue(LEGACY_THEME_STORAGE_KEY, preference);
+  } else {
+    removeStorageValue(LEGACY_THEME_STORAGE_KEY);
+  }
+};
+
+export const persistExplicitThemePreference = (preference: ExplicitThemePreference) => {
+  writeStorageValue(APP_THEME_STORAGE_KEY, preference);
+  writeStorageValue(LEGACY_THEME_STORAGE_KEY, preference);
+};
+
+export const migrateLegacyThemePreference = (): StoredThemePreference | null => {
+  const appPreference = readStorageValue(APP_THEME_STORAGE_KEY);
+  if (isStoredThemePreference(appPreference)) {
+    return appPreference;
+  }
+
+  const legacyPreference = readStorageValue(LEGACY_THEME_STORAGE_KEY);
+  if (!isExplicitThemePreference(legacyPreference)) {
+    return null;
+  }
+
+  persistExplicitThemePreference(legacyPreference);
+  return legacyPreference;
+};
+
+export const explicitPreferenceFromDarkMode = (darkMode: boolean): ExplicitThemePreference =>
+  darkMode ? "dark" : "light";
+
+export const resolveSystemThemePreference = (): ExplicitThemePreference => {
+  if (typeof window !== "undefined" && window.matchMedia) {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+
+  return "dark";
+};
+
+export const isDarkThemePreference = (preference: StoredThemePreference): boolean =>
+  preference === "dark" || (preference === "system" && resolveSystemThemePreference() === "dark");

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -16,6 +16,7 @@ import { useTourRateSubscriptions } from '@/hooks/useTourRateSubscriptions';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { getCategoryFromAssignment } from '@/utils/roleCategory';
 import { hasPrepDayDateTypeForDate, isPrepDayBreakdown } from '@/utils/timesheetPrepDays';
+import { persistExplicitThemePreference } from '@/lib/theme';
 
 import { DashboardScreen } from '@/components/technician/DashboardScreen';
 import { JobsView } from '@/components/technician/JobsView';
@@ -111,7 +112,9 @@ const TechnicianDashboard = () => {
   );
 
   const toggleTheme = () => {
-    setTheme(isDark ? 'light' : 'dark');
+    const newTheme = isDark ? 'light' : 'dark';
+    persistExplicitThemePreference(newTheme);
+    setTheme(newTheme);
   };
 
   // Modal state

--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -13,6 +13,7 @@ import { es } from 'date-fns/locale';
 import { getCategoryFromAssignment } from '@/utils/roleCategory';
 import { labelForCode } from '@/utils/roles';
 import { hasPrepDayDateTypeForDate, isPrepDayBreakdown } from '@/utils/timesheetPrepDays';
+import { persistExplicitThemePreference } from '@/lib/theme';
 
 import {
   LayoutDashboard, Calendar as CalendarIcon, User, Menu,
@@ -127,9 +128,8 @@ export default function TechnicianSuperApp() {
 
   const toggleTheme = () => {
     const newTheme = isDark ? 'light' : 'dark';
+    persistExplicitThemePreference(newTheme);
     setTheme(newTheme);
-    // Keep legacy key in sync for backward compat with useTechnicianTheme
-    localStorage.setItem('theme-preference', newTheme);
   };
 
   // Modal state

--- a/src/pages/__tests__/TechnicianSuperApp.test.tsx
+++ b/src/pages/__tests__/TechnicianSuperApp.test.tsx
@@ -134,6 +134,7 @@ vi.mock("@/components/messages/DirectMessagesList", () => ({
 }));
 
 import TechnicianSuperApp from "../TechnicianSuperApp";
+import { APP_THEME_STORAGE_KEY } from "@/lib/theme";
 
 const LocationProbe = () => {
   const location = useLocation();
@@ -260,7 +261,7 @@ describe("TechnicianSuperApp", () => {
     });
   });
 
-  it("persists the legacy theme-preference key when toggling from the profile tab", async () => {
+  it("persists theme keys when toggling from the profile tab", async () => {
     const user = userEvent.setup();
     configureSupabase();
 
@@ -271,6 +272,7 @@ describe("TechnicianSuperApp", () => {
     await user.click(screen.getByRole("button", { name: /toggle theme/i }));
 
     expect(setThemeMock).toHaveBeenCalledWith("dark");
+    expect(window.localStorage.getItem(APP_THEME_STORAGE_KEY)).toBe("dark");
     expect(window.localStorage.getItem("theme-preference")).toBe("dark");
   });
 });


### PR DESCRIPTION
## Summary
- centralize app and legacy theme storage handling
- use profile dark_mode only as a first-run fallback when no local theme is stored
- stop DB preference loads from directly mutating the document theme class or overwriting next-themes state
- add regression tests for storage migration, root fallback sync, layout toggle persistence, and technician app toggle persistence

## Validation
- npm install --legacy-peer-deps
- npm run lint
- npm run test:run
- npm run build