### PR TITLE
[codex] reduce tour hook any debt

### DIFF
--- a/src/hooks/__tests__/useTourDateFlexFolders.test.tsx
+++ b/src/hooks/__tests__/useTourDateFlexFolders.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import React from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestQueryClient } from "@/test/createTestQueryClient";
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+const { createAllFoldersForJobMock, toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  createAllFoldersForJobMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/utils/flex-folders/folders", () => ({
+  createAllFoldersForJob: createAllFoldersForJobMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  },
+}));
+
+import { useTourDateFlexFolders } from "@/hooks/useTourDateFlexFolders";
+
+const createWrapper = () => {
+  const queryClient = createTestQueryClient();
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useTourDateFlexFolders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    createAllFoldersForJobMock.mockResolvedValue(undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  it("creates Flex folders for a tour date and marks the linked job as created", async () => {
+    const job = {
+      id: "job-1",
+      title: "Tour Stop",
+      start_time: "2026-07-05T08:30:00.000Z",
+      end_time: "2026-07-05T23:00:00.000Z",
+      job_type: "tourdate",
+    };
+    const jobQuery = createMockQueryBuilder({ data: job, error: null });
+    const updateQuery = createMockQueryBuilder({ data: null, error: null });
+    const builders = [jobQuery, updateQuery];
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "jobs") {
+        return builders.shift() ?? createMockQueryBuilder({ data: null, error: null });
+      }
+      return createMockQueryBuilder();
+    });
+
+    const { result } = renderHook(() => useTourDateFlexFolders("tour-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.createIndividualFolders({ id: "tour-date-1", date: "2026-07-05" });
+    });
+
+    expect(createAllFoldersForJobMock).toHaveBeenCalledWith(
+      job,
+      "2026-07-05T08:30:00.000Z",
+      "2026-07-05T23:00:00.000Z",
+      "260705",
+    );
+    expect(updateQuery.update).toHaveBeenCalledWith({ flex_folders_created: true });
+    expect(updateQuery.eq).toHaveBeenCalledWith("id", "job-1");
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith("push", {
+      body: { action: "broadcast", type: "flex.folders.created", job_id: "job-1" },
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith(expect.stringContaining("Flex folders created successfully"));
+  });
+
+  it("surfaces missing-job errors through the Sonner error toast", async () => {
+    const jobQuery = createMockQueryBuilder({ data: null, error: null });
+    mockSupabase.from.mockReturnValue(jobQuery);
+
+    const { result } = renderHook(() => useTourDateFlexFolders("tour-1"), {
+      wrapper: createWrapper(),
+    });
+
+    let thrown: unknown;
+    await act(async () => {
+      try {
+        await result.current.createIndividualFolders({ id: "missing-date", date: "2026-07-05" });
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    expect(thrown).toBeInstanceOf(Error);
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to create Flex folders: No job found for tour date missing-date",
+      );
+    });
+  });
+});

