### PR TITLE
Reduce utility explicit any debt

### DIFF
--- a/src/utils/__tests__/typedUtilities.test.ts
+++ b/src/utils/__tests__/typedUtilities.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { findClosestFestival, calculatePageForFestival } from "@/utils/dateUtils";
+import { shouldAutoComplete } from "@/utils/jobStatusUtils";
+import { throttle } from "@/utils/throttle";
+import {
+  aggregateJobTimesheets,
+  type AssignmentLookupRow,
+  type TimesheetRowWithTechnician,
+} from "@/utils/timesheetAssignments";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("typed utility regressions", () => {
+  it("finds the closest festival and calculates its page", () => {
+    vi.useFakeTimers().setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    const festivals = [
+      { id: "festival-1", start_time: "2026-06-20T10:00:00Z", title: "Later" },
+      { id: "festival-2", start_time: "2026-06-09T10:00:00Z", title: "Closest" },
+      { id: "festival-3", start_time: "2026-07-01T10:00:00Z", title: "Latest" },
+    ];
+
+    const closest = findClosestFestival(festivals);
+
+    expect(closest?.id).toBe("festival-2");
+    expect(calculatePageForFestival(festivals, closest, 2)).toBe(1);
+    expect(calculatePageForFestival(festivals, festivals[2], 2)).toBe(2);
+  });
+
+  it("checks auto-completion against the job closure window", () => {
+    vi.useFakeTimers().setSystemTime(new Date("2026-06-20T12:00:00Z"));
+
+    expect(shouldAutoComplete({
+      id: "job-1",
+      end_time: "2026-06-01T18:00:00Z",
+      status: "Confirmado",
+      timezone: "Europe/Madrid",
+    })).toBe(true);
+    expect(shouldAutoComplete({
+      id: "job-2",
+      end_time: "2026-06-01T18:00:00Z",
+      status: "Cancelado",
+      timezone: "Europe/Madrid",
+    })).toBe(false);
+  });
+
+  it("runs throttled calls immediately, then flushes or cancels trailing calls", () => {
+    vi.useFakeTimers().setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    const calls: string[] = [];
+    const throttled = throttle((value: string) => {
+      calls.push(value);
+    }, 100);
+
+    throttled("first");
+    throttled("second");
+    expect(calls).toEqual(["first"]);
+
+    vi.advanceTimersByTime(100);
+    expect(calls).toEqual(["first", "second"]);
+
+    throttled("third");
+    throttled.cancel();
+    vi.advanceTimersByTime(100);
+    expect(calls).toEqual(["first", "second"]);
+  });
+
+  it("aggregates timesheet rows and preserves matching assignment metadata", () => {
+    const technician = {
+      id: "tech-1",
+      first_name: "Alex",
+      last_name: "Tech",
+      nickname: "AT",
+      department: "sound",
+    };
+    const timesheets: TimesheetRowWithTechnician[] = [
+      {
+        job_id: "job-1",
+        technician_id: "tech-1",
+        date: "2026-06-11",
+        is_schedule_only: false,
+        technician,
+      },
+      {
+        job_id: "job-1",
+        technician_id: "tech-1",
+        date: "2026-06-10",
+        is_schedule_only: false,
+        technician,
+      },
+    ];
+    const assignment: AssignmentLookupRow = {
+      technician_id: "tech-1",
+      status: "confirmed",
+      sound_role: "foh",
+      profiles: technician,
+    };
+
+    expect(aggregateJobTimesheets(timesheets, { "job-1": [assignment] })).toEqual({
+      "job-1": [
+        {
+          technician_id: "tech-1",
+          technician,
+          dates: ["2026-06-10", "2026-06-11"],
+          status: "confirmed",
+          source: "assignment",
+          roles: {
+            sound_role: "foh",
+            lights_role: undefined,
+            video_role: undefined,
+          },
+          original_assignment: assignment,
+        },
+      ],
+    });
+  });
+});

--- a/src/utils/__tests__/typedUtilities.test.ts
+++ b/src/utils/__tests__/typedUtilities.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import { findClosestFestival, calculatePageForFestival } from "@/utils/dateUtils";
-import { shouldAutoComplete } from "@/utils/jobStatusUtils";
+import { shouldAutoComplete, type AutoCompleteJobResult } from "@/utils/jobStatusUtils";
 import { throttle } from "@/utils/throttle";
 import {
   aggregateJobTimesheets,
@@ -44,6 +44,25 @@ describe("typed utility regressions", () => {
       status: "Cancelado",
       timezone: "Europe/Madrid",
     })).toBe(false);
