### PR TITLE
refactor(types): reduce task hook any debt

### DIFF
--- a/src/hooks/__tests__/useTaskMutations.test.ts
+++ b/src/hooks/__tests__/useTaskMutations.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/services/taskCompletion", () => ({
+  completeTask: vi.fn(),
+  revertTask: vi.fn(),
+}));
+
+import { useTaskMutations } from "@/hooks/useTaskMutations";
+
+describe("useTaskMutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+  });
+
+  it("creates tasks only for normalized assignees without an existing task", async () => {
+    const existingQuery = createMockQueryBuilder({
+      data: [{ assigned_to: "tech-1" }],
+      error: null,
+    });
+    const insertQuery = createMockQueryBuilder({
+      data: [{ id: "task-2", assigned_to: "tech-2" }],
+      error: null,
+    });
+    const taskBuilders = [existingQuery, insertQuery];
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "sound_job_tasks") {
+        return taskBuilders.shift() ?? createMockQueryBuilder({ data: [], error: null });
+      }
+      return createMockQueryBuilder();
+    });
+
+    const { createTaskForUsers } = useTaskMutations("job-1", "sound");
+    const result = await createTaskForUsers("prep", [" tech-1 ", "tech-2", "tech-2", ""], "2026-02-01");
+
+    expect(existingQuery.in).toHaveBeenCalledWith("assigned_to", ["tech-1", "tech-2"]);
+    expect(existingQuery.eq).toHaveBeenCalledWith("job_id", "job-1");
+    expect(insertQuery.insert).toHaveBeenCalledWith([
+      {
+        task_type: "prep",
+        status: "not_started",
+        progress: 0,
+        job_id: "job-1",
+        due_at: "2026-02-01",
+        assigned_to: "tech-2",
+      },
+    ]);
+    expect(result).toEqual({
+      created: [{ id: "task-2", assigned_to: "tech-2" }],
+      skippedAssigneeIds: ["tech-1"],
+    });
+  });
+
+  it("normalizes tracked updates before storing and broadcasting task changes", async () => {
+    const existingTaskQuery = createMockQueryBuilder({
+      data: {
+        id: "task-1",
+        task_type: "prep",
+        assigned_to: "tech-2",
+        job_id: "job-1",
+        tour_id: null,
+        due_at: "2026-01-01T00:00:00.000Z",
+        priority: "normal",
+      },
+      error: null,
+    });
+    const updateQuery = createMockQueryBuilder({ data: null, error: null });
+    const taskBuilders = [existingTaskQuery, updateQuery];
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: "manager-1" } },
+      error: null,
+    });
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "sound_job_tasks") {
+        return taskBuilders.shift() ?? createMockQueryBuilder({ data: null, error: null });
+      }
+      return createMockQueryBuilder();
+    });
+
+    const { updateTask } = useTaskMutations("job-1", "sound");
+    await updateTask("task-1", {
+      due_at: "2026-01-02",
+      priority: "high",
+      notes: undefined,
+    });
+
+    expect(updateQuery.update).toHaveBeenCalledWith({
+      due_at: "2026-01-02T00:00:00.000Z",
+      priority: "high",
+    });
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith("push", {
+      body: {
+        action: "broadcast",
+        type: "task.updated",
+        job_id: "job-1",
+        tour_id: undefined,
+        recipient_id: "tech-2",
+        user_ids: ["manager-1", "tech-2"],
+        task_id: "task-1",
+        task_type: "prep",
+        changes: {
+          due_at: {
+            from: "2026-01-01T00:00:00.000Z",
+            to: "2026-01-02T00:00:00.000Z",
+          },
+          priority: {
+            from: "normal",
+            to: "high",
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/hooks/__tests__/useTourDefaultSets.test.tsx
+++ b/src/hooks/__tests__/useTourDefaultSets.test.tsx
@@ -95,6 +95,7 @@ describe("useTourDefaultSets", () => {
     });
 
     await waitFor(() => {
+      expect(result.current.defaultSets).toHaveLength(1);
       expect(result.current.defaultTables).toHaveLength(1);
     });
 

--- a/src/hooks/__tests__/useTourDefaultSets.test.tsx
+++ b/src/hooks/__tests__/useTourDefaultSets.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestQueryClient } from "@/test/createTestQueryClient";
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+import type { TourDefaultSet, TourDefaultTable } from "@/hooks/useTourDefaultSets";
+
+const { toastMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+import { useTourDefaultSets } from "@/hooks/useTourDefaultSets";
+
+const createWrapper = () => {
+  const queryClient = createTestQueryClient();
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const createSet = (overrides: Partial<TourDefaultSet> = {}): TourDefaultSet => ({
+  id: "set-1",
+  tour_id: "tour-1",
+  name: "Main",
+  description: "Main package",
+  department: "sound",
+  package_size: "m",
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+const createTable = (overrides: Partial<TourDefaultTable> = {}): TourDefaultTable => ({
+  id: "table-1",
+  set_id: "set-1",
+  table_name: "Main power",
+  table_data: {
+    rows: [{ quantity: "1", componentId: "amp-1", watts: "1200", componentName: "Amp" }],
+    safetyMargin: 10,
+  },
+  table_type: "power",
+  total_value: 1200,
+  metadata: {
+    order_index: 1,
+    current_per_phase: 5.2,
+  },
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("useTourDefaultSets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+  });
+
+  it("duplicates a default set and preserves child table snapshots", async () => {
+    const sourceSet = createSet();
+    const sourceTable = createTable();
+    const copiedSet = createSet({ id: "set-copy", name: "Main Copy" });
+
+    const setQuery = createMockQueryBuilder<TourDefaultSet[]>({ data: [sourceSet], error: null });
+    const tableQuery = createMockQueryBuilder<TourDefaultTable[]>({ data: [sourceTable], error: null });
+    const insertSet = createMockQueryBuilder<TourDefaultSet>({ data: copiedSet, error: null });
+    const insertTables = createMockQueryBuilder<null>({ data: null, error: null });
+
+    const setBuilders = [setQuery, insertSet];
+    const tableBuilders = [tableQuery, insertTables];
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "tour_default_sets") {
+        return setBuilders.shift() ?? createMockQueryBuilder<TourDefaultSet[]>({ data: [sourceSet], error: null });
+      }
+      if (table === "tour_default_tables") {
+        return tableBuilders.shift() ?? createMockQueryBuilder<TourDefaultTable[]>({ data: [sourceTable], error: null });
+      }
+      return createMockQueryBuilder();
+    });
+
+    const { result } = renderHook(() => useTourDefaultSets("tour-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.defaultTables).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await result.current.duplicateSet({ setId: "set-1", name: "Main Copy" });
+    });
+
+    expect(insertSet.insert).toHaveBeenCalledWith({
+      tour_id: "tour-1",
+      name: "Main Copy",
+      description: "Main package",
+      department: "sound",
+      package_size: "m",
+    });
+    expect(insertTables.insert).toHaveBeenCalledWith([
+      {
+        set_id: "set-copy",
+        table_name: "Main power",
+        table_data: sourceTable.table_data,
+        table_type: "power",
+        total_value: 1200,
+        metadata: sourceTable.metadata,
+      },
+    ]);
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Success",
+        description: "Default set duplicated successfully",
+      }),
+    );
+  });
+
+  it("shows the mutation error message when creating a default set fails", async () => {
+    const insertError = new Error("duplicate package size");
+    const setQuery = createMockQueryBuilder<TourDefaultSet[]>({ data: [], error: null });
+    const insertSet = createMockQueryBuilder<null>({ data: null, error: insertError });
+    const setBuilders = [setQuery, insertSet];
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "tour_default_sets") {
+        return setBuilders.shift() ?? createMockQueryBuilder<TourDefaultSet[]>({ data: [], error: null });
+      }
+      return createMockQueryBuilder();
+    });
+
+    const { result } = renderHook(() => useTourDefaultSets("tour-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(setQuery.order).toHaveBeenCalledWith("created_at", { ascending: true });
+    });
+
+    let caughtError: unknown;
+    await act(async () => {
+      try {
+        await result.current.createSet({
+          tour_id: "tour-1",
+          name: "Main",
+          description: null,
+          department: "sound",
+          package_size: "m",
+        });
+      } catch (error) {
+        caughtError = error;
+      }
+    });
+
+    expect(caughtError).toBe(insertError);
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Error",
+        description: "duplicate package size",
+        variant: "destructive",
+      }),
+    );
+  });
+});

