### PR TITLE
[codex] Type token manager auth flow

### DIFF
--- a/src/lib/__tests__/token-manager.test.ts
+++ b/src/lib/__tests__/token-manager.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { Session } from "@supabase/supabase-js";
+
+import { TokenManager, type TokenRefreshResult } from "@/lib/token-manager";
+
+const mocks = vi.hoisted(() => ({
+  onAuthStateChange: vi.fn(),
+  getSession: vi.fn(),
+  refreshSession: vi.fn(),
+  signOut: vi.fn(),
+  subscribeAppRuntimeEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: mocks.onAuthStateChange,
+      getSession: mocks.getSession,
+      refreshSession: mocks.refreshSession,
+      signOut: mocks.signOut,
+    },
+  },
+}));
+
+vi.mock("@/runtime/app-runtime-events", () => ({
+  APP_RUNTIME_EVENTS: {
+    RESUME: "resume",
+  },
+  subscribeAppRuntimeEvent: mocks.subscribeAppRuntimeEvent,
+}));
+
+function resetTokenManagerSingleton(): void {
+  (TokenManager as unknown as { instance?: TokenManager }).instance = undefined;
+}
+
+describe("TokenManager typing and expiry helpers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    resetTokenManagerSingleton();
+    mocks.onAuthStateChange.mockReset();
+    mocks.getSession.mockReset();
+    mocks.refreshSession.mockReset();
+    mocks.signOut.mockReset();
+    mocks.subscribeAppRuntimeEvent.mockReset();
+  });
+
+  afterEach(() => {
+    resetTokenManagerSingleton();
+    vi.useRealTimers();
+  });
+
+  it("calculates refresh timing from typed session expiry data", () => {
+    const manager = TokenManager.getInstance();
+    const expiresAt = Math.floor((Date.now() + 20 * 60 * 1000) / 1000);
+
+    expect(manager.calculateRefreshTime({ expires_at: expiresAt })).toBe(15 * 60 * 1000);
+    expect(manager.calculateRefreshTime(null)).toBe(30 * 60 * 1000);
+  });
+
+  it("detects sessions that are close to expiry", () => {
+    const manager = TokenManager.getInstance();
+    const expiresAt = Math.floor((Date.now() + 4 * 60 * 1000) / 1000);
+
+    expect(manager.checkTokenExpiration({ expires_at: expiresAt })).toBe(true);
+    expect(manager.checkTokenExpiration({ expires_at: expiresAt }, 60 * 1000)).toBe(false);
+    expect(manager.checkTokenExpiration(undefined)).toBe(false);
+  });
+
+  it("exposes typed session and refresh result contracts", () => {
+    expectTypeOf<ReturnType<TokenManager["getSession"]>>().toEqualTypeOf<Promise<Session | null>>();
+    expectTypeOf<ReturnType<TokenManager["refreshToken"]>>().toEqualTypeOf<Promise<TokenRefreshResult>>();
+    expectTypeOf<ReturnType<TokenManager["refreshTokenWithBackoff"]>>().toEqualTypeOf<Promise<TokenRefreshResult>>();
+  });
+});

--- a/src/lib/__tests__/token-manager.test.ts
+++ b/src/lib/__tests__/token-manager.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
-import type { Session } from "@supabase/supabase-js";
+import type { AuthError, Session } from "@supabase/supabase-js";
 
 import { TokenManager, type TokenRefreshResult } from "@/lib/token-manager";
 
