### PR TITLE
Reduce entity and artist explicit any debt

### DIFF
--- a/src/hooks/__tests__/useArtistMutations.test.tsx
+++ b/src/hooks/__tests__/useArtistMutations.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import React from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestQueryClient } from "@/test/createTestQueryClient";
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+const { toastMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+import { useArtistMutations } from "@/hooks/useArtistMutations";
+
+const createWrapper = () => {
+  const queryClient = createTestQueryClient();
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useArtistMutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("normalizes empty artist time fields when creating an artist", async () => {
+    const insertBuilder = createMockQueryBuilder({
+      data: { id: "artist-1", name: "Main Act" },
+      error: null,
+    });
+    mockSupabase.from.mockReturnValue(insertBuilder);
+
+    const { result } = renderHook(() => useArtistMutations("job-1", "2026-06-29"), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.createArtist({
+        name: "Main Act",
+        show_start: "",
+        show_end: "23:00",
+        soundcheck_start: "",
+      });
+    });
+
+    await waitFor(() => {
+      expect(insertBuilder.insert).toHaveBeenCalledWith([
+        {
+          name: "Main Act",
+          show_start: null,
+          show_end: "23:00",
+          soundcheck_start: null,
+          job_id: "job-1",
+        },
+      ]);
+    });
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "Success",
+      description: "Artist created successfully",
+    });
+  });
+
+  it("normalizes empty artist time fields when updating an artist", async () => {
+    const updateBuilder = createMockQueryBuilder({
+      data: { id: "artist-1", name: "Main Act Updated" },
+      error: null,
+    });
+    mockSupabase.from.mockReturnValue(updateBuilder);
+
+    const { result } = renderHook(() => useArtistMutations("job-1", "2026-06-29"), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.updateArtist({
+        id: "artist-1",
+        name: "Main Act Updated",
+        show_end: "",
+        soundcheck_end: "18:00",
+      });
+    });
+
+    await waitFor(() => {
+      expect(updateBuilder.update).toHaveBeenCalledWith({
+        name: "Main Act Updated",
+        show_end: null,
+        soundcheck_end: "18:00",
+      });
+    });
+    expect(updateBuilder.eq).toHaveBeenCalledWith("id", "artist-1");
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "Success",
+      description: "Artist updated successfully",
+    });
+  });
+
+  it("surfaces Supabase error messages in create failure toasts", async () => {
+    const insertBuilder = createMockQueryBuilder({
+      data: null,
+      error: { message: "Festival artist insert failed" },
+    });
+    mockSupabase.from.mockReturnValue(insertBuilder);
+
+    const { result } = renderHook(() => useArtistMutations("job-1", "2026-06-29"), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.createArtist({ name: "Main Act" });
+    });
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "Error",
+        description: "Could not create artist: Festival artist insert failed",
+        variant: "destructive",
+      });
+    });
+  });
+});