--- a/src/hooks/useTaskMutations.ts
+++ b/src/hooks/useTaskMutations.ts
@@ -3,6 +3,27 @@ import { completeTask, revertTask, Department } from '@/services/taskCompletion'
 import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
 
 type Dept = 'sound'|'lights'|'video';
+type TaskUpdateFields = Record<string, unknown>;
+type TaskInsertPayload = {
+  task_type: string;
+  status: 'not_started';
+  progress: number;
+  job_id?: string;
+  tour_id?: string;
+  assigned_to?: string;
+  due_at?: string;
+};
+type TaskRow = {
+  id?: string;
+  task_type?: string;
+  assigned_to?: string | null;
+  job_id?: string | null;
+  tour_id?: string | null;
+  [field: string]: unknown;
+};
+type ExistingTaskAssigneeRow = {
+  assigned_to: string | null;
+};
 
 const TASK_TABLE: Record<Dept, string> = {
   sound: 'sound_job_tasks',
@@ -22,7 +43,7 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
   const contextId = tourId || jobId;
   const TRACKED_TASK_FIELDS = ['due_at', 'priority', 'requirements', 'notes', 'details'];
 
-  const sanitizeTaskUpdateValue = (field: string, value: any) => {
+  const sanitizeTaskUpdateValue = (field: string, value: unknown) => {
     if (value === undefined) return undefined;
     if (value === null) return null;
 
@@ -36,7 +57,7 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
     return value;
   };
 
-  const normalizeTaskValue = (field: string, value: any): any => {
+  const normalizeTaskValue = (field: string, value: unknown): unknown => {
     if (value === undefined) return undefined;
     if (value === null) return null;
 
@@ -62,8 +83,8 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
     return value;
   };
 
-  const trackedUpdatesFrom = (fields: Record<string, any>) => {
-    const tracked: Record<string, any> = {};
+  const trackedUpdatesFrom = (fields: TaskUpdateFields) => {
+    const tracked: TaskUpdateFields = {};
     for (const [key, value] of Object.entries(fields)) {
       if (TRACKED_TASK_FIELDS.includes(key)) {
         tracked[key] = sanitizeTaskUpdateValue(key, value);
@@ -72,7 +93,7 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
     return tracked;
   };
 
-  const notifyTaskUpdated = async (task: any, updates: Record<string, any>) => {
+  const notifyTaskUpdated = async (task: TaskRow, updates: TaskUpdateFields) => {
     if (!task?.assigned_to) return;
 
     const changes: Record<string, { from: unknown; to: unknown }> = {};
@@ -114,8 +135,8 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
     }
   };
 
-  const updateTaskWithNotification = async (id: string, fields: Record<string, any>) => {
-    const sanitizedFields: Record<string, any> = {};
+  const updateTaskWithNotification = async (id: string, fields: TaskUpdateFields) => {
+    const sanitizedFields: TaskUpdateFields = {};
     for (const [key, value] of Object.entries(fields)) {
       const sanitized = sanitizeTaskUpdateValue(key, value);
       if (sanitized !== undefined) {
@@ -128,7 +149,7 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
     }
 
     const trackedUpdates = trackedUpdatesFrom(sanitizedFields);
-    let existingTask: any | null = null;
+    let existingTask: TaskRow | null = null;
 
     if (Object.keys(trackedUpdates).length > 0) {
       const { data, error } = await supabase
@@ -140,7 +161,7 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
       if (error) {
         console.warn('useTaskMutations.updateTaskWithNotification fetch failed', error);
       } else {
-        existingTask = data;
+        existingTask = data as TaskRow | null;
       }
     }
 
@@ -153,7 +174,7 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
   };
 
   const createTask = async (task_type: string, assigned_to?: string | null, due_at?: string | null) => {
-    const payload: any = { task_type, status: 'not_started', progress: 0 };
+    const payload: TaskInsertPayload = { task_type, status: 'not_started', progress: 0 };
     if (tourId) {
       payload.tour_id = tourId;
     } else if (jobId) {
@@ -185,7 +206,7 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
       return { created: [], skippedAssigneeIds: assigneeIds };
     }
 
-    const payloadBase: any = { task_type, status: 'not_started', progress: 0 };
+    const payloadBase: TaskInsertPayload = { task_type, status: 'not_started', progress: 0 };
     if (tourId) {
       payloadBase.tour_id = tourId;
     } else if (jobId) {
@@ -210,9 +231,9 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
     if (existingError) throw existingError;
 
     const existingAssignees = new Set(
-      (existingTasks || [])
-        .map((row: any) => row.assigned_to)
-        .filter((id: string | null) => Boolean(id))
+      ((existingTasks || []) as ExistingTaskAssigneeRow[])
+        .map((row) => row.assigned_to)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
     );
 
     const assigneeIdsToCreate = normalizedAssigneeIds.filter((id) => !existingAssignees.has(id));
@@ -232,7 +253,7 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
     return { created: data || [], skippedAssigneeIds };
   };
 
-  const updateTask = async (id: string, fields: Record<string, any>) => {
+  const updateTask = async (id: string, fields: TaskUpdateFields) => {
     await updateTaskWithNotification(id, fields);
   };
 

--- a/src/hooks/useTourDefaultSets.ts
+++ b/src/hooks/useTourDefaultSets.ts
@@ -41,7 +41,7 @@ const getMutationErrorMessage = (error: unknown, fallback: string): string => {
   return fallback;
 };
 
-export const useTourDefaultSets = (tourId: string, department?: string) => {
+export const useTourDefaultSets = (tourId: string, department?: TourDefaultDepartment) => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 

--- a/src/hooks/useTourDefaultSets.ts
+++ b/src/hooks/useTourDefaultSets.ts
@@ -7,12 +7,14 @@ import { useToast } from "@/hooks/use-toast";
 import { queryKeys } from "@/lib/react-query";
 import type { TourPackageSize } from "@/utils/tourPackages";
 
+type TourDefaultDepartment = 'sound' | 'lights' | 'video';
+
 export interface TourDefaultSet {
   id: string;
   tour_id: string;
   name: string;
   description?: string | null;
-  department: 'sound' | 'lights' | 'video';
+  department: TourDefaultDepartment;
   package_size?: TourPackageSize | null;
   created_at: string;
   updated_at: string;
@@ -29,6 +31,15 @@ export interface TourDefaultTable {
   created_at: string;
   updated_at: string;
 }
+
+const getMutationErrorMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  return fallback;
+};
 
 export const useTourDefaultSets = (tourId: string, department?: string) => {
   const { toast } = useToast();
@@ -94,10 +105,10 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         description: "Default set created successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to create default set",
+        description: getMutationErrorMessage(error, "Failed to create default set"),
         variant: "destructive",
       });
     },
@@ -125,10 +136,10 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         description: "Default set updated successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to update default set",
+        description: getMutationErrorMessage(error, "Failed to update default set"),
         variant: "destructive",
       });
     },
@@ -153,10 +164,10 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         description: "Default table saved successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to save default table",
+        description: getMutationErrorMessage(error, "Failed to save default table"),
         variant: "destructive",
       });
     },
@@ -182,10 +193,10 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         description: "Default table updated successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to update default table",
+        description: getMutationErrorMessage(error, "Failed to update default table"),
         variant: "destructive",
       });
     },