@@ -34,6 +34,11 @@ vi.mock("@/runtime/app-runtime-events", () => ({
 function resetTokenManagerSingleton(): void {
   (TokenManager as unknown as { instance?: TokenManager }).instance = undefined;
 }
+
+type RefreshSessionResponse = {
+  data: { session: Session | null };
+  error: AuthError | null;
+};
 
 describe("TokenManager typing and expiry helpers", () => {
   beforeEach(() => {
@@ -69,9 +74,36 @@ describe("TokenManager typing and expiry helpers", () => {
     expect(manager.checkTokenExpiration(undefined)).toBe(false);
   });
 
+  it("reports concurrent refresh attempts as skipped without using the error field", async () => {
+    let resolveRefresh: (value: RefreshSessionResponse) => void = () => {};
+    mocks.refreshSession.mockReturnValue(new Promise<RefreshSessionResponse>((resolve) => {
+      resolveRefresh = resolve;
+    }));
+
+    const manager = TokenManager.getInstance();
+    const inFlightRefresh = manager.refreshToken();
+
+    expect(mocks.refreshSession).toHaveBeenCalledTimes(1);
+    await expect(manager.refreshToken()).resolves.toEqual({
+      session: null,
+      error: null,
+      skipped: true,
+    });
+
+    resolveRefresh({ data: { session: null }, error: null });
+    await expect(inFlightRefresh).resolves.toEqual({
+      session: null,
+      error: null,
+      skipped: false,
+    });
+  });
+
   it("exposes typed session and refresh result contracts", () => {
     expectTypeOf<ReturnType<TokenManager["getSession"]>>().toEqualTypeOf<Promise<Session | null>>();
     expectTypeOf<ReturnType<TokenManager["refreshToken"]>>().toEqualTypeOf<Promise<TokenRefreshResult>>();
     expectTypeOf<ReturnType<TokenManager["refreshTokenWithBackoff"]>>().toEqualTypeOf<Promise<TokenRefreshResult>>();
+    expectTypeOf<ReturnType<TokenManager["signOut"]>>().toEqualTypeOf<
+      Promise<{ error: AuthError | Error | null }>
+    >();
   });
 });

--- a/src/lib/token-manager.ts
+++ b/src/lib/token-manager.ts
@@ -1,6 +1,17 @@
 import { supabase } from '@/lib/supabase';
-import { Session } from '@supabase/supabase-js';
+import type { AuthError, Session } from '@supabase/supabase-js';
 import { APP_RUNTIME_EVENTS, subscribeAppRuntimeEvent } from '@/runtime/app-runtime-events';
+
+export type TokenRefreshResult = {
+  session: Session | null;
+  error: AuthError | Error | null | false;
+};
+
+export type SessionExpiry = Pick<Session, 'expires_at'> | null | undefined;
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
 
 /**
  * Token Manager - Singleton class for managing auth tokens and refresh logic
@@ -124,7 +135,7 @@ export class TokenManager {
   /**
    * Refresh the token
    */
-  public async refreshToken(): Promise<any> {
+  public async refreshToken(): Promise<TokenRefreshResult> {
     if (this.isRefreshing) {
       console.log('Token refresh already in progress');
       return { session: null, error: false };
@@ -160,7 +171,7 @@ export class TokenManager {
     } catch (error) {
       console.error('Exception during token refresh:', error);
       this.recordFailure();
-      return { session: null, error };
+      return { session: null, error: normalizeError(error) };
     } finally {
       this.isRefreshing = false;
     }
@@ -169,7 +180,7 @@ export class TokenManager {
   /**
    * Get the current session, optionally refreshing it if needed
    */
-  public async getSession(forceRefresh = false): Promise<any> {
+  public async getSession(forceRefresh = false): Promise<Session | null> {
     if (forceRefresh) {
       await this.refreshToken();
     }
@@ -180,7 +191,7 @@ export class TokenManager {
   /**
    * Sign the user out
    */
-  public async signOut(): Promise<{ error: any }> {
+  public async signOut(): Promise<{ error: AuthError | Error | null }> {
     try {
       // Clear cached session
       this.updateCachedSession(null);
@@ -189,14 +200,14 @@ export class TokenManager {
       return { error };
     } catch (error) {
       console.error('Error during sign out:', error);
-      return { error };
+      return { error: normalizeError(error) };
     }
   }
   
   /**
    * Schedule the next token refresh based on expiry time
    */
-  private scheduleNextRefresh(session: any): void {
+  private scheduleNextRefresh(session: SessionExpiry): void {
     if (this.refreshTimeout) {
       clearTimeout(this.refreshTimeout);
       this.refreshTimeout = null;
@@ -264,7 +275,7 @@ export class TokenManager {
    * @param session Current authentication session
    * @returns Milliseconds until next refresh
    */
-  public calculateRefreshTime(session: any): number {
+  public calculateRefreshTime(session: SessionExpiry): number {
     if (!session?.expires_at) {
       // Default refresh every 30 minutes if no expiry
       return 30 * 60 * 1000;
@@ -290,7 +301,7 @@ export class TokenManager {
    * @param thresholdMs Time in milliseconds that is considered "close to expiration"
    * @returns Boolean indicating if token is close to expiration
    */
-  public checkTokenExpiration(session: any, thresholdMs: number = 5 * 60 * 1000): boolean {
+  public checkTokenExpiration(session: SessionExpiry, thresholdMs: number = 5 * 60 * 1000): boolean {
     if (!session?.expires_at) {
       return false;
     }
@@ -391,7 +402,7 @@ export class TokenManager {
   /**
    * Enhanced refresh with backoff
    */
-  public async refreshTokenWithBackoff(): Promise<any> {
+  public async refreshTokenWithBackoff(): Promise<TokenRefreshResult> {
     const backoffDelay = this.calculateBackoffDelay();
     
     if (backoffDelay > 0) {

--- a/src/lib/token-manager.ts
+++ b/src/lib/token-manager.ts
@@ -4,7 +4,8 @@ import { APP_RUNTIME_EVENTS, subscribeAppRuntimeEvent } from '@/runtime/app-runt
 
 export type TokenRefreshResult = {
   session: Session | null;
-  error: AuthError | Error | null | false;
+  error: AuthError | Error | null;
+  skipped: boolean;
 };
 
 export type SessionExpiry = Pick<Session, 'expires_at'> | null | undefined;
@@ -138,13 +139,13 @@ export class TokenManager {
   public async refreshToken(): Promise<TokenRefreshResult> {
     if (this.isRefreshing) {
       console.log('Token refresh already in progress');
-      return { session: null, error: false };
+      return { session: null, error: null, skipped: true };
     }
     
     // Circuit breaker check
     if (this.isCircuitBreakerOpen()) {
       console.log('Circuit breaker is open, skipping refresh');
-      return { session: null, error: new Error('Circuit breaker open') };
+      return { session: null, error: new Error('Circuit breaker open'), skipped: false };
     }
     
     try {
@@ -155,7 +156,7 @@ export class TokenManager {
       if (error) {
         console.error('Error refreshing token:', error);
         this.recordFailure();
-        return { session: null, error };
+        return { session: null, error, skipped: false };
       }
       
       if (data.session) {
@@ -164,14 +165,14 @@ export class TokenManager {
         this.recordSuccess();
         this.notifySubscribers();
         this.scheduleNextRefresh(data.session);
-        return { session: data.session, error: null };
+        return { session: data.session, error: null, skipped: false };
       }
       
-      return { session: null, error: null };
+      return { session: null, error: null, skipped: false };
     } catch (error) {
       console.error('Exception during token refresh:', error);
       this.recordFailure();
-      return { session: null, error: normalizeError(error) };
+      return { session: null, error: normalizeError(error), skipped: false };
     } finally {
       this.isRefreshing = false;
     }


### PR DESCRIPTION
## Summary
- replace TokenManager `any` return and session expiry types with explicit Supabase/auth contracts
- separate concurrent refresh skips from real auth errors with a `skipped` result field
- add focused tests for token expiry helpers, concurrent refresh skips, and public type contracts

## Affected Route / Feature
- Auth token management in `src/lib/token-manager.ts`
- Consumers that call `TokenManager.refreshToken()` continue to receive falsy `error` for skipped concurrent refreshes, now via `error: null` plus `skipped: true`

## Risk Assessment
- Low runtime risk: behavior is intentionally equivalent for existing callers, with stronger result typing.
- Main risk area is auth refresh coordination, covered by focused tests, full unit tests, typecheck, and CI.

## Impact Checklist
- No schema changes
- No Supabase Edge Function changes
- No dependency changes
- Removes seven explicit `any` usages from `src/lib/token-manager.ts`

## Rollback Plan
- Revert the two commits in this PR to restore the prior TokenManager result shape.

## Migration Impact
- None. No migrations or production Supabase push required.

## Validation
- npm install --legacy-peer-deps
- npx vitest run src/lib/__tests__/token-manager.test.ts
- npx eslint src/lib/token-manager.ts src/lib/__tests__/token-manager.test.ts --format stylish
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- npm run governance:filesize
- git diff --check