+  });
+
+  it("widens auto-completed job status without erasing caller fields", () => {
+    type ConfirmedJob = {
+      id: string;
+      end_time: string;
+      status: "Confirmado";
+      projectCode: string;
+    };
+
+    expectTypeOf<AutoCompleteJobResult<ConfirmedJob>>().toMatchTypeOf<
+      | ConfirmedJob
+      | {
+          id: string;
+          end_time: string;
+          status: "Confirmado" | "Completado";
+          projectCode: string;
+        }
+    >();
   });
 
   it("runs throttled calls immediately, then flushes or cancels trailing calls", () => {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -3,12 +3,17 @@
  * Utility functions for date operations
  */
 
+export type FestivalDateCandidate = {
+  id: string;
+  start_time: string | number | Date;
+};
+
 /**
  * Find the festival closest to today's date
  * @param festivals Array of festival jobs
  * @returns The festival closest to today or null if no festivals
  */
-export const findClosestFestival = (festivals: any[]) => {
+export const findClosestFestival = <T extends FestivalDateCandidate>(festivals: T[] | null | undefined): T | null => {
   if (!festivals || festivals.length === 0) return null;
 
   const today = new Date();
@@ -40,7 +45,11 @@ export const findClosestFestival = (festivals: any[]) => {
  * @param itemsPerPage Number of items per page
  * @returns Page number (1-based) or 1 if not found
  */
-export const calculatePageForFestival = (festivals: any[], targetFestival: any, itemsPerPage: number) => {
+export const calculatePageForFestival = <T extends { id: string }>(
+  festivals: T[],
+  targetFestival: T | null | undefined,
+  itemsPerPage: number,
+): number => {
   if (!targetFestival || !festivals.length) return 1;
   
   const index = festivals.findIndex(festival => festival.id === targetFestival.id);

--- a/src/utils/flex-folders/buildFlexUrl.ts
+++ b/src/utils/flex-folders/buildFlexUrl.ts
@@ -15,6 +15,18 @@ export interface ElementDetails {
   documentNumber?: string;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function unwrapFlexField(value: unknown): unknown {
+  return isRecord(value) && 'data' in value ? value.data : value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return value == null ? undefined : String(value);
+}
+
 /**
  * Fetches element details from Flex API to get definitionId
  * @param elementId - The element ID to fetch
@@ -41,13 +53,13 @@ export async function getElementDetails(
       return { elementId };
     }
 
-    const data = await response.json<Record<string, any>>();
+    const data = await response.json<Record<string, unknown>>();
     
     // Extract definitionId from the response
     // The response structure has fields wrapped in objects with data property
-    const definitionId = data?.elementDefinitionId?.data || data?.definitionId?.data || data?.definitionId;
-    const name = data?.name?.data || data?.documentName?.data;
-    const documentNumber = data?.documentNumber?.data;
+    const definitionId = optionalString(unwrapFlexField(data.elementDefinitionId) || unwrapFlexField(data.definitionId));
+    const name = optionalString(unwrapFlexField(data.name) || unwrapFlexField(data.documentName));
+    const documentNumber = optionalString(unwrapFlexField(data.documentNumber));
 
     console.log(`[buildFlexUrl] Element details fetched:`, { elementId, definitionId, name, documentNumber });
 

--- a/src/utils/flex-folders/openFlexElement.ts
+++ b/src/utils/flex-folders/openFlexElement.ts
@@ -111,7 +111,7 @@ export async function openFlexElement(options: OpenFlexElementOptions): Promise<
     if (placeholderWindow) {
       try {
         // Manually nullify opener to replicate 'noopener' behavior
-        (placeholderWindow as any).opener = null;
+        placeholderWindow.opener = null;
         // Ensure it starts blank (some browsers may reuse content)
         placeholderWindow.location.href = 'about:blank';
       } catch (noop) {

--- a/src/utils/jobStatusUtils.ts
+++ b/src/utils/jobStatusUtils.ts
@@ -2,11 +2,17 @@ import { supabase } from "@/integrations/supabase/client";
 import { isJobPastClosureWindow } from "@/utils/jobClosureUtils";
 
 export type JobStatus = "Tentativa" | "Confirmado" | "Completado" | "Cancelado";
+export type AutoCompletableJob = {
+  id: string;
+  end_time?: string | null;
+  timezone?: string | null;
+  status?: JobStatus | string | null;
+};
 
 /**
  * Checks if a job should be automatically completed based on its end date
  */
-export const shouldAutoComplete = (job: any): boolean => {
+export const shouldAutoComplete = (job: AutoCompletableJob | null | undefined): boolean => {
   if (!job?.end_time || job.status === "Cancelado" || job.status === "Completado") {
     return false;
   }
@@ -18,7 +24,9 @@ export const shouldAutoComplete = (job: any): boolean => {
 /**
  * Automatically updates job statuses for past jobs
  */
-export const autoCompleteJobs = async (jobs: any[]): Promise<{ updatedJobs: any[], updatedCount: number }> => {
+export const autoCompleteJobs = async <T extends AutoCompletableJob>(
+  jobs: T[],
+): Promise<{ updatedJobs: T[], updatedCount: number }> => {
   const jobsToUpdate = jobs.filter(shouldAutoComplete);
   
   if (jobsToUpdate.length === 0) {
@@ -41,7 +49,7 @@ export const autoCompleteJobs = async (jobs: any[]): Promise<{ updatedJobs: any[
         return { ...job, status: 'Completado' };
       }
       return job;
-    });
+    }) as T[];
 
     return { updatedJobs, updatedCount: jobsToUpdate.length };
   } catch (error) {

--- a/src/utils/jobStatusUtils.ts
+++ b/src/utils/jobStatusUtils.ts
@@ -8,6 +8,9 @@ export type AutoCompletableJob = {
   timezone?: string | null;
   status?: JobStatus | string | null;
 };
+export type AutoCompleteJobResult<T extends AutoCompletableJob> =
+  | T
+  | (Omit<T, "status"> & { status: T["status"] | "Completado" });
 
 /**
  * Checks if a job should be automatically completed based on its end date
@@ -26,7 +29,7 @@ export const shouldAutoComplete = (job: AutoCompletableJob | null | undefined): 
  */
 export const autoCompleteJobs = async <T extends AutoCompletableJob>(
   jobs: T[],
-): Promise<{ updatedJobs: T[], updatedCount: number }> => {
+): Promise<{ updatedJobs: AutoCompleteJobResult<T>[], updatedCount: number }> => {
   const jobsToUpdate = jobs.filter(shouldAutoComplete);
   
   if (jobsToUpdate.length === 0) {
@@ -44,12 +47,12 @@ export const autoCompleteJobs = async <T extends AutoCompletableJob>(
     if (error) throw error;
 
     // Update local job data
-    const updatedJobs = jobs.map(job => {
+    const updatedJobs = jobs.map((job): AutoCompleteJobResult<T> => {
       if (jobsToUpdate.some(updateJob => updateJob.id === job.id)) {
         return { ...job, status: 'Completado' };
       }
       return job;
-    }) as T[];
+    });
 
     return { updatedJobs, updatedCount: jobsToUpdate.length };
   } catch (error) {

--- a/src/utils/micListTransform.ts
+++ b/src/utils/micListTransform.ts
@@ -13,22 +13,28 @@ export interface WiredMic {
   notes?: string;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 /**
  * Hydrate microphone data from database format to UI format
  *
  * @param dbData - Raw data from database (could be JSONB string or array)
  * @returns Array of WiredMic objects for UI consumption
  */
-export function hydrateFromDB(dbData: any): WiredMic[] {
+export function hydrateFromDB(dbData: unknown): WiredMic[] {
   // Handle null or undefined
   if (!dbData) {
     return [];
   }
 
+  let parsedData = dbData;
+
   // Handle JSON string (from some database queries)
-  if (typeof dbData === 'string') {
+  if (typeof parsedData === 'string') {
     try {
-      dbData = JSON.parse(dbData);
+      parsedData = JSON.parse(parsedData);
     } catch (e) {
       console.error('Failed to parse microphone data:', e);
       return [];
@@ -36,13 +42,13 @@ export function hydrateFromDB(dbData: any): WiredMic[] {
   }
 
   // Handle empty array
-  if (!Array.isArray(dbData) || dbData.length === 0) {
+  if (!Array.isArray(parsedData) || parsedData.length === 0) {
     return [];
   }
 
   // Validate and normalize data
-  return dbData
-    .filter(mic => mic && typeof mic === 'object' && mic.model)
+  return parsedData
+    .filter((mic): mic is Record<string, unknown> => isRecord(mic) && Boolean(mic.model))
     .map(mic => ({
       model: String(mic.model),
       quantity: typeof mic.quantity === 'number' && mic.quantity > 0 ? mic.quantity : 1,
@@ -150,7 +156,7 @@ export function getTotalMicCount(micList: WiredMic[]): number {
  * @param data - Data to validate
  * @returns Validation result with errors if any
  */
-export function validateMicList(data: any): { valid: boolean; errors: string[] } {
+export function validateMicList(data: unknown): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
   if (!data) {
@@ -163,7 +169,7 @@ export function validateMicList(data: any): { valid: boolean; errors: string[] }
   }
 
   data.forEach((mic, index) => {
-    if (!mic || typeof mic !== 'object') {
+    if (!isRecord(mic)) {
       errors.push(`Item at index ${index} is not a valid object`);
       return;
     }

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,11 +1,11 @@
-export type ThrottledFunction<T extends (...args: any[]) => void> = ((...args: Parameters<T>) => void) & {
+export type ThrottledFunction<T extends (...args: never[]) => void> = ((...args: Parameters<T>) => void) & {
   cancel: () => void;
 };
 
 /**
  * Lightweight throttle implementation to avoid extra dependencies on critical paths.
  */
-export function throttle<T extends (...args: any[]) => void>(fn: T, wait: number): ThrottledFunction<T> {
+export function throttle<T extends (...args: never[]) => void>(fn: T, wait: number): ThrottledFunction<T> {
   let timeout: ReturnType<typeof setTimeout> | null = null;
   let lastArgs: Parameters<T> | null = null;
   let lastCall = 0;

--- a/src/utils/timesheetAssignments.ts
+++ b/src/utils/timesheetAssignments.ts
@@ -30,12 +30,21 @@ export interface AggregatedTimesheetAssignment {
     lights_role?: string;
     video_role?: string;
   };
-  original_assignment?: any;
+  original_assignment?: AssignmentLookupRow;
+}
+
+export interface AssignmentLookupRow {
+  technician_id: string;
+  status?: string | null;
+  sound_role?: string | null;
+  lights_role?: string | null;
+  video_role?: string | null;
+  profiles?: TimesheetRowWithTechnician['technician'] | null;
 }
 
 export function aggregateJobTimesheets(
   timesheetRows: TimesheetRowWithTechnician[],
-  assignmentLookup: Record<string, any[]>
+  assignmentLookup: Record<string, AssignmentLookupRow[]>
 ): Record<string, AggregatedTimesheetAssignment[]> {
   const result: Record<string, AggregatedTimesheetAssignment[]> = {};
 


### PR DESCRIPTION
## Summary
- Replace explicit `any` in shared utility helpers with generic and unknown-safe types.
- Preserve Flex element field unwrapping while typing API JSON as unknown records.
- Add regression coverage for date utilities, auto-completion checks, throttle behavior, and timesheet assignment aggregation.

## Validation
- npm install --legacy-peer-deps
- npx vitest run src/utils/__tests__/typedUtilities.test.ts src/utils/__tests__/micListTransform.test.ts src/utils/flex-folders/__tests__/buildFlexUrl.test.ts src/utils/flex-folders/__tests__/openFlexElement.test.ts
- npx eslint src/utils/dateUtils.ts src/utils/jobStatusUtils.ts src/utils/throttle.ts src/utils/timesheetAssignments.ts src/utils/micListTransform.ts src/utils/flex-folders/buildFlexUrl.ts src/utils/flex-folders/openFlexElement.ts src/utils/__tests__/typedUtilities.test.ts --format stylish
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- npm run governance:filesize
- git diff --check

Explicit any count: 1650 -> 1636 (-14).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in job auto-completion, festival date/page selection, timesheet grouping, microphone list handling, and throttled actions.
  * Better handling of invalid or missing data in several utilities to reduce unexpected behavior.

* **Tests**
  * Added regression coverage for date calculations, auto-complete logic, throttling behavior, and timesheet aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->