--- a/src/hooks/__tests__/useEntityQueries.test.tsx
+++ b/src/hooks/__tests__/useEntityQueries.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEntityListQuery, useEntityMutation } from "@/hooks/useEntityQueries";
+import { queryClient } from "@/lib/react-query";
+
+type WidgetRow = {
+  id: string;
+  name: string;
+};
+
+type WidgetMutation = {
+  id?: string;
+  isDelete?: boolean;
+  name?: string;
+  [key: string]: unknown;
+};
+
+const jsonResponse = (body: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe("useEntityQueries", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    queryClient.clear();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("builds list query URLs from filter values", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ id: "widget-1", name: "Main" }]));
+
+    const { result } = renderHook(
+      () =>
+        useEntityListQuery<WidgetRow>("widgets", {
+          page: 2,
+          active: true,
+          search: "main stage",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([{ id: "widget-1", name: "Main" }]);
+    expect(fetchMock).toHaveBeenCalledWith("/api/widgets?page=2&active=true&search=main%20stage", {
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  it("routes create, update, and delete mutations to the expected REST methods", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ id: "widget-1", name: "Created" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "widget-1", name: "Updated" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "widget-1", name: "Deleted" }));
+    const onSuccess = vi.fn();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(
+      () =>
+        useEntityMutation<WidgetRow, WidgetMutation>("widgets", {
+          onSuccessInvalidation: ["widgets", "widget-summary"],
+          onSuccess,
+          retry: false,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "Created" });
+      await result.current.mutateAsync({ id: "widget-1", name: "Updated" });
+      await result.current.mutateAsync({ id: "widget-1", isDelete: true });
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/widgets",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "Created" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/widgets/widget-1",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ id: "widget-1", name: "Updated" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/api/widgets/widget-1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(3);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["widgets"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["widget-summary"] });
+  });
+
+  it("restores optimistic data and calls onError when a mutation fails", async () => {
+    const previousData: WidgetRow = { id: "widget-1", name: "Before" };
+    queryClient.setQueryData(["widgets"], previousData);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ message: "boom" }, { status: 500, statusText: "Nope" }));
+    const onError = vi.fn();
+    const optimisticUpdate = vi.fn((variables: WidgetMutation) => {
+      queryClient.setQueryData(["widgets"], { id: variables.id, name: variables.name });
+    });
+
+    const { result } = renderHook(
+      () =>
+        useEntityMutation<WidgetRow, WidgetMutation>("widgets", {
+          optimisticUpdate,
+          onError,
+          retry: false,
+        }),
+      { wrapper },
+    );
+
+    let thrown: unknown;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ id: "widget-1", name: "Broken" });
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(queryClient.getQueryData(["widgets"])).toEqual(previousData);
+    expect(optimisticUpdate).toHaveBeenCalledWith({ id: "widget-1", name: "Broken" });
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      { id: "widget-1", name: "Broken" },
+      { previousData },
+      expect.objectContaining({ client: expect.any(Object) }),
+    );
+  });
+});

--- a/src/hooks/useArtistMutations.ts
+++ b/src/hooks/useArtistMutations.ts
@@ -1,15 +1,24 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/hooks/use-toast";
-
+import type { Database } from "@/integrations/supabase/types";
 
 import { queryKeys } from "@/lib/react-query";
