### PR TITLE
Improve staffing messaging and payout invoice instructions

### DIFF
--- a/src/components/jobs/PayoutEmailPreview.tsx
+++ b/src/components/jobs/PayoutEmailPreview.tsx
@@ -18,6 +18,7 @@ import { HOUSE_TECH_LABEL } from '@/utils/autonomo';
 const MADRID_TIMEZONE = 'Europe/Madrid';
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const INVOICE_SUBMISSION_EMAIL = 'administracion@sector-pro.com';
+const INVOICE_CC_EMAIL = 'administracion@mfo-producciones.com';
 
 function escapeHtml(value: string): string {
   return value
@@ -300,6 +301,7 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
                   ${safeCompanyDetails ? `<li><b>Empresa de facturación:</b> ${safeCompanyDetails.legalName} (CIF: ${safeCompanyDetails.cif}, ${safeCompanyDetails.address})</li>` : ''}
                   ${safeLpoNumber ? `<li><b>LPO:</b> ${safeLpoNumber}</li>` : ''}
                   <li><b>Enviar factura a:</b> <a href="mailto:${INVOICE_SUBMISSION_EMAIL}" style="color:#1e40af;text-decoration:underline;">${INVOICE_SUBMISSION_EMAIL}</a></li>
+                  <li><b>Poner en copia a:</b> <a href="mailto:${INVOICE_CC_EMAIL}" style="color:#1e40af;text-decoration:underline;">${INVOICE_CC_EMAIL}</a></li>
                 </ul>
               </div>
             </td>
@@ -392,7 +394,7 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
                   </div>
                   <div>
                     <div className="font-semibold">CC:</div>
-                    <div>administracion@mfo-producciones.com</div>
+                    <div>{INVOICE_CC_EMAIL}</div>
                   </div>
                   <div>
                     <div className="font-semibold">Asunto:</div>
@@ -417,10 +419,16 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
                     <div>{selectedAttachment.full_name} ({selectedAttachment.is_house_tech ? HOUSE_TECH_LABEL : selectedAttachment.autonomo ? 'Autónomo' : 'No autónomo'})</div>
                   </div>
                   {selectedAttachment.autonomo && !selectedAttachment.is_house_tech && (
-                    <div>
-                      <div className="font-semibold">Enviar factura a:</div>
-                      <div>{INVOICE_SUBMISSION_EMAIL}</div>
-                    </div>
+                    <>
+                      <div>
+                        <div className="font-semibold">Enviar factura a:</div>
+                        <div>{INVOICE_SUBMISSION_EMAIL}</div>
+                      </div>
+                      <div>
+                        <div className="font-semibold">Poner en copia a:</div>
+                        <div>{INVOICE_CC_EMAIL}</div>
+                      </div>
+                    </>
                   )}
                   <div>
                     <div className="font-semibold">Fechas trabajadas:</div>

--- a/src/components/jobs/__tests__/PayoutEmailPreview.test.tsx
+++ b/src/components/jobs/__tests__/PayoutEmailPreview.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PayoutEmailPreview } from '@/components/jobs/PayoutEmailPreview';
+import type { JobPayoutEmailContextResult } from '@/lib/job-payout-email';
+
+vi.mock('@/services/dataLayerClient', () => ({
+  dataLayerClient: {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+          })),
+        })),
+      })),
+    })),
+  },
+}));
+
+const renderPreview = (context: JobPayoutEmailContextResult) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PayoutEmailPreview open onClose={vi.fn()} context={context} jobTitle={context.job.title} />
+    </QueryClientProvider>,
+  );
+};
+
+describe('PayoutEmailPreview', () => {
+  it('shows the required invoice CC instruction for autonomo technicians', async () => {
+    const context: JobPayoutEmailContextResult = {
+      job: {
+        id: 'job-1',
+        title: 'Festival Job',
+        start_time: '2026-04-16T08:00:00.000Z',
+        end_time: '2026-04-16T18:00:00.000Z',
+        tour_id: null,
+        invoicing_company: 'Sector Pro',
+      },
+      payouts: [],
+      profiles: [],
+      lpoMap: new Map([['tech-1', 'LPO-001']]),
+      timesheetMap: new Map([
+        [
+          'tech-1',
+          [
+            {
+              date: '2026-04-16',
+              hours_rounded: 8,
+              total_eur: 100,
+            },
+          ],
+        ],
+      ]),
+      attachments: [
+        {
+          technician_id: 'tech-1',
+          email: 'ana@example.com',
+          full_name: 'Ana Lopez',
+          payout: {
+            job_id: 'job-1',
+            technician_id: 'tech-1',
+            timesheets_total_eur: 100,
+            extras_total_eur: 0,
+            expenses_total_eur: 0,
+            total_eur: 100,
+            extras_breakdown: { items: [], total_eur: 0 },
+            expenses_breakdown: [],
+            vehicle_disclaimer: false,
+          },
+          pdfBase64: btoa('pdf'),
+          filename: 'pago.pdf',
+          autonomo: true,
+          is_house_tech: false,
+          lpo_number: 'LPO-001',
+        },
+      ],
+      missingEmails: [],
+    };
+
+    renderPreview(context);
+
+    expect(await screen.findByText(/Enviar factura a:/i)).toBeInTheDocument();
+    expect(screen.getByText('administracion@sector-pro.com')).toBeInTheDocument();
+    expect(screen.getByText(/Poner en copia a:/i)).toBeInTheDocument();
+    expect(screen.getByText('administracion@mfo-producciones.com')).toBeInTheDocument();
+  });
+});

