### PR TITLE
[codex] Type mobile viewport access

### DIFF
--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ReactNode } from "react";
+
+import { useViewport, ViewportProvider } from "@/hooks/use-mobile";
+
+const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
+
+function createVisualViewport(width: number, height: number): VisualViewport {
+  const eventTarget = new EventTarget();
+
+  return {
+    width,
+    height,
+    offsetLeft: 0,
+    offsetTop: 0,
+    pageLeft: 0,
+    pageTop: 0,
+    scale: 1,
+    onresize: null,
+    onscroll: null,
+    addEventListener: eventTarget.addEventListener.bind(eventTarget),
+    removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+    dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget),
+  } as unknown as VisualViewport;
+}
+
+function setVisualViewport(visualViewport: VisualViewport): void {
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: visualViewport,
+  });
+}
+
+describe("useViewport", () => {
+  afterEach(() => {
+    if (originalVisualViewport) {
+      Object.defineProperty(window, "visualViewport", originalVisualViewport);
+      return;
+    }
+
+    Reflect.deleteProperty(window, "visualViewport");
+  });
+
+  it("prefers visualViewport dimensions when available", () => {
+    setVisualViewport(createVisualViewport(390.4, 721.6));
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ViewportProvider>{children}</ViewportProvider>
+    );
+
+    const { result } = renderHook(() => useViewport(), { wrapper });
+
+    expect(result.current.width).toBe(390);
+    expect(result.current.height).toBe(722);
+    expect(result.current.breakpoint).toBe("xs");
+    expect(result.current.isMobile).toBe(true);
+  });
+});

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -70,7 +70,7 @@ export function ViewportProvider({
     }
 
     // Prefer visualViewport when available to better reflect on-screen size
-    const vv = (window as any).visualViewport as VisualViewport | undefined
+    const vv = window.visualViewport
     const width = Math.round((vv?.width ?? window.innerWidth) || 0)
     const height = Math.round((vv?.height ?? window.innerHeight) || 0)
     return { width, height }
@@ -84,7 +84,7 @@ export function ViewportProvider({
     window.addEventListener("resize", handleResize)
     window.addEventListener("orientationchange", handleResize)
 
-    const vv = (window as any).visualViewport as VisualViewport | undefined
+    const vv = window.visualViewport
     vv?.addEventListener("resize", handleResize)
 
     return () => {


### PR DESCRIPTION
## Summary
- replace untyped `window as any` visualViewport access with the standard typed DOM property
- add a focused hook test proving `ViewportProvider` still prefers visualViewport dimensions

## Affected Route / Feature
- Shared mobile viewport detection in `src/hooks/use-mobile.tsx`
- Components using `ViewportProvider`, `useViewport`, or `useIsMobile` keep the same runtime behavior

## Risk Assessment
- Low risk: this is a type-only access cleanup using the same DOM API already used elsewhere in the app.
- The regression test covers the visualViewport sizing branch.

## Impact Checklist
- No schema changes
- No Supabase Edge Function changes
- No dependency changes
- Removes two explicit `any` usages from `src/hooks/use-mobile.tsx`

## Rollback Plan
- Revert this PR to restore the previous casts.

## Migration Impact
- None. No migrations or production Supabase push required.

## Validation
- npx vitest run src/hooks/__tests__/use-mobile.test.tsx
- npx eslint src/hooks/use-mobile.tsx src/hooks/__tests__/use-mobile.test.tsx --format stylish
- npm run typecheck
- npm run lint
- npm run test:run
- npm run build
- npm run governance:filesize
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport size detection so the app more reliably recognizes mobile-sized screens and updates layout-related values correctly.
* **Tests**
  * Added coverage for viewport behavior in browser-like test environments, including handling of `visualViewport` and cleanup between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->