@@ -210,10 +221,10 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         description: "Default set deleted successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to delete default set",
+        description: getMutationErrorMessage(error, "Failed to delete default set"),
         variant: "destructive",
       });
     },
@@ -279,10 +290,10 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         description: "Default set duplicated successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to duplicate default set",
+        description: getMutationErrorMessage(error, "Failed to duplicate default set"),
         variant: "destructive",
       });
     },
@@ -329,10 +340,10 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         description: "Default table(s) copied successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to copy default tables",
+        description: getMutationErrorMessage(error, "Failed to copy default tables"),
         variant: "destructive",
       });
     },
@@ -356,10 +367,10 @@ export const useTourDefaultSets = (tourId: string, department?: string) => {
         description: "Default table deleted successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Error",
-        description: error.message || "Failed to delete default table",
+        description: getMutationErrorMessage(error, "Failed to delete default table"),
         variant: "destructive",
       });
     },


### PR DESCRIPTION
## Summary
- removes explicit `any` usage from `useTaskMutations` by typing task insert payloads, update fields, fetched task rows, and duplicate-assignee rows
- replaces mutation error `any` handlers in `useTourDefaultSets` with `unknown` handling and a shared message formatter
- adds focused tests for task duplicate prevention, task update push notifications, tour default duplication, and mutation error toasts
- reduces explicit-any warning backlog from 1755 to 1733 (-22)

## Validation
- `npm run typecheck`
- `npx vitest run src/hooks/__tests__/useTourDefaultSets.test.tsx src/hooks/__tests__/useTaskMutations.test.ts`
- `npm run lint`
- `npm run test:run`
- `npm run build`

No Supabase migrations included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task updates so changes are saved in a more consistent format and synced reliably.
  * Task assignment now ignores duplicate, empty, and invalid assignee entries, reducing duplicate task creation.
  * Error messages for default set actions are now clearer and more user-friendly.

* **Tests**
  * Added coverage for task mutation flows and default set duplication/error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->