### PR TITLE
feat: expand per-technician rate modes and add admin closure-window bypass

### DIFF
--- a/src/components/department/MobileAssignmentsDialog.tsx
+++ b/src/components/department/MobileAssignmentsDialog.tsx
@@ -254,7 +254,7 @@ export const MobileAssignmentsDialog: React.FC<MobileAssignmentsDialogProps> = (
                             variant="ghost"
                             size="sm"
                             className="text-red-300 hover:bg-red-500/10"
-                            onClick={() => removeAssignment(assignment.technician_id)}
+                            onClick={() => removeAssignment(assignment.technician_id, assignment)}
                             disabled={isRemoving[assignment.technician_id]}
                           >
                             {isRemoving[assignment.technician_id] ? (

--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -185,9 +185,40 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
   // Get current user's department or use the passed department
   const currentDepartment = department || user?.department || "sound";
 
+  // Existing assignments are sourced directly from job_assignments rather than
+  // the timesheet-derived realtime hook. Tour-date jobs only have schedule-only
+  // timesheets, which that hook filters out, leaving this dialog empty even
+  // though job_assignments rows exist. Reading job_assignments directly fixes
+  // role editing on tour dates (and keeps standard jobs working).
+  const { data: currentAssignments = [], refetch: refetchCurrentAssignments } = useQuery({
+    queryKey: queryKeys.scope('job-assignments-direct', jobId),
+    enabled: isOpen && !!jobId,
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient.from('job_assignments')
+        .select(`
+          technician_id,
+          sound_role,
+          lights_role,
+          video_role,
+          single_day,
+          assignment_date,
+          profiles (
+            first_name,
+            last_name,
+            email,
+            department
+          )
+        `)
+        .eq('job_id', jobId);
+      if (error) throw error;
+      return (data || []) as any[];
+    },
+    staleTime: 30_000,
+  });
+
   // Filter assignments to only show those for the current department
   const departmentAssignments = useMemo(() => {
-    return (assignments || []).filter((assignment: any) => {
+    return (currentAssignments || []).filter((assignment: any) => {
       if (currentDepartment === 'sound') {
         return assignment.sound_role && assignment.sound_role !== 'none';
       } else if (currentDepartment === 'lights') {
@@ -197,7 +228,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
       }
       return false;
     });
-  }, [assignments, currentDepartment]);
+  }, [currentAssignments, currentDepartment]);
 
   // Fetch job data to get start/end times for availability checking
   const { data: jobData, isLoading: isLoadingJob } = useQuery({
@@ -307,12 +338,12 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
   const reqForDept = useMemo(() => (reqSummary || []).find(r => r.department === currentDepartment) || null, [reqSummary, currentDepartment]);
   const assignedByRole = useMemo(() => {
     const m = new Map<string, number>();
-    (assignments || []).forEach((a: any) => {
+    (currentAssignments || []).forEach((a: any) => {
       const code = currentDepartment === 'sound' ? a.sound_role : currentDepartment === 'lights' ? a.lights_role : a.video_role;
       if (code) m.set(code, (m.get(code) || 0) + 1);
     });
     return m;
-  }, [assignments, currentDepartment]);
+  }, [currentAssignments, currentDepartment]);
   const remainingByRole = useMemo(() => {
     const m = new Map<string, number>();
     const roles = reqForDept?.roles || [];
@@ -627,7 +658,10 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
                           <AlertDialogFooter>
                             <AlertDialogCancel>Cancelar</AlertDialogCancel>
                             <AlertDialogAction
-                              onClick={() => removeAssignment(assignment.technician_id)}
+                              onClick={async () => {
+                                await removeAssignment(assignment.technician_id);
+                                refetchCurrentAssignments();
+                              }}
                             >
                               Continuar
                             </AlertDialogAction>
@@ -663,6 +697,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
                                   title: "Rol actualizado",
                                   description: "El rol de sonido se ha actualizado exitosamente",
                                 });
+                                refetchCurrentAssignments();
                                 onAssignmentChange();
                               } catch (error: any) {
                                 console.error("Error updating role:", error);
@@ -715,6 +750,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
                                   title: "Rol actualizado",
                                   description: "El rol de luces se ha actualizado exitosamente",
                                 });
+                                refetchCurrentAssignments();
                                 onAssignmentChange();
                               } catch (error: any) {
                                 console.error("Error updating role:", error);
@@ -767,6 +803,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
                                   title: "Rol actualizado",
                                   description: "El rol de video se ha actualizado exitosamente",
                                 });
