### PR TITLE
[codex] Fix stale tour default PDFs

### DIFF
--- a/src/utils/__tests__/jobDocumentsUpload.test.ts
+++ b/src/utils/__tests__/jobDocumentsUpload.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authGetUser: vi.fn(),
+  dbDeleteEq: vi.fn(),
+  dbDeleteLike: vi.fn(),
+  dbInsert: vi.fn(),
+  functionsInvoke: vi.fn(),
+  storageFrom: vi.fn(),
+  storageList: vi.fn(),
+  storageRemove: vi.fn(),
+  storageUpload: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: mocks.authGetUser,
+    },
+    from: vi.fn(() => ({
+      delete: vi.fn(() => ({
+        like: mocks.dbDeleteLike,
+      })),
+      insert: mocks.dbInsert,
+    })),
+    functions: {
+      invoke: mocks.functionsInvoke,
+    },
+    storage: {
+      from: mocks.storageFrom,
+    },
+  },
+}));
+
+import { uploadJobPdfWithCleanup } from "@/utils/jobDocumentsUpload";
+
+describe("job document PDF upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mocks.dbDeleteEq.mockResolvedValue({ error: null });
+    mocks.dbDeleteLike.mockReturnValue({ eq: mocks.dbDeleteEq });
+    mocks.dbInsert.mockResolvedValue({ error: null });
+    mocks.functionsInvoke.mockResolvedValue({ data: null, error: null });
+    mocks.storageFrom.mockReturnValue({
+      list: mocks.storageList,
+      remove: mocks.storageRemove,
+      upload: mocks.storageUpload,
+    });
+    mocks.storageList.mockResolvedValue({ data: [{ name: "old.pdf" }], error: null });
+    mocks.storageRemove.mockResolvedValue({ error: null });
+    mocks.storageUpload.mockResolvedValue({ error: null });
+  });
+
+  it("stores regenerated PDFs under a fresh object path while cleaning the stable job/category folder", async () => {
+    const pdfBlob = new Blob(["pdf"]);
+
+    await uploadJobPdfWithCleanup(
+      "job-1",
+      pdfBlob,
+      "Pesos Report - Show.pdf",
+      "calculators/pesos"
+    );
+
+    expect(mocks.storageList).toHaveBeenCalledWith("calculators/pesos/job-1");
+    expect(mocks.storageRemove).toHaveBeenCalledWith([
+      "calculators/pesos/job-1/old.pdf",
+    ]);
+    expect(mocks.dbDeleteLike).toHaveBeenCalledWith(
+      "file_path",
+      "calculators/pesos/job-1/%"
+    );
+    expect(mocks.dbDeleteEq).toHaveBeenCalledWith("job_id", "job-1");
+
+    const [objectPath, uploadedBlob, uploadOptions] = mocks.storageUpload.mock.calls[0];
+    expect(objectPath).toMatch(
+      /^calculators\/pesos\/job-1\/[a-zA-Z0-9-]+-Pesos_Report_-_Show\.pdf$/
+    );
+    expect(uploadedBlob).toBe(pdfBlob);
+    expect(uploadOptions).toMatchObject({
+      cacheControl: "0",
+      contentType: "application/pdf",
+      upsert: false,
+    });
+
+    expect(mocks.dbInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_name: "Pesos_Report_-_Show.pdf",
+        file_path: objectPath,
+        job_id: "job-1",
+      })
+    );
+  });
+});

