### PR TITLE
feat: restrict house tech festival permissions

### DIFF
--- a/src/components/festival/ArtistActionButtons.tsx
+++ b/src/components/festival/ArtistActionButtons.tsx
@@ -1,0 +1,93 @@
+import { Button } from "@/components/ui/button";
+import { FileText, ImageOff, ImagePlus, Link, Loader2, Pencil, Printer, Receipt, Trash2 } from "lucide-react";
+import type { ArtistGearComparison } from "@/utils/gearComparisonService";
+
+type ArtistActionArtist = {
+  id: string;
+  name: string;
+  date: string;
+  show_start: string;
+  show_end: string;
+  isaftermidnight?: boolean;
+  stage_plot_file_path?: string | null;
+};
+
+interface ArtistActionButtonsProps<TArtist extends ArtistActionArtist> {
+  artist: TArtist;
+  gearComparison?: ArtistGearComparison;
+  printingArtistId: string | null;
+  uploadingStagePlotArtistId: string | null;
+  deletingStagePlotArtistId: string | null;
+  deletingArtistId: string | null;
+  canDelete: boolean;
+  canCreateExtras: boolean;
+  isCreatingExtrasFor: (id: string) => boolean;
+  onGenerateLink: (artist: TArtist) => void;
+  onManageFiles: (artist: TArtist) => void;
+  onPrintArtist: (artist: TArtist) => void;
+  onOpenStagePlotCapture: (artist: TArtist) => void;
+  onDeleteStagePlot: (artist: TArtist) => void;
+  onEditArtist: (artist: TArtist) => void;
+  onDeleteArtist: (artist: TArtist) => void;
+  onCreateFlexExtras: (artistId: string, artistName: string, artistDate: string, showStart: string, showEnd: string, isAfterMidnight: boolean) => void;
+}
+
+export function ArtistActionButtons<TArtist extends ArtistActionArtist>({
+  artist,
+  gearComparison,
+  printingArtistId,
+  uploadingStagePlotArtistId,
+  deletingStagePlotArtistId,
+  deletingArtistId,
+  canDelete,
+  canCreateExtras,
+  isCreatingExtrasFor,
+  onGenerateLink,
+  onManageFiles,
+  onPrintArtist,
+  onOpenStagePlotCapture,
+  onDeleteStagePlot,
+  onEditArtist,
+  onDeleteArtist,
+  onCreateFlexExtras,
+}: ArtistActionButtonsProps<TArtist>) {
+  const handleCreateExtras = () => {
+    if (!canCreateExtras || !artist.date) return;
+    onCreateFlexExtras(artist.id, artist.name, artist.date, artist.show_start, artist.show_end, artist.isaftermidnight || false);
+  };
+
+  return (
+    <div className="flex items-center gap-1 flex-wrap">
+      <Button variant="ghost" size="icon" onClick={() => onGenerateLink(artist)} title="Generate form link">
+        <Link className="h-4 w-4" />
+      </Button>
+      <Button variant="ghost" size="icon" onClick={() => onManageFiles(artist)} title="Manage files/riders">
+        <FileText className="h-4 w-4" />
+      </Button>
+      <Button variant="ghost" size="icon" onClick={() => onPrintArtist(artist)} disabled={printingArtistId === artist.id} title="Print artist details">
+        {printingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Printer className="h-4 w-4" />}
+      </Button>
+      <Button variant="ghost" size="icon" onClick={() => onOpenStagePlotCapture(artist)} disabled={uploadingStagePlotArtistId === artist.id} title="Capture/upload stage plot">
+        {uploadingStagePlotArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImagePlus className="h-4 w-4" />}
+      </Button>
+      {artist.stage_plot_file_path && (
+        <Button variant="ghost" size="icon" onClick={() => onDeleteStagePlot(artist)} disabled={deletingStagePlotArtistId === artist.id} title="Delete stage plot">
+          {deletingStagePlotArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImageOff className="h-4 w-4" />}
+        </Button>
+      )}
+      {canCreateExtras && gearComparison?.mismatches.some((m) => m.severity === "error") && (
+        <Button variant="ghost" size="icon" onClick={handleCreateExtras} disabled={isCreatingExtrasFor(artist.id) || !artist.date} title="Crear presupuesto extras en Flex" className="text-amber-600 hover:text-amber-700 hover:bg-amber-50">
+          {isCreatingExtrasFor(artist.id) ? <Loader2 className="h-4 w-4 animate-spin" /> : <Receipt className="h-4 w-4" />}
+        </Button>
+      )}
+      <Button variant="ghost" size="icon" onClick={() => onEditArtist(artist)} title="Edit artist">
+        <Pencil className="h-4 w-4" />
+      </Button>
+      {canDelete && (
+        <Button variant="ghost" size="icon" onClick={() => onDeleteArtist(artist)} disabled={deletingArtistId === artist.id} title="Delete artist">
+          {deletingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/festival/ArtistManagementDialog.tsx
+++ b/src/components/festival/ArtistManagementDialog.tsx
@@ -23,7 +23,7 @@ export const ArtistManagementDialog = ({
   selectedDate,
   dayStartTime = "07:00"
 }: ArtistManagementDialogProps) => {
-  const { createArtist, updateArtist, isCreating, isUpdating } = useArtistMutations(jobId, selectedDate);
+  const { createArtistAsync, updateArtistAsync, isCreating, isUpdating } = useArtistMutations(jobId, selectedDate);
   const isMobile = useIsMobile();
   const formId = artist ? "artist-management-edit-form" : "artist-management-create-form";
 
@@ -31,10 +31,10 @@ export const ArtistManagementDialog = ({
     try {
       if (artist) {
         // Update existing artist
-        await updateArtist({ id: artist.id, ...data });
+        await updateArtistAsync({ id: artist.id, ...data });
       } else {
         // Create new artist
-        await createArtist(data);
+        await createArtistAsync(data);
       }
 
       // Close dialog and notify that there was an update

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { Loading } from "@/components/ui/loading";
 import { Badge } from "@/components/ui/badge";
-import { Pencil, Trash2, FileText, Loader2, Mic, Link, ExternalLink, Printer, ImagePlus, ImageOff, Receipt } from "lucide-react";
+import { ExternalLink, ImageOff, ImagePlus, Loader2, Mic } from "lucide-react";
 import { format, parseISO, isAfter, setHours, setMinutes } from "date-fns";
 import { ArtistFormLinkDialog } from "./ArtistFormLinkDialog";
 import { ArtistFormLinksDialog } from "./ArtistFormLinksDialog";
@@ -23,6 +23,7 @@ import { mapFestivalGearSetup, mapStageGearSetups } from "@/utils/festivalGearMa
 import { buildReadableFilename } from "@/utils/fileName";
 import { MobileArtistList } from "./mobile/MobileArtistList";
 import { useCreateExtrasPresupuesto } from "@/hooks/festival/useCreateExtrasPresupuesto";
+import { ArtistActionButtons } from "./ArtistActionButtons";
 
 interface Artist {
   id: string;
@@ -96,8 +97,8 @@ interface ArtistTableProps {
   jobId?: string;
   selectedDate?: string;
   onArtistStagePlotUpdated?: () => void;
-  canDelete?: boolean;
-  canCreateExtras?: boolean;
+  canDelete: boolean;
+  canCreateExtras: boolean;
 }
 
 type EquipmentSystem = {
@@ -147,8 +148,8 @@ export const ArtistTable = ({
   jobId,
   selectedDate,
   onArtistStagePlotUpdated,
-  canDelete = true,
-  canCreateExtras = true
+  canDelete,
+  canCreateExtras
 }: ArtistTableProps) => {
   const confirm = useConfirm();
   const { createExtrasPresupuesto, isCreatingExtrasFor } = useCreateExtrasPresupuesto(jobId);
@@ -555,6 +556,7 @@ export const ArtistTable = ({
   const sortedFilteredArtists = sortArtistsChronologically(filteredArtists as any) as Artist[];
   const hasArtistSubmittedData = sortedFilteredArtists.some((artist) => artist.artist_submitted);
   const handleDeleteClick = async (artist: Artist) => {
+    if (!canDelete) return;
     const confirmed = await confirm({
       title: "Eliminar artista",
       description: `¿Estás seguro de que quieres eliminar ${artist.name}?`,
@@ -1058,59 +1060,25 @@ export const ArtistTable = ({
                       </TableCell>
                       
                       <TableCell className="min-w-[200px]">
-                        <div className="flex items-center gap-1 flex-wrap">
-                          <Button variant="ghost" size="icon" onClick={() => handleGenerateLink(artist)} title="Generate form link">
-                            <Link className="h-4 w-4" />
-                          </Button>
-                          <Button variant="ghost" size="icon" onClick={() => handleManageFiles(artist)} title="Manage files/riders">
-                            <FileText className="h-4 w-4" />
-                          </Button>
-                          <Button variant="ghost" size="icon" onClick={() => handlePrintArtist(artist)} disabled={printingArtistId === artist.id} title="Print artist details">
-                            {printingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Printer className="h-4 w-4" />}
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => handleOpenStagePlotCapture(artist)}
-                            disabled={uploadingStagePlotArtistId === artist.id}
-                            title="Capture/upload stage plot"
-                          >
-                            {uploadingStagePlotArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImagePlus className="h-4 w-4" />}
-                          </Button>
-                          {artist.stage_plot_file_path && (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => handleDeleteStagePlot(artist)}
-                              disabled={deletingStagePlotArtistId === artist.id}
-                              title="Delete stage plot"
-                            >
-                              {deletingStagePlotArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImageOff className="h-4 w-4" />}
-                            </Button>
-                          )}
-                          {canCreateExtras && gearComparison?.mismatches.some(m => m.severity === 'error') && (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => createExtrasPresupuesto(artist.id, artist.name, artist.date, artist.show_start, artist.show_end, artist.isaftermidnight || false)}
-                              disabled={isCreatingExtrasFor(artist.id)}
-                              title="Crear presupuesto extras en Flex"
-                              className="text-amber-600 hover:text-amber-700 hover:bg-amber-50"
-                            >
-                              {isCreatingExtrasFor(artist.id)
-                                ? <Loader2 className="h-4 w-4 animate-spin" />
-                                : <Receipt className="h-4 w-4" />}
-                            </Button>
-                          )}
-                          <Button variant="ghost" size="icon" onClick={() => onEditArtist(artist)} title="Edit artist">
-                            <Pencil className="h-4 w-4" />
-                          </Button>
-                          {canDelete && (
-                            <Button variant="ghost" size="icon" onClick={() => handleDeleteClick(artist)} disabled={deletingArtistId === artist.id} title="Delete artist">
-                              {deletingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-                            </Button>
-                          )}
-                        </div>
+                        <ArtistActionButtons
+                          artist={artist}
+                          gearComparison={gearComparison}
+                          printingArtistId={printingArtistId}
+                          uploadingStagePlotArtistId={uploadingStagePlotArtistId}
+                          deletingStagePlotArtistId={deletingStagePlotArtistId}
+                          deletingArtistId={deletingArtistId}
+                          canDelete={canDelete}
+                          canCreateExtras={canCreateExtras}
+                          isCreatingExtrasFor={isCreatingExtrasFor}
+                          onGenerateLink={handleGenerateLink}
+                          onManageFiles={handleManageFiles}
+                          onPrintArtist={handlePrintArtist}
+                          onOpenStagePlotCapture={handleOpenStagePlotCapture}
+                          onDeleteStagePlot={handleDeleteStagePlot}
+                          onEditArtist={onEditArtist}
+                          onDeleteArtist={handleDeleteClick}
+                          onCreateFlexExtras={createExtrasPresupuesto}
+                        />
                       </TableCell>
                     </TableRow>
                   );

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -96,6 +96,8 @@ interface ArtistTableProps {
   jobId?: string;
   selectedDate?: string;
   onArtistStagePlotUpdated?: () => void;
+  canDelete?: boolean;
+  canCreateExtras?: boolean;
 }
 
 type EquipmentSystem = {
@@ -144,7 +146,9 @@ export const ArtistTable = ({
   dayStartTime,
   jobId,
   selectedDate,
-  onArtistStagePlotUpdated
+  onArtistStagePlotUpdated,
+  canDelete = true,
+  canCreateExtras = true
 }: ArtistTableProps) => {
   const confirm = useConfirm();
   const { createExtrasPresupuesto, isCreatingExtrasFor } = useCreateExtrasPresupuesto(jobId);
@@ -1084,7 +1088,7 @@ export const ArtistTable = ({
                               {deletingStagePlotArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImageOff className="h-4 w-4" />}
                             </Button>
                           )}
-                          {gearComparison?.mismatches.some(m => m.severity === 'error') && (
+                          {canCreateExtras && gearComparison?.mismatches.some(m => m.severity === 'error') && (
                             <Button
                               variant="ghost"
                               size="icon"
@@ -1101,9 +1105,11 @@ export const ArtistTable = ({
                           <Button variant="ghost" size="icon" onClick={() => onEditArtist(artist)} title="Edit artist">
                             <Pencil className="h-4 w-4" />
                           </Button>
-                          <Button variant="ghost" size="icon" onClick={() => handleDeleteClick(artist)} disabled={deletingArtistId === artist.id} title="Delete artist">
-                            {deletingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-                          </Button>
+                          {canDelete && (
+                            <Button variant="ghost" size="icon" onClick={() => handleDeleteClick(artist)} disabled={deletingArtistId === artist.id} title="Delete artist">
+                              {deletingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                            </Button>
+                          )}
                         </div>
                       </TableCell>
                     </TableRow>
@@ -1136,6 +1142,8 @@ export const ArtistTable = ({
               deletingStagePlotArtistId={deletingStagePlotArtistId}
               onCreateFlexExtras={createExtrasPresupuesto}
               isCreatingExtrasFor={isCreatingExtrasFor}
+              canDelete={canDelete}
+              canCreateExtras={canCreateExtras}
             />
           </div>
 

--- a/src/components/festival/FestivalGearSetupForm.tsx
+++ b/src/components/festival/FestivalGearSetupForm.tsx
@@ -25,6 +25,7 @@ interface FestivalGearSetupFormProps {
   jobId: string;
   stageNumber?: number;
   onSave?: () => void;
+  readOnly?: boolean;
 }
 
 const buildEmptyStageSetup = (maxStages = 1): GearSetupFormData => ({
@@ -91,7 +92,8 @@ const mapGearSetupRow = (row: FestivalGearSetupRow): FestivalGearSetup => ({
 export const FestivalGearSetupForm = ({
   jobId,
   stageNumber = 1,
-  onSave
+  onSave,
+  readOnly = false
 }: FestivalGearSetupFormProps) => {
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
@@ -242,6 +244,7 @@ export const FestivalGearSetupForm = ({
   }, [jobId, stageNumber, toast, isPrimaryStage]);
 
   const handleChange = (changes: Partial<GearSetupFormData>) => {
+    if (readOnly) return;
     console.log('=== HANDLE CHANGE DEBUG ===');
     console.log('Changes received:', changes);
     console.log('Current setup wired_mics before change:', setup.wired_mics);
@@ -256,6 +259,7 @@ export const FestivalGearSetupForm = ({
   };
 
   const handlePushToFlex = () => {
+    if (readOnly) return;
     if (!existingSetupId) {
       toast({
         title: "Configuración no guardada",
@@ -269,6 +273,7 @@ export const FestivalGearSetupForm = ({
 
   const handleFormSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (readOnly) return;
     setIsLoading(true);
 
     try {
@@ -666,29 +671,37 @@ export const FestivalGearSetupForm = ({
         </Accordion>
       </div>
 
-      <div className="flex gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={handlePushToFlex}
-          disabled={!existingSetupId || isLoading}
-          className="flex-1"
-        >
-          <Upload className="h-4 w-4 mr-2" />
-          Push to Flex Pullsheet
-        </Button>
+      {readOnly ? (
+        <Alert>
+          <AlertDescription className="text-sm">
+            Solo lectura: no tienes permisos para modificar la configuración de equipo.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handlePushToFlex}
+            disabled={!existingSetupId || isLoading}
+            className="flex-1"
+          >
+            <Upload className="h-4 w-4 mr-2" />
+            Push to Flex Pullsheet
+          </Button>
 
-        <Button type="submit" disabled={isLoading} className="flex-1">
-          <Save className="h-4 w-4 mr-2" />
-          {isLoading ? "Guardando..." : (
-            isPrimaryStage
-              ? "Guardar Configuración Global"
-              : hasStageSpecificSetup
-                ? `Actualizar Configuración de Stage ${stageNumber}`
-                : `Crear Configuración Personalizada para Stage ${stageNumber}`
-          )}
-        </Button>
-      </div>
+          <Button type="submit" disabled={isLoading} className="flex-1">
+            <Save className="h-4 w-4 mr-2" />
+            {isLoading ? "Guardando..." : (
+              isPrimaryStage
+                ? "Guardar Configuración Global"
+                : hasStageSpecificSetup
+                  ? `Actualizar Configuración de Stage ${stageNumber}`
+                  : `Crear Configuración Personalizada para Stage ${stageNumber}`
+            )}
+          </Button>
+        </div>
+      )}
 
       <PushToFlexPullsheetDialog
         open={showPushDialog}

--- a/src/components/festival/FestivalGearSetupForm.tsx
+++ b/src/components/festival/FestivalGearSetupForm.tsx
@@ -104,6 +104,7 @@ export const FestivalGearSetupForm = ({
   const [hasStageSpecificSetup, setHasStageSpecificSetup] = useState(false);
   const [showPushDialog, setShowPushDialog] = useState(false);
   const isPrimaryStage = stageNumber === 1;
+  const readOnlyField = () => readOnly;
 
   useEffect(() => {
     const fetchExistingSetup = async () => {
@@ -511,11 +512,13 @@ export const FestivalGearSetupForm = ({
         <FestivalConsoleSetupSection
           formData={setup}
           onChange={(changes) => handleChange(changes)}
+          readOnly={readOnly}
         />
 
         <WirelessSetupSection
           formData={getCompatibleFormData()}
           onChange={(changes) => handleChange(changes)}
+          readOnly={readOnly}
         />
 
         <FestivalMicKitConfig
@@ -526,24 +529,28 @@ export const FestivalGearSetupForm = ({
             console.log('FestivalMicKitConfig onChange called with:', wiredMics);
             handleChange({ wired_mics: wiredMics });
           }}
+          readOnly={readOnly}
         />
 
         <MonitorSetupSection
           formData={getCompatibleFormData()}
           onChange={(changes) => handleChange(changes)}
           gearSetup={globalSetup}
+          isFieldLocked={readOnlyField}
         />
 
         <ExtraRequirementsSection
           formData={getCompatibleFormData()}
           onChange={(changes) => handleChange(changes)}
           gearSetup={globalSetup}
+          isFieldLocked={readOnlyField}
         />
 
         <InfrastructureSection
           formData={getCompatibleFormData()}
           onChange={(changes) => handleChange(changes)}
           gearSetup={globalSetup}
+          isFieldLocked={readOnlyField}
         />
 
         <div className="space-y-4">
@@ -557,6 +564,7 @@ export const FestivalGearSetupForm = ({
         <NotesSection
           formData={getCompatibleFormData()}
           onChange={(changes) => handleChange(changes)}
+          isFieldLocked={readOnlyField}
         />
       </div>
 
@@ -571,6 +579,7 @@ export const FestivalGearSetupForm = ({
               <FestivalConsoleSetupSection
                 formData={setup}
                 onChange={(changes) => handleChange(changes)}
+                readOnly={readOnly}
               />
             </AccordionContent>
           </AccordionItem>
@@ -583,6 +592,7 @@ export const FestivalGearSetupForm = ({
               <WirelessSetupSection
                 formData={getCompatibleFormData()}
                 onChange={(changes) => handleChange(changes)}
+                readOnly={readOnly}
               />
             </AccordionContent>
           </AccordionItem>
@@ -600,6 +610,7 @@ export const FestivalGearSetupForm = ({
                   console.log('FestivalMicKitConfig onChange called with:', wiredMics);
                   handleChange({ wired_mics: wiredMics });
                 }}
+                readOnly={readOnly}
               />
             </AccordionContent>
           </AccordionItem>
@@ -613,6 +624,7 @@ export const FestivalGearSetupForm = ({
                 formData={getCompatibleFormData()}
                 onChange={(changes) => handleChange(changes)}
                 gearSetup={globalSetup}
+                isFieldLocked={readOnlyField}
               />
             </AccordionContent>
           </AccordionItem>
@@ -626,6 +638,7 @@ export const FestivalGearSetupForm = ({
                 formData={getCompatibleFormData()}
                 onChange={(changes) => handleChange(changes)}
                 gearSetup={globalSetup}
+                isFieldLocked={readOnlyField}
               />
             </AccordionContent>
           </AccordionItem>
@@ -639,6 +652,7 @@ export const FestivalGearSetupForm = ({
                 formData={getCompatibleFormData()}
                 onChange={(changes) => handleChange(changes)}
                 gearSetup={globalSetup}
+                isFieldLocked={readOnlyField}
               />
             </AccordionContent>
           </AccordionItem>
@@ -665,6 +679,7 @@ export const FestivalGearSetupForm = ({
               <NotesSection
                 formData={getCompatibleFormData()}
                 onChange={(changes) => handleChange(changes)}
+                isFieldLocked={readOnlyField}
               />
             </AccordionContent>
           </AccordionItem>

--- a/src/components/festival/form/sections/FestivalConsoleSetupSection.tsx
+++ b/src/components/festival/form/sections/FestivalConsoleSetupSection.tsx
@@ -17,9 +17,10 @@ interface FestivalConsoleSetupSectionProps {
     foh_waves_outboard?: string;
     mon_waves_outboard?: string;
   }) => void;
+  readOnly?: boolean;
 }
 
-export const FestivalConsoleSetupSection = ({ formData, onChange }: FestivalConsoleSetupSectionProps) => {
+export const FestivalConsoleSetupSection = ({ formData, onChange, readOnly = false }: FestivalConsoleSetupSectionProps) => {
   return (
     <div className="space-y-4 md:space-y-6 border rounded-lg p-3 md:p-4">
       <h3 className="text-base md:text-lg font-semibold">Configuración de Consoles</h3>
@@ -28,6 +29,7 @@ export const FestivalConsoleSetupSection = ({ formData, onChange }: FestivalCons
         consoles={formData.foh_consoles}
         onChange={(consoles) => onChange({ foh_consoles: consoles })}
         label="Consoles FOH"
+        readOnly={readOnly}
       />
       <div className="space-y-2">
         <Label htmlFor="festival-foh-waves-outboard">Waves / Outboard FOH</Label>
@@ -36,6 +38,7 @@ export const FestivalConsoleSetupSection = ({ formData, onChange }: FestivalCons
           value={formData.foh_waves_outboard || ""}
           onChange={(event) => onChange({ foh_waves_outboard: event.target.value })}
           placeholder="Ej: Waves + outboard analógico"
+          disabled={readOnly}
         />
       </div>
 
@@ -43,6 +46,7 @@ export const FestivalConsoleSetupSection = ({ formData, onChange }: FestivalCons
         consoles={formData.mon_consoles}
         onChange={(consoles) => onChange({ mon_consoles: consoles })}
         label="Consoles de Monitor"
+        readOnly={readOnly}
       />
       <div className="space-y-2">
         <Label htmlFor="festival-mon-waves-outboard">Waves / Outboard MON</Label>
@@ -51,6 +55,7 @@ export const FestivalConsoleSetupSection = ({ formData, onChange }: FestivalCons
           value={formData.mon_waves_outboard || ""}
           onChange={(event) => onChange({ mon_waves_outboard: event.target.value })}
           placeholder="Ej: Plugins/FX para monitores"
+          disabled={readOnly}
         />
       </div>
     </div>

--- a/src/components/festival/form/sections/WirelessSetupSection.tsx
+++ b/src/components/festival/form/sections/WirelessSetupSection.tsx
@@ -4,7 +4,7 @@ import { ProviderSelector } from "../shared/ProviderSelector";
 import { ArtistSectionProps } from "@/types/artist-form";
 import { useEffect } from "react";
 
-export const WirelessSetupSection = ({ formData, onChange }: ArtistSectionProps) => {
+export const WirelessSetupSection = ({ formData, onChange, readOnly = false }: ArtistSectionProps) => {
   // Auto-detect mixed providers for wireless systems
   const detectWirelessProvider = (systems: any[]) => {
     if (!systems || systems.length === 0) return "festival";
@@ -35,6 +35,8 @@ export const WirelessSetupSection = ({ formData, onChange }: ArtistSectionProps)
 
   // Auto-update provider when systems change
   useEffect(() => {
+    if (readOnly) return;
+
     const detectedWirelessProvider = detectWirelessProvider(formData.wireless_systems || []);
     const detectedIEMProvider = detectIEMProvider(formData.iem_systems || []);
     
@@ -45,7 +47,7 @@ export const WirelessSetupSection = ({ formData, onChange }: ArtistSectionProps)
     if (detectedIEMProvider !== formData.iem_provided_by) {
       onChange({ iem_provided_by: detectedIEMProvider });
     }
-  }, [formData.wireless_systems, formData.iem_systems]);
+  }, [formData.wireless_systems, formData.iem_systems, readOnly]);
 
   const handleWirelessChange = (systems: any[]) => {
     console.log('WirelessSetupSection: Wireless systems changed:', systems);
@@ -82,6 +84,7 @@ export const WirelessSetupSection = ({ formData, onChange }: ArtistSectionProps)
             onChange={handleWirelessChange}
             label="Sistemas Wireless"
             includeQuantityTypes={true}
+            readOnly={readOnly}
           />
           <ProviderSelector
             value={formData.wireless_provided_by || "festival"}
@@ -89,6 +92,7 @@ export const WirelessSetupSection = ({ formData, onChange }: ArtistSectionProps)
             label="Sistemas Wireless Proporcionados Por"
             id="wireless-provider"
             showMixed={true}
+            disabled={readOnly}
           />
         </div>
 
@@ -99,6 +103,7 @@ export const WirelessSetupSection = ({ formData, onChange }: ArtistSectionProps)
             label="Sistemas IEM"
             includeQuantityTypes={true}
             isIEM={true}
+            readOnly={readOnly}
           />
           <ProviderSelector
             value={formData.iem_provided_by || "festival"}
@@ -106,6 +111,7 @@ export const WirelessSetupSection = ({ formData, onChange }: ArtistSectionProps)
             label="Sistemas IEM Proporcionados Por"
             id="iem-provider"
             showMixed={true}
+            disabled={readOnly}
           />
         </div>
       </div>

--- a/src/components/festival/gear-setup/ConsoleConfig.tsx
+++ b/src/components/festival/gear-setup/ConsoleConfig.tsx
@@ -8,7 +8,7 @@ import { EquipmentSelect } from "../form/shared/EquipmentSelect";
 import { useEquipmentModels } from "@/hooks/useEquipmentModels";
 import { FESTIVAL_CONSOLE_OPTIONS } from "@/constants/festivalConsoleOptions";
 
-export const ConsoleConfig = ({ consoles, onChange, label }: ConsoleConfigProps) => {
+export const ConsoleConfig = ({ consoles, onChange, label, readOnly = false }: ConsoleConfigProps) => {
   const { models } = useEquipmentModels();
 
   const addConsole = () => {
@@ -49,6 +49,7 @@ export const ConsoleConfig = ({ consoles, onChange, label }: ConsoleConfigProps)
           variant="outline"
           size="sm"
           onClick={addConsole}
+          disabled={readOnly}
         >
           <Plus className="h-4 w-4 mr-2" />
           Añadir Console
@@ -64,6 +65,7 @@ export const ConsoleConfig = ({ consoles, onChange, label }: ConsoleConfigProps)
               options={mergedConsoleOptions}
               fallbackOptions={FESTIVAL_CONSOLE_OPTIONS}
               placeholder="Seleccionar console"
+              disabled={readOnly}
             />
           </div>
           <div className="w-24">
@@ -72,6 +74,7 @@ export const ConsoleConfig = ({ consoles, onChange, label }: ConsoleConfigProps)
               min="1"
               value={console.quantity}
               onChange={(e) => updateConsole(index, 'quantity', parseInt(e.target.value) || 0)}
+              disabled={readOnly}
             />
           </div>
           <Button
@@ -79,6 +82,7 @@ export const ConsoleConfig = ({ consoles, onChange, label }: ConsoleConfigProps)
             variant="ghost"
             size="icon"
             onClick={() => removeConsole(index)}
+            disabled={readOnly}
           >
             <Minus className="h-4 w-4" />
           </Button>

--- a/src/components/festival/gear-setup/FestivalMicKitConfig.tsx
+++ b/src/components/festival/gear-setup/FestivalMicKitConfig.tsx
@@ -14,9 +14,10 @@ interface FestivalMicKitConfigProps {
   stageNumber: number;
   wiredMics: WiredMic[];
   onChange: (mics: WiredMic[]) => void;
+  readOnly?: boolean;
 }
 
-export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }: FestivalMicKitConfigProps) => {
+export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange, readOnly = false }: FestivalMicKitConfigProps) => {
   const [analysisPreviewOpen, setAnalysisPreviewOpen] = useState(false);
   const [isLoadingRequirements, setIsLoadingRequirements] = useState(false);
 
@@ -35,6 +36,8 @@ export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }
   console.log('FestivalMicKitConfig render - wiredMics serialized:', JSON.stringify(wiredMics, null, 2));
 
   const handleLoadFromAnalysis = async () => {
+    if (readOnly) return;
+
     if (!analysisData) {
       toast.error("No hay datos de análisis disponibles");
       return;
@@ -49,7 +52,7 @@ export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }
   };
 
   const handleConfirmLoadRequirements = async () => {
-    if (!analysisData) return;
+    if (!analysisData || readOnly) return;
 
     setIsLoadingRequirements(true);
     
@@ -134,7 +137,7 @@ export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }
               variant="outline"
               size="sm"
               onClick={handleLoadFromAnalysis}
-              disabled={isAnalyzing}
+              disabled={readOnly || isAnalyzing}
             >
               <Calculator className="h-4 w-4 mr-2" />
               {isAnalyzing ? "Analizando..." : "Cargar desde Requisitos de Artistas"}
@@ -155,6 +158,7 @@ export const FestivalMicKitConfig = ({ jobId, stageNumber, wiredMics, onChange }
             value={safeWiredMics}
             onChange={handleMicsChange}
             availableMics={availableMics}
+            readOnly={readOnly}
             showExclusiveUse={true}
             showNotes={true}
           />

--- a/src/components/festival/mobile/MobileArtistCard.tsx
+++ b/src/components/festival/mobile/MobileArtistCard.tsx
@@ -187,6 +187,8 @@ interface MobileArtistCardProps {
   isCreatingExtrasFor: (id: string) => boolean;
   onCreateFlexExtras: (artistId: string, artistName: string, artistDate: string, showStart: string, showEnd: string, isAfterMidnight: boolean) => void;
   riderFiles?: MobileArtistRiderFile[];
+  canDelete?: boolean;
+  canCreateExtras?: boolean;
 }
 
 export const MobileArtistCard = ({
@@ -210,6 +212,8 @@ export const MobileArtistCard = ({
   isCreatingExtrasFor,
   onCreateFlexExtras,
   riderFiles = [],
+  canDelete = true,
+  canCreateExtras = true,
 }: MobileArtistCardProps) => {
   return (
     <div className="border rounded-xl bg-card overflow-hidden max-w-full">
@@ -391,7 +395,7 @@ export const MobileArtistCard = ({
               {deletingStagePlotArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImageOff className="h-4 w-4" />}
             </Button>
           )}
-          {gearComparison?.mismatches.some(m => m.severity === 'error') && (
+          {canCreateExtras && gearComparison?.mismatches.some(m => m.severity === 'error') && (
             <Button
               variant="ghost" size="icon" className="h-8 w-8 text-amber-600 hover:text-amber-700 hover:bg-amber-50"
               onClick={() => {
@@ -407,13 +411,15 @@ export const MobileArtistCard = ({
           <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onEditArtist(artist)}>
             <Pencil className="h-4 w-4" />
           </Button>
-          <Button
-            variant="ghost" size="icon" className="h-8 w-8 text-destructive"
-            onClick={() => onDeleteArtist(artist)}
-            disabled={deletingArtistId === artist.id}
-          >
-            {deletingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-          </Button>
+          {canDelete && (
+            <Button
+              variant="ghost" size="icon" className="h-8 w-8 text-destructive"
+              onClick={() => onDeleteArtist(artist)}
+              disabled={deletingArtistId === artist.id}
+            >
+              {deletingArtistId === artist.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/src/components/festival/mobile/MobileArtistCard.tsx
+++ b/src/components/festival/mobile/MobileArtistCard.tsx
@@ -187,8 +187,8 @@ interface MobileArtistCardProps {
   isCreatingExtrasFor: (id: string) => boolean;
   onCreateFlexExtras: (artistId: string, artistName: string, artistDate: string, showStart: string, showEnd: string, isAfterMidnight: boolean) => void;
   riderFiles?: MobileArtistRiderFile[];
-  canDelete?: boolean;
-  canCreateExtras?: boolean;
+  canDelete: boolean;
+  canCreateExtras: boolean;
 }
 
 export const MobileArtistCard = ({
@@ -212,9 +212,14 @@ export const MobileArtistCard = ({
   isCreatingExtrasFor,
   onCreateFlexExtras,
   riderFiles = [],
-  canDelete = true,
-  canCreateExtras = true,
+  canDelete,
+  canCreateExtras,
 }: MobileArtistCardProps) => {
+  const handleCreateFlexExtras = () => {
+    if (!canCreateExtras || !artist.date) return;
+    onCreateFlexExtras(artist.id, artist.name, artist.date, artist.show_start, artist.show_end, artist.isaftermidnight || false);
+  };
+
   return (
     <div className="border rounded-xl bg-card overflow-hidden max-w-full">
       {/* Header */}
@@ -398,10 +403,7 @@ export const MobileArtistCard = ({
           {canCreateExtras && gearComparison?.mismatches.some(m => m.severity === 'error') && (
             <Button
               variant="ghost" size="icon" className="h-8 w-8 text-amber-600 hover:text-amber-700 hover:bg-amber-50"
-              onClick={() => {
-                if (!artist.date) return;
-                onCreateFlexExtras(artist.id, artist.name, artist.date, artist.show_start, artist.show_end, artist.isaftermidnight || false);
-              }}
+              onClick={handleCreateFlexExtras}
               disabled={isCreatingExtrasFor(artist.id) || !artist.date}
               title="Crear presupuesto extras en Flex"
             >

--- a/src/components/festival/mobile/MobileArtistList.tsx
+++ b/src/components/festival/mobile/MobileArtistList.tsx
@@ -91,6 +91,8 @@ interface MobileArtistListProps {
   mode?: 'edit' | 'readonly';
   riderFilesByArtistId?: Record<string, MobileArtistRiderFile[]>;
   onDownloadRiderFile?: (file: MobileArtistRiderFile) => void;
+  canDelete?: boolean;
+  canCreateExtras?: boolean;
 }
 
 export const MobileArtistList = ({
@@ -117,6 +119,8 @@ export const MobileArtistList = ({
   mode = 'edit',
   riderFilesByArtistId = {},
   onDownloadRiderFile,
+  canDelete = true,
+  canCreateExtras = true,
 }: MobileArtistListProps) => {
   const [editingCategory, setEditingCategory] = useState<{
     artistId: string;
@@ -212,6 +216,8 @@ export const MobileArtistList = ({
             deletingStagePlotArtistId={deletingStagePlotArtistId}
             isCreatingExtrasFor={isCreatingExtrasFor}
             riderFiles={riderFilesByArtistId[artist.id] || []}
+            canDelete={canDelete}
+            canCreateExtras={canCreateExtras}
           />
         </div>
       ))}

--- a/src/components/festival/mobile/MobileArtistList.tsx
+++ b/src/components/festival/mobile/MobileArtistList.tsx
@@ -91,8 +91,8 @@ interface MobileArtistListProps {
   mode?: 'edit' | 'readonly';
   riderFilesByArtistId?: Record<string, MobileArtistRiderFile[]>;
   onDownloadRiderFile?: (file: MobileArtistRiderFile) => void;
-  canDelete?: boolean;
-  canCreateExtras?: boolean;
+  canDelete: boolean;
+  canCreateExtras: boolean;
 }
 
 export const MobileArtistList = ({
@@ -119,8 +119,8 @@ export const MobileArtistList = ({
   mode = 'edit',
   riderFilesByArtistId = {},
   onDownloadRiderFile,
-  canDelete = true,
-  canCreateExtras = true,
+  canDelete,
+  canCreateExtras,
 }: MobileArtistListProps) => {
   const [editingCategory, setEditingCategory] = useState<{
     artistId: string;

--- a/src/components/jobs/JobExtrasManagement.tsx
+++ b/src/components/jobs/JobExtrasManagement.tsx
@@ -40,6 +40,7 @@ const cardBase = "bg-card border-border text-card-foreground";
 const surface = "bg-muted/30 border-border";
 const subtle = "text-muted-foreground";
 const pill = "bg-primary/5 border-primary/10 text-primary dark:text-primary-foreground";
+const EMPTY_TECHNICIAN_ID = '00000000-0000-0000-0000-000000000000';
 
 export const JobExtrasManagement = ({
   jobId,
@@ -54,7 +55,9 @@ export const JobExtrasManagement = ({
   const { userRole, user } = useOptimizedAuth();
   const viewerIsManager = isManagementRole(userRole);
   const isManager = isManagerProp && viewerIsManager;
-  const technicianId = viewerIsManager ? technicianIdProp : (user?.id ?? technicianIdProp);
+  const technicianId = viewerIsManager ? technicianIdProp : user?.id;
+  const scopedTechnicianId = technicianId ?? EMPTY_TECHNICIAN_ID;
+  const assignmentScopeKey = isManager ? (technicianId ?? 'all') : scopedTechnicianId;
 
   const visibleTechnicianIdSet = useMemo(
     () => new Set(visibleTechnicianIds ?? []),
@@ -62,7 +65,7 @@ export const JobExtrasManagement = ({
   );
 
   const { data: assignments, isLoading: assignmentsLoading } = useQuery({
-    queryKey: queryKeys.scope('job-assignments', jobId, technicianId, visibleTechnicianIds?.join(',') ?? 'all'),
+    queryKey: queryKeys.scope('job-assignments', jobId, assignmentScopeKey, visibleTechnicianIds?.join(',') ?? 'all'),
     queryFn: async () => {
       let query = dataLayerClient.from('job_assignments')
         .select(`
@@ -78,7 +81,7 @@ export const JobExtrasManagement = ({
       if (!isManager) {
         // Non-managers are strictly limited to their own assignment. If their id
         // is somehow unknown, match nothing rather than leaking every technician.
-        query = query.eq('technician_id', technicianId ?? '00000000-0000-0000-0000-000000000000');
+        query = query.eq('technician_id', scopedTechnicianId);
       } else if (visibleTechnicianIds && visibleTechnicianIds.length > 0) {
         query = query.in('technician_id', visibleTechnicianIds);
       }
@@ -93,12 +96,12 @@ export const JobExtrasManagement = ({
   // Fetch custom travel rates for all assigned technicians
   const visibleAssignments = useMemo(
     () => (assignments ?? []).filter((assignment) => {
-      if (!isManager) return Boolean(technicianId) && assignment.technician_id === technicianId;
+      if (!isManager) return assignment.technician_id === scopedTechnicianId;
       if (technicianId) return assignment.technician_id === technicianId;
       if (!visibleTechnicianIds) return true;
       return visibleTechnicianIdSet.has(assignment.technician_id);
     }),
-    [assignments, isManager, technicianId, visibleTechnicianIds, visibleTechnicianIdSet]
+    [assignments, isManager, scopedTechnicianId, technicianId, visibleTechnicianIds, visibleTechnicianIdSet]
   );
 
   const techIds = useMemo(
@@ -120,7 +123,10 @@ export const JobExtrasManagement = ({
   });
 
   // If technicianId is provided (non-manager), restrict payouts to that technician
-  const { data: payoutTotals, isLoading: payoutLoading } = useJobPayoutTotals(jobId, technicianId);
+  const { data: payoutTotals, isLoading: payoutLoading } = useJobPayoutTotals(
+    jobId,
+    isManager ? technicianId : scopedTechnicianId,
+  );
 
   if (assignmentsLoading || payoutLoading || customTravelRatesLoading) {
     return (

--- a/src/components/jobs/JobExtrasManagement.tsx
+++ b/src/components/jobs/JobExtrasManagement.tsx
@@ -8,6 +8,7 @@ import { DollarSign, Users } from 'lucide-react';
 import { JobExtrasEditor } from './JobExtrasEditor';
 import { formatCurrency } from '@/lib/utils';
 import { useJobPayoutTotals } from '@/hooks/useJobPayoutTotals';
+import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { isManagementRole } from '@/utils/permissions';
 
 
@@ -42,10 +43,19 @@ const pill = "bg-primary/5 border-primary/10 text-primary dark:text-primary-fore
 
 export const JobExtrasManagement = ({
   jobId,
-  isManager = false,
-  technicianId,
+  isManager: isManagerProp = false,
+  technicianId: technicianIdProp,
   visibleTechnicianIds,
 }: JobExtrasManagementProps) => {
+  // Defense-in-depth: derive the viewer from auth so this component is safe no
+  // matter how a caller wires its props. A non-management viewer (e.g. a house
+  // tech) may only ever SEE and never EDIT their own extras — they can never see
+  // another technician's financial info even if a caller forgets to scope it.
+  const { userRole, user } = useOptimizedAuth();
+  const viewerIsManager = isManagementRole(userRole);
+  const isManager = isManagerProp && viewerIsManager;
+  const technicianId = viewerIsManager ? technicianIdProp : (user?.id ?? technicianIdProp);
+
   const visibleTechnicianIdSet = useMemo(
     () => new Set(visibleTechnicianIds ?? []),
     [visibleTechnicianIds]
@@ -65,9 +75,11 @@ export const JobExtrasManagement = ({
           )
         `)
         .eq('job_id', jobId);
-      if (technicianId && !isManager) {
-        query = query.eq('technician_id', technicianId);
-      } else if (isManager && visibleTechnicianIds && visibleTechnicianIds.length > 0) {
+      if (!isManager) {
+        // Non-managers are strictly limited to their own assignment. If their id
+        // is somehow unknown, match nothing rather than leaking every technician.
+        query = query.eq('technician_id', technicianId ?? '00000000-0000-0000-0000-000000000000');
+      } else if (visibleTechnicianIds && visibleTechnicianIds.length > 0) {
         query = query.in('technician_id', visibleTechnicianIds);
       }
       const { data, error } = await query;
@@ -81,11 +93,12 @@ export const JobExtrasManagement = ({
   // Fetch custom travel rates for all assigned technicians
   const visibleAssignments = useMemo(
     () => (assignments ?? []).filter((assignment) => {
+      if (!isManager) return Boolean(technicianId) && assignment.technician_id === technicianId;
       if (technicianId) return assignment.technician_id === technicianId;
       if (!visibleTechnicianIds) return true;
       return visibleTechnicianIdSet.has(assignment.technician_id);
     }),
-    [assignments, technicianId, visibleTechnicianIds, visibleTechnicianIdSet]
+    [assignments, isManager, technicianId, visibleTechnicianIds, visibleTechnicianIdSet]
   );
 
   const techIds = useMemo(

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -355,7 +355,7 @@ export function JobCardNewView({
 
         <div className="flex flex-wrap items-center justify-between gap-2 px-6">
           <div className="flex flex-wrap items-center gap-2">
-            {isProjectManagementPage && job.job_type !== "dryhire" && (
+            {isProjectManagementPage && !isHouseTech && job.job_type !== "dryhire" && (
               <button
                 type="button"
                 onClick={(e) => {
@@ -672,13 +672,15 @@ export function JobCardNewView({
 
           {isProjectManagementPage && (
             <>
-              <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
-                <DialogContent className="max-w-[96vw] w-[96vw] h-[96vh] p-0 overflow-hidden">
-                  <div className="h-full overflow-auto">
-                    <ModernHojaDeRuta jobId={job.id} />
-                  </div>
-                </DialogContent>
-              </Dialog>
+              {!isHouseTech && (
+                <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
+                  <DialogContent className="max-w-[96vw] w-[96vw] h-[96vh] p-0 overflow-hidden">
+                    <div className="h-full overflow-auto">
+                      <ModernHojaDeRuta jobId={job.id} />
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              )}
               <ProjectNotesDialog
                 open={projectNotesOpen}
                 onOpenChange={setProjectNotesOpen}

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -672,15 +672,13 @@ export function JobCardNewView({
 
           {isProjectManagementPage && (
             <>
-              {!isHouseTech && (
-                <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
-                  <DialogContent className="max-w-[96vw] w-[96vw] h-[96vh] p-0 overflow-hidden">
-                    <div className="h-full overflow-auto">
-                      <ModernHojaDeRuta jobId={job.id} />
-                    </div>
-                  </DialogContent>
-                </Dialog>
-              )}
+              <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
+                <DialogContent className="max-w-[96vw] w-[96vw] h-[96vh] p-0 overflow-hidden">
+                  <div className="h-full overflow-auto">
+                    <ModernHojaDeRuta jobId={job.id} />
+                  </div>
+                </DialogContent>
+              </Dialog>
               <ProjectNotesDialog
                 open={projectNotesOpen}
                 onOpenChange={setProjectNotesOpen}

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -58,13 +58,15 @@ function useVisualViewportBottomOffset() {
     window.addEventListener("resize", updateBottomOffset)
     window.addEventListener("orientationchange", updateBottomOffset)
     visualViewport?.addEventListener("resize", updateBottomOffset)
-    visualViewport?.addEventListener("scroll", updateBottomOffset)
+    // NOTE: we intentionally do NOT listen to visualViewport "scroll". That event
+    // fires continuously during momentum/rubber-band scrolling with transient
+    // offsets, which made the fixed bottom bar chase the viewport and visibly
+    // "unstick". Keyboard and browser-chrome changes still arrive via "resize".
 
     return () => {
       window.removeEventListener("resize", updateBottomOffset)
       window.removeEventListener("orientationchange", updateBottomOffset)
       visualViewport?.removeEventListener("resize", updateBottomOffset)
-      visualViewport?.removeEventListener("scroll", updateBottomOffset)
     }
   }, [])
 

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -514,6 +514,8 @@ export function TechnicianArtistReadOnlyModal({
                     mode="readonly"
                     riderFilesByArtistId={riderFilesByArtistId}
                     onDownloadRiderFile={handleDownloadRiderFile}
+                    canDelete={false}
+                    canCreateExtras={false}
                   />
                 </section>
               ))}

--- a/src/components/technician/TimesheetView.tsx
+++ b/src/components/technician/TimesheetView.tsx
@@ -313,7 +313,7 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
   return (
     <div className={`fixed inset-0 z-[60] ${theme.bg} flex flex-col`}>
       {/* Header */}
-      <div className={`sticky top-0 z-10 px-5 py-4 pt-[max(1rem,calc(env(safe-area-inset-top)+1rem))] border-b ${theme.divider} ${theme.bg}`}>
+      <div className={`shrink-0 z-10 px-5 py-4 pt-[max(1rem,calc(env(safe-area-inset-top)+1rem))] border-b ${theme.divider} ${theme.bg}`}>
         <div className="flex justify-between items-center">
           <div>
             <button
@@ -329,7 +329,7 @@ export const TimesheetView = ({ theme, isDark, job, onClose, userRole, userId }:
 
 
       {/* Content */}
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 min-h-0">
         <div className="p-5 space-y-5 pb-[max(2rem,calc(env(safe-area-inset-bottom)+1.5rem))]">
           {isLoading ? (
             <div className="flex items-center justify-center py-12">

--- a/src/features/festival-management/types.ts
+++ b/src/features/festival-management/types.ts
@@ -124,6 +124,7 @@ type FestivalManagementLocalVm = {
   assignmentDepartment: Department;
   artistCount: number;
   canEdit: boolean;
+  canUploadDocuments: boolean;
   departmentOptions: Department[];
   festivalStageOptions: FestivalStageOption[];
   flexError: string | null;
@@ -140,10 +141,12 @@ type FestivalManagementLocalVm = {
   isAssignmentDialogOpen: boolean;
   isFlexLoading: boolean;
   isGearRoute: boolean;
+  isHouseTech: boolean;
   isJobDetailsOpen: boolean;
   isJobPresetsOpen: boolean;
   isLoading: boolean;
   isManagementUser?: boolean;
+  isPlanningViewOnly: boolean;
   isRouteSheetOpen: boolean;
   isSchedulingRoute: boolean;
   isSingleJobMode: boolean;

--- a/src/features/festival-management/useFestivalManagementVm.ts
+++ b/src/features/festival-management/useFestivalManagementVm.ts
@@ -6,7 +6,13 @@ import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import type { Department } from "@/types/department";
-import { isManagementRole } from "@/utils/permissions";
+import {
+  canEditJobs,
+  canUploadFestivalDocuments,
+  isHouseTechRole,
+  isManagementRole,
+  isTechnicianRole,
+} from "@/utils/permissions";
 import { useFestivalAdminActions } from "@/features/festival-management/hooks/useFestivalAdminActions";
 import { useFestivalDocuments } from "@/features/festival-management/hooks/useFestivalDocuments";
 import { useFestivalFlexControls } from "@/features/festival-management/hooks/useFestivalFlexControls";
@@ -83,12 +89,11 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
   const isSchedulingRoute = location.pathname.includes("/scheduling");
   const isArtistRoute = location.pathname.includes("/artists");
   const isGearRoute = location.pathname.includes("/gear");
-  const canEdit = ["admin", "management", "logistics"].includes(userRole || "");
-  const isHouseTech = userRole === "house_tech";
-  const isViewOnly = userRole === "technician";
-  // House techs get a read-only view of planning + gear setup, but may still upload documents.
+  const canEdit = canEditJobs(userRole);
+  const isHouseTech = isHouseTechRole(userRole);
+  const isViewOnly = isTechnicianRole(userRole) && !isHouseTech;
   const isPlanningViewOnly = isViewOnly || isHouseTech;
-  const canUploadDocuments = canEdit || isHouseTech;
+  const canUploadDocuments = canUploadFestivalDocuments(userRole);
 
   useEffect(() => {
     if (!jobId) {

--- a/src/features/festival-management/useFestivalManagementVm.ts
+++ b/src/features/festival-management/useFestivalManagementVm.ts
@@ -84,7 +84,11 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
   const isArtistRoute = location.pathname.includes("/artists");
   const isGearRoute = location.pathname.includes("/gear");
   const canEdit = ["admin", "management", "logistics"].includes(userRole || "");
+  const isHouseTech = userRole === "house_tech";
   const isViewOnly = userRole === "technician";
+  // House techs get a read-only view of planning + gear setup, but may still upload documents.
+  const isPlanningViewOnly = isViewOnly || isHouseTech;
+  const canUploadDocuments = canEdit || isHouseTech;
 
   useEffect(() => {
     if (!jobId) {
@@ -172,10 +176,13 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
       humanizeDepartment: humanizeFestivalDepartment,
 
       canEdit,
+      canUploadDocuments,
       isArtistRoute,
       isGearRoute,
+      isHouseTech,
       isLoading: jobData.isLoading,
       isManagementUser,
+      isPlanningViewOnly,
       isSchedulingRoute,
       isSingleJobMode,
       isViewOnly,

--- a/src/hooks/useArtistMutations.ts
+++ b/src/hooks/useArtistMutations.ts
@@ -101,6 +101,8 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
   return {
     createArtist: createArtistMutation.mutate,
     updateArtist: updateArtistMutation.mutate,
+    createArtistAsync: createArtistMutation.mutateAsync,
+    updateArtistAsync: updateArtistMutation.mutateAsync,
     isCreating: createArtistMutation.isPending,
     isUpdating: updateArtistMutation.isPending,
   };

--- a/src/hooks/useHouseTechRates.ts
+++ b/src/hooks/useHouseTechRates.ts
@@ -4,13 +4,9 @@ import { toast } from 'sonner';
 import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
 import { recalculateTimesheets } from '@/hooks/useToggleJobRehearsalRate';
 
-/**
- * Recomputes a technician's non-approved timesheets so existing drafts pick up a
- * newly saved custom rate. Approved timesheets are intentionally left untouched
- * to avoid silently changing settled amounts. Failures are logged but never fail
- * the rate save itself (the rate is already persisted at this point).
- */
-async function recalcTechnicianDraftTimesheets(profileId: string): Promise<number> {
+type TimesheetRecalcResult = { count: number; failed: boolean };
+
+async function recalcTechnicianDraftTimesheets(profileId: string): Promise<TimesheetRecalcResult> {
   const { data: timesheets, error } = await supabase
     .from('timesheets')
     .select('id')
@@ -20,17 +16,17 @@ async function recalcTechnicianDraftTimesheets(profileId: string): Promise<numbe
 
   if (error) {
     console.warn('Could not load timesheets to recalc after rate change:', error);
-    return 0;
+    return { count: 0, failed: true };
   }
 
   const ids = (timesheets || []).map((ts) => ts.id);
-  if (ids.length === 0) return 0;
+  if (ids.length === 0) return { count: 0, failed: false };
 
   try {
-    return await recalculateTimesheets(ids);
+    return { count: await recalculateTimesheets(ids), failed: false };
   } catch (recalcError) {
     console.warn('Some timesheets failed to recalc after rate change:', recalcError);
-    return 0;
+    return { count: 0, failed: true };
   }
 }
 
@@ -107,19 +103,18 @@ export function useSaveHouseTechRate() {
 
       // Recompute the technician's existing (non-approved) timesheets so they
       // reflect the new custom rate instead of the previously cached base rate.
-      const recalculated = await recalcTechnicianDraftTimesheets(input.profile_id);
+      const recalc = await recalcTechnicianDraftTimesheets(input.profile_id);
 
-      return { rate: data, recalculated };
+      return { rate: data, recalc };
     },
     onSuccess: (result, variables) => {
       queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.houseTechRate(variables.profile_id) });
       queryClient.invalidateQueries({ queryKey: ['timesheets'] });
-      toast.success(
-        'House tech rate saved successfully',
-        result.recalculated > 0
-          ? { description: `${result.recalculated} parte(s) recalculado(s)` }
-          : undefined,
-      );
+      if (result.recalc.failed) {
+        toast.warning('House tech rate saved, but some draft timesheets could not be recalculated');
+        return;
+      }
+      toast.success('House tech rate saved successfully', result.recalc.count > 0 ? { description: `${result.recalc.count} parte(s) recalculado(s)` } : undefined);
     },
     onError: (error) => {
       console.error('Error saving house tech rate:', error);

--- a/src/hooks/useHouseTechRates.ts
+++ b/src/hooks/useHouseTechRates.ts
@@ -2,6 +2,37 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
+import { recalculateTimesheets } from '@/hooks/useToggleJobRehearsalRate';
+
+/**
+ * Recomputes a technician's non-approved timesheets so existing drafts pick up a
+ * newly saved custom rate. Approved timesheets are intentionally left untouched
+ * to avoid silently changing settled amounts. Failures are logged but never fail
+ * the rate save itself (the rate is already persisted at this point).
+ */
+async function recalcTechnicianDraftTimesheets(profileId: string): Promise<number> {
+  const { data: timesheets, error } = await supabase
+    .from('timesheets')
+    .select('id')
+    .eq('technician_id', profileId)
+    .eq('is_active', true)
+    .neq('status', 'approved');
+
+  if (error) {
+    console.warn('Could not load timesheets to recalc after rate change:', error);
+    return 0;
+  }
+
+  const ids = (timesheets || []).map((ts) => ts.id);
+  if (ids.length === 0) return 0;
+
+  try {
+    return await recalculateTimesheets(ids);
+  } catch (recalcError) {
+    console.warn('Some timesheets failed to recalc after rate change:', recalcError);
+    return 0;
+  }
+}
 
 export interface HouseTechRate {
   profile_id: string;
@@ -73,11 +104,22 @@ export function useSaveHouseTechRate() {
         .single();
 
       if (error) throw error;
-      return data;
+
+      // Recompute the technician's existing (non-approved) timesheets so they
+      // reflect the new custom rate instead of the previously cached base rate.
+      const recalculated = await recalcTechnicianDraftTimesheets(input.profile_id);
+
+      return { rate: data, recalculated };
     },
-    onSuccess: (data, variables) => {
+    onSuccess: (result, variables) => {
       queryClient.invalidateQueries({ queryKey: RATES_QUERY_KEYS.houseTechRate(variables.profile_id) });
-      toast.success('House tech rate saved successfully');
+      queryClient.invalidateQueries({ queryKey: ['timesheets'] });
+      toast.success(
+        'House tech rate saved successfully',
+        result.recalculated > 0
+          ? { description: `${result.recalculated} parte(s) recalculado(s)` }
+          : undefined,
+      );
     },
     onError: (error) => {
       console.error('Error saving house tech rate:', error);

--- a/src/hooks/useHouseTechRates.ts
+++ b/src/hooks/useHouseTechRates.ts
@@ -12,7 +12,7 @@ async function recalcTechnicianDraftTimesheets(profileId: string): Promise<Times
     .select('id')
     .eq('technician_id', profileId)
     .eq('is_active', true)
-    .neq('status', 'approved');
+    .in('status', ['draft', 'rejected']);
 
   if (error) {
     console.warn('Could not load timesheets to recalc after rate change:', error);

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -22,6 +22,8 @@ import { exportFullFestivalSchedulePDF, FullFestivalSchedulePdfData } from "@/ut
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { buildReadableFilename, formatDateForFilename } from "@/utils/fileName";
 import { getEffectiveFestivalDateType } from "@/constants/dateTypes";
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
+import { canCreateFestivalArtistExtras, canDeleteFestivalArtists } from "@/utils/permissions";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -32,6 +34,9 @@ const FestivalArtistManagement = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { toast } = useToast();
+  const { userRole } = useOptimizedAuth();
+  const canDeleteArtists = canDeleteFestivalArtists(userRole);
+  const canCreateArtistExtras = canCreateFestivalArtistExtras(userRole);
   const routeDate = searchParams.get("date") || "";
   
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -331,6 +336,7 @@ const FestivalArtistManagement = () => {
   };
   
   const handleDeleteArtist = async (artist: any) => {
+    if (!canDeleteArtists) return;
     deleteArtist(artist.id);
   };
   
@@ -758,6 +764,8 @@ const FestivalArtistManagement = () => {
                     jobId={jobId}
                     selectedDate={selectedDate}
                     onArtistStagePlotUpdated={invalidateArtists}
+                    canDelete={canDeleteArtists}
+                    canCreateExtras={canCreateArtistExtras}
                   />
                 </div>
               ) : (

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -24,8 +24,6 @@ import { buildReadableFilename, formatDateForFilename } from "@/utils/fileName";
 import { getEffectiveFestivalDateType } from "@/constants/dateTypes";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { canCreateFestivalArtistExtras, canDeleteFestivalArtists } from "@/utils/permissions";
-
-
 import { queryKeys } from "@/lib/react-query";
 const DAY_START_HOUR = 7; // Festival day starts at 7:00 AM
 
@@ -35,8 +33,7 @@ const FestivalArtistManagement = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { toast } = useToast();
   const { userRole } = useOptimizedAuth();
-  const canDeleteArtists = canDeleteFestivalArtists(userRole);
-  const canCreateArtistExtras = canCreateFestivalArtistExtras(userRole);
+  const artistActionPermissions = { canDelete: canDeleteFestivalArtists(userRole), canCreateExtras: canCreateFestivalArtistExtras(userRole) };
   const routeDate = searchParams.get("date") || "";
   
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -60,14 +57,7 @@ const FestivalArtistManagement = () => {
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState(false);
   const [isFullSchedulePrinting, setIsFullSchedulePrinting] = useState(false);
 
-  // Use React Query for artists data
-  const {
-    artists,
-    isLoading: artistsLoading,
-    deleteArtist,
-    isDeletingArtist,
-    invalidateArtists
-  } = useArtistsQuery(jobId, selectedDate, dayStartTime);
+  const { artists, isLoading: artistsLoading, deleteArtist, invalidateArtists } = useArtistsQuery(jobId, selectedDate, dayStartTime);
   const artistRows = artists as unknown as ComponentProps<typeof ArtistTable>["artists"];
   const {
     data: festivalSettings
@@ -335,8 +325,8 @@ const FestivalArtistManagement = () => {
     setIsDialogOpen(true);
   };
   
-  const handleDeleteArtist = async (artist: any) => {
-    if (!canDeleteArtists) return;
+  const handleDeleteArtist = (artist: any) => {
+    if (!artistActionPermissions.canDelete) return;
     deleteArtist(artist.id);
   };
   
@@ -764,8 +754,7 @@ const FestivalArtistManagement = () => {
                     jobId={jobId}
                     selectedDate={selectedDate}
                     onArtistStagePlotUpdated={invalidateArtists}
-                    canDelete={canDeleteArtists}
-                    canCreateExtras={canCreateArtistExtras}
+                    {...artistActionPermissions}
                   />
                 </div>
               ) : (

--- a/src/pages/FestivalGearManagement.tsx
+++ b/src/pages/FestivalGearManagement.tsx
@@ -312,16 +312,19 @@ const FestivalGearManagement = () => {
   };
 
   const handleAddStage = () => {
+    if (!canManageGear) return;
     handleUpdateMaxStages(maxStages + 1);
   };
 
   const handleStartEditStage = (stageNumber: number) => {
+    if (!canManageGear) return;
     const stage = stages.find(s => s.number === stageNumber);
     setEditingStage(stageNumber);
     setEditingStageName(stage?.name || `Stage ${stageNumber}`);
   };
 
   const handleSaveStageEdit = async () => {
+    if (!canManageGear) return;
     if (!editingStage || !editingStageName.trim()) {
       console.log("Save cancelled: missing stage number or name");
       setEditingStage(null);

--- a/src/pages/FestivalGearManagement.tsx
+++ b/src/pages/FestivalGearManagement.tsx
@@ -17,6 +17,8 @@ import { generateAndMergeFestivalPDFs } from "@/utils/pdf/festivalPdfGenerator";
 import { PrintOptions, PrintOptionsDialog } from "@/components/festival/pdf/PrintOptionsDialog";
 import { Badge } from "@/components/ui/badge";
 import { buildReadableFilename } from "@/utils/fileName";
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
+import { canManageFestivalGear } from "@/utils/permissions";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -30,6 +32,8 @@ const FestivalGearManagement = () => {
   const { jobId } = useParams();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { userRole } = useOptimizedAuth();
+  const canManageGear = canManageFestivalGear(userRole);
   const [jobTitle, setJobTitle] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [stages, setStages] = useState<StageInfo[]>([{ number: 1, name: "Stage 1" }]);
@@ -502,10 +506,12 @@ const FestivalGearManagement = () => {
                 Configura los escenarios para tu festival. Haz clic en el nombre de un escenario para editarlo.
               </CardDescription>
             </div>
-            <Button onClick={handleAddStage} size="sm" className="self-start sm:self-auto">
-              <Plus className="h-4 w-4 mr-2" />
-              Añadir Escenario
-            </Button>
+            {canManageGear && (
+              <Button onClick={handleAddStage} size="sm" className="self-start sm:self-auto">
+                <Plus className="h-4 w-4 mr-2" />
+                Añadir Escenario
+              </Button>
+            )}
           </div>
         </CardHeader>
         <CardContent>
@@ -549,7 +555,7 @@ const FestivalGearManagement = () => {
                       </Button>
                     </div>
                   </div>
-                ) : (
+                ) : canManageGear ? (
                   <Button
                     size="sm"
                     variant="ghost"
@@ -558,7 +564,7 @@ const FestivalGearManagement = () => {
                   >
                     <Edit2 className="h-3 w-3" />
                   </Button>
-                )}
+                ) : null}
               </div>
             ))}
           </div>
@@ -602,6 +608,7 @@ const FestivalGearManagement = () => {
               jobId={jobId || ''}
               stageNumber={selectedStage}
               onSave={handleSave}
+              readOnly={!canManageGear}
             />
           </CardContent>
         </Card>

--- a/src/pages/festival-management/FestivalManagementDialogs.tsx
+++ b/src/pages/festival-management/FestivalManagementDialogs.tsx
@@ -26,7 +26,8 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
     navigate,
     isSchedulingRoute,
     jobDates,
-    isViewOnly,
+    isPlanningViewOnly,
+    isHouseTech,
     isManagementUser,
 
     isAssignmentDialogOpen,
@@ -144,11 +145,13 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
         initialOptions={flexPickerOptions}
       />
 
-      <Dialog open={isRouteSheetOpen} onOpenChange={setIsRouteSheetOpen}>
-        <DialogContent className="max-w-[96vw] w-[96vw] max-h-[90vh] md:h-[90vh] p-0 overflow-hidden flex flex-col">
-          <div className="h-full overflow-auto">{jobId && <ModernHojaDeRuta jobId={jobId} />}</div>
-        </DialogContent>
-      </Dialog>
+      {!isHouseTech && (
+        <Dialog open={isRouteSheetOpen} onOpenChange={setIsRouteSheetOpen}>
+          <DialogContent className="max-w-[96vw] w-[96vw] max-h-[90vh] md:h-[90vh] p-0 overflow-hidden flex flex-col">
+            <div className="h-full overflow-auto">{jobId && <ModernHojaDeRuta jobId={jobId} />}</div>
+          </DialogContent>
+        </Dialog>
+      )}
 
       {isSchedulingRoute && (
         <div>
@@ -162,7 +165,7 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
             <FestivalScheduling
               jobId={jobId}
               jobDates={jobDates}
-              isViewOnly={isViewOnly}
+              isViewOnly={isPlanningViewOnly}
               onCreateWhatsappGroup={isManagementUser ? () => setIsWhatsappDialogOpen(true) : undefined}
             />
           ) : (

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -45,7 +45,10 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
     job,
     jobId,
     canEdit,
+    canUploadDocuments,
     isViewOnly,
+    isPlanningViewOnly,
+    isHouseTech,
     navigate,
 
     isSingleJobMode,
@@ -327,7 +330,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                     navigate(`/festival-management/${jobId}/gear`);
                   }}
                 >
-                  {isViewOnly ? "Ver Equipo" : "Gestionar Equipo"}
+                  {isPlanningViewOnly ? "Ver Equipo" : "Gestionar Equipo"}
                 </Button>
               </CardContent>
             </Card>
@@ -356,7 +359,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                     navigate(`/festival-management/${jobId}/scheduling`);
                   }}
                 >
-                  {isViewOnly ? "Ver Planificación" : "Gestionar Planificación"}
+                  {isPlanningViewOnly ? "Ver Planificación" : "Gestionar Planificación"}
                 </Button>
               </CardContent>
             </Card>
@@ -390,6 +393,9 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-3 md:gap-4">
+                {/* House techs may only upload documents — all other quick actions are hidden */}
+                {!isHouseTech && (
+                  <>
                 <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3">
                   <div className="flex items-center justify-between flex-wrap gap-2">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
@@ -524,8 +530,11 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                   </Button>
                 </div>
 
+                  </>
+                )}
+
                 {/* Upload Documents */}
-                {canEdit && (
+                {canUploadDocuments && (
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-blue-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
                       <Upload className="h-4 w-4 flex-shrink-0 text-blue-500" />

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -44,13 +44,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
   const {
     job,
     jobId,
-    canEdit,
-    canUploadDocuments,
-    isViewOnly,
-    isPlanningViewOnly,
-    isHouseTech,
-    navigate,
-
+    canEdit, canUploadDocuments, isPlanningViewOnly, isViewOnly, navigate,
     isSingleJobMode,
     isSchedulingRoute,
     isArtistRoute,
@@ -393,9 +387,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-3 md:gap-4">
-                {/* House techs may only upload documents — all other quick actions are hidden */}
-                {!isHouseTech && (
-                  <>
+                {!isPlanningViewOnly && <>
                 <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3">
                   <div className="flex items-center justify-between flex-wrap gap-2">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
@@ -530,10 +522,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                   </Button>
                 </div>
 
-                  </>
-                )}
-
-                {/* Upload Documents */}
+                </>}
                 {canUploadDocuments && (
                   <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3 bg-gradient-to-br from-background to-blue-500/5">
                     <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">

--- a/src/routes/app-route-manifest.tsx
+++ b/src/routes/app-route-manifest.tsx
@@ -942,7 +942,7 @@ export const appRoutes: readonly AppRoute[] = [
     path: "/hoja-de-ruta",
     component: ModernHojaDeRuta,
     layout: "app",
-    access: "managementAndHouseTech",
+    access: "management",
     subscriptions: "hojaDeRuta",
     breadcrumb: { label: "Hoja de ruta" },
     nav: {

--- a/src/services/ratesService.ts
+++ b/src/services/ratesService.ts
@@ -125,7 +125,9 @@ export async function fetchHouseTechOverrides(): Promise<HouseTechOverrideListIt
   const { data: technicians, error: techniciansError } = await supabase
     .from('profiles')
     .select('id, first_name, last_name, default_timesheet_category, role')
-    .in('role', ['house_tech', 'technician'])
+    // Technicians and house techs always qualify; admin/management users only
+    // when they are flagged assignable as tech (they can be staffed on jobs).
+    .or('role.in.(house_tech,technician),and(assignable_as_tech.eq.true,role.in.(admin,management))')
     .order('first_name', { ascending: true });
 
   if (techniciansError) throw techniciansError;

--- a/src/types/artist-form.ts
+++ b/src/types/artist-form.ts
@@ -59,5 +59,6 @@ export interface ArtistSectionProps {
   onChange: (changes: any) => void;
   gearSetup?: FestivalGearSetup | null;
   isFieldLocked?: (field: string) => boolean;
+  readOnly?: boolean;
   language?: 'es' | 'en';
 }

--- a/src/types/festival-gear.ts
+++ b/src/types/festival-gear.ts
@@ -17,6 +17,7 @@ export interface ConsoleConfigProps {
   consoles: ConsoleSetup[];
   onChange: (consoles: ConsoleSetup[]) => void;
   label: string;
+  readOnly?: boolean;
 }
 
 export interface GearSetupFormData {

--- a/src/utils/permissions.test.ts
+++ b/src/utils/permissions.test.ts
@@ -8,8 +8,14 @@ import {
   canDeleteDocuments,
   canDeleteSoundVisionFiles,
   canDeleteTourDocuments,
+  canCreateFestivalArtistExtras,
+  canDeleteFestivalArtists,
+  canManageFestivalGear,
+  canManageFestivalScheduling,
   canManageJobAssignments,
   canManagePayouts,
+  canUploadFestivalDocuments,
+  isHouseTechRole,
   canPrintFestivalDocuments,
   canReceiveMorningSummary,
   canSubmitTechnicianIncidentReports,
@@ -140,6 +146,32 @@ describe('management role helpers', () => {
     expect(canManageJobAssignments('house_tech')).toBe(true);
     expect(canManageJobAssignments('logistics')).toBe(false);
     expect(canManageJobAssignments('technician')).toBe(false);
+  });
+
+  it('restricts festival planning and gear editing to management, read-only for house techs', () => {
+    expect(isHouseTechRole('house_tech')).toBe(true);
+    expect(isHouseTechRole('management')).toBe(false);
+
+    expect(canManageFestivalScheduling('admin')).toBe(true);
+    expect(canManageFestivalScheduling('management')).toBe(true);
+    expect(canManageFestivalScheduling('house_tech')).toBe(false);
+
+    expect(canManageFestivalGear('management')).toBe(true);
+    expect(canManageFestivalGear('house_tech')).toBe(false);
+  });
+
+  it('lets house techs upload festival documents but not delete artists or create extras', () => {
+    expect(canUploadFestivalDocuments('management')).toBe(true);
+    expect(canUploadFestivalDocuments('logistics')).toBe(true);
+    expect(canUploadFestivalDocuments('house_tech')).toBe(true);
+    expect(canUploadFestivalDocuments('technician')).toBe(false);
+
+    expect(canDeleteFestivalArtists('admin')).toBe(true);
+    expect(canDeleteFestivalArtists('management')).toBe(true);
+    expect(canDeleteFestivalArtists('house_tech')).toBe(false);
+
+    expect(canCreateFestivalArtistExtras('management')).toBe(true);
+    expect(canCreateFestivalArtistExtras('house_tech')).toBe(false);
   });
 
   it('centralizes document and festival print permissions', () => {

--- a/src/utils/permissions.test.ts
+++ b/src/utils/permissions.test.ts
@@ -143,7 +143,7 @@ describe('management role helpers', () => {
   it('centralizes mobile assignment permissions', () => {
     expect(canManageJobAssignments('admin')).toBe(true);
     expect(canManageJobAssignments('management')).toBe(true);
-    expect(canManageJobAssignments('house_tech')).toBe(true);
+    expect(canManageJobAssignments('house_tech')).toBe(false);
     expect(canManageJobAssignments('logistics')).toBe(false);
     expect(canManageJobAssignments('technician')).toBe(false);
   });

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -123,6 +123,23 @@ export const canSubmitTechnicianIncidentReports = (role: UserRole): boolean =>
 export const canManageFestivalArtists = (role: UserRole) =>
   FESTIVAL_ARTIST_ALLOWED_ROLES.includes(role as AppUserRole);
 
+export const isHouseTechRole = (role: UserRole): boolean => role === 'house_tech';
+
+// Festival planning (scheduling) and gear setup are read-only for house techs;
+// only management roles may edit them.
+export const canManageFestivalScheduling = (role: UserRole): boolean => isManagementRole(role);
+
+export const canManageFestivalGear = (role: UserRole): boolean => isManagementRole(role);
+
+// House techs may add/edit artists but must not delete them or create Flex extras budgets.
+export const canDeleteFestivalArtists = (role: UserRole): boolean => isManagementRole(role);
+
+export const canCreateFestivalArtistExtras = (role: UserRole): boolean => isManagementRole(role);
+
+// House techs may upload documents to a job but get no other festival quick actions.
+export const canUploadFestivalDocuments = (role: UserRole): boolean =>
+  canUploadDocuments(role) || isHouseTechRole(role);
+
 export const canUploadSoundVisionFiles = (role: UserRole) =>
   SOUND_VISION_UPLOAD_ALLOWED_ROLES.includes(role as AppUserRole);
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -105,8 +105,9 @@ export const canPrintFestivalDocuments = (role: UserRole) => canUploadDocuments(
 
 export const canCreateFolders = (role: UserRole) => PROJECT_MANAGEMENT_ALLOWED_ROLES.includes(role as AppUserRole);
 
+// House techs may view assignments but must not add or remove them.
 export const canManageJobAssignments = (role: UserRole): boolean =>
-  isManagementRole(role) || role === 'house_tech';
+  isManagementRole(role);
 
 export const canViewAchievements = (role: UserRole): boolean =>
   isTechnicianRole(role) || isManagementRole(role);

--- a/supabase/migrations/20260701120000_align_festival_artist_mutation_policies.sql
+++ b/supabase/migrations/20260701120000_align_festival_artist_mutation_policies.sql
@@ -1,0 +1,22 @@
+drop policy if exists "p_festival_artists_public_delete_8f2ede" on public.festival_artists;
+drop policy if exists "p_festival_artists_public_insert_d3bb11" on public.festival_artists;
+drop policy if exists "p_festival_artists_public_update_4616fe" on public.festival_artists;
+
+create policy "p_festival_artists_public_delete_8f2ede"
+on public.festival_artists
+for delete
+to authenticated
+using (public.get_current_user_role() = any (array['admin'::text, 'management'::text]));
+
+create policy "p_festival_artists_public_insert_d3bb11"
+on public.festival_artists
+for insert
+to authenticated
+with check (public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'house_tech'::text]));
+
+create policy "p_festival_artists_public_update_4616fe"
+on public.festival_artists
+for update
+to authenticated
+using (public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'house_tech'::text]))
+with check (public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'house_tech'::text]));

--- a/supabase/tests/database/festival_artist_permissions.sql
+++ b/supabase/tests/database/festival_artist_permissions.sql
@@ -1,0 +1,87 @@
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+SET search_path TO public, extensions;
+
+SELECT plan(6);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artists'
+      AND policyname IN (
+        'p_festival_artists_public_delete_8f2ede',
+        'p_festival_artists_public_insert_d3bb11',
+        'p_festival_artists_public_update_4616fe'
+      )
+  ),
+  3,
+  'festival_artists keeps the expected mutation policies'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artists'
+      AND cmd IN ('INSERT', 'UPDATE', 'DELETE')
+      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%logistics%'
+  ),
+  'festival_artists mutation policies do not allow logistics'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artists'
+      AND cmd = 'INSERT'
+      AND with_check ILIKE '%house_tech%'
+  ),
+  'house techs may insert festival artists'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artists'
+      AND cmd = 'UPDATE'
+      AND qual ILIKE '%house_tech%'
+      AND with_check ILIKE '%house_tech%'
+  ),
+  'house techs may update festival artists'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artists'
+      AND cmd = 'DELETE'
+      AND qual ILIKE '%admin%'
+      AND qual ILIKE '%management%'
+      AND qual NOT ILIKE '%house_tech%'
+      AND qual NOT ILIKE '%logistics%'
+  ),
+  'festival artist deletes remain management-only'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artists'
+      AND cmd = 'SELECT'
+      AND qual ILIKE '%house_tech%'
+  ),
+  'house techs retain festival artist read access'
+);
+
+SELECT * FROM finish();


### PR DESCRIPTION
## Summary
- Restricts house-tech festival access to locked-down planning/gear views and document upload only where intended.
- Keeps festival artists add/editable for house techs, while moving delete and Flex extras creation to management-only UI and RLS permissions.
- Hardens read-only gear setup controls and internal action handlers so hidden buttons are not the only authorization boundary.
- Fixes review findings around redundant role checks, swallowed timesheet recalculation failures, and stale artist-dialog success behavior.

## Impact
- House tech users can view required festival planning/gear context and upload documents, but cannot manage gear stages, delete artists, create extras, or access hoja de ruta actions.
- Management/admin users retain the full festival management workflow.
- Logistics users no longer have direct `festival_artists` mutation access through RLS.

## Tests
- `npm run lint`
- `npm run typecheck`
- `npm run governance`
- `npm run test:critical`
- `npm run test:run`
- `npm run build`
- `npm run budget:bundle`
- `npm run test:e2e`
- `supabase db reset --local --no-seed`
- `supabase db lint --local --fail-on error --schema public,auth`
- `supabase test db supabase/tests/database`

## Database / Migration
- Adds `20260701120000_align_festival_artist_mutation_policies.sql` to realign `festival_artists` mutation policies with app routes.
- Delete is admin/management only.
- Insert/update are admin/management/house_tech.
- Logistics is removed from direct insert/update/delete policies.
- Adds pgtap coverage in `supabase/tests/database/festival_artist_permissions.sql`.

## Risk
- Medium: this changes authorization behavior for festival artist mutations.
- Primary compatibility risk is any hidden logistics-only workflow that previously wrote directly to `festival_artists`; this should now go through management/house-tech flows or explicit RPCs if needed.

## Rollback
- Revert this PR to restore the prior UI gates and database policies.
- If only the database policy change needs rollback, apply a follow-up migration restoring the previous `festival_artists` mutation policy role sets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only mode across festival gear/setup forms and related controls.
  * Introduced role-based visibility for artist actions, extra creation, and document upload.
  * Updated festival management views to show different actions for house tech vs. management roles.

* **Bug Fixes**
  * Fixed delete and extras actions so they only appear when permitted.
  * Improved layout behavior in the technician timesheet view and mobile navigation bar.

* **Tests**
  * Added and updated permission coverage for festival artist, gear, and scheduling access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->