### PR TITLE
[codex] reduce push notification any debt

### DIFF
--- a/supabase/functions/push/apns.ts
+++ b/supabase/functions/push/apns.ts
@@ -4,6 +4,14 @@ import type { PushPayload, PushSendResult } from "./types.ts";
 const APNS_HOST = APNS_ENV === "sandbox" ? "https://api.sandbox.push.apple.com" : "https://api.push.apple.com";
 const JWT_TTL_SECONDS = 50 * 60;
 
+type TokenCleanupClient = {
+  from: (table: string) => {
+    delete: () => {
+      eq: (column: string, value: string) => Promise<unknown> | unknown;
+    };
+  };
+};
+
 let cachedJwt: { token: string; issuedAt: number } | null = null;
 
 const base64UrlEncode = (input: Uint8Array | string): string => {
@@ -77,7 +85,7 @@ const getApnsJwt = async (): Promise<string | null> => {
 };
 
 export async function sendNativePushNotification(
-  client: { from: (table: string) => any },
+  client: TokenCleanupClient,
   deviceToken: string,
   payload: PushPayload,
 ): Promise<PushSendResult> {

--- a/supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
+++ b/supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
@@ -44,6 +44,7 @@ import { CARLOS_AGENT_NAME } from "../staffingIdentity.ts";
 import {
   getActiveAssignmentDepartmentsFromRow,
   getJobDepartment,
+  normalizeDepartmentRolesPayload,
 } from "../../data.ts";
 
 function createStaffingContext(overrides: Partial<BroadcastEventContext> = {}): BroadcastEventContext {
@@ -418,6 +419,37 @@ describe("push broadcast event message builders", () => {
       video_role: null,
       production_role: "pm",
     })).toEqual(["lights", "production"]);
+  });
+
+  it("normalizes department role payloads from unknown input", () => {
+    expect(normalizeDepartmentRolesPayload([
+      null,
+      { department: "", total_required: 3, roles: [{ role_code: "foh", quantity: 1 }] },
+      {
+        department: "sound",
+        total_required: "2",
+        roles: [
+          { role_code: "foh", quantity: "1", notes: "lead" },
+          { role_code: 123, quantity: 1 },
+        ],
+      },
+      {
+        department: "video",
+        total_required: "invalid",
+        roles: [{ role_code: "cam", quantity: "2", notes: 7 }],
+      },
+    ])).toEqual([
+      {
+        department: "sound",
+        total_required: 2,
+        roles: [{ role_code: "foh", quantity: 1, notes: "lead" }],
+      },
+      {
+        department: "video",
+        total_required: 0,
+        roles: [{ role_code: "cam", quantity: 2, notes: "7" }],
+      },
+    ]);
   });
 
   it("resolves unambiguous job departments from job_departments", async () => {

--- a/supabase/functions/push/broadcast/staffingRouting.ts
+++ b/supabase/functions/push/broadcast/staffingRouting.ts
@@ -7,6 +7,10 @@ import {
 } from "../data.ts";
 
 type BroadcastClient = ReturnType<typeof createClient>;
+type ProfileDepartmentRow = {
+  id?: string | null;
+  department?: string | null;
+};
 
 export function isStaffingEventCode(type: string): boolean {
   return type.startsWith("staffing.");
@@ -77,7 +81,8 @@ export async function filterStaffingRoutesForDepartment(
     const { data, error } = await client
       .from("profiles")
       .select("id, department")
-      .in("id", targetedManagementUserIds);
+      .in("id", targetedManagementUserIds)
+      .returns<ProfileDepartmentRow[]>();
 
     if (error) {
       console.error("[push/broadcast] Failed to scope staffing management_user routes", {
@@ -86,8 +91,8 @@ export async function filterStaffingRoutesForDepartment(
       });
     } else {
       for (const profile of data || []) {
-        if (normalizeDepartment((profile as any).department) === scopedDepartment) {
-          managementUsersInScope.add((profile as any).id);
+        if (normalizeDepartment(profile.department) === scopedDepartment && profile.id) {
+          managementUsersInScope.add(profile.id);
         }
       }
     }

--- a/supabase/functions/push/data.ts
+++ b/supabase/functions/push/data.ts
@@ -1,31 +1,55 @@
 import { createClient } from "./deps.ts";
 import type { BroadcastBody, DepartmentRoleSummary } from "./types.ts";
 
+type IdRow = { id?: string | null };
+type ProfileDepartmentRow = { department?: string | null };
+type TimesheetTechnicianRow = { technician_id?: string | null };
+type AdminStaffingPreferenceRow = IdRow & {
+  department?: string | null;
+  notification_preferences?: Array<{ staffing_scope?: string | null }> | null;
+};
+type SoundVisionFileVenueRow = {
+  venue?: { name?: string | null } | Array<{ name?: string | null }> | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getStringIds(rows: IdRow[] | null | undefined): string[] {
+  return (rows ?? [])
+    .map((row) => row.id)
+    .filter((id): id is string => Boolean(id));
+}
+
 export async function getManagementUserIds(client: ReturnType<typeof createClient>): Promise<string[]> {
   const { data, error } = await client
     .from('profiles')
     .select('id')
-    .in('role', ['admin','management','logistics']);
+    .in('role', ['admin','management','logistics'])
+    .returns<IdRow[]>();
   if (error || !data) return [];
-  return data.map((r: any) => r.id).filter(Boolean);
+  return getStringIds(data);
 }
 
 export async function getSoundDepartmentUserIds(client: ReturnType<typeof createClient>): Promise<string[]> {
   const { data, error } = await client
     .from('profiles')
     .select('id')
-    .eq('department', 'sound');
+    .eq('department', 'sound')
+    .returns<IdRow[]>();
   if (error || !data) return [];
-  return data.map((r: any) => r.id).filter(Boolean);
+  return getStringIds(data);
 }
 
 export async function getManagementOnlyUserIds(client: ReturnType<typeof createClient>): Promise<string[]> {
   const { data, error } = await client
     .from('profiles')
     .select('id')
-    .eq('role', 'management');
+    .eq('role', 'management')
+    .returns<IdRow[]>();
   if (error || !data) return [];
-  return data.map((r: any) => r.id).filter(Boolean);
+  return getStringIds(data);
 }
 
 export async function getLogisticsManagementRecipients(client: ReturnType<typeof createClient>): Promise<string[]> {
@@ -33,9 +57,10 @@ export async function getLogisticsManagementRecipients(client: ReturnType<typeof
     .from('profiles')
     .select('id')
     .eq('role', 'management')
-    .in('department', ['logistics', 'production']);
+    .in('department', ['logistics', 'production'])
+    .returns<IdRow[]>();
   if (error || !data) return [];
-  return data.map((r: any) => r.id).filter(Boolean);
+  return getStringIds(data);
 }
 
 // Admin helpers and department-scoped management targeting
@@ -43,9 +68,10 @@ export async function getAdminUserIds(client: ReturnType<typeof createClient>): 
   const { data, error } = await client
     .from('profiles')
     .select('id')
-    .eq('role', 'admin');
+    .eq('role', 'admin')
+    .returns<IdRow[]>();
   if (error || !data) return [];
-  return data.map((r: any) => r.id).filter(Boolean);
+  return getStringIds(data);
 }
 
 /**
@@ -67,7 +93,8 @@ export async function getAdminUserIdsForStaffingNotifications(
         department,
         notification_preferences!inner(staffing_scope)
       `)
-      .eq('role', 'admin');
+      .eq('role', 'admin')
+      .returns<AdminStaffingPreferenceRow[]>();
 
     if (error || !admins) {
       console.error('Failed to fetch admin notification preferences:', error);
@@ -75,8 +102,8 @@ export async function getAdminUserIdsForStaffingNotifications(
       return [];
     }
 
-    const relevantAdmins = admins.filter((admin: any) => {
-      const prefs = admin.notification_preferences;
+    const relevantAdmins = admins.filter((admin) => {
+      const prefs = admin.notification_preferences ?? [];
       // If no preferences set, default to all_departments
       if (!prefs || !prefs.length) return true;
 
@@ -87,13 +114,13 @@ export async function getAdminUserIdsForStaffingNotifications(
 
       // If preference is own_department, only include if job department matches admin's department
       if (staffingScope === 'own_department') {
-        return jobDepartment && admin.department === jobDepartment;
+        return Boolean(jobDepartment && admin.department === jobDepartment);
       }
 
       return false;
     });
 
-    return relevantAdmins.map((admin: any) => admin.id).filter(Boolean);
+    return getStringIds(relevantAdmins);
   } catch (err) {
     console.error('Exception in getAdminUserIdsForStaffingNotifications:', err);
     // Fail-closed: return empty so scoped notifications stay limited to deptMgmt
@@ -107,9 +134,10 @@ export async function getManagementByDepartmentUserIds(client: ReturnType<typeof
     .from('profiles')
     .select('id')
     .eq('role', 'management')
-    .eq('department', department);
+    .eq('department', department)
+    .returns<IdRow[]>();
   if (error || !data) return [];
-  return data.map((r: any) => r.id).filter(Boolean);
+  return getStringIds(data);
 }
 
 export async function getManagementAndAdminByDepartmentUserIds(
@@ -121,9 +149,10 @@ export async function getManagementAndAdminByDepartmentUserIds(
     .from('profiles')
     .select('id')
     .in('role', ['admin', 'management'])
-    .eq('department', department);
+    .eq('department', department)
+    .returns<IdRow[]>();
   if (error || !data) return [];
-  return data.map((r: any) => r.id).filter(Boolean);
+  return getStringIds(data);
 }
 
 /**
@@ -182,14 +211,16 @@ export async function getTimesheetSubmittingTechDepartment(
         .eq('job_id', jobId)
         .eq('technician_id', actorId)
         .eq('status', 'submitted')
-        .limit(1);
+        .limit(1)
+        .returns<IdRow[]>();
       if (anySubmitted && anySubmitted.length) {
         const { data: prof } = await client
           .from('profiles')
           .select('department')
           .eq('id', actorId)
+          .returns<ProfileDepartmentRow>()
           .maybeSingle();
-        return (prof as any)?.department ?? null;
+        return prof?.department ?? null;
       }
     }
 
@@ -202,15 +233,17 @@ export async function getTimesheetSubmittingTechDepartment(
         .eq('status', 'submitted')
         .order('updated_at', { ascending: false })
         .limit(1)
+        .returns<TimesheetTechnicianRow>()
         .maybeSingle();
-      const techId = (row as any)?.technician_id as string | undefined;
+      const techId = row?.technician_id ?? undefined;
       if (techId) {
         const { data: prof } = await client
           .from('profiles')
           .select('department')
           .eq('id', techId)
+          .returns<ProfileDepartmentRow>()
           .maybeSingle();
-        return (prof as any)?.department ?? null;
+        return prof?.department ?? null;
       }
     }
   } catch (_) {
@@ -223,8 +256,9 @@ export async function getTimesheetSubmittingTechDepartment(
         .from('profiles')
         .select('department')
         .eq('id', actorId)
+        .returns<ProfileDepartmentRow>()
         .maybeSingle();
-      return (prof as any)?.department ?? null;
+      return prof?.department ?? null;
     } catch (_) { /* ignore */ }
   }
   return null;
@@ -235,24 +269,35 @@ export async function getJobParticipantUserIds(client: ReturnType<typeof createC
   const { data, error } = await client
     .from('job_assignments')
     .select('technician_id')
-    .eq('job_id', jobId);
+    .eq('job_id', jobId)
+    .returns<TimesheetTechnicianRow[]>();
   if (error || !data) return [];
-  const ids = data.map((r: any) => r.technician_id).filter(Boolean);
+  const ids = data
+    .map((row) => row.technician_id)
+    .filter((id): id is string => Boolean(id));
   return Array.from(new Set(ids));
 }
 
-function parseDepartmentRoleSummary(raw: any): DepartmentRoleSummary | null {
-  if (!raw) return null;
+function parseDepartmentRoleSummary(raw: unknown): DepartmentRoleSummary | null {
+  if (!isRecord(raw)) return null;
   const department = typeof raw.department === 'string' ? raw.department : '';
   if (!department) return null;
   const total = Number(raw.total_required ?? 0);
   const roles = Array.isArray(raw.roles)
     ? raw.roles
-        .map((role: any) => ({
-          role_code: typeof role?.role_code === 'string' ? role.role_code : '',
-          quantity: Number(role?.quantity ?? 0),
-          notes: role?.notes ?? null,
-        }))
+        .map((role) => {
+          const roleRecord = isRecord(role) ? role : {};
+          const notes = roleRecord.notes == null
+            ? null
+            : typeof roleRecord.notes === 'string'
+              ? roleRecord.notes
+              : String(roleRecord.notes);
+          return {
+            role_code: typeof roleRecord.role_code === 'string' ? roleRecord.role_code : '',
+            quantity: Number(roleRecord.quantity ?? 0),
+            notes,
+          };
+        })
         .filter((role) => role.role_code)
     : [];
   return {
@@ -482,8 +527,10 @@ export async function resolveSoundVisionVenueName(
         .from('soundvision_files')
         .select('venue:venues(name)')
         .eq('id', body.file_id)
+        .returns<SoundVisionFileVenueRow>()
         .maybeSingle();
-      const venueName = (data as any)?.venue?.name as string | undefined;
+      const venue = Array.isArray(data?.venue) ? data.venue[0] : data?.venue;
+      const venueName = typeof venue?.name === 'string' ? venue.name : undefined;
       if (venueName) {
         return venueName;
       }

--- a/supabase/functions/push/format.ts
+++ b/supabase/functions/push/format.ts
@@ -94,15 +94,14 @@ export function summarizeTaskChanges(changes: BroadcastBody['changes']): string 
   }
 
   const entries: Array<{ field: string; from?: unknown; to?: unknown; hasFrom: boolean; hasTo: boolean }> = [];
-  for (const [field, raw] of Object.entries(changes as Record<string, any>)) {
+  for (const [field, raw] of Object.entries(changes as Record<string, unknown>)) {
     if (field === 'updated_at' || field === 'updatedAt') continue;
     if (raw && typeof raw === 'object' && ('from' in raw || 'to' in raw)) {
-      const from = (raw as any).from;
-      const to = (raw as any).to;
+      const change = raw as { from?: unknown; to?: unknown };
       entries.push({
         field,
-        from: normalizeTaskChangeValue(field, from),
-        to: normalizeTaskChangeValue(field, to),
+        from: normalizeTaskChangeValue(field, change.from),
+        to: normalizeTaskChangeValue(field, change.to),
         hasFrom: Object.prototype.hasOwnProperty.call(raw, 'from'),
         hasTo: Object.prototype.hasOwnProperty.call(raw, 'to'),
       });
@@ -142,4 +141,3 @@ export function summarizeTaskChanges(changes: BroadcastBody['changes']): string 
 
   return parts.join('; ');
 }
-

--- a/supabase/functions/push/scheduled.ts
+++ b/supabase/functions/push/scheduled.ts
@@ -3,7 +3,65 @@ import { EVENT_TYPES } from "./config.ts";
 import { jsonResponse } from "./http.ts";
 import { sendNativePushNotification } from "./apns.ts";
 import { sendPushNotification } from "./webpush.ts";
-import type { CheckScheduledBody, NativePushTokenRow, PushPayload } from "./types.ts";
+import type {
+  CheckScheduledBody,
+  NativePushTokenRow,
+  PushPayload,
+  PushSendResult,
+  PushSubscriptionRow,
+} from "./types.ts";
+
+type MorningSummaryAssignment = MorningSummaryData["assignments"][number];
+type MorningSummaryUnavailable = MorningSummaryData["unavailable"][number];
+type MorningSummaryTech = MorningSummaryData["allTechs"][number];
+
+type LegacyAvailabilityRow = {
+  technician_id?: string | null;
+  status?: string | null;
+};
+
+type ScheduleConfigRow = {
+  enabled: boolean;
+  timezone?: string | null;
+  schedule_time: string;
+  days_of_week?: number[] | null;
+  last_sent_at?: string | null;
+};
+
+type MorningSummarySubscriptionRow = {
+  user_id: string;
+  subscribed_departments: string[] | null;
+};
+
+type PushDeliveryResult = {
+  endpoint: string;
+  ok: boolean;
+  status?: number;
+  skipped?: boolean;
+  user_id: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getErrorCode(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  return typeof value.code === 'string' ? value.code : null;
+}
+
+function getErrorMessage(value: unknown): string | unknown {
+  if (value instanceof Error) return value.message;
+  if (isRecord(value) && typeof value.message === 'string') return value.message;
+  return value;
+}
+
+function getPushSendMetadata(result: PushSendResult): Pick<PushDeliveryResult, 'status' | 'skipped'> {
+  return {
+    status: 'status' in result ? result.status : undefined,
+    skipped: 'skipped' in result ? result.skipped : undefined,
+  };
+}
 
 const loadNativeTokens = async (
   client: ReturnType<typeof createClient>,
@@ -81,7 +139,8 @@ async function getMorningSummaryDataForDepartment(
     .eq('date', targetDate)
     .eq('profile.department', department)
     .eq('profile.role', 'house_tech')
-    .eq('profile.warehouse_duty_exempt', false);
+    .eq('profile.warehouse_duty_exempt', false)
+    .returns<MorningSummaryAssignment[]>();
 
   // 2) Get today's unavailability for this department (primary source)
   const { data: unavailable = [] } = await client
@@ -95,8 +154,9 @@ async function getMorningSummaryDataForDepartment(
     .eq('status', 'unavailable')
     .eq('profile.department', department)
     .eq('profile.role', 'house_tech')
-    .eq('profile.warehouse_duty_exempt', false);
-  const unavailableHouseOnly = unavailable as any[];
+    .eq('profile.warehouse_duty_exempt', false)
+    .returns<MorningSummaryUnavailable[]>();
+  const unavailableHouseOnly: MorningSummaryUnavailable[] = [...unavailable];
 
   // 3) Get all house techs in department (population)
   const { data: allTechs = [] } = await client
@@ -104,53 +164,56 @@ async function getMorningSummaryDataForDepartment(
     .select('id, first_name, last_name, nickname')
     .eq('department', department)
     .eq('role', 'house_tech')
-    .eq('warehouse_duty_exempt', false);
+    .eq('warehouse_duty_exempt', false)
+    .returns<MorningSummaryTech[]>();
 
   // 4) Legacy fallback: include legacy table marks (technician_availability)
   // Some environments still record travel/sick/day_off/vacation here.
   // We treat these as 'unavailable' for the day if they aren't already present.
   try {
-    const techIds = (allTechs as any[]).map(t => t.id);
+    const techIds = allTechs.map(t => t.id);
     if (techIds.length) {
       const { data: legacyRows, error: legacyErr } = await client
         .from('technician_availability')
         .select('technician_id, date, status')
         .in('technician_id', techIds)
         .eq('date', targetDate)
-        .in('status', ['vacation', 'travel', 'sick', 'day_off']);
+        .in('status', ['vacation', 'travel', 'sick', 'day_off'])
+        .returns<LegacyAvailabilityRow[]>();
       if (!legacyErr && legacyRows && legacyRows.length) {
-        const existing = new Set<string>((unavailableHouseOnly as any[]).map(u => (u as any).user_id));
-        for (const row of legacyRows as any[]) {
-          if (!existing.has(row.technician_id)) {
-            const prof = (allTechs as any[]).find(t => t.id === row.technician_id);
+        const existing = new Set<string>(unavailableHouseOnly.map(u => u.user_id));
+        for (const row of legacyRows) {
+          const technicianId = row.technician_id;
+          if (technicianId && !existing.has(technicianId)) {
+            const prof = allTechs.find(t => t.id === technicianId);
             if (prof) {
-              (unavailableHouseOnly as any[]).push({
-                user_id: row.technician_id,
-                source: row.status,
+              unavailableHouseOnly.push({
+                user_id: technicianId,
+                source: row.status ?? 'legacy',
                 profile: {
                   first_name: prof.first_name,
                   last_name: prof.last_name,
                   nickname: prof.nickname,
                 },
               });
-              existing.add(row.technician_id);
+              existing.add(technicianId);
             }
           }
         }
       }
     }
-  } catch (e: any) {
+  } catch (e: unknown) {
     // Ignore if legacy table missing
-    if (!(e && e.code === '42P01')) {
+    if (getErrorCode(e) !== '42P01') {
       // Log non-table-missing errors for visibility
-      console.log('morning summary legacy availability lookup warning:', e?.message || e);
+      console.log('morning summary legacy availability lookup warning:', getErrorMessage(e));
     }
   }
 
   return {
-    assignments: assignments as any,
-    unavailable: unavailableHouseOnly as any,
-    allTechs: allTechs as any,
+    assignments,
+    unavailable: unavailableHouseOnly,
+    allTechs,
   };
 }
 
@@ -408,12 +471,13 @@ async function checkAndGetScheduleConfig(
   client: ReturnType<typeof createClient>,
   eventType: string,
   force: boolean = false,
-): Promise<{ shouldSend: boolean; config: any | null }> {
+): Promise<{ shouldSend: boolean; config: ScheduleConfigRow | null }> {
   // Get schedule configuration
   const { data: config, error } = await client
     .from('push_notification_schedules')
     .select('*')
     .eq('event_type', eventType)
+    .returns<ScheduleConfigRow>()
     .maybeSingle();
 
   if (error || !config) {
@@ -526,7 +590,7 @@ export async function handleCheckScheduled(
   // Check if it's time to send
   const { shouldSend, config } = await checkAndGetScheduleConfig(client, type, body.force);
 
-  if (!shouldSend) {
+  if (!shouldSend || !config) {
     return jsonResponse({ status: 'skipped', reason: 'Not scheduled time or already sent' });
   }
 
@@ -552,7 +616,8 @@ export async function handleCheckScheduled(
     const { data: subscriptions, error: subsError } = await client
       .from('morning_summary_subscriptions')
       .select('user_id, subscribed_departments')
-      .eq('enabled', true);
+      .eq('enabled', true)
+      .returns<MorningSummarySubscriptionRow[]>();
 
     if (subsError) {
       console.error('❌ Failed to load subscriptions:', subsError);
@@ -570,12 +635,12 @@ export async function handleCheckScheduled(
     const departmentDataCache = new Map<string, MorningSummaryData>();
 
     // Process each user
-    const allResults: Array<{ endpoint: string; ok: boolean; status?: number; skipped?: boolean; user_id: string }> = [];
+    const allResults: PushDeliveryResult[] = [];
     let successfulUsers = 0;
 
     for (const subscription of subscriptions) {
       const userId = subscription.user_id;
-      const departments = subscription.subscribed_departments as string[];
+      const departments = subscription.subscribed_departments ?? [];
 
       if (!departments || departments.length === 0) {
         console.log(`⚠️ User ${userId} has no departments subscribed`);
@@ -614,7 +679,8 @@ export async function handleCheckScheduled(
       const { data: pushSubs, error: pushSubsErr } = await client
         .from('push_subscriptions')
         .select('endpoint, p256dh, auth')
-        .eq('user_id', userId);
+        .eq('user_id', userId)
+        .returns<PushSubscriptionRow[]>();
 
       if (pushSubsErr) {
         console.error(`  ❌ Failed to load push subscriptions for user ${userId}:`, pushSubsErr);
@@ -655,8 +721,7 @@ export async function handleCheckScheduled(
           allResults.push({
             endpoint: pushSub.endpoint,
             ok: result.ok,
-            status: 'status' in result ? (result as any).status : undefined,
-            skipped: 'skipped' in result ? (result as any).skipped : undefined,
+            ...getPushSendMetadata(result),
             user_id: userId,
           });
           if (result.ok) userSent = true;
@@ -669,8 +734,7 @@ export async function handleCheckScheduled(
           allResults.push({
             endpoint: `apns:${tokenRow.device_token}`,
             ok: result.ok,
-            status: 'status' in result ? (result as any).status : undefined,
-            skipped: 'skipped' in result ? (result as any).skipped : undefined,
+            ...getPushSendMetadata(result),
             user_id: userId,
           });
           if (result.ok) userSent = true;

--- a/supabase/functions/push/webpush.ts
+++ b/supabase/functions/push/webpush.ts
@@ -2,6 +2,19 @@ import { createClient, webpush } from "./deps.ts";
 import { CONTACT_EMAIL, PUSH_CONFIG, VAPID_PRIVATE_KEY, VAPID_PUBLIC_KEY } from "./config.ts";
 import type { PushPayload, PushSendResult, PushSubscriptionRow } from "./types.ts";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function numberFromUnknown(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
 console.log('🔐 VAPID keys loaded:', {
   publicKeyPresent: !!VAPID_PUBLIC_KEY,
   privateKeyPresent: !!VAPID_PRIVATE_KEY,
@@ -53,11 +66,12 @@ export async function sendPushNotification(
     console.log('✅ Push notification sent successfully');
     return { ok: true };
   } catch (err) {
-    const status = (err as any)?.statusCode ?? (err as any)?.status ?? 500;
+    const errorInfo = isRecord(err) ? err : {};
+    const status = numberFromUnknown(errorInfo.statusCode) ?? numberFromUnknown(errorInfo.status) ?? 500;
     console.error('❌ Push send error:', {
       status,
-      message: (err as any)?.message,
-      body: (err as any)?.body,
+      message: typeof errorInfo.message === 'string' ? errorInfo.message : undefined,
+      body: errorInfo.body,
       endpoint: subscription.endpoint.substring(0, 50) + '...',
       error: err
     });
@@ -76,4 +90,3 @@ export async function sendPushNotification(
     return { ok: false, status };
   }
 }
-


### PR DESCRIPTION
## Summary
- replace explicit any usage in push notification data/scheduled/web/APNs helpers with narrow row and error shapes
- type staffing route filtering, task-change formatting, push delivery metadata, and SoundVision venue lookup paths
- add regression coverage for unknown department role payload normalization

## Any debt
- no-explicit-any warnings: 1693 -> 1650 (-43) from the post-#767 baseline
- touched push notification files now have zero explicit any matches

## Validation
- npm install --legacy-peer-deps
- npx vitest run supabase/functions/push/broadcast/__tests__/eventMessages.test.ts
- npm run typecheck
- npm run lint
- npm run lint:functions
- npm run test:run
- npm run build
- npm run governance:filesize
- git diff --check