--- a/src/hooks/__tests__/useTourDateFlexFolders.test.tsx
+++ b/src/hooks/__tests__/useTourDateFlexFolders.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import React from "react";
+import type { ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -33,7 +33,7 @@ import { useTourDateFlexFolders } from "@/hooks/useTourDateFlexFolders";
 const createWrapper = () => {
   const queryClient = createTestQueryClient();
 
-  return ({ children }: { children: React.ReactNode }) => (
+  return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 };

--- a/src/hooks/__tests__/useTourOverrideMode.test.tsx
+++ b/src/hooks/__tests__/useTourOverrideMode.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+const { toastMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+import { useTourOverrideMode } from "@/hooks/useTourOverrideMode";
+
+describe("useTourOverrideMode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("loads resolved defaults, joined location data, and existing overrides", async () => {
+    const defaultSet = {
+      id: "set-1",
+      tour_id: "tour-1",
+      department: "sound",
+      name: "Sound M",
+      package_size: "m",
+    };
+    const defaultTable = {
+      id: "table-1",
+      set_id: "set-1",
+      table_name: "Main power",
+      table_type: "power",
+      total_value: 1200,
+      table_data: {
+        rows: [{ quantity: "1", componentId: "amp-1", watts: "1200", weight: "0" }],
+      },
+      metadata: null as null,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    };
+    const powerOverride = {
+      id: "power-1",
+      tour_date_id: "tour-date-1",
+      department: "sound",
+      table_name: "Override power",
+      pdu_type: "CEE",
+      total_watts: 900,
+      current_per_phase: 4.1,
+    };
+    const weightOverride = {
+      id: "weight-1",
+      tour_date_id: "tour-date-1",
+      department: "sound",
+      item_name: "Cases",
+      weight_kg: 42,
+    };
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "tours") {
+        return createMockQueryBuilder({ data: { name: "Summer Tour" }, error: null });
+      }
+      if (table === "tour_dates") {
+        return createMockQueryBuilder({
+          data: {
+            date: "2026-07-05",
+            tour_id: "tour-1",
+            is_tour_pack_only: false,
+            sound_package_size: "m",
+            sound_default_set_id: null,
+            lights_package_size: null,
+            lights_default_set_id: null,
+            video_package_size: null,
+            video_default_set_id: null,
+            locations: [{ name: "Madrid" }],
+          },
+          error: null,
+        });
+      }
+      if (table === "tour_default_sets") {
+        return createMockQueryBuilder({ data: [defaultSet], error: null });
+      }
+      if (table === "tour_default_tables") {
+        return createMockQueryBuilder({ data: [defaultTable], error: null });
+      }
+      if (table === "tour_date_power_overrides") {
+        return createMockQueryBuilder({ data: [powerOverride], error: null });
+      }
+      if (table === "tour_date_weight_overrides") {
+        return createMockQueryBuilder({ data: [weightOverride], error: null });
+      }
+      return createMockQueryBuilder();
+    });
+
+    const { result } = renderHook(() => useTourOverrideMode("tour-1", "tour-date-1", "sound"));
+
+    await waitFor(() => {
+      expect(result.current.overrideData?.locationName).toBe("Madrid");
+    });
+
+    expect(result.current.overrideData).toMatchObject({
+      tourId: "tour-1",
+      tourDateId: "tour-date-1",
+      tourName: "Summer Tour",
+      tourDate: "2026-07-05",
+    });
+    expect(result.current.overrideData?.defaults).toHaveLength(1);
+    expect(result.current.overrideData?.defaults[0].table_data.rows?.[0].watts).toBe("1200");
+    expect(result.current.overrideData?.overrides).toEqual([powerOverride, weightOverride]);
+    expect(result.current.overrideData?.defaultSetResolution?.status).toBe("resolved");
+  });
+
+  it("saves weight overrides with tour date and department context", async () => {
+    const insertBuilder = createMockQueryBuilder({ data: null, error: null });
+    const weightBuilders = [
+      createMockQueryBuilder({ data: [], error: null }),
+      insertBuilder,
+    ];
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "tours") {
+        return createMockQueryBuilder({ data: { name: "Summer Tour" }, error: null });
+      }
+      if (table === "tour_dates") {
+        return createMockQueryBuilder({
+          data: {
+            date: "2026-07-05",
+            tour_id: "tour-1",
+            is_tour_pack_only: false,
+            video_package_size: null,
+            video_default_set_id: null,
+            locations: { name: "Madrid" },
+          },
+          error: null,
+        });
+      }
+      if (table === "tour_default_sets") {
+        return createMockQueryBuilder({ data: [], error: null });
+      }
+      if (table === "tour_date_power_overrides") {
+        return createMockQueryBuilder({ data: [], error: null });
+      }
+      if (table === "tour_date_weight_overrides") {
+        return weightBuilders.shift() ?? createMockQueryBuilder({ data: [], error: null });
+      }
+      return createMockQueryBuilder();
+    });
+
+    const { result } = renderHook(() => useTourOverrideMode("tour-1", "tour-date-1", "video"));
+
+    await waitFor(() => {
+      expect(result.current.overrideData?.locationName).toBe("Madrid");
+    });
+
+    await result.current.saveOverride("weight", {
+      item_name: "Cases",
+      weight_kg: 42,
+      override_data: { rows: [{ quantity: "1", componentId: "case-1", weight: "42" }] },
+    });
+
+    expect(insertBuilder.insert).toHaveBeenCalledWith({
+      tour_date_id: "tour-date-1",
+      department: "video",
+      item_name: "Cases",
+      weight_kg: 42,
+      override_data: { rows: [{ quantity: "1", componentId: "case-1", weight: "42" }] },
+    });
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "Success",
+      description: "Override saved successfully",
+    });
+  });
+});

