### PR TITLE
[codex] Block declined staffing candidates on same dates

### DIFF
--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -120,6 +120,64 @@ function toFiniteNumber(value: unknown): number | null {
   return Number.isFinite(numeric) ? numeric : null;
 }
 
+type StaffingJoinedJob = {
+  id?: string | null;
+  title?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+};
+
+type StaffingRequestDateScope = {
+  id?: string | null;
+  job_id?: string | null;
+  phase?: string | null;
+  status?: string | null;
+  role_code?: string | null;
+  target_date?: string | null;
+  single_day?: boolean | null;
+  updated_at?: string | null;
+  jobs?: StaffingJoinedJob | StaffingJoinedJob[] | null;
+  job?: StaffingJoinedJob | null;
+};
+
+type StaffingEventRoleRow = {
+  staffing_request_id?: string | null;
+  meta?: { role?: unknown } | null;
+};
+
+function staffingRolePrefix(roleCode?: string | null): string | null {
+  const normalized = typeof roleCode === 'string' ? roleCode.trim() : '';
+  if (!normalized) return null;
+  return normalized.replace(/-[RET]$/i, '') || null;
+}
+
+function staffingRequestOverlapsTargetDates(request: StaffingRequestDateScope, targetDates: string[]): boolean {
+  const normalizedTargetDates = targetDates
+    .map((date) => dateOnly(date))
+    .filter((date): date is string => Boolean(date));
+  if (normalizedTargetDates.length === 0) return true;
+
+  const requestTargetDate = dateOnly(request?.target_date);
+  if (request?.single_day === true && requestTargetDate) {
+    return normalizedTargetDates.includes(requestTargetDate);
+  }
+
+  const job = joinedSingle(request?.jobs ?? request?.job);
+  const jobStart = dateOnly(job?.start_time);
+  const jobEnd = dateOnly(job?.end_time);
+  if (jobStart && jobEnd) {
+    const first = jobStart <= jobEnd ? jobStart : jobEnd;
+    const last = jobStart <= jobEnd ? jobEnd : jobStart;
+    return normalizedTargetDates.some((date) => date >= first && date <= last);
+  }
+
+  if (requestTargetDate) {
+    return normalizedTargetDates.includes(requestTargetDate);
+  }
+
+  return true;
+}
+
 function distanceKm(
   lat1: number | null,
   lon1: number | null,
@@ -617,6 +675,7 @@ serve(createHttpHandler(async (req) => {
           sameRoleRequestResult,
           jobAvailabilityRequestResult,
           rolelessDeclineResult,
+          crossJobDeclineResult,
           campaignPolicyResult,
         ] = await Promise.all([
           supabase
@@ -656,6 +715,13 @@ serve(createHttpHandler(async (req) => {
             .in('phase', ['availability', 'offer'])
             .eq('status', 'declined')
             .or('role_code.is.null,role_code.eq.'),
+          supabase
+            .from('staffing_requests')
+            .select('id, job_id, phase, status, role_code, target_date, single_day, updated_at, jobs(id, title, start_time, end_time)')
+            .eq('profile_id', profile_id)
+            .neq('job_id', job_id)
+            .eq('status', 'declined')
+            .in('phase', ['availability', 'offer']),
           typeof campaign_id === 'string' && campaign_id
             ? supabase
               .from('staffing_campaigns')
@@ -672,6 +738,7 @@ serve(createHttpHandler(async (req) => {
           sameRoleRequestResult.error,
           jobAvailabilityRequestResult.error,
           rolelessDeclineResult.error,
+          crossJobDeclineResult.error,
           campaignPolicyResult.error,
         ].filter(Boolean);
 
@@ -716,6 +783,53 @@ serve(createHttpHandler(async (req) => {
             || !request.target_date
             || targetDates.includes(request.target_date)
           ));
+        const crossJobDeclineRows = ((crossJobDeclineResult.data || []) as StaffingRequestDateScope[])
+          .map((request) => ({
+            ...request,
+            job: joinedSingle(request.jobs),
+          }))
+          .filter((request) => staffingRequestOverlapsTargetDates(request, targetDates));
+        const crossJobDeclineIds = crossJobDeclineRows
+          .map((request) => String(request.id || ''))
+          .filter(Boolean);
+        const crossJobDeclineEventRoles = new Map<string, string>();
+        if (crossJobDeclineIds.length > 0) {
+          const { data: declineEvents, error: declineEventsError } = await supabase
+            .from('staffing_events')
+            .select('staffing_request_id, event, meta, created_at')
+            .in('staffing_request_id', crossJobDeclineIds)
+            .in('event', ['email_sent', 'whatsapp_sent'])
+            .order('created_at', { ascending: false });
+
+          if (declineEventsError) {
+            console.error('❌ RECOMMENDATION GUARD FAILED: cross-job decline role lookup', declineEventsError);
+            return new Response(JSON.stringify({
+              error: 'Unable to verify technician availability',
+              details: { errors: [declineEventsError] },
+            }), {
+              status: 500,
+              headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+            });
+          }
+
+          for (const event of (declineEvents || []) as StaffingEventRoleRow[]) {
+            const requestId = String(event.staffing_request_id || '');
+            if (!requestId || crossJobDeclineEventRoles.has(requestId)) continue;
+            const eventRole = typeof event.meta?.role === 'string'
+              ? event.meta.role.trim()
+              : '';
+            if (eventRole) crossJobDeclineEventRoles.set(requestId, eventRole);
+          }
+        }
+        const targetRolePrefix = staffingRolePrefix(roleCode);
+        const crossJobDeclines = crossJobDeclineRows.filter((request) => {
+          if (request.phase === 'availability') return true;
+          const requestRole = typeof request.role_code === 'string' && request.role_code.trim()
+            ? request.role_code
+            : crossJobDeclineEventRoles.get(String(request.id || '')) || null;
+          const requestRolePrefix = staffingRolePrefix(requestRole);
+          return !targetRolePrefix || !requestRolePrefix || requestRolePrefix === targetRolePrefix;
+        });
         const campaignPolicy = (campaignPolicyResult.data?.policy || {}) as any;
         const rolePolicy = roleCode && campaignPolicy?.role_profiles
           ? campaignPolicy.role_profiles[roleCode]
@@ -775,6 +889,7 @@ serve(createHttpHandler(async (req) => {
           || sameRoleRequests.length > 0
           || jobAvailabilityRequests.length > 0
           || rolelessDeclines.length > 0
+          || crossJobDeclines.length > 0
         ) {
           const blockDetails = {
             conflict_type: 'stale_recommendation',
@@ -798,6 +913,19 @@ serve(createHttpHandler(async (req) => {
             same_role_requests: sameRoleRequests,
             job_availability_requests: jobAvailabilityRequests,
             roleless_declines: rolelessDeclines,
+            cross_job_declines: crossJobDeclines.map((request) => ({
+              id: request.id,
+              job_id: request.job_id,
+              phase: request.phase,
+              status: request.status,
+              role_code: request.role_code || crossJobDeclineEventRoles.get(String(request.id || '')) || null,
+              target_date: request.target_date,
+              single_day: request.single_day,
+              updated_at: request.updated_at,
+              title: request.job?.title,
+              start_time: request.job?.start_time,
+              end_time: request.job?.end_time,
+            })),
             target_dates: targetDates,
             target_job: {
               id: job.id,

--- a/supabase/functions/send-staffing-email/index.ts
+++ b/supabase/functions/send-staffing-email/index.ts
@@ -142,7 +142,7 @@ type StaffingRequestDateScope = {
 
 type StaffingEventRoleRow = {
   staffing_request_id?: string | null;
-  meta?: { role?: unknown } | null;
+  meta?: { phase?: unknown; role?: unknown } | null;
 };
 
 function staffingRolePrefix(roleCode?: string | null): string | null {
@@ -793,6 +793,11 @@ serve(createHttpHandler(async (req) => {
           .map((request) => String(request.id || ''))
           .filter(Boolean);
         const crossJobDeclineEventRoles = new Map<string, string>();
+        const crossJobDeclinePhaseById = new Map(
+          crossJobDeclineRows
+            .map((request): [string, string | null] => [String(request.id || ''), request.phase || null])
+            .filter(([requestId]) => Boolean(requestId))
+        );
         if (crossJobDeclineIds.length > 0) {
           const { data: declineEvents, error: declineEventsError } = await supabase
             .from('staffing_events')
@@ -815,6 +820,11 @@ serve(createHttpHandler(async (req) => {
           for (const event of (declineEvents || []) as StaffingEventRoleRow[]) {
             const requestId = String(event.staffing_request_id || '');
             if (!requestId || crossJobDeclineEventRoles.has(requestId)) continue;
+            const expectedPhase = crossJobDeclinePhaseById.get(requestId);
+            const eventPhase = typeof event.meta?.phase === 'string'
+              ? event.meta.phase.trim()
+              : '';
+            if (!expectedPhase || eventPhase !== expectedPhase) continue;
             const eventRole = typeof event.meta?.role === 'string'
               ? event.meta.role.trim()
               : '';

--- a/supabase/migrations/20260630120000_block_same_date_declined_staffing_requests.sql
+++ b/supabase/migrations/20260630120000_block_same_date_declined_staffing_requests.sql
@@ -1,0 +1,133 @@
+-- Treat declined staffing requests on overlapping dates as a hard exclusion.
+--
+-- Availability responses are job-scoped, so a declined availability request for
+-- another job on the same dates means Carlos should not ask the technician again.
+-- Declined offers are role-sensitive: block when the prior offer role is missing
+-- or matches the current role prefix.
+
+CREATE INDEX IF NOT EXISTS idx_staffing_requests_declined_profile_job_date
+  ON public.staffing_requests (profile_id, job_id, phase, target_date)
+  WHERE status = 'declined';
+
+DO $$
+DECLARE
+  v_sql text;
+BEGIN
+  SELECT pg_get_functiondef('public.rank_staffing_candidates(uuid,text,text,text,jsonb)'::regprocedure)
+  INTO v_sql;
+
+  IF POSITION(
+$old$
+      AND (
+        v_normalized_role_code IS NULL
+        OR NOT EXISTS (
+          SELECT 1
+          FROM staffing_requests sr
+          WHERE sr.job_id = p_job_id
+            AND sr.profile_id = p.id
+            AND NULLIF(BTRIM(sr.role_code), '') = v_normalized_role_code
+            AND sr.phase = 'offer'
+            AND sr.status IN ('pending', 'confirmed', 'declined')
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM technician_availability ta
+$old$ IN v_sql) = 0
+  THEN
+    RAISE EXCEPTION 'Failed to find rank_staffing_candidates staffing request exclusion block';
+  END IF;
+
+  v_sql := replace(
+    v_sql,
+$old$
+      AND (
+        v_normalized_role_code IS NULL
+        OR NOT EXISTS (
+          SELECT 1
+          FROM staffing_requests sr
+          WHERE sr.job_id = p_job_id
+            AND sr.profile_id = p.id
+            AND NULLIF(BTRIM(sr.role_code), '') = v_normalized_role_code
+            AND sr.phase = 'offer'
+            AND sr.status IN ('pending', 'confirmed', 'declined')
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM technician_availability ta
+$old$,
+$new$
+      AND (
+        v_normalized_role_code IS NULL
+        OR NOT EXISTS (
+          SELECT 1
+          FROM staffing_requests sr
+          WHERE sr.job_id = p_job_id
+            AND sr.profile_id = p.id
+            AND NULLIF(BTRIM(sr.role_code), '') = v_normalized_role_code
+            AND sr.phase = 'offer'
+            AND sr.status IN ('pending', 'confirmed', 'declined')
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM staffing_requests sr
+        JOIN jobs declined_job ON declined_job.id = sr.job_id
+        LEFT JOIN LATERAL (
+          SELECT NULLIF(BTRIM(se.meta->>'role'), '') AS event_role_code
+          FROM staffing_events se
+          WHERE se.staffing_request_id = sr.id
+            AND se.event IN ('email_sent', 'whatsapp_sent')
+            AND se.meta->>'phase' = sr.phase
+            AND NULLIF(BTRIM(se.meta->>'role'), '') IS NOT NULL
+          ORDER BY se.created_at DESC
+          LIMIT 1
+        ) latest_role ON true
+        WHERE sr.profile_id = p.id
+          AND sr.job_id IS DISTINCT FROM p_job_id
+          AND sr.status = 'declined'
+          AND sr.phase IN ('availability', 'offer')
+          AND EXISTS (
+            SELECT 1
+            FROM target_dates td
+            WHERE (
+              COALESCE(sr.single_day, false) = true
+              AND sr.target_date IS NOT NULL
+              AND td.target_date = sr.target_date
+            ) OR (
+              (COALESCE(sr.single_day, false) = false OR sr.target_date IS NULL)
+              AND td.target_date BETWEEN declined_job.start_time::date AND declined_job.end_time::date
+            )
+          )
+          AND (
+            sr.phase = 'availability'
+            OR v_role_prefix IS NULL
+            OR public.staffing_role_prefix(
+              COALESCE(NULLIF(BTRIM(sr.role_code), ''), latest_role.event_role_code)
+            ) IS NULL
+            OR public.staffing_role_prefix(
+              COALESCE(NULLIF(BTRIM(sr.role_code), ''), latest_role.event_role_code)
+            ) = v_role_prefix
+          )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM technician_availability ta
+$new$
+  );
+
+  IF v_sql NOT LIKE '%declined_job ON declined_job.id = sr.job_id%'
+    OR v_sql NOT LIKE '%sr.job_id IS DISTINCT FROM p_job_id%'
+    OR v_sql NOT LIKE '%sr.phase = ''availability''%'
+    OR v_sql NOT LIKE '%td.target_date BETWEEN declined_job.start_time::date AND declined_job.end_time::date%'
+  THEN
+    RAISE EXCEPTION 'Failed to patch rank_staffing_candidates with same-date declined request blocking';
+  END IF;
+
+  EXECUTE v_sql;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO service_role;

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -32,6 +32,11 @@ const surroundingJobAwarenessMigration = readFileSync(
   "utf-8",
 );
 
+const sameDateDeclineBlockingMigration = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260630120000_block_same_date_declined_staffing_requests.sql"),
+  "utf-8",
+);
+
 const staffingSweeperScheduleMigration = readFileSync(
   join(process.cwd(), "supabase/migrations/20260520130000_schedule_staffing_sweeper.sql"),
   "utf-8",
@@ -129,6 +134,17 @@ describe("smarter staffing recommendation migration", () => {
     expect(declinedPenaltyMigration).toContain("Declined role requests:");
   });
 
+  it("blocks same-date declined staffing requests from other jobs", () => {
+    expect(sameDateDeclineBlockingMigration).toContain("rank_staffing_candidates(uuid,text,text,text,jsonb)");
+    expect(sameDateDeclineBlockingMigration).not.toContain("RETURNS TABLE");
+    expect(sameDateDeclineBlockingMigration).toContain("idx_staffing_requests_declined_profile_job_date");
+    expect(sameDateDeclineBlockingMigration).toContain("sr.job_id IS DISTINCT FROM p_job_id");
+    expect(sameDateDeclineBlockingMigration).toContain("sr.status = 'declined'");
+    expect(sameDateDeclineBlockingMigration).toContain("sr.phase = 'availability'");
+    expect(sameDateDeclineBlockingMigration).toContain("td.target_date BETWEEN declined_job.start_time::date AND declined_job.end_time::date");
+    expect(sameDateDeclineBlockingMigration).toContain("public.staffing_role_prefix");
+  });
+
   it("applies profile cost/rate scoring without changing the candidate RPC shape", () => {
     expect(profileRateScoringMigration).toContain("rank_staffing_candidates(uuid,text,text,text,jsonb)");
     expect(profileRateScoringMigration).not.toContain("RETURNS TABLE");
@@ -196,6 +212,9 @@ describe("smarter staffing recommendation migration", () => {
     expect(sendStaffingEmailFunction).toContain("same_role_requests");
     expect(sendStaffingEmailFunction).toContain("job_availability_requests");
     expect(sendStaffingEmailFunction).toContain("roleless_declines");
+    expect(sendStaffingEmailFunction).toContain("cross_job_declines");
+    expect(sendStaffingEmailFunction).toContain("staffingRequestOverlapsTargetDates");
+    expect(sendStaffingEmailFunction).toContain("staffingRolePrefix");
     expect(sendStaffingEmailFunction).toContain("adjacent_assignments");
     expect(sendStaffingEmailFunction).toContain("adjacent_job_policy");
     expect(sendStaffingEmailFunction).toContain("urgentAdjacentMode");

--- a/tests/assignments/staffing-recommendations.test.ts
+++ b/tests/assignments/staffing-recommendations.test.ts
@@ -140,9 +140,11 @@ describe("smarter staffing recommendation migration", () => {
     expect(sameDateDeclineBlockingMigration).toContain("idx_staffing_requests_declined_profile_job_date");
     expect(sameDateDeclineBlockingMigration).toContain("sr.job_id IS DISTINCT FROM p_job_id");
     expect(sameDateDeclineBlockingMigration).toContain("sr.status = 'declined'");
+    expect(sameDateDeclineBlockingMigration).toContain("sr.phase IN ('availability', 'offer')");
     expect(sameDateDeclineBlockingMigration).toContain("sr.phase = 'availability'");
     expect(sameDateDeclineBlockingMigration).toContain("td.target_date BETWEEN declined_job.start_time::date AND declined_job.end_time::date");
     expect(sameDateDeclineBlockingMigration).toContain("public.staffing_role_prefix");
+    expect(sameDateDeclineBlockingMigration).toContain("latest_role.event_role_code");
   });
 
   it("applies profile cost/rate scoring without changing the candidate RPC shape", () => {
@@ -215,6 +217,9 @@ describe("smarter staffing recommendation migration", () => {
     expect(sendStaffingEmailFunction).toContain("cross_job_declines");
     expect(sendStaffingEmailFunction).toContain("staffingRequestOverlapsTargetDates");
     expect(sendStaffingEmailFunction).toContain("staffingRolePrefix");
+    expect(sendStaffingEmailFunction).toContain("|| crossJobDeclines.length > 0");
+    expect(sendStaffingEmailFunction).toContain("cross_job_declines: crossJobDeclines.map");
+    expect(sendStaffingEmailFunction).toContain("filter((request) => staffingRequestOverlapsTargetDates(request, targetDates))");
     expect(sendStaffingEmailFunction).toContain("adjacent_assignments");
     expect(sendStaffingEmailFunction).toContain("adjacent_job_policy");
     expect(sendStaffingEmailFunction).toContain("urgentAdjacentMode");


### PR DESCRIPTION
## Summary

- Treat declined staffing requests from other jobs on overlapping dates as a hard exclusion in `rank_staffing_candidates`.
- Make declined availability date-level: if a tech said no to availability for another job on that date, Carlos should not recommend them again for that date.
- Keep declined offers role-prefix aware, using `role_code` or the original send event role metadata when needed.
- Add the same cross-job decline guard to `send-staffing-email` so stale recommendation modals cannot still send to a blocked tech.

## Root Cause

The ranking RPC only blocked declined staffing requests for the same target job. Cross-job declines on the same dates were only reflected as a scoring penalty, so a tech who had already declined a human-sent request for those dates could still appear as a candidate.

## Risk Assessment

- Medium database risk: the migration patches `rank_staffing_candidates`, but the change is a scoped hard-exclusion branch plus a partial index, with regression tests asserting the migration structure.
- Low Edge Function risk: the send guard only runs for selected recommendation sends and reuses the target job dates already loaded for stale recommendation validation.
- Main behavioral risk is over-blocking offer declines when prior role metadata is missing; this is intentional because ambiguous same-date human declines should be treated conservatively.

## Impact Checklist

- Candidate recommendations: affected techs with overlapping cross-job declines are removed from Carlos recommendations.
- Staffing sends: stale recommendation sends now return a 409 with `cross_job_declines` details instead of sending to an ineligible tech.
- Database: adds one partial index and replaces the existing ranking RPC body; no table shape or RLS policy changes.
- Operations: production requires applying the Supabase migration before relying on the merged app behavior.

## Rollback Plan

- Revert this PR if the behavior needs to be removed from the app and Edge Function.
- For database rollback, restore the prior `rank_staffing_candidates` definition through a follow-up migration and drop `idx_staffing_requests_declined_profile_job_date` if the index is no longer useful.

## Migration Impact

- New migration: `20260630120000_block_same_date_declined_staffing_requests.sql`.
- Dry run shows only this migration pending against the linked production project.
- Before merge, run `supabase db push --linked --dry-run`, apply the linked migration, and confirm a second dry run reports the remote database is up to date.

## Validation

- `npm run test:run -- tests/assignments/staffing-recommendations.test.ts`
- `npm run typecheck`
- `npm run lint:functions` (0 errors; existing warnings remain)
- `npm run ci:db:migrations`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run test:critical`
- `npm run test:run`
- `npm run build`
- `npm run budget:bundle`
- `supabase db push --linked --dry-run` (shows only `20260630120000_block_same_date_declined_staffing_requests.sql` pending)

Local `supabase db reset --local --no-seed` could not run because Docker is not running on this machine.