### PR TITLE
[codex] Make Carlos aware of adjacent jobs

### DIFF
--- a/src/components/matrix/StaffingCandidateList.tsx
+++ b/src/components/matrix/StaffingCandidateList.tsx
@@ -364,6 +364,7 @@ export const StaffingCandidateList: React.FC<StaffingCandidateListProps> = ({
               department,
               channel,
               require_no_conflicts: true,
+              campaign_id: campaignId,
               idempotency_key: `campaign:${campaignId}:${roleCode}:${profileId}:availability:${channel}`
             })
           }

--- a/src/features/staffing/__tests__/crewingProfiles.test.ts
+++ b/src/features/staffing/__tests__/crewingProfiles.test.ts
@@ -104,6 +104,42 @@ describe('crewing profile inference', () => {
     expect(policy.channel).toBe('whatsapp');
   });
 
+  it('passes surrounding-job policy overrides into campaign policy', () => {
+    const policy = buildCampaignPolicy({
+      mode: 'assisted',
+      selectedJobProfile: 'standard',
+      inferProfileFromJobType: false,
+      roleProfiles: {},
+      availabilityTtlHours: 24,
+      offerTtlHours: 2,
+      softConflictPolicy: 'warn',
+      excludeFridge: false,
+      sendChannel: 'email',
+      costScoring: {
+        enabled: false,
+        penaltyStrength: 'disabled',
+        maxRatePenalty: 0,
+      },
+      waves: {
+        mode: 'manual_selection',
+        buffer: 0,
+        waitMinutes: 15,
+        maxWaves: 1,
+        autoSendNextWave: false,
+      },
+      tickIntervalSeconds: 300,
+      surroundingJobs: {
+        enabled: false,
+        maxLocationDistanceKm: 12,
+      },
+    });
+
+    expect(policy.surrounding_jobs).toEqual({
+      enabled: false,
+      max_location_distance_km: 12,
+    });
+  });
+
   it('groups ranked candidates into recommended waves from required count plus buffer', () => {
     expect(recommendedWaveNumber(0, 2, 1)).toBe(1);
     expect(recommendedWaveNumber(2, 2, 1)).toBe(1);

--- a/src/features/staffing/__tests__/crewingProfiles.test.ts
+++ b/src/features/staffing/__tests__/crewingProfiles.test.ts
@@ -91,6 +91,10 @@ describe('crewing profile inference', () => {
     expect(policy.weights.skills).toBe(0.4);
     expect(policy.weights.cost_efficiency).toBe(0.03);
     expect(policy.cost_scoring.enabled).toBe(true);
+    expect(policy.surrounding_jobs).toEqual({
+      enabled: true,
+      max_location_distance_km: 25,
+    });
     expect(policy.waves).toMatchObject({
       mode: 'controlled_waves',
       buffer: 1,
@@ -106,4 +110,3 @@ describe('crewing profile inference', () => {
     expect(recommendedWaveNumber(3, 2, 1)).toBe(2);
   });
 });
-

--- a/src/features/staffing/crewingProfiles.ts
+++ b/src/features/staffing/crewingProfiles.ts
@@ -469,6 +469,10 @@ export function buildCampaignPolicy(input: BuildCampaignPolicyInput) {
       escalate_weak_critical_pool: true,
       require_manager_approval_for_low_confidence: true,
     },
+    surrounding_jobs: {
+      enabled: true,
+      max_location_distance_km: 25,
+    },
     audit: {
       log_inferred_profile: true,
       log_profile_override: true,

--- a/src/features/staffing/crewingProfiles.ts
+++ b/src/features/staffing/crewingProfiles.ts
@@ -79,6 +79,10 @@ export type BuildCampaignPolicyInput = {
   };
   tickIntervalSeconds: number;
   weightOverrides?: Partial<ScoringWeights>;
+  surroundingJobs?: {
+    enabled?: boolean;
+    maxLocationDistanceKm?: number;
+  };
 };
 
 export const JOB_PROFILE_LABELS: Record<JobProfileName, string> = {
@@ -470,8 +474,8 @@ export function buildCampaignPolicy(input: BuildCampaignPolicyInput) {
       require_manager_approval_for_low_confidence: true,
     },
     surrounding_jobs: {
-      enabled: true,
-      max_location_distance_km: 25,
+      enabled: input.surroundingJobs?.enabled ?? true,
+      max_location_distance_km: input.surroundingJobs?.maxLocationDistanceKm ?? 25,
     },
     audit: {
       log_inferred_profile: true,

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -95,6 +95,55 @@ function rangesOverlapInclusive(
   return aStart <= bEnd && aEnd >= bStart;
 }
 
+function addDaysToDateKey(dateKey: string | null | undefined, days: number): string | null {
+  if (!dateKey) return null;
+  const parsed = new Date(`${dateKey}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().split('T')[0];
+}
+
+function dateKeyInRange(dateKey: string | null, start?: string | null, end?: string | null): boolean {
+  if (!dateKey) return false;
+  const startKey = dateOnly(start);
+  const endKey = dateOnly(end);
+  if (!startKey || !endKey) return false;
+  const first = startKey <= endKey ? startKey : endKey;
+  const last = startKey <= endKey ? endKey : startKey;
+  return dateKey >= first && dateKey <= last;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function distanceKm(
+  lat1: number | null,
+  lon1: number | null,
+  lat2: number | null,
+  lon2: number | null
+): number | null {
+  if (lat1 === null || lon1 === null || lat2 === null || lon2 === null) return null;
+  const toRad = (value: number) => value * Math.PI / 180;
+  const earthRadiusKm = 6371;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  return earthRadiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function jobLocation(job: any): { latitude: number | null; longitude: number | null } {
+  const location = joinedSingle(job?.locations);
+  return {
+    latitude: toFiniteNumber(location?.latitude),
+    longitude: toFiniteNumber(location?.longitude),
+  };
+}
+
 function joinedSingle<T>(value: T | T[] | null | undefined): T | null {
   if (Array.isArray(value)) return value[0] ?? null;
   return value ?? null;
@@ -430,7 +479,8 @@ serve(createHttpHandler(async (req) => {
             title,
             start_time,
             end_time,
-            locations(formatted_address)
+            tour_id,
+            locations(formatted_address, latitude, longitude)
           `)
           .eq("id", job_id)
           .maybeSingle(),
@@ -565,6 +615,7 @@ serve(createHttpHandler(async (req) => {
           sameRoleRequestResult,
           jobAvailabilityRequestResult,
           rolelessDeclineResult,
+          campaignPolicyResult,
         ] = await Promise.all([
           supabase
             .from('job_assignments')
@@ -573,7 +624,7 @@ serve(createHttpHandler(async (req) => {
             .eq('technician_id', profile_id),
           supabase
             .from('job_assignments')
-            .select('id, job_id, status, jobs(id, title, start_time, end_time)')
+            .select('id, job_id, status, jobs(id, title, start_time, end_time, tour_id, locations(id, latitude, longitude))')
             .eq('technician_id', profile_id)
             .neq('job_id', job_id),
           roleCode
@@ -603,6 +654,13 @@ serve(createHttpHandler(async (req) => {
             .in('phase', ['availability', 'offer'])
             .eq('status', 'declined')
             .or('role_code.is.null,role_code.eq.'),
+          typeof campaign_id === 'string' && campaign_id
+            ? supabase
+              .from('staffing_campaigns')
+              .select('policy')
+              .eq('id', campaign_id)
+              .maybeSingle()
+            : Promise.resolve({ data: null, error: null }),
         ]);
 
         const guardErrors = [
@@ -611,6 +669,7 @@ serve(createHttpHandler(async (req) => {
           sameRoleRequestResult.error,
           jobAvailabilityRequestResult.error,
           rolelessDeclineResult.error,
+          campaignPolicyResult.error,
         ].filter(Boolean);
 
         if (guardErrors.length > 0) {
@@ -654,10 +713,62 @@ serve(createHttpHandler(async (req) => {
             || !request.target_date
             || targetDates.includes(request.target_date)
           ));
+        const campaignPolicy = (campaignPolicyResult.data?.policy || {}) as any;
+        const rolePolicy = roleCode && campaignPolicy?.role_profiles
+          ? campaignPolicy.role_profiles[roleCode]
+          : null;
+        const adjacentGuardEnabled = campaignPolicy?.surrounding_jobs?.enabled !== false;
+        const adjacentMaxDistanceKm = toFiniteNumber(campaignPolicy?.surrounding_jobs?.max_location_distance_km) ?? 25;
+        const urgentAdjacentMode =
+          campaignPolicy?.profile?.selected_job_profile === 'emergency_fill'
+          || campaignPolicy?.profile?.inferred_job_profile === 'emergency_fill'
+          || rolePolicy?.selected_profile === 'emergency_fill'
+          || rolePolicy?.inferred_profile === 'emergency_fill';
+        const sortedTargetDates = [...targetDates].sort();
+        const previousTargetDate = addDaysToDateKey(sortedTargetDates[0], -1);
+        const nextTargetDate = addDaysToDateKey(sortedTargetDates[sortedTargetDates.length - 1], 1);
+        const targetLocation = jobLocation(job);
+        const targetTourId = typeof job.tour_id === 'string' ? job.tour_id : null;
+        const adjacentAssignments = (activeAssignmentResult.data || [])
+          .filter((assignment: any) => assignment.status !== 'declined')
+          .map((assignment: any) => ({
+            ...assignment,
+            job: joinedSingle(assignment.jobs),
+          }))
+          .filter((assignment: any) => {
+            const assignmentTourId = typeof assignment.job?.tour_id === 'string' ? assignment.job.tour_id : null;
+            if (targetTourId && assignmentTourId && targetTourId === assignmentTourId) return false;
+            return dateKeyInRange(previousTargetDate, assignment.job?.start_time, assignment.job?.end_time)
+              || dateKeyInRange(nextTargetDate, assignment.job?.start_time, assignment.job?.end_time);
+          })
+          .map((assignment: any) => {
+            const otherLocation = jobLocation(assignment.job);
+            return {
+              id: assignment.id,
+              status: assignment.status,
+              job_id: assignment.job_id,
+              title: assignment.job?.title,
+              start_time: assignment.job?.start_time,
+              end_time: assignment.job?.end_time,
+              tour_id: assignment.job?.tour_id || null,
+              distance_km: distanceKm(
+                targetLocation.latitude,
+                targetLocation.longitude,
+                otherLocation.latitude,
+                otherLocation.longitude,
+              ),
+            };
+          });
+        const blockingAdjacentAssignments = adjacentGuardEnabled && !urgentAdjacentMode
+          ? adjacentAssignments.filter((assignment: any) =>
+            assignment.distance_km === null || assignment.distance_km > adjacentMaxDistanceKm
+          )
+          : [];
 
         if (
           activeTargetAssignments.length > 0
           || overlappingAssignments.length > 0
+          || blockingAdjacentAssignments.length > 0
           || sameRoleRequests.length > 0
           || jobAvailabilityRequests.length > 0
           || rolelessDeclines.length > 0
@@ -673,6 +784,14 @@ serve(createHttpHandler(async (req) => {
               start_time: assignment.job?.start_time,
               end_time: assignment.job?.end_time,
             })),
+            adjacent_assignments: blockingAdjacentAssignments,
+            adjacent_job_policy: {
+              enabled: adjacentGuardEnabled,
+              urgent: urgentAdjacentMode,
+              max_location_distance_km: adjacentMaxDistanceKm,
+              previous_target_date: previousTargetDate,
+              next_target_date: nextTargetDate,
+            },
             same_role_requests: sameRoleRequests,
             job_availability_requests: jobAvailabilityRequests,
             roleless_declines: rolelessDeclines,

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -114,6 +114,8 @@ function dateKeyInRange(dateKey: string | null, start?: string | null, end?: str
 }
 
 function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string' && value.trim() === '') return null;
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : null;
 }
@@ -657,8 +659,9 @@ serve(createHttpHandler(async (req) => {
           typeof campaign_id === 'string' && campaign_id
             ? supabase
               .from('staffing_campaigns')
-              .select('policy')
+              .select('policy, job_id')
               .eq('id', campaign_id)
+              .eq('job_id', job_id)
               .maybeSingle()
             : Promise.resolve({ data: null, error: null }),
         ]);

--- a/supabase/functions/staffing-orchestrator/__tests__/policyUtils.test.ts
+++ b/supabase/functions/staffing-orchestrator/__tests__/policyUtils.test.ts
@@ -52,6 +52,10 @@ describe("staffing orchestrator policy utilities", () => {
     expect(policy.offer_ttl_hours).toBe(2);
     expect(policy.soft_conflict_policy).toBe("block");
     expect(policy.escalation).toMatchObject({ minimum_auto_book_score: 75 });
+    expect(policy.surrounding_jobs).toEqual({
+      enabled: true,
+      max_location_distance_km: 25,
+    });
     expect(policy.role_profiles?.["SND-PA-LEAD"]).toMatchObject({
       inferred_profile: "high_risk_critical",
       selected_profile: "high_risk_critical",
@@ -77,6 +81,9 @@ describe("staffing orchestrator policy utilities", () => {
         cost_scoring: {
           penalty_strength: "high",
           max_rate_penalty: 20,
+        },
+        surrounding_jobs: {
+          max_location_distance_km: 15,
         },
         channel: "whatsapp",
       },
@@ -105,6 +112,10 @@ describe("staffing orchestrator policy utilities", () => {
       enabled: true,
       penalty_strength: "high",
       max_rate_penalty: 20,
+    });
+    expect(policy.surrounding_jobs).toEqual({
+      enabled: true,
+      max_location_distance_km: 15,
     });
   });
 

--- a/supabase/functions/staffing-orchestrator/policyUtils.ts
+++ b/supabase/functions/staffing-orchestrator/policyUtils.ts
@@ -39,6 +39,10 @@ export interface CampaignPolicy {
   auto_close?: Record<string, boolean>;
   audit?: Record<string, boolean>;
   escalation?: Record<string, unknown>;
+  surrounding_jobs?: {
+    enabled?: boolean;
+    max_location_distance_km?: number;
+  };
   escalation_steps: string[];
 }
 
@@ -311,6 +315,10 @@ export function normalizeCampaignPolicy(
       escalate_weak_critical_pool: true,
       require_manager_approval_for_low_confidence: true,
       ...(basePolicy.escalation || {}),
+    },
+    surrounding_jobs: {
+      enabled: basePolicy.surrounding_jobs?.enabled ?? true,
+      max_location_distance_km: Number(basePolicy.surrounding_jobs?.max_location_distance_km ?? 25),
     },
     audit: {
       log_inferred_profile: true,

--- a/supabase/migrations/20260630100000_staffing_surrounding_job_awareness.sql
+++ b/supabase/migrations/20260630100000_staffing_surrounding_job_awareness.sql
@@ -1,0 +1,241 @@
+-- Make staffing recommendations aware of surrounding assignments.
+--
+-- A technician booked on adjacent dates should not be contacted for a separate
+-- back-to-back job unless the adjacent venues are very close to the target
+-- venue, or the campaign is running in Cobertura urgente (emergency_fill) mode.
+-- Jobs in the same non-null tour are treated as one coherent run and are not
+-- blocked by this guard.
+
+DO $$
+DECLARE
+  v_sql text;
+BEGIN
+  SELECT pg_get_functiondef('public.rank_staffing_candidates(uuid,text,text,text,jsonb)'::regprocedure)
+  INTO v_sql;
+
+  v_sql := replace(
+    v_sql,
+$old$
+  v_base_lat double precision := 40.4168;
+  v_base_lng double precision := -3.7038;
+$old$,
+$new$
+  v_base_lat double precision := 40.4168;
+  v_base_lng double precision := -3.7038;
+  v_target_lat double precision;
+  v_target_lng double precision;
+  v_target_tour_id uuid;
+  v_surrounding_jobs_enabled boolean := COALESCE((p_policy->'surrounding_jobs'->>'enabled')::boolean, true);
+  v_surrounding_jobs_max_distance_km double precision := COALESCE((p_policy->'surrounding_jobs'->>'max_location_distance_km')::double precision, 25);
+  v_surrounding_jobs_is_urgent boolean :=
+    COALESCE(p_policy->'profile'->>'selected_job_profile', p_policy->'profile'->>'inferred_job_profile', '') = 'emergency_fill'
+    OR COALESCE(p_policy->'role_profiles'->NULLIF(BTRIM(COALESCE(p_role_code, '')), '')->>'selected_profile', '') = 'emergency_fill'
+    OR COALESCE(p_policy->'role_profiles'->NULLIF(BTRIM(COALESCE(p_role_code, '')), '')->>'inferred_profile', '') = 'emergency_fill';
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+  SELECT j.start_time, j.end_time
+  INTO v_job_start, v_job_end
+  FROM jobs j
+  WHERE j.id = p_job_id;
+$old$,
+$new$
+  SELECT
+    j.start_time,
+    j.end_time,
+    j.tour_id,
+    l.latitude::double precision,
+    l.longitude::double precision
+  INTO v_job_start, v_job_end, v_target_tour_id, v_target_lat, v_target_lng
+  FROM jobs j
+  LEFT JOIN locations l ON l.id = j.location_id
+  WHERE j.id = p_job_id;
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+          AND NOT (j2.time_range && tstzrange(v_job_start, v_job_end, '[]'))
+      ) AS has_same_day_job
+    FROM profiles p
+$old$,
+$new$
+          AND NOT (j2.time_range && tstzrange(v_job_start, v_job_end, '[]'))
+      ) AS has_same_day_job,
+      EXISTS (
+        SELECT 1
+        FROM job_assignments ja3
+        JOIN jobs j3 ON j3.id = ja3.job_id
+        WHERE ja3.technician_id = p.id
+          AND ja3.job_id IS DISTINCT FROM p_job_id
+          AND COALESCE(ja3.status, 'invited') <> 'declined'
+          AND (
+            v_target_tour_id IS NULL
+            OR j3.tour_id IS NULL
+            OR j3.tour_id <> v_target_tour_id
+          )
+          AND (v_job_start::date - 1) BETWEEN j3.start_time::date AND j3.end_time::date
+      ) AS has_previous_day_job,
+      EXISTS (
+        SELECT 1
+        FROM job_assignments ja4
+        JOIN jobs j4 ON j4.id = ja4.job_id
+        WHERE ja4.technician_id = p.id
+          AND ja4.job_id IS DISTINCT FROM p_job_id
+          AND COALESCE(ja4.status, 'invited') <> 'declined'
+          AND (
+            v_target_tour_id IS NULL
+            OR j4.tour_id IS NULL
+            OR j4.tour_id <> v_target_tour_id
+          )
+          AND (v_job_end::date + 1) BETWEEN j4.start_time::date AND j4.end_time::date
+      ) AS has_next_day_job,
+      (
+        SELECT MAX(
+          distance_km(
+            v_target_lat,
+            v_target_lng,
+            l5.latitude::double precision,
+            l5.longitude::double precision
+          )
+        )
+        FROM job_assignments ja5
+        JOIN jobs j5 ON j5.id = ja5.job_id
+        LEFT JOIN locations l5 ON l5.id = j5.location_id
+        WHERE ja5.technician_id = p.id
+          AND ja5.job_id IS DISTINCT FROM p_job_id
+          AND COALESCE(ja5.status, 'invited') <> 'declined'
+          AND (
+            v_target_tour_id IS NULL
+            OR j5.tour_id IS NULL
+            OR j5.tour_id <> v_target_tour_id
+          )
+          AND (
+            (v_job_start::date - 1) BETWEEN j5.start_time::date AND j5.end_time::date
+            OR (v_job_end::date + 1) BETWEEN j5.start_time::date AND j5.end_time::date
+          )
+          AND v_target_lat IS NOT NULL
+          AND v_target_lng IS NOT NULL
+          AND l5.latitude IS NOT NULL
+          AND l5.longitude IS NOT NULL
+      ) AS max_surrounding_job_distance_km,
+      EXISTS (
+        SELECT 1
+        FROM job_assignments ja6
+        JOIN jobs j6 ON j6.id = ja6.job_id
+        LEFT JOIN locations l6 ON l6.id = j6.location_id
+        WHERE ja6.technician_id = p.id
+          AND ja6.job_id IS DISTINCT FROM p_job_id
+          AND COALESCE(ja6.status, 'invited') <> 'declined'
+          AND (
+            v_target_tour_id IS NULL
+            OR j6.tour_id IS NULL
+            OR j6.tour_id <> v_target_tour_id
+          )
+          AND (
+            (v_job_start::date - 1) BETWEEN j6.start_time::date AND j6.end_time::date
+            OR (v_job_end::date + 1) BETWEEN j6.start_time::date AND j6.end_time::date
+          )
+          AND (
+            v_target_lat IS NULL
+            OR v_target_lng IS NULL
+            OR l6.latitude IS NULL
+            OR l6.longitude IS NULL
+          )
+      ) AS has_unknown_surrounding_job_location
+    FROM profiles p
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+      wr.rate_penalty,
+      GREATEST(0, 100 - ROUND(wr.rate_penalty * 10)::int) AS cost_efficiency_score,
+      wr.jobs_worked,
+$old$,
+$new$
+      wr.rate_penalty,
+      GREATEST(0, 100 - ROUND(wr.rate_penalty * 10)::int) AS cost_efficiency_score,
+      wr.has_previous_day_job,
+      wr.has_next_day_job,
+      wr.max_surrounding_job_distance_km,
+      wr.has_unknown_surrounding_job_location,
+      wr.jobs_worked,
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+      wr.has_same_day_job AS soft_conflict,
+      false AS hard_conflict
+$old$,
+$new$
+      wr.has_same_day_job AS soft_conflict,
+      (
+        v_surrounding_jobs_enabled
+        AND NOT v_surrounding_jobs_is_urgent
+        AND (wr.has_previous_day_job OR wr.has_next_day_job)
+        AND (
+          wr.has_unknown_surrounding_job_location
+          OR wr.max_surrounding_job_distance_km IS NULL
+          OR wr.max_surrounding_job_distance_km > v_surrounding_jobs_max_distance_km
+        )
+      ) AS hard_conflict
+$new$
+  );
+
+  v_sql := replace(
+    v_sql,
+$old$
+    (CASE
+      WHEN f.rate_penalty > 0
+      THEN jsonb_build_array(
+        'Rate adjustment: -' || ROUND(f.rate_penalty::numeric, 1) ||
+        ' (' || ROUND(((f.rate_ratio - 1) * 100)::numeric, 0) || '% above standard)'
+      )
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE WHEN f.soft_conflict THEN jsonb_build_array('Same-day job (different time)') ELSE '[]'::jsonb END) AS reasons
+$old$,
+$new$
+    (CASE
+      WHEN f.rate_penalty > 0
+      THEN jsonb_build_array(
+        'Rate adjustment: -' || ROUND(f.rate_penalty::numeric, 1) ||
+        ' (' || ROUND(((f.rate_ratio - 1) * 100)::numeric, 0) || '% above standard)'
+      )
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE
+      WHEN (f.has_previous_day_job OR f.has_next_day_job) AND v_surrounding_jobs_is_urgent
+      THEN jsonb_build_array('Adjacent jobs allowed by Cobertura urgente')
+      WHEN (f.has_previous_day_job OR f.has_next_day_job) AND f.max_surrounding_job_distance_km IS NOT NULL
+      THEN jsonb_build_array('Adjacent jobs within ' || ROUND(f.max_surrounding_job_distance_km::numeric, 1) || 'km')
+      WHEN (f.has_previous_day_job OR f.has_next_day_job) AND NOT v_surrounding_jobs_enabled
+      THEN jsonb_build_array('Adjacent job guard disabled')
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE WHEN f.soft_conflict THEN jsonb_build_array('Same-day job (different time)') ELSE '[]'::jsonb END) AS reasons
+$new$
+  );
+
+  IF v_sql NOT LIKE '%v_surrounding_jobs_max_distance_km%'
+    OR v_sql NOT LIKE '%has_previous_day_job%'
+    OR v_sql NOT LIKE '%has_next_day_job%'
+    OR v_sql NOT LIKE '%Adjacent jobs allowed by Cobertura urgente%'
+  THEN
+    RAISE EXCEPTION 'Failed to patch rank_staffing_candidates with surrounding job awareness';
+  END IF;
+
+  EXECUTE v_sql;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO service_role;

--- a/supabase/migrations/20260630100000_staffing_surrounding_job_awareness.sql
+++ b/supabase/migrations/20260630100000_staffing_surrounding_job_awareness.sql
@@ -13,6 +13,15 @@ BEGIN
   SELECT pg_get_functiondef('public.rank_staffing_candidates(uuid,text,text,text,jsonb)'::regprocedure)
   INTO v_sql;
 
+  IF POSITION(
+$old$
+  v_base_lat double precision := 40.4168;
+  v_base_lng double precision := -3.7038;
+$old$ IN v_sql) = 0
+  THEN
+    RAISE EXCEPTION 'Failed to find rank_staffing_candidates coordinate declaration block';
+  END IF;
+
   v_sql := replace(
     v_sql,
 $old$
@@ -33,6 +42,17 @@ $new$
     OR COALESCE(p_policy->'role_profiles'->NULLIF(BTRIM(COALESCE(p_role_code, '')), '')->>'inferred_profile', '') = 'emergency_fill';
 $new$
   );
+
+  IF POSITION(
+$old$
+  SELECT j.start_time, j.end_time
+  INTO v_job_start, v_job_end
+  FROM jobs j
+  WHERE j.id = p_job_id;
+$old$ IN v_sql) = 0
+  THEN
+    RAISE EXCEPTION 'Failed to find rank_staffing_candidates target job metadata block';
+  END IF;
 
   v_sql := replace(
     v_sql,
@@ -55,6 +75,16 @@ $new$
   WHERE j.id = p_job_id;
 $new$
   );
+
+  IF POSITION(
+$old$
+          AND NOT (j2.time_range && tstzrange(v_job_start, v_job_end, '[]'))
+      ) AS has_same_day_job
+    FROM profiles p
+$old$ IN v_sql) = 0
+  THEN
+    RAISE EXCEPTION 'Failed to find rank_staffing_candidates adjacent assignment projection block';
+  END IF;
 
   v_sql := replace(
     v_sql,
@@ -151,6 +181,16 @@ $new$
 $new$
   );
 
+  IF POSITION(
+$old$
+      wr.rate_penalty,
+      GREATEST(0, 100 - ROUND(wr.rate_penalty * 10)::int) AS cost_efficiency_score,
+      wr.jobs_worked,
+$old$ IN v_sql) = 0
+  THEN
+    RAISE EXCEPTION 'Failed to find rank_staffing_candidates candidate field forwarding block';
+  END IF;
+
   v_sql := replace(
     v_sql,
 $old$
@@ -168,6 +208,15 @@ $new$
       wr.jobs_worked,
 $new$
   );
+
+  IF POSITION(
+$old$
+      wr.has_same_day_job AS soft_conflict,
+      false AS hard_conflict
+$old$ IN v_sql) = 0
+  THEN
+    RAISE EXCEPTION 'Failed to find rank_staffing_candidates hard conflict block';
+  END IF;
 
   v_sql := replace(
     v_sql,
@@ -189,6 +238,22 @@ $new$
       ) AS hard_conflict
 $new$
   );
+
+  IF POSITION(
+$old$
+    (CASE
+      WHEN f.rate_penalty > 0
+      THEN jsonb_build_array(
+        'Rate adjustment: -' || ROUND(f.rate_penalty::numeric, 1) ||
+        ' (' || ROUND(((f.rate_ratio - 1) * 100)::numeric, 0) || '% above standard)'
+      )
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE WHEN f.soft_conflict THEN jsonb_build_array('Same-day job (different time)') ELSE '[]'::jsonb END) AS reasons
+$old$ IN v_sql) = 0
+  THEN
+    RAISE EXCEPTION 'Failed to find rank_staffing_candidates reasons block';
+  END IF;
 
   v_sql := replace(
     v_sql,
@@ -213,12 +278,15 @@ $new$
       ELSE '[]'::jsonb
     END) ||
     (CASE
-      WHEN (f.has_previous_day_job OR f.has_next_day_job) AND v_surrounding_jobs_is_urgent
-      THEN jsonb_build_array('Adjacent jobs allowed by Cobertura urgente')
-      WHEN (f.has_previous_day_job OR f.has_next_day_job) AND f.max_surrounding_job_distance_km IS NOT NULL
-      THEN jsonb_build_array('Adjacent jobs within ' || ROUND(f.max_surrounding_job_distance_km::numeric, 1) || 'km')
       WHEN (f.has_previous_day_job OR f.has_next_day_job) AND NOT v_surrounding_jobs_enabled
       THEN jsonb_build_array('Adjacent job guard disabled')
+      WHEN (f.has_previous_day_job OR f.has_next_day_job) AND v_surrounding_jobs_enabled AND v_surrounding_jobs_is_urgent
+      THEN jsonb_build_array('Adjacent jobs allowed by Cobertura urgente')
+      WHEN (f.has_previous_day_job OR f.has_next_day_job)
+        AND v_surrounding_jobs_enabled
+        AND f.max_surrounding_job_distance_km IS NOT NULL
+        AND f.max_surrounding_job_distance_km <= v_surrounding_jobs_max_distance_km
+      THEN jsonb_build_array('Adjacent jobs within ' || ROUND(f.max_surrounding_job_distance_km::numeric, 1) || 'km')
       ELSE '[]'::jsonb
     END) ||
     (CASE WHEN f.soft_conflict THEN jsonb_build_array('Same-day job (different time)') ELSE '[]'::jsonb END) AS reasons

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -152,7 +152,7 @@ describe("smarter staffing recommendation migration", () => {
     expect(surroundingJobAwarenessMigration).toContain("has_previous_day_job");
     expect(surroundingJobAwarenessMigration).toContain("has_next_day_job");
     expect(surroundingJobAwarenessMigration).toContain("wr.has_previous_day_job OR wr.has_next_day_job");
-    expect(surroundingJobAwarenessMigration).toContain("j3.tour_id <> v_target_tour_id");
+    expect(surroundingJobAwarenessMigration).toMatch(/v_target_tour_id IS NULL\s+OR j3\.tour_id IS NULL\s+OR j3\.tour_id <> v_target_tour_id/);
     expect(surroundingJobAwarenessMigration).toContain("max_surrounding_job_distance_km");
     expect(surroundingJobAwarenessMigration).toContain("v_surrounding_jobs_enabled");
     expect(surroundingJobAwarenessMigration).toContain("Adjacent jobs allowed by Cobertura urgente");
@@ -201,6 +201,8 @@ describe("smarter staffing recommendation migration", () => {
     expect(sendStaffingEmailFunction).toContain("urgentAdjacentMode");
     expect(sendStaffingEmailFunction).toContain("targetTourId");
     expect(sendStaffingEmailFunction).toContain("distanceKm(");
+    expect(sendStaffingEmailFunction).toContain("value.trim() === ''");
+    expect(sendStaffingEmailFunction).toContain(".eq('job_id', job_id)");
     expect(staffingCandidateList).toContain("campaign_id: campaignId");
     expect(sendStaffingEmailFunction).toContain("status: 409");
   });

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -27,6 +27,11 @@ const profileRateScoringMigration = readFileSync(
   "utf-8",
 );
 
+const surroundingJobAwarenessMigration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260630100000_staffing_surrounding_job_awareness.sql"),
+  "utf-8",
+);
+
 const staffingSweeperScheduleMigration = readFileSync(
   join(process.cwd(), "supabase/migrations/20260520130000_schedule_staffing_sweeper.sql"),
   "utf-8",
@@ -71,6 +76,11 @@ const staffingOrchestratorFunction = readFileSync(
 
 const staffingOrchestratorPolicyUtils = readFileSync(
   join(process.cwd(), "supabase/functions/staffing-orchestrator/policyUtils.ts"),
+  "utf-8",
+);
+
+const staffingCandidateList = readFileSync(
+  join(process.cwd(), "src/components/matrix/StaffingCandidateList.tsx"),
   "utf-8",
 );
 
@@ -131,6 +141,23 @@ describe("smarter staffing recommendation migration", () => {
     expect(profileRateScoringMigration).toContain("Rate adjustment:");
   });
 
+  it("blocks adjacent separate-job candidates unless close or urgent", () => {
+    expect(surroundingJobAwarenessMigration).toContain("rank_staffing_candidates(uuid,text,text,text,jsonb)");
+    expect(surroundingJobAwarenessMigration).not.toContain("RETURNS TABLE");
+    expect(surroundingJobAwarenessMigration).toContain("v_surrounding_jobs_max_distance_km");
+    expect(surroundingJobAwarenessMigration).toContain("max_location_distance_km')::double precision, 25");
+    expect(surroundingJobAwarenessMigration).toContain("v_target_tour_id");
+    expect(surroundingJobAwarenessMigration).toContain("selected_job_profile");
+    expect(surroundingJobAwarenessMigration).toContain("emergency_fill");
+    expect(surroundingJobAwarenessMigration).toContain("has_previous_day_job");
+    expect(surroundingJobAwarenessMigration).toContain("has_next_day_job");
+    expect(surroundingJobAwarenessMigration).toContain("wr.has_previous_day_job OR wr.has_next_day_job");
+    expect(surroundingJobAwarenessMigration).toContain("j3.tour_id <> v_target_tour_id");
+    expect(surroundingJobAwarenessMigration).toContain("max_surrounding_job_distance_km");
+    expect(surroundingJobAwarenessMigration).toContain("v_surrounding_jobs_enabled");
+    expect(surroundingJobAwarenessMigration).toContain("Adjacent jobs allowed by Cobertura urgente");
+  });
+
   it("filters hard collisions and unavailability before candidates are returned", () => {
     expect(smarterMigration).toMatch(/FROM technician_availability ta/);
     expect(smarterMigration).toMatch(/JOIN target_dates td ON td\.target_date = ta\.date/);
@@ -169,6 +196,12 @@ describe("smarter staffing recommendation migration", () => {
     expect(sendStaffingEmailFunction).toContain("same_role_requests");
     expect(sendStaffingEmailFunction).toContain("job_availability_requests");
     expect(sendStaffingEmailFunction).toContain("roleless_declines");
+    expect(sendStaffingEmailFunction).toContain("adjacent_assignments");
+    expect(sendStaffingEmailFunction).toContain("adjacent_job_policy");
+    expect(sendStaffingEmailFunction).toContain("urgentAdjacentMode");
+    expect(sendStaffingEmailFunction).toContain("targetTourId");
+    expect(sendStaffingEmailFunction).toContain("distanceKm(");
+    expect(staffingCandidateList).toContain("campaign_id: campaignId");
     expect(sendStaffingEmailFunction).toContain("status: 409");
   });
 


### PR DESCRIPTION
## Summary
- Add surrounding-job awareness to `rank_staffing_candidates` so Carlos blocks technicians with adjacent-day separate jobs unless the venues are within 25 km or the campaign/role is Cobertura urgente.
- Treat jobs in the same non-null tour as one coherent run so tour back-to-back staffing is not blocked.
- Mirror the same adjacent-job stale recommendation guard in `send-staffing-email`, and pass `campaign_id` from manual candidate-list sends so urgent-mode policy context is available.

## Risk Assessment
- Medium: this changes staffing eligibility and stale-send blocking for adjacent-day work.
- Main risk is over-blocking when job or adjacent-job coordinates are missing; this is intentional for normal mode and bypassed only for same-tour jobs or Cobertura urgente.
- The RPC signature and return shape are unchanged.

## Impact Checklist
- Staffing candidate ranking: affected for separate jobs on previous/next dates.
- Manual and automated availability sends: affected when `require_no_conflicts` is enabled.
- Tours: same non-null tour jobs remain eligible.
- Dependencies: no package changes.

## Rollback Plan
- Revert this PR to restore prior ranking and send-guard behavior.
- If the database migration has already been applied, deploy a follow-up migration that restores the previous `rank_staffing_candidates` function definition from the pre-change migration chain.
- No data backfill is required.

## Migration Impact
- Includes Supabase migration `20260630100000_staffing_surrounding_job_awareness.sql`.
- The migration patches `public.rank_staffing_candidates(uuid,text,text,text,jsonb)` in place without changing its signature or grants.
- Production `supabase db push --linked --dry-run`, apply, and follow-up dry run are required before merge.

## Validation
- `npm run test:run` - 211 files / 1150 tests passed
- `npm run test:critical` - 22 files / 103 tests passed
- `npm run typecheck`
- `npm run build`
- `npm run governance`
- `npm run budget:bundle`
- `npm run ci:db:migrations`
- `npm run lint:functions` - 0 errors, existing warnings only
- `npm run lint` - 0 errors, existing warnings only after review fixes
- Focused review-fix tests: `npm run test:run -- supabase/functions/staffing-orchestrator/__tests__/policyUtils.test.ts src/features/staffing/__tests__/crewingProfiles.test.ts tests/assignments/staffing-recommendations.test.ts` - 29 tests passed
- `npx eslint src/components/matrix/StaffingCandidateList.tsx` - 0 errors, existing warnings only

## Deployment Notes
- Cloudflare Pages branch preview is green.
- GitHub CI and CodeRabbit status checks are green on head `0acd5b8`.
- Local `supabase db reset/lint/test` could not run because Docker is not reachable in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staffing recommendations now consider nearby-day assignments, helping reduce conflicts from adjacent jobs when sending availability requests.
  * Campaign policies can now include a surrounding-jobs distance setting to support more flexible staffing decisions.

* **Bug Fixes**
  * Improved staffing candidate blocking behavior so close-by assignments are handled more consistently.
  * Availability emails now include campaign context, making campaign-based staffing flows more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
