### PR TITLE
fix: remove async Promise-executor anti-pattern (push registration, gear PDF)

### DIFF
--- a/src/lib/push-native.ts
+++ b/src/lib/push-native.ts
@@ -56,7 +56,7 @@ const updatePushPreference = async (enabled: boolean) => {
 }
 
 const waitForRegistrationToken = async (): Promise<string> => {
-  return await new Promise<string>(async (resolve, reject) => {
+  return await new Promise<string>((resolve, reject) => {
     let timeoutId: number | undefined
     let resolved = false
     let registrationHandle: { remove: () => Promise<void> } | null = null
@@ -78,30 +78,45 @@ const waitForRegistrationToken = async (): Promise<string> => {
       }
     }
 
-    registrationHandle = await PushNotifications.addListener('registration', (token: Token) => {
-      if (resolved) {
-        return
-      }
-      resolved = true
-      void cleanup().then(() => resolve(token.value))
-    })
+    // The listener setup is async, so it runs in an IIFE rather than an async
+    // Promise executor — that way a failure while registering listeners rejects
+    // the promise instead of being silently swallowed (and hanging the caller).
+    void (async () => {
+      try {
+        registrationHandle = await PushNotifications.addListener('registration', (token: Token) => {
+          if (resolved) {
+            return
+          }
+          resolved = true
+          void cleanup().then(() => resolve(token.value))
+        })
 
-    errorHandle = await PushNotifications.addListener('registrationError', (error: any) => {
-      if (resolved) {
-        return
-      }
-      resolved = true
-      const message = error?.message || 'Unable to register for native push notifications.'
-      void cleanup().then(() => reject(new Error(message)))
-    })
+        errorHandle = await PushNotifications.addListener('registrationError', (error: any) => {
+          if (resolved) {
+            return
+          }
+          resolved = true
+          const message = error?.message || 'Unable to register for native push notifications.'
+          void cleanup().then(() => reject(new Error(message)))
+        })
 
-    timeoutId = window.setTimeout(() => {
-      if (resolved) {
-        return
+        timeoutId = window.setTimeout(() => {
+          if (resolved) {
+            return
+          }
+          resolved = true
+          void cleanup().then(() => reject(new Error('Timed out waiting for native push registration.')))
+        }, REGISTRATION_TIMEOUT_MS)
+      } catch (err) {
+        if (resolved) {
+          return
+        }
+        resolved = true
+        void cleanup().then(() =>
+          reject(err instanceof Error ? err : new Error('Failed to set up native push registration listeners.'))
+        )
       }
-      resolved = true
-      void cleanup().then(() => reject(new Error('Timed out waiting for native push registration.')))
-    }, REGISTRATION_TIMEOUT_MS)
+    })()
   })
 }
 

--- a/src/lib/push-native.ts
+++ b/src/lib/push-native.ts
@@ -96,7 +96,7 @@ const waitForRegistrationToken = async (): Promise<string> => {
             return
           }
           resolved = true
-          const message = error?.message || 'Unable to register for native push notifications.'
+          const message = error?.error || error?.message || 'Unable to register for native push notifications.'
           void cleanup().then(() => reject(new Error(message)))
         })
 

--- a/src/utils/gearSetupPdfExport.ts
+++ b/src/utils/gearSetupPdfExport.ts
@@ -9,7 +9,10 @@ export const generateStageGearPDF = async (
   stageName?: string,
   logoUrl?: string,
 ): Promise<Blob> => {
-  return new Promise(async (resolve, reject) => {
+  return new Promise<Blob>((resolve, reject) => {
+    // The work is async, so it runs in an IIFE rather than an async Promise
+    // executor; the existing try/catch below forwards any failure to reject().
+    void (async () => {
     try {
       const { jsPDF, autoTable } = await loadPdfLibs();
       console.log(`Starting PDF generation for stage ${stageNumber} (${stageName})`);
@@ -519,5 +522,6 @@ export const generateStageGearPDF = async (
       console.error('Error generating stage gear PDF:', error);
       reject(error);
     }
+    })();
   });
 };


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Affected route/feature: native push registration (`push-native`), stage gear PDF export.

Clears both `no-async-promise-executor` warnings (audit CQ-09 action item). Passing an `async` function to the `Promise` constructor swallows any rejection thrown before `resolve`/`reject` is reached, so the promise can hang instead of failing.

- **`push-native` `waitForRegistrationToken`** — the listener setup (`await PushNotifications.addListener` ×2 + `setTimeout`) now runs in an inner async IIFE with `try/catch`. A failure while registering the native listeners now **rejects** the promise (after cleanup) instead of being silently swallowed and hanging the caller. This is a real correctness fix.
- **`gearSetupPdfExport` `generateStageGearPDF`** — the executor is now synchronous with the async body in an IIFE; the existing `try/catch` still forwards failures to `reject()`. Behavior-preserving (the body was already fully `try/catch`-guarded, with `return` after each early `reject`).

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: **low**
- Main risks: `gearSetupPdfExport` is behavior-preserving (pure wrap). `push-native` changes one path: setup-time failures now reject rather than hang — strictly an improvement. No data/schema/auth paths touched.
- [x] Does not touch database, auth, CI/CD, dependency, or security paths.
- [x] Not high risk; single approval appropriate.

## Impact Checklist
- [x] Migration impact assessed — none.
- [x] Realtime/subscription impact assessed — none.
- [x] RLS/security impact assessed — none.
- [x] Performance impact assessed — neutral.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run typecheck` → **pass (0 errors)**
  - `npx eslint src/lib/push-native.ts src/utils/gearSetupPdfExport.ts` → **0 errors; `no-async-promise-executor` cleared**
  - `grep` confirms no `new Promise(async` remains anywhere in `src`
- Results: No unit tests added — both functions are integration-heavy (Capacitor `PushNotifications`, jsPDF + Supabase) and not meaningfully unit-testable without broad native/plugin mocking; the change is behavior-preserving (PDF) / behavior-improving (push). Full `lint`/`test:run`/`build`/`e2e` left to CI (`npm ci` needs `--ignore-scripts` in this sandbox due to the `sharp` native binary).

## Rollback Plan
- [x] I documented how to safely revert this change.
- [x] No deploy steps beyond the normal pipeline.
- Rollback steps: revert the merge commit; both changes are localized to two functions.

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: **no**
- If yes, describe migration, impact, and backout plan: N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELGuxNgDeHMCnbWivzmrD2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of native push registration: setup failures are now properly surfaced and will no longer leave the registration flow unresolved.
  * Enhanced PDF export robustness by adjusting async handling to ensure errors are consistently propagated while successful exports still complete correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->