### PR TITLE
fix: stabilize corporate email freelance recipients

### DIFF
--- a/src/components/emails/CorporateEmailComposer.tsx
+++ b/src/components/emails/CorporateEmailComposer.tsx
@@ -23,6 +23,8 @@ import { X, Upload, FileText, Image as ImageIcon, Send, Users } from "lucide-rea
 import DOMPurify from "dompurify";
 import { RichTextEditor } from "./RichTextEditor";
 import type {
+  CorporateEmailRole,
+  CorporateEmailTechFilter,
   SelectedRecipient,
   SendCorporateEmailRequest,
   SendCorporateEmailResponse,
@@ -378,7 +380,8 @@ export function CorporateEmailComposer() {
     // Build recipient criteria
     const profileIds: string[] = [];
     const departments: string[] = [];
-    const roles: Array<'admin' | 'management' | 'staff' | 'freelance'> = [];
+    const roles: CorporateEmailRole[] = [];
+    const techFilters: CorporateEmailTechFilter[] = [];
 
     selectedRecipients.forEach((recipient) => {
       if (recipient.type === "individual" && recipient.profileId) {
@@ -387,6 +390,8 @@ export function CorporateEmailComposer() {
         departments.push(recipient.department);
       } else if (recipient.type === "role" && recipient.role) {
         roles.push(recipient.role);
+      } else if (recipient.type === "techFilter" && recipient.techFilter) {
+        techFilters.push(recipient.techFilter);
       }
     });
 
@@ -397,6 +402,7 @@ export function CorporateEmailComposer() {
         profileIds: profileIds.length > 0 ? profileIds : undefined,
         departments: departments.length > 0 ? departments : undefined,
         roles: roles.length > 0 ? roles : undefined,
+        techFilters: techFilters.length > 0 ? techFilters : undefined,
       },
       pdfAttachments: pdfAttachments.length > 0 ? pdfAttachments : undefined,
       inlineImages: inlineImages.length > 0 ? inlineImages : undefined,
@@ -407,11 +413,15 @@ export function CorporateEmailComposer() {
 
   // Get unique departments and roles for quick selection
   const uniqueDepartments = Array.from(new Set(profiles.map((p) => p.department).filter(Boolean)));
-  const roleOptions: Array<{ value: 'admin' | 'management' | 'staff' | 'freelance'; label: string }> = [
+  const roleOptions: Array<{ value: CorporateEmailRole; label: string }> = [
     { value: "admin", label: "Administradores" },
     { value: "management", label: "Gestión" },
-    { value: "staff", label: "Personal" },
-    { value: "freelance", label: "Freelance" },
+    { value: "logistics", label: "Logística" },
+    { value: "technician", label: "Técnicos" },
+    { value: "house_tech", label: "Plantilla" },
+  ];
+  const techFilterOptions: Array<{ value: CorporateEmailTechFilter; label: string }> = [
+    { value: "autonomos", label: "Autónomos" },
   ];
 
   return (
@@ -430,7 +440,7 @@ export function CorporateEmailComposer() {
         <div className="space-y-2">
           <Label htmlFor="recipients">Destinatarios</Label>
           <p className="text-xs text-muted-foreground">
-            Múltiples filtros se combinan con lógica AND (ej: "Sonido" + "Personal" = solo personal de sonido)
+            Múltiples filtros se combinan con lógica AND (ej: "Sonido" + "Técnicos" = solo técnicos de sonido)
           </p>
           <div className="flex flex-wrap gap-2 mb-2">
             {selectedRecipients.map((recipient) => (
@@ -480,6 +490,24 @@ export function CorporateEmailComposer() {
                         }}
                       >
                         {role.label}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+
+                  <CommandGroup heading="Por tipo de técnico">
+                    {techFilterOptions.map((filter) => (
+                      <CommandItem
+                        key={filter.value}
+                        onSelect={() => {
+                          addRecipient({
+                            id: `tech_filter_${filter.value}`,
+                            label: filter.label,
+                            type: "techFilter",
+                            techFilter: filter.value,
+                          });
+                        }}
+                      >
+                        {filter.label}
                       </CommandItem>
                     ))}
                   </CommandGroup>

--- a/src/types/corporate-email.ts
+++ b/src/types/corporate-email.ts
@@ -32,16 +32,30 @@ export interface PdfAttachment {
   size: number;
 }
 
+export type CorporateEmailRole =
+  | 'admin'
+  | 'management'
+  | 'logistics'
+  | 'technician'
+  | 'house_tech'
+  | 'oscar';
+
+export type CorporateEmailTechFilter = 'autonomos';
+
 /**
  * Recipient selection criteria
  */
 export interface RecipientCriteria {
   /** Explicit profile IDs to include */
   profileIds?: string[];
+  /** Direct email addresses to include */
+  emails?: string[];
   /** Department names to include all members */
   departments?: string[];
   /** User roles to include all matching profiles */
-  roles?: Array<'admin' | 'management' | 'staff' | 'freelance'>;
+  roles?: CorporateEmailRole[];
+  /** Technician-only filters, such as autonomous/freelance technicians */
+  techFilters?: CorporateEmailTechFilter[];
 }
 
 /**
@@ -124,11 +138,13 @@ export interface SelectedRecipient {
   /** Display label */
   label: string;
   /** Type of recipient */
-  type: 'individual' | 'department' | 'role';
+  type: 'individual' | 'department' | 'role' | 'techFilter';
   /** For individuals, the profile ID */
   profileId?: string;
   /** For departments, the department name */
   department?: string;
   /** For roles, the role name */
-  role?: 'admin' | 'management' | 'staff' | 'freelance';
+  role?: CorporateEmailRole;
+  /** For technician filters, the filter code */
+  techFilter?: CorporateEmailTechFilter;
 }

--- a/supabase/functions/send-corporate-email/__tests__/recipientFilters.test.ts
+++ b/supabase/functions/send-corporate-email/__tests__/recipientFilters.test.ts
@@ -22,9 +22,26 @@ describe("corporate email recipient filters", () => {
   it("keeps the autonomos option separate from app roles", () => {
     expect(normalizeRecipientCriteria({ departments: ["sound"], techFilters: ["autonomos"] })).toMatchObject({
       departments: ["sound"],
-      roles: [],
+      roles: ["technician"],
       autonomosOnly: true,
       ignoredTechFilters: [],
+    });
+  });
+
+  it("makes autonomos override conflicting role selections", () => {
+    expect(normalizeRecipientCriteria({ roles: ["logistics"], techFilters: ["autonomos"] })).toMatchObject({
+      roles: ["technician"],
+      autonomosOnly: true,
+      ignoredRoles: [],
+    });
+  });
+
+  it("preserves valid department filters when role values are unsupported", () => {
+    expect(normalizeRecipientCriteria({ roles: ["not_a_role"], departments: ["sound"] })).toMatchObject({
+      departments: ["sound"],
+      roles: [],
+      autonomosOnly: false,
+      ignoredRoles: ["not_a_role"],
     });
   });
 

--- a/supabase/functions/send-corporate-email/__tests__/recipientFilters.test.ts
+++ b/supabase/functions/send-corporate-email/__tests__/recipientFilters.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeRecipientCriteria } from "../recipientFilters.ts";
+
+describe("corporate email recipient filters", () => {
+  it("maps legacy freelance role selections to autonomous technicians", () => {
+    expect(normalizeRecipientCriteria({ roles: ["freelance"] })).toMatchObject({
+      roles: ["technician"],
+      autonomosOnly: true,
+      ignoredRoles: [],
+    });
+  });
+
+  it("maps legacy staff role selections to technicians", () => {
+    expect(normalizeRecipientCriteria({ roles: ["staff"] })).toMatchObject({
+      roles: ["technician"],
+      autonomosOnly: false,
+      ignoredRoles: [],
+    });
+  });
+
+  it("keeps the autonomos option separate from app roles", () => {
+    expect(normalizeRecipientCriteria({ departments: ["sound"], techFilters: ["autonomos"] })).toMatchObject({
+      departments: ["sound"],
+      roles: [],
+      autonomosOnly: true,
+      ignoredTechFilters: [],
+    });
+  });
+
+  it("ignores unsupported role values instead of passing them to the database enum", () => {
+    expect(normalizeRecipientCriteria({ roles: ["freelance", "not_a_role"] })).toMatchObject({
+      roles: ["technician"],
+      autonomosOnly: true,
+      ignoredRoles: ["not_a_role"],
+    });
+  });
+});

--- a/supabase/functions/send-corporate-email/index.ts
+++ b/supabase/functions/send-corporate-email/index.ts
@@ -214,7 +214,14 @@ async function fetchRecipientEmails(criteria: RecipientCriteria): Promise<string
   const hasAutonomosFilter = normalizedCriteria.autonomosOnly;
   const hasUnusableRoleFilter = normalizedCriteria.roleCriteriaProvided && !hasRoleFilter;
 
-  if (hasUnusableRoleFilter) {
+  if (normalizedCriteria.ignoredRoles.length > 0 || normalizedCriteria.ignoredTechFilters.length > 0) {
+    console.warn("[fetchRecipientEmails] Ignoring unsupported recipient filters:", {
+      ignoredRoles: normalizedCriteria.ignoredRoles,
+      ignoredTechFilters: normalizedCriteria.ignoredTechFilters,
+    });
+  }
+
+  if (hasUnusableRoleFilter && !hasDepartmentFilter && !hasAutonomosFilter) {
     console.warn("[fetchRecipientEmails] Ignoring profile filter query because no usable roles were provided:", {
       ignoredRoles: normalizedCriteria.ignoredRoles,
     });

--- a/supabase/functions/send-corporate-email/index.ts
+++ b/supabase/functions/send-corporate-email/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { wrapInCorporateTemplate } from "../_shared/corporateEmailTemplate.ts";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
+import { normalizeRecipientCriteria, type RecipientCriteria } from "./recipientFilters.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -53,14 +54,6 @@ interface PdfAttachment {
   content: string;
   filename: string;
   size: number;
-}
-
-interface RecipientCriteria {
-  profileIds?: string[];
-  /** Direct recipient emails (bypass profiles lookup). */
-  emails?: string[];
-  departments?: string[];
-  roles?: Array<'admin' | 'management' | 'staff' | 'freelance'>;
 }
 
 interface SendCorporateEmailRequest {
@@ -178,12 +171,13 @@ function getSenderName(department: string | null): string {
  * - Department and role filters use AND logic (users must match both)
  * - Within each filter type (departments/roles), it's OR logic
  *
- * Example: departments=[sound, lights] AND roles=[staff]
- * Returns: Users in (Sound OR Lights) AND with Staff role
+ * Example: departments=[sound, lights] AND roles=[technician]
+ * Returns: users in (Sound OR Lights) AND with technician role
  */
 async function fetchRecipientEmails(criteria: RecipientCriteria): Promise<string[]> {
   const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
   const emails = new Set<string>();
+  const normalizedCriteria = normalizeRecipientCriteria(criteria);
 
   // 0. Always include explicit emails (if any)
   if (criteria.emails && criteria.emails.length > 0) {
@@ -215,14 +209,23 @@ async function fetchRecipientEmails(criteria: RecipientCriteria): Promise<string
   }
 
   // 2. Fetch by department AND role filters (intersection logic)
-  const hasDepartmentFilter = criteria.departments && criteria.departments.length > 0;
-  const hasRoleFilter = criteria.roles && criteria.roles.length > 0;
+  const hasDepartmentFilter = normalizedCriteria.departments.length > 0;
+  const hasRoleFilter = normalizedCriteria.roles.length > 0;
+  const hasAutonomosFilter = normalizedCriteria.autonomosOnly;
+  const hasUnusableRoleFilter = normalizedCriteria.roleCriteriaProvided && !hasRoleFilter;
 
-  if (hasDepartmentFilter || hasRoleFilter) {
+  if (hasUnusableRoleFilter) {
+    console.warn("[fetchRecipientEmails] Ignoring profile filter query because no usable roles were provided:", {
+      ignoredRoles: normalizedCriteria.ignoredRoles,
+    });
+  } else if (hasDepartmentFilter || hasRoleFilter || hasAutonomosFilter) {
     console.log("[fetchRecipientEmails] Applying filters:", {
-      departments: criteria.departments || [],
-      roles: criteria.roles || [],
-      logic: hasDepartmentFilter && hasRoleFilter ? "AND" : "single filter",
+      departments: normalizedCriteria.departments,
+      roles: normalizedCriteria.roles,
+      techFilters: hasAutonomosFilter ? ["autonomos"] : [],
+      ignoredRoles: normalizedCriteria.ignoredRoles,
+      ignoredTechFilters: normalizedCriteria.ignoredTechFilters,
+      logic: [hasDepartmentFilter, hasRoleFilter, hasAutonomosFilter].filter(Boolean).length > 1 ? "AND" : "single filter",
     });
 
     // Build query with AND logic between department and role
@@ -233,12 +236,18 @@ async function fetchRecipientEmails(criteria: RecipientCriteria): Promise<string
 
     // Add department filter (OR within departments)
     if (hasDepartmentFilter) {
-      query = query.in("department", criteria.departments!);
+      query = query.in("department", normalizedCriteria.departments);
     }
 
     // Add role filter (OR within roles)
     if (hasRoleFilter) {
-      query = query.in("role", criteria.roles!);
+      query = query.in("role", normalizedCriteria.roles);
+    }
+
+    // Autonomous/freelance recipients are regular technicians marked autonomo=true.
+    // The role condition keeps admin/management rows out even though profiles.autonomo defaults true.
+    if (hasAutonomosFilter) {
+      query = query.eq("role", "technician").eq("autonomo", true);
     }
 
     const { data, error } = await query;
@@ -513,6 +522,7 @@ serve(async (req) => {
       profileIds: body.recipients.profileIds?.length || 0,
       departments: body.recipients.departments || [],
       roles: body.recipients.roles || [],
+      techFilters: body.recipients.techFilters || [],
     });
     const fetchedRecipientEmails = await fetchRecipientEmails(body.recipients);
 

--- a/supabase/functions/send-corporate-email/recipientFilters.ts
+++ b/supabase/functions/send-corporate-email/recipientFilters.ts
@@ -85,6 +85,11 @@ export function normalizeRecipientCriteria(criteria: RecipientCriteria): Normali
     ignoredTechFilters.push(filter);
   }
 
+  if (autonomosOnly) {
+    roles.clear();
+    roles.add("technician");
+  }
+
   return {
     departments,
     roles: Array.from(roles),

--- a/supabase/functions/send-corporate-email/recipientFilters.ts
+++ b/supabase/functions/send-corporate-email/recipientFilters.ts
@@ -1,0 +1,96 @@
+export type CorporateEmailRole =
+  | "admin"
+  | "user"
+  | "management"
+  | "logistics"
+  | "technician"
+  | "house_tech"
+  | "wallboard"
+  | "oscar";
+
+export type LegacyCorporateEmailRole = "staff" | "freelance";
+export type CorporateEmailTechFilter = "autonomos";
+
+export interface RecipientCriteria {
+  profileIds?: string[];
+  /** Direct recipient emails (bypass profiles lookup). */
+  emails?: string[];
+  departments?: string[];
+  roles?: Array<CorporateEmailRole | LegacyCorporateEmailRole | string>;
+  techFilters?: Array<CorporateEmailTechFilter | string>;
+}
+
+export interface NormalizedRecipientCriteria {
+  departments: string[];
+  roles: CorporateEmailRole[];
+  autonomosOnly: boolean;
+  roleCriteriaProvided: boolean;
+  ignoredRoles: string[];
+  ignoredTechFilters: string[];
+}
+
+const VALID_ROLES = new Set<CorporateEmailRole>([
+  "admin",
+  "user",
+  "management",
+  "logistics",
+  "technician",
+  "house_tech",
+  "wallboard",
+  "oscar",
+]);
+
+export function normalizeRecipientCriteria(criteria: RecipientCriteria): NormalizedRecipientCriteria {
+  const departments = Array.from(
+    new Set((criteria.departments ?? []).map((department) => String(department).trim()).filter(Boolean)),
+  );
+  const roleCriteriaProvided = Array.isArray(criteria.roles) && criteria.roles.length > 0;
+  const roles = new Set<CorporateEmailRole>();
+  const ignoredRoles: string[] = [];
+  let autonomosOnly = false;
+
+  for (const rawRole of criteria.roles ?? []) {
+    const role = String(rawRole).trim();
+    if (!role) continue;
+
+    if (role === "staff") {
+      roles.add("technician");
+      continue;
+    }
+
+    if (role === "freelance") {
+      roles.add("technician");
+      autonomosOnly = true;
+      continue;
+    }
+
+    if (VALID_ROLES.has(role as CorporateEmailRole)) {
+      roles.add(role as CorporateEmailRole);
+      continue;
+    }
+
+    ignoredRoles.push(role);
+  }
+
+  const ignoredTechFilters: string[] = [];
+  for (const rawFilter of criteria.techFilters ?? []) {
+    const filter = String(rawFilter).trim();
+    if (!filter) continue;
+
+    if (filter === "autonomos") {
+      autonomosOnly = true;
+      continue;
+    }
+
+    ignoredTechFilters.push(filter);
+  }
+
+  return {
+    departments,
+    roles: Array.from(roles),
+    autonomosOnly,
+    roleCriteriaProvided,
+    ignoredRoles,
+    ignoredTechFilters,
+  };
+}


### PR DESCRIPTION
## Summary
- fix corporate email recipient lookup so legacy/stale role values like `freelance` and `staff` do not hit the profiles.role enum directly
- add a dedicated `Autónomos` recipient option backed by `profiles.autonomo = true` and `role = technician`
- update corporate email recipient types and add regression coverage for recipient filter normalization

## Validation
- `npm install --legacy-peer-deps` (restored generated package-lock change)
- `npm run test:run -- supabase/functions/send-corporate-email/__tests__/recipientFilters.test.ts`
- `npm run typecheck`
- `npm run lint:functions` (existing warnings only)
- `npm run lint` (existing warnings only)
- `npm run test:run`
- `npm run build`
- `npm run governance`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering email recipients by technician type, alongside existing audience filters.
  * Expanded role-based recipient selection with updated role options for more precise targeting.

* **Bug Fixes**
  * Improved handling of legacy recipient filters so older selections continue to work correctly.
  * Prevented unsupported recipient values from affecting email delivery targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->