### PR TITLE
[codex] Allow NWM file uploads

### DIFF
--- a/src/components/festival/ArtistRequirementsForm.tsx
+++ b/src/components/festival/ArtistRequirementsForm.tsx
@@ -1012,7 +1012,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
 
                     <div className="space-y-2">
                       <label htmlFor="public-rider-upload" className="text-sm font-medium">
-                        {tx("Subir rider(s) (PDF, Word, imagen, SoundVision o CAD)", "Upload rider file(s) (PDF, Word, image, SoundVision, or CAD)")}
+                        {tx("Subir rider(s) (PDF, Word, imagen, SoundVision, NWM o CAD)", "Upload rider file(s) (PDF, Word, image, SoundVision, NWM, or CAD)")}
                       </label>
                       <Input
                         id="public-rider-upload"

--- a/src/components/soundvision/SoundVisionInteractiveMap.tsx
+++ b/src/components/soundvision/SoundVisionInteractiveMap.tsx
@@ -969,7 +969,7 @@ export const SoundVisionInteractiveMap = ({ theme, isDark, onClose }: SoundVisio
                                         <SelectItem value="all">Todos los tipos</SelectItem>
                                         <SelectItem value=".xmlp">.xmlp (Proyecto)</SelectItem>
                                         <SelectItem value=".xmls">.xmls (Escena)</SelectItem>
-                                        <SelectItem value=".xmlc">.xmlc (Config)</SelectItem>
+                                        <SelectItem value=".xmlc">.xmlc (Config)</SelectItem><SelectItem value=".nwm">.nwm (NWM)</SelectItem>
                                     </SelectContent>
                                 </Select>
 

--- a/src/components/soundvision/SoundVisionSearchFilters.tsx
+++ b/src/components/soundvision/SoundVisionSearchFilters.tsx
@@ -70,6 +70,7 @@ export const SoundVisionSearchFilters = ({
             <SelectItem value=".xmlp">.xmlp (Proyecto)</SelectItem>
             <SelectItem value=".xmls">.xmls (Escena)</SelectItem>
             <SelectItem value=".xmlc">.xmlc (Configuración)</SelectItem>
+            <SelectItem value=".nwm">.nwm (Modelo NWM)</SelectItem>
           </SelectContent>
         </Select>
 

--- a/src/lib/enhanced-security-config.ts
+++ b/src/lib/enhanced-security-config.ts
@@ -84,6 +84,7 @@ const DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS = new Set([
   'xmlp',
   'xmlc',
   'xmls',
+  'nwm',
   'dwg',
   'dfx',
   'dxf',

--- a/src/utils/__tests__/documentUploadValidation.test.ts
+++ b/src/utils/__tests__/documentUploadValidation.test.ts
@@ -14,7 +14,7 @@ const createFile = (name: string, type = "") =>
   new File(["technical file"], name, { type });
 
 describe("document upload validation", () => {
-  const technicalExtensions = [".xmlp", ".xmlc", ".xmls", ".dwg", ".dfx", ".dxf"];
+  const technicalExtensions = [".xmlp", ".xmlc", ".xmls", ".nwm", ".dwg", ".dfx", ".dxf"];
 
   it("exposes technical and CAD formats in the shared accept string", () => {
     for (const extension of technicalExtensions) {
@@ -27,6 +27,7 @@ describe("document upload validation", () => {
       createFile("project.xmlp", "application/xml"),
       createFile("config.xmlc", "text/xml"),
       createFile("scene.xmls"),
+      createFile("model.nwm", "application/octet-stream"),
       createFile("plot.dwg", "application/octet-stream"),
       createFile("legacy.dfx"),
       createFile("cad-export.dxf", "application/dxf"),
@@ -44,7 +45,7 @@ describe("document upload validation", () => {
 
 describe("SoundVision file validation", () => {
   it("accepts the SoundVision and CAD formats used by technical teams", () => {
-    for (const extension of [".xmlp", ".xmlc", ".xmls", ".dwg", ".dfx", ".dxf"]) {
+    for (const extension of [".xmlp", ".xmlc", ".xmls", ".nwm", ".dwg", ".dfx", ".dxf"]) {
       expect(SOUNDVISION_ALLOWED_FILE_TYPES).toContain(extension);
       expect(validateSoundVisionFile(createFile(`venue${extension}`, "application/octet-stream"))).toEqual({
         valid: true,

--- a/src/utils/documentUploadValidation.ts
+++ b/src/utils/documentUploadValidation.ts
@@ -1,6 +1,6 @@
 import { validateFileUpload } from "@/lib/enhanced-security-config";
 
-export const DOCUMENT_UPLOAD_ACCEPT = ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.webp,.txt,.xmlp,.xmlc,.xmls,.dwg,.dfx,.dxf";
+export const DOCUMENT_UPLOAD_ACCEPT = ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.webp,.txt,.xmlp,.xmlc,.xmls,.nwm,.dwg,.dfx,.dxf";
 
 export const getDocumentUploadValidationError = (files: File[]) => {
   for (const file of files) {

--- a/src/utils/soundvisionFileValidation.ts
+++ b/src/utils/soundvisionFileValidation.ts
@@ -4,8 +4,9 @@
 // .xmlp - Archivo de proyecto (proyecto SoundVision completo)
 // .xmls - Archivo de escena (contexto de recinto/geometría)
 // .xmlc - Archivo de configuración (exportaciones como posiciones de altavoces)
+// .nwm - Archivo de modelo NWM usado como referencia técnica
 // .dwg/.dxf/.dfx - Planos CAD usados como referencia técnica
-export const ALLOWED_FILE_TYPES = ['.xmlp', '.xmls', '.xmlc', '.dwg', '.dxf', '.dfx'];
+export const ALLOWED_FILE_TYPES = ['.xmlp', '.xmls', '.xmlc', '.nwm', '.dwg', '.dxf', '.dfx'];
 export const ALLOWED_MIME_TYPES = [
   'application/xml',
   'text/xml',

--- a/supabase/functions/upload-public-artist-rider/index.ts
+++ b/supabase/functions/upload-public-artist-rider/index.ts
@@ -27,6 +27,7 @@ const ALLOWED_EXTENSIONS = new Set([
   "xmlp",
   "xmlc",
   "xmls",
+  "nwm",
   "dwg",
   "dfx",
   "dxf",


### PR DESCRIPTION
## Summary

- Adds `.nwm` to the shared document upload accept list and security validator.
- Allows `.nwm` in the SoundVision upload validator and filter dropdowns.
- Allows `.nwm` through the public artist rider upload Edge Function allowlist.
- Extends document upload validation tests to cover `.nwm` files.

## Why

NWM technical files were blocked by extension allowlists even when uploaded as generic binary files (`application/octet-stream`). This aligns NWM with the existing SoundVision/CAD technical file handling.

## Validation

- `npm ci --legacy-peer-deps`
- `npm run test:run -- src/utils/__tests__/documentUploadValidation.test.ts`
- `npm run lint`
- `npm run lint:functions`
- `npm run build`
- `npm run test:run`