### PR TITLE
feat(a11y): adopt SubmitButton in auth forms (L-2)

### DIFF
--- a/docs/UI_UX_AUDIT.md
+++ b/docs/UI_UX_AUDIT.md
@@ -17,6 +17,8 @@ This audit is being actioned on the same branch. Status as of the latest commit:
 | **Phase 1 — Shared primitives** | ✅ Done | `Loading`/`PageLoading`/`Spinner`, `EmptyState`, `SubmitButton` (a11y-correct, token-themed, unit-tested); adopted in `App.tsx` route fallback. |
 | **C-2 — Dark mode (Auth)** | ✅ Done | Auth signup/recovery view migrated from hardcoded slate/white to semantic tokens. |
 | **M-1 — Native confirm/alert** | ✅ Done | `ConfirmDialogProvider` + `useConfirm` added & wired; **all** native `window.confirm` sites migrated (14 `.tsx` + 3 `.ts` job-card hooks). A source-scan test (`no-native-confirm.test.ts`) guards against regressions. |
+| **L-2 — Double-submit guard** | 🟡 Partial | Standalone auth forms (login, signup, forgot/reset password) migrated to the shared `SubmitButton`, adding `aria-busy` and removing duplicated loading markup. Broader app-wide adoption is a follow-up. |
+| **M-3 — Image alt text** | ✅ Verified (no change) | The audit's "~55" was a grep artifact (same-line miss; `alt` sits on adjacent lines in multiline JSX, and `>` inside `opt => …` truncated naive scans). A robust multiline-aware scan finds **0** genuine `<img>`-without-`alt` violations in `src/`. |
 | **Phase 1 — Toast consolidation (H-2)** | ⬜ Pending | Large mechanical migration (~155 files); recommend a dedicated reviewed pass. |
 | **Phase 1 — ESLint guardrails** | ⬜ Pending | Needs `eslint-plugin-jsx-a11y` + color rules (dependency install). |
 | **Phases 2–5** | ⬜ Pending | See roadmap below. |

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Loader2, ArrowLeft } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 
@@ -89,16 +90,9 @@ export const ForgotPasswordForm = ({ onBack }: ForgotPasswordFormProps) => {
       </div>
 
       <div className="flex flex-col space-y-4">
-        <Button type="submit" disabled={isLoading}>
-          {isLoading ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Sending Reset Link...
-            </>
-          ) : (
-            'Send Reset Link'
-          )}
-        </Button>
+        <SubmitButton type="submit" loading={isLoading} loadingText="Sending Reset Link...">
+          Send Reset Link
+        </SubmitButton>
         
         <Button type="button" variant="ghost" onClick={onBack}>
           <ArrowLeft className="mr-2 h-4 w-4" />

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,9 +1,9 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Loader2 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 
@@ -65,16 +65,9 @@ export const LoginForm = ({ onShowSignUp, onShowForgotPassword }: LoginFormProps
       </div>
 
       <div className="flex flex-col space-y-4">
-        <Button type="submit" disabled={isLoading}>
-          {isLoading ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Logging in...
-            </>
-          ) : (
-            'Log In'
-          )}
-        </Button>
+        <SubmitButton type="submit" loading={isLoading} loadingText="Logging in...">
+          Log In
+        </SubmitButton>
         
         <Button 
           type="button" 

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
@@ -202,16 +202,9 @@ export const ResetPasswordForm = ({ onSuccess }: ResetPasswordFormProps) => {
         />
       </div>
 
-      <Button type="submit" disabled={isLoading} className="w-full">
-        {isLoading ? (
-          <>
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            Updating Password...
-          </>
-        ) : (
-          'Update Password'
-        )}
-      </Button>
+      <SubmitButton type="submit" loading={isLoading} loadingText="Updating Password..." className="w-full">
+        Update Password
+      </SubmitButton>
     </form>
   );
 };

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,6 +1,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { SubmitButton } from "@/components/ui/submit-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -350,16 +351,9 @@ export const SignUpForm = ({ onBack, preventAutoLogin = false }: SignUpFormProps
       )}
 
       <div className="flex flex-col space-y-4">
-        <Button type="submit" disabled={isLoading}>
-          {isLoading ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Creando Cuenta...
-            </>
-          ) : (
-            preventAutoLogin ? 'Crear Usuario' : 'Crear Cuenta'
-          )}
-        </Button>
+        <SubmitButton type="submit" loading={isLoading} loadingText="Creando Cuenta...">
+          {preventAutoLogin ? 'Crear Usuario' : 'Crear Cuenta'}
+        </SubmitButton>
 
         {onBack && (
           <Button type="button" variant="ghost" onClick={onBack}>

--- a/src/components/auth/__tests__/ForgotPasswordForm.submit.test.tsx
+++ b/src/components/auth/__tests__/ForgotPasswordForm.submit.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const authState = vi.fn()
+vi.mock("@/hooks/useOptimizedAuth", () => ({
+  useOptimizedAuth: () => authState(),
+}))
+
+import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm"
+
+describe("ForgotPasswordForm submit button (SubmitButton adoption)", () => {
+  beforeEach(() => {
+    authState.mockReset()
+  })
+
+  it("disables the submit button and marks aria-busy while loading", () => {
+    authState.mockReturnValue({ requestPasswordReset: vi.fn(), isLoading: true })
+    render(<ForgotPasswordForm onBack={() => {}} />)
+
+    const submit = screen.getByRole("button", { name: /Sending Reset Link/i })
+    expect(submit).toBeDisabled()
+    expect(submit).toHaveAttribute("aria-busy", "true")
+  })
+
+  it("is enabled and not busy when idle", () => {
+    authState.mockReturnValue({ requestPasswordReset: vi.fn(), isLoading: false })
+    render(<ForgotPasswordForm onBack={() => {}} />)
+
+    const submit = screen.getByRole("button", { name: "Send Reset Link" })
+    expect(submit).toBeEnabled()
+    expect(submit).not.toHaveAttribute("aria-busy")
+  })
+})


### PR DESCRIPTION
## Summary

Addresses **L-2** (double-submit guard / async feedback) from `docs/UI_UX_AUDIT.md` by migrating the four standalone auth forms to the shared `SubmitButton` primitive.

Forms: `LoginForm`, `SignUpForm`, `ForgotPasswordForm`, `ResetPasswordForm`.

Each previously hand-rolled `<Button disabled={isLoading}>` with an inline `Loader2` spinner. They already prevented double-submit, but **lacked `aria-busy`**, so submission wasn't announced to assistive tech. `SubmitButton` adds `aria-busy`, shows the spinner, disables while loading, and removes duplicated markup.

## Bonus: M-3 correction

Verified **M-3 (image alt text)**: a robust multiline-aware scan finds **0** genuine `<img>`-without-`alt` violations in `src/`. The audit's "~55" was a grep artifact. Recorded in the progress table; no code change needed.

## Tests

- `ForgotPasswordForm.submit.test.tsx` — asserts the submit button is **disabled + `aria-busy`** while loading, and **enabled + not busy** when idle.

## Notes

Rebased onto `main` after the audit PR (#735) merged — `SubmitButton` is now on `main`, so this is a clean, standalone diff (auth forms + test + doc table rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)