--- a/src/utils/__tests__/tourDefaultDocumentSync.test.ts
+++ b/src/utils/__tests__/tourDefaultDocumentSync.test.ts
@@ -94,9 +94,11 @@ describe("tour default document sync planning", () => {
     const soundWeightUpload = findUploadPlanItem(plan);
     expect(soundWeightUpload).toMatchObject({
       action: "upload",
-      objectPath: "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight.pdf",
       fileName: "Enterprise Tour - 2026-07-10 - Madrid - Sound S - Small peso.pdf",
     });
+    expect(soundWeightUpload?.objectPath).toMatch(
+      /^tours\/tour-1\/auto-generated\/default-pdfs\/date-1\/sound-weight-[a-z0-9]+\.pdf$/
+    );
 
     expect(
       plan.some(
@@ -110,7 +112,7 @@ describe("tour default document sync planning", () => {
     expect(plan).toHaveLength(6);
   });
 
-  it("keeps the same object path when a date switches package size", () => {
+  it("uses a new object path when a date switches package size", () => {
     const sPlan = buildTourDefaultDocumentPlan(buildData());
     const mPlan = buildTourDefaultDocumentPlan(
       buildData({
@@ -123,9 +125,37 @@ describe("tour default document sync planning", () => {
     const sUpload = findUploadPlanItem(sPlan);
     const mUpload = findUploadPlanItem(mPlan);
 
-    expect(sUpload?.objectPath).toBe(mUpload?.objectPath);
+    expect(sUpload?.objectPath).not.toBe(mUpload?.objectPath);
+    expect(sUpload?.objectPath).toContain(
+      "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight-"
+    );
+    expect(mUpload?.objectPath).toContain(
+      "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight-"
+    );
     expect(sUpload?.fileName).toContain("Sound S - Small");
     expect(mUpload?.fileName).toContain("Sound M - Medium");
+  });
+
+  it("uses a new object path when resolved table content changes", () => {
+    const firstPlan = buildTourDefaultDocumentPlan(buildData());
+    const changedPlan = buildTourDefaultDocumentPlan(
+      buildData({
+        defaultTables: [
+          buildTable({
+            table_data: {
+              rows: [{ quantity: "2", componentName: "K1", weight: "106", totalWeight: 212 }],
+            },
+            total_value: 212,
+          }),
+        ],
+      })
+    );
+
+    const firstUpload = findUploadPlanItem(firstPlan);
+    const changedUpload = findUploadPlanItem(changedPlan);
+
+    expect(firstUpload?.objectPath).not.toBe(changedUpload?.objectPath);
+    expect(changedUpload?.fileName).toContain("Sound S - Small");
   });
 
   it("uses the current package size when a date still has a stale explicit default set id", () => {
@@ -153,9 +183,11 @@ describe("tour default document sync planning", () => {
 
     expect(soundWeightUpload).toMatchObject({
       action: "upload",
-      objectPath: "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight.pdf",
       fileName: "Enterprise Tour - 2026-07-10 - Madrid - Sound XL - Extra Large peso.pdf",
     });
+    expect(soundWeightUpload?.objectPath).toMatch(
+      /^tours\/tour-1\/auto-generated\/default-pdfs\/date-1\/sound-weight-[a-z0-9]+\.pdf$/
+    );
   });
 
   it("cleans the stable slot instead of leaving stale files when package resolution is ambiguous", () => {

--- a/src/utils/jobDocumentsUpload.ts
+++ b/src/utils/jobDocumentsUpload.ts
@@ -15,6 +15,9 @@ const sanitizePathSegment = (value: string) =>
     .replace(/\.+/g, ".")
     .replace(/^\.+|\.+$/g, "") || "scope";
 
+const createDocumentVersionSegment = () =>
+  globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
 /**
  * Upload a job-related PDF to the job-documents bucket under a category folder,
  * first cleaning up any previous versions for that job and category.
@@ -35,7 +38,7 @@ export const uploadJobPdfWithCleanup = async (
     ? `/${sanitizePathSegment(options.cleanupScope)}`
     : "";
   const baseFolder = `${category}/${jobId}${scopeFolder}`; // e.g. calculators/pesos/<jobId>/<stage>
-  const objectPath = `${baseFolder}/${sanitizedFileName}`;
+  const objectPath = `${baseFolder}/${createDocumentVersionSegment()}-${sanitizedFileName}`;
 
   try {
     // 1) Remove any existing files for this job/category
@@ -72,7 +75,7 @@ export const uploadJobPdfWithCleanup = async (
     const { error: uploadError } = await supabase.storage
       .from("job-documents")
       .upload(objectPath, pdfBlob, {
-        cacheControl: "3600",
+        cacheControl: "0",
         upsert: false,
         contentType: "application/pdf",
       });

--- a/src/utils/tourDefaultDocumentSync.ts
+++ b/src/utils/tourDefaultDocumentSync.ts
@@ -138,7 +138,31 @@ const getPdfTypeLabel = (type: TourDefaultDocumentType) =>
 const cleanDisplayFilePart = (value: string): string =>
   value.replace(/[\\/\r\n]+/g, " ").replace(/\s+/g, " ").trim();
 
-export const getTourDefaultDocumentObjectPath = ({
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "undefined";
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+
+  return `{${Object.entries(value as JsonRecord)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+    .join(",")}}`;
+};
+
+const hashString = (value: string): string => {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const getTourDefaultDocumentSlotPrefix = ({
   tourId,
   tourDateId,
   department,
@@ -149,7 +173,29 @@ export const getTourDefaultDocumentObjectPath = ({
   department: PackageDepartment;
   type: TourDefaultDocumentType;
 }) =>
-  `tours/${tourId}/${AUTO_DEFAULT_DOCUMENT_ROOT}/${tourDateId}/${department}-${type}.pdf`;
+  `tours/${tourId}/${AUTO_DEFAULT_DOCUMENT_ROOT}/${tourDateId}/${department}-${type}`;
+
+export const getTourDefaultDocumentObjectPath = ({
+  tourId,
+  tourDateId,
+  department,
+  type,
+  versionKey,
+}: {
+  tourId: string;
+  tourDateId: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+  versionKey?: string;
+}) => {
+  const slotPrefix = getTourDefaultDocumentSlotPrefix({
+    tourId,
+    tourDateId,
+    department,
+    type,
+  });
+  return versionKey ? `${slotPrefix}-${versionKey}.pdf` : `${slotPrefix}.pdf`;
+};
 
 export const getTourDefaultDocumentFileName = ({
   tourName,
@@ -196,6 +242,104 @@ const sortTourDefaultTables = (tables: TourDefaultTableRow[]) =>
     if (leftOrder !== rightOrder) return leftOrder - rightOrder;
     return toJobTimezone(left.created_at).getTime() - toJobTimezone(right.created_at).getTime();
   });
+
+const sortOverrides = <
+  TOverride extends {
+    id: string;
+    created_at?: string | null;
+    updated_at?: string | null;
+  },
+>(
+  overrides: TOverride[]
+) =>
+  [...overrides].sort((left, right) => {
+    const leftTime = left.created_at ? toJobTimezone(left.created_at).getTime() : 0;
+    const rightTime = right.created_at ? toJobTimezone(right.created_at).getTime() : 0;
+    if (leftTime !== rightTime) return leftTime - rightTime;
+    return left.id.localeCompare(right.id);
+  });
+
+const buildTourDefaultDocumentVersionKey = ({
+  tour,
+  tourDate,
+  department,
+  type,
+  defaultSet,
+  defaultTables,
+  powerOverrides,
+  weightOverrides,
+  packageLabel,
+}: {
+  tour: TourRow;
+  tourDate: TourDateRow;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+  defaultSet: TourDefaultSetRow;
+  defaultTables: TourDefaultTableRow[];
+  powerOverrides: TourDatePowerOverrideRow[];
+  weightOverrides: TourDateWeightOverrideRow[];
+  packageLabel: string;
+}) =>
+  hashString(
+    stableStringify({
+      department,
+      type,
+      packageLabel,
+      tour: {
+        id: tour.id,
+        name: tour.name,
+      },
+      tourDate: {
+        id: tourDate.id,
+        date: tourDate.date,
+        start_date: tourDate.start_date,
+        locationName: getTourDateLocationName(tourDate),
+        sound_package_size: tourDate.sound_package_size,
+        lights_package_size: tourDate.lights_package_size,
+        video_package_size: tourDate.video_package_size,
+        sound_default_set_id: tourDate.sound_default_set_id,
+        lights_default_set_id: tourDate.lights_default_set_id,
+        video_default_set_id: tourDate.video_default_set_id,
+      },
+      defaultSet: {
+        id: defaultSet.id,
+        name: defaultSet.name,
+        package_size: defaultSet.package_size,
+        updated_at: defaultSet.updated_at,
+      },
+      defaultTables: sortTourDefaultTables(defaultTables).map((table) => ({
+        id: table.id,
+        table_name: table.table_name,
+        table_type: table.table_type,
+        total_value: table.total_value,
+        table_data: table.table_data,
+        metadata: table.metadata,
+        updated_at: table.updated_at,
+      })),
+      powerOverrides: sortOverrides(powerOverrides).map((override) => ({
+        id: override.id,
+        table_name: override.table_name,
+        total_watts: override.total_watts,
+        current_per_phase: override.current_per_phase,
+        pdu_type: override.pdu_type,
+        custom_pdu_type: override.custom_pdu_type,
+        position: override.position,
+        custom_position: override.custom_position,
+        includes_hoist: override.includes_hoist,
+        override_data: override.override_data,
+        updated_at: override.updated_at,
+      })),
+      weightOverrides: sortOverrides(weightOverrides).map((override) => ({
+        id: override.id,
+        item_name: override.item_name,
+        weight_kg: override.weight_kg,
+        quantity: override.quantity,
+        category: override.category,
+        override_data: override.override_data,
+        updated_at: override.updated_at,
+      })),
+    })
+  );
 
 const getTableRiggingPoint = (metadata: unknown) => {
   const record = getRecord(metadata);
@@ -288,6 +432,17 @@ const buildUploadPlanItem = ({
 }): Extract<TourDefaultDocumentPlanItem, { action: "upload" }> => {
   const locationName = getTourDateLocationName(tourDate);
   const jobDate = tourDate.date || tourDate.start_date;
+  const versionKey = buildTourDefaultDocumentVersionKey({
+    tour,
+    tourDate,
+    department,
+    type,
+    defaultSet,
+    defaultTables,
+    powerOverrides,
+    weightOverrides,
+    packageLabel,
+  });
 
   return {
     action: "upload",
@@ -305,6 +460,7 @@ const buildUploadPlanItem = ({
       tourDateId: tourDate.id,
       department,
       type,
+      versionKey,
     }),
     fileName: getTourDefaultDocumentFileName({
       tourName: tour.name,
@@ -520,26 +676,55 @@ const loadTourDefaultDocumentSyncData = async ({
   };
 };
 
-const cleanupTourDefaultDocument = async ({
+const cleanupTourDefaultDocumentSlot = async ({
   client,
   tourId,
-  objectPath,
+  tourDateId,
+  department,
+  type,
 }: {
   client: SupabaseClientLike;
   tourId: string;
-  objectPath: string;
+  tourDateId: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
 }) => {
-  const { error: storageError } = await client.storage
-    .from(TOUR_DOCUMENTS_BUCKET)
-    .remove([objectPath]);
+  const slotPrefix = getTourDefaultDocumentSlotPrefix({
+    tourId,
+    tourDateId,
+    department,
+    type,
+  });
 
-  if (storageError) throw storageError;
+  const { data: existingDocuments, error: loadError } = await client
+    .from("tour_documents")
+    .select("file_path")
+    .eq("tour_id", tourId)
+    .like("file_path", `${slotPrefix}%`);
+
+  if (loadError) throw loadError;
+
+  const paths = Array.from(
+    new Set(
+      (existingDocuments || [])
+        .map((document) => document.file_path)
+        .filter((path): path is string => typeof path === "string" && path.length > 0)
+    )
+  );
+
+  if (paths.length > 0) {
+    const { error: storageError } = await client.storage
+      .from(TOUR_DOCUMENTS_BUCKET)
+      .remove(paths);
+
+    if (storageError) throw storageError;
+  }
 
   const { error } = await client
     .from("tour_documents")
     .delete()
     .eq("tour_id", tourId)
-    .eq("file_path", objectPath);
+    .like("file_path", `${slotPrefix}%`);
 
   if (error) throw error;
 };
@@ -555,15 +740,12 @@ export const cleanupTourDefaultDocumentsForDate = async ({
 }) => {
   for (const department of PACKAGE_DEPARTMENTS) {
     for (const type of TOUR_DEFAULT_DOCUMENT_TYPES) {
-      await cleanupTourDefaultDocument({
+      await cleanupTourDefaultDocumentSlot({
         client,
         tourId,
-        objectPath: getTourDefaultDocumentObjectPath({
-          tourId,
-          tourDateId,
-          department,
-          type,
-        }),
+        tourDateId,
+        department,
+        type,
       });
     }
   }
@@ -572,22 +754,34 @@ export const cleanupTourDefaultDocumentsForDate = async ({
 const uploadTourDefaultDocument = async ({
   client,
   tourId,
+  tourDateId,
+  department,
+  type,
   objectPath,
   fileName,
   pdfBlob,
 }: {
   client: SupabaseClientLike;
   tourId: string;
+  tourDateId: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
   objectPath: string;
   fileName: string;
   pdfBlob: Blob;
 }) => {
-  await cleanupTourDefaultDocument({ client, tourId, objectPath });
+  await cleanupTourDefaultDocumentSlot({
+    client,
+    tourId,
+    tourDateId,
+    department,
+    type,
+  });
 
   const { error: uploadError } = await client.storage
     .from(TOUR_DOCUMENTS_BUCKET)
     .upload(objectPath, pdfBlob, {
-      cacheControl: "3600",
+      cacheControl: "0",
       upsert: false,
       contentType: "application/pdf",
     });
@@ -687,7 +881,13 @@ export const syncTourDefaultDocuments = async ({
   for (const item of plan) {
     try {
       if (item.action === "cleanup") {
-        await cleanupTourDefaultDocument({ client, tourId, objectPath: item.objectPath });
+        await cleanupTourDefaultDocumentSlot({
+          client,
+          tourId,
+          tourDateId: item.tourDate.id,
+          department: item.department,
+          type: item.type,
+        });
         result.removed += 1;
         if (item.reason !== "no_tables") result.skipped += 1;
         continue;
@@ -701,6 +901,9 @@ export const syncTourDefaultDocuments = async ({
       await uploadTourDefaultDocument({
         client,
         tourId,
+        tourDateId: item.tourDate.id,
+        department: item.department,
+        type: item.type,
         objectPath: item.objectPath,
         fileName: item.fileName,
         pdfBlob,

--- a/src/utils/tourDefaultDocumentSync.ts
+++ b/src/utils/tourDefaultDocumentSync.ts
@@ -11,9 +11,15 @@ import {
   type PackageDepartment,
 } from "@/utils/tourPackages";
 import { buildNormalizedTourPowerTables } from "@/utils/tourPowerTables";
+import {
+  buildTourDefaultDocumentVersionKey,
+  getTourDefaultDocumentObjectPath,
+  getTourDefaultDocumentSlotPrefix,
+} from "@/utils/tourDefaultDocumentVersioning";
+
+export { getTourDefaultDocumentObjectPath } from "@/utils/tourDefaultDocumentVersioning";
 
 const TOUR_DOCUMENTS_BUCKET = "tour-documents";
-const AUTO_DEFAULT_DOCUMENT_ROOT = "auto-generated/default-pdfs";
 const TOUR_DEFAULT_DOCUMENT_TYPES = ["power", "weight"] as const;
 const UNKNOWN_LOCATION_LABEL = "Ubicación desconocida";
 
@@ -138,65 +144,6 @@ const getPdfTypeLabel = (type: TourDefaultDocumentType) =>
 const cleanDisplayFilePart = (value: string): string =>
   value.replace(/[\\/\r\n]+/g, " ").replace(/\s+/g, " ").trim();
 
-const stableStringify = (value: unknown): string => {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value) ?? "undefined";
-  }
-
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
-  }
-
-  return `{${Object.entries(value as JsonRecord)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
-    .join(",")}}`;
-};
-
-const hashString = (value: string): string => {
-  let hash = 2166136261;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return (hash >>> 0).toString(36);
-};
-
-const getTourDefaultDocumentSlotPrefix = ({
-  tourId,
-  tourDateId,
-  department,
-  type,
-}: {
-  tourId: string;
-  tourDateId: string;
-  department: PackageDepartment;
-  type: TourDefaultDocumentType;
-}) =>
-  `tours/${tourId}/${AUTO_DEFAULT_DOCUMENT_ROOT}/${tourDateId}/${department}-${type}`;
-
-export const getTourDefaultDocumentObjectPath = ({
-  tourId,
-  tourDateId,
-  department,
-  type,
-  versionKey,
-}: {
-  tourId: string;
-  tourDateId: string;
-  department: PackageDepartment;
-  type: TourDefaultDocumentType;
-  versionKey?: string;
-}) => {
-  const slotPrefix = getTourDefaultDocumentSlotPrefix({
-    tourId,
-    tourDateId,
-    department,
-    type,
-  });
-  return versionKey ? `${slotPrefix}-${versionKey}.pdf` : `${slotPrefix}.pdf`;
-};
-
 export const getTourDefaultDocumentFileName = ({
   tourName,
   date,
@@ -242,104 +189,6 @@ const sortTourDefaultTables = (tables: TourDefaultTableRow[]) =>
     if (leftOrder !== rightOrder) return leftOrder - rightOrder;
     return toJobTimezone(left.created_at).getTime() - toJobTimezone(right.created_at).getTime();
   });
-
-const sortOverrides = <
-  TOverride extends {
-    id: string;
-    created_at?: string | null;
-    updated_at?: string | null;
-  },
->(
-  overrides: TOverride[]
-) =>
-  [...overrides].sort((left, right) => {
-    const leftTime = left.created_at ? toJobTimezone(left.created_at).getTime() : 0;
-    const rightTime = right.created_at ? toJobTimezone(right.created_at).getTime() : 0;
-    if (leftTime !== rightTime) return leftTime - rightTime;
-    return left.id.localeCompare(right.id);
-  });
-
-const buildTourDefaultDocumentVersionKey = ({
-  tour,
-  tourDate,
-  department,
-  type,
-  defaultSet,
-  defaultTables,
-  powerOverrides,
-  weightOverrides,
-  packageLabel,
-}: {
-  tour: TourRow;
-  tourDate: TourDateRow;
-  department: PackageDepartment;
-  type: TourDefaultDocumentType;
-  defaultSet: TourDefaultSetRow;
-  defaultTables: TourDefaultTableRow[];
-  powerOverrides: TourDatePowerOverrideRow[];
-  weightOverrides: TourDateWeightOverrideRow[];
-  packageLabel: string;
-}) =>
-  hashString(
-    stableStringify({
-      department,
-      type,
-      packageLabel,
-      tour: {
-        id: tour.id,
-        name: tour.name,
-      },
-      tourDate: {
-        id: tourDate.id,
-        date: tourDate.date,
-        start_date: tourDate.start_date,
-        locationName: getTourDateLocationName(tourDate),
-        sound_package_size: tourDate.sound_package_size,
-        lights_package_size: tourDate.lights_package_size,
-        video_package_size: tourDate.video_package_size,
-        sound_default_set_id: tourDate.sound_default_set_id,
-        lights_default_set_id: tourDate.lights_default_set_id,
-        video_default_set_id: tourDate.video_default_set_id,
-      },
-      defaultSet: {
-        id: defaultSet.id,
-        name: defaultSet.name,
-        package_size: defaultSet.package_size,
-        updated_at: defaultSet.updated_at,
-      },
-      defaultTables: sortTourDefaultTables(defaultTables).map((table) => ({
-        id: table.id,
-        table_name: table.table_name,
-        table_type: table.table_type,
-        total_value: table.total_value,
-        table_data: table.table_data,
-        metadata: table.metadata,
-        updated_at: table.updated_at,
-      })),
-      powerOverrides: sortOverrides(powerOverrides).map((override) => ({
-        id: override.id,
-        table_name: override.table_name,
-        total_watts: override.total_watts,
-        current_per_phase: override.current_per_phase,
-        pdu_type: override.pdu_type,
-        custom_pdu_type: override.custom_pdu_type,
-        position: override.position,
-        custom_position: override.custom_position,
-        includes_hoist: override.includes_hoist,
-        override_data: override.override_data,
-        updated_at: override.updated_at,
-      })),
-      weightOverrides: sortOverrides(weightOverrides).map((override) => ({
-        id: override.id,
-        item_name: override.item_name,
-        weight_kg: override.weight_kg,
-        quantity: override.quantity,
-        category: override.category,
-        override_data: override.override_data,
-        updated_at: override.updated_at,
-      })),
-    })
-  );
 
 const getTableRiggingPoint = (metadata: unknown) => {
   const record = getRecord(metadata);
@@ -435,6 +284,7 @@ const buildUploadPlanItem = ({
   const versionKey = buildTourDefaultDocumentVersionKey({
     tour,
     tourDate,
+    locationName,
     department,
     type,
     defaultSet,

--- a/src/utils/tourDefaultDocumentVersioning.ts
+++ b/src/utils/tourDefaultDocumentVersioning.ts
@@ -1,0 +1,246 @@
+import { toJobTimezone } from "@/utils/timezoneUtils";
+import type { PackageDepartment } from "@/utils/tourPackages";
+
+const AUTO_DEFAULT_DOCUMENT_ROOT = "auto-generated/default-pdfs";
+
+export type TourDefaultDocumentType = "power" | "weight";
+
+type JsonRecord = Record<string, unknown>;
+
+interface VersionTourRow {
+  id: string;
+  name: string;
+}
+
+interface VersionTourDateRow {
+  id: string;
+  date?: string | null;
+  start_date?: string | null;
+  sound_package_size?: string | null;
+  lights_package_size?: string | null;
+  video_package_size?: string | null;
+  sound_default_set_id?: string | null;
+  lights_default_set_id?: string | null;
+  video_default_set_id?: string | null;
+}
+
+interface VersionDefaultSetRow {
+  id: string;
+  name?: string | null;
+  package_size?: string | null;
+  updated_at?: string | null;
+}
+
+interface VersionDefaultTableRow {
+  id: string;
+  table_name?: string | null;
+  table_type?: string | null;
+  total_value?: number | null;
+  table_data?: unknown;
+  metadata?: unknown;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+interface VersionPowerOverrideRow {
+  id: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  table_name?: string | null;
+  total_watts?: number | null;
+  current_per_phase?: number | null;
+  pdu_type?: string | null;
+  custom_pdu_type?: string | null;
+  position?: string | null;
+  custom_position?: string | null;
+  includes_hoist?: boolean | null;
+  override_data?: unknown;
+}
+
+interface VersionWeightOverrideRow {
+  id: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  item_name?: string | null;
+  weight_kg?: number | null;
+  quantity?: number | null;
+  category?: string | null;
+  override_data?: unknown;
+}
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const getRecord = (value: unknown): JsonRecord =>
+  isRecord(value) ? value : {};
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "undefined";
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+
+  return `{${Object.entries(value as JsonRecord)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+    .join(",")}}`;
+};
+
+const hashString = (value: string): string => {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const sortDefaultTables = <TTable extends VersionDefaultTableRow>(tables: TTable[]) =>
+  [...tables].sort((left, right) => {
+    const leftOrder = getNumber(getRecord(left.metadata).order_index) ?? 999;
+    const rightOrder = getNumber(getRecord(right.metadata).order_index) ?? 999;
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+    const leftTime = left.created_at ? toJobTimezone(left.created_at).getTime() : 0;
+    const rightTime = right.created_at ? toJobTimezone(right.created_at).getTime() : 0;
+    return leftTime - rightTime;
+  });
+
+const sortOverrides = <
+  TOverride extends {
+    id: string;
+    created_at?: string | null;
+  },
+>(
+  overrides: TOverride[]
+) =>
+  [...overrides].sort((left, right) => {
+    const leftTime = left.created_at ? toJobTimezone(left.created_at).getTime() : 0;
+    const rightTime = right.created_at ? toJobTimezone(right.created_at).getTime() : 0;
+    if (leftTime !== rightTime) return leftTime - rightTime;
+    return left.id.localeCompare(right.id);
+  });
+
+export const getTourDefaultDocumentSlotPrefix = ({
+  tourId,
+  tourDateId,
+  department,
+  type,
+}: {
+  tourId: string;
+  tourDateId: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+}) =>
+  `tours/${tourId}/${AUTO_DEFAULT_DOCUMENT_ROOT}/${tourDateId}/${department}-${type}`;
+
+export const getTourDefaultDocumentObjectPath = ({
+  tourId,
+  tourDateId,
+  department,
+  type,
+  versionKey,
+}: {
+  tourId: string;
+  tourDateId: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+  versionKey?: string;
+}) => {
+  const slotPrefix = getTourDefaultDocumentSlotPrefix({
+    tourId,
+    tourDateId,
+    department,
+    type,
+  });
+  return versionKey ? `${slotPrefix}-${versionKey}.pdf` : `${slotPrefix}.pdf`;
+};
+
+export const buildTourDefaultDocumentVersionKey = ({
+  tour,
+  tourDate,
+  locationName,
+  department,
+  type,
+  defaultSet,
+  defaultTables,
+  powerOverrides,
+  weightOverrides,
+  packageLabel,
+}: {
+  tour: VersionTourRow;
+  tourDate: VersionTourDateRow;
+  locationName: string;
+  department: PackageDepartment;
+  type: TourDefaultDocumentType;
+  defaultSet: VersionDefaultSetRow;
+  defaultTables: VersionDefaultTableRow[];
+  powerOverrides: VersionPowerOverrideRow[];
+  weightOverrides: VersionWeightOverrideRow[];
+  packageLabel: string;
+}) =>
+  hashString(
+    stableStringify({
+      department,
+      type,
+      packageLabel,
+      tour: {
+        id: tour.id,
+        name: tour.name,
+      },
+      tourDate: {
+        id: tourDate.id,
+        date: tourDate.date,
+        start_date: tourDate.start_date,
+        locationName,
+        sound_package_size: tourDate.sound_package_size,
+        lights_package_size: tourDate.lights_package_size,
+        video_package_size: tourDate.video_package_size,
+        sound_default_set_id: tourDate.sound_default_set_id,
+        lights_default_set_id: tourDate.lights_default_set_id,
+        video_default_set_id: tourDate.video_default_set_id,
+      },
+      defaultSet: {
+        id: defaultSet.id,
+        name: defaultSet.name,
+        package_size: defaultSet.package_size,
+        updated_at: defaultSet.updated_at,
+      },
+      defaultTables: sortDefaultTables(defaultTables).map((table) => ({
+        id: table.id,
+        table_name: table.table_name,
+        table_type: table.table_type,
+        total_value: table.total_value,
+        table_data: table.table_data,
+        metadata: table.metadata,
+        updated_at: table.updated_at,
+      })),
+      powerOverrides: sortOverrides(powerOverrides).map((override) => ({
+        id: override.id,
+        table_name: override.table_name,
+        total_watts: override.total_watts,
+        current_per_phase: override.current_per_phase,
+        pdu_type: override.pdu_type,
+        custom_pdu_type: override.custom_pdu_type,
+        position: override.position,
+        custom_position: override.custom_position,
+        includes_hoist: override.includes_hoist,
+        override_data: override.override_data,
+        updated_at: override.updated_at,
+      })),
+      weightOverrides: sortOverrides(weightOverrides).map((override) => ({
+        id: override.id,
+        item_name: override.item_name,
+        weight_kg: override.weight_kg,
+        quantity: override.quantity,
+        category: override.category,
+        override_data: override.override_data,
+        updated_at: override.updated_at,
+      })),
+    })
+  );

--- a/src/utils/tourDefaultDocumentVersioning.ts
+++ b/src/utils/tourDefaultDocumentVersioning.ts
@@ -108,7 +108,8 @@ const sortDefaultTables = <TTable extends VersionDefaultTableRow>(tables: TTable
     if (leftOrder !== rightOrder) return leftOrder - rightOrder;
     const leftTime = left.created_at ? toJobTimezone(left.created_at).getTime() : 0;
     const rightTime = right.created_at ? toJobTimezone(right.created_at).getTime() : 0;
-    return leftTime - rightTime;
+    if (leftTime !== rightTime) return leftTime - rightTime;
+    return left.id.localeCompare(right.id);
   });
 
 const sortOverrides = <


### PR DESCRIPTION
## Summary
- Make generated tour default peso/consumo PDFs cache-safe by storing them under content-versioned object paths.
- Clean all previous generated files for the same tour date, department, and document type before inserting the refreshed document row.
- Make regenerated job calculator PDFs use a fresh storage object path while keeping the visible filename stable.

## Root Cause
Generated PDFs were being replaced at stable storage paths with a one-hour cache window. After a tour date package size changed, the database filename could reflect the new package while the downloaded/viewed object could still serve stale PDF content from the previous generation.

## Impact
Changing a tour date package size or editing its default tables now produces a new PDF storage key and removes old generated versions for that date slot. Job document PDF regeneration follows the same cache-safe pattern.

## Validation
- `npm run test:run -- src/utils/__tests__/tourDefaultDocumentSync.test.ts src/utils/__tests__/jobDocumentsUpload.test.ts src/features/technical-tools/weights/__tests__/weightPersistence.test.ts src/features/technical-tools/power/__tests__/powerUploadPersistence.test.ts`
- `npm run typecheck`
- `npm run lint` (existing warnings only, 0 errors)
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default and regenerated PDFs now use versioned, unique storage paths to reduce overwrite and collision risk.

* **Bug Fixes**
  * Sync cleanup now removes all files in the relevant storage slot (and their database records) before uploading the updated PDF.
  * Document regeneration correctly updates paths and filenames when underlying defaults, tables, or package sizing change.
  * Upload caching behavior was updated so refreshed PDFs are served more reliably.

* **Tests**
  * Enhanced assertions to validate the new dynamic versioned path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->