--- a/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
+++ b/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
@@ -671,9 +671,12 @@ describe('OptimizedMatrixCell', () => {
     const user = userEvent.setup();
     const staffingStatus: MatrixStaffingStatus = {
       availability_status: ' Requested ',
+      availability_job_title: 'Load-in Day',
+      pending_availability_job_titles: ['Load-in Day', 'Arena Show'],
       availability_requested_by: null,
       availability_created_at: '2026-04-08T09:15:00.000Z',
       offer_status: ' SENT ',
+      offer_job_title: 'Arena Show',
       offer_requested_by: 'manager-2',
       offer_created_at: '2026-04-09T11:00:00.000Z',
     };
@@ -697,6 +700,8 @@ describe('OptimizedMatrixCell', () => {
     await waitFor(() => {
       expect(screen.getAllByText(/Disponibilidad: Solicitada/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/Oferta: Enviada/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Trabajos: Load-in Day, Arena Show/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Trabajo: Arena Show/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/Enviado por: Second Manager/i).length).toBeGreaterThan(0);
     });
     expect(screen.queryByText(/Enviado por:\s*null/i)).not.toBeInTheDocument();

--- a/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
+++ b/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
@@ -706,4 +706,42 @@ describe('OptimizedMatrixCell', () => {
     });
     expect(screen.queryByText(/Enviado por:\s*null/i)).not.toBeInTheDocument();
   });
+
+  it('does not render internal job ids as staffing tooltip labels', async () => {
+    const user = userEvent.setup();
+    const staffingStatus: MatrixStaffingStatus = {
+      availability_status: 'requested',
+      availability_job_id: 'job-internal-availability',
+      availability_job_title: null,
+      pending_availability_job_ids: ['job-internal-availability'],
+      pending_availability_job_titles: [],
+      offer_status: 'sent',
+      offer_job_id: 'job-internal-offer',
+      offer_job_title: null,
+      pending_offer_job_ids: ['job-internal-offer'],
+      pending_offer_job_titles: [],
+    };
+
+    render(
+      <OptimizedMatrixCell
+        technician={mockTechnician}
+        date={mockDate}
+        width={160}
+        height={60}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onClick={vi.fn()}
+        staffingStatusByDateProvided={staffingStatus}
+      />
+    );
+
+    await user.hover(getCellElement());
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Disponibilidad: Solicitada/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Oferta: Enviada/i).length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(/job-internal-availability/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/job-internal-offer/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/matrix/optimized-matrix-cell/OptimizedMatrixCellTooltip.tsx
+++ b/src/components/matrix/optimized-matrix-cell/OptimizedMatrixCellTooltip.tsx
@@ -23,6 +23,16 @@ type OptimizedMatrixCellTooltipProps = {
   profileNamesMap: Map<string, string>;
 };
 
+const uniqueLabels = (values?: Array<string | null | undefined>): string[] => {
+  if (!values?.length) return [];
+  return Array.from(new Set(values.map((value) => value?.trim()).filter(Boolean) as string[]));
+};
+
+const formatJobLabel = (labels: string[]): string | null => {
+  if (labels.length === 0) return null;
+  return `${labels.length > 1 ? 'Trabajos' : 'Trabajo'}: ${labels.join(', ')}`;
+};
+
 export const OptimizedMatrixCellTooltip = ({
   displayName,
   technician,
@@ -32,82 +42,109 @@ export const OptimizedMatrixCellTooltip = ({
   availability,
   staffingStatusByDate,
   profileNamesMap,
-}: OptimizedMatrixCellTooltipProps) => (
-  <div className="space-y-1 text-sm">
-    <div className="font-semibold">
-      {displayName}
-    </div>
-    <div className="text-muted-foreground">
-      {technician.department}
-    </div>
-    {hasAssignment && (
-      <div className="text-xs">
-        <div>{assignment.job?.title}</div>
-        <div className="text-muted-foreground">
-          {labelForCode(assignment.sound_role || assignment.lights_role || assignment.video_role)}
-        </div>
-        {assignment.single_day && assignment.assignment_date && (
-          <div className="text-muted-foreground">
-            Día único: {formatInTimeZone(new Date(`${assignment.assignment_date}T00:00:00`), 'Europe/Madrid', 'MMM d', { locale: es })}
-          </div>
-        )}
-        <div className={`capitalize ${assignment.status === 'confirmed' ? 'text-green-600' : assignment.status === 'declined' ? 'text-red-600' : 'text-yellow-600'}`}>
-          Estado: {assignmentStatusLabel(assignment.status)}
-        </div>
-        {assignment.assigned_by && profileNamesMap.has(assignment.assigned_by) && (
-          <div className="text-muted-foreground">
-            Asignado por: {profileNamesMap.get(assignment.assigned_by)}
-          </div>
-        )}
-        {assignment.assigned_at && formatDateTimeEs(assignment.assigned_at) && (
-          <div className="text-muted-foreground">
-            Fecha: {formatDateTimeEs(assignment.assigned_at)}
-          </div>
-        )}
+}: OptimizedMatrixCellTooltipProps) => {
+  const availabilityJobLabel = formatJobLabel(
+    uniqueLabels(
+      staffingStatusByDate?.pending_availability_job_titles?.length
+        ? staffingStatusByDate.pending_availability_job_titles
+        : [staffingStatusByDate?.availability_job_title],
+    ),
+  );
+  const offerJobLabel = formatJobLabel(
+    uniqueLabels(
+      staffingStatusByDate?.pending_offer_job_titles?.length
+        ? staffingStatusByDate.pending_offer_job_titles
+        : [staffingStatusByDate?.offer_job_title],
+    ),
+  );
+
+  return (
+    <div className="space-y-1 text-sm">
+      <div className="font-semibold">
+        {displayName}
       </div>
-    )}
-    {!hasAssignment && !isUnavailable && staffingStatusByDate && (
-      <div className="text-xs space-y-2 pt-1">
-        {availabilityStatusLabel(staffingStatusByDate.availability_status) && (
-          <div>
-            <div className="text-yellow-700">
-              Disponibilidad: {availabilityStatusLabel(staffingStatusByDate.availability_status)}
+      <div className="text-muted-foreground">
+        {technician.department}
+      </div>
+      {hasAssignment && (
+        <div className="text-xs">
+          <div>{assignment.job?.title}</div>
+          <div className="text-muted-foreground">
+            {labelForCode(assignment.sound_role || assignment.lights_role || assignment.video_role)}
+          </div>
+          {assignment.single_day && assignment.assignment_date && (
+            <div className="text-muted-foreground">
+              Día único: {formatInTimeZone(new Date(`${assignment.assignment_date}T00:00:00`), 'Europe/Madrid', 'MMM d', { locale: es })}
             </div>
-            {staffingStatusByDate.availability_requested_by && profileNamesMap.has(staffingStatusByDate.availability_requested_by) && (
-              <div className="text-muted-foreground">
-                Enviado por: {profileNamesMap.get(staffingStatusByDate.availability_requested_by)}
-              </div>
-            )}
-            {staffingStatusByDate.availability_created_at && formatDateTimeEs(staffingStatusByDate.availability_created_at) && (
-              <div className="text-muted-foreground">
-                Fecha: {formatDateTimeEs(staffingStatusByDate.availability_created_at)}
-              </div>
-            )}
+          )}
+          <div className={`capitalize ${assignment.status === 'confirmed' ? 'text-green-600' : assignment.status === 'declined' ? 'text-red-600' : 'text-yellow-600'}`}>
+            Estado: {assignmentStatusLabel(assignment.status)}
           </div>
-        )}
-        {offerStatusLabel(staffingStatusByDate.offer_status) && (
-          <div>
-            <div className="text-blue-700">
-              Oferta: {offerStatusLabel(staffingStatusByDate.offer_status)}
+          {assignment.assigned_by && profileNamesMap.has(assignment.assigned_by) && (
+            <div className="text-muted-foreground">
+              Asignado por: {profileNamesMap.get(assignment.assigned_by)}
             </div>
-            {staffingStatusByDate.offer_requested_by && profileNamesMap.has(staffingStatusByDate.offer_requested_by) && (
-              <div className="text-muted-foreground">
-                Enviado por: {profileNamesMap.get(staffingStatusByDate.offer_requested_by)}
+          )}
+          {assignment.assigned_at && formatDateTimeEs(assignment.assigned_at) && (
+            <div className="text-muted-foreground">
+              Fecha: {formatDateTimeEs(assignment.assigned_at)}
+            </div>
+          )}
+        </div>
+      )}
+      {!hasAssignment && !isUnavailable && staffingStatusByDate && (
+        <div className="text-xs space-y-2 pt-1">
+          {availabilityStatusLabel(staffingStatusByDate.availability_status) && (
+            <div>
+              <div className="text-yellow-700">
+                Disponibilidad: {availabilityStatusLabel(staffingStatusByDate.availability_status)}
               </div>
-            )}
-            {staffingStatusByDate.offer_created_at && formatDateTimeEs(staffingStatusByDate.offer_created_at) && (
-              <div className="text-muted-foreground">
-                Fecha: {formatDateTimeEs(staffingStatusByDate.offer_created_at)}
+              {availabilityJobLabel && (
+                <div className="text-muted-foreground">
+                  {availabilityJobLabel}
+                </div>
+              )}
+              {staffingStatusByDate.availability_requested_by && profileNamesMap.has(staffingStatusByDate.availability_requested_by) && (
+                <div className="text-muted-foreground">
+                  Enviado por: {profileNamesMap.get(staffingStatusByDate.availability_requested_by)}
+                </div>
+              )}
+              {staffingStatusByDate.availability_created_at && formatDateTimeEs(staffingStatusByDate.availability_created_at) && (
+                <div className="text-muted-foreground">
+                  Fecha: {formatDateTimeEs(staffingStatusByDate.availability_created_at)}
+                </div>
+              )}
+            </div>
+          )}
+          {offerStatusLabel(staffingStatusByDate.offer_status) && (
+            <div>
+              <div className="text-blue-700">
+                Oferta: {offerStatusLabel(staffingStatusByDate.offer_status)}
               </div>
-            )}
-          </div>
-        )}
-      </div>
-    )}
-    {isUnavailable && !hasAssignment && (
-      <div className="text-xs text-muted-foreground">
-        No disponible{availability.notes ? `: ${availability.notes}` : ''}
-      </div>
-    )}
-  </div>
-);
+              {offerJobLabel && (
+                <div className="text-muted-foreground">
+                  {offerJobLabel}
+                </div>
+              )}
+              {staffingStatusByDate.offer_requested_by && profileNamesMap.has(staffingStatusByDate.offer_requested_by) && (
+                <div className="text-muted-foreground">
+                  Enviado por: {profileNamesMap.get(staffingStatusByDate.offer_requested_by)}
+                </div>
+              )}
+              {staffingStatusByDate.offer_created_at && formatDateTimeEs(staffingStatusByDate.offer_created_at) && (
+                <div className="text-muted-foreground">
+                  Fecha: {formatDateTimeEs(staffingStatusByDate.offer_created_at)}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+      {isUnavailable && !hasAssignment && (
+        <div className="text-xs text-muted-foreground">
+          No disponible{availability.notes ? `: ${availability.notes}` : ''}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/matrix/optimized-matrix-cell/types.ts
+++ b/src/components/matrix/optimized-matrix-cell/types.ts
@@ -29,13 +29,17 @@ export interface MatrixStaffingStatus {
   availability_status: string | null;
   offer_status: string | null;
   availability_job_id?: string | null;
+  availability_job_title?: string | null;
   offer_job_id?: string | null;
+  offer_job_title?: string | null;
   availability_requested_by?: string | null;
   availability_created_at?: string | null;
   offer_requested_by?: string | null;
   offer_created_at?: string | null;
   pending_availability_job_ids?: string[];
+  pending_availability_job_titles?: string[];
   pending_offer_job_ids?: string[];
+  pending_offer_job_titles?: string[];
 }
 
 export interface OptimizedMatrixCellProps {

--- a/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
+++ b/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
@@ -247,7 +247,7 @@ export function useStaffingMatrixStatuses(
               // Collect ALL non-expired job IDs for this phase (to ensure complete cell clearing)
               if (r.status !== 'expired' && !acc.pending_availability_job_ids.includes(r.job_id)) {
                 acc.pending_availability_job_ids.push(r.job_id)
-                acc.pending_availability_job_titles.push(jobTitle || r.job_id)
+                if (jobTitle) acc.pending_availability_job_titles.push(jobTitle)
               }
               const accT = acc.availability_updated_at || 0
               if (t > accT) {
@@ -263,7 +263,7 @@ export function useStaffingMatrixStatuses(
               // Collect ALL non-expired job IDs for this phase (to ensure complete cell clearing)
               if (r.status !== 'expired' && !acc.pending_offer_job_ids.includes(r.job_id)) {
                 acc.pending_offer_job_ids.push(r.job_id)
-                acc.pending_offer_job_titles.push(jobTitle || r.job_id)
+                if (jobTitle) acc.pending_offer_job_titles.push(jobTitle)
               }
               const accT = acc.offer_updated_at || 0
               if (t > accT) {

--- a/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
+++ b/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
@@ -20,6 +20,7 @@ const toMatrixStatus = (value: string | null): Status => {
 
 export interface MatrixJobLite {
   id: string
+  title?: string | null
   start_time: string
   end_time: string
 }
@@ -31,14 +32,18 @@ interface ByJobStatus {
 
 interface ByDateStatus extends ByJobStatus {
   availability_job_id?: string | null
+  availability_job_title?: string | null
   offer_job_id?: string | null
+  offer_job_title?: string | null
   availability_requested_by?: string | null
   availability_created_at?: string | null
   offer_requested_by?: string | null
   offer_created_at?: string | null
   // Arrays of ALL job IDs with pending requests for this date (for bulk cancel)
   pending_availability_job_ids?: string[]
+  pending_availability_job_titles?: string[]
   pending_offer_job_ids?: string[]
+  pending_offer_job_titles?: string[]
 }
 
 interface StaffingRequestRow {
@@ -59,13 +64,17 @@ interface LatestByPhaseAccumulator {
   availability_updated_at: number
   offer_updated_at: number
   availability_job_id: string | null
+  availability_job_title: string | null
   offer_job_id: string | null
+  offer_job_title: string | null
   availability_requested_by: string | null
   availability_created_at: string | null
   offer_requested_by: string | null
   offer_created_at: string | null
   pending_availability_job_ids: string[]
+  pending_availability_job_titles: string[]
   pending_offer_job_ids: string[]
+  pending_offer_job_titles: string[]
 }
 
 const createLatestByPhaseAccumulator = (): LatestByPhaseAccumulator => ({
@@ -74,13 +83,17 @@ const createLatestByPhaseAccumulator = (): LatestByPhaseAccumulator => ({
   availability_updated_at: 0,
   offer_updated_at: 0,
   availability_job_id: null,
+  availability_job_title: null,
   offer_job_id: null,
+  offer_job_title: null,
   availability_requested_by: null,
   availability_created_at: null,
   offer_requested_by: null,
   offer_created_at: null,
   pending_availability_job_ids: [],
-  pending_offer_job_ids: []
+  pending_availability_job_titles: [],
+  pending_offer_job_ids: [],
+  pending_offer_job_titles: []
 })
 
 export function useStaffingMatrixStatuses(
@@ -177,11 +190,11 @@ export function useStaffingMatrixStatuses(
       }
 
       // Build job lookup with parsed dates for overlap check
-      const jobLookup = new Map<string, { id: string, start: Date, end: Date }>()
+      const jobLookup = new Map<string, { id: string, title: string | null, start: Date, end: Date }>()
       jobs.forEach(j => {
         const start = j.start_time ? new Date(j.start_time) : new Date()
         const end = j.end_time ? new Date(j.end_time) : new Date()
-        jobLookup.set(j.id, { id: j.id, start, end })
+        jobLookup.set(j.id, { id: j.id, title: j.title?.trim() || null, start, end })
       })
 
       // Group requests by technician for faster lookups
@@ -229,10 +242,12 @@ export function useStaffingMatrixStatuses(
           const initialAcc = createLatestByPhaseAccumulator()
           const latest = matchingRequests.reduce((acc, r) => {
             const t = r.updated_at ? new Date(r.updated_at).getTime() : 0
+            const jobTitle = jobLookup.get(r.job_id)?.title ?? null
             if (r.phase === 'availability') {
               // Collect ALL non-expired job IDs for this phase (to ensure complete cell clearing)
               if (r.status !== 'expired' && !acc.pending_availability_job_ids.includes(r.job_id)) {
                 acc.pending_availability_job_ids.push(r.job_id)
+                acc.pending_availability_job_titles.push(jobTitle || r.job_id)
               }
               const accT = acc.availability_updated_at || 0
               if (t > accT) {
@@ -240,6 +255,7 @@ export function useStaffingMatrixStatuses(
                 acc.availability_status = mapped
                 acc.availability_updated_at = t
                 acc.availability_job_id = r.job_id
+                acc.availability_job_title = jobTitle
                 acc.availability_requested_by = r.requested_by ?? null
                 acc.availability_created_at = r.created_at ?? null
               }
@@ -247,6 +263,7 @@ export function useStaffingMatrixStatuses(
               // Collect ALL non-expired job IDs for this phase (to ensure complete cell clearing)
               if (r.status !== 'expired' && !acc.pending_offer_job_ids.includes(r.job_id)) {
                 acc.pending_offer_job_ids.push(r.job_id)
+                acc.pending_offer_job_titles.push(jobTitle || r.job_id)
               }
               const accT = acc.offer_updated_at || 0
               if (t > accT) {
@@ -254,6 +271,7 @@ export function useStaffingMatrixStatuses(
                 acc.offer_status = mapped
                 acc.offer_updated_at = t
                 acc.offer_job_id = r.job_id
+                acc.offer_job_title = jobTitle
                 acc.offer_requested_by = r.requested_by ?? null
                 acc.offer_created_at = r.created_at ?? null
               }
@@ -267,13 +285,17 @@ export function useStaffingMatrixStatuses(
               availability_status: latest.availability_status as Status,
               offer_status: latest.offer_status as Status,
               availability_job_id: latest.availability_job_id,
+              availability_job_title: latest.availability_job_title,
               offer_job_id: latest.offer_job_id,
+              offer_job_title: latest.offer_job_title,
               availability_requested_by: latest.availability_requested_by,
               availability_created_at: latest.availability_created_at,
               offer_requested_by: latest.offer_requested_by,
               offer_created_at: latest.offer_created_at,
               pending_availability_job_ids: latest.pending_availability_job_ids,
-              pending_offer_job_ids: latest.pending_offer_job_ids
+              pending_availability_job_titles: latest.pending_availability_job_titles,
+              pending_offer_job_ids: latest.pending_offer_job_ids,
+              pending_offer_job_titles: latest.pending_offer_job_titles
             })
           }
         })

--- a/supabase/functions/send-job-payout-email/__tests__/invoiceInstructions.test.ts
+++ b/supabase/functions/send-job-payout-email/__tests__/invoiceInstructions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildInvoiceRecipientListItems,
+  INVOICE_CC_EMAIL,
+  INVOICE_SUBMISSION_EMAIL,
+} from "../invoiceInstructions.ts";
+
+describe("job payout invoice instructions", () => {
+  it("shows the invoice recipient and required CC address", () => {
+    const html = buildInvoiceRecipientListItems();
+
+    expect(html).toContain(`mailto:${INVOICE_SUBMISSION_EMAIL}`);
+    expect(html).toContain(INVOICE_SUBMISSION_EMAIL);
+    expect(html).toContain("Enviar factura a:");
+    expect(html).toContain(`mailto:${INVOICE_CC_EMAIL}`);
+    expect(html).toContain(INVOICE_CC_EMAIL);
+    expect(html).toContain("Poner en copia a:");
+  });
+});

--- a/supabase/functions/send-job-payout-email/index.ts
+++ b/supabase/functions/send-job-payout-email/index.ts
@@ -16,8 +16,11 @@ import {
 import { requireAdminOrManagement } from "../_shared/auth.ts";
 import { getInvoicingCompanyDetails } from "../_shared/invoicing-company-data.ts";
 import { sendBrevoEmail } from "../_shared/brevo.ts";
+import {
+  buildInvoiceRecipientListItems,
+  INVOICE_CC_EMAIL,
+} from "./invoiceInstructions.ts";
 
-const INVOICE_SUBMISSION_EMAIL = "administracion@sector-pro.com";
 const MADRID_TIMEZONE = "Europe/Madrid";
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_PAYOUT_EMAIL_BODY_BYTES = 25 * 1024 * 1024;
@@ -442,7 +445,7 @@ serve(createHttpHandler(async (req) => {
                       <ul style="margin:8px 0 0 18px;padding:0;line-height:1.55;">
                         ${companyDetails ? `<li><b>Empresa de facturación:</b> ${escapeHtml(companyDetails.legalName)} (CIF: ${escapeHtml(companyDetails.cif)}, ${escapeHtml(companyDetails.address)})</li>` : ''}
                         ${tech.lpo_number ? `<li><b>LPO:</b> ${escapeHtml(tech.lpo_number)}</li>` : ''}
-                        <li><b>Enviar factura a:</b> <a href="mailto:${INVOICE_SUBMISSION_EMAIL}" style="color:#1e40af;text-decoration:underline;">${INVOICE_SUBMISSION_EMAIL}</a></li>
+                        ${buildInvoiceRecipientListItems()}
                       </ul>
                     </div>
                   </td>
@@ -503,7 +506,7 @@ serve(createHttpHandler(async (req) => {
       };
 
       // Always CC administration
-      emailPayload['cc'] = [{ email: 'administracion@mfo-producciones.com' }];
+      emailPayload['cc'] = [{ email: INVOICE_CC_EMAIL }];
 
       if (DEBUG) {
         console.log('[send-job-payout-email][debug] Sending email with attachment:', {

--- a/supabase/functions/send-job-payout-email/invoiceInstructions.ts
+++ b/supabase/functions/send-job-payout-email/invoiceInstructions.ts
@@ -1,0 +1,8 @@
+export const INVOICE_SUBMISSION_EMAIL = "administracion@sector-pro.com";
+export const INVOICE_CC_EMAIL = "administracion@mfo-producciones.com";
+
+export function buildInvoiceRecipientListItems(): string {
+  return `
+                        <li><b>Enviar factura a:</b> <a href="mailto:${INVOICE_SUBMISSION_EMAIL}" style="color:#1e40af;text-decoration:underline;">${INVOICE_SUBMISSION_EMAIL}</a></li>
+                        <li><b>Poner en copia a:</b> <a href="mailto:${INVOICE_CC_EMAIL}" style="color:#1e40af;text-decoration:underline;">${INVOICE_CC_EMAIL}</a></li>`;
+}

--- a/supabase/functions/send-staffing-email/__tests__/messageUtils.test.ts
+++ b/supabase/functions/send-staffing-email/__tests__/messageUtils.test.ts
@@ -31,7 +31,7 @@ describe("messageUtils", () => {
     ).toContain("a=decline");
   });
 
-  it("renders channel-specific WhatsApp copy without email wording", () => {
+  it("renders availability WhatsApp copy without job details", () => {
     const text = buildWhatsAppStaffingMessage({
       phase: "availability",
       fullName: "Marco Arancibia Sanchez",
@@ -50,9 +50,43 @@ describe("messageUtils", () => {
       declineUrl: "https://sector-pro.work/staffing/decline/request-1/token-1",
     });
 
-    expect(text).toContain("Consulta de disponibilidad para Operación Triunfo Tour 2026.");
+    expect(text).toContain("Consulta de disponibilidad.");
+    expect(text).toContain("jueves, 16 de abril de 2026");
+    expect(text).toContain("sábado, 18 de abril de 2026");
     expect(text).toContain("Confirmar disponibilidad: https://sector-pro.work/staffing/confirm/request-1/token-1");
     expect(text).toContain("No disponible: https://sector-pro.work/staffing/decline/request-1/token-1");
+    expect(text).not.toContain("Operación Triunfo Tour 2026");
+    expect(text).not.toContain("Montador");
+    expect(text).not.toContain("08:00");
+    expect(text).not.toContain("Bilbao Exhibition Centre");
     expect(text).not.toContain("Este email");
+  });
+
+  it("keeps formal offer WhatsApp copy detailed", () => {
+    const text = buildWhatsAppStaffingMessage({
+      phase: "offer",
+      fullName: "Marco Arancibia Sanchez",
+      jobTitle: "Operación Triunfo Tour 2026",
+      roleLabel: "Montador — Técnico",
+      normalizedDates: ["jueves, 16 de abril de 2026"],
+      isSingleDayRequest: true,
+      targetDateLabel: "jueves, 16 de abril de 2026",
+      startDate: "jueves, 16 de abril de 2026",
+      endDate: "sábado, 18 de abril de 2026",
+      callTime: "08:00",
+      location: "Bilbao Exhibition Centre (BEC)",
+      note: "Oferta formal con condiciones cerradas.",
+      tourPdfSignedUrl: "https://example.test/tour.pdf",
+      confirmUrl: "https://sector-pro.work/staffing/confirm/request-1/token-1",
+      declineUrl: "https://sector-pro.work/staffing/decline/request-1/token-1",
+    });
+
+    expect(text).toContain("Tienes una oferta para Operación Triunfo Tour 2026.");
+    expect(text).toContain("- Rol: Montador — Técnico");
+    expect(text).toContain("- Horario: 08:00");
+    expect(text).toContain("- Ubicación: Bilbao Exhibition Centre (BEC)");
+    expect(text).toContain("Oferta formal con condiciones cerradas.");
+    expect(text).toContain("Calendario del tour (PDF): https://example.test/tour.pdf");
+    expect(text).toContain("Aceptar oferta: https://sector-pro.work/staffing/confirm/request-1/token-1");
   });
 });

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -1195,6 +1195,14 @@ serve(createHttpHandler(async (req) => {
       const multiDatesHtml = normalizedDates.length > 1
         ? `<div><b>Fechas seleccionadas:</b></div><ul style="margin:8px 0 0 16px;padding:0;">${normalizedDates.map(d => `<li>${fmtDate(`${d}T00:00:00Z`)}</li>`).join('')}</ul>`
         : '';
+      const dateDetailsHtml = normalizedDates.length > 1 ? multiDatesHtml : datesRowHtml;
+      const offerDetailsHtml = phase === 'offer'
+        ? `
+                            <div><b>Horario:</b> ${callTime}</div>
+                            <div><b>Ubicación:</b> ${loc}</div>
+                            ${roleLabel ? `<div><b>Rol:</b> ${roleLabel}</div>` : ''}`
+        : '';
+      const detailsTitle = phase === 'availability' ? 'Fechas consultadas' : 'Detalles del trabajo';
 
       // Determine singular vs plural for availability message
       const isMultipleDates = normalizedDates.length > 1;
@@ -1250,19 +1258,17 @@ serve(createHttpHandler(async (req) => {
                     <table role="presentation" cellspacing="0" cellpadding="0" style="width:100%;background:#f9fafb;border:1px solid #e5e7eb;border-radius:8px;">
                       <tr>
                         <td style="padding:16px;">
-                          <div style="color:#111827;font-weight:bold;margin-bottom:4px;">Detalles del trabajo</div>
+                          <div style="color:#111827;font-weight:bold;margin-bottom:4px;">${detailsTitle}</div>
                           <div style="color:#374151;line-height:1.55;">
-                            ${normalizedDates.length > 1 ? multiDatesHtml : datesRowHtml}
-                            <div><b>Horario:</b> ${callTime}</div>
-                            <div><b>Ubicación:</b> ${loc}</div>
-                            ${roleLabel ? `<div><b>Rol:</b> ${roleLabel}</div>` : ''}
+                            ${dateDetailsHtml}
+                            ${offerDetailsHtml}
                           </div>
                         </td>
                       </tr>
                     </table>
                   </td>
                 </tr>
-                ${tourPdfSignedUrl ? `
+                ${phase === 'offer' && tourPdfSignedUrl ? `
                 <tr>
                   <td style="padding:12px 24px 0 24px;">
                     <div style=\"background:#fff7ed;border:1px solid #fed7aa;border-radius:8px;padding:12px;\">
@@ -1323,7 +1329,7 @@ serve(createHttpHandler(async (req) => {
           endDate,
           callTime,
           location: loc,
-          tourPdfSignedUrl,
+          tourPdfSignedUrl: phase === 'offer' ? tourPdfSignedUrl : null,
           confirmUrl: whatsappConfirmUrl,
           declineUrl: whatsappDeclineUrl,
         });

--- a/supabase/functions/send-staffing-email/messageUtils.ts
+++ b/supabase/functions/send-staffing-email/messageUtils.ts
@@ -62,7 +62,7 @@ export function buildWhatsAppStaffingMessage(
   const lines: string[] = [fullName ? `Hola ${fullName},` : "Hola,"];
 
   if (args.phase === "availability") {
-    lines.push(`Consulta de disponibilidad para ${jobTitle}.`);
+    lines.push("Consulta de disponibilidad.");
   } else {
     lines.push(`Tienes una oferta para ${jobTitle}.`);
   }
@@ -70,7 +70,7 @@ export function buildWhatsAppStaffingMessage(
   lines.push("");
   lines.push("Resumen:");
 
-  if (roleLabel) {
+  if (args.phase === "offer" && roleLabel) {
     lines.push(`- Rol: ${roleLabel}`);
   }
 
@@ -85,15 +85,17 @@ export function buildWhatsAppStaffingMessage(
     lines.push(`- Fechas: ${args.startDate}${args.endDate ? ` — ${args.endDate}` : ""}`);
   }
 
-  lines.push(`- Horario: ${args.callTime}`);
-  lines.push(`- Ubicación: ${args.location}`);
+  if (args.phase === "offer") {
+    lines.push(`- Horario: ${args.callTime}`);
+    lines.push(`- Ubicación: ${args.location}`);
+  }
 
-  if (note) {
+  if (args.phase === "offer" && note) {
     lines.push("");
     lines.push(note);
   }
 
-  if (args.tourPdfSignedUrl) {
+  if (args.phase === "offer" && args.tourPdfSignedUrl) {
     lines.push("");
     lines.push(`Calendario del tour (PDF): ${args.tourPdfSignedUrl}`);
   }

--- a/supabase/functions/staffing-click/__tests__/followupUtils.test.ts
+++ b/supabase/functions/staffing-click/__tests__/followupUtils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildStaffingClickWhatsappFollowupMessage } from "../followupUtils.ts";
+import {
+  buildStaffingClickWhatsappFollowupMessage,
+  shouldSendStaffingClickWhatsappFollowup,
+} from "../followupUtils.ts";
 
 describe("staffing click follow-up messages", () => {
   it("builds availability follow-up WhatsApp copy", () => {
@@ -19,5 +22,11 @@ describe("staffing click follow-up messages", () => {
     expect(buildStaffingClickWhatsappFollowupMessage("offer", "declined")).toBe(
       "Lamentamos que no estés disponible, en otra ocasión será. Gracias igualmente.",
     );
+  });
+
+  it("sends follow-up when the request used WhatsApp even if another send event is newer", () => {
+    expect(shouldSendStaffingClickWhatsappFollowup("whatsapp", null)).toBe(true);
+    expect(shouldSendStaffingClickWhatsappFollowup("", { event: "whatsapp_sent" })).toBe(true);
+    expect(shouldSendStaffingClickWhatsappFollowup("email", null)).toBe(false);
   });
 });

--- a/supabase/functions/staffing-click/__tests__/followupUtils.test.ts
+++ b/supabase/functions/staffing-click/__tests__/followupUtils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { buildStaffingClickWhatsappFollowupMessage } from "../followupUtils.ts";
+
+describe("staffing click follow-up messages", () => {
+  it("builds availability follow-up WhatsApp copy", () => {
+    expect(buildStaffingClickWhatsappFollowupMessage("availability", "confirmed")).toBe(
+      "Gracias por confirmar tu disponibilidad, recibirás otro mensaje con una oferta formal y más detalles de confirmarse el trabajo.",
+    );
+    expect(buildStaffingClickWhatsappFollowupMessage("availability", "declined")).toBe(
+      "Lamentamos que no estés disponible, en otra ocasión será, gracias igualmente.",
+    );
+  });
+
+  it("builds offer follow-up WhatsApp copy", () => {
+    expect(buildStaffingClickWhatsappFollowupMessage("offer", "confirmed")).toBe(
+      "Gracias por confirmar este trabajo con nosotros, la oferta queda cerrada y has sido añadido al equipo para este bolo, el departamento de producción te contactará más adelante con más detalles, saludos!",
+    );
+    expect(buildStaffingClickWhatsappFollowupMessage("offer", "declined")).toBe(
+      "Lamentamos que no estés disponible, en otra ocasión será. Gracias igualmente.",
+    );
+  });
+});

--- a/supabase/functions/staffing-click/followupUtils.ts
+++ b/supabase/functions/staffing-click/followupUtils.ts
@@ -1,0 +1,21 @@
+export type StaffingClickPhase = "availability" | "offer";
+export type StaffingClickStatus = "confirmed" | "declined";
+
+export function buildStaffingClickWhatsappFollowupMessage(
+  phase: StaffingClickPhase | string,
+  status: StaffingClickStatus,
+): string {
+  if (phase === "offer") {
+    if (status === "confirmed") {
+      return "Gracias por confirmar este trabajo con nosotros, la oferta queda cerrada y has sido añadido al equipo para este bolo, el departamento de producción te contactará más adelante con más detalles, saludos!";
+    }
+
+    return "Lamentamos que no estés disponible, en otra ocasión será. Gracias igualmente.";
+  }
+
+  if (status === "confirmed") {
+    return "Gracias por confirmar tu disponibilidad, recibirás otro mensaje con una oferta formal y más detalles de confirmarse el trabajo.";
+  }
+
+  return "Lamentamos que no estés disponible, en otra ocasión será, gracias igualmente.";
+}

--- a/supabase/functions/staffing-click/followupUtils.ts
+++ b/supabase/functions/staffing-click/followupUtils.ts
@@ -1,6 +1,13 @@
 export type StaffingClickPhase = "availability" | "offer";
 export type StaffingClickStatus = "confirmed" | "declined";
 
+export function shouldSendStaffingClickWhatsappFollowup(
+  channelHint: string,
+  whatsappSend: unknown,
+): boolean {
+  return channelHint === "whatsapp" || Boolean(whatsappSend);
+}
+
 export function buildStaffingClickWhatsappFollowupMessage(
   phase: StaffingClickPhase | string,
   status: StaffingClickStatus,

--- a/supabase/functions/staffing-click/index.ts
+++ b/supabase/functions/staffing-click/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
 import { detectConflictForAssignment, type AssignmentCoverage, type JobTimeInfo } from "./conflictUtils.ts";
+import { buildStaffingClickWhatsappFollowupMessage } from "./followupUtils.ts";
 import { parseStaffingClickRequest } from "./requestUtils.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
@@ -19,6 +20,183 @@ function b64uToU8(b64u: string) {
   const b64 = b64u.replace(/-/g,'+').replace(/_/g,'/') + '=='.slice(0,(4-(b64u.length%4))%4);
   const bin = atob(b64);
   return new Uint8Array([...bin].map(c => c.charCodeAt(0)));
+}
+
+function scheduleBackgroundTask(task: Promise<unknown>) {
+  if (typeof EdgeRuntime !== 'undefined' && 'waitUntil' in EdgeRuntime) {
+    EdgeRuntime.waitUntil(task);
+  } else {
+    void task;
+  }
+}
+
+function normalizeBase(value: string): string {
+  let base = (value || '').trim();
+  if (!/^https?:\/\//i.test(base)) base = `https://${base}`;
+  return base.replace(/\/+$/, '');
+}
+
+function normalizePhone(raw: string, defaultCountry: string): { ok: true; value: string } | { ok: false; reason: string } {
+  if (!raw) return { ok: false, reason: 'empty' } as const;
+  const trimmed = raw.trim();
+  if (!trimmed) return { ok: false, reason: 'empty' } as const;
+  let digits = trimmed.replace(/[\s\-()]/g, '');
+  if (digits.startsWith('00')) digits = `+${digits.slice(2)}`;
+  if (!digits.startsWith('+')) {
+    if (/^[67]\d{8}$/.test(digits)) {
+      digits = `+34${digits}`;
+    } else {
+      const countryCode = defaultCountry.startsWith('+') ? defaultCountry : `+${defaultCountry}`;
+      digits = `${countryCode}${digits}`;
+    }
+  }
+  if (!/^\+\d{7,15}$/.test(digits)) return { ok: false, reason: 'invalid_format' } as const;
+  return { ok: true, value: digits } as const;
+}
+
+async function sendStaffingClickWhatsappFollowup(params: {
+  supabase: ReturnType<typeof createClient>;
+  staffingRequestId: string;
+  channelHint: string;
+  profileId: string;
+  requestedBy: string | null;
+  phase: string;
+  status: 'confirmed' | 'declined';
+}) {
+  const { supabase, staffingRequestId, channelHint, profileId, requestedBy, phase, status } = params;
+
+  try {
+    const [{ data: latestSend, error: latestSendError }, { data: tech, error: techError }, { data: requester, error: requesterError }] = await Promise.all([
+      supabase
+        .from('staffing_events')
+        .select('event, created_at')
+        .eq('staffing_request_id', staffingRequestId)
+        .in('event', ['whatsapp_sent', 'email_sent'])
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from('profiles')
+        .select('phone')
+        .eq('id', profileId)
+        .maybeSingle(),
+      requestedBy
+        ? supabase
+          .from('profiles')
+          .select('waha_endpoint')
+          .eq('id', requestedBy)
+          .maybeSingle()
+        : Promise.resolve({ data: null, error: null }),
+    ]);
+
+    if (latestSendError) {
+      console.warn('[staffing-click] Follow-up channel lookup failed', latestSendError);
+    }
+    if (techError) {
+      console.warn('[staffing-click] Follow-up technician lookup failed', techError);
+      return;
+    }
+    if (requesterError) {
+      console.warn('[staffing-click] Follow-up requester lookup failed', requesterError);
+    }
+
+    const wasWhatsappRequest = channelHint === 'whatsapp' || latestSend?.event === 'whatsapp_sent';
+    if (!wasWhatsappRequest) return;
+
+    const normalizedPhone = normalizePhone(tech?.phone || '', Deno.env.get('WA_DEFAULT_COUNTRY_CODE') || '+34');
+    if (!normalizedPhone.ok) {
+      await supabase.from('staffing_events').insert({
+        staffing_request_id: staffingRequestId,
+        event: 'whatsapp_followup_failed',
+        meta: { phase, status, reason: normalizedPhone.reason },
+      });
+      return;
+    }
+
+    const base = normalizeBase(requester?.waha_endpoint || 'https://waha.sector-pro.work');
+    const { data: cfg } = await supabase.rpc('get_waha_config', { base_url: base });
+    const apiKey = (cfg?.[0] as any)?.api_key || Deno.env.get('WAHA_API_KEY') || '';
+    const session = (cfg?.[0] as any)?.session || Deno.env.get('WAHA_SESSION') || 'default';
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (apiKey) headers['X-API-Key'] = apiKey;
+
+    const chatId = normalizedPhone.value.replace(/^\+/, '').replace(/\D/g, '') + '@c.us';
+    const text = buildStaffingClickWhatsappFollowupMessage(phase, status);
+    const basePayload = { chatId, text, linkPreview: false } as const;
+    const attemptCandidates = [
+      { url: `${base}/api/${encodeURIComponent(session)}/sendText`, body: { ...basePayload } },
+      { url: `${base}/api/sendText`, body: { ...basePayload, session } },
+      { url: `${base}/api/sendText?session=${encodeURIComponent(session)}`, body: { ...basePayload } },
+      { url: `${base}/api/sendText`, body: { ...basePayload } },
+    ] as const;
+    const attempts = attemptCandidates.filter((candidate, index, array) => {
+      const key = `${candidate.url}|${JSON.stringify(candidate.body)}`;
+      return array.findIndex((item) => `${item.url}|${JSON.stringify(item.body)}` === key) === index;
+    });
+
+    const timeoutMs = Number(Deno.env.get('WAHA_FETCH_TIMEOUT_MS') || 15000);
+    const overallMs = Number(Deno.env.get('STAFFING_WA_OVERALL_TIMEOUT_MS') || 14000);
+    const started = Date.now();
+    const attemptErrors: Array<{ url: string; status?: number; message?: string; body?: string }> = [];
+    let sent = false;
+    let lastStatus: number | undefined;
+
+    for (const attempt of attempts) {
+      const remaining = overallMs - (Date.now() - started) - 200;
+      if (remaining <= 200) {
+        attemptErrors.push({ url: attempt.url, message: 'skipped_due_to_time_budget' });
+        continue;
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(new DOMException('timeout', 'AbortError')), Math.min(timeoutMs, remaining));
+      try {
+        const response = await fetch(attempt.url, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(attempt.body),
+          signal: controller.signal,
+        });
+        lastStatus = response.status;
+        const responseBody = await response.text().catch(() => '');
+        if (response.ok) {
+          sent = true;
+          break;
+        }
+        attemptErrors.push({ url: attempt.url, status: response.status, body: responseBody.slice(0, 500) });
+      } catch (error) {
+        attemptErrors.push({
+          url: attempt.url,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    await supabase.from('staffing_events').insert({
+      staffing_request_id: staffingRequestId,
+      event: sent ? 'whatsapp_followup_sent' : 'whatsapp_followup_failed',
+      meta: {
+        phase,
+        status,
+        http_status: sent ? 200 : (lastStatus ?? 0),
+        attempts: sent ? undefined : attemptErrors,
+        chat_suffix: chatId.slice(-10),
+      },
+    });
+  } catch (error) {
+    console.warn('[staffing-click] WhatsApp follow-up failed', error);
+    await supabase.from('staffing_events').insert({
+      staffing_request_id: staffingRequestId,
+      event: 'whatsapp_followup_failed',
+      meta: {
+        phase,
+        status,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
 }
 
 serve(async (req) => {
@@ -654,6 +832,16 @@ serve(async (req) => {
         });
       }
     }
+
+    scheduleBackgroundTask(sendStaffingClickWhatsappFollowup({
+      supabase,
+      staffingRequestId: rid,
+      channelHint: c,
+      profileId: row.profile_id,
+      requestedBy: row.requested_by ?? null,
+      phase: row.phase,
+      status: newStatus,
+    }));
 
     const phaseText = row.phase === 'offer' ? 'la oferta' : 'la disponibilidad';
     const isOk = newStatus === 'confirmed';

--- a/supabase/functions/staffing-click/index.ts
+++ b/supabase/functions/staffing-click/index.ts
@@ -2,7 +2,10 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
 import { detectConflictForAssignment, type AssignmentCoverage, type JobTimeInfo } from "./conflictUtils.ts";
-import { buildStaffingClickWhatsappFollowupMessage } from "./followupUtils.ts";
+import {
+  buildStaffingClickWhatsappFollowupMessage,
+  shouldSendStaffingClickWhatsappFollowup,
+} from "./followupUtils.ts";
 import { parseStaffingClickRequest } from "./requestUtils.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
@@ -66,13 +69,12 @@ async function sendStaffingClickWhatsappFollowup(params: {
   const { supabase, staffingRequestId, channelHint, profileId, requestedBy, phase, status } = params;
 
   try {
-    const [{ data: latestSend, error: latestSendError }, { data: tech, error: techError }, { data: requester, error: requesterError }] = await Promise.all([
+    const [{ data: whatsappSend, error: whatsappSendError }, { data: tech, error: techError }, { data: requester, error: requesterError }] = await Promise.all([
       supabase
         .from('staffing_events')
-        .select('event, created_at')
+        .select('event')
         .eq('staffing_request_id', staffingRequestId)
-        .in('event', ['whatsapp_sent', 'email_sent'])
-        .order('created_at', { ascending: false })
+        .eq('event', 'whatsapp_sent')
         .limit(1)
         .maybeSingle(),
       supabase
@@ -89,8 +91,8 @@ async function sendStaffingClickWhatsappFollowup(params: {
         : Promise.resolve({ data: null, error: null }),
     ]);
 
-    if (latestSendError) {
-      console.warn('[staffing-click] Follow-up channel lookup failed', latestSendError);
+    if (whatsappSendError) {
+      console.warn('[staffing-click] Follow-up channel lookup failed', whatsappSendError);
     }
     if (techError) {
       console.warn('[staffing-click] Follow-up technician lookup failed', techError);
@@ -100,7 +102,7 @@ async function sendStaffingClickWhatsappFollowup(params: {
       console.warn('[staffing-click] Follow-up requester lookup failed', requesterError);
     }
 
-    const wasWhatsappRequest = channelHint === 'whatsapp' || latestSend?.event === 'whatsapp_sent';
+    const wasWhatsappRequest = shouldSendStaffingClickWhatsappFollowup(channelHint, whatsappSend);
     if (!wasWhatsappRequest) return;
 
     const normalizedPhone = normalizePhone(tech?.phone || '', Deno.env.get('WA_DEFAULT_COUNTRY_CODE') || '+34');


### PR DESCRIPTION
## Summary
- Show job titles in matrix staffing hover metadata for availability and offer states
- Remove job details from availability enquiries while keeping offer messages detailed
- Send WhatsApp follow-up messages after staffing link responses
- Add the required invoice CC instruction to job payout emails and preview

## Validation
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing emails and previews now show both the invoice submission and CC recipients for autonomous technicians.
  * Staffing click actions can now send automated WhatsApp follow-up messages for confirmed/declined responses.
  * Staffing matrix tooltips now display job titles alongside availability and offer statuses.

* **Bug Fixes**
  * Availability messages are now cleaner and no longer include extra job details.
  * Offer messages now consistently include role, schedule, location, notes, and the tour PDF link only when relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->