### PR TITLE
[codex] Show Carlos staffing activity

### DIFF
--- a/scripts/governance/edge-function-exposure.json
+++ b/scripts/governance/edge-function-exposure.json
@@ -98,8 +98,8 @@
     },
     "send-staffing-email": {
       "class": "privileged-role",
-      "verifyJwt": true,
-      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; browser callers must be authenticated admin/management, while the staffing orchestrator may call with the service-role key and an audited actor fallback."
+      "verifyJwt": false,
+      "internalGuard": "Gateway JWT is disabled so browser CORS preflight reaches the shared HTTP wrapper. Runtime auth accepts service-role bearer/apikey for automation, otherwise requireAdminOrManagement validates the caller JWT and requires admin/management before any staffing send."
     },
     "send-timesheet-reminder": { "class": "privileged-role", "verifyJwt": true },
     "send-tour-availability": {

--- a/src/components/matrix/OptimizedAssignmentMatrix.tsx
+++ b/src/components/matrix/OptimizedAssignmentMatrix.tsx
@@ -451,8 +451,8 @@ export const OptimizedAssignmentMatrix = ({
       if (assignment?.assigned_by) ids.add(assignment.assigned_by);
     });
     staffingMaps?.byDate?.forEach((status) => {
-      if (status?.availability_requested_by) ids.add(status.availability_requested_by);
-      if (status?.offer_requested_by) ids.add(status.offer_requested_by);
+      if (!status?.availability_actor_label && status?.availability_requested_by) ids.add(status.availability_requested_by);
+      if (!status?.offer_actor_label && status?.offer_requested_by) ids.add(status.offer_requested_by);
     });
     return Array.from(ids);
   }, [allAssignments, staffingMaps]);

--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -121,8 +121,26 @@ const ROLE_ACTIVITY_STATUS_LABELS: Record<string, string> = {
   declined: 'rechazada'
 }
 