+                                refetchCurrentAssignments();
                                 onAssignmentChange();
                               } catch (error: any) {
                                 console.error("Error updating role:", error);

--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -621,7 +621,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
                             <AlertDialogCancel>Cancelar</AlertDialogCancel>
                             <AlertDialogAction
                               onClick={async () => {
-                                await removeAssignment(assignment.technician_id);
+                                await removeAssignment(assignment.technician_id, assignment);
                                 refetchCurrentAssignments();
                               }}
                             >

--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -1,4 +1,3 @@
-
 import {
   AlertDialog,
   AlertDialogAction,
@@ -32,11 +31,10 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/use-toast";
-import { AlertCircle } from "lucide-react";
 import { Job } from "@/types/job";
 import { User } from "@/types/user";
 import { useEffect, useState, useMemo } from "react";
-import { Loader2, RefreshCw, ExternalLink, CalendarIcon } from "lucide-react";
+import { AlertCircle, Loader2, RefreshCw, ExternalLink, CalendarIcon } from "lucide-react";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { useJobAssignmentsRealtime } from "@/hooks/useJobAssignmentsRealtime";
 import { useFlexCrewAssignments } from "@/hooks/useFlexCrewAssignments";
@@ -51,7 +49,7 @@ import { fromZonedTime, formatInTimeZone } from "date-fns-tz";
 import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 import { syncTimesheetCategoriesForAssignment } from '@/services/syncTimesheetCategories';
 import { isDepartmentManagementRole, isManagementRole } from '@/utils/permissions';
-
+import { useDirectJobAssignments } from '@/hooks/useDirectJobAssignments';
 
 import { queryKeys } from "@/lib/react-query";
 const MADRID_TIME_ZONE = 'Europe/Madrid';
@@ -79,14 +77,6 @@ type JobDateTypeRow = {
 type JobWithDateTypes = Job & {
   job_date_types?: JobDateTypeRow[];
 };
-
-interface Assignment {
-  technician_id: string;
-  sound_role: string;
-  lights_role: string;
-}
-
-// Role options from centralized registry (codes with labels)
 
 // Helper function to sync timesheet categories when assignment roles change
 const syncTimesheetCategories = async (jobId: string, technicianId: string) => {
@@ -185,36 +175,8 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
   // Get current user's department or use the passed department
   const currentDepartment = department || user?.department || "sound";
 
-  // Existing assignments are sourced directly from job_assignments rather than
-  // the timesheet-derived realtime hook. Tour-date jobs only have schedule-only
-  // timesheets, which that hook filters out, leaving this dialog empty even
-  // though job_assignments rows exist. Reading job_assignments directly fixes
-  // role editing on tour dates (and keeps standard jobs working).
-  const { data: currentAssignments = [], refetch: refetchCurrentAssignments } = useQuery({
-    queryKey: queryKeys.scope('job-assignments-direct', jobId),
-    enabled: isOpen && !!jobId,
-    queryFn: async () => {
-      const { data, error } = await dataLayerClient.from('job_assignments')
-        .select(`
-          technician_id,
-          sound_role,
-          lights_role,
-          video_role,
-          single_day,
-          assignment_date,
-          profiles (
-            first_name,
-            last_name,
-            email,
-            department
-          )
-        `)
-        .eq('job_id', jobId);
-      if (error) throw error;
-      return (data || []) as any[];
-    },
-    staleTime: 30_000,
-  });
+  const { data: currentAssignments = [], refetch: refetchCurrentAssignments } =
+    useDirectJobAssignments(jobId, isOpen);
 
   // Filter assignments to only show those for the current department
   const departmentAssignments = useMemo(() => {
@@ -435,7 +397,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
   };
 
   const handleSaveAssignments = async () => {
-    const assignmentsToProcess: Assignment[] = [];
+    const assignmentsToProcess: Array<{ technician_id: string; sound_role: string; lights_role: string }> = [];
 
     // Process current assignments for Flex integration
     assignments.forEach((assignment) => {

--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -34,7 +34,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Job } from "@/types/job";
 import { User } from "@/types/user";
 import { useEffect, useState, useMemo } from "react";
-import { AlertCircle, Loader2, RefreshCw, ExternalLink, CalendarIcon } from "lucide-react";
+import { AlertCircle, Loader2, RefreshCw, ExternalLink } from "lucide-react";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { useJobAssignmentsRealtime } from "@/hooks/useJobAssignmentsRealtime";
 import { useFlexCrewAssignments } from "@/hooks/useFlexCrewAssignments";

--- a/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
+++ b/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
@@ -257,6 +257,7 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
             isClosureLocked={data.isClosureLocked}
             getTechOverride={data.getTechOverride}
             getTechRateModeDateSelection={data.getTechRateModeDateSelection}
+            getTechRateModeFixedAmount={data.getTechRateModeFixedAmount}
             setTechnicianRateModeMutation={data.setTechnicianRateModeMutation}
             overrideActorMap={data.overrideActorMap}
             editingTechId={actions.editingTechId}

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -591,17 +591,22 @@ function RateModeDateRow({
   const [fixedInput, setFixedInput] = React.useState<string>(
     fixedAmount != null ? String(fixedAmount) : '',
   );
+  const [isPendingFixedMode, setIsPendingFixedMode] = React.useState(false);
 
   // Keep the local input in sync when the persisted value changes elsewhere.
   React.useEffect(() => {
     setFixedInput(fixedAmount != null ? String(fixedAmount) : '');
-  }, [fixedAmount]);
+    setIsPendingFixedMode(false);
+  }, [fixedAmount, selectedMode]);
 
   const commitFixedAmount = React.useCallback(() => {
     if (!setTechnicianRateModeMutation) return;
-    const parsed = Number.parseFloat(fixedInput.replace(',', '.'));
-    const nextAmount = Number.isFinite(parsed) ? Math.round(parsed * 100) / 100 : 0;
-    if ((fixedAmount ?? 0) === nextAmount) return;
+    const normalized = fixedInput.trim().replace(',', '.');
+    const parsed = Number.parseFloat(normalized);
+    if (!Number.isFinite(parsed) || parsed < 0) return;
+    const nextAmount = Math.round(parsed * 100) / 100;
+    if (selectedMode === 'fixed' && !isPendingFixedMode && (fixedAmount ?? 0) === nextAmount) return;
+    setIsPendingFixedMode(false);
     setTechnicianRateModeMutation.mutate({
       jobId,
       technicianId: techId,
@@ -609,7 +614,9 @@ function RateModeDateRow({
       mode: 'fixed',
       fixedAmountEur: nextAmount,
     });
-  }, [setTechnicianRateModeMutation, fixedInput, fixedAmount, jobId, techId, dateStr]);
+  }, [setTechnicianRateModeMutation, fixedInput, fixedAmount, selectedMode, isPendingFixedMode, jobId, techId, dateStr]);
+
+  const visibleMode = isPendingFixedMode ? 'fixed' : selectedMode;
 
   return (
     <div className="flex flex-col gap-2 rounded-md border border-border/60 px-3 py-2">
@@ -620,18 +627,22 @@ function RateModeDateRow({
         </div>
 
         <Select
-          value={selectedMode}
+          value={visibleMode}
           onValueChange={(nextMode) => {
             const mode = nextMode as TechnicianDateRateMode;
-            if (mode === selectedMode) return;
+            if (mode === selectedMode && !isPendingFixedMode) return;
             if (!setTechnicianRateModeMutation) return;
+            if (mode === 'fixed' && fixedAmount == null) {
+              setIsPendingFixedMode(true);
+              return;
+            }
+            setIsPendingFixedMode(false);
             setTechnicianRateModeMutation.mutate({
               jobId,
               technicianId: techId,
               date: dateStr,
               mode,
-              // Seed a fixed amount so the row never violates the NOT NULL check.
-              fixedAmountEur: mode === 'fixed' ? (fixedAmount ?? 0) : undefined,
+              fixedAmountEur: mode === 'fixed' ? fixedAmount : undefined,
             });
           }}
           disabled={disabled}
@@ -655,7 +666,7 @@ function RateModeDateRow({
         </Select>
       </div>
 
-      {selectedMode === 'fixed' && (
+      {visibleMode === 'fixed' && (
         <div className="flex items-center justify-end gap-2">
           <span className="text-xs text-muted-foreground">Importe fijo (€):</span>
           <Input

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertCircle, ChevronDown, Clock, CheckCircle, ExternalLink, Send, Receipt } from 'lucide-react';
@@ -54,8 +55,9 @@ interface TechnicianPayoutCardProps {
   /* Override */
   getTechOverride: (techId: string) => JobPayoutOverride | undefined;
   getTechRateModeDateSelection?: (techId: string, date: string) => TechnicianDateRateMode;
+  getTechRateModeFixedAmount?: (techId: string, date: string) => number | null;
   setTechnicianRateModeMutation?: {
-    mutate: (args: { jobId: string; technicianId: string; date: string; mode: TechnicianDateRateMode }) => void;
+    mutate: (args: { jobId: string; technicianId: string; date: string; mode: TechnicianDateRateMode; fixedAmountEur?: number | null }) => void;
     isPending: boolean;
   };
   overrideActorMap: Map<string, { name: string; email: string | null }>;
@@ -97,6 +99,7 @@ export function TechnicianPayoutCard({
   isClosureLocked,
   getTechOverride,
   getTechRateModeDateSelection,
+  getTechRateModeFixedAmount,
   setTechnicianRateModeMutation,
   overrideActorMap,
   editingTechId,
@@ -153,7 +156,14 @@ export function TechnicianPayoutCard({
     }
     return 'inherit' as TechnicianDateRateMode;
   }, [getTechRateModeDateSelection, techId]);
-  const showAdminRateModeSection = isTourDate && canViewTechnicianRateModePanel && technicianTimesheetDates.length > 0;
+  // Available on both tour dates and standard jobs; tour-only modes are filtered in the row.
+  const showAdminRateModeSection = canViewTechnicianRateModePanel && technicianTimesheetDates.length > 0;
+  const safeGetTechRateModeFixedAmount = React.useCallback((date: string) => {
+    if (typeof getTechRateModeFixedAmount === 'function') {
+      return getTechRateModeFixedAmount(techId, date);
+    }
+    return null;
+  }, [getTechRateModeFixedAmount, techId]);
   const activeRateModeOverrideCount = React.useMemo(() => {
     return technicianTimesheetDates.reduce((count, dateStr) => {
       return count + (safeGetTechRateModeDateSelection(dateStr) === 'inherit' ? 0 : 1);
@@ -488,51 +498,20 @@ export function TechnicianPayoutCard({
             </CollapsibleTrigger>
 
             <CollapsibleContent className="space-y-2">
-              {technicianTimesheetDates.map((dateStr) => {
-                const selectedMode = safeGetTechRateModeDateSelection(dateStr);
-                const inheritsRehearsal = rehearsalDateSet.has(dateStr);
-                const inheritedLabel = inheritsRehearsal ? 'Ensayo' : 'Estándar';
-                const dateLabel = formatInTimeZone(parseISO(dateStr), 'Europe/Madrid', 'EEE d MMM', {
-                  locale: es,
-                });
-
-                return (
-                  <div
-                    key={`${techId}-${dateStr}`}
-                    className="flex flex-col gap-2 rounded-md border border-border/60 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
-                  >
-                    <div className="min-w-0">
-                      <div className="text-sm font-medium capitalize">{dateLabel}</div>
-                      <div className="text-xs text-muted-foreground">Tarifa global: {inheritedLabel}</div>
-                    </div>
-
-                    <Select
-                      value={selectedMode}
-                      onValueChange={(nextMode) => {
-                        const mode = nextMode as TechnicianDateRateMode;
-                        if (mode === selectedMode) return;
-                        if (!setTechnicianRateModeMutation) return;
-                        setTechnicianRateModeMutation.mutate({
-                          jobId,
-                          technicianId: techId,
-                          date: dateStr,
-                          mode,
-                        });
-                      }}
-                      disabled={!hasRateModeHandlers || (setTechnicianRateModeMutation?.isPending ?? false)}
-                    >
-                      <SelectTrigger className="h-8 w-full text-xs sm:w-[220px]">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="inherit">Heredar ({inheritedLabel})</SelectItem>
-                        <SelectItem value="rehearsal">Forzar ensayo</SelectItem>
-                        <SelectItem value="standard">Forzar estándar</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                );
-              })}
+              {technicianTimesheetDates.map((dateStr) => (
+                <RateModeDateRow
+                  key={`${techId}-${dateStr}`}
+                  jobId={jobId}
+                  techId={techId}
+                  dateStr={dateStr}
+                  isTourDate={isTourDate}
+                  selectedMode={safeGetTechRateModeDateSelection(dateStr)}
+                  fixedAmount={safeGetTechRateModeFixedAmount(dateStr)}
+                  inheritsRehearsal={rehearsalDateSet.has(dateStr)}
+                  disabled={!hasRateModeHandlers || (setTechnicianRateModeMutation?.isPending ?? false)}
+                  setTechnicianRateModeMutation={setTechnicianRateModeMutation}
+                />
+              ))}
             </CollapsibleContent>
             {setTechnicianRateModeMutation?.isPending && (
               <div className="text-xs text-muted-foreground animate-pulse">Actualizando tarifa calculada…</div>
@@ -576,6 +555,134 @@ export function TechnicianPayoutCard({
           {formatCurrency(getTechOverride(techId)?.override_amount_eur ?? effectiveTotal)}
         </Badge>
       </div>
+    </div>
+  );
+}
+
+interface RateModeDateRowProps {
+  jobId: string;
+  techId: string;
+  dateStr: string;
+  isTourDate: boolean;
+  selectedMode: TechnicianDateRateMode;
+  fixedAmount: number | null;
+  inheritsRehearsal: boolean;
+  disabled: boolean;
+  setTechnicianRateModeMutation?: {
+    mutate: (args: { jobId: string; technicianId: string; date: string; mode: TechnicianDateRateMode; fixedAmountEur?: number | null }) => void;
+    isPending: boolean;
+  };
+}
+
+function RateModeDateRow({
+  jobId,
+  techId,
+  dateStr,
+  isTourDate,
+  selectedMode,
+  fixedAmount,
+  inheritsRehearsal,
+  disabled,
+  setTechnicianRateModeMutation,
+}: RateModeDateRowProps) {
+  const inheritedLabel = inheritsRehearsal ? 'Ensayo' : 'Estándar';
+  const dateLabel = formatInTimeZone(parseISO(dateStr), 'Europe/Madrid', 'EEE d MMM', { locale: es });
+
+  const [fixedInput, setFixedInput] = React.useState<string>(
+    fixedAmount != null ? String(fixedAmount) : '',
+  );
+
+  // Keep the local input in sync when the persisted value changes elsewhere.
+  React.useEffect(() => {
+    setFixedInput(fixedAmount != null ? String(fixedAmount) : '');
+  }, [fixedAmount]);
+
+  const commitFixedAmount = React.useCallback(() => {
+    if (!setTechnicianRateModeMutation) return;
+    const parsed = Number.parseFloat(fixedInput.replace(',', '.'));
+    const nextAmount = Number.isFinite(parsed) ? Math.round(parsed * 100) / 100 : 0;
+    if ((fixedAmount ?? 0) === nextAmount) return;
+    setTechnicianRateModeMutation.mutate({
+      jobId,
+      technicianId: techId,
+      date: dateStr,
+      mode: 'fixed',
+      fixedAmountEur: nextAmount,
+    });
+  }, [setTechnicianRateModeMutation, fixedInput, fixedAmount, jobId, techId, dateStr]);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-border/60 px-3 py-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="text-sm font-medium capitalize">{dateLabel}</div>
+          <div className="text-xs text-muted-foreground">Tarifa global: {inheritedLabel}</div>
+        </div>
+
+        <Select
+          value={selectedMode}
+          onValueChange={(nextMode) => {
+            const mode = nextMode as TechnicianDateRateMode;
+            if (mode === selectedMode) return;
+            if (!setTechnicianRateModeMutation) return;
+            setTechnicianRateModeMutation.mutate({
+              jobId,
+              technicianId: techId,
+              date: dateStr,
+              mode,
+              // Seed a fixed amount so the row never violates the NOT NULL check.
+              fixedAmountEur: mode === 'fixed' ? (fixedAmount ?? 0) : undefined,
+            });
+          }}
+          disabled={disabled}
+        >
+          <SelectTrigger className="h-8 w-full text-xs sm:w-[240px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="inherit">Heredar ({inheritedLabel})</SelectItem>
+            <SelectItem value="rehearsal">Forzar ensayo</SelectItem>
+            <SelectItem value="standard">Forzar estándar</SelectItem>
+            {isTourDate && (
+              <>
+                <SelectItem value="tour_multipliers">Forzar multiplicadores de gira</SelectItem>
+                <SelectItem value="no_multipliers">Sin multiplicadores (base)</SelectItem>
+                <SelectItem value="hourly">Tarifa por horas</SelectItem>
+              </>
+            )}
+            <SelectItem value="fixed">Importe fijo</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {selectedMode === 'fixed' && (
+        <div className="flex items-center justify-end gap-2">
+          <span className="text-xs text-muted-foreground">Importe fijo (€):</span>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step="0.01"
+            min="0"
+            value={fixedInput}
+            onChange={(e) => setFixedInput(e.target.value)}
+            onBlur={commitFixedAmount}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                (e.target as HTMLInputElement).blur();
+              }
+            }}
+            disabled={disabled}
+            className="h-8 w-28 text-xs"
+          />
+        </div>
+      )}
+
+      {selectedMode === 'hourly' && (
+        <div className="text-[11px] text-muted-foreground text-right">
+          Se factura por horas del parte de esta fecha.
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/jobs/payout-totals/types.ts
+++ b/src/components/jobs/payout-totals/types.ts
@@ -26,6 +26,7 @@ export interface JobMetadata {
   end_time: string | null;
   timezone: string | null;
   tour_id: string | null;
+  tour_date_id: string | null;
   rates_approved: boolean | null;
   job_type: string | null;
   invoicing_company: string | null;

--- a/src/components/jobs/payout-totals/types.ts
+++ b/src/components/jobs/payout-totals/types.ts
@@ -65,8 +65,9 @@ export interface JobPayoutData {
   toggleDateRehearsalMutation: { mutate: (args: { jobId: string; date: string; enabled: boolean }) => void; isPending: boolean };
   toggleAllDatesRehearsalMutation: { mutate: (args: { jobId: string; dates: string[]; enabled: boolean }) => void; isPending: boolean };
   getTechRateModeDateSelection: (techId: string, date: string) => TechnicianDateRateMode;
+  getTechRateModeFixedAmount: (techId: string, date: string) => number | null;
   setTechnicianRateModeMutation: {
-    mutate: (args: { jobId: string; technicianId: string; date: string; mode: TechnicianDateRateMode }) => void;
+    mutate: (args: { jobId: string; technicianId: string; date: string; mode: TechnicianDateRateMode; fixedAmountEur?: number | null }) => void;
     isPending: boolean;
   };
   standardPayoutTotals: JobPayoutTotals[];

--- a/src/components/jobs/payout-totals/useJobPayoutData.ts
+++ b/src/components/jobs/payout-totals/useJobPayoutData.ts
@@ -6,7 +6,7 @@ import { useManagerJobQuotes } from '@/hooks/useManagerJobQuotes';
 import { useJobTechnicianPayoutOverrides } from '@/hooks/useJobPayoutOverride';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { useJobRehearsalDates, useToggleDateRehearsalRate, useToggleAllDatesRehearsalRate } from '@/hooks/useToggleJobRehearsalRate';
-import { useJobTechnicianRateModeDates, useSetTechnicianDateRateMode } from '@/hooks/useTechnicianRateModeDates';
+import { useJobTechnicianRateModeDates, useSetTechnicianDateRateMode, type TechnicianDateRateMode } from '@/hooks/useTechnicianRateModeDates';
 import type { TechnicianProfileWithEmail } from '@/lib/job-payout-email';
 import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
 import { canManagePayouts, isAdminRole, isAdministrativeDepartment } from '@/utils/permissions';
@@ -60,7 +60,9 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
 
   const jobType = jobMeta?.job_type ?? null;
   const isTourDate = jobType === 'tourdate';
-  const isClosureLocked = isJobPastClosureWindow(jobMeta?.end_time, jobMeta?.timezone ?? 'Europe/Madrid');
+  // Admins can approve/edit payouts even after the 7-day closure window.
+  const isClosureLocked =
+    !isAdmin && isJobPastClosureWindow(jobMeta?.end_time, jobMeta?.timezone ?? 'Europe/Madrid');
   const shouldLoadStandardTotals = !!jobId && !isTourDate && !jobMetaLoading;
   const shouldLoadTourQuotes = !!jobId && isTourDate;
 
@@ -115,7 +117,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
 
   const { data: technicianTimesheetDatesMap = new Map<string, string[]>() } = useQuery({
     queryKey: queryKeys.scope('job-tech-timesheet-dates', jobId),
-    enabled: !!jobId && isTourDate && !jobMetaLoading,
+    enabled: !!jobId && !jobMetaLoading,
     queryFn: async () => {
       const { data, error } = await dataLayerClient.from('timesheets')
         .select('technician_id, date')
@@ -427,9 +429,9 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     [jobTimesheetDates, rehearsalDateSet]
   );
 
-  /* ── Admin-only technician/date rate-mode exceptions ── */
+  /* ── Admin-only technician/date rate-mode exceptions (tour dates + standard jobs) ── */
   const shouldProbeTechnicianRateModes =
-    !!jobId && isTourDate && !jobMetaLoading && (isManager || isAdminOrAdministrative);
+    !!jobId && !jobMetaLoading && (isManager || isAdminOrAdministrative);
   const {
     data: technicianRateModeDates = [],
     error: technicianRateModeError,
@@ -440,25 +442,40 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
   const canViewTechnicianRateModePanel = shouldProbeTechnicianRateModes && !technicianRateModeError;
 
   const technicianRateModeMap = React.useMemo(() => {
-    const map = new Map<string, Map<string, 'rehearsal' | 'standard'>>();
+    const map = new Map<string, Map<string, TechnicianDateRateMode>>();
 
     technicianRateModeDates.forEach((row) => {
       if (!map.has(row.technician_id)) {
         map.set(row.technician_id, new Map());
       }
 
-      map.get(row.technician_id)!.set(
-        row.date,
-        row.use_rehearsal_rate ? 'rehearsal' : 'standard',
-      );
+      // rate_mode is the source of truth; fall back to the legacy boolean for
+      // any pre-migration row that somehow lacks it.
+      const mode = (row.rate_mode ?? (row.use_rehearsal_rate ? 'rehearsal' : 'standard')) as TechnicianDateRateMode;
+      map.get(row.technician_id)!.set(row.date, mode);
     });
 
     return map;
   }, [technicianRateModeDates]);
 
-  const getTechRateModeDateSelection = React.useCallback((techId: string, date: string) => {
+  const technicianRateModeFixedMap = React.useMemo(() => {
+    const map = new Map<string, Map<string, number | null>>();
+    technicianRateModeDates.forEach((row) => {
+      if (!map.has(row.technician_id)) {
+        map.set(row.technician_id, new Map());
+      }
+      map.get(row.technician_id)!.set(row.date, row.fixed_amount_eur ?? null);
+    });
+    return map;
+  }, [technicianRateModeDates]);
+
+  const getTechRateModeDateSelection = React.useCallback((techId: string, date: string): TechnicianDateRateMode => {
     return technicianRateModeMap.get(techId)?.get(date) ?? 'inherit';
   }, [technicianRateModeMap]);
+
+  const getTechRateModeFixedAmount = React.useCallback((techId: string, date: string): number | null => {
+    return technicianRateModeFixedMap.get(techId)?.get(date) ?? null;
+  }, [technicianRateModeFixedMap]);
 
   /* ── Grand total ── */
   const calculatedGrandTotal = React.useMemo(() => {
@@ -510,6 +527,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     toggleDateRehearsalMutation,
     toggleAllDatesRehearsalMutation,
     getTechRateModeDateSelection,
+    getTechRateModeFixedAmount,
     setTechnicianRateModeMutation,
     standardPayoutTotals,
   };

--- a/src/components/jobs/payout-totals/useJobPayoutData.ts
+++ b/src/components/jobs/payout-totals/useJobPayoutData.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { formatInTimeZone } from 'date-fns-tz';
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useJobPayoutTotals } from '@/hooks/useJobPayoutTotals';
 import { useManagerJobQuotes } from '@/hooks/useManagerJobQuotes';
@@ -19,10 +20,62 @@ import { NON_AUTONOMO_DEDUCTION_EUR } from './types';
 
 import { queryKeys } from "@/lib/react-query";
 const FIN_DOC_VIEW_ID = '8238f39c-f42e-11e0-a8de-00e08175e43e';
+const MADRID_TIMEZONE = 'Europe/Madrid';
+
 type TimesheetRow = Pick<
   Database['public']['Tables']['timesheets']['Row'],
   'technician_id' | 'amount_eur' | 'amount_breakdown' | 'approved_by_manager'
 >;
+
+type PayoutDateTimesheetRow = {
+  technician_id: string | null;
+  date: string | null;
+};
+
+type PayoutDateAssignmentRow = {
+  technician_id: string | null;
+  single_day: boolean | null;
+  assignment_date: string | null;
+};
+
+type PayoutDateTypeRow = {
+  date: string | null;
+  type: string | null;
+};
+
+type PayoutTourDateRow = {
+  start_date: string | null;
+  end_date: string | null;
+  date: string | null;
+};
+
+function toMadridDateKey(value: string | null | undefined): string | null {
+  if (!value) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return formatInTimeZone(parsed, MADRID_TIMEZONE, 'yyyy-MM-dd');
+}
+
+function compareDateKeys(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function enumerateDateRange(start: string | null, end: string | null): string[] {
+  if (!start) return [];
+  const [startYear, startMonth, startDay] = start.split('-').map(Number);
+  const [endYear, endMonth, endDay] = (end ?? start).split('-').map(Number);
+  const startDate = Date.UTC(startYear, startMonth - 1, startDay);
+  const endDate = Date.UTC(endYear, endMonth - 1, endDay);
+  const safeEndDate = endDate < startDate ? startDate : endDate;
+  const dates: string[] = [];
+
+  for (let cursor = startDate; cursor <= safeEndDate; cursor += 86_400_000) {
+    dates.push(new Date(cursor).toISOString().slice(0, 10));
+  }
+
+  return dates;
+}
 
 function isPrepDayBreakdown(amountBreakdown: TimesheetRow['amount_breakdown']): boolean {
   if (!amountBreakdown || typeof amountBreakdown !== 'object' || Array.isArray(amountBreakdown)) {
@@ -49,7 +102,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     enabled: !!jobId,
     queryFn: async () => {
       const { data, error } = await dataLayerClient.from('jobs')
-        .select('id, title, start_time, end_time, timezone, tour_id, rates_approved, job_type, invoicing_company')
+        .select('id, title, start_time, end_time, timezone, tour_id, tour_date_id, rates_approved, job_type, invoicing_company')
         .eq('id', jobId)
         .maybeSingle();
       if (error) throw error;
@@ -62,7 +115,12 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
   const isTourDate = jobType === 'tourdate';
   // Admins can approve/edit payouts even after the 7-day closure window.
   const isClosureLocked =
-    !isAdmin && isJobPastClosureWindow(jobMeta?.end_time, jobMeta?.timezone ?? 'Europe/Madrid');
+    !isAdmin
+    && (
+      jobMetaLoading
+      || Boolean(jobMetaError)
+      || Boolean(jobMeta && isJobPastClosureWindow(jobMeta.end_time, jobMeta.timezone ?? 'Europe/Madrid'))
+    );
   const shouldLoadStandardTotals = !!jobId && !isTourDate && !jobMetaLoading;
   const shouldLoadTourQuotes = !!jobId && isTourDate;
 
@@ -119,24 +177,122 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     queryKey: queryKeys.scope('job-tech-timesheet-dates', jobId),
     enabled: !!jobId && !jobMetaLoading,
     queryFn: async () => {
-      const { data, error } = await dataLayerClient.from('timesheets')
-        .select('technician_id, date')
-        .eq('job_id', jobId)
-        .eq('is_active', true);
+      const tourDateQuery = jobMeta?.tour_date_id
+        ? dataLayerClient.from('tour_dates')
+          .select('start_date, end_date, date')
+          .eq('id', jobMeta.tour_date_id)
+          .maybeSingle()
+        : Promise.resolve({ data: null, error: null });
 
-      if (error) throw error;
+      const [timesheetResult, assignmentResult, dateTypeResult, tourDateResult] = await Promise.all([
+        dataLayerClient.from('timesheets')
+          .select('technician_id, date')
+          .eq('job_id', jobId)
+          .eq('is_active', true),
+        dataLayerClient.from('job_assignments')
+          .select('technician_id, single_day, assignment_date')
+          .eq('job_id', jobId),
+        dataLayerClient.from('job_date_types')
+          .select('date, type')
+          .eq('job_id', jobId),
+        tourDateQuery,
+      ]);
+
+      if (timesheetResult.error) throw timesheetResult.error;
+      if (assignmentResult.error) throw assignmentResult.error;
+      if (dateTypeResult.error) throw dateTypeResult.error;
+      if (tourDateResult.error) throw tourDateResult.error;
 
       const byTech = new Map<string, Set<string>>();
-      (data || []).forEach((row) => {
-        if (!row.technician_id || !row.date) return;
-        if (!byTech.has(row.technician_id)) {
-          byTech.set(row.technician_id, new Set());
+      const activeTimesheetDatesByTech = new Map<string, Set<string>>();
+      const singleDayDatesByTech = new Map<string, Set<string>>();
+      const technicianIds = new Set<string>();
+
+      const timesheetRows = (timesheetResult.data || []) as PayoutDateTimesheetRow[];
+      const assignmentRows = (assignmentResult.data || []) as PayoutDateAssignmentRow[];
+      const dateTypeRows = (dateTypeResult.data || []) as PayoutDateTypeRow[];
+      const tourDate = tourDateResult.data as PayoutTourDateRow | null;
+
+      const prepDates = new Set(
+        dateTypeRows
+          .filter((row) => row.type === 'prep_day')
+          .map((row) => toMadridDateKey(row.date))
+          .filter((date): date is string => Boolean(date)),
+      );
+
+      const addDateToMap = (map: Map<string, Set<string>>, techId: string, date: string) => {
+        if (!map.has(techId)) {
+          map.set(techId, new Set());
         }
-        byTech.get(row.technician_id)!.add(row.date);
+        map.get(techId)!.add(date);
+      };
+
+      const addPayableDate = (techId: string | null | undefined, rawDate: string | null | undefined) => {
+        if (!techId) return;
+        const date = toMadridDateKey(rawDate);
+        if (!date || prepDates.has(date)) return;
+        technicianIds.add(techId);
+        addDateToMap(byTech, techId, date);
+      };
+
+      timesheetRows.forEach((row) => {
+        const date = toMadridDateKey(row.date);
+        if (!row.technician_id || !date || prepDates.has(date)) return;
+        technicianIds.add(row.technician_id);
+        addDateToMap(activeTimesheetDatesByTech, row.technician_id, date);
+        addDateToMap(byTech, row.technician_id, date);
+      });
+
+      assignmentRows.forEach((row) => {
+        if (!row.technician_id) return;
+        technicianIds.add(row.technician_id);
+        if (!row.single_day) return;
+
+        const date = toMadridDateKey(row.assignment_date);
+        if (!date || prepDates.has(date)) return;
+        addDateToMap(singleDayDatesByTech, row.technician_id, date);
+        addDateToMap(byTech, row.technician_id, date);
+      });
+
+      const rawScheduledRows = dateTypeRows
+        .map((row) => ({ date: toMadridDateKey(row.date), type: row.type }))
+        .filter((row): row is { date: string; type: string } => Boolean(row.date) && Boolean(row.type) && row.type !== 'prep_day');
+      const hasScheduledDateTypes = rawScheduledRows.length > 0;
+      const scheduledDates = rawScheduledRows
+        .filter((row) => row.type !== 'rigging')
+        .map((row) => row.date);
+      const riggingDates = rawScheduledRows
+        .filter((row) => row.type === 'rigging')
+        .map((row) => row.date);
+
+      const jobStartDate = toMadridDateKey(jobMeta?.start_time);
+      const jobEndDate = toMadridDateKey(jobMeta?.end_time) ?? jobStartDate;
+      const scheduleStart = toMadridDateKey(tourDate?.start_date)
+        ?? jobStartDate
+        ?? toMadridDateKey(tourDate?.date);
+      const scheduleEnd = toMadridDateKey(tourDate?.end_date)
+        ?? jobEndDate
+        ?? toMadridDateKey(tourDate?.start_date)
+        ?? toMadridDateKey(tourDate?.date)
+        ?? jobStartDate;
+      const fallbackScheduleDates = hasScheduledDateTypes
+        ? []
+        : enumerateDateRange(scheduleStart, scheduleEnd).filter((date) => !prepDates.has(date));
+
+      technicianIds.forEach((techId) => {
+        if ((singleDayDatesByTech.get(techId)?.size ?? 0) > 0) return;
+
+        scheduledDates.forEach((date) => addPayableDate(techId, date));
+        riggingDates.forEach((date) => {
+          if (activeTimesheetDatesByTech.get(techId)?.has(date)) {
+            addPayableDate(techId, date);
+          }
+        });
+        fallbackScheduleDates.forEach((date) => addPayableDate(techId, date));
       });
 
       return new Map(
-        Array.from(byTech.entries()).map(([techId, dates]) => [techId, Array.from(dates).sort()]),
+        Array.from(byTech.entries()).map(([techId, dates]) => [techId, Array.from(dates).sort(compareDateKeys)]),
       );
     },
     staleTime: 30_000,

--- a/src/components/timesheet/TimesheetView.tsx
+++ b/src/components/timesheet/TimesheetView.tsx
@@ -37,7 +37,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ExpenseList, ExpenseSummaryCard } from "@/components/expenses";
 import { useJobExpenses } from "@/hooks/useJobExpenses";
-import { isManagementRole, isTechnicianRole } from "@/utils/permissions";
+import { isAdminRole, isManagementRole, isTechnicianRole } from "@/utils/permissions";
 
 import { TimesheetEditForm } from "./TimesheetEditForm";
 import { TimesheetRejectDialog } from "./TimesheetRejectDialog";
@@ -84,16 +84,23 @@ export const TimesheetView = ({
     staleTime: 60_000,
   });
 
+  const isAdmin = isAdminRole(userRole);
+
   // On error, allow actions (fail-open) rather than permanently locking users out.
   // When jobMeta is undefined (loading), default to locked=true to prevent
   // actions until we know the actual closure status.
   // When jobMeta is null (not found), allow actions (job doesn't exist or has no end_time).
-  const isClosureLocked = (() => {
+  const isPastClosureWindow = (() => {
     if (jobMetaError) return false; // fail-open on error
-    if (jobMeta === undefined) return true; // locked while loading
+    if (jobMeta === undefined) return true; // treat as locked while loading
     if (!jobMeta) return false; // job not found, allow actions
     return isJobPastClosureWindow(jobMeta.end_time, jobMeta.timezone ?? 'Europe/Madrid');
   })();
+
+  // Admins can approve/edit timesheets even after the 7-day closure window.
+  const isClosureLocked = isPastClosureWindow && !isAdmin;
+  // Surface when an admin is bypassing the closed window so the action is visible.
+  const isAdminOverridingClosure = isPastClosureWindow && isAdmin && jobMeta !== undefined;
 
   const [selectedDate, setSelectedDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [editingTimesheet, setEditingTimesheet] = useState<string | null>(null);
@@ -468,6 +475,17 @@ export const TimesheetView = ({
             </div>
           </div>
         </div>
+      )}
+
+      {isAdminOverridingClosure && (
+        <Alert className="border-amber-500/40 bg-amber-500/10">
+          <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-300" />
+          <AlertTitle>Ventana de cierre vencida</AlertTitle>
+          <AlertDescription>
+            Han pasado más de 7 días desde el fin del trabajo. Como administrador puedes seguir
+            aprobando y editando partes — estas acciones quedan registradas.
+          </AlertDescription>
+        </Alert>
       )}
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/timesheet/TimesheetView.tsx
+++ b/src/components/timesheet/TimesheetView.tsx
@@ -1,7 +1,5 @@
 
 import { useState, useMemo, useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { createQueryKey } from "@/lib/optimized-react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -20,9 +18,7 @@ import { format, parseISO } from "date-fns";
 import { es } from "date-fns/locale";
 import { useToast } from "@/hooks/use-toast";
 import { sendTimesheetReminder } from "@/lib/timesheet-reminder-email";
-import { dataLayerClient } from "@/services/dataLayerClient";
 import { formatCurrency } from "@/lib/utils";
-import { isJobPastClosureWindow } from "@/utils/jobClosureUtils";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -37,10 +33,11 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ExpenseList, ExpenseSummaryCard } from "@/components/expenses";
 import { useJobExpenses } from "@/hooks/useJobExpenses";
-import { isAdminRole, isManagementRole, isTechnicianRole } from "@/utils/permissions";
+import { isManagementRole, isTechnicianRole } from "@/utils/permissions";
 
 import { TimesheetEditForm } from "./TimesheetEditForm";
 import { TimesheetRejectDialog } from "./TimesheetRejectDialog";
+import { useJobClosureLock } from "@/hooks/useJobClosureLock";
 import { calculateHours } from "./utils";
 import { isPrepDayBreakdown, isPrepDayTimesheet, prepDayHourlyRate } from "@/utils/timesheetPrepDays";
 
@@ -70,37 +67,7 @@ export const TimesheetView = ({
   // Expense state and queries - must be before any early returns
   const { data: expenses = [] } = useJobExpenses(jobId);
 
-  const { data: jobMeta, isError: jobMetaError } = useQuery({
-    queryKey: createQueryKey.jobs.meta(jobId),
-    enabled: !!jobId,
-    queryFn: async () => {
-      const { data, error } = await dataLayerClient.from('jobs')
-        .select('id, end_time, timezone')
-        .eq('id', jobId)
-        .maybeSingle();
-      if (error) throw error;
-      return data as { id: string; end_time: string | null; timezone: string | null } | null;
-    },
-    staleTime: 60_000,
-  });
-
-  const isAdmin = isAdminRole(userRole);
-
-  // On error, allow actions (fail-open) rather than permanently locking users out.
-  // When jobMeta is undefined (loading), default to locked=true to prevent
-  // actions until we know the actual closure status.
-  // When jobMeta is null (not found), allow actions (job doesn't exist or has no end_time).
-  const isPastClosureWindow = (() => {
-    if (jobMetaError) return false; // fail-open on error
-    if (jobMeta === undefined) return true; // treat as locked while loading
-    if (!jobMeta) return false; // job not found, allow actions
-    return isJobPastClosureWindow(jobMeta.end_time, jobMeta.timezone ?? 'Europe/Madrid');
-  })();
-
-  // Admins can approve/edit timesheets even after the 7-day closure window.
-  const isClosureLocked = isPastClosureWindow && !isAdmin;
-  // Surface when an admin is bypassing the closed window so the action is visible.
-  const isAdminOverridingClosure = isPastClosureWindow && isAdmin && jobMeta !== undefined;
+  const { isClosureLocked, isAdminOverridingClosure } = useJobClosureLock(jobId, userRole);
 
   const [selectedDate, setSelectedDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [editingTimesheet, setEditingTimesheet] = useState<string | null>(null);

--- a/src/components/tours/TourAssignmentDialog.tsx
+++ b/src/components/tours/TourAssignmentDialog.tsx
@@ -143,8 +143,8 @@ export const TourAssignmentDialog = ({
     }
   });
 
-  // Update role mutation — relies on tour_assignment_update_trigger to propagate
-  // the new role to every job in the tour (job_assignments).
+  // Update role mutation: tour_assignment_update_trigger propagates the new
+  // role only to today-or-future tour jobs.
   const updateRoleMutation = useMutation({
     mutationFn: async ({ assignmentId, role }: { assignmentId: string; role: string }) => {
       const { error } = await dataLayerClient.from('tour_assignments')
@@ -154,7 +154,7 @@ export const TourAssignmentDialog = ({
       if (error) throw error;
     },
     onSuccess: () => {
-      toast.success('Role updated successfully - automatically applied to all tour jobs');
+      toast.success('Role updated successfully - automatically applied to future tour jobs');
       refetch();
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-assignments') });
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-details') });

--- a/src/components/tours/TourAssignmentDialog.tsx
+++ b/src/components/tours/TourAssignmentDialog.tsx
@@ -143,6 +143,29 @@ export const TourAssignmentDialog = ({
     }
   });
 
+  // Update role mutation — relies on tour_assignment_update_trigger to propagate
+  // the new role to every job in the tour (job_assignments).
+  const updateRoleMutation = useMutation({
+    mutationFn: async ({ assignmentId, role }: { assignmentId: string; role: string }) => {
+      const { error } = await dataLayerClient.from('tour_assignments')
+        .update({ role })
+        .eq('id', assignmentId);
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Role updated successfully - automatically applied to all tour jobs');
+      refetch();
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-assignments') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-details') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('jobs') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('optimized-jobs') });
+    },
+    onError: (error: any) => {
+      toast.error(`Failed to update role: ${error.message}`);
+    }
+  });
+
   // Delete assignment mutation
   const deleteAssignmentMutation = useMutation({
     mutationFn: async (assignmentId: string) => {
@@ -200,16 +223,18 @@ export const TourAssignmentDialog = ({
     }
   };
 
-  const getAvailableRoles = () => {
-    if (!selectedDepartment) return [] as Array<{ value: string; label: string }>;
+  const getRolesForDepartment = (department: string): Array<{ value: string; label: string }> => {
+    if (!department) return [];
     // Technical departments: use role codes registry
-    if (['sound','lights','video'].includes(selectedDepartment)) {
-      return roleOptionsForDiscipline(selectedDepartment).map(opt => ({ value: opt.code, label: opt.label }));
+    if (['sound','lights','video'].includes(department)) {
+      return roleOptionsForDiscipline(department).map(opt => ({ value: opt.code, label: opt.label }));
     }
     // Non-technical: use static labels
-    const labels = NON_TECH_ROLE_LABELS[selectedDepartment] || [];
+    const labels = NON_TECH_ROLE_LABELS[department] || [];
     return labels.map(l => ({ value: l, label: l }));
   };
+
+  const getAvailableRoles = () => getRolesForDepartment(selectedDepartment);
 
   const groupedAssignments = assignments.reduce((acc, assignment) => {
     if (!acc[assignment.department]) {
@@ -222,7 +247,7 @@ export const TourAssignmentDialog = ({
   return (
     <>
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl w-[95vw] md:w-full max-h-[95vh] md:max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-4xl w-[95vw] md:w-full max-h-[95vh] md:max-h-[90vh] overflow-y-auto pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))]">
         <DialogHeader>
           <DialogTitle className="flex flex-wrap items-center gap-2 text-base md:text-lg">
             <Users className="h-4 w-4 md:h-5 md:w-5" />
@@ -287,14 +312,44 @@ export const TourAssignmentDialog = ({
                             <div className="flex-1">
                               <div className="flex items-center gap-2">
                                 <span className="font-medium">
-                                  {assignment.profiles 
+                                  {assignment.profiles
                                     ? `${assignment.profiles.first_name} ${assignment.profiles.last_name}`
                                     : assignment.external_technician_name
                                   }
                                 </span>
-                                <Badge variant="outline" className="text-xs">
-                                  {labelForCode(assignment.role) || assignment.role}
-                                </Badge>
+                                {readOnly ? (
+                                  <Badge variant="outline" className="text-xs">
+                                    {labelForCode(assignment.role) || assignment.role}
+                                  </Badge>
+                                ) : (
+                                  <Select
+                                    value={assignment.role}
+                                    onValueChange={(role) => {
+                                      if (role && role !== assignment.role) {
+                                        updateRoleMutation.mutate({ assignmentId: assignment.id, role });
+                                      }
+                                    }}
+                                    disabled={updateRoleMutation.isPending}
+                                  >
+                                    <SelectTrigger className="h-7 w-auto min-w-[160px] text-xs">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {(() => {
+                                        const opts = getRolesForDepartment(assignment.department);
+                                        const hasCurrent = opts.some(o => o.value === assignment.role);
+                                        const finalOpts = hasCurrent || !assignment.role
+                                          ? opts
+                                          : [{ value: assignment.role, label: labelForCode(assignment.role) || assignment.role }, ...opts];
+                                        return finalOpts.map(opt => (
+                                          <SelectItem key={opt.value} value={opt.value}>
+                                            {opt.label}
+                                          </SelectItem>
+                                        ));
+                                      })()}
+                                    </SelectContent>
+                                  </Select>
+                                )}
                                 {assignment.external_technician_name && (
                                   <Badge variant="secondary" className="text-xs">
                                     External

--- a/src/components/tours/TourAssignmentDialog.tsx
+++ b/src/components/tours/TourAssignmentDialog.tsx
@@ -307,74 +307,79 @@ export const TourAssignmentDialog = ({
                         {dept.label}
                       </h4>
                       <div className="space-y-2">
-                        {deptAssignments.map(assignment => (
-                          <div key={assignment.id} className="flex items-center justify-between p-2 bg-muted rounded">
-                            <div className="flex-1">
-                              <div className="flex items-center gap-2">
-                                <span className="font-medium">
-                                  {assignment.profiles
-                                    ? `${assignment.profiles.first_name} ${assignment.profiles.last_name}`
-                                    : assignment.external_technician_name
-                                  }
-                                </span>
-                                {readOnly ? (
-                                  <Badge variant="outline" className="text-xs">
-                                    {labelForCode(assignment.role) || assignment.role}
-                                  </Badge>
-                                ) : (
-                                  <Select
-                                    value={assignment.role}
-                                    onValueChange={(role) => {
-                                      if (role && role !== assignment.role) {
-                                        updateRoleMutation.mutate({ assignmentId: assignment.id, role });
-                                      }
-                                    }}
-                                    disabled={updateRoleMutation.isPending}
-                                  >
-                                    <SelectTrigger className="h-7 w-auto min-w-[160px] text-xs">
-                                      <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                      {(() => {
-                                        const opts = getRolesForDepartment(assignment.department);
-                                        const hasCurrent = opts.some(o => o.value === assignment.role);
-                                        const finalOpts = hasCurrent || !assignment.role
-                                          ? opts
-                                          : [{ value: assignment.role, label: labelForCode(assignment.role) || assignment.role }, ...opts];
-                                        return finalOpts.map(opt => (
+                        {deptAssignments.map(assignment => {
+                          const opts = getRolesForDepartment(assignment.department);
+                          const canSyncRoleToJobs =
+                            Boolean(assignment.technician_id)
+                            && ['sound', 'lights', 'video'].includes(assignment.department)
+                            && opts.length > 0;
+                          const hasCurrent = opts.some(o => o.value === assignment.role);
+                          const finalOpts = hasCurrent || !assignment.role
+                            ? opts
+                            : [{ value: assignment.role, label: labelForCode(assignment.role) || assignment.role }, ...opts];
+
+                          return (
+                            <div key={assignment.id} className="flex items-center justify-between p-2 bg-muted rounded">
+                              <div className="flex-1">
+                                <div className="flex items-center gap-2">
+                                  <span className="font-medium">
+                                    {assignment.profiles
+                                      ? `${assignment.profiles.first_name} ${assignment.profiles.last_name}`
+                                      : assignment.external_technician_name
+                                    }
+                                  </span>
+                                  {readOnly || !canSyncRoleToJobs ? (
+                                    <Badge variant="outline" className="text-xs">
+                                      {labelForCode(assignment.role) || assignment.role}
+                                    </Badge>
+                                  ) : (
+                                    <Select
+                                      value={assignment.role}
+                                      onValueChange={(role) => {
+                                        if (role && role !== assignment.role) {
+                                          updateRoleMutation.mutate({ assignmentId: assignment.id, role });
+                                        }
+                                      }}
+                                      disabled={updateRoleMutation.isPending}
+                                    >
+                                      <SelectTrigger className="h-7 w-auto min-w-[160px] text-xs">
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        {finalOpts.map(opt => (
                                           <SelectItem key={opt.value} value={opt.value}>
                                             {opt.label}
                                           </SelectItem>
-                                        ));
-                                      })()}
-                                    </SelectContent>
-                                  </Select>
+                                        ))}
+                                      </SelectContent>
+                                    </Select>
+                                  )}
+                                  {assignment.external_technician_name && (
+                                    <Badge variant="secondary" className="text-xs">
+                                      External
+                                    </Badge>
+                                  )}
+                                </div>
+                                {assignment.profiles?.email && (
+                                  <p className="text-sm text-muted-foreground">{assignment.profiles.email}</p>
                                 )}
-                                {assignment.external_technician_name && (
-                                  <Badge variant="secondary" className="text-xs">
-                                    External
-                                  </Badge>
+                                {assignment.notes && (
+                                  <p className="text-sm text-muted-foreground italic">{assignment.notes}</p>
                                 )}
                               </div>
-                              {assignment.profiles?.email && (
-                                <p className="text-sm text-muted-foreground">{assignment.profiles.email}</p>
-                              )}
-                              {assignment.notes && (
-                                <p className="text-sm text-muted-foreground italic">{assignment.notes}</p>
+                              {!readOnly && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => handleDeleteAssignment(assignment.id)}
+                                  className="text-destructive hover:text-destructive"
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </Button>
                               )}
                             </div>
-                            {!readOnly && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleDeleteAssignment(assignment.id)}
-                                className="text-destructive hover:text-destructive"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            )}
-                          </div>
-                        ))}
+                          );
+                        })}
                       </div>
                     </div>
                   );

--- a/src/hooks/useDirectJobAssignments.ts
+++ b/src/hooks/useDirectJobAssignments.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import { dataLayerClient } from '@/services/dataLayerClient';
+import { queryKeys } from '@/lib/react-query';
+
+export type DirectJobAssignment = {
+  technician_id: string;
+  sound_role: string | null;
+  lights_role: string | null;
+  video_role: string | null;
+  single_day: boolean | null;
+  assignment_date: string | null;
+  profiles: {
+    first_name: string | null;
+    last_name: string | null;
+    email: string | null;
+    department: string | null;
+  } | null;
+};
+
+export function useDirectJobAssignments(jobId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: queryKeys.scope('job-assignments-direct', jobId),
+    enabled: enabled && !!jobId,
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient.from('job_assignments')
+        .select(`
+          technician_id,
+          sound_role,
+          lights_role,
+          video_role,
+          single_day,
+          assignment_date,
+          profiles (
+            first_name,
+            last_name,
+            email,
+            department
+          )
+        `)
+        .eq('job_id', jobId);
+
+      if (error) throw error;
+      return (data || []) as unknown as DirectJobAssignment[];
+    },
+    staleTime: 30_000,
+  });
+}

--- a/src/hooks/useJobAssignmentsRealtime.ts
+++ b/src/hooks/useJobAssignmentsRealtime.ts
@@ -16,6 +16,8 @@ export interface AssignmentInsertOptions {
   addAsConfirmed?: boolean;
 }
 
+type AssignmentRemovalContext = Pick<Assignment, 'technician_id' | 'sound_role' | 'lights_role' | 'video_role'>;
+
 export const buildAssignmentInsertPayload = (
   jobId: string,
   technicianId: string,
@@ -360,7 +362,7 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
     }
   };
 
-  const removeAssignment = async (technicianId: string) => {
+  const removeAssignment = async (technicianId: string, renderedAssignment?: AssignmentRemovalContext) => {
     try {
       setIsRemoving(prev => ({ ...prev, [technicianId]: true }));
 
@@ -378,7 +380,10 @@ export const useJobAssignmentsRealtime = (jobId: string) => {
       });
 
       // Get the assignment details before removal for Flex cleanup
-      const assignmentToRemove = assignments.find(a => a.technician_id === technicianId);
+      const assignmentToRemove =
+        renderedAssignment?.technician_id === technicianId
+          ? renderedAssignment
+          : assignments.find(a => a.technician_id === technicianId);
 
       // Remove from database - IMPORTANT: Delete timesheets first to avoid orphaned records
       const { error: timesheetError } = await supabase

--- a/src/hooks/useJobClosureLock.ts
+++ b/src/hooks/useJobClosureLock.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { createQueryKey } from '@/lib/optimized-react-query';
+import { dataLayerClient } from '@/services/dataLayerClient';
+import { isJobPastClosureWindow } from '@/utils/jobClosureUtils';
+import { isAdminRole } from '@/utils/permissions';
+
+type JobClosureMeta = {
+  id: string;
+  end_time: string | null;
+  timezone: string | null;
+};
+
+export function useJobClosureLock(jobId: string, userRole: string | null | undefined) {
+  const { data: jobMeta, isError: jobMetaError } = useQuery({
+    queryKey: createQueryKey.jobs.meta(jobId),
+    enabled: !!jobId,
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient.from('jobs')
+        .select('id, end_time, timezone')
+        .eq('id', jobId)
+        .maybeSingle();
+      if (error) throw error;
+      return data as JobClosureMeta | null;
+    },
+    staleTime: 60_000,
+  });
+
+  const isPastClosureWindow = (() => {
+    if (jobMetaError) return false;
+    if (jobMeta === undefined) return true;
+    if (!jobMeta) return false;
+    return isJobPastClosureWindow(jobMeta.end_time, jobMeta.timezone ?? 'Europe/Madrid');
+  })();
+
+  const isAdmin = isAdminRole(userRole);
+
+  return {
+    isClosureLocked: isPastClosureWindow && !isAdmin,
+    isAdminOverridingClosure: isPastClosureWindow && isAdmin && jobMeta !== undefined,
+  };
+}

--- a/src/hooks/useJobClosureLock.ts
+++ b/src/hooks/useJobClosureLock.ts
@@ -25,17 +25,16 @@ export function useJobClosureLock(jobId: string, userRole: string | null | undef
     staleTime: 60_000,
   });
 
+  const isAdmin = isAdminRole(userRole);
   const isPastClosureWindow = (() => {
-    if (jobMetaError) return false;
+    if (jobMetaError) return true;
     if (jobMeta === undefined) return true;
     if (!jobMeta) return false;
     return isJobPastClosureWindow(jobMeta.end_time, jobMeta.timezone ?? 'Europe/Madrid');
   })();
 
-  const isAdmin = isAdminRole(userRole);
-
   return {
     isClosureLocked: isPastClosureWindow && !isAdmin,
-    isAdminOverridingClosure: isPastClosureWindow && isAdmin && jobMeta !== undefined,
+    isAdminOverridingClosure: isPastClosureWindow && isAdmin && jobMeta !== undefined && !jobMetaError,
   };
 }

--- a/src/hooks/useTechnicianRateModeDates.ts
+++ b/src/hooks/useTechnicianRateModeDates.ts
@@ -117,6 +117,12 @@ export function useSetTechnicianDateRateMode() {
   return useMutation({
     mutationFn: async ({ jobId, technicianId, date, mode, fixedAmountEur }: SetTechnicianDateRateModeParams) => {
       let createdTimesheet = false;
+      const normalizedFixedAmount =
+        mode === 'fixed' && fixedAmountEur != null ? Math.round(Number(fixedAmountEur) * 100) / 100 : null;
+
+      if (mode === 'fixed' && (normalizedFixedAmount == null || !Number.isFinite(normalizedFixedAmount) || normalizedFixedAmount < 0)) {
+        throw new Error('A non-negative fixed amount is required');
+      }
 
       if (mode === 'inherit') {
         const { error } = await supabase
@@ -135,7 +141,7 @@ export function useSetTechnicianDateRateMode() {
           rate_mode: mode,
           // Maintain the legacy boolean so any unmigrated reader still works.
           use_rehearsal_rate: mode === 'rehearsal',
-          fixed_amount_eur: mode === 'fixed' ? (fixedAmountEur ?? 0) : null,
+          fixed_amount_eur: normalizedFixedAmount,
         };
 
         const { error } = await supabase

--- a/src/hooks/useTechnicianRateModeDates.ts
+++ b/src/hooks/useTechnicianRateModeDates.ts
@@ -6,9 +6,35 @@ import { invalidateRehearsalRateQueries, recalculateTimesheets } from '@/hooks/u
 
 
 import { queryKeys } from "@/lib/react-query";
-export type TechnicianDateRateMode = 'inherit' | 'rehearsal' | 'standard';
 
-type TechnicianRateModeRow = Tables<'job_technician_rate_mode_dates'>;
+/**
+ * Per-technician/per-date rate exception modes.
+ * - `inherit`          → no row; follow the job-wide rehearsal toggle.
+ * - `rehearsal`        → force the rehearsal flat rate.
+ * - `standard`         → force the standard day/hours rate.
+ * - `tour_multipliers` → force tour multipliers even off the full-week tour team.
+ * - `no_multipliers`   → force the plain base day rate (multiplier 1.0).
+ * - `hourly`           → price from the timesheet's worked hours (auto-creates a draft).
+ * - `fixed`            → use a custom fixed EUR amount.
+ */
+export type TechnicianDateRateMode =
+  | 'inherit'
+  | 'rehearsal'
+  | 'standard'
+  | 'tour_multipliers'
+  | 'no_multipliers'
+  | 'hourly'
+  | 'fixed';
+
+/** Modes that price a date from a real timesheet, so one must exist. */
+const MODES_NEEDING_TIMESHEET: TechnicianDateRateMode[] = ['hourly'];
+
+// The generated Supabase types lag behind the migration that adds rate_mode /
+// fixed_amount_eur, so widen the row locally instead of editing types.ts.
+type TechnicianRateModeRow = Tables<'job_technician_rate_mode_dates'> & {
+  rate_mode: TechnicianDateRateMode;
+  fixed_amount_eur: number | null;
+};
 
 interface UseJobTechnicianRateModeDatesOptions {
   enabled?: boolean;
@@ -26,11 +52,11 @@ export function useJobTechnicianRateModeDates(
     queryFn: async (): Promise<TechnicianRateModeRow[]> => {
       const { data, error } = await supabase
         .from('job_technician_rate_mode_dates')
-        .select('job_id, technician_id, date, use_rehearsal_rate, created_at, created_by, updated_at, updated_by')
+        .select('job_id, technician_id, date, use_rehearsal_rate, rate_mode, fixed_amount_eur, created_at, created_by, updated_at, updated_by')
         .eq('job_id', jobId);
 
       if (error) throw error;
-      return (data || []) as TechnicianRateModeRow[];
+      return (data || []) as unknown as TechnicianRateModeRow[];
     },
     staleTime: 30_000,
   });
@@ -41,13 +67,57 @@ interface SetTechnicianDateRateModeParams {
   technicianId: string;
   date: string;
   mode: TechnicianDateRateMode;
+  /** Required when mode === 'fixed'. */
+  fixedAmountEur?: number | null;
+}
+
+/**
+ * Ensures an active timesheet exists for the job/date/tech, creating a draft if
+ * not. Mirrors the insert shape used by useTimesheets.createTimesheet so the DB
+ * trigger resolves the category and default times. Returns the affected
+ * timesheet ids so the caller can recalculate them.
+ */
+async function ensureTimesheetForDate(
+  jobId: string,
+  technicianId: string,
+  date: string,
+): Promise<string[]> {
+  const { data: existing, error: existingError } = await supabase
+    .from('timesheets')
+    .select('id')
+    .eq('job_id', jobId)
+    .eq('technician_id', technicianId)
+    .eq('date', date)
+    .eq('is_active', true);
+
+  if (existingError) throw existingError;
+
+  if (existing && existing.length > 0) {
+    return existing.map((row) => row.id);
+  }
+
+  const { data: created, error: createError } = await supabase
+    .from('timesheets')
+    .insert({
+      job_id: jobId,
+      technician_id: technicianId,
+      date,
+      created_by: (await supabase.auth.getUser()).data.user?.id,
+    })
+    .select('id')
+    .single();
+
+  if (createError) throw createError;
+  return created ? [created.id] : [];
 }
 
 export function useSetTechnicianDateRateMode() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ jobId, technicianId, date, mode }: SetTechnicianDateRateModeParams) => {
+    mutationFn: async ({ jobId, technicianId, date, mode, fixedAmountEur }: SetTechnicianDateRateModeParams) => {
+      let createdTimesheet = false;
+
       if (mode === 'inherit') {
         const { error } = await supabase
           .from('job_technician_rate_mode_dates')
@@ -58,19 +128,36 @@ export function useSetTechnicianDateRateMode() {
 
         if (error) throw error;
       } else {
+        const upsertRow: Record<string, unknown> = {
+          job_id: jobId,
+          technician_id: technicianId,
+          date,
+          rate_mode: mode,
+          // Maintain the legacy boolean so any unmigrated reader still works.
+          use_rehearsal_rate: mode === 'rehearsal',
+          fixed_amount_eur: mode === 'fixed' ? (fixedAmountEur ?? 0) : null,
+        };
+
         const { error } = await supabase
           .from('job_technician_rate_mode_dates')
-          .upsert(
-            {
-              job_id: jobId,
-              technician_id: technicianId,
-              date,
-              use_rehearsal_rate: mode === 'rehearsal',
-            },
-            { onConflict: 'job_id,technician_id,date' },
-          );
+          // Cast: rate_mode/fixed_amount_eur are not yet in the generated types.
+          .upsert(upsertRow as never, { onConflict: 'job_id,technician_id,date' });
 
         if (error) throw error;
+
+        // Modes priced from a real timesheet must have one to surface.
+        if (MODES_NEEDING_TIMESHEET.includes(mode)) {
+          const before = await supabase
+            .from('timesheets')
+            .select('id')
+            .eq('job_id', jobId)
+            .eq('technician_id', technicianId)
+            .eq('date', date)
+            .eq('is_active', true);
+          const hadTimesheet = (before.data?.length ?? 0) > 0;
+          await ensureTimesheetForDate(jobId, technicianId, date);
+          createdTimesheet = !hadTimesheet;
+        }
       }
 
       const { data: timesheets, error: timesheetError } = await supabase
@@ -87,11 +174,14 @@ export function useSetTechnicianDateRateMode() {
         timesheets?.map((timesheet) => timesheet.id) ?? [],
       );
 
-      return { jobId, technicianId, date, mode, recalculated };
+      return { jobId, technicianId, date, mode, recalculated, createdTimesheet };
     },
     onSuccess: (result) => {
       invalidateRehearsalRateQueries(queryClient, result.jobId);
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('job-technician-rate-mode-dates', result.jobId) });
+      if (result.createdTimesheet) {
+        toast.success('Se creó un parte en borrador para introducir horas');
+      }
     },
     onError: (error) => {
       console.error('[useSetTechnicianDateRateMode] Error:', error);

--- a/src/hooks/useToggleJobRehearsalRate.ts
+++ b/src/hooks/useToggleJobRehearsalRate.ts
@@ -47,6 +47,8 @@ export const invalidateRehearsalRateQueries = (queryClient: QueryClient, jobId: 
     ['tour-job-rate-quotes-manager'],
     ['technician-tour-rate-quotes'],
     ['timesheets'],
+    ['job-timesheet-dates', jobId],
+    ['job-tech-timesheet-dates', jobId],
     ['job-tech-payout', jobId, 'tour-timesheet-data'],
   ]);
 };

--- a/src/utils/__tests__/job-payout-payable-dates-guard.test.ts
+++ b/src/utils/__tests__/job-payout-payable-dates-guard.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('job payout payable-date source guard', () => {
+  const source = readFileSync(
+    join(
+      __dirname,
+      '..',
+      '..',
+      'components',
+      'jobs',
+      'payout-totals',
+      'useJobPayoutData.ts',
+    ),
+    'utf-8',
+  );
+
+  it('builds technician rate-mode dates from all payable-date sources', () => {
+    expect(source).toMatch(/queryKeys\.scope\('job-tech-timesheet-dates', jobId\)/);
+    expect(source).toMatch(/from\('timesheets'\)[\s\S]*select\('technician_id, date'\)/);
+    expect(source).toMatch(/from\('job_assignments'\)[\s\S]*select\('technician_id, single_day, assignment_date'\)/);
+    expect(source).toMatch(/from\('job_date_types'\)[\s\S]*select\('date, type'\)/);
+    expect(source).toMatch(/from\('tour_dates'\)[\s\S]*select\('start_date, end_date, date'\)/);
+    expect(source).toMatch(/row\.type === 'prep_day'/);
+    expect(source).toMatch(/row\.type !== 'rigging'/);
+    expect(source).toMatch(/fallbackScheduleDates/);
+  });
+
+  it('keeps payout edits locked for non-admins while closure metadata is unknown', () => {
+    expect(source).toMatch(/!isAdmin[\s\S]*jobMetaLoading[\s\S]*Boolean\(jobMetaError\)[\s\S]*isJobPastClosureWindow/);
+  });
+});

--- a/src/utils/__tests__/technician-rate-mode-guard.test.ts
+++ b/src/utils/__tests__/technician-rate-mode-guard.test.ts
@@ -56,7 +56,12 @@ describe("technician/date rate-mode migration guard", () => {
 
   it("guards expanded fixed/hourly rate modes from unsafe payout states", () => {
     expect(expandedMigration).toMatch(/rate_mode IN \('rehearsal','standard','tour_multipliers','no_multipliers','hourly','fixed'\)/i);
+    expect(expandedMigration).toMatch(/ALTER COLUMN rate_mode DROP DEFAULT/i);
+    expect(expandedMigration).toMatch(/tg_job_technician_rate_mode_dates_sync_legacy/i);
+    expect(expandedMigration).toMatch(/WHEN COALESCE\(NEW\.use_rehearsal_rate, FALSE\) THEN 'rehearsal'/i);
+    expect(expandedMigration).toMatch(/WHEN COALESCE\(trmd\.use_rehearsal_rate, FALSE\) THEN 'rehearsal'/i);
     expect(expandedMigration).toMatch(/fixed_amount_eur IS NOT NULL AND fixed_amount_eur >= 0/i);
+    expect(expandedMigration).toMatch(/RAISE EXCEPTION 'Invalid fixed amount for timesheet %'/i);
     expect(expandedMigration).toMatch(/COUNT\(\*\) FILTER \(WHERE cpd\.eff_mode = 'hourly'\)::int/i);
     expect(expandedMigration).toMatch(/COUNT\(\*\) FILTER \(WHERE cpd\.eff_mode = 'fixed'\)::int/i);
     expect(expandedMigration).toMatch(/'hourly_total_eur', hourly_total/i);

--- a/src/utils/__tests__/technician-rate-mode-guard.test.ts
+++ b/src/utils/__tests__/technician-rate-mode-guard.test.ts
@@ -13,6 +13,18 @@ describe("technician/date rate-mode migration guard", () => {
     "20260411223000_add_admin_only_technician_rate_modes.sql",
   );
   const migration = readFileSync(migrationPath, "utf-8");
+  const expandedMigration = readFileSync(
+    join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "supabase",
+      "migrations",
+      "20260628120000_expand_technician_rate_modes.sql",
+    ),
+    "utf-8",
+  );
 
   it("creates an admin-only technician/date override table", () => {
     expect(migration).toMatch(/CREATE TABLE IF NOT EXISTS public\.job_technician_rate_mode_dates/i);
@@ -40,5 +52,14 @@ describe("technician/date rate-mode migration guard", () => {
     expect(migration).toMatch(/v_rate_mode_source := 'technician_override'/i);
     expect(migration).toMatch(/COALESCE\(trmd\.use_rehearsal_rate,\s*jrd\.job_id IS NOT NULL\)/i);
     expect(migration).toMatch(/technician_override_days/i);
+  });
+
+  it("guards expanded fixed/hourly rate modes from unsafe payout states", () => {
+    expect(expandedMigration).toMatch(/rate_mode IN \('rehearsal','standard','tour_multipliers','no_multipliers','hourly','fixed'\)/i);
+    expect(expandedMigration).toMatch(/fixed_amount_eur IS NOT NULL AND fixed_amount_eur >= 0/i);
+    expect(expandedMigration).toMatch(/COUNT\(\*\) FILTER \(WHERE cpd\.eff_mode = 'hourly'\)::int/i);
+    expect(expandedMigration).toMatch(/COUNT\(\*\) FILTER \(WHERE cpd\.eff_mode = 'fixed'\)::int/i);
+    expect(expandedMigration).toMatch(/'hourly_total_eur', hourly_total/i);
+    expect(expandedMigration).toMatch(/'fixed_total_eur', fixed_total/i);
   });
 });

--- a/src/utils/__tests__/tour-assignment-role-update-guard.test.ts
+++ b/src/utils/__tests__/tour-assignment-role-update-guard.test.ts
@@ -22,6 +22,8 @@ describe('tour assignment role update migration guard', () => {
     expect(codeOnly).toMatch(/CREATE OR REPLACE FUNCTION public\.sync_tour_assignment_role_update_to_future_jobs\(\)/i);
     expect(codeOnly).toMatch(/v_today date := \(now\(\) AT TIME ZONE 'Europe\/Madrid'\)::date/i);
     expect(codeOnly).toMatch(/j\.job_type = 'tourdate'/i);
+    expect(codeOnly).toMatch(/NEW\.department NOT IN \('sound', 'lights', 'video'\)/i);
+    expect(codeOnly).toMatch(/NEW\.department IN \('sound', 'lights', 'video'\)/i);
     expect(codeOnly).toMatch(/COALESCE\([\s\S]*?jdt\.schedule_start[\s\S]*?td\.start_date[\s\S]*?j\.start_time AT TIME ZONE 'Europe\/Madrid'[\s\S]*?td\.date[\s\S]*?\) >= v_today/i);
     expect(codeOnly).toMatch(/INSERT INTO public\.job_assignments/i);
     expect(codeOnly).toMatch(/EXECUTE FUNCTION public\.sync_tour_assignment_role_update_to_future_jobs\(\)/i);

--- a/src/utils/__tests__/tour-assignment-role-update-guard.test.ts
+++ b/src/utils/__tests__/tour-assignment-role-update-guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('tour assignment role update migration guard', () => {
+  const migrationPath = join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'supabase',
+    'migrations',
+    '20260628121000_sync_tour_assignment_role_updates.sql',
+  );
+  const migration = readFileSync(migrationPath, 'utf-8');
+  const codeOnly = migration
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('--'))
+    .join('\n');
+
+  it('syncs role updates only to today-or-future tour-date jobs', () => {
+    expect(codeOnly).toMatch(/CREATE OR REPLACE FUNCTION public\.sync_tour_assignment_role_update_to_future_jobs\(\)/i);
+    expect(codeOnly).toMatch(/v_today date := \(now\(\) AT TIME ZONE 'Europe\/Madrid'\)::date/i);
+    expect(codeOnly).toMatch(/j\.job_type = 'tourdate'/i);
+    expect(codeOnly).toMatch(/COALESCE\([\s\S]*?jdt\.schedule_start[\s\S]*?td\.start_date[\s\S]*?j\.start_time AT TIME ZONE 'Europe\/Madrid'[\s\S]*?td\.date[\s\S]*?\) >= v_today/i);
+    expect(codeOnly).toMatch(/INSERT INTO public\.job_assignments/i);
+    expect(codeOnly).toMatch(/EXECUTE FUNCTION public\.sync_tour_assignment_role_update_to_future_jobs\(\)/i);
+    expect(codeOnly).not.toMatch(/EXECUTE FUNCTION public\.sync_tour_assignments_to_jobs\(\)/i);
+  });
+});

--- a/supabase/migrations/20260628120000_expand_technician_rate_modes.sql
+++ b/supabase/migrations/20260628120000_expand_technician_rate_modes.sql
@@ -1,0 +1,1269 @@
+-- Expand the admin-only per-technician/per-date pricing exceptions beyond the
+-- original rehearsal/standard boolean. Adds a richer `rate_mode` plus an
+-- optional `fixed_amount_eur`, and teaches both pricing engines about the new
+-- modes:
+--   * rehearsal        -> rehearsal flat rate (unchanged)
+--   * standard         -> standard day/hours rate (unchanged default)
+--   * tour_multipliers -> force tour multipliers for this tech+date even when
+--                         the technician is not a full-week tour-team member
+--   * no_multipliers   -> force the plain base day rate (multiplier = 1.0)
+--   * hourly           -> price the date from the technician timesheet's
+--                         worked-hours amount instead of the flat tour day rate
+--   * fixed            -> use a custom fixed EUR amount for the tech+date
+--
+-- Absence of a row still means "inherit the job-wide rehearsal toggle".
+-- `use_rehearsal_rate` is kept (and maintained = rate_mode = 'rehearsal') so any
+-- not-yet-updated reader keeps working.
+
+-- ---------------------------------------------------------------------------
+-- Part A — schema
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.job_technician_rate_mode_dates
+  ADD COLUMN IF NOT EXISTS rate_mode text,
+  ADD COLUMN IF NOT EXISTS fixed_amount_eur numeric(10,2);
+
+-- Backfill existing rows from the legacy boolean.
+UPDATE public.job_technician_rate_mode_dates
+SET rate_mode = CASE WHEN use_rehearsal_rate THEN 'rehearsal' ELSE 'standard' END
+WHERE rate_mode IS NULL;
+
+ALTER TABLE public.job_technician_rate_mode_dates
+  ALTER COLUMN rate_mode SET DEFAULT 'standard',
+  ALTER COLUMN rate_mode SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'job_technician_rate_mode_dates_rate_mode_check'
+  ) THEN
+    ALTER TABLE public.job_technician_rate_mode_dates
+      ADD CONSTRAINT job_technician_rate_mode_dates_rate_mode_check
+      CHECK (rate_mode IN ('rehearsal','standard','tour_multipliers','no_multipliers','hourly','fixed'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'job_technician_rate_mode_dates_fixed_amount_check'
+  ) THEN
+    ALTER TABLE public.job_technician_rate_mode_dates
+      ADD CONSTRAINT job_technician_rate_mode_dates_fixed_amount_check
+      CHECK (rate_mode <> 'fixed' OR fixed_amount_eur IS NOT NULL);
+  END IF;
+END
+$$;
+
+COMMENT ON COLUMN public.job_technician_rate_mode_dates.rate_mode IS
+  'Pricing mode for this technician/date exception: rehearsal, standard, tour_multipliers, no_multipliers, hourly, fixed. Missing row = inherit job-wide rehearsal toggle.';
+COMMENT ON COLUMN public.job_technician_rate_mode_dates.fixed_amount_eur IS
+  'Custom fixed EUR amount applied when rate_mode = fixed.';
+
+-- ---------------------------------------------------------------------------
+-- Part B — compute_timesheet_amount_2025 (standard jobs + all timesheet pricing)
+-- Adds the `fixed` short-circuit and reads rate_mode for the rehearsal decision.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.compute_timesheet_amount_2025(
+  _timesheet_id uuid,
+  _persist boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_timesheet RECORD;
+  v_job_type TEXT;
+  v_category TEXT;
+  v_rate_card RECORD;
+  v_worked_hours NUMERIC;
+  v_raw_worked_hours NUMERIC;
+  v_billable_hours NUMERIC;
+  v_base_day_amount NUMERIC := 0;
+  v_plus_10_12_hours NUMERIC := 0;
+  v_plus_10_12_amount NUMERIC := 0;
+  v_overtime_hours NUMERIC := 0;
+  v_overtime_amount NUMERIC := 0;
+  v_total_amount NUMERIC := 0;
+  v_breakdown JSONB;
+  v_result JSONB;
+  v_is_rehearsal BOOLEAN := FALSE;
+  v_is_extended_shift BOOLEAN := FALSE;
+  v_rehearsal_flat_rate NUMERIC := NULL;
+  v_is_autonomo BOOLEAN := TRUE;
+  v_is_house_tech BOOLEAN := FALSE;
+  v_is_reduced_rehearsal BOOLEAN := FALSE;
+  v_autonomo_discount NUMERIC := 0;
+  v_forced_rehearsal BOOLEAN := FALSE;
+  v_technician_rate_mode_override BOOLEAN := NULL;
+  v_has_technician_rate_mode_override BOOLEAN := FALSE;
+  v_rate_mode_source TEXT := 'standard';
+  v_rate_mode TEXT := NULL;
+  v_fixed_amount NUMERIC := NULL;
+BEGIN
+  -- Fetch timesheet with job info, category, autonomo status, and role-based flags
+  SELECT
+    t.*,
+    j.job_type,
+    CASE WHEN p.role = 'technician' THEN COALESCE(p.autonomo, true) ELSE true END as is_autonomo,
+    COALESCE(p.role = 'house_tech', false) as is_house_tech,
+    COALESCE(p.role IN ('house_tech', 'admin', 'management'), false) as is_reduced_rehearsal,
+    COALESCE(
+      t.category,
+      CASE
+        WHEN a.sound_role LIKE '%-R' OR a.lights_role LIKE '%-R' OR a.video_role LIKE '%-R' THEN 'responsable'
+        WHEN a.sound_role LIKE '%-E' OR a.lights_role LIKE '%-E' OR a.video_role LIKE '%-E' THEN 'especialista'
+        WHEN a.sound_role LIKE '%-T' OR a.lights_role LIKE '%-T' OR a.video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END,
+      'tecnico'
+    ) as category
+  INTO v_timesheet
+  FROM public.timesheets t
+  LEFT JOIN public.jobs j ON t.job_id = j.id
+  LEFT JOIN public.job_assignments a ON t.job_id = a.job_id AND t.technician_id = a.technician_id
+  LEFT JOIN public.profiles p ON t.technician_id = p.id
+  WHERE t.id = _timesheet_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Timesheet not found: %', _timesheet_id;
+  END IF;
+
+  IF NOT (
+    auth.role() = 'service_role'
+    OR public.is_admin_or_management()
+    OR auth.uid() = v_timesheet.technician_id
+  ) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  v_job_type := v_timesheet.job_type;
+  v_category := v_timesheet.category;
+
+  -- Rehearsal/fixed pricing uses technician/date overrides first, then the
+  -- job-wide rehearsal toggle table.
+  IF v_timesheet.date IS NOT NULL AND v_timesheet.job_id IS NOT NULL THEN
+    SELECT trmd.use_rehearsal_rate, trmd.rate_mode, trmd.fixed_amount_eur
+    INTO v_technician_rate_mode_override, v_rate_mode, v_fixed_amount
+    FROM public.job_technician_rate_mode_dates trmd
+    WHERE trmd.job_id = v_timesheet.job_id
+      AND trmd.technician_id = v_timesheet.technician_id
+      AND trmd.date = v_timesheet.date;
+
+    IF FOUND THEN
+      v_has_technician_rate_mode_override := TRUE;
+      v_forced_rehearsal := COALESCE(v_rate_mode = 'rehearsal', v_technician_rate_mode_override, FALSE);
+      v_rate_mode_source := 'technician_override';
+    ELSE
+      SELECT EXISTS (
+        SELECT 1 FROM public.job_rehearsal_dates
+        WHERE job_id = v_timesheet.job_id AND date = v_timesheet.date
+      ) INTO v_forced_rehearsal;
+
+      v_rate_mode_source := CASE
+        WHEN v_forced_rehearsal THEN 'job_rehearsal_date'
+        ELSE 'standard'
+      END;
+    END IF;
+  END IF;
+
+  v_is_rehearsal := v_forced_rehearsal;
+
+  -- Get autonomo / house_tech / reduced rehearsal status from the main query
+  v_is_autonomo := v_timesheet.is_autonomo;
+  v_is_house_tech := v_timesheet.is_house_tech;
+  v_is_reduced_rehearsal := v_timesheet.is_reduced_rehearsal;
+
+  -- Calculate worked hours once for both rehearsal and standard paths
+  IF v_timesheet.end_time < v_timesheet.start_time OR COALESCE(v_timesheet.ends_next_day, false) THEN
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      v_timesheet.end_time - v_timesheet.start_time + INTERVAL '24 hours'
+    )) / 3600.0 - (COALESCE(v_timesheet.break_minutes, 0) / 60.0);
+  ELSE
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      v_timesheet.end_time - v_timesheet.start_time
+    )) / 3600.0 - (COALESCE(v_timesheet.break_minutes, 0) / 60.0);
+  END IF;
+  -- Preserve raw fractional hours for audit trail, then round to nearest whole hour
+  -- IMPORTANT: Do NOT change this to half-hour rounding (ROUND(x*2)/2). See PR #467.
+  v_raw_worked_hours := v_worked_hours;
+  v_worked_hours := ROUND(v_worked_hours);
+
+  -- Fixed-amount override short-circuits both rehearsal and standard pricing.
+  IF v_rate_mode = 'fixed' THEN
+    v_total_amount := COALESCE(v_fixed_amount, 0);
+    v_billable_hours := v_worked_hours;
+
+    v_breakdown := jsonb_build_object(
+      'worked_hours', v_raw_worked_hours,
+      'worked_hours_rounded', v_worked_hours,
+      'hours_rounded', v_worked_hours,
+      'billable_hours', v_billable_hours,
+      'is_fixed_amount', true,
+      'fixed_amount_eur', v_total_amount,
+      'base_amount_eur', v_total_amount,
+      'base_day_eur', v_total_amount,
+      'plus_10_12_hours', 0,
+      'plus_10_12_eur', 0,
+      'plus_10_12_amount_eur', 0,
+      'overtime_hours', 0,
+      'overtime_hour_eur', 0,
+      'overtime_amount_eur', 0,
+      'total_eur', v_total_amount,
+      'category', v_category,
+      'forced_rehearsal_rate', false,
+      'rate_mode_source', 'technician_override',
+      'has_technician_rate_mode_override', true,
+      'technician_rate_mode', 'fixed'
+    );
+
+    v_result := jsonb_build_object(
+      'timesheet_id', _timesheet_id,
+      'amount_eur', v_total_amount,
+      'amount_breakdown', v_breakdown
+    );
+
+    IF _persist THEN
+      UPDATE public.timesheets
+      SET
+        amount_eur = v_total_amount,
+        amount_breakdown = v_breakdown,
+        category = v_category,
+        updated_at = NOW()
+      WHERE id = _timesheet_id;
+    END IF;
+
+    RETURN v_result;
+  END IF;
+
+  -- Handle rehearsal flat rate
+  IF v_is_rehearsal THEN
+    -- Check for custom rehearsal rate first
+    SELECT rehearsal_day_eur INTO v_rehearsal_flat_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = v_timesheet.technician_id;
+
+    -- If no custom rate, use role-based defaults:
+    -- house_tech / admin / management -> EUR 60, regular technicians -> EUR 180
+    IF v_rehearsal_flat_rate IS NULL THEN
+      IF v_is_reduced_rehearsal THEN
+        v_rehearsal_flat_rate := 60.00;
+      ELSE
+        v_rehearsal_flat_rate := 180.00;
+      END IF;
+    END IF;
+
+    -- Apply discount for non-autonomo regular technicians only.
+    -- House techs, admin, and management are exempt from the autonomo discount.
+    IF NOT v_is_autonomo AND NOT v_is_reduced_rehearsal THEN
+      v_autonomo_discount := 30.00;
+      v_rehearsal_flat_rate := v_rehearsal_flat_rate - v_autonomo_discount;
+    END IF;
+
+    v_total_amount := v_rehearsal_flat_rate;
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rehearsal_flat_rate;
+
+    v_breakdown := jsonb_build_object(
+      'worked_hours', v_raw_worked_hours,
+      'worked_hours_rounded', v_worked_hours,
+      'hours_rounded', v_worked_hours,
+      'billable_hours', v_billable_hours,
+      'is_rehearsal', true,
+      'is_rehearsal_flat_rate', true,
+      'rehearsal_rate_eur', v_rehearsal_flat_rate,
+      'autonomo_discount_eur', v_autonomo_discount,
+      'base_day_before_discount_eur', CASE WHEN v_autonomo_discount > 0 THEN v_rehearsal_flat_rate + v_autonomo_discount ELSE v_rehearsal_flat_rate END,
+      'base_amount_eur', v_rehearsal_flat_rate,
+      'base_day_eur', v_rehearsal_flat_rate,
+      'plus_10_12_hours', 0,
+      'plus_10_12_eur', 0,
+      'plus_10_12_amount_eur', 0,
+      'overtime_hours', 0,
+      'overtime_hour_eur', 0,
+      'overtime_amount_eur', 0,
+      'total_eur', v_total_amount,
+      'category', 'rehearsal',
+      'forced_rehearsal_rate', v_forced_rehearsal,
+      'rate_mode_source', v_rate_mode_source,
+      'has_technician_rate_mode_override', v_has_technician_rate_mode_override,
+      'technician_rate_mode_override_rehearsal', v_technician_rate_mode_override
+    );
+
+    v_result := jsonb_build_object(
+      'timesheet_id', _timesheet_id,
+      'amount_eur', v_total_amount,
+      'amount_breakdown', v_breakdown
+    );
+
+    IF _persist THEN
+      UPDATE public.timesheets
+      SET
+        amount_eur = v_total_amount,
+        amount_breakdown = v_breakdown,
+        category = v_category,
+        updated_at = NOW()
+      WHERE id = _timesheet_id;
+    END IF;
+
+    RETURN v_result;
+  END IF;
+
+  -- Standard rate card lookup (non-rehearsal).
+  -- House-tech OT is category-aware; non-house roles preserve legacy behavior.
+  SELECT
+    COALESCE(
+      CASE
+        WHEN v_category = 'responsable' THEN COALESCE(ctr.base_day_responsable_eur, ctr.base_day_especialista_eur, ctr.base_day_eur)
+        WHEN v_category = 'especialista' THEN COALESCE(ctr.base_day_especialista_eur, ctr.base_day_eur)
+        ELSE ctr.base_day_eur
+      END,
+      (SELECT rc.base_day_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)
+    ) AS base_day_eur,
+    COALESCE(ctr.plus_10_12_eur, (SELECT rc.plus_10_12_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)) as plus_10_12_eur,
+    COALESCE(
+      CASE
+        WHEN v_is_house_tech AND v_category = 'tecnico' THEN ctr.overtime_hour_eur
+        WHEN v_is_house_tech AND v_category = 'especialista' THEN COALESCE(ctr.overtime_hour_especialista_eur, ctr.overtime_hour_eur)
+        WHEN v_is_house_tech AND v_category = 'responsable' THEN COALESCE(
+          ctr.overtime_hour_responsable_eur,
+          CASE WHEN ctr.overtime_hour_eur = 15.00 THEN 20.00 END,
+          ctr.overtime_hour_eur
+        )
+        ELSE ctr.overtime_hour_eur
+      END,
+      (SELECT rc.overtime_hour_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)
+    ) as overtime_hour_eur
+  INTO v_rate_card
+  FROM public.custom_tech_rates ctr
+  WHERE ctr.profile_id = v_timesheet.technician_id;
+
+  IF NOT FOUND THEN
+    SELECT * INTO v_rate_card
+    FROM public.rate_cards_2025
+    WHERE category = v_category;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Rate card not found for category: %', v_category;
+    END IF;
+  END IF;
+
+  -- Handle evento jobs (fixed 12-hour rate)
+  IF v_job_type = 'evento' THEN
+    v_billable_hours := 12.0;
+    v_base_day_amount := v_rate_card.base_day_eur;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+    v_overtime_hours := 0;
+    v_overtime_amount := 0;
+    v_total_amount := v_base_day_amount + v_plus_10_12_amount;
+  -- Handle extended shifts (21+ hours / over 20.5 hrs): double base rate only
+  ELSIF v_worked_hours > 20.5 THEN
+    v_is_extended_shift := TRUE;
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rate_card.base_day_eur * 2;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := 0;
+    v_overtime_hours := 0;
+    v_overtime_amount := 0;
+    v_total_amount := v_base_day_amount;
+  ELSE
+    -- Standard rate calculation tiers
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rate_card.base_day_eur;
+
+    IF v_worked_hours <= 10.5 THEN
+      v_total_amount := v_base_day_amount;
+    ELSIF v_worked_hours <= 12.5 THEN
+      v_plus_10_12_hours := 0;
+      v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+      v_total_amount := v_base_day_amount + v_plus_10_12_amount;
+    ELSE
+      v_plus_10_12_hours := 0;
+      v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+
+      v_overtime_hours := v_worked_hours - 12;
+
+      v_overtime_amount := v_rate_card.overtime_hour_eur * v_overtime_hours;
+      v_total_amount := v_base_day_amount + v_plus_10_12_amount + v_overtime_amount;
+    END IF;
+  END IF;
+
+  v_breakdown := jsonb_build_object(
+    'worked_hours', v_raw_worked_hours,
+    'worked_hours_rounded', v_worked_hours,
+    'hours_rounded', v_worked_hours,
+    'billable_hours', v_billable_hours,
+    'is_evento', (v_job_type = 'evento'),
+    'is_extended_shift', v_is_extended_shift,
+    'is_double_base_rate', v_is_extended_shift,
+    'base_amount_eur', COALESCE(v_base_day_amount, 0),
+    'base_day_eur', COALESCE(v_base_day_amount, 0),
+    'single_base_day_eur', CASE WHEN v_is_extended_shift THEN v_rate_card.base_day_eur ELSE v_base_day_amount END,
+    'plus_10_12_hours', COALESCE(v_plus_10_12_hours, 0),
+    'plus_10_12_eur', v_rate_card.plus_10_12_eur,
+    'plus_10_12_amount_eur', COALESCE(v_plus_10_12_amount, 0),
+    'overtime_hours', COALESCE(v_overtime_hours, 0),
+    'overtime_hour_eur', v_rate_card.overtime_hour_eur,
+    'overtime_amount_eur', COALESCE(v_overtime_amount, 0),
+    'total_eur', v_total_amount,
+    'category', v_category,
+    'forced_rehearsal_rate', false,
+    'rate_mode_source', v_rate_mode_source,
+    'has_technician_rate_mode_override', v_has_technician_rate_mode_override,
+    'technician_rate_mode_override_rehearsal', v_technician_rate_mode_override
+  );
+
+  v_result := jsonb_build_object(
+    'timesheet_id', _timesheet_id,
+    'amount_eur', v_total_amount,
+    'amount_breakdown', v_breakdown
+  );
+
+  IF _persist THEN
+    UPDATE public.timesheets
+    SET
+      amount_eur = v_total_amount,
+      amount_breakdown = v_breakdown,
+      category = v_category,
+      updated_at = NOW()
+    WHERE id = _timesheet_id;
+  END IF;
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.compute_timesheet_amount_2025(uuid,boolean) IS
+  'Calculates timesheet amounts based on rate cards. Hours rounded to nearest whole number (not half hour). Rehearsal flat rate: EUR 60 for house_tech/admin/management roles, EUR 180 for regular technicians. Pricing precedence per technician/date is job_technician_rate_mode_dates (rate_mode: fixed short-circuits to fixed_amount_eur; rehearsal forces the rehearsal flat rate; standard/hourly/tour_multipliers/no_multipliers use the standard hours-based tiers), then job_rehearsal_dates. House-tech overtime is category-aware.';
+
+-- ---------------------------------------------------------------------------
+-- Part C — compute_tour_job_rate_quote_2025 (tour dates)
+-- Resolves each payable date's effective rate_mode and prices it:
+--   rehearsal -> rehearsal day rate; standard -> base day rate w/ team multiplier;
+--   tour_multipliers -> base day rate w/ forced multiplier; no_multipliers -> base
+--   day rate w/ multiplier 1.0; hourly -> the date's timesheet amount; fixed ->
+--   fixed_amount_eur.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  et timestamptz;
+  job_start_date date;
+  job_end_date date;
+  tour_group uuid;
+  tour_date_ref uuid;
+  schedule_start date;
+  schedule_end date;
+  scheduled_days int := 1;
+  rehearsal_days int := 0;
+  standard_days int := 0;
+  technician_override_days int := 0;
+  hourly_days int := 0;
+  fixed_days int := 0;
+  hourly_total numeric(10,2) := 0;
+  fixed_total numeric(10,2) := 0;
+  forced_multiplier_days int := 0;
+  no_multiplier_days int := 0;
+  cat text;
+  house boolean := false;
+  is_autonomo boolean := true;
+  is_reduced_rehearsal boolean := false;
+  standard_discount_per_day numeric(10,2) := 0;
+  rehearsal_discount_per_day numeric(10,2) := 0;
+  total_autonomo_discount numeric(10,2) := 0;
+  standard_base_before_discount numeric(10,2) := 0;
+  standard_after_discount numeric(10,2) := 0;
+  standard_multiplier_bonus numeric(10,2) := 0;
+  multiplied_standard_days int := 0;
+  rehearsal_base_before_discount numeric(10,2) := 0;
+  team_member boolean := false;
+  has_override boolean := false;
+  standard_base numeric(10,2);
+  standard_day_rate numeric(10,2) := 0;
+  rehearsal_day_rate numeric(10,2) := 0;
+  standard_total numeric(10,2) := 0;
+  rehearsal_total numeric(10,2) := 0;
+  total_base numeric(10,2) := 0;
+  base_calculation_total numeric(10,2) := 0;
+  after_discount_total numeric(10,2) := 0;
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  display_multiplier numeric(6,3) := 1.0;
+  display_per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  has_custom_standard_rate boolean := FALSE;
+  has_custom_rehearsal_rate boolean := FALSE;
+  has_custom_rate boolean := FALSE;
+  display_category text := 'rehearsal';
+  job_date_type_start date;
+  job_date_type_end date;
+  tour_date_start date;
+  tour_date_end date;
+  tour_date_legacy_date date;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT job_type, start_time, end_time, tour_id, tour_date_id
+  INTO jtype, st, et, tour_group, tour_date_ref
+  FROM public.jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  job_start_date := (st AT TIME ZONE 'Europe/Madrid')::date;
+  job_end_date := COALESCE((et AT TIME ZONE 'Europe/Madrid')::date, job_start_date);
+
+  SELECT MIN(jdt.date), MAX(jdt.date)
+  INTO job_date_type_start, job_date_type_end
+  FROM public.job_date_types jdt
+  WHERE jdt.job_id = _job_id
+    AND jdt.type <> 'prep_day';
+
+  SELECT td.start_date, td.end_date, td.date
+  INTO tour_date_start, tour_date_end, tour_date_legacy_date
+  FROM public.tour_dates td
+  WHERE td.id = tour_date_ref;
+
+  schedule_start := COALESCE(
+    job_date_type_start,
+    tour_date_start,
+    job_start_date,
+    tour_date_legacy_date
+  );
+  schedule_end := COALESCE(
+    job_date_type_end,
+    tour_date_end,
+    job_end_date,
+    tour_date_start,
+    tour_date_legacy_date,
+    job_start_date
+  );
+
+  schedule_start := COALESCE(schedule_start, job_start_date);
+  schedule_end := COALESCE(schedule_end, schedule_start, job_end_date, job_start_date);
+  IF schedule_end < schedule_start THEN
+    schedule_end := schedule_start;
+  END IF;
+
+  WITH raw_scheduled_job_date_type_dates AS (
+    SELECT DISTINCT jdt.date AS payable_date, jdt.type
+    FROM public.job_date_types jdt
+    WHERE jdt.job_id = _job_id
+      AND jdt.type <> 'prep_day'
+  ),
+  scheduled_job_date_type_dates AS (
+    SELECT raw.payable_date
+    FROM raw_scheduled_job_date_type_dates raw
+    WHERE raw.type <> 'rigging'
+       OR EXISTS (
+          SELECT 1
+          FROM public.job_assignments rja
+          WHERE rja.job_id = _job_id
+            AND rja.technician_id = _tech_id
+            AND COALESCE(rja.single_day, FALSE)
+            AND rja.assignment_date = raw.payable_date
+        )
+       OR EXISTS (
+          SELECT 1
+          FROM public.timesheets rt
+          WHERE rt.job_id = _job_id
+            AND rt.technician_id = _tech_id
+            AND rt.date = raw.payable_date
+            AND COALESCE(rt.is_active, TRUE)
+        )
+  ),
+  active_timesheet_dates AS (
+    SELECT DISTINCT t.date AS payable_date
+    FROM public.timesheets t
+    WHERE t.job_id = _job_id
+      AND t.technician_id = _tech_id
+      AND COALESCE(t.is_active, TRUE)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = t.job_id
+          AND prep_jdt.date = t.date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  single_day_assignment_dates AS (
+    SELECT DISTINCT ja.assignment_date AS payable_date
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id
+      AND ja.technician_id = _tech_id
+      AND COALESCE(ja.single_day, FALSE)
+      AND ja.assignment_date IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = ja.job_id
+          AND prep_jdt.date = ja.assignment_date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  fallback_schedule_dates AS (
+    SELECT generated_series.date_value::date AS payable_date
+    FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS generated_series(date_value)
+    WHERE NOT EXISTS (SELECT 1 FROM raw_scheduled_job_date_type_dates)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = _job_id
+          AND prep_jdt.date = generated_series.date_value::date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  payable_dates AS (
+    SELECT payable_date
+    FROM active_timesheet_dates
+    UNION
+    SELECT payable_date
+    FROM single_day_assignment_dates
+    UNION
+    SELECT payable_date
+    FROM scheduled_job_date_type_dates
+    WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+    UNION
+    SELECT payable_date
+    FROM fallback_schedule_dates
+    WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+  ),
+  classified_payable_dates AS (
+    SELECT
+      pd.payable_date,
+      (trmd.job_id IS NOT NULL) AS has_override,
+      COALESCE(
+        trmd.rate_mode,
+        CASE WHEN jrd.job_id IS NOT NULL THEN 'rehearsal' ELSE 'standard' END
+      ) AS eff_mode,
+      trmd.fixed_amount_eur,
+      (
+        SELECT COALESCE(SUM(COALESCE(t.amount_eur, 0)), 0)
+        FROM public.timesheets t
+        WHERE t.job_id = _job_id
+          AND t.technician_id = _tech_id
+          AND t.date = pd.payable_date
+          AND COALESCE(t.is_active, TRUE)
+      ) AS ts_amount
+    FROM payable_dates pd
+    LEFT JOIN public.job_technician_rate_mode_dates trmd
+      ON trmd.job_id = _job_id
+     AND trmd.technician_id = _tech_id
+     AND trmd.date = pd.payable_date
+    LEFT JOIN public.job_rehearsal_dates jrd
+      ON jrd.job_id = _job_id
+     AND jrd.date = pd.payable_date
+  )
+  SELECT
+    COUNT(*)::int,
+    COUNT(*) FILTER (WHERE cpd.eff_mode = 'rehearsal')::int,
+    COUNT(*) FILTER (WHERE cpd.has_override)::int,
+    COUNT(*) FILTER (WHERE cpd.eff_mode = 'hourly')::int,
+    COUNT(*) FILTER (WHERE cpd.eff_mode = 'fixed')::int,
+    ROUND(COALESCE(SUM(cpd.ts_amount) FILTER (WHERE cpd.eff_mode = 'hourly'), 0), 2),
+    ROUND(COALESCE(SUM(cpd.fixed_amount_eur) FILTER (WHERE cpd.eff_mode = 'fixed'), 0), 2)
+  INTO scheduled_days, rehearsal_days, technician_override_days, hourly_days, fixed_days, hourly_total, fixed_total
+  FROM classified_payable_dates cpd;
+
+  scheduled_days := COALESCE(scheduled_days, 0);
+  rehearsal_days := LEAST(COALESCE(rehearsal_days, 0), scheduled_days);
+  hourly_days := COALESCE(hourly_days, 0);
+  fixed_days := COALESCE(fixed_days, 0);
+  standard_days := GREATEST(0, scheduled_days - rehearsal_days - hourly_days - fixed_days);
+
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END,
+    COALESCE(role IN ('house_tech', 'admin', 'management'), false)
+  INTO house, is_autonomo, is_reduced_rehearsal
+  FROM public.profiles
+  WHERE id = _tech_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','profile_not_found','technician_id',_tech_id);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(bool_or(ja.use_tour_multipliers), FALSE)
+    INTO has_override
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+
+    has_override := COALESCE(has_override, FALSE);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(
+      EXISTS (
+        SELECT 1
+        FROM public.tour_assignments ta
+        WHERE ta.tour_id = tour_group
+          AND ta.technician_id = _tech_id
+      ) OR has_override,
+      FALSE
+    )
+    INTO team_member;
+
+    team_member := COALESCE(team_member, FALSE);
+  END IF;
+
+  SELECT iso_year, iso_week INTO y, w
+  FROM public.iso_year_week_madrid(st);
+
+  IF standard_days > 0 THEN
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM public.job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id
+    ORDER BY assigned_at DESC
+    LIMIT 1;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM public.profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+
+    IF cat = 'responsable' THEN
+      SELECT COALESCE(
+        tour_base_responsable_eur,
+        base_day_responsable_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSIF cat = 'especialista' THEN
+      SELECT COALESCE(
+        tour_base_especialista_eur,
+        tour_base_other_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      SELECT COALESCE(
+        tour_base_other_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    END IF;
+
+    IF standard_base IS NOT NULL THEN
+      has_custom_standard_rate := TRUE;
+      has_custom_rate := TRUE;
+    ELSE
+      SELECT base_day_eur INTO standard_base
+      FROM public.rate_cards_tour_2025
+      WHERE category = cat;
+
+      IF standard_base IS NULL THEN
+        RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+      END IF;
+    END IF;
+
+    standard_base_before_discount := standard_base;
+
+    IF NOT house AND NOT is_autonomo THEN
+      standard_discount_per_day := 30.00;
+      standard_base := standard_base - standard_discount_per_day;
+    END IF;
+
+    standard_after_discount := standard_base;
+    standard_day_rate := ROUND(standard_base * per_job_multiplier, 2);
+    standard_total := ROUND(standard_day_rate * standard_days, 2);
+
+    -- This deliberately duplicates the canonical payable-date CTEs above
+    -- because PL/pgSQL CTEs cannot be reused across separate statements. Keep
+    -- raw_scheduled_job_date_type_dates, scheduled_job_date_type_dates,
+    -- active_timesheet_dates, single_day_assignment_dates, and
+    -- fallback_schedule_dates in sync with the first copy, or refactor them
+    -- into a shared SQL function.
+    WITH raw_scheduled_job_date_type_dates AS (
+      SELECT DISTINCT jdt.date AS payable_date, jdt.type
+      FROM public.job_date_types jdt
+      WHERE jdt.job_id = _job_id
+        AND jdt.type <> 'prep_day'
+    ),
+    scheduled_job_date_type_dates AS (
+      SELECT raw.payable_date
+      FROM raw_scheduled_job_date_type_dates raw
+      WHERE raw.type <> 'rigging'
+         OR EXISTS (
+            SELECT 1
+            FROM public.job_assignments rja
+            WHERE rja.job_id = _job_id
+              AND rja.technician_id = _tech_id
+              AND COALESCE(rja.single_day, FALSE)
+              AND rja.assignment_date = raw.payable_date
+          )
+         OR EXISTS (
+            SELECT 1
+            FROM public.timesheets rt
+            WHERE rt.job_id = _job_id
+              AND rt.technician_id = _tech_id
+              AND rt.date = raw.payable_date
+              AND COALESCE(rt.is_active, TRUE)
+          )
+    ),
+    active_timesheet_dates AS (
+      SELECT DISTINCT t.date AS payable_date
+      FROM public.timesheets t
+      WHERE t.job_id = _job_id
+        AND t.technician_id = _tech_id
+        AND COALESCE(t.is_active, TRUE)
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = t.job_id
+            AND prep_jdt.date = t.date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    single_day_assignment_dates AS (
+      SELECT DISTINCT ja.assignment_date AS payable_date
+      FROM public.job_assignments ja
+      WHERE ja.job_id = _job_id
+        AND ja.technician_id = _tech_id
+        AND COALESCE(ja.single_day, FALSE)
+        AND ja.assignment_date IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = ja.job_id
+            AND prep_jdt.date = ja.assignment_date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    fallback_schedule_dates AS (
+      SELECT generated_series.date_value::date AS payable_date
+      FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS generated_series(date_value)
+      WHERE NOT EXISTS (SELECT 1 FROM raw_scheduled_job_date_type_dates)
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = _job_id
+            AND prep_jdt.date = generated_series.date_value::date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    payable_dates AS (
+      SELECT payable_date
+      FROM active_timesheet_dates
+      UNION
+      SELECT payable_date
+      FROM single_day_assignment_dates
+      UNION
+      SELECT payable_date
+      FROM scheduled_job_date_type_dates
+      WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+      UNION
+      SELECT payable_date
+      FROM fallback_schedule_dates
+      WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+    ),
+    standard_payable_dates AS (
+      SELECT
+        pd.payable_date,
+        COALESCE(
+          trmd.rate_mode,
+          CASE WHEN jrd.job_id IS NOT NULL THEN 'rehearsal' ELSE 'standard' END
+        ) AS eff_mode
+      FROM payable_dates pd
+      LEFT JOIN public.job_technician_rate_mode_dates trmd
+        ON trmd.job_id = _job_id
+       AND trmd.technician_id = _tech_id
+       AND trmd.date = pd.payable_date
+      LEFT JOIN public.job_rehearsal_dates jrd
+        ON jrd.job_id = _job_id
+       AND jrd.date = pd.payable_date
+      WHERE COALESCE(
+              trmd.rate_mode,
+              CASE WHEN jrd.job_id IS NOT NULL THEN 'rehearsal' ELSE 'standard' END
+            ) IN ('standard','tour_multipliers','no_multipliers')
+    ),
+    date_multipliers AS (
+      SELECT
+        spd.payable_date,
+        spd.eff_mode,
+        CASE
+          WHEN NOT team_member AND spd.eff_mode <> 'tour_multipliers' THEN 1
+          ELSE GREATEST(COALESCE(weekly_counts.cnt, 0), 1)
+        END AS week_count,
+        CASE
+          WHEN spd.eff_mode = 'no_multipliers' THEN 1.0::numeric
+          WHEN NOT team_member AND spd.eff_mode <> 'tour_multipliers' THEN 1.0::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 1 THEN 1.5::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 2 THEN 1.125::numeric
+          ELSE 1.0::numeric
+        END AS week_multiplier,
+        CASE
+          WHEN spd.eff_mode = 'no_multipliers' THEN 1.0::numeric
+          WHEN NOT team_member AND spd.eff_mode <> 'tour_multipliers' THEN 1.0::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 1 THEN 1.5::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 2 THEN 1.125::numeric
+          ELSE 1.0::numeric
+        END AS date_multiplier
+      FROM standard_payable_dates spd
+      CROSS JOIN LATERAL public.iso_year_week_madrid(spd.payable_date::timestamptz) iw
+      LEFT JOIN LATERAL (
+        WITH tour_jobs AS (
+          SELECT
+            j.id AS job_id,
+            j.start_time,
+            j.end_time,
+            j.tour_date_id
+          FROM public.jobs j
+          WHERE j.job_type = 'tourdate'
+            AND j.tour_id = tour_group
+            AND j.status != 'Cancelado'
+        ),
+        technician_job_assignments AS (
+          SELECT DISTINCT ja.job_id
+          FROM public.job_assignments ja
+          JOIN tour_jobs tj
+            ON tj.job_id = ja.job_id
+          WHERE ja.technician_id = _tech_id
+        ),
+        raw_scheduled_job_date_type_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            jdt.date AS payable_date,
+            jdt.type
+          FROM tour_jobs tj
+          JOIN public.job_date_types jdt
+            ON jdt.job_id = tj.job_id
+           AND jdt.type <> 'prep_day'
+        ),
+        scheduled_job_date_type_dates AS (
+          SELECT raw.job_id, raw.payable_date
+          FROM raw_scheduled_job_date_type_dates raw
+          JOIN technician_job_assignments tja
+            ON tja.job_id = raw.job_id
+          WHERE raw.type <> 'rigging'
+             OR EXISTS (
+                SELECT 1
+                FROM public.job_assignments rja
+                WHERE rja.job_id = raw.job_id
+                  AND rja.technician_id = _tech_id
+                  AND COALESCE(rja.single_day, FALSE)
+                  AND rja.assignment_date = raw.payable_date
+              )
+             OR EXISTS (
+                SELECT 1
+                FROM public.timesheets rt
+                WHERE rt.job_id = raw.job_id
+                  AND rt.technician_id = _tech_id
+                  AND rt.date = raw.payable_date
+                  AND COALESCE(rt.is_active, TRUE)
+              )
+        ),
+        active_timesheet_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            t.date AS payable_date
+          FROM tour_jobs tj
+          JOIN public.timesheets t
+            ON t.job_id = tj.job_id
+           AND t.technician_id = _tech_id
+           AND COALESCE(t.is_active, TRUE)
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM public.job_date_types prep_jdt
+            WHERE prep_jdt.job_id = t.job_id
+              AND prep_jdt.date = t.date
+              AND prep_jdt.type = 'prep_day'
+          )
+        ),
+        single_day_assignment_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            ja.assignment_date AS payable_date
+          FROM tour_jobs tj
+          JOIN public.job_assignments ja
+            ON ja.job_id = tj.job_id
+           AND ja.technician_id = _tech_id
+           AND COALESCE(ja.single_day, FALSE)
+           AND ja.assignment_date IS NOT NULL
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM public.job_date_types prep_jdt
+            WHERE prep_jdt.job_id = ja.job_id
+              AND prep_jdt.date = ja.assignment_date
+              AND prep_jdt.type = 'prep_day'
+          )
+        ),
+        jobs_with_single_day_assignments AS (
+          SELECT DISTINCT job_id
+          FROM single_day_assignment_dates
+        ),
+        job_ranges AS (
+          SELECT
+            tj.job_id,
+            COALESCE(
+              MIN(raw.payable_date),
+              td.start_date,
+              (tj.start_time AT TIME ZONE 'Europe/Madrid')::date,
+              td.date
+            ) AS schedule_start,
+            COALESCE(
+              MAX(raw.payable_date),
+              td.end_date,
+              (tj.end_time AT TIME ZONE 'Europe/Madrid')::date,
+              td.start_date,
+              td.date,
+              (tj.start_time AT TIME ZONE 'Europe/Madrid')::date
+            ) AS schedule_end
+          FROM tour_jobs tj
+          LEFT JOIN public.tour_dates td
+            ON td.id = tj.tour_date_id
+          LEFT JOIN raw_scheduled_job_date_type_dates raw
+            ON raw.job_id = tj.job_id
+          GROUP BY
+            tj.job_id,
+            tj.start_time,
+            tj.end_time,
+            td.start_date,
+            td.end_date,
+            td.date
+        ),
+        fallback_schedule_dates AS (
+          SELECT
+            jr.job_id,
+            generated_series.date_value::date AS payable_date
+          FROM job_ranges jr
+          JOIN technician_job_assignments tja
+            ON tja.job_id = jr.job_id
+          CROSS JOIN LATERAL generate_series(
+            jr.schedule_start,
+            GREATEST(jr.schedule_start, jr.schedule_end),
+            INTERVAL '1 day'
+          ) AS generated_series(date_value)
+          WHERE NOT EXISTS (
+              SELECT 1
+              FROM raw_scheduled_job_date_type_dates raw
+              WHERE raw.job_id = jr.job_id
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.job_date_types prep_jdt
+              WHERE prep_jdt.job_id = jr.job_id
+                AND prep_jdt.date = generated_series.date_value::date
+                AND prep_jdt.type = 'prep_day'
+            )
+        ),
+        counted_payable_dates AS (
+          SELECT job_id, payable_date
+          FROM active_timesheet_dates
+          UNION
+          SELECT job_id, payable_date
+          FROM single_day_assignment_dates
+          UNION
+          SELECT job_id, payable_date
+          FROM scheduled_job_date_type_dates scheduled
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM jobs_with_single_day_assignments single_day_jobs
+            WHERE single_day_jobs.job_id = scheduled.job_id
+          )
+          UNION
+          SELECT job_id, payable_date
+          FROM fallback_schedule_dates fallback
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM jobs_with_single_day_assignments single_day_jobs
+            WHERE single_day_jobs.job_id = fallback.job_id
+          )
+        )
+        SELECT COUNT(DISTINCT cpd.payable_date)::int AS cnt
+        FROM counted_payable_dates cpd
+        CROSS JOIN LATERAL public.iso_year_week_madrid(cpd.payable_date::timestamptz) other_iw
+        WHERE other_iw.iso_year = iw.iso_year
+          AND other_iw.iso_week = iw.iso_week
+      ) weekly_counts ON TRUE
+    )
+    SELECT
+      ROUND(COALESCE(SUM(standard_after_discount * dm.date_multiplier), 0), 2),
+      ROUND(COALESCE(SUM((standard_after_discount * dm.date_multiplier) - standard_after_discount), 0), 2),
+      COUNT(*) FILTER (WHERE dm.date_multiplier > 1.0)::int,
+      COUNT(*) FILTER (WHERE dm.eff_mode = 'tour_multipliers')::int,
+      COUNT(*) FILTER (WHERE dm.eff_mode = 'no_multipliers')::int,
+      GREATEST(COALESCE(MAX(dm.week_count), 1), 1)::int,
+      COALESCE(ROUND(SUM(dm.week_multiplier * dm.week_count) / NULLIF(SUM(dm.week_count), 0), 3), 1.0),
+      COALESCE(ROUND(SUM(dm.date_multiplier * dm.week_count) / NULLIF(SUM(dm.week_count), 0), 3), 1.0)
+    INTO standard_total, standard_multiplier_bonus, multiplied_standard_days, forced_multiplier_days, no_multiplier_days, cnt, display_multiplier, display_per_job_multiplier
+    FROM date_multipliers dm;
+
+    per_job_multiplier := display_per_job_multiplier;
+    mult := display_multiplier;
+    standard_day_rate := ROUND(standard_total / GREATEST(standard_days, 1), 2);
+    display_category := cat;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+    display_multiplier := 1.0;
+    display_per_job_multiplier := 1.0;
+  END IF;
+
+  IF rehearsal_days > 0 THEN
+    SELECT rehearsal_day_eur INTO rehearsal_day_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF rehearsal_day_rate IS NOT NULL THEN
+      has_custom_rehearsal_rate := TRUE;
+      has_custom_rate := TRUE;
+      rehearsal_base_before_discount := rehearsal_day_rate;
+    ELSE
+      IF is_reduced_rehearsal THEN
+        rehearsal_day_rate := 60.00;
+        rehearsal_base_before_discount := 60.00;
+      ELSE
+        rehearsal_day_rate := 180.00;
+        rehearsal_base_before_discount := 180.00;
+      END IF;
+    END IF;
+
+    IF NOT is_autonomo AND NOT is_reduced_rehearsal THEN
+      rehearsal_discount_per_day := 30.00;
+      rehearsal_day_rate := rehearsal_day_rate - rehearsal_discount_per_day;
+    END IF;
+
+    rehearsal_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+
+    IF standard_days = 0 THEN
+      display_category := 'rehearsal';
+    END IF;
+  END IF;
+
+  total_base := ROUND(standard_total + rehearsal_total + hourly_total + fixed_total, 2);
+  total_autonomo_discount := ROUND(
+    (standard_discount_per_day * standard_days) + (rehearsal_discount_per_day * rehearsal_days),
+    2
+  );
+  base_calculation_total := ROUND(
+    (standard_base_before_discount * standard_days) + (rehearsal_base_before_discount * rehearsal_days)
+      + hourly_total + fixed_total,
+    2
+  );
+
+  IF standard_days > 0 THEN
+    after_discount_total := ROUND(
+      (standard_after_discount * standard_days) + (rehearsal_day_rate * rehearsal_days)
+        + hourly_total + fixed_total,
+      2
+    );
+  ELSE
+    after_discount_total := ROUND(
+      (rehearsal_day_rate * rehearsal_days) + hourly_total + fixed_total,
+      2
+    );
+  END IF;
+
+  extras := public.extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(total_base + extras_total, 2);
+
+  disclaimer := public.needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,
+    'category', display_category,
+    'base_day_eur', total_base,
+    'has_custom_rate', has_custom_rate,
+    'autonomo_discount_eur', total_autonomo_discount,
+    'base_day_before_discount_eur', base_calculation_total,
+    'week_count', cnt,
+    'multiplier', ROUND(display_multiplier, 3),
+    'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', total_base,
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', final_total,
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', base_calculation_total,
+      'autonomo_discount', total_autonomo_discount,
+      'after_discount', after_discount_total,
+      'multiplier', ROUND(display_multiplier, 3),
+      'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+      'final_base', total_base,
+      'has_custom_rate', has_custom_rate,
+      'has_custom_standard_rate', has_custom_standard_rate,
+      'has_custom_rehearsal_rate', has_custom_rehearsal_rate,
+      'scheduled_days', scheduled_days,
+      'rehearsal_days', rehearsal_days,
+      'standard_days', standard_days,
+      'technician_override_days', technician_override_days,
+      'multiplied_standard_days', multiplied_standard_days,
+      'standard_multiplier_bonus_eur', standard_multiplier_bonus,
+      'hourly_days', hourly_days,
+      'hourly_total_eur', hourly_total,
+      'fixed_days', fixed_days,
+      'fixed_total_eur', fixed_total,
+      'forced_multiplier_days', forced_multiplier_days,
+      'no_multiplier_days', no_multiplier_days,
+      'rehearsal_rate_eur', CASE WHEN rehearsal_days > 0 THEN rehearsal_day_rate ELSE NULL END,
+      'standard_day_rate_eur', CASE WHEN standard_days > 0 THEN standard_day_rate ELSE NULL END,
+      'forced_rehearsal_rate', (rehearsal_days > 0),
+      'prep_days_excluded_from_multiplier', true,
+      'rigging_dates_scoped_to_assigned_techs', true,
+      'weekly_multiplier_rule', '1_date_1_5x__2_dates_1_125x__3_plus_1x',
+      'per_payable_date_weekly_multipliers', true,
+      'weekly_multiplier_count_uses_timesheets', true
+    )
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) FROM PUBLIC;
+
+COMMENT ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) IS
+  'Calculates tour job rate quotes. Each payable date resolves an effective rate_mode from job_technician_rate_mode_dates (rehearsal, standard, tour_multipliers, no_multipliers, hourly, fixed) then job_rehearsal_dates. Standard-family dates use the per-payable-date weekly multipliers (1 date 1.5x, 2 dates 1.125x each, 3+ dates 1x); tour_multipliers forces those multipliers even off-team, no_multipliers forces 1x. Hourly dates add the technician timesheet amount; fixed dates add fixed_amount_eur. Prep days are excluded.';

--- a/supabase/migrations/20260628120000_expand_technician_rate_modes.sql
+++ b/supabase/migrations/20260628120000_expand_technician_rate_modes.sql
@@ -29,8 +29,54 @@ SET rate_mode = CASE WHEN use_rehearsal_rate THEN 'rehearsal' ELSE 'standard' EN
 WHERE rate_mode IS NULL;
 
 ALTER TABLE public.job_technician_rate_mode_dates
-  ALTER COLUMN rate_mode SET DEFAULT 'standard',
+  ALTER COLUMN rate_mode DROP DEFAULT,
   ALTER COLUMN rate_mode SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.tg_job_technician_rate_mode_dates_sync_legacy()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.rate_mode IS NULL THEN
+      NEW.rate_mode := CASE
+        WHEN COALESCE(NEW.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+        ELSE 'standard'
+      END;
+    ELSE
+      NEW.use_rehearsal_rate := NEW.rate_mode = 'rehearsal';
+    END IF;
+  ELSIF NEW.rate_mode IS DISTINCT FROM OLD.rate_mode THEN
+    NEW.use_rehearsal_rate := NEW.rate_mode = 'rehearsal';
+  ELSIF NEW.use_rehearsal_rate IS DISTINCT FROM OLD.use_rehearsal_rate
+    AND COALESCE(OLD.rate_mode, 'standard') IN ('standard', 'rehearsal')
+    AND COALESCE(NEW.rate_mode, 'standard') IN ('standard', 'rehearsal') THEN
+    NEW.rate_mode := CASE
+      WHEN COALESCE(NEW.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+      ELSE 'standard'
+    END;
+  ELSIF NEW.rate_mode IS NULL THEN
+    NEW.rate_mode := CASE
+      WHEN COALESCE(NEW.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+      ELSE 'standard'
+    END;
+  ELSE
+    NEW.use_rehearsal_rate := NEW.rate_mode = 'rehearsal';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_job_technician_rate_mode_dates_sync_legacy
+  ON public.job_technician_rate_mode_dates;
+
+CREATE TRIGGER trg_job_technician_rate_mode_dates_sync_legacy
+  BEFORE INSERT OR UPDATE OF rate_mode, use_rehearsal_rate
+  ON public.job_technician_rate_mode_dates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.tg_job_technician_rate_mode_dates_sync_legacy();
 
 DO $$
 BEGIN
@@ -154,7 +200,11 @@ BEGIN
 
     IF FOUND THEN
       v_has_technician_rate_mode_override := TRUE;
-      v_forced_rehearsal := COALESCE(v_rate_mode = 'rehearsal', v_technician_rate_mode_override, FALSE);
+      v_rate_mode := COALESCE(
+        v_rate_mode,
+        CASE WHEN COALESCE(v_technician_rate_mode_override, FALSE) THEN 'rehearsal' ELSE 'standard' END
+      );
+      v_forced_rehearsal := v_rate_mode = 'rehearsal';
       v_rate_mode_source := 'technician_override';
     ELSE
       SELECT EXISTS (
@@ -193,7 +243,11 @@ BEGIN
 
   -- Fixed-amount override short-circuits both rehearsal and standard pricing.
   IF v_rate_mode = 'fixed' THEN
-    v_total_amount := COALESCE(v_fixed_amount, 0);
+    IF v_fixed_amount IS NULL OR v_fixed_amount < 0 THEN
+      RAISE EXCEPTION 'Invalid fixed amount for timesheet %', _timesheet_id;
+    END IF;
+
+    v_total_amount := v_fixed_amount;
     v_billable_hours := v_worked_hours;
 
     v_breakdown := jsonb_build_object(
@@ -658,7 +712,11 @@ BEGIN
       (trmd.job_id IS NOT NULL) AS has_override,
       COALESCE(
         trmd.rate_mode,
-        CASE WHEN jrd.job_id IS NOT NULL THEN 'rehearsal' ELSE 'standard' END
+        CASE
+          WHEN COALESCE(trmd.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+          WHEN jrd.job_id IS NOT NULL THEN 'rehearsal'
+          ELSE 'standard'
+        END
       ) AS eff_mode,
       trmd.fixed_amount_eur,
       (
@@ -903,7 +961,11 @@ BEGIN
         pd.payable_date,
         COALESCE(
           trmd.rate_mode,
-          CASE WHEN jrd.job_id IS NOT NULL THEN 'rehearsal' ELSE 'standard' END
+          CASE
+            WHEN COALESCE(trmd.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+            WHEN jrd.job_id IS NOT NULL THEN 'rehearsal'
+            ELSE 'standard'
+          END
         ) AS eff_mode
       FROM payable_dates pd
       LEFT JOIN public.job_technician_rate_mode_dates trmd
@@ -915,7 +977,11 @@ BEGIN
        AND jrd.date = pd.payable_date
       WHERE COALESCE(
               trmd.rate_mode,
-              CASE WHEN jrd.job_id IS NOT NULL THEN 'rehearsal' ELSE 'standard' END
+              CASE
+                WHEN COALESCE(trmd.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+                WHEN jrd.job_id IS NOT NULL THEN 'rehearsal'
+                ELSE 'standard'
+              END
             ) IN ('standard','tour_multipliers','no_multipliers')
     ),
     date_multipliers AS (

--- a/supabase/migrations/20260628120000_expand_technician_rate_modes.sql
+++ b/supabase/migrations/20260628120000_expand_technician_rate_modes.sql
@@ -49,7 +49,7 @@ BEGIN
   ) THEN
     ALTER TABLE public.job_technician_rate_mode_dates
       ADD CONSTRAINT job_technician_rate_mode_dates_fixed_amount_check
-      CHECK (rate_mode <> 'fixed' OR fixed_amount_eur IS NOT NULL);
+      CHECK (rate_mode <> 'fixed' OR (fixed_amount_eur IS NOT NULL AND fixed_amount_eur >= 0));
   END IF;
 END
 $$;
@@ -1171,6 +1171,15 @@ BEGIN
     IF standard_days = 0 THEN
       display_category := 'rehearsal';
     END IF;
+  END IF;
+
+  IF standard_days = 0 AND rehearsal_days = 0 THEN
+    display_category := CASE
+      WHEN hourly_days > 0 AND fixed_days > 0 THEN 'mixed'
+      WHEN hourly_days > 0 THEN 'hourly'
+      WHEN fixed_days > 0 THEN 'fixed'
+      ELSE display_category
+    END;
   END IF;
 
   total_base := ROUND(standard_total + rehearsal_total + hourly_total + fixed_total, 2);

--- a/supabase/migrations/20260628121000_sync_tour_assignment_role_updates.sql
+++ b/supabase/migrations/20260628121000_sync_tour_assignment_role_updates.sql
@@ -20,6 +20,10 @@ BEGIN
     RETURN NEW;
   END IF;
 
+  IF NEW.department NOT IN ('sound', 'lights', 'video') THEN
+    RETURN NEW;
+  END IF;
+
   WITH future_tour_jobs AS (
     SELECT j.id AS job_id
     FROM public.jobs j
@@ -93,5 +97,9 @@ DROP TRIGGER IF EXISTS tour_assignment_update_trigger ON public.tour_assignments
 CREATE TRIGGER tour_assignment_update_trigger
   AFTER UPDATE OF role ON public.tour_assignments
   FOR EACH ROW
-  WHEN (NEW.technician_id IS NOT NULL AND NEW.role IS DISTINCT FROM OLD.role)
+  WHEN (
+    NEW.technician_id IS NOT NULL
+    AND NEW.department IN ('sound', 'lights', 'video')
+    AND NEW.role IS DISTINCT FROM OLD.role
+  )
   EXECUTE FUNCTION public.sync_tour_assignment_role_update_to_future_jobs();

--- a/supabase/migrations/20260628121000_sync_tour_assignment_role_updates.sql
+++ b/supabase/migrations/20260628121000_sync_tour_assignment_role_updates.sql
@@ -1,0 +1,17 @@
+-- Tour team role edits must reach every job in the tour.
+--
+-- tour_assignments already syncs to job_assignments on INSERT
+-- (tour_assignment_insert_trigger) and DELETE (tour_assignment_delete_trigger),
+-- but there was no trigger for UPDATEs, so changing a team member's role left
+-- the per-job job_assignments rows stale. Reuse the existing insert-sync
+-- function (it INSERTs ... ON CONFLICT DO UPDATE for every tour job, updating
+-- the department role column only on assignment_source = 'tour' rows) for
+-- role updates as well.
+
+DROP TRIGGER IF EXISTS tour_assignment_update_trigger ON public.tour_assignments;
+
+CREATE TRIGGER tour_assignment_update_trigger
+  AFTER UPDATE OF role ON public.tour_assignments
+  FOR EACH ROW
+  WHEN (NEW.technician_id IS NOT NULL AND NEW.role IS DISTINCT FROM OLD.role)
+  EXECUTE FUNCTION public.sync_tour_assignments_to_jobs();

--- a/supabase/migrations/20260628121000_sync_tour_assignment_role_updates.sql
+++ b/supabase/migrations/20260628121000_sync_tour_assignment_role_updates.sql
@@ -1,12 +1,92 @@
--- Tour team role edits must reach every job in the tour.
+-- Tour team role edits must reach future jobs in the tour without rewriting
+-- historical job_assignments.
 --
 -- tour_assignments already syncs to job_assignments on INSERT
 -- (tour_assignment_insert_trigger) and DELETE (tour_assignment_delete_trigger),
 -- but there was no trigger for UPDATEs, so changing a team member's role left
--- the per-job job_assignments rows stale. Reuse the existing insert-sync
--- function (it INSERTs ... ON CONFLICT DO UPDATE for every tour job, updating
--- the department role column only on assignment_source = 'tour' rows) for
--- role updates as well.
+-- future per-job job_assignments rows stale. This trigger deliberately does not
+-- reuse sync_tour_assignments_to_jobs because that insert-sync function touches
+-- every job in the tour, including past dates.
+
+CREATE OR REPLACE FUNCTION public.sync_tour_assignment_role_update_to_future_jobs()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  v_today date := (now() AT TIME ZONE 'Europe/Madrid')::date;
+BEGIN
+  IF NEW.technician_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  WITH future_tour_jobs AS (
+    SELECT j.id AS job_id
+    FROM public.jobs j
+    LEFT JOIN public.tour_dates td
+      ON td.id = j.tour_date_id
+    LEFT JOIN LATERAL (
+      SELECT MIN(jdt.date) AS schedule_start
+      FROM public.job_date_types jdt
+      WHERE jdt.job_id = j.id
+        AND jdt.type <> 'prep_day'
+    ) jdt ON TRUE
+    WHERE j.tour_id = NEW.tour_id
+      AND j.job_type = 'tourdate'
+      AND COALESCE(
+        jdt.schedule_start,
+        td.start_date,
+        (j.start_time AT TIME ZONE 'Europe/Madrid')::date,
+        td.date
+      ) >= v_today
+  )
+  INSERT INTO public.job_assignments (
+    job_id,
+    technician_id,
+    sound_role,
+    lights_role,
+    video_role,
+    assigned_by,
+    assigned_at,
+    assignment_source
+  )
+  SELECT
+    ftj.job_id,
+    NEW.technician_id,
+    CASE WHEN NEW.department = 'sound' THEN NEW.role END,
+    CASE WHEN NEW.department = 'lights' THEN NEW.role END,
+    CASE WHEN NEW.department = 'video' THEN NEW.role END,
+    NEW.assigned_by,
+    NEW.assigned_at,
+    'tour'
+  FROM future_tour_jobs ftj
+  ON CONFLICT (job_id, technician_id)
+  DO UPDATE SET
+    sound_role = CASE
+      WHEN NEW.department = 'sound' AND EXCLUDED.assignment_source = 'tour'
+      THEN NEW.role
+      ELSE job_assignments.sound_role
+    END,
+    lights_role = CASE
+      WHEN NEW.department = 'lights' AND EXCLUDED.assignment_source = 'tour'
+      THEN NEW.role
+      ELSE job_assignments.lights_role
+    END,
+    video_role = CASE
+      WHEN NEW.department = 'video' AND EXCLUDED.assignment_source = 'tour'
+      THEN NEW.role
+      ELSE job_assignments.video_role
+    END,
+    assigned_at = CASE
+      WHEN EXCLUDED.assignment_source = 'tour'
+      THEN NEW.assigned_at
+      ELSE job_assignments.assigned_at
+    END
+  WHERE job_assignments.assignment_source = 'tour';
+
+  RETURN NEW;
+END;
+$$;
 
 DROP TRIGGER IF EXISTS tour_assignment_update_trigger ON public.tour_assignments;
 
@@ -14,4 +94,4 @@ CREATE TRIGGER tour_assignment_update_trigger
   AFTER UPDATE OF role ON public.tour_assignments
   FOR EACH ROW
   WHEN (NEW.technician_id IS NOT NULL AND NEW.role IS DISTINCT FROM OLD.role)
-  EXECUTE FUNCTION public.sync_tour_assignments_to_jobs();
+  EXECUTE FUNCTION public.sync_tour_assignment_role_update_to_future_jobs();


### PR DESCRIPTION
Admins can now pick richer per-technician/per-date pricing modes from the
payout panel beyond rehearsal/standard: force tour multipliers, force base
(no multipliers), bill by hours (auto-creates a draft timesheet), and a custom
fixed amount. Options apply to tour dates and standard jobs.

- migration: add rate_mode + fixed_amount_eur to job_technician_rate_mode_dates
  (backfilled from the legacy boolean); rework compute_tour_job_rate_quote_2025
  to resolve each payable date's mode and price hourly/fixed/forced/no-multiplier
  dates; add a fixed-amount short-circuit to compute_timesheet_amount_2025.
- hook: expand TechnicianDateRateMode, persist rate_mode/fixed amount, and
  ensure a draft timesheet exists for hourly mode.
- ui: job-type-aware option list with a fixed-amount input and hourly hint.
- closure: admins bypass the 7-day window in the payout panel and TimesheetView,
  with a visible override notice.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011nYX36XWmkcGQbViyEFxBh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Technicians can now have per-day rate overrides, including fixed euro amounts and additional rate options.
  * Assignment dialogs now support editing roles directly and keep assignment lists refreshed after changes.
  * Admins can continue approving or editing after the closure window, with a clear in-app notice.

* **Bug Fixes**
  * Improved payout and timesheet calculations to better reflect the latest assignment and rate settings.
  * Role changes in tours now stay in sync across assignment views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->