### PR TITLE
Fix cancelled tour completed jobs

### DIFF
--- a/src/components/tours/TourCard.tsx
+++ b/src/components/tours/TourCard.tsx
@@ -454,6 +454,8 @@ export const TourCard = memo(function TourCard({ tour, onTourClick, onManageDate
       // Invalidate queries to refresh the UI
       await queryClient.invalidateQueries({ queryKey: queryKeys.scope('tours') });
       await queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour', tour.id) });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.scope('jobs') });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.scope('optimized-jobs') });
 
       toast({
         title: "Success",

--- a/src/components/tours/TourManagementDialog.tsx
+++ b/src/components/tours/TourManagementDialog.tsx
@@ -143,14 +143,16 @@ export const TourManagementDialog = ({
 
       if (error) throw error;
 
-      // When cancelling a tour, mark all its tourdate jobs as Cancelado
+      // When cancelling a started tour, only future tour dates should stop happening.
       if (newStatus === 'cancelled') {
         const { error: jobsErr } = await dataLayerClient.from('jobs')
           .update({ status: 'Cancelado' })
           .eq('tour_id', tour.id)
-          .eq('job_type', 'tourdate');
+          .eq('job_type', 'tourdate')
+          .neq('status', 'Completado')
+          .gt('start_time', new Date().toISOString());
         if (jobsErr) {
-          console.warn('Failed to mark tour jobs as Cancelado:', jobsErr);
+          console.warn('Failed to mark future tour jobs as Cancelado:', jobsErr);
         }
       }
 

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -4,6 +4,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useMultiTableSubscription } from "@/hooks/useSubscription";
 import { toast } from "sonner";
 import { trackError } from "@/lib/errorTracking";
+import { shouldHideJobForTourState } from "@/utils/cancelledTourJobs";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -109,16 +110,10 @@ export const useJobs = () => {
 
           const allJobs = jobs || [];
 
-          // Filter out jobs from cancelled/deleted tours and explicitly cancelled jobs
+          // Keep historical/completed jobs visible when a started tour is cancelled.
           const filteredJobs = allJobs.filter((job: any) => {
-            if (job.status === 'Cancelado') return false;
-
             const tourMeta = job?.tour_date?.tour;
-            if (tourMeta && (tourMeta.status === 'cancelled' || tourMeta.deleted === true)) {
-              return false;
-            }
-
-            return true;
+            return !shouldHideJobForTourState(job, tourMeta);
           });
 
           return filteredJobs;

--- a/src/hooks/useOptimizedJobs.ts
+++ b/src/hooks/useOptimizedJobs.ts
@@ -5,6 +5,7 @@ import { useMultiTableSubscription } from "@/hooks/useSubscription";
 import { Department } from "@/types/department";
 import { sanitizeLogData } from "@/lib/enhanced-security-config";
 import { OPS_JOB_TYPES_NO_DRYHIRE, OPS_JOB_TYPES_WITH_DRYHIRE } from "@/utils/jobType";
+import { shouldHideJobForTourState } from "@/utils/cancelledTourJobs";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -200,15 +201,7 @@ export const useOptimizedJobs = (
         ...job,
         tour_meta: job.tour_id ? tourMetaMap[job.tour_id] ?? null : null,
       }))
-      .filter(job => {
-        const meta = job.tour_meta;
-        // Hide anything tied to a cancelled/deleted tour
-        if (meta && (meta.status === 'cancelled' || meta.deleted === true)) {
-          return false;
-        }
-        // Also hide jobs explicitly cancelled
-        return job.status !== 'Cancelado';
-      });
+      .filter(job => !shouldHideJobForTourState(job, job.tour_meta));
 
     const duration = Date.now() - startTime;
     if (debug) {

--- a/src/utils/__tests__/cancelledTourJobs.test.ts
+++ b/src/utils/__tests__/cancelledTourJobs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldHideJobForTourState } from "@/utils/cancelledTourJobs";
+
+const nowMs = Date.parse("2026-06-29T12:00:00.000Z");
+
+describe("cancelled tour job visibility", () => {
+  it("keeps completed jobs visible when the parent tour is cancelled", () => {
+    expect(
+      shouldHideJobForTourState(
+        { status: "Completado", start_time: "2026-07-01T12:00:00.000Z" },
+        { status: "cancelled", deleted: false },
+        nowMs,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps already-started non-cancelled jobs visible when the parent tour is cancelled", () => {
+    expect(
+      shouldHideJobForTourState(
+        { status: "Confirmado", start_time: "2026-06-28T12:00:00.000Z" },
+        { status: "cancelled", deleted: false },
+        nowMs,
+      ),
+    ).toBe(false);
+  });
+
+  it("hides future non-completed jobs when the parent tour is cancelled", () => {
+    expect(
+      shouldHideJobForTourState(
+        { status: "Confirmado", start_time: "2026-06-30T12:00:00.000Z" },
+        { status: "cancelled", deleted: false },
+        nowMs,
+      ),
+    ).toBe(true);
+  });
+
+  it("always hides explicitly cancelled jobs", () => {
+    expect(
+      shouldHideJobForTourState(
+        { status: "Cancelado", start_time: "2026-06-28T12:00:00.000Z" },
+        { status: "cancelled", deleted: false },
+        nowMs,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/utils/__tests__/tour-cancellation-migration-guard.test.ts
+++ b/src/utils/__tests__/tour-cancellation-migration-guard.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("tour cancellation migration guard", () => {
+  const migration = readFileSync(
+    join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "supabase",
+      "migrations",
+      "20260629120000_limit_tour_cancellation_to_future_jobs.sql",
+    ),
+    "utf-8",
+  );
+  const codeOnly = migration
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n");
+
+  it("cascades cancellation only to future non-completed tour jobs", () => {
+    expect(codeOnly).toMatch(/CREATE OR REPLACE FUNCTION public\.cascade_tour_cancellation\(\)/i);
+    expect(codeOnly).toMatch(/j\.start_time > now\(\)/i);
+    expect(codeOnly).toMatch(/j\.status NOT IN \(\s*'Cancelado'::public\.job_status,\s*'Completado'::public\.job_status\s*\)/i);
+  });
+
+  it("repairs only past cancelled jobs with status history or worked timesheet evidence", () => {
+    expect(codeOnly).toMatch(/WITH worked_cancelled_past_tour_jobs AS/i);
+    expect(codeOnly).toMatch(/j\.end_time <= now\(\)/i);
+    expect(codeOnly).toMatch(/FROM public\.activity_log al/i);
+    expect(codeOnly).toMatch(/al\.payload #>> '\{diff,status,from\}' = 'Completado'/i);
+    expect(codeOnly).toMatch(/al\.payload #>> '\{diff,status,to\}' = 'Cancelado'/i);
+    expect(codeOnly).toMatch(/ts\.status IN \(\s*'submitted'::public\.timesheet_status,\s*'approved'::public\.timesheet_status\s*\)/i);
+    expect(codeOnly).toMatch(/COALESCE\(ts\.is_schedule_only, false\) = false/i);
+  });
+});

--- a/src/utils/cancelledTourJobs.ts
+++ b/src/utils/cancelledTourJobs.ts
@@ -1,0 +1,49 @@
+export type CancelledTourJobState = {
+  status?: string | null;
+  start_time?: string | null;
+};
+
+export type CancelledTourMeta = {
+  status?: string | null;
+  deleted?: boolean | null;
+} | null | undefined;
+
+const JOB_STATUS_CANCELLED = "Cancelado";
+const JOB_STATUS_COMPLETED = "Completado";
+const TOUR_STATUS_CANCELLED = "cancelled";
+
+export const isJobScheduledInFuture = (
+  job: CancelledTourJobState,
+  nowMs: number = Date.now(),
+) => {
+  if (!job.start_time) {
+    return true;
+  }
+
+  const startMs = Date.parse(job.start_time);
+  return Number.isNaN(startMs) || startMs > nowMs;
+};
+
+export const shouldHideJobForTourState = (
+  job: CancelledTourJobState,
+  tourMeta: CancelledTourMeta,
+  nowMs: number = Date.now(),
+) => {
+  if (job.status === JOB_STATUS_CANCELLED) {
+    return true;
+  }
+
+  if (tourMeta?.deleted === true) {
+    return true;
+  }
+
+  if (tourMeta?.status !== TOUR_STATUS_CANCELLED) {
+    return false;
+  }
+
+  if (job.status === JOB_STATUS_COMPLETED) {
+    return false;
+  }
+
+  return isJobScheduledInFuture(job, nowMs);
+};

--- a/supabase/migrations/20260629120000_limit_tour_cancellation_to_future_jobs.sql
+++ b/supabase/migrations/20260629120000_limit_tour_cancellation_to_future_jobs.sql
@@ -1,0 +1,63 @@
+-- Limit "tour not happening" cascades to work that has not started yet.
+-- Completed and already-started jobs remain historical records even when the
+-- parent tour is cancelled.
+
+CREATE OR REPLACE FUNCTION public.cascade_tour_cancellation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.status = 'cancelled' AND (OLD.status IS NULL OR OLD.status != 'cancelled') THEN
+    UPDATE public.jobs j
+    SET status = 'Cancelado'::public.job_status
+    WHERE j.tour_id = NEW.id
+      AND j.start_time > now()
+      AND j.status NOT IN (
+        'Cancelado'::public.job_status,
+        'Completado'::public.job_status
+      );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Conservative repair for jobs previously overwritten by the old cascade.
+-- Only restore past cancelled tour jobs when activity history or worked
+-- timesheets prove the date happened; avoid guessing on tours that were
+-- cancelled before the crew worked.
+WITH worked_cancelled_past_tour_jobs AS (
+  SELECT DISTINCT j.id
+  FROM public.jobs j
+  INNER JOIN public.tours t ON t.id = j.tour_id
+  WHERE t.status = 'cancelled'
+    AND j.status = 'Cancelado'::public.job_status
+    AND j.end_time <= now()
+    AND (
+      EXISTS (
+        SELECT 1
+        FROM public.activity_log al
+        WHERE al.job_id = j.id
+          AND al.code = 'job.updated'
+          AND al.payload #>> '{diff,status,from}' = 'Completado'
+          AND al.payload #>> '{diff,status,to}' = 'Cancelado'
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM public.timesheets ts
+        WHERE ts.job_id = j.id
+          AND ts.is_active = true
+          AND COALESCE(ts.is_schedule_only, false) = false
+          AND ts.status IN (
+            'submitted'::public.timesheet_status,
+            'approved'::public.timesheet_status
+          )
+        )
+      )
+    )
+)
+UPDATE public.jobs j
+SET status = 'Completado'::public.job_status
+FROM worked_cancelled_past_tour_jobs worked
+WHERE j.id = worked.id;

--- a/supabase/migrations/20260629120000_limit_tour_cancellation_to_future_jobs.sql
+++ b/supabase/migrations/20260629120000_limit_tour_cancellation_to_future_jobs.sql
@@ -53,7 +53,6 @@ WITH worked_cancelled_past_tour_jobs AS (
             'submitted'::public.timesheet_status,
             'approved'::public.timesheet_status
           )
-        )
       )
     )
 )


### PR DESCRIPTION
## Summary
- limit tour cancellation cascades to future non-completed jobs
- keep completed and already-started jobs visible when a parent tour is cancelled
- add a migration repair for past cancelled tour jobs with completion history or worked timesheets

## Validation
- npm run lint
- npm run test:run
- npm run build
- npm run typecheck
- npm run ci:db:migrations