--- a/src/hooks/__tests__/useTourOverrideMode.test.tsx
+++ b/src/hooks/__tests__/useTourOverrideMode.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import React from "react";
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/src/hooks/__tests__/useTourOverrideMode.test.tsx
+++ b/src/hooks/__tests__/useTourOverrideMode.test.tsx
@@ -177,4 +177,71 @@ describe("useTourOverrideMode", () => {
       description: "Override saved successfully",
     });
   });
+
+  it("saves power overrides with hook context taking precedence over payload keys", async () => {
+    const insertBuilder = createMockQueryBuilder({ data: null, error: null });
+    const powerBuilders = [
+      createMockQueryBuilder({ data: [], error: null }),
+      insertBuilder,
+    ];
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "tours") {
+        return createMockQueryBuilder({ data: { name: "Summer Tour" }, error: null });
+      }
+      if (table === "tour_dates") {
+        return createMockQueryBuilder({
+          data: {
+            date: "2026-07-05",
+            tour_id: "tour-1",
+            is_tour_pack_only: false,
+            sound_package_size: null,
+            sound_default_set_id: null,
+            locations: { name: "Madrid" },
+          },
+          error: null,
+        });
+      }
+      if (table === "tour_default_sets") {
+        return createMockQueryBuilder({ data: [], error: null });
+      }
+      if (table === "tour_date_power_overrides") {
+        return powerBuilders.shift() ?? createMockQueryBuilder({ data: [], error: null });
+      }
+      if (table === "tour_date_weight_overrides") {
+        return createMockQueryBuilder({ data: [], error: null });
+      }
+      return createMockQueryBuilder();
+    });
+
+    const { result } = renderHook(() => useTourOverrideMode("tour-1", "tour-date-1", "sound"));
+
+    await waitFor(() => {
+      expect(result.current.overrideData?.locationName).toBe("Madrid");
+    });
+
+    const payloadWithConflictingContext = {
+      table_name: "Main power",
+      total_watts: 1200,
+      current_per_phase: 5.2,
+      pdu_type: "CEE",
+      tour_date_id: "wrong-date",
+      department: "lights",
+    };
+
+    await result.current.saveOverride("power", payloadWithConflictingContext);
+
+    expect(insertBuilder.insert).toHaveBeenCalledWith({
+      table_name: "Main power",
+      total_watts: 1200,
+      current_per_phase: 5.2,
+      pdu_type: "CEE",
+      tour_date_id: "tour-date-1",
+      department: "sound",
+    });
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "Success",
+      description: "Override saved successfully",
+    });
+  });
 });

--- a/src/hooks/useTourDateFlexFolders.ts
+++ b/src/hooks/useTourDateFlexFolders.ts
@@ -4,16 +4,39 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import { createAllFoldersForJob } from "@/utils/flex-folders/folders";
 import { toast } from "sonner";
-
+import type { Database } from "@/integrations/supabase/types";
+import type { FlexFolderJob } from "@/utils/flex-folders/folder-creation/types";
 
 import { queryKeys } from "@/lib/react-query";
