### PR TITLE
refactor(types): reduce explicit any debt batch 3

### DIFF
--- a/src/components/matrix/StaffingOfferList.tsx
+++ b/src/components/matrix/StaffingOfferList.tsx
@@ -35,6 +35,41 @@ interface AvailabilityResponse {
   responded_at?: string | null
 }
 
+type StaffingRequestRow = {
+  id: string
+  profile_id: string | null
+  status: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+type StaffingEventMeta = {
+  phase?: string
+  role?: string
+}
+
+type StaffingEventRow = {
+  staffing_request_id: string | null
+  event: string | null
+  meta: StaffingEventMeta | null
+  created_at: string | null
+}
+
+type StaffingProfileRow = {
+  id: string
+  first_name: string | null
+  last_name: string | null
+  nickname: string | null
+  email: string | null
+}
+
+type SendOffersResult = { sent: number }
+
+const toAvailabilityStatus = (status: string | null): AvailabilityResponse['status'] => {
+  if (status === 'confirmed' || status === 'declined') return status
+  return 'pending'
+}
+
 export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
   campaignId,
   roleCode,
@@ -55,7 +90,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
 
   // Availability responses are job-scoped, but the original send event carries
   // manager intent for which role card should display the response.
-  const { data: responses, isLoading } = useQuery({
+  const { data: responses, isLoading } = useQuery<AvailabilityResponse[]>({
     queryKey: queryKeys.scope('staffing_availability_responses', jobId, roleCode),
     queryFn: async () => {
       const { data: directRequests, error: directError } = await dataLayerClient.from('staffing_requests')
@@ -66,8 +101,8 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
 
       if (directError) throw directError
 
-      const requestRows = directRequests || []
-      const requestIds = requestRows.map((item: any) => item.id).filter(Boolean)
+      const requestRows = (directRequests || []) as StaffingRequestRow[]
+      const requestIds = requestRows.map((item) => item.id).filter(Boolean)
       if (requestIds.length === 0) return []
 
       const { data: sentEvents, error: sentEventsError } = await dataLayerClient.from('staffing_events')
@@ -79,20 +114,20 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
       if (sentEventsError) throw sentEventsError
 
       const latestAvailabilityRoleByRequestId = new Map<string, string>()
-      ;[...(sentEvents || [])]
-        .sort((a: any, b: any) => (
+      ;[...((sentEvents || []) as StaffingEventRow[])]
+        .sort((a, b) => (
           new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime()
         ))
-        .forEach((event: any) => {
-        const requestId = String(event.staffing_request_id || '')
-        const meta = event?.meta || {}
-        if (!requestId || latestAvailabilityRoleByRequestId.has(requestId)) return
-        if (meta.phase !== 'availability' || !meta.role) return
-        latestAvailabilityRoleByRequestId.set(requestId, String(meta.role))
-      })
+        .forEach((event) => {
+          const requestId = String(event.staffing_request_id || '')
+          const meta = event?.meta || {}
+          if (!requestId || latestAvailabilityRoleByRequestId.has(requestId)) return
+          if (meta.phase !== 'availability' || !meta.role) return
+          latestAvailabilityRoleByRequestId.set(requestId, String(meta.role))
+        })
 
-      const latestRequestByProfileId = new Map<string, any>()
-      requestRows.forEach((item: any) => {
+      const latestRequestByProfileId = new Map<string, StaffingRequestRow>()
+      requestRows.forEach((item) => {
         if (latestAvailabilityRoleByRequestId.get(String(item.id)) !== roleCode) return
         const profileId = String(item.profile_id || '')
         if (!profileId || latestRequestByProfileId.has(profileId)) return
@@ -109,29 +144,30 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
       if (profilesError) throw profilesError
 
       const profilesById = new Map(
-        (profiles || []).map((profile: any) => [String(profile.id), profile])
+        ((profiles || []) as StaffingProfileRow[]).map((profile) => [String(profile.id), profile])
       )
 
       return Array.from(latestRequestByProfileId.entries()).map(([profileId, item]) => {
-        const profile: any = profilesById.get(profileId) || {}
-        const fullName = `${profile.first_name || ''} ${profile.last_name || ''}`.trim()
+        const profile = profilesById.get(profileId)
+        const fullName = `${profile?.first_name || ''} ${profile?.last_name || ''}`.trim()
+        const status = toAvailabilityStatus(item.status)
         const respondedAt =
-          item.status && String(item.status).toLowerCase() !== 'pending'
+          status !== 'pending'
             ? (item.updated_at || item.created_at)
             : null
 
         return {
           profile_id: profileId,
-          full_name: fullName || profile.nickname || profile.email || 'Unknown',
-          status: item.status,
+          full_name: fullName || profile?.nickname || profile?.email || 'Unknown',
+          status,
           responded_at: respondedAt,
-        } as AvailabilityResponse
+        }
       })
     }
   })
 
   // Send offers mutation
-  const sendOffersMutation = useMutation({
+  const sendOffersMutation = useMutation<SendOffersResult, Error>({
     mutationFn: async () => {
       const selectedProfiles = Array.from(selectedForOffer)
       if (selectedProfiles.length === 0) {
@@ -163,7 +199,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
           }
         )
 
-        const payload = await response.json().catch(() => ({}))
+        const payload = (await response.json().catch(() => ({}))) as { error?: string }
         if (!response.ok) {
           throw new Error(payload?.error || 'Failed to send offer')
         }
@@ -179,7 +215,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
 
       return { sent: selectedProfiles.length }
     },
-    onSuccess: (data: any) => {
+    onSuccess: (data) => {
       toast({
         title: 'Offers sent',
         description: `Sent offers to ${data?.sent ?? selectedForOffer.size} candidates by ${channel}`
@@ -189,7 +225,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId) })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_requests', jobId) })
     },
-    onError: (error: any) => {
+    onError: (error) => {
       toast({
         title: 'Error',
         description: error.message,
@@ -198,9 +234,9 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
     }
   })
 
-  const confirmedResponses = responses?.filter((r: any) => r.status === 'confirmed') || []
-  const declinedResponses = responses?.filter((r: any) => r.status === 'declined') || []
-  const pendingResponses = responses?.filter((r: any) => r.status === 'pending') || []
+  const confirmedResponses = responses?.filter((r) => r.status === 'confirmed') || []
+  const declinedResponses = responses?.filter((r) => r.status === 'declined') || []
+  const pendingResponses = responses?.filter((r) => r.status === 'pending') || []
   const hasResponseRows = Boolean(responses && responses.length > 0)
   const displayedConfirmedAvailability = hasResponseRows ? confirmedResponses.length : confirmedAvailability
   const displayedPendingAvailability = hasResponseRows ? pendingResponses.length : pendingAvailability
@@ -278,7 +314,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
 
           {confirmedResponses.length > 0 ? (
             <div className="space-y-2 bg-green-50 p-3 rounded border border-green-200">
-              {confirmedResponses.map((response: any) => (
+              {confirmedResponses.map((response) => (
                 <label
                   key={response.profile_id}
                   className="flex items-center gap-3 p-2 bg-white rounded hover:bg-green-50 cursor-pointer"
@@ -318,7 +354,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
               </span>
             </div>
             <div className="space-y-2 bg-yellow-50 p-3 rounded border border-yellow-200">
-              {pendingResponses.map((response: any) => (
+              {pendingResponses.map((response) => (
                 <div
                   key={response.profile_id}
                   className="flex items-center justify-between p-2 bg-white rounded"
@@ -344,7 +380,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
               </span>
             </div>
             <div className="space-y-2 bg-red-50 p-3 rounded border border-red-200">
-              {declinedResponses.map((response: any) => (
+              {declinedResponses.map((response) => (
                 <div
                   key={response.profile_id}
                   className="flex items-center justify-between p-2 bg-white rounded"

--- a/src/hooks/useJobRequiredRoles.ts
+++ b/src/hooks/useJobRequiredRoles.ts
@@ -48,19 +48,20 @@ interface SaveJobRequirementsResult {
   deleted: string[]
 }
 
-function parseSummaryRow(row: any): RequiredRoleSummaryItem | null {
-  if (!row) return null
-  const roles = Array.isArray(row.roles)
-    ? (row.roles as any[]).map((r) => ({
-        role_code: r.role_code as string,
-        quantity: Number(r.quantity || 0),
-        notes: (r.notes ?? null) as string | null,
+function parseSummaryRow(row: unknown): RequiredRoleSummaryItem | null {
+  const record = (row ?? null) as { job_id?: unknown; department?: unknown; total_required?: unknown; roles?: unknown } | null
+  if (!record || typeof record.job_id !== 'string' || typeof record.department !== 'string') return null
+  const roles = Array.isArray(record.roles)
+    ? (record.roles as Array<Record<string, unknown>>).map((role) => ({
+        role_code: typeof role.role_code === 'string' ? role.role_code : String(role.role_code ?? ''),
+        quantity: Number(role.quantity || 0),
+        notes: typeof role.notes === 'string' ? role.notes : null,
       }))
     : []
   return {
-    job_id: row.job_id as string,
-    department: row.department as string,
-    total_required: Number(row.total_required || 0),
+    job_id: record.job_id,
+    department: record.department,
+    total_required: Number(record.total_required || 0),
     roles,
   }
 }

--- a/src/hooks/useMyTours.ts
+++ b/src/hooks/useMyTours.ts
@@ -6,8 +6,42 @@ import { supabase } from "@/integrations/supabase/client";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { createQueryKey } from "@/lib/optimized-react-query";
 
-type DynamicSupabaseClient = { from: (table: string) => any };
+type DynamicQueryResult = { data: unknown; error: unknown };
+type DynamicSupabaseQuery = PromiseLike<DynamicQueryResult> & {
+  select: (columns: string) => DynamicSupabaseQuery;
+  eq: (column: string, value: unknown) => DynamicSupabaseQuery;
+};
+type DynamicSupabaseClient = { from: (table: string) => DynamicSupabaseQuery };
 const dynamicSupabase = supabase as unknown as DynamicSupabaseClient;
+
+type TourDateRow = { id?: string; date?: string | null };
+type MyTourRow = {
+  id: string;
+  name: string;
+  description?: string | null;
+  color?: string | null;
+  status?: string | null;
+  start_date?: string | null;
+  end_date?: string | null;
+  tour_dates?: TourDateRow[] | null;
+};
+type CrewTourAssignmentRow = {
+  role?: string | null;
+  department?: string | null;
+  notes?: string | null;
+  tours?: MyTourRow | MyTourRow[] | null;
+};
+type TimesheetTourRow = {
+  date?: string | null;
+  jobs?: {
+    tour?: MyTourRow | MyTourRow[] | null;
+  } | Array<{
+    tour?: MyTourRow | MyTourRow[] | null;
+  }> | null;
+};
+
+const firstRow = <T,>(value: T | T[] | null | undefined): T | null =>
+  Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
 
 export interface MyTour {
   id: string;
@@ -100,11 +134,12 @@ export const useMyTours = () => {
       // NOTE: Use Madrid-local 'today' (yyyy-MM-dd) for date-only comparisons.
 
       const personalStatsByTourId = new Map<string, { total: number; upcoming: number }>();
-      (timeRows || []).forEach((row: any) => {
-        const job = row.jobs as any;
-        const tour = job?.tour as any;
-        const tourId = tour?.id as string | undefined;
-        const dateStr = row.date as string | undefined;
+      const timesheetRows = Array.isArray(timeRows) ? (timeRows as TimesheetTourRow[]) : [];
+      timesheetRows.forEach((row) => {
+        const job = firstRow(row.jobs);
+        const tour = firstRow(job?.tour);
+        const tourId = tour?.id;
+        const dateStr = row.date ?? undefined;
         if (!tourId || !dateStr) return;
         // tour.status already filtered server-side
 
@@ -118,12 +153,12 @@ export const useMyTours = () => {
 
       const byTourId = new Map<string, MyTour>();
 
-      const upsert = (tour: any, meta: Partial<MyTour>) => {
+      const upsert = (tour: MyTourRow | null | undefined, meta: Partial<MyTour>) => {
         if (!tour?.id) return;
 
         const tourDates = tour.tour_dates || [];
         const tourUpcomingDates = tourDates.filter(
-          (dateEntry: any) => (dateEntry?.date as string | undefined) ? dateEntry.date >= today : false
+          (dateEntry) => dateEntry?.date ? dateEntry.date >= today : false
         ).length;
 
         const personalStats = personalStatsByTourId.get(tour.id);
@@ -154,7 +189,7 @@ export const useMyTours = () => {
           id: tour.id,
           name: tour.name,
           description: tour.description,
-          color: tour.color,
+          color: tour.color || '#7E69AB',
           start_date: tour.start_date,
           end_date: tour.end_date,
           assignment_role: meta.assignment_role || 'Por bolo',
@@ -166,25 +201,25 @@ export const useMyTours = () => {
       };
 
       // Crew tours
-      (crewAssignments || []).forEach((assignment: any) => {
-        const tour = assignment.tours as any;
+      ((crewAssignments || []) as CrewTourAssignmentRow[]).forEach((assignment) => {
+        const tour = firstRow(assignment.tours);
         upsert(tour, {
-          assignment_role: assignment.role,
-          assignment_department: assignment.department,
-          assignment_notes: assignment.notes,
+          assignment_role: assignment.role || undefined,
+          assignment_department: assignment.department || undefined,
+          assignment_notes: assignment.notes || undefined,
         });
       });
 
       // Timesheet-based tours (canonical)
-      (timeRows || []).forEach((row: any) => {
-        const job = row.jobs as any;
-        const tour = job?.tour as any;
+      timesheetRows.forEach((row) => {
+        const job = firstRow(row.jobs);
+        const tour = firstRow(job?.tour);
         if (!tour) return;
         // tour.status already filtered server-side
 
         upsert(tour, {
           assignment_role: 'Por bolo',
-          assignment_department: (userDepartment || 'unknown') as any,
+          assignment_department: userDepartment || 'unknown',
         });
       });
 

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -33,11 +33,66 @@ type JobDocumentRow = {
   [key: string]: unknown;
 };
 
+type JobProfileRef = {
+  first_name?: string | null;
+  nickname?: string | null;
+  last_name?: string | null;
+  department?: string | null;
+  [key: string]: unknown;
+};
+
+type JobAssignmentForCard = {
+  job_id?: string | null;
+  technician_id: string;
+  profiles?: JobProfileRef | JobProfileRef[] | null;
+  sound_role?: string | null;
+  lights_role?: string | null;
+  video_role?: string | null;
+  status?: string | null;
+  single_day?: boolean | null;
+  assignment_date?: string | null;
+  assigned_at?: string | null;
+  _timesheet_dates?: string[];
+  _scheduled_work_dates?: string[];
+  [key: string]: unknown;
+};
+
+type TimesheetForCard = {
+  technician_id?: string | null;
+  date?: string | null;
+  profiles?: JobProfileRef | JobProfileRef[] | null;
+};
+
+type JobDateTypeForCard = {
+  date?: string | null;
+  type?: string | null;
+};
+
+type OptimizedJobCardJob = {
+  id: string;
+  color?: string | null;
+  darkColor?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  job_type?: string | null;
+  tour_date?: unknown;
+  job_assignments?: JobAssignmentForCard[] | null;
+  job_documents?: JobDocumentRow[] | null;
+  job_date_types?: JobDateTypeForCard[] | null;
+  [key: string]: unknown;
+};
+
+const normalizeProfile = (profile: JobProfileRef | JobProfileRef[] | null | undefined): JobProfileRef | null =>
+  Array.isArray(profile) ? (profile[0] ?? null) : (profile ?? null);
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
 export const useOptimizedJobCard = (
-  job: any,
+  job: OptimizedJobCardJob,
   department: string,
   userRole: string | null,
-  onEditClick: (job: any) => void,
+  onEditClick: (job: OptimizedJobCardJob) => void,
   onDeleteClick: (jobId: string) => void,
   onJobClick: (jobId: string) => void,
   options?: UseOptimizedJobCardOptions
@@ -63,7 +118,7 @@ export const useOptimizedJobCard = (
 
   // Local state
   const [collapsed, setCollapsed] = useState(true);
-  const [assignments, setAssignments] = useState(job.job_assignments || []);
+  const [assignments, setAssignments] = useState<JobAssignmentForCard[]>(job.job_assignments || []);
   const [documents, setDocuments] = useState<JobDocumentRow[]>((job.job_documents || []) as JobDocumentRow[]);
   const [soundTaskDialogOpen, setSoundTaskDialogOpen] = useState(false);
   const [lightsTaskDialogOpen, setLightsTaskDialogOpen] = useState(false);
@@ -79,7 +134,6 @@ export const useOptimizedJobCard = (
     setDocuments((job.job_documents || []) as JobDocumentRow[]);
   }, [job.job_documents]);
 
-  const normalizeProfile = (p: any) => Array.isArray(p) ? p[0] : p;
   const jobScheduledWorkDates = useMemo(() => getScheduledWorkDateKeys({
     job_date_types: job?.job_date_types,
     start_time: job?.start_time,
@@ -92,7 +146,7 @@ export const useOptimizedJobCard = (
   const refreshAssignments = useCallback(async () => {
     if (!job?.id) return;
     try {
-      const baseAssignments: any[] = Array.isArray(job?.job_assignments) ? job.job_assignments : [];
+      const baseAssignments: JobAssignmentForCard[] = Array.isArray(job?.job_assignments) ? job.job_assignments : [];
 
       const { data: directTimesheets, error: tsError } = await supabase
         .from('timesheets')
@@ -109,13 +163,13 @@ export const useOptimizedJobCard = (
       }
 
       // Fallback to visibility function to avoid RLS gaps (mirrors JobDetailsDialog)
-      let visibleTimesheets: any[] = [];
+      let visibleTimesheets: TimesheetForCard[] = [];
       try {
         const { data: visible, error: visErr } = await supabase
           .rpc('get_timesheet_amounts_visible')
           .eq('job_id', job.id);
         if (!visErr && Array.isArray(visible)) {
-          visibleTimesheets = visible;
+          visibleTimesheets = visible as TimesheetForCard[];
         }
       } catch (err) {
         console.warn('Error fetching visible timesheets for job card:', err);
@@ -123,8 +177,8 @@ export const useOptimizedJobCard = (
 
       // Merge direct + visible and de-duplicate per technician
       const timesheetsByTech = new Map<string, string[]>();
-      const timesheetProfileByTech = new Map<string, any>();
-      const addTimesheetRow = (t: any) => {
+      const timesheetProfileByTech = new Map<string, JobProfileRef | null>();
+      const addTimesheetRow = (t: TimesheetForCard) => {
         if (!t?.technician_id || !t?.date) return;
         const existing = timesheetsByTech.get(t.technician_id) || [];
         existing.push(t.date);
@@ -134,7 +188,7 @@ export const useOptimizedJobCard = (
         }
       };
 
-      (directTimesheets || []).forEach(addTimesheetRow);
+      ((directTimesheets || []) as TimesheetForCard[]).forEach(addTimesheetRow);
       visibleTimesheets.forEach(addTimesheetRow);
 
       // Deduplicate and sort dates per technician
@@ -163,7 +217,7 @@ export const useOptimizedJobCard = (
         ? computedScheduledWorkDates
         : jobScheduledWorkDates;
 
-      const mergedAssignments: any[] = (baseAssignments || []).map((a: any) => ({
+      const mergedAssignments: JobAssignmentForCard[] = (baseAssignments || []).map((a) => ({
         ...a,
         profiles: normalizeProfile(a.profiles),
         _timesheet_dates: normalizedTimesheetsByTech.get(a.technician_id) || [],
@@ -171,7 +225,7 @@ export const useOptimizedJobCard = (
       }));
 
       // If timesheets exist for technicians not in job_assignments (edge cases), include them so badges still appear
-      const assignmentTechIds = new Set((baseAssignments || []).map((a: any) => a.technician_id));
+      const assignmentTechIds = new Set((baseAssignments || []).map((a) => a.technician_id));
       normalizedTimesheetsByTech.forEach((dates, techId) => {
         if (assignmentTechIds.has(techId)) return;
         mergedAssignments.push({
@@ -199,7 +253,7 @@ export const useOptimizedJobCard = (
   // Keep local state in sync with incoming job prop updates for instant UI
   useEffect(() => {
     const nextAssignments = Array.isArray(job.job_assignments)
-      ? job.job_assignments.map((assignment: any) => ({
+      ? job.job_assignments.map((assignment) => ({
         ...assignment,
         _scheduled_work_dates: jobScheduledWorkDates,
       }))
@@ -300,7 +354,7 @@ export const useOptimizedJobCard = (
       sound: soundSet.size,
       lights: lightsSet.size,
       video: videoSet.size
-    } as any;
+    };
 
     const countsByRole: Record<string, number> = {};
     Object.entries(roleSets).forEach(([role, set]) => countsByRole[role] = set.size);
@@ -312,7 +366,7 @@ export const useOptimizedJobCard = (
   const requiredVsAssigned = useMemo(() => {
     const byDept: Record<string, { required: number; assigned: number; roles: Array<{ role_code: string; required: number; assigned: number }> }> = {};
     for (const dept of ['sound', 'lights', 'video']) {
-      const sum = reqByDept.get?.(dept as any) || (reqSummary.find(r => r.department === dept) ?? null);
+      const sum = reqByDept.get?.(dept) || (reqSummary.find(r => r.department === dept) ?? null);
       const required = sum?.total_required ?? 0;
       const roles = (sum?.roles || []).map((r) => ({
         role_code: r.role_code,
@@ -411,8 +465,8 @@ export const useOptimizedJobCard = (
             body: { action: 'broadcast', type: 'document.uploaded', job_id: job.id, file_name: file.name }
           });
         } catch { /* best-effort push notification; ignore delivery failures */ }
-      } catch (err: any) {
-        failedMessages.push(`${file.name}: ${err?.message || String(err)}`);
+      } catch (err: unknown) {
+        failedMessages.push(`${file.name}: ${getErrorMessage(err)}`);
       }
     }
 
@@ -437,7 +491,7 @@ export const useOptimizedJobCard = (
     });
   }, [job.id, department, queryClient, toast]);
 
-  const handleDeleteDocument = useCallback(async (doc: any) => {
+  const handleDeleteDocument = useCallback(async (doc: JobDocumentRow) => {
     if (doc?.read_only) {
       console.error('Attempted to delete read-only document', doc);
       return;
@@ -474,7 +528,7 @@ export const useOptimizedJobCard = (
           body: { action: 'broadcast', type: 'document.deleted', job_id: job.id, file_name: doc.file_name }
         });
       } catch { /* best-effort push notification; ignore delivery failures */ }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Delete error:', err);
     }
   }, [job.id, confirm]);

--- a/src/lib/multitab-coordinator.ts
+++ b/src/lib/multitab-coordinator.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, type QueryKey } from '@tanstack/react-query';
 import {
   UnifiedSubscriptionManager,
   type RealtimeSubscriptionFilter,
@@ -21,8 +21,8 @@ export interface RouteSubscriptionRequest {
 
 interface TabMessage {
   type: 'cache-update' | 'invalidate' | 'leader-election' | 'heartbeat' | 'subscription-request' | 'subscription-release';
-  queryKey?: any;
-  data?: any;
+  queryKey?: QueryKey;
+  data?: unknown;
   tabId?: string;
   timestamp?: number;
   tables?: string[];
@@ -52,7 +52,7 @@ export class MultiTabCoordinator {
   private visibilityUnsubscribe: (() => void) | null = null;
   private queryCacheUnsubscribe: (() => void) | null = null;
   private lastBroadcastedUpdatedAt: Map<string, number> = new Map();
-  private pendingBroadcasts: Map<string, { queryKey: any; data: any; updatedAt: number }> = new Map();
+  private pendingBroadcasts: Map<string, { queryKey: QueryKey; data: unknown; updatedAt: number }> = new Map();
   private broadcastFlushTimeout: number | null = null;
   private lockAcquired: boolean = false;
   private lastLeaderSeen: number = Date.now();
@@ -99,14 +99,15 @@ export class MultiTabCoordinator {
           }
           break;
           
-        case 'invalidate':
+        case 'invalidate': {
           const refetchType = this.isLeader ? 'active' : 'none';
           if (queryKey) {
-            this.queryClient.invalidateQueries({ queryKey, refetchType } as any);
+            this.queryClient.invalidateQueries({ queryKey, refetchType });
           } else {
-            this.queryClient.invalidateQueries({ refetchType } as any);
+            this.queryClient.invalidateQueries({ refetchType });
           }
           break;
+        }
           
         case 'leader-election':
           if (timestamp && timestamp > this.lastLeaderSeen) {
@@ -336,9 +337,9 @@ export class MultiTabCoordinator {
       const query = event.query;
       if (query.state.status !== 'success') return;
 
-      const queryKey = query.queryKey as any;
+      const queryKey = query.queryKey;
       const serializedKey = JSON.stringify(queryKey);
-      const updatedAt = (query.state as any).dataUpdatedAt ?? 0;
+      const updatedAt = query.state.dataUpdatedAt ?? 0;
       const last = this.lastBroadcastedUpdatedAt.get(serializedKey) ?? 0;
       if (updatedAt <= last) return;
 
@@ -454,13 +455,13 @@ export class MultiTabCoordinator {
     }
   }
 
-  public invalidateQueries(queryKey?: any) {
+  public invalidateQueries(queryKey?: QueryKey) {
     // Always invalidate locally first
     const refetchType = this.isLeader ? 'active' : 'none';
     if (queryKey) {
-      this.queryClient.invalidateQueries({ queryKey, refetchType } as any);
+      this.queryClient.invalidateQueries({ queryKey, refetchType });
     } else {
-      this.queryClient.invalidateQueries({ refetchType } as any);
+      this.queryClient.invalidateQueries({ refetchType });
     }
     
     // If we're the leader, broadcast to other tabs


### PR DESCRIPTION
## Summary
- removes explicit `any` usage from the optimized job card hook, staffing offer list, required-role summary parser, my tours hook, and multitab coordinator
- replaces API/data-boundary casts with local row types and `unknown`-first narrowing
- reduces the current explicit-any warning backlog from 1812 to 1755 warnings (-57)

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`

No Supabase migrations included.