### PR TITLE
[codex] allow technical document upload formats

### DIFF
--- a/src/components/festival/ArtistRequirementsForm.tsx
+++ b/src/components/festival/ArtistRequirementsForm.tsx
@@ -19,11 +19,11 @@ import { ArtistSectionProps } from "@/types/artist-form";
 import { Download, Eye, FileText, Loader2, Printer, Trash2 } from "lucide-react";
 import { normalizeWirelessSystem, normalizeWirelessSystems } from "@/lib/wirelessSystemNormalizer";
 import { mapFestivalGearSetup } from "@/utils/festivalGearMappers";
+import { DOCUMENT_UPLOAD_ACCEPT } from "@/utils/documentUploadValidation";
 
 interface ArtistRequirementsFormProps {
   isBlank?: boolean;
 }
-
 interface PublicFormContextResponse {
   ok: boolean;
   error?: string;
@@ -1012,12 +1012,12 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
 
                     <div className="space-y-2">
                       <label htmlFor="public-rider-upload" className="text-sm font-medium">
-                        {tx("Subir rider(s) (PDF, Word o imagen)", "Upload rider file(s) (PDF, Word, or image)")}
+                        {tx("Subir rider(s) (PDF, Word, imagen, SoundVision o CAD)", "Upload rider file(s) (PDF, Word, image, SoundVision, or CAD)")}
                       </label>
                       <Input
                         id="public-rider-upload"
                         type="file"
-                        accept=".pdf,.doc,.docx,.txt,.png,.jpg,.jpeg,.webp"
+                        accept={DOCUMENT_UPLOAD_ACCEPT}
                         multiple
                         onChange={handleRiderUpload}
                         disabled={isUploadingRider}

--- a/src/lib/enhanced-security-config.ts
+++ b/src/lib/enhanced-security-config.ts
@@ -71,6 +71,49 @@ const SENSITIVE_PATTERNS = [
   /api.?key/i,
 ];
 
+const DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS = new Set([
+  'pdf',
+  'doc',
+  'docx',
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+  'txt',
+  'xmlp',
+  'xmlc',
+  'xmls',
+  'dwg',
+  'dfx',
+  'dxf',
+]);
+
+const DOCUMENT_UPLOAD_ALLOWED_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'text/plain',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/xml',
+  'text/xml',
+  'application/octet-stream',
+  'application/acad',
+  'application/x-acad',
+  'application/autocad_dwg',
+  'application/dwg',
+  'application/x-dwg',
+  'image/vnd.dwg',
+  'application/dxf',
+  'application/x-dxf',
+  'application/vnd.dxf',
+  'image/vnd.dxf',
+  'drawing/x-dxf',
+]);
+
 /**
  * Enhanced input sanitization with XSS protection
  */