+
+type JobRow = Database["public"]["Tables"]["jobs"]["Row"];
+type TourDateRow = Database["public"]["Tables"]["tour_dates"]["Row"];
+type TourDateFolderInput = Pick<TourDateRow, "id" | "date">;
+type JobFolderStatusRow = Pick<JobRow, "flex_folders_created">;
+type FolderCreationResult = {
+  job: FlexFolderJob;
+  tourDate: TourDateFolderInput;
+};
+type FolderBatchResult =
+  | { tourDate: TourDateFolderInput; success: true }
+  | { tourDate: TourDateFolderInput; success: false; error: unknown };
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return "Unknown error";
+};
+
 export const useTourDateFlexFolders = (tourId: string) => {
   const [creatingAll, setCreatingAll] = useState(false);
   const [creatingIndividual, setCreatingIndividual] = useState<Set<string>>(new Set());
   const queryClient = useQueryClient();
 
   const createFoldersForTourDate = useMutation({
-    mutationFn: async (tourDate: any) => {
+    mutationFn: async (tourDate: TourDateFolderInput): Promise<FolderCreationResult> => {
       console.log('Creating Flex folders for tour date:', tourDate);
       
       const { data: job, error: jobError } = await supabase
@@ -65,18 +88,18 @@ export const useTourDateFlexFolders = (tourId: string) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('jobs') });
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('tour-dates', tourId) });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       console.error('Error creating Flex folders:', error);
-      toast.error(`Failed to create Flex folders: ${error.message}`);
+      toast.error(`Failed to create Flex folders: ${getErrorMessage(error)}`);
     }
   });
 
   const createFoldersForAllTourDates = useMutation({
-    mutationFn: async (tourDates: any[]) => {
+    mutationFn: async (tourDates: TourDateFolderInput[]) => {
       console.log('Creating Flex folders for all tour dates:', tourDates.length);
       setCreatingAll(true);
       
-      const results = [];
+      const results: FolderBatchResult[] = [];
       let successCount = 0;
       let errorCount = 0;
 
@@ -88,7 +111,8 @@ export const useTourDateFlexFolders = (tourId: string) => {
             .eq('tour_date_id', tourDate.id)
             .single();
 
-          if (job?.flex_folders_created) {
+          const folderStatus = job as JobFolderStatusRow | null;
+          if (folderStatus?.flex_folders_created) {
             console.log(`Skipping ${tourDate.id} - folders already exist`);
             continue;
           }
@@ -124,14 +148,14 @@ export const useTourDateFlexFolders = (tourId: string) => {
         toast.error(`Failed to create folders for ${data.errorCount} tour dates`);
       }
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       setCreatingAll(false);
       console.error('Error creating all Flex folders:', error);
-      toast.error(`Failed to create Flex folders: ${error.message}`);
+      toast.error(`Failed to create Flex folders: ${getErrorMessage(error)}`);
     }
   });
 
-  const createIndividualFolders = async (tourDate: any) => {
+  const createIndividualFolders = async (tourDate: TourDateFolderInput) => {
     // Prevent multiple clicks for the same tour date
     if (creatingIndividual.has(tourDate.id)) {
       console.log('Folder creation already in progress for tour date:', tourDate.id);
@@ -150,7 +174,7 @@ export const useTourDateFlexFolders = (tourId: string) => {
     }
   };
 
-  const createAllFolders = async (tourDates: any[]) => {
+  const createAllFolders = async (tourDates: TourDateFolderInput[]) => {
     if (creatingAll) {
       console.log('Bulk folder creation already in progress');
       return;

--- a/src/hooks/useTourOverrideMode.ts
+++ b/src/hooks/useTourOverrideMode.ts
@@ -36,7 +36,14 @@ type PowerOverrideRow = Database['public']['Tables']['tour_date_power_overrides'
 type WeightOverrideRow = Database['public']['Tables']['tour_date_weight_overrides']['Row'];
 type PowerOverrideInsert = Database['public']['Tables']['tour_date_power_overrides']['Insert'];
 type WeightOverrideInsert = Database['public']['Tables']['tour_date_weight_overrides']['Insert'];
-type OverrideInput = Record<string, unknown>;
+type OverrideContextKey = 'tour_date_id' | 'department';
+type OverrideSnapshotKey = 'override_data';
+type OverrideInputPayload<TInsert> = Omit<TInsert, OverrideContextKey | OverrideSnapshotKey> & {
+  override_data?: unknown;
+};
+type PowerOverrideInput = OverrideInputPayload<PowerOverrideInsert>;
+type WeightOverrideInput = OverrideInputPayload<WeightOverrideInsert>;
+type OverrideInput = PowerOverrideInput | WeightOverrideInput;
 type TourOverrideRow = PowerOverrideRow | WeightOverrideRow;
 type LocationJoin =
   | { name?: string | null }
@@ -195,10 +202,18 @@ export const useTourOverrideMode = (
     loadOverrideData();
   }, [tourId, tourDateId, department, isOverrideMode, toast]);
 
-  const saveOverride = async (
+  async function saveOverride(
+    type: 'power',
+    overrideData: PowerOverrideInput
+  ): Promise<boolean | undefined>;
+  async function saveOverride(
+    type: 'weight',
+    overrideData: WeightOverrideInput
+  ): Promise<boolean | undefined>;
+  async function saveOverride(
     type: 'power' | 'weight',
     overrideData: OverrideInput
-  ) => {
+  ): Promise<boolean | undefined> {
     if (!tourDateId || !department) return;
 
     try {
@@ -206,16 +221,16 @@ export const useTourOverrideMode = (
         ? await supabase
           .from('tour_date_power_overrides')
           .insert({
+            ...(overrideData as PowerOverrideInput),
             tour_date_id: tourDateId,
-            department,
-            ...overrideData
+            department
           } as PowerOverrideInsert)
         : await supabase
           .from('tour_date_weight_overrides')
           .insert({
+            ...(overrideData as WeightOverrideInput),
             tour_date_id: tourDateId,
-            department,
-            ...overrideData
+            department
           } as WeightOverrideInsert);
 
       if (result.error) throw result.error;
@@ -235,7 +250,7 @@ export const useTourOverrideMode = (
       });
       return false;
     }
-  };
+  }
 
   return {
     isOverrideMode,

--- a/src/hooks/useTourOverrideMode.ts
+++ b/src/hooks/useTourOverrideMode.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/lib/supabase';
 import { useToast } from '@/hooks/use-toast';
+import type { Database } from '@/integrations/supabase/types';
 import {
   getPackageResolutionMessage,
   isPackageDepartment,
@@ -11,16 +12,58 @@ import {
   type TourPackageDateLike,
 } from '@/utils/tourPackages';
 
+type TourDefaultTableRow = Database['public']['Tables']['tour_default_tables']['Row'];
+type TourDefaultTableData = {
+  rows?: Array<{
+    quantity: string;
+    componentId: string;
+    watts: string;
+    weight: string;
+    componentName?: string;
+    lineName?: string;
+    totalWatts?: number;
+    totalWeight?: number;
+    pf?: string;
+    fixtureType?: string;
+    [key: string]: unknown;
+  }>;
+  [key: string]: unknown;
+};
+type TourDefaultTableWithData = Omit<TourDefaultTableRow, 'table_data'> & {
+  table_data: TourDefaultTableData;
+};
+type PowerOverrideRow = Database['public']['Tables']['tour_date_power_overrides']['Row'];
+type WeightOverrideRow = Database['public']['Tables']['tour_date_weight_overrides']['Row'];
+type PowerOverrideInsert = Database['public']['Tables']['tour_date_power_overrides']['Insert'];
+type WeightOverrideInsert = Database['public']['Tables']['tour_date_weight_overrides']['Insert'];
+type OverrideInput = Record<string, unknown>;
+type TourOverrideRow = PowerOverrideRow | WeightOverrideRow;
+type LocationJoin =
+  | { name?: string | null }
+  | Array<{ name?: string | null }>
+  | null
+  | undefined;
+
+type TourDateWithLocation = TourPackageDateLike & {
+  date: string;
+  locations?: LocationJoin;
+};
+
 interface TourOverrideData {
   tourId: string;
   tourDateId: string;
   tourName: string;
   tourDate: string;
   locationName: string;
-  defaults: any[];
-  overrides: any[];
+  defaults: TourDefaultTableWithData[];
+  overrides: TourOverrideRow[];
   defaultSetResolution?: ResolveDefaultSetResult<TourDefaultSetLike>;
 }
+
+const getLocationName = (locations: LocationJoin): string => {
+  const location = Array.isArray(locations) ? locations[0] : locations;
+  return location?.name || 'Unknown Location';
+};
 
 export const useTourOverrideMode = (
   tourId?: string,
@@ -67,7 +110,8 @@ export const useTourOverrideMode = (
 
         if (tourDateError) throw tourDateError;
 
-        let defaultTables: any[] = [];
+        const tourDate = tourDateData as TourDateWithLocation;
+        let defaultTables: TourDefaultTableWithData[] = [];
         let defaultSetResolution: ResolveDefaultSetResult<TourDefaultSetLike> | undefined;
 
         if (isPackageDepartment(department)) {
@@ -80,7 +124,7 @@ export const useTourOverrideMode = (
           if (setsError) throw setsError;
 
           defaultSetResolution = resolveDefaultSetForTourDate({
-            tourDate: tourDateData as TourPackageDateLike,
+            tourDate,
             department,
             defaultSets: (defaultSets || []) as TourDefaultSetLike[],
           });
@@ -92,7 +136,7 @@ export const useTourOverrideMode = (
               .eq('set_id', defaultSetResolution.set.id);
 
             if (defaultsError) throw defaultsError;
-            defaultTables = data || [];
+            defaultTables = (data || []) as TourDefaultTableWithData[];
           } else {
             const message = getPackageResolutionMessage(defaultSetResolution);
             if (message) {
@@ -127,12 +171,12 @@ export const useTourOverrideMode = (
           tourId,
           tourDateId,
           tourName: tourData.name,
-          tourDate: tourDateData.date,
-          locationName: (tourDateData.locations as any)?.name || 'Unknown Location',
+          tourDate: tourDate.date,
+          locationName: getLocationName(tourDate.locations),
           defaults: defaultTables,
           overrides: [
-            ...(powerOverrides.data || []),
-            ...(weightOverrides.data || [])
+            ...((powerOverrides.data || []) as PowerOverrideRow[]),
+            ...((weightOverrides.data || []) as WeightOverrideRow[])
           ],
           defaultSetResolution,
         });
@@ -153,24 +197,28 @@ export const useTourOverrideMode = (
 
   const saveOverride = async (
     type: 'power' | 'weight',
-    overrideData: any
+    overrideData: OverrideInput
   ) => {
     if (!tourDateId || !department) return;
 
     try {
-      const tableName = type === 'power' 
-        ? 'tour_date_power_overrides' 
-        : 'tour_date_weight_overrides';
+      const result = type === 'power'
+        ? await supabase
+          .from('tour_date_power_overrides')
+          .insert({
+            tour_date_id: tourDateId,
+            department,
+            ...overrideData
+          } as PowerOverrideInsert)
+        : await supabase
+          .from('tour_date_weight_overrides')
+          .insert({
+            tour_date_id: tourDateId,
+            department,
+            ...overrideData
+          } as WeightOverrideInsert);
 
-      const { error } = await supabase
-        .from(tableName)
-        .insert({
-          tour_date_id: tourDateId,
-          department,
-          ...overrideData
-        });
-
-      if (error) throw error;
+      if (result.error) throw result.error;
 
       toast({
         title: 'Success',


### PR DESCRIPTION
## Summary
- remove explicit `any` usage from tour date Flex folder creation and tour override mode
- use generated Supabase table types for tour defaults, overrides, jobs, and tour date inputs
- add regression coverage for Flex folder creation and override loading/saving behavior
- harden tour override saves so hook-owned tour date and department context wins over payload keys

## Any debt
- explicit `any` warnings: 1713 -> 1702 (-11)
- touched source hooks now have 0 explicit `any` warnings

## Risk
Low. This is a typed refactor around existing hook behavior, with one data-integrity hardening fix in `saveOverride` and regression tests for both insert branches.

## Impact
- Users: no UI flow changes expected
- Data: tour override inserts keep the hook-resolved `tour_date_id` and `department` even if a payload contains conflicting keys
- Type debt: reduces the explicit `any` backlog without adding new warnings

## Rollback
Revert this PR/merge commit. No database changes or production data migration are involved.

## Migration status
No Supabase migrations.