-// Helper function to format artist time data
-const formatArtistTimeData = (artistData: any) => {
-  const formattedData = { ...artistData };
-  const timeFields = ['show_start', 'show_end', 'soundcheck_start', 'soundcheck_end'];
 
-  timeFields.forEach(field => {
+type FestivalArtistInsert = Database["public"]["Tables"]["festival_artists"]["Insert"];
+type FestivalArtistUpdate = Database["public"]["Tables"]["festival_artists"]["Update"];
+type FestivalArtistUpdatePayload = FestivalArtistUpdate & { id: string };
+type ArtistTimeField = "show_start" | "show_end" | "soundcheck_start" | "soundcheck_end";
+type ArtistTimePayload = (FestivalArtistInsert | FestivalArtistUpdate) &
+  Partial<Record<ArtistTimeField, string | null>>;
+
+const artistTimeFields: ArtistTimeField[] = ["show_start", "show_end", "soundcheck_start", "soundcheck_end"];
+
+// Helper function to format artist time data
+const formatArtistTimeData = <T extends ArtistTimePayload>(artistData: T): T => {
+  const formattedData = { ...artistData };
+
+  artistTimeFields.forEach(field => {
     if (formattedData[field] === '') {
       formattedData[field] = null;
     }
@@ -17,12 +26,21 @@ const formatArtistTimeData = (artistData: any) => {
   return formattedData;
 };
 
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return "Unknown error";
+};
+
 export const useArtistMutations = (jobId: string | undefined, selectedDate: string) => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
   const createArtistMutation = useMutation({
-    mutationFn: async (artistData: any) => {
+    mutationFn: async (artistData: FestivalArtistInsert) => {
       const dataToInsert = formatArtistTimeData({ ...artistData, job_id: jobId });
       const { data, error } = await supabase
         .from("festival_artists")
@@ -40,18 +58,18 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
         description: "Artist created successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       console.error("Error creating artist:", error);
       toast({
         title: "Error",
-        description: "Could not create artist: " + error.message,
+        description: "Could not create artist: " + getErrorMessage(error),
         variant: "destructive",
       });
     }
   });
 
   const updateArtistMutation = useMutation({
-    mutationFn: async ({ id, ...updateData }: any) => {
+    mutationFn: async ({ id, ...updateData }: FestivalArtistUpdatePayload) => {
       const dataToUpdate = formatArtistTimeData(updateData);
       const { data, error } = await supabase
         .from("festival_artists")
@@ -70,11 +88,11 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
         description: "Artist updated successfully",
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       console.error("Error updating artist:", error);
       toast({
         title: "Error",
-        description: "Could not update artist: " + error.message,
+        description: "Could not update artist: " + getErrorMessage(error),
         variant: "destructive",
       });
     }

--- a/src/hooks/useEntityQueries.ts
+++ b/src/hooks/useEntityQueries.ts
@@ -3,6 +3,11 @@ import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from "@tan
 import { queryKeys, queryClient } from "@/lib/react-query";
 import { ApiService } from "@/lib/api-service";
 
+type EntityMutationVariables = {
+  id?: string | number;
+  isDelete?: boolean;
+} & Record<string, unknown>;
+
 // Create custom hooks for specific data types with appropriate overrides
 export const useEntityQuery = <T>(
   entityType: string,
@@ -21,7 +26,7 @@ export const useEntityQuery = <T>(
 // Create a hook for entity list queries
 export const useEntityListQuery = <T>(
   entityType: string,
-  filters?: Record<string, any>,
+  filters?: Record<string, unknown>,
   options?: UseQueryOptions<T[]>
 ) => {
   const apiService = ApiService.getInstance();
@@ -46,7 +51,7 @@ interface MutationContext<T> {
 }
 
 // Create a hook for entity mutations with optimistic updates
-export const useEntityMutation = <T, TVariables extends object>(
+export const useEntityMutation = <T, TVariables extends EntityMutationVariables>(
   entityType: string,
   options?: UseMutationOptions<T, Error, TVariables, MutationContext<T>> & {
     optimisticUpdate?: (variables: TVariables) => void;
@@ -54,52 +59,53 @@ export const useEntityMutation = <T, TVariables extends object>(
   }
 ) => {
   const apiService = ApiService.getInstance();
+  const { optimisticUpdate, onSuccessInvalidation, ...mutationOptions } = options ?? {};
   
   return useMutation({
+    ...mutationOptions,
     mutationFn: (variables: TVariables) => {
       const isCreate = !('id' in variables);
-      const isDelete = 'isDelete' in variables && (variables as any).isDelete;
+      const isDelete = variables.isDelete === true;
       
       if (isDelete) {
-        const id = (variables as any).id;
+        const id = variables.id;
         return apiService.delete<T>(`/api/${entityType}/${id}`);
       } else if (isCreate) {
         return apiService.post<T>(`/api/${entityType}`, variables);
       } else {
-        const id = (variables as any).id;
+        const id = variables.id;
         return apiService.put<T>(`/api/${entityType}/${id}`, variables);
       }
     },
-    onMutate: async (variables): Promise<MutationContext<T>> => {
-      if (options?.optimisticUpdate) {
+    onMutate: async (variables, mutationContext): Promise<MutationContext<T>> => {
+      const optionContext = (await mutationOptions.onMutate?.(variables, mutationContext)) ?? {};
+      if (optimisticUpdate) {
         await queryClient.cancelQueries({ queryKey: queryKeys.custom(entityType) });
         
         // Get the current data and type cast it
         const previousData = queryClient.getQueryData<T>([entityType]);
         
         // Perform optimistic update
-        options.optimisticUpdate(variables);
+        optimisticUpdate(variables);
         
         // Return typed context
-        return { previousData };
+        return { ...optionContext, previousData };
       }
-      return {};
+      return optionContext ?? {};
     },
-    onError: (err, variables, context) => {
+    onError: (err, variables, context, mutationContext) => {
       // If we have previous data, roll back to it
       if (context?.previousData) {
         queryClient.setQueryData([entityType], context.previousData);
       }
       
       // Call the original onError if it exists
-      if (options?.onError) {
-        (options.onError as any)(err, variables, context);
-      }
+      mutationOptions.onError?.(err, variables, context, mutationContext);
     },
-    onSuccess: (data, variables, context) => {
+    onSuccess: (data, variables, context, mutationContext) => {
       // Invalidate relevant queries
-      if (options?.onSuccessInvalidation) {
-        options.onSuccessInvalidation.forEach(key => {
+      if (onSuccessInvalidation) {
+        onSuccessInvalidation.forEach(key => {
           queryClient.invalidateQueries({ queryKey: queryKeys.custom(key) });
         });
       } else {
@@ -108,10 +114,7 @@ export const useEntityMutation = <T, TVariables extends object>(
       }
       
       // Call the original onSuccess if it exists
-      if (options?.onSuccess) {
-        (options.onSuccess as any)(data, variables, context);
-      }
+      mutationOptions.onSuccess?.(data, variables, context, mutationContext);
     },
-    ...options,
   });
 };

--- a/src/lib/api-service.ts
+++ b/src/lib/api-service.ts
@@ -31,7 +31,7 @@ export class ApiService {
     }
   }
   
-  async post<T>(url: string, data: any): Promise<T> {
+  async post<T>(url: string, data: unknown): Promise<T> {
     try {
       const response = await fetch(url, {
         method: 'POST',
@@ -52,7 +52,7 @@ export class ApiService {
     }
   }
   
-  async put<T>(url: string, data: any): Promise<T> {
+  async put<T>(url: string, data: unknown): Promise<T> {
     try {
       const response = await fetch(url, {
         method: 'PUT',

--- a/src/types/tourScheduling.ts
+++ b/src/types/tourScheduling.ts
@@ -6,6 +6,11 @@
  * for tour settings, schedules, contacts, and itinerary data.
  */
 
+import type { Database, Json } from "@/integrations/supabase/types";
+
+type PublicTableRow<TableName extends keyof Database["public"]["Tables"]> =
+  Database["public"]["Tables"][TableName]["Row"];
+
 // ============================================================================
 // TOUR SETTINGS TYPES
 // ============================================================================
@@ -64,7 +69,7 @@ export interface TravelSegment {
     bus_company?: string;
     vehicle_registration?: string;
     seats?: number;
-    [key: string]: any;
+    [key: string]: Json | undefined;
   };
 }
 
@@ -288,7 +293,7 @@ export interface TimelineEventMetadata {
   // General
   color?: string;
   icon?: string;
-  [key: string]: any;
+  [key: string]: Json | undefined;
 }
 
 // ============================================================================
@@ -323,11 +328,11 @@ export interface DefaultTiming {
 // ============================================================================
 
 export interface CompleteTourDateInfo {
-  tour_date: any; // from tour_dates table
-  hoja_de_ruta: any; // from hoja_de_ruta table
-  accommodation: any | null; // from tour_accommodations table
-  travel_from: any[] | null; // from tour_travel_segments table
-  travel_to: any[] | null; // from tour_travel_segments table
+  tour_date: PublicTableRow<"tour_dates">;
+  hoja_de_ruta: PublicTableRow<"hoja_de_ruta"> | null;
+  accommodation: PublicTableRow<"tour_accommodations"> | null;
+  travel_from: PublicTableRow<"tour_travel_segments">[] | null;
+  travel_to: PublicTableRow<"tour_travel_segments">[] | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- remove explicit any usage from entity query helpers, API service payloads, tour scheduling types, and artist mutations
- preserve entity mutation rollback/invalidation callbacks by preventing options from overwriting wrapper handlers
- add focused regression tests for entity query/mutation behavior and artist time-field normalization/error toasts

## Any debt
- explicit any baseline: 1733 -> 1713 (-20)
- touched source files now report 0 explicit any warnings

## Validation
- npm run typecheck
- npx vitest run src/hooks/__tests__/useEntityQueries.test.tsx src/hooks/__tests__/useArtistMutations.test.tsx
- npx eslint src/hooks/useEntityQueries.ts src/lib/api-service.ts src/types/tourScheduling.ts src/hooks/useArtistMutations.ts src/hooks/__tests__/useEntityQueries.test.tsx src/hooks/__tests__/useArtistMutations.test.tsx
- npm run lint
- npm run test:run
- npm run build

No Supabase migrations.