@@ -181,19 +224,14 @@ export function validateFileUpload(file: File): {
   if (nameParts.length > 2) {
     errors.push('El nombre del archivo no puede contener múltiples extensiones');
   }
-  
-  // Allowed file types
-  const allowedTypes = [
-    'application/pdf',
-    'image/jpeg',
-    'image/png',
-    'image/gif',
-    'text/plain',
-    'application/msword',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  ];
-  
-  if (!allowedTypes.includes(file.type)) {
+
+  const extension = nameParts.length > 1 ? nameParts[nameParts.length - 1].toLowerCase() : '';
+  if (!extension || !DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS.has(extension)) {
+    errors.push('Tipo de archivo no permitido');
+  }
+
+  const mimeType = file.type.toLowerCase();
+  if (mimeType && !DOCUMENT_UPLOAD_ALLOWED_MIME_TYPES.has(mimeType)) {
     errors.push('Tipo de archivo no permitido');
   }
   

--- a/src/utils/__tests__/documentUploadValidation.test.ts
+++ b/src/utils/__tests__/documentUploadValidation.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import {
+  DOCUMENT_UPLOAD_ACCEPT,
+  getDocumentUploadValidationError,
+} from "@/utils/documentUploadValidation";
+import {
+  ALLOWED_FILE_TYPES as SOUNDVISION_ALLOWED_FILE_TYPES,
+  validateFile as validateSoundVisionFile,
+} from "@/utils/soundvisionFileValidation";
+
+const createFile = (name: string, type = "") =>
+  new File(["technical file"], name, { type });
+
+describe("document upload validation", () => {
+  const technicalExtensions = [".xmlp", ".xmlc", ".xmls", ".dwg", ".dfx", ".dxf"];
+
+  it("exposes technical and CAD formats in the shared accept string", () => {
+    for (const extension of technicalExtensions) {
+      expect(DOCUMENT_UPLOAD_ACCEPT.split(",")).toContain(extension);
+    }
+  });
+
+  it("accepts SoundVision and CAD files through the shared document validator", () => {
+    const files = [
+      createFile("project.xmlp", "application/xml"),
+      createFile("config.xmlc", "text/xml"),
+      createFile("scene.xmls"),
+      createFile("plot.dwg", "application/octet-stream"),
+      createFile("legacy.dfx"),
+      createFile("cad-export.dxf", "application/dxf"),
+      createFile("stage-plot.webp", "image/webp"),
+    ];
+
+    expect(getDocumentUploadValidationError(files)).toBeNull();
+  });
+
+  it("still rejects unsupported extensions", () => {
+    expect(getDocumentUploadValidationError([createFile("payload.exe", "application/octet-stream")]))
+      .toContain("Tipo de archivo no permitido");
+  });
+});
+
+describe("SoundVision file validation", () => {
+  it("accepts the SoundVision and CAD formats used by technical teams", () => {
+    for (const extension of [".xmlp", ".xmlc", ".xmls", ".dwg", ".dfx", ".dxf"]) {
+      expect(SOUNDVISION_ALLOWED_FILE_TYPES).toContain(extension);
+      expect(validateSoundVisionFile(createFile(`venue${extension}`, "application/octet-stream"))).toEqual({
+        valid: true,
+      });
+    }
+  });
+});

--- a/src/utils/documentUploadValidation.ts
+++ b/src/utils/documentUploadValidation.ts
@@ -1,6 +1,6 @@
 import { validateFileUpload } from "@/lib/enhanced-security-config";
 
-export const DOCUMENT_UPLOAD_ACCEPT = ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.txt";
+export const DOCUMENT_UPLOAD_ACCEPT = ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.webp,.txt,.xmlp,.xmlc,.xmls,.dwg,.dfx,.dxf";
 
 export const getDocumentUploadValidationError = (files: File[]) => {
   for (const file of files) {

--- a/src/utils/soundvisionFileValidation.ts
+++ b/src/utils/soundvisionFileValidation.ts
@@ -4,11 +4,23 @@
 // .xmlp - Archivo de proyecto (proyecto SoundVision completo)
 // .xmls - Archivo de escena (contexto de recinto/geometría)
 // .xmlc - Archivo de configuración (exportaciones como posiciones de altavoces)
-export const ALLOWED_FILE_TYPES = ['.xmlp', '.xmls', '.xmlc'];
+// .dwg/.dxf/.dfx - Planos CAD usados como referencia técnica
+export const ALLOWED_FILE_TYPES = ['.xmlp', '.xmls', '.xmlc', '.dwg', '.dxf', '.dfx'];
 export const ALLOWED_MIME_TYPES = [
   'application/xml',
   'text/xml',
   'application/octet-stream', // Some systems may report XML files as octet-stream
+  'application/acad',
+  'application/x-acad',
+  'application/autocad_dwg',
+  'application/dwg',
+  'application/x-dwg',
+  'image/vnd.dwg',
+  'application/dxf',
+  'application/x-dxf',
+  'application/vnd.dxf',
+  'image/vnd.dxf',
+  'drawing/x-dxf',
 ];
 export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB in bytes
 

--- a/supabase/functions/upload-public-artist-rider/index.ts
+++ b/supabase/functions/upload-public-artist-rider/index.ts
@@ -15,7 +15,22 @@ const INGRESS_RATE_LIMIT_WINDOW_SECONDS = 60;
 const INGRESS_RATE_LIMIT_MAX_REQUESTS = 30;
 const TOKEN_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
 const TOKEN_RATE_LIMIT_MAX_REQUESTS = 50;
-const ALLOWED_EXTENSIONS = new Set(["pdf", "doc", "docx", "txt", "png", "jpg", "jpeg", "webp"]);
+const ALLOWED_EXTENSIONS = new Set([
+  "pdf",
+  "doc",
+  "docx",
+  "txt",
+  "png",
+  "jpg",
+  "jpeg",
+  "webp",
+  "xmlp",
+  "xmlc",
+  "xmls",
+  "dwg",
+  "dfx",
+  "dxf",
+]);
 const ALLOWED_MIME_TYPES = new Set([
   "application/pdf",
   "application/msword",
@@ -24,6 +39,20 @@ const ALLOWED_MIME_TYPES = new Set([
   "image/png",
   "image/jpeg",
   "image/webp",
+  "application/xml",
+  "text/xml",
+  "application/octet-stream",
+  "application/acad",
+  "application/x-acad",
+  "application/autocad_dwg",
+  "application/dwg",
+  "application/x-dwg",
+  "image/vnd.dwg",
+  "application/dxf",
+  "application/x-dxf",
+  "application/vnd.dxf",
+  "image/vnd.dxf",
+  "drawing/x-dxf",
 ]);
 
 type UploadFormRow = {


### PR DESCRIPTION
## Summary
- Allow SoundVision and CAD technical files in shared document upload validation: `.xmlp`, `.xmlc`, `.xmls`, `.dwg`, `.dfx`, and `.dxf`.
- Mirror the same extension/MIME allowlist in the public artist rider upload Edge Function.
- Reuse the shared accept string in the public artist rider form and update the upload label.
- Add regression tests covering the new upload formats, existing `.webp` support, and unsupported extension rejection.

## Validation
- `npm install --legacy-peer-deps`
- `npx vitest run src/utils/__tests__/documentUploadValidation.test.ts`
- `npx eslint src/lib/enhanced-security-config.ts src/utils/documentUploadValidation.ts src/utils/soundvisionFileValidation.ts src/utils/__tests__/documentUploadValidation.test.ts src/components/festival/ArtistRequirementsForm.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run lint:functions`

## Deployment notes
- No Supabase migrations.
- Edge Function code changed; merging to `main` should deploy the frontend and function path through the usual production pipeline.