+const getActivityTimestamp = (activity?: CandidatePhaseActivity) => {
+  const value = activity?.updated_at || activity?.created_at
+  const timestamp = value ? parseISO(value).getTime() : 0
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+const getLatestCandidateActivity = (activity?: CandidateActivity) => {
+  const availability = activity?.availability
+  const offer = activity?.offer
+
+  if (!availability) return offer
+  if (!offer) return availability
+
+  return getActivityTimestamp(offer) >= getActivityTimestamp(availability)
+    ? offer
+    : availability
+}
+
 const getCandidateActivityLabel = (activity?: CandidateActivity) => {
-  const latest = activity?.offer || activity?.availability
+  const latest = getLatestCandidateActivity(activity)
   if (!latest) return null
 
   const phaseLabel = latest.phase === 'offer' ? 'Oferta' : 'Disponibilidad'
@@ -131,7 +149,7 @@ const getCandidateActivityLabel = (activity?: CandidateActivity) => {
 }
 
 const getCandidateActivityClassName = (activity?: CandidateActivity) => {
-  const latest = activity?.offer || activity?.availability
+  const latest = getLatestCandidateActivity(activity)
   if (!latest) return ''
   if (latest.status === 'confirmed') return 'bg-green-100 text-green-800'
   if (latest.status === 'declined') return 'bg-red-100 text-red-800'
@@ -525,6 +543,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
           {candidates.map((candidate, index) => {
             const rolelessConsultation = rolelessConsultations[candidate.profile_id]
             const activity = roleActivity[candidate.profile_id]
+            const latestActivity = getLatestCandidateActivity(activity)
             const activityLabel = getCandidateActivityLabel(activity)
             const isNextCandidate = candidate.profile_id === nextCandidateProfileId
             const reasons = Array.isArray(candidate.reasons) ? candidate.reasons.map(String) : []
@@ -572,7 +591,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                     ) : (
                       <Badge variant="outline">Estado: No contactado</Badge>
                     )}
-                    {activityLabel && readOnly && actorLabel && (
+                    {activityLabel && readOnly && actorLabel && latestActivity?.request_origin === 'auto_staffing' && (
                       <Badge variant="outline">Enviado por {actorLabel}</Badge>
                     )}
                     {candidate.final_score >= 80 && (

--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -27,6 +27,9 @@ interface StaffingCandidateListProps {
   assignedCount?: number
   confirmedAvailability?: number
   pendingAvailability?: number
+  mode?: 'assisted' | 'auto'
+  readOnly?: boolean
+  actorLabel?: string
 }
 
 type StaffingChannel = 'email' | 'whatsapp'
@@ -55,6 +58,41 @@ interface RolelessConsultation {
   updated_at: string | null
 }
 
+interface CandidateRequestRow {
+  id: string
+  profile_id: string | null
+  phase: string | null
+  status: string | null
+  target_date: string | null
+  single_day: boolean | null
+  updated_at: string | null
+  created_at: string | null
+  role_code: string | null
+}
+
+interface CandidateEventMeta {
+  phase?: string
+  role?: string
+  request_origin?: string
+}
+
+interface CandidateEventRow {
+  staffing_request_id: string | null
+  event: string | null
+  meta: CandidateEventMeta | null
+  created_at: string | null
+}
+
+interface CandidatePhaseActivity {
+  phase: 'availability' | 'offer'
+  status: string
+  created_at: string | null
+  updated_at: string | null
+  request_origin?: string | null
+}
+
+type CandidateActivity = Partial<Record<'availability' | 'offer', CandidatePhaseActivity>>
+
 const ROLELESS_PHASE_LABELS: Record<string, string> = {
   availability: 'disponibilidad',
   offer: 'oferta'
@@ -76,6 +114,29 @@ const getRolelessConsultationLabel = (consultation: RolelessConsultation) => {
   return `Solicitud previa de ${phase} sin rol: ${status}${scope}`
 }
 
+const ROLE_ACTIVITY_STATUS_LABELS: Record<string, string> = {
+  pending: 'enviada',
+  confirmed: 'confirmada',
+  declined: 'rechazada'
+}
+
+const getCandidateActivityLabel = (activity?: CandidateActivity) => {
+  const latest = activity?.offer || activity?.availability
+  if (!latest) return null
+
+  const phaseLabel = latest.phase === 'offer' ? 'Oferta' : 'Disponibilidad'
+  const statusLabel = ROLE_ACTIVITY_STATUS_LABELS[latest.status] ?? latest.status
+  return `${phaseLabel} ${statusLabel}`
+}
+
+const getCandidateActivityClassName = (activity?: CandidateActivity) => {
+  const latest = activity?.offer || activity?.availability
+  if (!latest) return ''
+  if (latest.status === 'confirmed') return 'bg-green-100 text-green-800'
+  if (latest.status === 'declined') return 'bg-red-100 text-red-800'
+  return latest.phase === 'offer' ? 'bg-blue-100 text-blue-800' : 'bg-yellow-100 text-yellow-800'
+}
+
 export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
   campaignId,
   roleCode,
@@ -85,7 +146,10 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
   requiredCount = 0,
   assignedCount = 0,
   confirmedAvailability = 0,
-  pendingAvailability = 0
+  pendingAvailability = 0,
+  mode = 'assisted',
+  readOnly = false,
+  actorLabel
 }) => {
   const { toast } = useToast()
   const queryClient = useQueryClient()
@@ -99,14 +163,14 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
 
   // Fetch ranked candidates
   const { data: candidates, isLoading } = useQuery({
-    queryKey: queryKeys.scope('staffing_candidates', jobId, department, roleCode),
+    queryKey: queryKeys.scope('staffing_candidates', jobId, department, roleCode, mode),
     queryFn: async () => {
       try {
         const { data, error } = await dataLayerClient.rpc('rank_staffing_candidates', {
           p_job_id: jobId,
           p_department: department,
           p_role_code: roleCode,
-          p_mode: 'assisted',
+          p_mode: mode,
           p_policy: policy
         })
 
@@ -181,6 +245,77 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
     enabled: candidateIds.length > 0
   })
 
+  const { data: roleActivity = {} } = useQuery<Record<string, CandidateActivity>>({
+    queryKey: queryKeys.scope('staffing_candidate_role_activity', jobId, roleCode, candidateIds),
+    queryFn: async () => {
+      if (candidateIds.length === 0) return {}
+
+      const { data: requests, error } = await dataLayerClient.from('staffing_requests')
+        .select('id, profile_id, phase, status, target_date, single_day, updated_at, created_at, role_code')
+        .eq('job_id', jobId)
+        .in('profile_id', candidateIds)
+        .in('phase', ['availability', 'offer'])
+        .in('status', ['pending', 'confirmed', 'declined'])
+        .order('updated_at', { ascending: false })
+
+      if (error) {
+        console.error('Error fetching candidate staffing activity:', error)
+        return {}
+      }
+
+      const requestRows = (requests || []) as CandidateRequestRow[]
+      const requestIds = requestRows.map((request) => request.id).filter(Boolean)
+      const eventMetaByRequestId = new Map<string, CandidateEventMeta>()
+
+      if (requestIds.length > 0) {
+        const { data: sentEvents, error: sentEventsError } = await dataLayerClient.from('staffing_events')
+          .select('staffing_request_id, event, meta, created_at')
+          .in('staffing_request_id', requestIds)
+          .in('event', ['email_sent', 'whatsapp_sent'])
+          .order('created_at', { ascending: false })
+
+        if (sentEventsError) {
+          console.error('Error fetching candidate staffing events:', sentEventsError)
+        } else {
+          ;[...((sentEvents || []) as CandidateEventRow[])]
+            .sort((a, b) => (
+              new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime()
+            ))
+            .forEach((event) => {
+              const requestId = String(event.staffing_request_id || '')
+              if (!requestId || eventMetaByRequestId.has(requestId)) return
+              eventMetaByRequestId.set(requestId, event.meta || {})
+            })
+        }
+      }
+
+      return requestRows.reduce((acc, request) => {
+        const phase = request.phase === 'availability' || request.phase === 'offer'
+          ? request.phase
+          : null
+        const profileId = String(request.profile_id || '')
+        if (!phase || !profileId) return acc
+
+        const eventMeta = eventMetaByRequestId.get(String(request.id)) || {}
+        const requestRole = String(request.role_code || eventMeta.role || '')
+        if (requestRole !== roleCode) return acc
+
+        if (!acc[profileId]) acc[profileId] = {}
+        if (acc[profileId][phase]) return acc
+
+        acc[profileId][phase] = {
+          phase,
+          status: request.status || 'pending',
+          created_at: request.created_at,
+          updated_at: request.updated_at,
+          request_origin: eventMeta.request_origin || null
+        }
+        return acc
+      }, {} as Record<string, CandidateActivity>)
+    },
+    enabled: candidateIds.length > 0
+  })
+
   // Send availability mutation
   const sendAvailabilityMutation = useMutation({
     mutationFn: async () => {
@@ -240,6 +375,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId) })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_candidates', jobId) })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_roleless_consultations', jobId) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_candidate_role_activity', jobId, roleCode) })
     },
     onError: (error: any) => {
       toast({
@@ -304,6 +440,14 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
     const wave = recommendedWaveNumber(index, requiredCount, waveBuffer)
     return wave > maxWaves ? `Tras oleada ${maxWaves}` : `Oleada ${wave}`
   }
+  const nextCandidateProfileId = useMemo(() => {
+    if (!readOnly || !candidates?.length) return null
+
+    return candidates.find((candidate) => {
+      const activity = roleActivity[candidate.profile_id]
+      return !activity?.availability && !activity?.offer
+    })?.profile_id ?? null
+  }, [candidates, readOnly, roleActivity])
 
   if (isLoading) {
     return (
@@ -330,46 +474,57 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{roleCode} - Recomendaciones de candidatos</CardTitle>
+        <CardTitle>
+          {roleCode} - {readOnly && actorLabel ? `Decisión de ${actorLabel}` : 'Recomendaciones de candidatos'}
+        </CardTitle>
         <CardDescription>
-          Los {candidates.length} candidatos mejor clasificados por habilidades, experiencia en el rol, proximidad y confiabilidad
+          {readOnly && actorLabel
+            ? `${actorLabel} evalúa estos ${candidates.length} candidatos por ranking y estado de contacto`
+            : `Los ${candidates.length} candidatos mejor clasificados por habilidades, experiencia en el rol, proximidad y confiabilidad`}
         </CardDescription>
         {roleSummary}
       </CardHeader>
 
       <CardContent className="space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded border bg-background p-3">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            {channel === 'whatsapp' ? <MessageCircle size={16} /> : <Mail size={16} />}
-            Enviar disponibilidad por
+        {!readOnly && (
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded border bg-background p-3">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              {channel === 'whatsapp' ? <MessageCircle size={16} /> : <Mail size={16} />}
+              Enviar disponibilidad por
+            </div>
+            <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
+              <SelectTrigger aria-label="Seleccionar canal de disponibilidad" className="w-[160px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="email">Email</SelectItem>
+                <SelectItem value="whatsapp">WhatsApp</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
-          <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
-            <SelectTrigger aria-label="Seleccionar canal de disponibilidad" className="w-[160px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="email">Email</SelectItem>
-              <SelectItem value="whatsapp">WhatsApp</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        )}
 
         {/* Select all checkbox */}
-        <div className="flex items-center gap-2 p-2 bg-muted rounded">
-          <Checkbox
-            aria-label="Seleccionar todos los candidatos"
-            checked={selectedCandidates.size === candidates.length && candidates.length > 0}
-            onCheckedChange={toggleSelectAll}
-          />
-          <span className="text-sm font-medium">
-            Seleccionar todos ({selectedCandidates.size} seleccionados)
-          </span>
-        </div>
+        {!readOnly && (
+          <div className="flex items-center gap-2 p-2 bg-muted rounded">
+            <Checkbox
+              aria-label="Seleccionar todos los candidatos"
+              checked={selectedCandidates.size === candidates.length && candidates.length > 0}
+              onCheckedChange={toggleSelectAll}
+            />
+            <span className="text-sm font-medium">
+              Seleccionar todos ({selectedCandidates.size} seleccionados)
+            </span>
+          </div>
+        )}
 
         {/* Candidate list */}
         <div className="space-y-2 max-h-96 overflow-y-auto">
           {candidates.map((candidate, index) => {
             const rolelessConsultation = rolelessConsultations[candidate.profile_id]
+            const activity = roleActivity[candidate.profile_id]
+            const activityLabel = getCandidateActivityLabel(activity)
+            const isNextCandidate = candidate.profile_id === nextCandidateProfileId
             const reasons = Array.isArray(candidate.reasons) ? candidate.reasons.map(String) : []
             const rateReason = reasons.find((reason) => /rate adjustment|custom rate|candidate rate|standard role rate/i.test(reason))
             const waveLabel = waveLabelForIndex(index)
@@ -379,12 +534,14 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                 key={candidate.profile_id}
                 className="flex items-start gap-3 p-3 border rounded hover:bg-muted"
               >
-                <Checkbox
-                  aria-label={`Seleccionar ${candidate.full_name}`}
-                  checked={selectedCandidates.has(candidate.profile_id)}
-                  onCheckedChange={() => toggleCandidate(candidate.profile_id)}
-                  className="mt-1"
-                />
+                {!readOnly && (
+                  <Checkbox
+                    aria-label={`Seleccionar ${candidate.full_name}`}
+                    checked={selectedCandidates.has(candidate.profile_id)}
+                    onCheckedChange={() => toggleCandidate(candidate.profile_id)}
+                    className="mt-1"
+                  />
+                )}
 
                 <Avatar className="h-10 w-10 shrink-0">
                   <AvatarImage
@@ -402,7 +559,20 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
                     <Badge variant="outline">Puesto #{index + 1}</Badge>
                     <Badge variant="secondary">Perfil: {JOB_PROFILE_LABELS[roleProfileName] || roleProfileName}</Badge>
                     <Badge variant="outline">{waveLabel}</Badge>
-                    <Badge variant="outline">Estado: No contactado</Badge>
+                    {activityLabel ? (
+                      <Badge className={getCandidateActivityClassName(activity)}>
+                        {activityLabel}
+                      </Badge>
+                    ) : isNextCandidate ? (
+                      <Badge className="bg-blue-100 text-blue-800">
+                        Siguiente candidato
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline">Estado: No contactado</Badge>
+                    )}
+                    {activityLabel && readOnly && actorLabel && (
+                      <Badge variant="outline">Enviado por {actorLabel}</Badge>
+                    )}
                     {candidate.final_score >= 80 && (
                       <Badge className="bg-green-100 text-green-800">⭐ Destacado</Badge>
                     )}
@@ -490,16 +660,18 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
         </div>
 
         {/* Action buttons */}
-        <div className="flex gap-2 pt-4 border-t">
-          <Button
-            onClick={() => sendAvailabilityMutation.mutate()}
-            disabled={selectedCandidates.size === 0 || sendAvailabilityMutation.isPending}
-          >
-            {sendAvailabilityMutation.isPending
-              ? 'Enviando...'
-              : `Enviar disponibilidad (${selectedCandidates.size}) por ${channel === 'whatsapp' ? 'WhatsApp' : 'Email'}`}
-          </Button>
-        </div>
+        {!readOnly && (
+          <div className="flex gap-2 pt-4 border-t">
+            <Button
+              onClick={() => sendAvailabilityMutation.mutate()}
+              disabled={selectedCandidates.size === 0 || sendAvailabilityMutation.isPending}
+            >
+              {sendAvailabilityMutation.isPending
+                ? 'Enviando...'
+                : `Enviar disponibilidad (${selectedCandidates.size}) por ${channel === 'whatsapp' ? 'WhatsApp' : 'Email'}`}
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -8,6 +8,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast'
+import { parseISO } from 'date-fns'
 import { Info, Mail, MessageCircle } from 'lucide-react'
 import {
   JOB_PROFILE_LABELS,
@@ -279,7 +280,8 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
         } else {
           ;[...((sentEvents || []) as CandidateEventRow[])]
             .sort((a, b) => (
-              new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime()
+              parseISO(b.created_at || '1970-01-01T00:00:00.000Z').getTime() -
+              parseISO(a.created_at || '1970-01-01T00:00:00.000Z').getTime()
             ))
             .forEach((event) => {
               const requestId = String(event.staffing_request_id || '')

--- a/src/components/matrix/StaffingOfferList.tsx
+++ b/src/components/matrix/StaffingOfferList.tsx
@@ -24,6 +24,8 @@ interface StaffingOfferListProps {
   pendingAvailability?: number
   acceptedOffers?: number
   pendingOffers?: number
+  readOnly?: boolean
+  actorLabel?: string
 }
 
 type StaffingChannel = 'email' | 'whatsapp'
@@ -41,6 +43,10 @@ type StaffingRequestRow = {
   status: string | null
   created_at: string | null
   updated_at: string | null
+}
+
+type OfferRequestRow = StaffingRequestRow & {
+  role_code: string | null
 }
 
 type StaffingEventMeta = {
@@ -65,9 +71,29 @@ type StaffingProfileRow = {
 
 type SendOffersResult = { sent: number }
 
+type SentOffer = {
+  profile_id: string
+  full_name: string
+  status: 'confirmed' | 'declined' | 'pending'
+  sent_at: string | null
+  updated_at: string | null
+}
+
 const toAvailabilityStatus = (status: string | null): AvailabilityResponse['status'] => {
   if (status === 'confirmed' || status === 'declined') return status
   return 'pending'
+}
+
+const offerStatusLabel = (status: SentOffer['status']) => {
+  if (status === 'confirmed') return 'Offer accepted'
+  if (status === 'declined') return 'Offer declined'
+  return 'Offer sent'
+}
+
+const offerStatusBadgeClassName = (status: SentOffer['status']) => {
+  if (status === 'confirmed') return 'bg-green-100 text-green-800'
+  if (status === 'declined') return 'bg-red-100 text-red-800'
+  return 'bg-blue-100 text-blue-800'
 }
 
 export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
@@ -81,7 +107,9 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
   confirmedAvailability = 0,
   pendingAvailability = 0,
   acceptedOffers = 0,
-  pendingOffers = 0
+  pendingOffers = 0,
+  readOnly = false,
+  actorLabel
 }) => {
   const { toast } = useToast()
   const queryClient = useQueryClient()
@@ -166,6 +194,54 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
     }
   })
 
+  const { data: sentOffers = [] } = useQuery<SentOffer[]>({
+    queryKey: queryKeys.scope('staffing_sent_offers', jobId, roleCode),
+    queryFn: async () => {
+      const { data: offerRequests, error } = await dataLayerClient.from('staffing_requests')
+        .select('id, profile_id, status, created_at, updated_at, role_code')
+        .eq('job_id', jobId)
+        .eq('phase', 'offer')
+        .eq('role_code', roleCode)
+        .in('status', ['pending', 'confirmed', 'declined'])
+        .order('updated_at', { ascending: false })
+
+      if (error) throw error
+
+      const latestOfferByProfile = new Map<string, OfferRequestRow>()
+      ;((offerRequests || []) as OfferRequestRow[]).forEach((request) => {
+        const profileId = String(request.profile_id || '')
+        if (!profileId || latestOfferByProfile.has(profileId)) return
+        latestOfferByProfile.set(profileId, request)
+      })
+
+      const profileIds = Array.from(latestOfferByProfile.keys())
+      if (profileIds.length === 0) return []
+
+      const { data: profiles, error: profilesError } = await dataLayerClient.from('profiles')
+        .select('id, first_name, last_name, nickname, email')
+        .in('id', profileIds)
+
+      if (profilesError) throw profilesError
+
+      const profilesById = new Map(
+        ((profiles || []) as StaffingProfileRow[]).map((profile) => [String(profile.id), profile])
+      )
+
+      return Array.from(latestOfferByProfile.entries()).map(([profileId, offer]) => {
+        const profile = profilesById.get(profileId)
+        const fullName = `${profile?.first_name || ''} ${profile?.last_name || ''}`.trim()
+
+        return {
+          profile_id: profileId,
+          full_name: fullName || profile?.nickname || profile?.email || 'Unknown',
+          status: toAvailabilityStatus(offer.status),
+          sent_at: offer.created_at,
+          updated_at: offer.updated_at,
+        }
+      })
+    }
+  })
+
   // Send offers mutation
   const sendOffersMutation = useMutation<SendOffersResult, Error>({
     mutationFn: async () => {
@@ -224,6 +300,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId, roleCode) })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_availability_responses', jobId) })
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_requests', jobId) })
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('staffing_sent_offers', jobId, roleCode) })
     },
     onError: (error) => {
       toast({
@@ -241,6 +318,10 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
   const displayedConfirmedAvailability = hasResponseRows ? confirmedResponses.length : confirmedAvailability
   const displayedPendingAvailability = hasResponseRows ? pendingResponses.length : pendingAvailability
   const displayedDeclinedAvailability = hasResponseRows ? declinedResponses.length : 0
+  const sentOfferAcceptedCount = sentOffers.filter((offer) => offer.status === 'confirmed').length
+  const sentOfferPendingCount = sentOffers.filter((offer) => offer.status === 'pending').length
+  const displayedAcceptedOffers = sentOffers.length > 0 ? sentOfferAcceptedCount : acceptedOffers
+  const displayedPendingOffers = sentOffers.length > 0 ? sentOfferPendingCount : pendingOffers
 
   const statusSummary = (
     <div className="flex flex-wrap gap-2 pt-2">
@@ -249,8 +330,8 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
       <Badge variant="outline">Availability: {displayedConfirmedAvailability} yes</Badge>
       <Badge variant="outline">{displayedPendingAvailability} pending</Badge>
       <Badge variant="outline">{displayedDeclinedAvailability} no</Badge>
-      {(acceptedOffers > 0 || pendingOffers > 0) && (
-        <Badge variant="outline">Offers: {acceptedOffers} accepted / {pendingOffers} pending</Badge>
+      {(displayedAcceptedOffers > 0 || displayedPendingOffers > 0) && (
+        <Badge variant="outline">Offers: {displayedAcceptedOffers} accepted / {displayedPendingOffers} pending</Badge>
       )}
     </div>
   )
@@ -279,29 +360,35 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{roleCode} - Availability Responses</CardTitle>
+        <CardTitle>
+          {roleCode} - {readOnly && actorLabel ? `Ofertas de ${actorLabel}` : 'Availability Responses'}
+        </CardTitle>
         <CardDescription>
-          Manage offers for candidates who confirmed availability
+          {readOnly && actorLabel
+            ? `${actorLabel} muestra disponibilidad recibida y ofertas enviadas para este rol`
+            : 'Manage offers for candidates who confirmed availability'}
         </CardDescription>
         {statusSummary}
       </CardHeader>
 
       <CardContent className="space-y-6">
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded border bg-background p-3">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            {channel === 'whatsapp' ? <MessageCircle size={16} /> : <Mail size={16} />}
-            Send offers by
+        {!readOnly && (
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded border bg-background p-3">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              {channel === 'whatsapp' ? <MessageCircle size={16} /> : <Mail size={16} />}
+              Send offers by
+            </div>
+            <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
+              <SelectTrigger aria-label="Select offer channel" className="w-[160px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="email">Email</SelectItem>
+                <SelectItem value="whatsapp">WhatsApp</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
-          <Select value={channel} onValueChange={(value) => setChannel(value as StaffingChannel)}>
-            <SelectTrigger aria-label="Select offer channel" className="w-[160px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="email">Email</SelectItem>
-              <SelectItem value="whatsapp">WhatsApp</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+        )}
 
         {/* Confirmed responses */}
         <div>
@@ -315,15 +402,17 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
           {confirmedResponses.length > 0 ? (
             <div className="space-y-2 bg-green-50 p-3 rounded border border-green-200">
               {confirmedResponses.map((response) => (
-                <label
+                <div
                   key={response.profile_id}
-                  className="flex items-center gap-3 p-2 bg-white rounded hover:bg-green-50 cursor-pointer"
+                  className="flex items-center gap-3 p-2 bg-white rounded hover:bg-green-50"
                 >
-                  <Checkbox
-                    aria-label={`Select ${response.full_name} for offer`}
-                    checked={selectedForOffer.has(response.profile_id)}
-                    onCheckedChange={() => toggleForOffer(response.profile_id)}
-                  />
+                  {!readOnly && (
+                    <Checkbox
+                      aria-label={`Select ${response.full_name} for offer`}
+                      checked={selectedForOffer.has(response.profile_id)}
+                      onCheckedChange={() => toggleForOffer(response.profile_id)}
+                    />
+                  )}
                   <div className="flex-1 min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
                       <p className="font-medium text-sm">{response.full_name}</p>
@@ -336,7 +425,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                         : 'No response time'}
                     </p>
                   </div>
-                </label>
+                </div>
               ))}
             </div>
           ) : (
@@ -396,8 +485,47 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
           </div>
         )}
 
+        {/* Sent offers */}
+        {(readOnly || sentOffers.length > 0) && (
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <Badge className="bg-blue-100 text-blue-800">Offer activity</Badge>
+              <span className="text-sm font-medium">
+                {sentOffers.length} sent
+              </span>
+            </div>
+            {sentOffers.length > 0 ? (
+              <div className="space-y-2 bg-blue-50 p-3 rounded border border-blue-200">
+                {sentOffers.map((offer) => (
+                  <div
+                    key={offer.profile_id}
+                    className="flex flex-wrap items-center justify-between gap-2 p-2 bg-white rounded"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium">{offer.full_name}</p>
+                      <p className="text-xs text-gray-600">
+                        {offer.sent_at ? format(new Date(offer.sent_at), 'PPp') : 'No send time'}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {readOnly && actorLabel && (
+                        <Badge variant="outline">Enviado por {actorLabel}</Badge>
+                      )}
+                      <Badge className={offerStatusBadgeClassName(offer.status)}>
+                        {offerStatusLabel(offer.status)}
+                      </Badge>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500 italic">No offers sent yet</p>
+            )}
+          </div>
+        )}
+
         {/* Send offers button */}
-        {confirmedResponses.length > 0 && (
+        {!readOnly && confirmedResponses.length > 0 && (
           <div className="flex gap-2 pt-4 border-t">
             <Button
               onClick={() => sendOffersMutation.mutate()}
@@ -417,7 +545,9 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
         {responses && responses.length === 0 && (
           <div className="text-center py-6">
             <p className="text-gray-500 text-sm">
-              No availability requests sent yet. Start by sending availability requests from the candidate list.
+              {readOnly
+                ? 'No availability requests sent yet for this role.'
+                : 'No availability requests sent yet. Start by sending availability requests from the candidate list.'}
             </p>
           </div>
         )}

--- a/src/components/matrix/StaffingOfferList.tsx
+++ b/src/components/matrix/StaffingOfferList.tsx
@@ -400,7 +400,10 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
           </div>
 
           {confirmedResponses.length > 0 ? (
-            <div className="space-y-2 bg-green-50 p-3 rounded border border-green-200">
+            <div
+              className="space-y-2 bg-green-50 p-3 rounded border border-green-200"
+              data-testid="staffing-confirmed-responses"
+            >
               {confirmedResponses.map((response) => (
                 <div
                   key={response.profile_id}
@@ -495,7 +498,10 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
               </span>
             </div>
             {sentOffers.length > 0 ? (
-              <div className="space-y-2 bg-blue-50 p-3 rounded border border-blue-200">
+              <div
+                className="space-y-2 bg-blue-50 p-3 rounded border border-blue-200"
+                data-testid="staffing-offer-activity"
+              >
                 {sentOffers.map((offer) => (
                   <div
                     key={offer.profile_id}

--- a/src/components/matrix/StaffingOfferList.tsx
+++ b/src/components/matrix/StaffingOfferList.tsx
@@ -7,7 +7,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { useToast } from '@/hooks/use-toast'
-import { format } from 'date-fns'
+import { format, parseISO } from 'date-fns'
 import { Mail, MessageCircle } from 'lucide-react'
 
 
@@ -504,7 +504,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                     <div className="min-w-0">
                       <p className="text-sm font-medium">{offer.full_name}</p>
                       <p className="text-xs text-gray-600">
-                        {offer.sent_at ? format(new Date(offer.sent_at), 'PPp') : 'No send time'}
+                        {offer.sent_at ? format(parseISO(offer.sent_at), 'PPp') : 'No send time'}
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">

--- a/src/components/matrix/StaffingOfferList.tsx
+++ b/src/components/matrix/StaffingOfferList.tsx
@@ -52,6 +52,7 @@ type OfferRequestRow = StaffingRequestRow & {
 type StaffingEventMeta = {
   phase?: string
   role?: string
+  request_origin?: string | null
 }
 
 type StaffingEventRow = {
@@ -77,6 +78,7 @@ type SentOffer = {
   status: 'confirmed' | 'declined' | 'pending'
   sent_at: string | null
   updated_at: string | null
+  request_origin: string | null
 }
 
 const toAvailabilityStatus = (status: string | null): AvailabilityResponse['status'] => {
@@ -94,6 +96,11 @@ const offerStatusBadgeClassName = (status: SentOffer['status']) => {
   if (status === 'confirmed') return 'bg-green-100 text-green-800'
   if (status === 'declined') return 'bg-red-100 text-red-800'
   return 'bg-blue-100 text-blue-800'
+}
+
+const getEventTimestamp = (value: string | null | undefined) => {
+  const timestamp = value ? parseISO(value).getTime() : 0
+  return Number.isFinite(timestamp) ? timestamp : 0
 }
 
 export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
@@ -201,15 +208,39 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
         .select('id, profile_id, status, created_at, updated_at, role_code')
         .eq('job_id', jobId)
         .eq('phase', 'offer')
-        .eq('role_code', roleCode)
         .in('status', ['pending', 'confirmed', 'declined'])
         .order('updated_at', { ascending: false })
 
       if (error) throw error
 
+      const requestRows = (offerRequests || []) as OfferRequestRow[]
+      const requestIds = requestRows.map((request) => request.id).filter(Boolean)
+      const latestOfferEventByRequestId = new Map<string, StaffingEventMeta>()
+
+      if (requestIds.length > 0) {
+        const { data: sentEvents, error: sentEventsError } = await dataLayerClient.from('staffing_events')
+          .select('staffing_request_id, event, meta, created_at')
+          .in('staffing_request_id', requestIds)
+          .in('event', ['email_sent', 'whatsapp_sent'])
+          .order('created_at', { ascending: false })
+
+        if (sentEventsError) throw sentEventsError
+
+        ;[...((sentEvents || []) as StaffingEventRow[])]
+          .sort((a, b) => getEventTimestamp(b.created_at) - getEventTimestamp(a.created_at))
+          .forEach((event) => {
+            const requestId = String(event.staffing_request_id || '')
+            if (!requestId || latestOfferEventByRequestId.has(requestId)) return
+            latestOfferEventByRequestId.set(requestId, event.meta || {})
+          })
+      }
+
       const latestOfferByProfile = new Map<string, OfferRequestRow>()
-      ;((offerRequests || []) as OfferRequestRow[]).forEach((request) => {
+      requestRows.forEach((request) => {
         const profileId = String(request.profile_id || '')
+        const eventMeta = latestOfferEventByRequestId.get(String(request.id)) || {}
+        const requestRole = String(request.role_code || eventMeta.role || '')
+        if (requestRole !== roleCode) return
         if (!profileId || latestOfferByProfile.has(profileId)) return
         latestOfferByProfile.set(profileId, request)
       })
@@ -230,6 +261,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
       return Array.from(latestOfferByProfile.entries()).map(([profileId, offer]) => {
         const profile = profilesById.get(profileId)
         const fullName = `${profile?.first_name || ''} ${profile?.last_name || ''}`.trim()
+        const eventMeta = latestOfferEventByRequestId.get(String(offer.id)) || {}
 
         return {
           profile_id: profileId,
@@ -237,6 +269,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
           status: toAvailabilityStatus(offer.status),
           sent_at: offer.created_at,
           updated_at: offer.updated_at,
+          request_origin: eventMeta.request_origin || null,
         }
       })
     }
@@ -514,7 +547,7 @@ export const StaffingOfferList: React.FC<StaffingOfferListProps> = ({
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
-                      {readOnly && actorLabel && (
+                      {readOnly && actorLabel && offer.request_origin === 'auto_staffing' && (
                         <Badge variant="outline">Enviado por {actorLabel}</Badge>
                       )}
                       <Badge className={offerStatusBadgeClassName(offer.status)}>

--- a/src/components/matrix/StaffingOrchestratorPanel.tsx
+++ b/src/components/matrix/StaffingOrchestratorPanel.tsx
@@ -8,6 +8,7 @@ import { StaffingCampaignPanel } from './StaffingCampaignPanel'
 import { StaffingCandidateList } from './StaffingCandidateList'
 import { StaffingOfferList } from './StaffingOfferList'
 import { StaffingAutoModePanel } from './StaffingAutoModePanel'
+import { CARLOS_AGENT_NAME } from '@/features/staffing/carlos'
 import { parseSummaryRow } from '@/pages/job-assignment-matrix/utils'
 import {
   useStaffingCampaignRealtime,
@@ -207,78 +208,79 @@ export const StaffingOrchestratorPanel: React.FC<StaffingOrchestratorPanelProps>
         )}
       </TabsContent>
 
-      {/* Candidates tab - Assisted mode only */}
-      {campaign.mode === 'assisted' && (
-        <TabsContent value="candidates" className="space-y-4">
-          {campaignRoles && campaignRoles.length > 0 ? (
-            <div className="space-y-4">
-              {campaignRoles
-                .filter((r) => r.stage !== 'filled')
-                .map((role) => (
-                  <StaffingCandidateList
-                    key={role.id}
-                    campaignId={campaign.id}
-                    roleCode={role.role_code}
-                    jobId={jobId}
-                    department={department}
-                    policy={campaign.policy}
-                    requiredCount={getRequiredCount(role.role_code)}
-                    assignedCount={Number(role.assigned_count || 0)}
-                    confirmedAvailability={Number(role.confirmed_availability || 0)}
-                    pendingAvailability={Number(role.pending_availability || 0)}
-                  />
-                ))}
-              {campaignRoles.every((r) => r.stage === 'filled') && (
-                <Card>
-                  <CardContent className="pt-6">
-                    <p className="text-center text-gray-600">
-                      All roles are filled! 🎉
-                    </p>
-                  </CardContent>
-                </Card>
-              )}
-            </div>
-          ) : (
-            <Card>
-              <CardContent className="pt-6">
-                <p className="text-gray-500">No roles configured for this campaign.</p>
-              </CardContent>
-            </Card>
-          )}
-        </TabsContent>
-      )}
-
-      {/* Offers tab - Assisted mode only */}
-      {campaign.mode === 'assisted' && (
-        <TabsContent value="offers" className="space-y-4">
-          {campaignRoles && campaignRoles.length > 0 ? (
-            <div className="space-y-4">
-              {campaignRoles.map((role) => (
-                <StaffingOfferList
+      {/* Candidates tab */}
+      <TabsContent value="candidates" className="space-y-4">
+        {campaignRoles && campaignRoles.length > 0 ? (
+          <div className="space-y-4">
+            {campaignRoles
+              .filter((r) => campaign.mode === 'auto' || r.stage !== 'filled')
+              .map((role) => (
+                <StaffingCandidateList
                   key={role.id}
                   campaignId={campaign.id}
                   roleCode={role.role_code}
                   jobId={jobId}
                   department={department}
-                  offerMessage={campaign.offer_message}
+                  policy={campaign.policy}
                   requiredCount={getRequiredCount(role.role_code)}
                   assignedCount={Number(role.assigned_count || 0)}
                   confirmedAvailability={Number(role.confirmed_availability || 0)}
                   pendingAvailability={Number(role.pending_availability || 0)}
-                  acceptedOffers={Number(role.accepted_offers || 0)}
-                  pendingOffers={Number(role.pending_offers || 0)}
+                  mode={campaign.mode}
+                  readOnly={campaign.mode === 'auto'}
+                  actorLabel={campaign.mode === 'auto' ? CARLOS_AGENT_NAME : undefined}
                 />
               ))}
-            </div>
-          ) : (
-            <Card>
-              <CardContent className="pt-6">
-                <p className="text-gray-500">No roles configured for this campaign.</p>
-              </CardContent>
-            </Card>
-          )}
-        </TabsContent>
-      )}
+            {campaign.mode === 'assisted' && campaignRoles.every((r) => r.stage === 'filled') && (
+              <Card>
+                <CardContent className="pt-6">
+                  <p className="text-center text-gray-600">
+                    All roles are filled!
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        ) : (
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-gray-500">No roles configured for this campaign.</p>
+            </CardContent>
+          </Card>
+        )}
+      </TabsContent>
+
+      {/* Offers tab */}
+      <TabsContent value="offers" className="space-y-4">
+        {campaignRoles && campaignRoles.length > 0 ? (
+          <div className="space-y-4">
+            {campaignRoles.map((role) => (
+              <StaffingOfferList
+                key={role.id}
+                campaignId={campaign.id}
+                roleCode={role.role_code}
+                jobId={jobId}
+                department={department}
+                offerMessage={campaign.offer_message}
+                requiredCount={getRequiredCount(role.role_code)}
+                assignedCount={Number(role.assigned_count || 0)}
+                confirmedAvailability={Number(role.confirmed_availability || 0)}
+                pendingAvailability={Number(role.pending_availability || 0)}
+                acceptedOffers={Number(role.accepted_offers || 0)}
+                pendingOffers={Number(role.pending_offers || 0)}
+                readOnly={campaign.mode === 'auto'}
+                actorLabel={campaign.mode === 'auto' ? CARLOS_AGENT_NAME : undefined}
+              />
+            ))}
+          </div>
+        ) : (
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-gray-500">No roles configured for this campaign.</p>
+            </CardContent>
+          </Card>
+        )}
+      </TabsContent>
 
       {/* Settings tab */}
       <TabsContent value="settings" className="space-y-4">

--- a/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
+++ b/src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx
@@ -673,7 +673,8 @@ describe('OptimizedMatrixCell', () => {
       availability_status: ' Requested ',
       availability_job_title: 'Load-in Day',
       pending_availability_job_titles: ['Load-in Day', 'Arena Show'],
-      availability_requested_by: null,
+      availability_requested_by: 'manager-1',
+      availability_actor_label: 'C.A.R.L.O.S.',
       availability_created_at: '2026-04-08T09:15:00.000Z',
       offer_status: ' SENT ',
       offer_job_title: 'Arena Show',
@@ -691,7 +692,7 @@ describe('OptimizedMatrixCell', () => {
         onSelect={vi.fn()}
         onClick={vi.fn()}
         staffingStatusByDateProvided={staffingStatus}
-        profileNamesMap={new Map([['manager-2', 'Second Manager']])}
+        profileNamesMap={new Map([['manager-1', 'First Manager'], ['manager-2', 'Second Manager']])}
       />
     );
 
@@ -702,8 +703,10 @@ describe('OptimizedMatrixCell', () => {
       expect(screen.getAllByText(/Oferta: Enviada/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/Trabajos: Load-in Day, Arena Show/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/Trabajo: Arena Show/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/Enviado por: C\.A\.R\.L\.O\.S\./i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/Enviado por: Second Manager/i).length).toBeGreaterThan(0);
     });
+    expect(screen.queryByText(/Enviado por: First Manager/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Enviado por:\s*null/i)).not.toBeInTheDocument();
   });
 

--- a/src/components/matrix/__tests__/StaffingCandidateList.test.tsx
+++ b/src/components/matrix/__tests__/StaffingCandidateList.test.tsx
@@ -236,10 +236,12 @@ describe('StaffingCandidateList', () => {
       expect(screen.getByText('Next Tech')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Disponibilidad enviada')).toBeInTheDocument()
-    expect(screen.getByText('Oferta enviada')).toBeInTheDocument()
-    expect(screen.getAllByText(`Enviado por ${CARLOS_AGENT_NAME}`)).toHaveLength(1)
-    expect(screen.getByText('Siguiente candidato')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Disponibilidad enviada')).toBeInTheDocument()
+      expect(screen.getByText('Oferta enviada')).toBeInTheDocument()
+      expect(screen.getAllByText(`Enviado por ${CARLOS_AGENT_NAME}`)).toHaveLength(1)
+      expect(screen.getByText('Siguiente candidato')).toBeInTheDocument()
+    })
     expect(screen.queryByText('Enviar disponibilidad por')).not.toBeInTheDocument()
   })
 })

--- a/src/components/matrix/__tests__/StaffingCandidateList.test.tsx
+++ b/src/components/matrix/__tests__/StaffingCandidateList.test.tsx
@@ -54,6 +54,7 @@ const createQueryBuilder = (table: string) => {
         data: [
           { id: 'tech-1', profile_picture_url: null },
           { id: 'tech-2', profile_picture_url: null },
+          { id: 'tech-3', profile_picture_url: null },
         ],
         error: null,
       }
@@ -71,6 +72,26 @@ const createQueryBuilder = (table: string) => {
               request_origin: 'auto_staffing',
             },
             created_at: '2026-04-10T08:05:00.000Z',
+          },
+          {
+            staffing_request_id: 'req-offer-old-1',
+            event: 'email_sent',
+            meta: {
+              phase: 'offer',
+              role: 'foh',
+              request_origin: 'auto_staffing',
+            },
+            created_at: '2026-04-10T07:00:00.000Z',
+          },
+          {
+            staffing_request_id: 'req-offer-manual-1',
+            event: 'email_sent',
+            meta: {
+              phase: 'offer',
+              role: 'foh',
+              request_origin: 'manual',
+            },
+            created_at: '2026-04-10T08:30:00.000Z',
           },
         ],
         error: null,
@@ -90,6 +111,28 @@ const createQueryBuilder = (table: string) => {
             updated_at: '2026-04-10T08:05:00.000Z',
             created_at: '2026-04-10T08:00:00.000Z',
             role_code: null,
+          },
+          {
+            id: 'req-offer-old-1',
+            profile_id: 'tech-1',
+            phase: 'offer',
+            status: 'pending',
+            target_date: null,
+            single_day: false,
+            updated_at: '2026-04-10T07:00:00.000Z',
+            created_at: '2026-04-10T07:00:00.000Z',
+            role_code: 'foh',
+          },
+          {
+            id: 'req-offer-manual-1',
+            profile_id: 'tech-2',
+            phase: 'offer',
+            status: 'pending',
+            target_date: null,
+            single_day: false,
+            updated_at: '2026-04-10T08:30:00.000Z',
+            created_at: '2026-04-10T08:30:00.000Z',
+            role_code: 'foh',
           },
         ],
         error: null,
@@ -139,7 +182,7 @@ describe('StaffingCandidateList', () => {
         },
         {
           profile_id: 'tech-2',
-          full_name: 'Next Tech',
+          full_name: 'Manual Tech',
           department: 'sound',
           skills_score: 78,
           distance_to_madrid_km: 20.1,
@@ -150,6 +193,21 @@ describe('StaffingCandidateList', () => {
           soft_conflict: false,
           hard_conflict: false,
           final_score: 81,
+          reasons: [],
+        },
+        {
+          profile_id: 'tech-3',
+          full_name: 'Next Tech',
+          department: 'sound',
+          skills_score: 75,
+          distance_to_madrid_km: 22.3,
+          proximity_score: 68,
+          experience_score: 70,
+          reliability_score: 74,
+          fairness_score: 76,
+          soft_conflict: false,
+          hard_conflict: false,
+          final_score: 79,
           reasons: [],
         },
       ],
@@ -174,11 +232,13 @@ describe('StaffingCandidateList', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Confirmed Tech')).toBeInTheDocument()
+      expect(screen.getByText('Manual Tech')).toBeInTheDocument()
       expect(screen.getByText('Next Tech')).toBeInTheDocument()
     })
 
     expect(screen.getByText('Disponibilidad enviada')).toBeInTheDocument()
-    expect(screen.getByText(`Enviado por ${CARLOS_AGENT_NAME}`)).toBeInTheDocument()
+    expect(screen.getByText('Oferta enviada')).toBeInTheDocument()
+    expect(screen.getAllByText(`Enviado por ${CARLOS_AGENT_NAME}`)).toHaveLength(1)
     expect(screen.getByText('Siguiente candidato')).toBeInTheDocument()
     expect(screen.queryByText('Enviar disponibilidad por')).not.toBeInTheDocument()
   })

--- a/src/components/matrix/__tests__/StaffingCandidateList.test.tsx
+++ b/src/components/matrix/__tests__/StaffingCandidateList.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CARLOS_AGENT_NAME } from '@/features/staffing/carlos'
+import { StaffingCandidateList } from '../StaffingCandidateList'
+
+type QueryResult = {
+  data: Array<Record<string, unknown>>
+  error: Error | null
+}
+
+const { fromMock, rpcMock, toastMock } = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  rpcMock: vi.fn(),
+  toastMock: vi.fn(),
+}))
+
+vi.mock('@/services/dataLayerClient', () => ({
+  dataLayerClient: {
+    auth: {
+      getSession: vi.fn(),
+    },
+    from: fromMock,
+    rpc: rpcMock,
+  },
+}))
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const createQueryBuilder = (table: string) => {
+  let selected = ''
+  const resolve = (): QueryResult => {
+    if (table === 'profiles') {
+      return {
+        data: [
+          { id: 'tech-1', profile_picture_url: null },
+          { id: 'tech-2', profile_picture_url: null },
+        ],
+        error: null,
+      }
+    }
+
+    if (table === 'staffing_events') {
+      return {
+        data: [
+          {
+            staffing_request_id: 'req-availability-1',
+            event: 'whatsapp_sent',
+            meta: {
+              phase: 'availability',
+              role: 'foh',
+              request_origin: 'auto_staffing',
+            },
+            created_at: '2026-04-10T08:05:00.000Z',
+          },
+        ],
+        error: null,
+      }
+    }
+
+    if (table === 'staffing_requests' && selected.includes('role_code')) {
+      return {
+        data: [
+          {
+            id: 'req-availability-1',
+            profile_id: 'tech-1',
+            phase: 'availability',
+            status: 'pending',
+            target_date: null,
+            single_day: false,
+            updated_at: '2026-04-10T08:05:00.000Z',
+            created_at: '2026-04-10T08:00:00.000Z',
+            role_code: null,
+          },
+        ],
+        error: null,
+      }
+    }
+
+    return { data: [], error: null }
+  }
+
+  const builder: any = {
+    select: vi.fn((value: string) => {
+      selected = value
+      return builder
+    }),
+    eq: vi.fn(() => builder),
+    in: vi.fn(() => builder),
+    or: vi.fn(() => builder),
+    order: vi.fn(() => Promise.resolve(resolve())),
+    then: vi.fn((onFulfilled, onRejected) => Promise.resolve(resolve()).then(onFulfilled, onRejected)),
+  }
+  return builder
+}
+
+describe('StaffingCandidateList', () => {
+  beforeEach(() => {
+    fromMock.mockReset()
+    rpcMock.mockReset()
+    toastMock.mockReset()
+
+    fromMock.mockImplementation((table: string) => createQueryBuilder(table))
+    rpcMock.mockResolvedValue({
+      data: [
+        {
+          profile_id: 'tech-1',
+          full_name: 'Confirmed Tech',
+          department: 'sound',
+          skills_score: 91,
+          distance_to_madrid_km: 12.4,
+          proximity_score: 80,
+          experience_score: 84,
+          reliability_score: 89,
+          fairness_score: 72,
+          soft_conflict: false,
+          hard_conflict: false,
+          final_score: 92,
+          reasons: [],
+        },
+        {
+          profile_id: 'tech-2',
+          full_name: 'Next Tech',
+          department: 'sound',
+          skills_score: 78,
+          distance_to_madrid_km: 20.1,
+          proximity_score: 70,
+          experience_score: 76,
+          reliability_score: 80,
+          fairness_score: 82,
+          soft_conflict: false,
+          hard_conflict: false,
+          final_score: 81,
+          reasons: [],
+        },
+      ],
+      error: null,
+    })
+  })
+
+  it('shows Carlos role activity and next candidate without manual send controls', async () => {
+    render(
+      <StaffingCandidateList
+        campaignId="campaign-1"
+        roleCode="foh"
+        jobId="job-1"
+        department="sound"
+        policy={{}}
+        mode="auto"
+        readOnly
+        actorLabel={CARLOS_AGENT_NAME}
+      />,
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Confirmed Tech')).toBeInTheDocument()
+      expect(screen.getByText('Next Tech')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Disponibilidad enviada')).toBeInTheDocument()
+    expect(screen.getByText(`Enviado por ${CARLOS_AGENT_NAME}`)).toBeInTheDocument()
+    expect(screen.getByText('Siguiente candidato')).toBeInTheDocument()
+    expect(screen.queryByText('Enviar disponibilidad por')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/matrix/__tests__/StaffingOfferList.test.tsx
+++ b/src/components/matrix/__tests__/StaffingOfferList.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CARLOS_AGENT_NAME } from '@/features/staffing/carlos'
+import { StaffingOfferList } from '../StaffingOfferList'
+
+type QueryResult = {
+  data: Array<Record<string, unknown>>
+  error: Error | null
+}
+
+const { fromMock, toastMock } = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  toastMock: vi.fn(),
+}))
+
+vi.mock('@/services/dataLayerClient', () => ({
+  dataLayerClient: {
+    auth: {
+      getSession: vi.fn(),
+    },
+    from: fromMock,
+  },
+}))
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const createQueryBuilder = (table: string) => {
+  let selected = ''
+  const resolve = (): QueryResult => {
+    if (table === 'staffing_requests' && selected.includes('role_code')) {
+      return {
+        data: [
+          {
+            id: 'offer-1',
+            profile_id: 'tech-1',
+            status: 'pending',
+            created_at: '2026-04-10T09:00:00.000Z',
+            updated_at: '2026-04-10T09:00:00.000Z',
+            role_code: 'foh',
+          },
+        ],
+        error: null,
+      }
+    }
+
+    if (table === 'staffing_requests') {
+      return {
+        data: [
+          {
+            id: 'availability-1',
+            profile_id: 'tech-1',
+            status: 'confirmed',
+            created_at: '2026-04-10T08:00:00.000Z',
+            updated_at: '2026-04-10T08:30:00.000Z',
+          },
+        ],
+        error: null,
+      }
+    }
+
+    if (table === 'staffing_events') {
+      return {
+        data: [
+          {
+            staffing_request_id: 'availability-1',
+            event: 'email_sent',
+            meta: {
+              phase: 'availability',
+              role: 'foh',
+            },
+            created_at: '2026-04-10T08:05:00.000Z',
+          },
+        ],
+        error: null,
+      }
+    }
+
+    if (table === 'profiles') {
+      return {
+        data: [
+          {
+            id: 'tech-1',
+            first_name: 'Offer',
+            last_name: 'Tech',
+            nickname: null,
+            email: 'offer@example.com',
+          },
+        ],
+        error: null,
+      }
+    }
+
+    return { data: [], error: null }
+  }
+
+  const builder: any = {
+    select: vi.fn((value: string) => {
+      selected = value
+      return builder
+    }),
+    eq: vi.fn(() => builder),
+    in: vi.fn(() => builder),
+    order: vi.fn(() => Promise.resolve(resolve())),
+    then: vi.fn((onFulfilled, onRejected) => Promise.resolve(resolve()).then(onFulfilled, onRejected)),
+  }
+  return builder
+}
+
+describe('StaffingOfferList', () => {
+  beforeEach(() => {
+    fromMock.mockReset()
+    toastMock.mockReset()
+    fromMock.mockImplementation((table: string) => createQueryBuilder(table))
+  })
+
+  it('shows sent Carlos offers in read-only mode without manual offer controls', async () => {
+    render(
+      <StaffingOfferList
+        campaignId="campaign-1"
+        roleCode="foh"
+        jobId="job-1"
+        department="sound"
+        readOnly
+        actorLabel={CARLOS_AGENT_NAME}
+      />,
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Offer Tech').length).toBeGreaterThan(0)
+    })
+
+    expect(screen.getByText('Offer sent')).toBeInTheDocument()
+    expect(screen.getByText(`Enviado por ${CARLOS_AGENT_NAME}`)).toBeInTheDocument()
+    expect(screen.queryByText('Send offers by')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Send Offers/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/matrix/__tests__/StaffingOfferList.test.tsx
+++ b/src/components/matrix/__tests__/StaffingOfferList.test.tsx
@@ -56,6 +56,14 @@ const createQueryBuilder = (table: string) => {
             status: 'pending',
             created_at: '2026-04-10T09:00:00.000Z',
             updated_at: '2026-04-10T09:00:00.000Z',
+            role_code: null,
+          },
+          {
+            id: 'offer-2',
+            profile_id: 'tech-2',
+            status: 'pending',
+            created_at: '2026-04-10T09:05:00.000Z',
+            updated_at: '2026-04-10T09:05:00.000Z',
             role_code: 'foh',
           },
         ],
@@ -90,6 +98,26 @@ const createQueryBuilder = (table: string) => {
             },
             created_at: '2026-04-10T08:05:00.000Z',
           },
+          {
+            staffing_request_id: 'offer-1',
+            event: 'email_sent',
+            meta: {
+              phase: 'offer',
+              role: 'foh',
+              request_origin: 'auto_staffing',
+            },
+            created_at: '2026-04-10T09:00:00.000Z',
+          },
+          {
+            staffing_request_id: 'offer-2',
+            event: 'email_sent',
+            meta: {
+              phase: 'offer',
+              role: 'foh',
+              request_origin: 'manual',
+            },
+            created_at: '2026-04-10T09:05:00.000Z',
+          },
         ],
         error: null,
       }
@@ -104,6 +132,13 @@ const createQueryBuilder = (table: string) => {
             last_name: 'Tech',
             nickname: null,
             email: 'offer@example.com',
+          },
+          {
+            id: 'tech-2',
+            first_name: 'Manual',
+            last_name: 'Offer',
+            nickname: null,
+            email: 'manual@example.com',
           },
         ],
         error: null,
@@ -148,10 +183,11 @@ describe('StaffingOfferList', () => {
 
     await waitFor(() => {
       expect(screen.getAllByText('Offer Tech').length).toBeGreaterThan(0)
+      expect(screen.getByText('Manual Offer')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('Offer sent')).toBeInTheDocument()
-    expect(screen.getByText(`Enviado por ${CARLOS_AGENT_NAME}`)).toBeInTheDocument()
+    expect(screen.getAllByText('Offer sent')).toHaveLength(2)
+    expect(screen.getAllByText(`Enviado por ${CARLOS_AGENT_NAME}`)).toHaveLength(1)
     expect(screen.queryByText('Send offers by')).not.toBeInTheDocument()
     expect(screen.queryByText(/Send Offers/i)).not.toBeInTheDocument()
   })

--- a/src/components/matrix/__tests__/StaffingOrchestratorPanel.test.tsx
+++ b/src/components/matrix/__tests__/StaffingOrchestratorPanel.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CARLOS_AGENT_NAME } from '@/features/staffing/carlos'
+import { StaffingOrchestratorPanel } from '../StaffingOrchestratorPanel'
+
+const { useQueryMock } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useQuery: useQueryMock,
+  }
+})
+
+vi.mock('@/hooks/useStaffingCampaignRealtime', () => ({
+  useStaffingCampaignRealtime: vi.fn(),
+  useStaffingCampaignRolesRealtime: vi.fn(),
+  useStaffingRequestsRealtime: vi.fn(),
+}))
+
+vi.mock('../StaffingCampaignPanel', () => ({
+  StaffingCampaignPanel: () => <div data-testid="campaign-panel" />,
+}))
+
+vi.mock('../StaffingAutoModePanel', () => ({
+  StaffingAutoModePanel: () => <div data-testid="auto-mode-panel" />,
+}))
+
+vi.mock('../StaffingCandidateList', () => ({
+  StaffingCandidateList: (props: {
+    actorLabel?: string
+    mode?: string
+    readOnly?: boolean
+    roleCode: string
+  }) => (
+    <div
+      data-testid="candidate-list"
+      data-actor={props.actorLabel}
+      data-mode={props.mode}
+      data-readonly={String(props.readOnly)}
+    >
+      {props.roleCode}
+    </div>
+  ),
+}))
+
+vi.mock('../StaffingOfferList', () => ({
+  StaffingOfferList: (props: {
+    actorLabel?: string
+    readOnly?: boolean
+    roleCode: string
+  }) => (
+    <div
+      data-testid="offer-list"
+      data-actor={props.actorLabel}
+      data-readonly={String(props.readOnly)}
+    >
+      {props.roleCode}
+    </div>
+  ),
+}))
+
+const autoCampaign = {
+  id: 'campaign-1',
+  job_id: 'job-1',
+  department: 'sound',
+  mode: 'auto',
+  status: 'active',
+  policy: {},
+  created_at: '2026-04-10T08:00:00.000Z',
+  updated_at: '2026-04-10T08:00:00.000Z',
+}
+
+const campaignRoles = [
+  {
+    id: 'role-1',
+    campaign_id: 'campaign-1',
+    role_code: 'foh',
+    assigned_count: 0,
+    pending_availability: 1,
+    confirmed_availability: 0,
+    pending_offers: 0,
+    accepted_offers: 0,
+    stage: 'availability',
+  },
+]
+
+describe('StaffingOrchestratorPanel', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset()
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown[] }) => {
+      const scope = String(queryKey[0])
+      if (scope === 'staffing_campaign') {
+        return { data: autoCampaign, refetch: vi.fn(), isLoading: false }
+      }
+      if (scope === 'staffing_campaign_roles') {
+        return { data: campaignRoles, isLoading: false }
+      }
+      if (scope === 'staffing_required_roles') {
+        return {
+          data: {
+            roles: [{ role_code: 'foh', quantity: 1 }],
+          },
+          isLoading: false,
+        }
+      }
+      return { data: null, isLoading: false }
+    })
+  })
+
+  it('keeps Candidates and Offers visible in Carlos auto mode as read-only activity tabs', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <StaffingOrchestratorPanel
+        jobId="job-1"
+        department="sound"
+        jobTitle="Arena Show"
+      />,
+    )
+
+    await user.click(screen.getByRole('tab', { name: 'Candidates' }))
+    const candidateList = screen.getByTestId('candidate-list')
+    expect(candidateList).toHaveAttribute('data-mode', 'auto')
+    expect(candidateList).toHaveAttribute('data-readonly', 'true')
+    expect(candidateList).toHaveAttribute('data-actor', CARLOS_AGENT_NAME)
+
+    await user.click(screen.getByRole('tab', { name: 'Offers' }))
+    const offerList = screen.getByTestId('offer-list')
+    expect(offerList).toHaveAttribute('data-readonly', 'true')
+    expect(offerList).toHaveAttribute('data-actor', CARLOS_AGENT_NAME)
+  })
+})

--- a/src/components/matrix/optimized-assignment-matrix/__tests__/useMatrixScrollState.test.tsx
+++ b/src/components/matrix/optimized-assignment-matrix/__tests__/useMatrixScrollState.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMatrixScrollState } from "../useMatrixScrollState";
+
+vi.mock("@/hooks/useDragScroll", () => ({
+  useDragScroll: vi.fn(),
+}));
+
+const defaultArgs = {
+  dates: [new Date("2026-04-10T00:00:00.000Z"), new Date("2026-04-11T00:00:00.000Z")],
+  techniciansLength: 2,
+  cellWidth: 120,
+  cellHeight: 48,
+  matrixWidth: 240,
+  mobile: false,
+  isInitialLoading: false,
+  canExpandBefore: false,
+  canExpandAfter: false,
+};
+
+const createScrollableDiv = (overrides: Partial<Pick<HTMLDivElement, "scrollLeft" | "scrollTop">> = {}) => {
+  const element = document.createElement("div");
+  Object.defineProperties(element, {
+    scrollLeft: { value: overrides.scrollLeft ?? 0, writable: true },
+    scrollTop: { value: overrides.scrollTop ?? 0, writable: true },
+    scrollWidth: { value: 500, writable: true },
+    scrollHeight: { value: 500, writable: true },
+    clientWidth: { value: 200, writable: true },
+    clientHeight: { value: 120, writable: true },
+  });
+  return element;
+};
+
+describe("useMatrixScrollState", () => {
+  const rafCallbacks: FrameRequestCallback[] = [];
+  let originalRequestAnimationFrame: typeof window.requestAnimationFrame | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    rafCallbacks.length = 0;
+    originalRequestAnimationFrame = window.requestAnimationFrame;
+    window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    });
+  });
+
+  afterEach(() => {
+    if (originalRequestAnimationFrame) {
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+    } else {
+      delete (window as Partial<Window>).requestAnimationFrame;
+    }
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const flushAnimationFrames = () => {
+    while (rafCallbacks.length > 0) {
+      rafCallbacks.shift()?.(performance.now());
+    }
+  };
+
+  it("captures date header scroll values before throttled work runs", () => {
+    const { result } = renderHook(() => useMatrixScrollState(defaultArgs));
+    const header = createScrollableDiv({ scrollLeft: 96 });
+    const main = createScrollableDiv();
+
+    result.current.dateHeadersRef.current = header;
+    result.current.mainScrollRef.current = main;
+
+    const event = { currentTarget: header } as React.UIEvent<HTMLDivElement>;
+
+    act(() => {
+      result.current.handleDateHeadersScroll(event);
+    });
+    (event as unknown as { currentTarget: HTMLDivElement | null }).currentTarget = null;
+
+    expect(() => {
+      act(() => {
+        vi.runOnlyPendingTimers();
+        flushAnimationFrames();
+      });
+    }).not.toThrow();
+    expect(main.scrollLeft).toBe(96);
+  });
+
+  it("ignores pending scroll sync frames after unmount", () => {
+    const { result, unmount } = renderHook(() => useMatrixScrollState(defaultArgs));
+    const main = createScrollableDiv({ scrollLeft: 120, scrollTop: 40 });
+
+    result.current.mainScrollRef.current = main;
+
+    act(() => {
+      result.current.handleMainScroll({ currentTarget: main } as React.UIEvent<HTMLDivElement>);
+    });
+    unmount();
+
+    expect(() => {
+      act(() => {
+        flushAnimationFrames();
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/components/matrix/optimized-assignment-matrix/useMatrixScrollState.ts
+++ b/src/components/matrix/optimized-assignment-matrix/useMatrixScrollState.ts
@@ -43,6 +43,7 @@ export const useMatrixScrollState = ({
   const updateScheduledRef = useRef(false);
   const autoScrolledRef = useRef(false);
   const prevDatesRef = useRef<Date[] | null>(null);
+  const isMountedRef = useRef(true);
 
   const [visibleRows, setVisibleRows] = useState({ start: 0, end: Math.min(techniciansLength - 1, 20) });
   const [visibleCols, setVisibleCols] = useState({ start: 0, end: Math.min(dates.length - 1, 14) });
@@ -59,6 +60,11 @@ export const useMatrixScrollState = ({
     syncInProgressRef.current = true;
 
     requestAnimationFrame(() => {
+      if (!isMountedRef.current) {
+        syncInProgressRef.current = false;
+        return;
+      }
+
       try {
         if (source !== "dateHeaders" && dateHeadersRef.current) {
           dateHeadersRef.current.scrollLeft = scrollLeft;
@@ -115,6 +121,7 @@ export const useMatrixScrollState = ({
     updateScheduledRef.current = true;
     requestAnimationFrame(() => {
       updateScheduledRef.current = false;
+      if (!isMountedRef.current) return;
       updateVisibleWindow();
     });
   }, [updateVisibleWindow]);
@@ -177,9 +184,8 @@ export const useMatrixScrollState = ({
     syncScrollPositions,
   ]);
 
-  const handleDateHeadersScrollCore = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+  const handleDateHeadersScrollCore = useCallback((scrollLeft: number) => {
     if (syncInProgressRef.current) return;
-    const scrollLeft = e.currentTarget.scrollLeft;
     syncScrollPositions(scrollLeft, mainScrollRef.current?.scrollTop || 0, "dateHeaders");
     lastKnownScrollRef.current.left = scrollLeft;
     updateNavAvailability();
@@ -194,10 +200,23 @@ export const useMatrixScrollState = ({
   }, [scheduleVisibleWindowUpdate, syncScrollPositions]);
 
   const handleMainScroll = handleMainScrollCore;
-  const handleDateHeadersScroll = useMemo(
-    () => throttle(handleDateHeadersScrollCore, 12),
-    [handleDateHeadersScrollCore],
-  );
+  const handleDateHeadersScroll = useMemo(() => {
+    const throttled = throttle(handleDateHeadersScrollCore, 12);
+    const handler = ((e: React.UIEvent<HTMLDivElement>) => {
+      throttled(e.currentTarget.scrollLeft);
+    }) as ((e: React.UIEvent<HTMLDivElement>) => void) & { cancel: () => void };
+    handler.cancel = throttled.cancel;
+    return handler;
+  }, [handleDateHeadersScrollCore]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      syncInProgressRef.current = false;
+      updateScheduledRef.current = false;
+    };
+  }, []);
 
   useEffect(() => () => {
     handleDateHeadersScroll.cancel();
@@ -239,8 +258,11 @@ export const useMatrixScrollState = ({
 
     let retries = 0;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
 
     const attemptScroll = () => {
+      if (cancelled || !isMountedRef.current) return;
+
       const success = scrollToToday();
       if (success) {
         autoScrolledRef.current = true;
@@ -248,13 +270,14 @@ export const useMatrixScrollState = ({
       }
 
       retries += 1;
-      if (retries < MAX_AUTO_SCROLL_RETRIES) {
+      if (retries < MAX_AUTO_SCROLL_RETRIES && !cancelled) {
         timeoutId = setTimeout(attemptScroll, 100 * retries);
       }
     };
 
     timeoutId = setTimeout(attemptScroll, 50);
     return () => {
+      cancelled = true;
       if (timeoutId) {
         clearTimeout(timeoutId);
       }

--- a/src/components/matrix/optimized-matrix-cell/OptimizedMatrixCellTooltip.tsx
+++ b/src/components/matrix/optimized-matrix-cell/OptimizedMatrixCellTooltip.tsx
@@ -57,6 +57,16 @@ export const OptimizedMatrixCellTooltip = ({
         : [staffingStatusByDate?.offer_job_title],
     ),
   );
+  const availabilityActorLabel =
+    staffingStatusByDate?.availability_actor_label ||
+    (staffingStatusByDate?.availability_requested_by && profileNamesMap.has(staffingStatusByDate.availability_requested_by)
+      ? profileNamesMap.get(staffingStatusByDate.availability_requested_by)
+      : null);
+  const offerActorLabel =
+    staffingStatusByDate?.offer_actor_label ||
+    (staffingStatusByDate?.offer_requested_by && profileNamesMap.has(staffingStatusByDate.offer_requested_by)
+      ? profileNamesMap.get(staffingStatusByDate.offer_requested_by)
+      : null);
 
   return (
     <div className="space-y-1 text-sm">
@@ -104,9 +114,9 @@ export const OptimizedMatrixCellTooltip = ({
                   {availabilityJobLabel}
                 </div>
               )}
-              {staffingStatusByDate.availability_requested_by && profileNamesMap.has(staffingStatusByDate.availability_requested_by) && (
+              {availabilityActorLabel && (
                 <div className="text-muted-foreground">
-                  Enviado por: {profileNamesMap.get(staffingStatusByDate.availability_requested_by)}
+                  Enviado por: {availabilityActorLabel}
                 </div>
               )}
               {staffingStatusByDate.availability_created_at && formatDateTimeEs(staffingStatusByDate.availability_created_at) && (
@@ -126,9 +136,9 @@ export const OptimizedMatrixCellTooltip = ({
                   {offerJobLabel}
                 </div>
               )}
-              {staffingStatusByDate.offer_requested_by && profileNamesMap.has(staffingStatusByDate.offer_requested_by) && (
+              {offerActorLabel && (
                 <div className="text-muted-foreground">
-                  Enviado por: {profileNamesMap.get(staffingStatusByDate.offer_requested_by)}
+                  Enviado por: {offerActorLabel}
                 </div>
               )}
               {staffingStatusByDate.offer_created_at && formatDateTimeEs(staffingStatusByDate.offer_created_at) && (

--- a/src/components/matrix/optimized-matrix-cell/types.ts
+++ b/src/components/matrix/optimized-matrix-cell/types.ts
@@ -33,8 +33,10 @@ export interface MatrixStaffingStatus {
   offer_job_id?: string | null;
   offer_job_title?: string | null;
   availability_requested_by?: string | null;
+  availability_actor_label?: string | null;
   availability_created_at?: string | null;
   offer_requested_by?: string | null;
+  offer_actor_label?: string | null;
   offer_created_at?: string | null;
   pending_availability_job_ids?: string[];
   pending_availability_job_titles?: string[];

--- a/src/features/staffing/hooks/__tests__/useStaffingMatrixStatuses.test.tsx
+++ b/src/features/staffing/hooks/__tests__/useStaffingMatrixStatuses.test.tsx
@@ -164,4 +164,80 @@ describe('useStaffingMatrixStatuses', () => {
     expect(status?.pending_availability_job_titles).toEqual(['Load-in Day', 'Arena Show'])
     expect(status?.pending_offer_job_titles).toEqual(['Arena Show'])
   })
+
+  it('uses request ids from the RPC fallback to attribute Carlos activity', async () => {
+    rpcMock.mockImplementation((fn: string) => {
+      if (fn === 'get_assignment_matrix_staffing_filtered') {
+        return Promise.resolve({ data: [], error: null })
+      }
+
+      if (fn === 'get_staffing_requests_matrix_filtered') {
+        return Promise.resolve({
+          data: [
+            {
+              id: 'rpc-availability-1',
+              job_id: 'job-1',
+              profile_id: 'tech-1',
+              phase: 'availability',
+              status: 'pending',
+              updated_at: '2026-04-10T08:00:00.000Z',
+              single_day: false,
+              target_date: null,
+              created_at: '2026-04-10T07:55:00.000Z',
+              requested_by: 'manager-1',
+            },
+          ],
+          error: null,
+        })
+      }
+
+      return Promise.resolve({ data: [], error: null })
+    })
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === 'staffing_requests') {
+        return createQueryBuilder({ data: [], error: new Error('direct read blocked') })
+      }
+
+      if (table === 'staffing_events') {
+        return createQueryBuilder({
+          data: [
+            {
+              staffing_request_id: 'rpc-availability-1',
+              event: 'email_sent',
+              meta: { request_origin: 'auto_staffing' },
+              created_at: '2026-04-10T07:56:00.000Z',
+            },
+          ],
+          error: null,
+        })
+      }
+
+      return createQueryBuilder({ data: [], error: null })
+    })
+
+    const { result } = renderHook(
+      () => useStaffingMatrixStatuses(
+        ['tech-1'],
+        [
+          {
+            id: 'job-1',
+            title: 'Fallback Show',
+            start_time: '2026-04-10T06:00:00.000Z',
+            end_time: '2026-04-10T23:00:00.000Z',
+          },
+        ],
+        [new Date('2026-04-10T12:00:00.000Z')],
+      ),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const status = result.current.data?.byDate.get('tech-1-2026-04-10')
+    expect(status).toMatchObject({
+      availability_status: 'requested',
+      availability_actor_label: CARLOS_AGENT_NAME,
+    })
+  })
 })

--- a/src/features/staffing/hooks/__tests__/useStaffingMatrixStatuses.test.tsx
+++ b/src/features/staffing/hooks/__tests__/useStaffingMatrixStatuses.test.tsx
@@ -4,17 +4,30 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { CARLOS_AGENT_NAME } from '@/features/staffing/carlos'
 import { useStaffingMatrixStatuses } from '../useStaffingMatrixStatuses'
 
-const { rpcMock } = vi.hoisted(() => ({
+const { fromMock, rpcMock } = vi.hoisted(() => ({
+  fromMock: vi.fn(),
   rpcMock: vi.fn(),
 }))
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
+    from: fromMock,
     rpc: rpcMock,
   },
 }))
+
+const createQueryBuilder = (result: { data: unknown[]; error: unknown | null }) => {
+  const builder: any = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    in: vi.fn(() => builder),
+    order: vi.fn(() => Promise.resolve(result)),
+  }
+  return builder
+}
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -32,6 +45,7 @@ const createWrapper = () => {
 
 describe('useStaffingMatrixStatuses', () => {
   beforeEach(() => {
+    fromMock.mockReset()
     rpcMock.mockReset()
   })
 
@@ -41,10 +55,15 @@ describe('useStaffingMatrixStatuses', () => {
         return Promise.resolve({ data: [], error: null })
       }
 
-      if (fn === 'get_staffing_requests_matrix_filtered') {
-        return Promise.resolve({
+      return Promise.resolve({ data: [], error: null })
+    })
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === 'staffing_requests') {
+        return createQueryBuilder({
           data: [
             {
+              id: 'req-av-1',
               job_id: 'job-1',
               profile_id: 'tech-1',
               phase: 'availability',
@@ -56,6 +75,7 @@ describe('useStaffingMatrixStatuses', () => {
               requested_by: 'manager-1',
             },
             {
+              id: 'req-av-2',
               job_id: 'job-2',
               profile_id: 'tech-1',
               phase: 'availability',
@@ -67,6 +87,7 @@ describe('useStaffingMatrixStatuses', () => {
               requested_by: 'manager-2',
             },
             {
+              id: 'req-offer-1',
               job_id: 'job-2',
               profile_id: 'tech-1',
               phase: 'offer',
@@ -82,7 +103,27 @@ describe('useStaffingMatrixStatuses', () => {
         })
       }
 
-      return Promise.resolve({ data: [], error: null })
+      if (table === 'staffing_events') {
+        return createQueryBuilder({
+          data: [
+            {
+              staffing_request_id: 'req-av-2',
+              event: 'whatsapp_sent',
+              meta: { request_origin: 'auto_staffing' },
+              created_at: '2026-04-10T08:56:00.000Z',
+            },
+            {
+              staffing_request_id: 'req-offer-1',
+              event: 'email_sent',
+              meta: { request_origin: 'auto_staffing' },
+              created_at: '2026-04-10T09:56:00.000Z',
+            },
+          ],
+          error: null,
+        })
+      }
+
+      return createQueryBuilder({ data: [], error: null })
     })
 
     const { result } = renderHook(
@@ -117,6 +158,8 @@ describe('useStaffingMatrixStatuses', () => {
       offer_status: 'sent',
       offer_job_id: 'job-2',
       offer_job_title: 'Arena Show',
+      availability_actor_label: CARLOS_AGENT_NAME,
+      offer_actor_label: CARLOS_AGENT_NAME,
     })
     expect(status?.pending_availability_job_titles).toEqual(['Load-in Day', 'Arena Show'])
     expect(status?.pending_offer_job_titles).toEqual(['Arena Show'])

--- a/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
+++ b/src/features/staffing/hooks/useStaffingMatrixStatuses.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '@/integrations/supabase/client'
 import { format } from 'date-fns'
+import { CARLOS_AGENT_NAME } from '@/features/staffing/carlos'
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -36,8 +37,10 @@ interface ByDateStatus extends ByJobStatus {
   offer_job_id?: string | null
   offer_job_title?: string | null
   availability_requested_by?: string | null
+  availability_actor_label?: string | null
   availability_created_at?: string | null
   offer_requested_by?: string | null
+  offer_actor_label?: string | null
   offer_created_at?: string | null
   // Arrays of ALL job IDs with pending requests for this date (for bulk cancel)
   pending_availability_job_ids?: string[]
@@ -47,6 +50,7 @@ interface ByDateStatus extends ByJobStatus {
 }
 
 interface StaffingRequestRow {
+  id?: string | null
   job_id: string
   profile_id: string
   phase: 'availability' | 'offer'
@@ -56,6 +60,15 @@ interface StaffingRequestRow {
   target_date: string | Date | null
   created_at: string | null
   requested_by: string | null
+}
+
+interface StaffingEventRow {
+  staffing_request_id: string | null
+  event: string | null
+  meta: {
+    request_origin?: string | null
+  } | null
+  created_at: string | null
 }
 
 interface LatestByPhaseAccumulator {
@@ -68,8 +81,10 @@ interface LatestByPhaseAccumulator {
   offer_job_id: string | null
   offer_job_title: string | null
   availability_requested_by: string | null
+  availability_actor_label: string | null
   availability_created_at: string | null
   offer_requested_by: string | null
+  offer_actor_label: string | null
   offer_created_at: string | null
   pending_availability_job_ids: string[]
   pending_availability_job_titles: string[]
@@ -87,8 +102,10 @@ const createLatestByPhaseAccumulator = (): LatestByPhaseAccumulator => ({
   offer_job_id: null,
   offer_job_title: null,
   availability_requested_by: null,
+  availability_actor_label: null,
   availability_created_at: null,
   offer_requested_by: null,
+  offer_actor_label: null,
   offer_created_at: null,
   pending_availability_job_ids: [],
   pending_availability_job_titles: [],
@@ -171,22 +188,79 @@ export function useStaffingMatrixStatuses(
 
       // 2) Date-based statuses derived from staffing_requests across visible jobs
       const reqRows: StaffingRequestRow[] = []
+      let shouldFallbackToRequestsRpc = false
       try {
         const { data, error } = await supabase
-          .rpc('get_staffing_requests_matrix_filtered', {
-            p_job_ids: jobIds,
-            p_profile_ids: technicianIds
-          })
+          .from('staffing_requests')
+          .select('id, job_id, profile_id, phase, status, updated_at, single_day, target_date, created_at, requested_by')
+          .in('job_id', jobIds)
+          .in('profile_id', technicianIds)
+          .in('phase', ['availability', 'offer'])
+          .order('updated_at', { ascending: false })
 
         if (error) {
-          console.warn('Staffing matrix requests RPC error:', error)
+          console.warn('Staffing matrix requests query error:', error)
+          shouldFallbackToRequestsRpc = true
         } else if (data?.length) {
           data.forEach(row => {
             reqRows.push(row as StaffingRequestRow)
           })
         }
       } catch (e) {
-        console.warn('Staffing matrix requests RPC error:', e)
+        console.warn('Staffing matrix requests query error:', e)
+        shouldFallbackToRequestsRpc = true
+      }
+
+      if (shouldFallbackToRequestsRpc) {
+        try {
+          const { data, error } = await supabase
+            .rpc('get_staffing_requests_matrix_filtered', {
+              p_job_ids: jobIds,
+              p_profile_ids: technicianIds
+            })
+
+          if (error) {
+            console.warn('Staffing matrix requests RPC error:', error)
+          } else if (data?.length) {
+            data.forEach(row => {
+              reqRows.push(row as StaffingRequestRow)
+            })
+          }
+        } catch (e) {
+          console.warn('Staffing matrix requests RPC error:', e)
+        }
+      }
+
+      const autoStaffingRequestIds = new Set<string>()
+      try {
+        const requestIds = Array.from(new Set(reqRows.map((row) => row.id).filter(Boolean) as string[]))
+        if (requestIds.length > 0) {
+          const requestIdBatches = chunk(requestIds, 200)
+          const eventPromises = requestIdBatches.map((batch) => (
+            Promise.resolve(supabase
+              .from('staffing_events')
+              .select('staffing_request_id, event, meta, created_at')
+              .in('staffing_request_id', batch)
+              .in('event', ['email_sent', 'whatsapp_sent'])
+              .order('created_at', { ascending: false }))
+          ))
+          const eventResults = await Promise.all(eventPromises)
+          eventResults.forEach((res) => {
+            if (res.error) {
+              console.warn('Staffing matrix events query error:', res.error)
+              return
+            }
+            ;((res.data || []) as StaffingEventRow[]).forEach((event) => {
+              const requestId = String(event.staffing_request_id || '')
+              if (!requestId || autoStaffingRequestIds.has(requestId)) return
+              if (event.meta?.request_origin === 'auto_staffing') {
+                autoStaffingRequestIds.add(requestId)
+              }
+            })
+          })
+        }
+      } catch (e) {
+        console.warn('Staffing matrix events query error:', e)
       }
 
       // Build job lookup with parsed dates for overlap check
@@ -251,12 +325,15 @@ export function useStaffingMatrixStatuses(
               }
               const accT = acc.availability_updated_at || 0
               if (t > accT) {
-	                const mapped = r.status === 'pending' ? 'requested' : (r.status === 'expired' ? null : toMatrixStatus(r.status))
+                const mapped = r.status === 'pending' ? 'requested' : (r.status === 'expired' ? null : toMatrixStatus(r.status))
                 acc.availability_status = mapped
                 acc.availability_updated_at = t
                 acc.availability_job_id = r.job_id
                 acc.availability_job_title = jobTitle
                 acc.availability_requested_by = r.requested_by ?? null
+                acc.availability_actor_label = r.id && autoStaffingRequestIds.has(r.id)
+                  ? CARLOS_AGENT_NAME
+                  : null
                 acc.availability_created_at = r.created_at ?? null
               }
             } else if (r.phase === 'offer') {
@@ -267,12 +344,15 @@ export function useStaffingMatrixStatuses(
               }
               const accT = acc.offer_updated_at || 0
               if (t > accT) {
-	                const mapped = r.status === 'pending' ? 'sent' : (r.status === 'expired' ? null : toMatrixStatus(r.status))
+                const mapped = r.status === 'pending' ? 'sent' : (r.status === 'expired' ? null : toMatrixStatus(r.status))
                 acc.offer_status = mapped
                 acc.offer_updated_at = t
                 acc.offer_job_id = r.job_id
                 acc.offer_job_title = jobTitle
                 acc.offer_requested_by = r.requested_by ?? null
+                acc.offer_actor_label = r.id && autoStaffingRequestIds.has(r.id)
+                  ? CARLOS_AGENT_NAME
+                  : null
                 acc.offer_created_at = r.created_at ?? null
               }
             }
@@ -289,8 +369,10 @@ export function useStaffingMatrixStatuses(
               offer_job_id: latest.offer_job_id,
               offer_job_title: latest.offer_job_title,
               availability_requested_by: latest.availability_requested_by,
+              availability_actor_label: latest.availability_actor_label,
               availability_created_at: latest.availability_created_at,
               offer_requested_by: latest.offer_requested_by,
+              offer_actor_label: latest.offer_actor_label,
               offer_created_at: latest.offer_created_at,
               pending_availability_job_ids: latest.pending_availability_job_ids,
               pending_availability_job_titles: latest.pending_availability_job_titles,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -10656,6 +10656,7 @@ export type Database = {
         Args: { p_job_ids: string[]; p_profile_ids: string[] }
         Returns: {
           created_at: string
+          id: string
           job_id: string
           phase: string
           profile_id: string

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -37,6 +37,9 @@ verify_jwt = true
 [functions.send-job-payout-email]
 verify_jwt = true
 
+[functions.send-staffing-email]
+verify_jwt = false
+
 [functions.send-timesheet-reminder]
 verify_jwt = true
 

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -1313,7 +1313,7 @@ serve(createHttpHandler(async (req) => {
       console.log('🔗 CONFIRM LINKS GENERATED:', {
         email: desiredChannel === 'email',
         whatsapp: desiredChannel === 'whatsapp',
-        expires_at: new Date(exp * 1000).toISOString(),
+        expires_at: exp,
       });
       if (desiredChannel === 'whatsapp') {
         const text = buildWhatsAppStaffingMessage({

--- a/supabase/migrations/20260629223000_add_staffing_request_id_to_matrix_rpc.sql
+++ b/supabase/migrations/20260629223000_add_staffing_request_id_to_matrix_rpc.sql
@@ -1,0 +1,53 @@
+-- Include staffing request ids in the matrix fallback RPC so callers can join
+-- rows back to staffing_events for sender/origin metadata.
+
+DROP FUNCTION IF EXISTS public.get_staffing_requests_matrix_filtered(uuid[], uuid[]);
+
+CREATE OR REPLACE FUNCTION public.get_staffing_requests_matrix_filtered(
+  p_job_ids uuid[],
+  p_profile_ids uuid[]
+)
+RETURNS TABLE(
+  id uuid,
+  job_id uuid,
+  profile_id uuid,
+  phase text,
+  status text,
+  updated_at timestamptz,
+  single_day boolean,
+  target_date date,
+  created_at timestamptz,
+  requested_by uuid
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH authorized AS (
+    SELECT auth.role() = 'service_role' OR public.is_admin_or_management() AS allowed
+  )
+  SELECT
+    sr.id,
+    sr.job_id,
+    sr.profile_id,
+    sr.phase,
+    sr.status,
+    sr.updated_at,
+    sr.single_day,
+    sr.target_date,
+    sr.created_at,
+    sr.requested_by
+  FROM public.staffing_requests sr
+  CROSS JOIN authorized a
+  WHERE a.allowed
+    AND sr.job_id = ANY(p_job_ids)
+    AND sr.profile_id = ANY(p_profile_ids)
+  ORDER BY sr.profile_id, sr.job_id, sr.phase, sr.updated_at DESC NULLS LAST, sr.created_at DESC NULLS LAST;
+$function$;
+
+COMMENT ON FUNCTION public.get_staffing_requests_matrix_filtered(uuid[], uuid[])
+  IS 'Returns raw staffing request rows, including ids, for bounded matrix job/profile sets so callers can join staffing_events metadata.';
+
+GRANT EXECUTE ON FUNCTION public.get_staffing_requests_matrix_filtered(uuid[], uuid[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_staffing_requests_matrix_filtered(uuid[], uuid[]) TO service_role;

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -32,6 +32,18 @@ const staffingSweeperScheduleMigration = readFileSync(
   "utf-8",
 );
 
+const supabaseConfig = readFileSync(
+  join(process.cwd(), "supabase/config.toml"),
+  "utf-8",
+);
+
+const edgeFunctionExposure = JSON.parse(
+  readFileSync(
+    join(process.cwd(), "scripts/governance/edge-function-exposure.json"),
+    "utf-8",
+  ),
+);
+
 const sendStaffingEmailFunction = readFileSync(
   join(process.cwd(), "supabase/functions/send-staffing-email/index.ts"),
   "utf-8",
@@ -164,6 +176,18 @@ describe("smarter staffing recommendation migration", () => {
     expect(sendStaffingEmailFunction).toContain("isServiceRoleRequest");
     expect(sendStaffingEmailFunction).toContain("body?.actor_id");
     expect(staffingOrchestratorFunction).toContain("actor_id: campaign.created_by");
+  });
+
+  it("lets send-staffing-email handle CORS before enforcing internal auth", () => {
+    expect(supabaseConfig).toMatch(/\[functions\.send-staffing-email\]\s+verify_jwt = false/);
+    expect(edgeFunctionExposure.functions["send-staffing-email"]).toMatchObject({
+      class: "privileged-role",
+      verifyJwt: false,
+    });
+    expect(edgeFunctionExposure.functions["send-staffing-email"].internalGuard).toContain("requireAdminOrManagement");
+    expect(sendStaffingEmailFunction).toContain("createHttpHandler");
+    expect(sendStaffingEmailFunction).toContain("isServiceRoleRequest");
+    expect(sendStaffingEmailFunction).toContain("requireAdminOrManagement");
   });
 
   it("scopes staffing push notifications to the staffing department", () => {

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -190,6 +190,12 @@ describe("smarter staffing recommendation migration", () => {
     expect(sendStaffingEmailFunction).toContain("requireAdminOrManagement");
   });
 
+  it("does not convert the ISO staffing token expiry into an invalid date", () => {
+    expect(sendStaffingEmailFunction).toContain("const exp = new Date(Date.now() + 1000*60*60*48).toISOString()");
+    expect(sendStaffingEmailFunction).toContain("expires_at: exp");
+    expect(sendStaffingEmailFunction).not.toContain("new Date(exp * 1000)");
+  });
+
   it("scopes staffing push notifications to the staffing department", () => {
     expect(sendStaffingEmailFunction).toContain("department: staffingDepartment");
     expect(sendStaffingEmailFunction).toContain('supabase.from("job_departments")');

--- a/tests/e2e/staffing-recommendations.spec.ts
+++ b/tests/e2e/staffing-recommendations.spec.ts
@@ -247,11 +247,12 @@ test("auto-staffing shows role-less consultations and refreshes candidates after
   await expect(page.getByText("No hay candidatos disponibles para SND-PA-T")).toBeVisible();
 
   await page.getByRole("tab", { name: "Offers" }).click();
+  const confirmedResponses = page.getByTestId("staffing-confirmed-responses");
   await expect(page.getByText("Availability: 1 yes")).toBeVisible();
-  await expect(page.getByText("Confirmed Tech")).toBeVisible();
-  await expect(page.getByText("Other Role")).toHaveCount(0);
-  await expect(page.getByText("Availability yes")).toBeVisible();
-  await expect(page.getByText("Job availability").first()).toBeVisible();
+  await expect(confirmedResponses.getByText("Confirmed Tech")).toBeVisible();
+  await expect(confirmedResponses.getByText("Other Role")).toHaveCount(0);
+  await expect(confirmedResponses.getByText("Availability yes")).toBeVisible();
+  await expect(confirmedResponses.getByText("Job availability")).toBeVisible();
   await page.getByRole("checkbox", { name: /select confirmed tech for offer/i }).click();
   await page.getByRole("button", { name: /send offers \(1\) by email/i }).click();
 


### PR DESCRIPTION
## Summary
- keep the Candidates and Offers tabs active in Carlos auto mode as read-only activity views
- show Carlos candidate ranking, sent availability/offer status, next candidate, and sent offer activity
- attribute auto-staffing availability/offer hovers to `C.A.R.L.O.S.` from send-event metadata while preserving manual actor names
- hotfix `send-staffing-email` gateway config so browser CORS preflight reaches the function and internal auth returns the correct JSON response
- fix the `send-staffing-email` invalid expiry log conversion that could throw a 500 before delivery
- fix the matrix date-header scroll crash by throttling captured scroll values instead of React events and ignoring scheduled work after unmount
- scope the staffing smoke test to the confirmed-availability section now that Offers also shows sent-offer activity
- address CodeRabbit review threads: newest activity wins, Carlos badges only show for auto-originated sends, sent-offer activity reads event role/origin metadata, and the matrix fallback RPC returns request ids for event attribution

## Validation
- `npm run test:run -- src/components/matrix/__tests__/StaffingCandidateList.test.tsx src/components/matrix/__tests__/StaffingOfferList.test.tsx src/components/matrix/__tests__/StaffingOrchestratorPanel.test.tsx src/components/matrix/__tests__/OptimizedMatrixCell.test.tsx src/features/staffing/hooks/__tests__/useStaffingMatrixStatuses.test.tsx`
- `npm run test:run -- src/components/matrix/optimized-assignment-matrix/__tests__/useMatrixScrollState.test.tsx tests/assignments/staffing-recommendations.test.ts`
- `npm run test:run -- src/components/matrix/__tests__/StaffingOfferList.test.tsx`
- `npm run test:run -- src/components/matrix/__tests__/StaffingCandidateList.test.tsx src/components/matrix/__tests__/StaffingOfferList.test.tsx src/features/staffing/hooks/__tests__/useStaffingMatrixStatuses.test.tsx tests/assignments/staffing-recommendations.test.ts`
- `npx playwright test tests/e2e/staffing-recommendations.spec.ts --project=chromium`
- `npm run governance:source`
- `npm run governance:exposure`
- `npm run ci:db:migrations`
- `npm run governance:sql-grants`
- `npm run typecheck`
- `npx eslint src/components/matrix/StaffingOfferList.tsx tests/e2e/staffing-recommendations.spec.ts`
- `npx eslint src/components/matrix/StaffingCandidateList.tsx src/components/matrix/StaffingOfferList.tsx src/components/matrix/__tests__/StaffingCandidateList.test.tsx src/components/matrix/__tests__/StaffingOfferList.test.tsx src/features/staffing/hooks/useStaffingMatrixStatuses.ts src/features/staffing/hooks/__tests__/useStaffingMatrixStatuses.test.tsx tests/e2e/staffing-recommendations.spec.ts` (existing warnings only)
- `npm run lint:app` (existing warnings only)
- `npm run lint:functions` (existing warnings only)
- `npm run lint` (existing warnings only)
- `npm run build`
- `git diff --check`

## Deployment
- deployed `send-staffing-email` to Supabase project `syldobdcdsgfgjtbuwxm` with `--no-verify-jwt`
- redeployed `send-staffing-email` after the invalid-expiry 500 fix
- verified unauthenticated `OPTIONS` returns `204` with CORS headers
- verified unauthenticated `POST` reaches function code and returns internal `401 { code: "missing_authorization" }`
- database migration required for `get_staffing_requests_matrix_filtered` RPC id return; production dry-run/apply will be completed before merge
