### PR TITLE
[codex] Add WAHA endpoint status controls

### DIFF
--- a/src/components/settings/WahaEndpointSettings.tsx
+++ b/src/components/settings/WahaEndpointSettings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, QrCode, RefreshCw, Save, Smartphone, Unplug } from "lucide-react";
+import { Loader2, QrCode, RefreshCw, RotateCcw, Save, Smartphone, Unplug } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -10,6 +10,7 @@ import {
   getWahaEndpointLabel,
   normalizeWahaEndpoint,
   NO_WAHA_ENDPOINT,
+  type WahaEndpointOption,
   WAHA_ENDPOINTS,
 } from "@/constants/wahaEndpoints";
 import { toast } from "@/hooks/use-toast";
@@ -17,7 +18,14 @@ import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { queryKeys } from "@/lib/react-query";
 import { dataLayerClient } from "@/services/dataLayerClient";
 
-type WahaSessionStatus = "NOT_CONFIGURED" | "NOT_CREATED" | "STOPPED" | "STARTING" | "SCAN_QR_CODE" | "WORKING" | "FAILED" | "UNKNOWN";
+type WahaSessionStatus = "NOT_CONFIGURED" | "NOT_CREATED" | "STOPPED" | "STARTING" | "SCAN_QR_CODE" | "WORKING" | "FAILED" | "UNKNOWN" | "UNREACHABLE";
+
+type WahaEndpointStatus = WahaEndpointOption & {
+  session?: string | null;
+  status?: WahaSessionStatus | string | null;
+  me?: { id?: string; pushName?: string } | null;
+  error?: string | null;
+};
 
 type WahaSessionResponse = {
   endpoint: string | null;
@@ -28,6 +36,7 @@ type WahaSessionResponse = {
     dataUrl: string;
     mimetype: string;
   };
+  endpoints?: WahaEndpointStatus[];
 };
 
 async function invokeWahaSession(body: Record<string, unknown>) {
@@ -54,6 +63,8 @@ function statusLabel(status: string | null | undefined) {
       return "Sin iniciar";
     case "NOT_CONFIGURED":
       return "Sin configurar";
+    case "UNREACHABLE":
+      return "Sin respuesta";
     default:
       return "Desconocido";
   }
@@ -61,9 +72,13 @@ function statusLabel(status: string | null | undefined) {
 
 function statusVariant(status: string | null | undefined): "default" | "secondary" | "destructive" | "outline" {
   if (status === "WORKING") return "default";
-  if (status === "FAILED") return "destructive";
+  if (status === "FAILED" || status === "UNREACHABLE") return "destructive";
   if (status === "SCAN_QR_CODE" || status === "STARTING") return "secondary";
   return "outline";
+}
+
+function endpointHost(endpoint: string) {
+  return endpoint.replace(/^https?:\/\//, "");
 }
 
 export function WahaEndpointSettings() {
@@ -74,11 +89,23 @@ export function WahaEndpointSettings() {
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
 
   const queryKey = queryKeys.scope("waha-session", userId || "anonymous");
+  const endpointDirectoryQueryKey = queryKeys.scope("waha-session-endpoints", userId || "anonymous");
   const { data, isLoading, isFetching, error, refetch } = useQuery({
     queryKey,
     enabled: Boolean(userId),
     queryFn: () => invokeWahaSession({ action: "get" }),
     staleTime: 1000 * 30,
+  });
+  const {
+    data: endpointDirectory,
+    isFetching: isFetchingEndpointDirectory,
+    refetch: refetchEndpointDirectory,
+  } = useQuery({
+    queryKey: endpointDirectoryQueryKey,
+    enabled: Boolean(userId),
+    queryFn: () => invokeWahaSession({ action: "endpoints" }),
+    retry: false,
+    staleTime: 1000 * 60,
   });
 
   const savedEndpoint = normalizeWahaEndpoint(data?.endpoint);
@@ -92,26 +119,91 @@ export function WahaEndpointSettings() {
     setQrDataUrl(null);
   }, [savedEndpoint]);
 
-  const endpointOptions = useMemo(() => {
-    if (!savedEndpoint || WAHA_ENDPOINTS.some((option) => option.value === savedEndpoint)) {
-      return WAHA_ENDPOINTS;
+  const endpointOptions = useMemo<WahaEndpointStatus[]>(() => {
+    const configuredOptions = endpointDirectory?.endpoints?.length
+      ? endpointDirectory.endpoints
+      : data?.endpoints?.length
+        ? data.endpoints
+        : WAHA_ENDPOINTS;
+    const optionsByValue = new Map<string, WahaEndpointStatus>();
+
+    for (const option of configuredOptions) {
+      const normalized = normalizeWahaEndpoint(option.value);
+      if (!normalized) continue;
+
+      optionsByValue.set(normalized, {
+        ...option,
+        label: option.label || getWahaEndpointLabel(normalized),
+        value: normalized,
+      });
     }
 
-    return [
-      ...WAHA_ENDPOINTS,
-      { label: "Endpoint configurado", value: savedEndpoint },
-    ];
-  }, [savedEndpoint]);
+    if (savedEndpoint && !optionsByValue.has(savedEndpoint)) {
+      optionsByValue.set(savedEndpoint, {
+        label: getWahaEndpointLabel(savedEndpoint),
+        value: savedEndpoint,
+        session: data?.session,
+        status: data?.status,
+        me: data?.me,
+      });
+    }
+
+    return [...optionsByValue.values()].sort((a, b) => a.label.localeCompare(b.label, undefined, { numeric: true }));
+  }, [data?.endpoints, data?.me, data?.session, data?.status, endpointDirectory?.endpoints, savedEndpoint]);
+
+  const endpointStatusByValue = useMemo(() => {
+    return new Map(endpointOptions.map((option) => [option.value, option]));
+  }, [endpointOptions]);
+  const selectedEndpointStatus = selectedNormalized
+    ? endpointStatusByValue.get(selectedNormalized)?.status
+    : "NOT_CONFIGURED";
+  const displayedStatus = savedEndpoint && selectedNormalized === savedEndpoint && data?.status && data.status !== "UNKNOWN"
+    ? data.status
+    : selectedEndpointStatus || data?.status;
+
+  const updateSessionCaches = (result: WahaSessionResponse) => {
+    queryClient.setQueryData(queryKey, result);
+
+    if (!result.endpoint) return;
+
+    const normalizedResultEndpoint = normalizeWahaEndpoint(result.endpoint);
+    if (!normalizedResultEndpoint) return;
+
+    queryClient.setQueryData<WahaSessionResponse | undefined>(endpointDirectoryQueryKey, (current) => {
+      if (!current?.endpoints?.length) return current;
+
+      return {
+        ...current,
+        endpoint: result.endpoint,
+        session: result.session,
+        status: result.status,
+        me: result.me,
+        endpoints: current.endpoints.map((option) => {
+          const normalizedOptionEndpoint = normalizeWahaEndpoint(option.value);
+          if (normalizedOptionEndpoint !== normalizedResultEndpoint) return option;
+
+          return {
+            ...option,
+            session: result.session,
+            status: result.status,
+            me: result.me,
+            error: null,
+          };
+        }),
+      };
+    });
+  };
 
   const saveMutation = useMutation({
     mutationFn: () => invokeWahaSession({ action: "save", endpoint: selectedNormalized }),
-    onSuccess: async (result) => {
+    onSuccess: (result) => {
       setQrDataUrl(null);
-      await queryClient.setQueryData(queryKey, result);
+      updateSessionCaches(result);
       toast({
         title: result.endpoint ? "Endpoint WAHA guardado" : "Endpoint WAHA eliminado",
         description: result.endpoint ? getWahaEndpointLabel(result.endpoint) : "El envio por WhatsApp queda desactivado para esta cuenta.",
       });
+      void refetchEndpointDirectory();
     },
     onError: (err) => {
       toast({
@@ -124,9 +216,9 @@ export function WahaEndpointSettings() {
 
   const statusMutation = useMutation({
     mutationFn: () => invokeWahaSession({ action: "status" }),
-    onSuccess: async (result) => {
+    onSuccess: (result) => {
       setQrDataUrl(null);
-      await queryClient.setQueryData(queryKey, result);
+      updateSessionCaches(result);
     },
     onError: (err) => {
       toast({
@@ -139,9 +231,9 @@ export function WahaEndpointSettings() {
 
   const startMutation = useMutation({
     mutationFn: () => invokeWahaSession({ action: "start" }),
-    onSuccess: async (result) => {
+    onSuccess: (result) => {
       setQrDataUrl(null);
-      await queryClient.setQueryData(queryKey, result);
+      updateSessionCaches(result);
       toast({
         title: "Sesion WAHA iniciada",
         description: `La sesion ${result.session || "default"} esta ${statusLabel(result.status).toLowerCase()}.`,
@@ -156,15 +248,34 @@ export function WahaEndpointSettings() {
     },
   });
 
+  const restartMutation = useMutation({
+    mutationFn: () => invokeWahaSession({ action: "restart" }),
+    onSuccess: (result) => {
+      setQrDataUrl(null);
+      updateSessionCaches(result);
+      toast({
+        title: "Sesion WAHA reiniciada",
+        description: `La sesion ${result.session || "default"} esta ${statusLabel(result.status).toLowerCase()}.`,
+      });
+    },
+    onError: (err) => {
+      toast({
+        title: "No se pudo reiniciar la sesion WAHA",
+        description: err instanceof Error ? err.message : "Error desconocido",
+        variant: "destructive",
+      });
+    },
+  });
+
   const qrMutation = useMutation({
     mutationFn: () => invokeWahaSession({ action: "qr" }),
-    onSuccess: async (result) => {
+    onSuccess: (result) => {
       if (result.qr?.dataUrl) {
         setQrDataUrl(result.qr.dataUrl);
       } else {
         setQrDataUrl(null);
       }
-      await queryClient.setQueryData(queryKey, {
+      updateSessionCaches({
         ...result,
         qr: undefined,
       });
@@ -183,6 +294,7 @@ export function WahaEndpointSettings() {
     saveMutation.isPending ||
     statusMutation.isPending ||
     startMutation.isPending ||
+    restartMutation.isPending ||
     qrMutation.isPending;
   const canUseSessionControls = Boolean(savedEndpoint) && !hasUnsavedChange && !isBusy;
 
@@ -218,8 +330,8 @@ export function WahaEndpointSettings() {
         <div className="space-y-2">
           <div className="flex items-center justify-between gap-3">
             <span className="text-sm font-medium">Endpoint</span>
-            <Badge variant={statusVariant(data?.status)}>
-              {statusLabel(data?.status)}
+            <Badge variant={statusVariant(displayedStatus)}>
+              {statusLabel(displayedStatus)}
             </Badge>
           </div>
           <Select value={selectedEndpoint} onValueChange={setSelectedEndpoint} disabled={saveMutation.isPending}>
@@ -232,7 +344,16 @@ export function WahaEndpointSettings() {
               </SelectItem>
               {endpointOptions.map((option) => (
                 <SelectItem key={option.value} value={option.value}>
-                  {option.label} - {option.value.replace(/^https?:\/\//, "")}
+                  <span className="flex min-w-0 items-center justify-between gap-3">
+                    <span className="truncate">
+                      {option.label} - {endpointHost(option.value)}
+                    </span>
+                    {option.status && (
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {statusLabel(option.status)}
+                      </span>
+                    )}
+                  </span>
                 </SelectItem>
               ))}
             </SelectContent>
@@ -255,7 +376,7 @@ export function WahaEndpointSettings() {
         </Button>
       </div>
 
-      <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
         <Button
           type="button"
           variant="outline"
@@ -263,15 +384,17 @@ export function WahaEndpointSettings() {
           onClick={() => {
             if (savedEndpoint && !hasUnsavedChange) {
               statusMutation.mutate();
+              void refetchEndpointDirectory();
               return;
             }
 
             void refetch();
+            void refetchEndpointDirectory();
           }}
-          disabled={isFetching || isBusy}
+          disabled={isFetching || isFetchingEndpointDirectory || isBusy}
           className="w-full"
         >
-          <RefreshCw className={`mr-2 h-4 w-4 ${isFetching || statusMutation.isPending ? "animate-spin" : ""}`} />
+          <RefreshCw className={`mr-2 h-4 w-4 ${isFetching || isFetchingEndpointDirectory || statusMutation.isPending ? "animate-spin" : ""}`} />
           Actualizar
         </Button>
         <Button
@@ -291,11 +414,26 @@ export function WahaEndpointSettings() {
         </Button>
         <Button
           type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => restartMutation.mutate()}
+          disabled={!canUseSessionControls}
+          className="w-full"
+        >
+          {restartMutation.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <RotateCcw className="mr-2 h-4 w-4" />
+          )}
+          Reiniciar
+        </Button>
+        <Button
+          type="button"
           variant="secondary"
           size="sm"
           onClick={() => qrMutation.mutate()}
           disabled={!canUseSessionControls}
-          className="col-span-2 w-full md:col-span-1"
+          className="w-full"
         >
           {qrMutation.isPending ? (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -304,6 +442,31 @@ export function WahaEndpointSettings() {
           )}
           QR
         </Button>
+      </div>
+
+      <div className="rounded-md border p-3 text-sm">
+        <div className="flex items-center justify-between gap-3">
+          <span className="font-medium">Estado de endpoints</span>
+          {isFetchingEndpointDirectory && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Actualizando
+            </span>
+          )}
+        </div>
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          {endpointOptions.map((option) => (
+            <div key={option.value} className="flex min-w-0 items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2">
+              <span className="min-w-0">
+                <span className="block truncate font-medium">{option.label}</span>
+                <span className="block truncate text-xs text-muted-foreground">{endpointHost(option.value)}</span>
+              </span>
+              <Badge variant={statusVariant(option.status)} className="shrink-0">
+                {statusLabel(option.status)}
+              </Badge>
+            </div>
+          ))}
+        </div>
       </div>
 
       {hasUnsavedChange && (
@@ -323,7 +486,7 @@ export function WahaEndpointSettings() {
         <div className="rounded-md border p-3 text-sm">
           <div className="grid gap-1 sm:grid-cols-2">
             <span>
-              <span className="font-medium">Servidor:</span> {savedEndpoint.replace(/^https?:\/\//, "")}
+              <span className="font-medium">Servidor:</span> {endpointHost(savedEndpoint)}
             </span>
             <span>
               <span className="font-medium">Sesion:</span> {data?.session || "default"}

--- a/src/components/settings/WahaEndpointSettings.tsx
+++ b/src/components/settings/WahaEndpointSettings.tsx
@@ -162,7 +162,10 @@ export function WahaEndpointSettings() {
     : selectedEndpointStatus || data?.status;
 
   const updateSessionCaches = (result: WahaSessionResponse) => {
-    queryClient.setQueryData(queryKey, result);
+    queryClient.setQueryData<WahaSessionResponse | undefined>(queryKey, (current) => ({
+      ...result,
+      endpoints: result.endpoints ?? current?.endpoints,
+    }));
 
     if (!result.endpoint) return;
 

--- a/src/components/settings/__tests__/WahaEndpointSettings.test.tsx
+++ b/src/components/settings/__tests__/WahaEndpointSettings.test.tsx
@@ -29,6 +29,27 @@ vi.mock("@/hooks/use-toast", () => ({
 
 import { WahaEndpointSettings } from "@/components/settings/WahaEndpointSettings";
 
+type FunctionInvokeOptions = {
+  body?: Record<string, unknown>;
+};
+
+type MockFunctionResult = {
+  data: unknown;
+  error: Error | null;
+};
+
+function mockInvokeByAction(
+  handlers: Record<string, (options: FunctionInvokeOptions) => MockFunctionResult>,
+  fallback: (options: FunctionInvokeOptions) => MockFunctionResult,
+) {
+  mockSupabase.functions.invoke.mockImplementation(async (_name, options: FunctionInvokeOptions = {}) => {
+    const action = typeof options.body?.action === "string" ? options.body.action : "get";
+    const handler = handlers[action];
+
+    return handler ? handler(options) : fallback(options);
+  });
+}
+
 describe("WahaEndpointSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,31 +63,25 @@ describe("WahaEndpointSettings", () => {
   it("refreshes WAHA status for the saved endpoint", async () => {
     const user = userEvent.setup();
 
-    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
-      const action = options?.body?.action;
-
-      if (action === "status") {
-        return {
-          data: {
-            endpoint: "https://waha2.sector-pro.work",
-            session: "default",
-            status: "WORKING",
-            me: { pushName: "Sector Pro" },
-          },
-          error: null,
-        };
-      }
-
-      return {
+    mockInvokeByAction({
+      status: () => ({
         data: {
           endpoint: "https://waha2.sector-pro.work",
           session: "default",
-          status: "UNKNOWN",
-          me: null,
+          status: "WORKING",
+          me: { pushName: "Sector Pro" },
         },
         error: null,
-      };
-    });
+      }),
+    }, () => ({
+      data: {
+        endpoint: "https://waha2.sector-pro.work",
+        session: "default",
+        status: "UNKNOWN",
+        me: null,
+      },
+      error: null,
+    }));
 
     renderWithProviders(<WahaEndpointSettings />);
 
@@ -87,31 +102,25 @@ describe("WahaEndpointSettings", () => {
   it("saves a generated WAHA 6 endpoint", async () => {
     const user = userEvent.setup();
 
-    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
-      const action = options?.body?.action;
-
-      if (action === "save") {
-        return {
-          data: {
-            endpoint: options.body.endpoint,
-            session: "default",
-            status: "UNKNOWN",
-            me: null,
-          },
-          error: null,
-        };
-      }
-
-      return {
+    mockInvokeByAction({
+      save: (options) => ({
         data: {
-          endpoint: null,
+          endpoint: options.body?.endpoint ?? null,
           session: "default",
-          status: "NOT_CONFIGURED",
+          status: "UNKNOWN",
           me: null,
         },
         error: null,
-      };
-    });
+      }),
+    }, () => ({
+      data: {
+        endpoint: null,
+        session: "default",
+        status: "NOT_CONFIGURED",
+        me: null,
+      },
+      error: null,
+    }));
 
     renderWithProviders(<WahaEndpointSettings />);
 
@@ -140,47 +149,41 @@ describe("WahaEndpointSettings", () => {
   it("shows endpoint directory statuses in the config menu", async () => {
     const user = userEvent.setup();
 
-    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
-      const action = options?.body?.action;
-
-      if (action === "endpoints") {
-        return {
-          data: {
-            endpoint: "https://waha2.sector-pro.work",
-            session: "default",
-            status: "UNKNOWN",
-            me: null,
-            endpoints: [
-              {
-                label: "WAHA 2",
-                value: "https://waha2.sector-pro.work",
-                session: "default",
-                status: "WORKING",
-                me: { pushName: "Sector Pro" },
-              },
-              {
-                label: "WAHA 6",
-                value: "https://waha6.sector-pro.work",
-                session: "default",
-                status: "STOPPED",
-                me: null,
-              },
-            ],
-          },
-          error: null,
-        };
-      }
-
-      return {
+    mockInvokeByAction({
+      endpoints: () => ({
         data: {
           endpoint: "https://waha2.sector-pro.work",
           session: "default",
           status: "UNKNOWN",
           me: null,
+          endpoints: [
+            {
+              label: "WAHA 2",
+              value: "https://waha2.sector-pro.work",
+              session: "default",
+              status: "WORKING",
+              me: { pushName: "Sector Pro" },
+            },
+            {
+              label: "WAHA 6",
+              value: "https://waha6.sector-pro.work",
+              session: "default",
+              status: "STOPPED",
+              me: null,
+            },
+          ],
         },
         error: null,
-      };
-    });
+      }),
+    }, () => ({
+      data: {
+        endpoint: "https://waha2.sector-pro.work",
+        session: "default",
+        status: "UNKNOWN",
+        me: null,
+      },
+      error: null,
+    }));
 
     renderWithProviders(<WahaEndpointSettings />);
 
@@ -195,31 +198,25 @@ describe("WahaEndpointSettings", () => {
   it("restarts the saved WAHA session", async () => {
     const user = userEvent.setup();
 
-    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
-      const action = options?.body?.action;
-
-      if (action === "restart") {
-        return {
-          data: {
-            endpoint: "https://waha.sector-pro.work",
-            session: "default",
-            status: "WORKING",
-            me: { pushName: "Sector Pro" },
-          },
-          error: null,
-        };
-      }
-
-      return {
+    mockInvokeByAction({
+      restart: () => ({
         data: {
           endpoint: "https://waha.sector-pro.work",
           session: "default",
-          status: "FAILED",
-          me: null,
+          status: "WORKING",
+          me: { pushName: "Sector Pro" },
         },
         error: null,
-      };
-    });
+      }),
+    }, () => ({
+      data: {
+        endpoint: "https://waha.sector-pro.work",
+        session: "default",
+        status: "FAILED",
+        me: null,
+      },
+      error: null,
+    }));
 
     renderWithProviders(<WahaEndpointSettings />);
 
@@ -239,39 +236,67 @@ describe("WahaEndpointSettings", () => {
     );
   });
 
+  it("shows an error toast when WAHA restart fails", async () => {
+    const user = userEvent.setup();
+
+    mockInvokeByAction({
+      restart: () => ({
+        data: null,
+        error: new Error("restart failed"),
+      }),
+    }, () => ({
+      data: {
+        endpoint: "https://waha.sector-pro.work",
+        session: "default",
+        status: "FAILED",
+        me: null,
+      },
+      error: null,
+    }));
+
+    renderWithProviders(<WahaEndpointSettings />);
+
+    await screen.findByText(/WAHA 1 - waha\.sector-pro\.work/i);
+    await user.click(screen.getByRole("button", { name: /reiniciar/i }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "No se pudo reiniciar la sesion WAHA",
+          description: "restart failed",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
   it("renders the pairing QR returned by the proxy", async () => {
     const user = userEvent.setup();
     const dataUrl = "data:image/png;base64,abc123";
 
-    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
-      const action = options?.body?.action;
-
-      if (action === "qr") {
-        return {
-          data: {
-            endpoint: "https://waha.sector-pro.work",
-            session: "default",
-            status: "SCAN_QR_CODE",
-            me: null,
-            qr: {
-              dataUrl,
-              mimetype: "image/png",
-            },
-          },
-          error: null,
-        };
-      }
-
-      return {
+    mockInvokeByAction({
+      qr: () => ({
         data: {
           endpoint: "https://waha.sector-pro.work",
           session: "default",
           status: "SCAN_QR_CODE",
           me: null,
+          qr: {
+            dataUrl,
+            mimetype: "image/png",
+          },
         },
         error: null,
-      };
-    });
+      }),
+    }, () => ({
+      data: {
+        endpoint: "https://waha.sector-pro.work",
+        session: "default",
+        status: "SCAN_QR_CODE",
+        me: null,
+      },
+      error: null,
+    }));
 
     renderWithProviders(<WahaEndpointSettings />);
 

--- a/src/components/settings/__tests__/WahaEndpointSettings.test.tsx
+++ b/src/components/settings/__tests__/WahaEndpointSettings.test.tsx
@@ -84,7 +84,7 @@ describe("WahaEndpointSettings", () => {
     expect(screen.getByText((_, element) => element?.textContent === "Cuenta vinculada: Sector Pro")).toBeInTheDocument();
   });
 
-  it("saves a selected WAHA endpoint", async () => {
+  it("saves a generated WAHA 6 endpoint", async () => {
     const user = userEvent.setup();
 
     mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
@@ -118,14 +118,14 @@ describe("WahaEndpointSettings", () => {
     await screen.findByText(/No hay un endpoint WAHA asignado/i);
 
     await user.click(screen.getByRole("combobox", { name: /endpoint waha/i }));
-    await user.click(await screen.findByRole("option", { name: /WAHA 3 - waha3\.sector-pro\.work/i }));
+    await user.click(await screen.findByRole("option", { name: /WAHA 6 - waha6\.sector-pro\.work/i }));
     await user.click(screen.getByRole("button", { name: /guardar/i }));
 
     await waitFor(() => {
       expect(mockSupabase.functions.invoke).toHaveBeenCalledWith("waha-session", {
         body: {
           action: "save",
-          endpoint: "https://waha3.sector-pro.work",
+          endpoint: "https://waha6.sector-pro.work",
         },
       });
     });
@@ -133,6 +133,108 @@ describe("WahaEndpointSettings", () => {
     expect(toastMock).toHaveBeenCalledWith(
       expect.objectContaining({
         title: "Endpoint WAHA guardado",
+      }),
+    );
+  });
+
+  it("shows endpoint directory statuses in the config menu", async () => {
+    const user = userEvent.setup();
+
+    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
+      const action = options?.body?.action;
+
+      if (action === "endpoints") {
+        return {
+          data: {
+            endpoint: "https://waha2.sector-pro.work",
+            session: "default",
+            status: "UNKNOWN",
+            me: null,
+            endpoints: [
+              {
+                label: "WAHA 2",
+                value: "https://waha2.sector-pro.work",
+                session: "default",
+                status: "WORKING",
+                me: { pushName: "Sector Pro" },
+              },
+              {
+                label: "WAHA 6",
+                value: "https://waha6.sector-pro.work",
+                session: "default",
+                status: "STOPPED",
+                me: null,
+              },
+            ],
+          },
+          error: null,
+        };
+      }
+
+      return {
+        data: {
+          endpoint: "https://waha2.sector-pro.work",
+          session: "default",
+          status: "UNKNOWN",
+          me: null,
+        },
+        error: null,
+      };
+    });
+
+    renderWithProviders(<WahaEndpointSettings />);
+
+    expect(await screen.findByText("Estado de endpoints")).toBeInTheDocument();
+    expect(await screen.findByText("waha6.sector-pro.work")).toBeInTheDocument();
+    expect(screen.getByText("Detenida")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: /endpoint waha/i }));
+    expect(await screen.findByRole("option", { name: /WAHA 6 - waha6\.sector-pro\.work/i })).toBeInTheDocument();
+  });
+
+  it("restarts the saved WAHA session", async () => {
+    const user = userEvent.setup();
+
+    mockSupabase.functions.invoke.mockImplementation(async (_name, options) => {
+      const action = options?.body?.action;
+
+      if (action === "restart") {
+        return {
+          data: {
+            endpoint: "https://waha.sector-pro.work",
+            session: "default",
+            status: "WORKING",
+            me: { pushName: "Sector Pro" },
+          },
+          error: null,
+        };
+      }
+
+      return {
+        data: {
+          endpoint: "https://waha.sector-pro.work",
+          session: "default",
+          status: "FAILED",
+          me: null,
+        },
+        error: null,
+      };
+    });
+
+    renderWithProviders(<WahaEndpointSettings />);
+
+    await screen.findByText(/WAHA 1 - waha\.sector-pro\.work/i);
+    await user.click(screen.getByRole("button", { name: /reiniciar/i }));
+
+    await waitFor(() => {
+      expect(mockSupabase.functions.invoke).toHaveBeenCalledWith("waha-session", {
+        body: { action: "restart" },
+      });
+    });
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Sesion WAHA reiniciada",
       }),
     );
   });

--- a/src/constants/wahaEndpoints.ts
+++ b/src/constants/wahaEndpoints.ts
@@ -1,10 +1,46 @@
-export const WAHA_ENDPOINTS = [
-  { label: "WAHA 1", value: "https://waha.sector-pro.work" },
-  { label: "WAHA 2", value: "https://waha2.sector-pro.work" },
-  { label: "WAHA 3", value: "https://waha3.sector-pro.work" },
-  { label: "WAHA 4", value: "https://waha4.sector-pro.work" },
-  { label: "WAHA 5", value: "https://waha5.sector-pro.work" },
-] as const;
+export type WahaEndpointOption = {
+  label: string;
+  value: string;
+};
+
+const DEFAULT_WAHA_ENDPOINT_FAMILY_SIZE = 6;
+const WAHA_ENDPOINT_ROOT_DOMAIN = "sector-pro.work";
+
+function wahaEndpointForIndex(index: number) {
+  return index === 1
+    ? `https://waha.${WAHA_ENDPOINT_ROOT_DOMAIN}`
+    : `https://waha${index}.${WAHA_ENDPOINT_ROOT_DOMAIN}`;
+}
+
+function getWahaEndpointIndex(endpoint: string | null | undefined) {
+  const normalized = normalizeWahaEndpoint(endpoint);
+  if (!normalized) return null;
+
+  try {
+    const host = new URL(normalized).hostname.toLowerCase();
+    const match = host.match(/^waha(\d*)\.sector-pro\.work$/);
+    if (!match) return null;
+
+    return match[1] ? Number(match[1]) : 1;
+  } catch {
+    return null;
+  }
+}
+
+export function buildWahaEndpointOptions(count = DEFAULT_WAHA_ENDPOINT_FAMILY_SIZE): WahaEndpointOption[] {
+  const safeCount = Number.isFinite(count) ? Math.max(1, Math.floor(count)) : DEFAULT_WAHA_ENDPOINT_FAMILY_SIZE;
+
+  return Array.from({ length: safeCount }, (_, index) => {
+    const endpointIndex = index + 1;
+
+    return {
+      label: `WAHA ${endpointIndex}`,
+      value: wahaEndpointForIndex(endpointIndex),
+    };
+  });
+}
+
+export const WAHA_ENDPOINTS = buildWahaEndpointOptions();
 
 export const NO_WAHA_ENDPOINT = "__none__";
 
@@ -18,5 +54,7 @@ export function normalizeWahaEndpoint(value: string | null | undefined) {
 export function getWahaEndpointLabel(endpoint: string | null | undefined) {
   const normalized = normalizeWahaEndpoint(endpoint);
   const match = WAHA_ENDPOINTS.find((option) => option.value === normalized);
-  return match?.label || normalized || "Sin endpoint";
+  const generatedIndex = getWahaEndpointIndex(normalized);
+
+  return match?.label || (generatedIndex ? `WAHA ${generatedIndex}` : normalized) || "Sin endpoint";
 }

--- a/supabase/functions/waha-session/index.ts
+++ b/supabase/functions/waha-session/index.ts
@@ -11,7 +11,7 @@ import {
 } from "../_shared/http.ts";
 import { normalizeBaseUrl } from "../_shared/waha.ts";
 
-type Action = "get" | "save" | "status" | "start" | "qr";
+type Action = "get" | "save" | "status" | "start" | "restart" | "qr" | "endpoints";
 
 type RequestBody = Record<string, unknown> & {
   action?: unknown;
@@ -38,38 +38,96 @@ type WahaSessionInfo = {
   } | null;
 };
 
-// Keep in sync with src/constants/wahaEndpoints.ts. Edge Functions cannot import
-// the frontend module directly, so the server keeps its own allow-list copy.
-const DEFAULT_ENDPOINTS = [
-  "https://waha.sector-pro.work",
-  "https://waha2.sector-pro.work",
-  "https://waha3.sector-pro.work",
-  "https://waha4.sector-pro.work",
-  "https://waha5.sector-pro.work",
-];
+type WahaEndpointOption = {
+  label: string;
+  value: string;
+};
 
-const ACTIONS = ["get", "save", "status", "start", "qr"] as const;
+type WahaEndpointStatus = WahaEndpointOption & {
+  session: string;
+  status: string;
+  me: WahaSessionInfo["me"];
+  error?: string | null;
+};
+
+const DEFAULT_ENDPOINT_FAMILY_MAX = 6;
+const MAX_ENDPOINT_FAMILY_MAX = 100;
+const WAHA_ENDPOINT_ROOT_DOMAIN = "sector-pro.work";
+
+const ACTIONS = ["get", "save", "status", "start", "restart", "qr", "endpoints"] as const;
 
 function isAction(value: string): value is Action {
   return (ACTIONS as readonly string[]).includes(value);
 }
 
-function getAllowedEndpointHosts() {
-  const configured = (Deno.env.get("WAHA_ALLOWED_ENDPOINTS") || "")
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
+function parsePositiveInt(value: string | undefined, fallback: number, max: number) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
 
+  return Math.min(max, Math.max(1, Math.floor(parsed)));
+}
+
+function wahaEndpointForIndex(index: number) {
+  return index === 1
+    ? `https://waha.${WAHA_ENDPOINT_ROOT_DOMAIN}`
+    : `https://waha${index}.${WAHA_ENDPOINT_ROOT_DOMAIN}`;
+}
+
+function getWahaEndpointLabel(endpoint: string) {
+  try {
+    const host = new URL(normalizeBaseUrl(endpoint)).hostname.toLowerCase();
+    const match = host.match(/^waha(\d*)\.sector-pro\.work$/);
+    if (match) {
+      return `WAHA ${match[1] ? Number(match[1]) : 1}`;
+    }
+
+    return host;
+  } catch {
+    return endpoint;
+  }
+}
+
+function pushEndpointOption(options: Map<string, WahaEndpointOption>, endpoint: string) {
+  try {
+    const normalized = normalizeEndpointForStorage(endpoint);
+    if (!normalized) return;
+
+    const host = new URL(normalized).host.toLowerCase();
+    options.set(host, {
+      label: getWahaEndpointLabel(normalized),
+      value: normalized,
+    });
+  } catch (error) {
+    console.warn("Ignoring invalid WAHA endpoint option", { endpoint, error });
+  }
+}
+
+function getConfiguredEndpointOptions(extraEndpoints: Array<string | null | undefined> = []) {
+  const familyMax = parsePositiveInt(
+    Deno.env.get("WAHA_ENDPOINT_FAMILY_MAX"),
+    DEFAULT_ENDPOINT_FAMILY_MAX,
+    MAX_ENDPOINT_FAMILY_MAX,
+  );
+  const options = new Map<string, WahaEndpointOption>();
+
+  for (let index = 1; index <= familyMax; index += 1) {
+    pushEndpointOption(options, wahaEndpointForIndex(index));
+  }
+
+  for (const endpoint of (Deno.env.get("WAHA_ALLOWED_ENDPOINTS") || "").split(",")) {
+    pushEndpointOption(options, endpoint);
+  }
+
+  for (const endpoint of extraEndpoints) {
+    if (endpoint) pushEndpointOption(options, endpoint);
+  }
+
+  return [...options.values()].sort((a, b) => a.label.localeCompare(b.label, "en", { numeric: true }));
+}
+
+function getAllowedEndpointHosts() {
   return new Set(
-    [...DEFAULT_ENDPOINTS, ...configured]
-      .map((endpoint) => {
-        try {
-          return new URL(normalizeBaseUrl(endpoint)).host.toLowerCase();
-        } catch {
-          return null;
-        }
-      })
-      .filter((host): host is string => Boolean(host)),
+    getConfiguredEndpointOptions().map((endpoint) => new URL(endpoint.value).host.toLowerCase()),
   );
 }
 
@@ -205,12 +263,17 @@ async function getWahaConfig(supabaseAdmin: ReturnType<typeof createClient>, end
   };
 }
 
-async function getSessionStatus(endpoint: string, session: string, apiKey: string) {
+async function getSessionStatus(
+  endpoint: string,
+  session: string,
+  apiKey: string,
+  timeoutMs = Number(Deno.env.get("WAHA_FETCH_TIMEOUT_MS") || 9000),
+) {
   const url = `${endpoint}/api/sessions/${encodeURIComponent(session)}`;
   const res = await fetchWithTimeout(url, {
     method: "GET",
     headers: headersFor(apiKey),
-  }, Number(Deno.env.get("WAHA_FETCH_TIMEOUT_MS") || 9000));
+  }, timeoutMs);
 
   if (res.status === 404) {
     return {
@@ -274,6 +337,67 @@ async function ensureSessionStarted(endpoint: string, session: string, apiKey: s
   }
 
   return getSessionStatus(endpoint, session, apiKey);
+}
+
+async function restartSession(endpoint: string, session: string, apiKey: string) {
+  const current = await getSessionStatus(endpoint, session, apiKey);
+  if (current.status === "NOT_CREATED") {
+    return ensureSessionStarted(endpoint, session, apiKey);
+  }
+
+  const res = await fetchWithTimeout(`${endpoint}/api/sessions/${encodeURIComponent(session)}/restart`, {
+    method: "POST",
+    headers: headersFor(apiKey),
+    body: JSON.stringify({}),
+  }, Number(Deno.env.get("WAHA_FETCH_TIMEOUT_MS") || 9000));
+
+  if (!res.ok) {
+    throw new HttpError(502, "WAHA session restart request failed", {
+      code: "waha_session_restart_failed",
+      details: { status: res.status, body: await readWahaError(res) },
+      exposeDetails: true,
+    });
+  }
+
+  return getSessionStatus(endpoint, session, apiKey);
+}
+
+function wahaEndpointErrorMessage(error: unknown) {
+  if (error instanceof HttpError) return error.message;
+  if (error instanceof Error) return error.message;
+  return "WAHA status request failed";
+}
+
+async function getEndpointStatuses(
+  supabaseAdmin: ReturnType<typeof createClient>,
+  extraEndpoints: Array<string | null | undefined> = [],
+) {
+  const timeoutMs = Number(Deno.env.get("WAHA_ENDPOINT_STATUS_TIMEOUT_MS") || 2500);
+  const options = getConfiguredEndpointOptions(extraEndpoints);
+
+  return await Promise.all(options.map(async (option): Promise<WahaEndpointStatus> => {
+    const { apiKey, session } = await getWahaConfig(supabaseAdmin, option.value);
+
+    try {
+      const status = await getSessionStatus(option.value, session, apiKey, timeoutMs);
+
+      return {
+        ...option,
+        session: status.session,
+        status: status.status,
+        me: status.me,
+        error: null,
+      };
+    } catch (error) {
+      return {
+        ...option,
+        session,
+        status: "UNREACHABLE",
+        me: null,
+        error: wahaEndpointErrorMessage(error),
+      };
+    }
+  }));
 }
 
 async function getQr(endpoint: string, session: string, apiKey: string) {
@@ -381,6 +505,7 @@ async function handler(req: Request) {
       session: endpoint ? (await getWahaConfig(supabaseAdmin, endpoint)).session : "default",
       status: endpoint ? "UNKNOWN" : "NOT_CONFIGURED",
       me: null,
+      endpoints: getConfiguredEndpointOptions([endpoint]),
     });
   }
 
@@ -392,6 +517,7 @@ async function handler(req: Request) {
       session: context.session,
       status: "NOT_CONFIGURED",
       me: null,
+      endpoints: action === "endpoints" ? await getEndpointStatuses(supabaseAdmin) : getConfiguredEndpointOptions(),
     });
   }
 
@@ -401,6 +527,17 @@ async function handler(req: Request) {
       session: context.session,
       status: "UNKNOWN",
       me: null,
+      endpoints: getConfiguredEndpointOptions([context.endpoint]),
+    });
+  }
+
+  if (action === "endpoints") {
+    return jsonResponse({
+      endpoint: context.endpoint,
+      session: context.session,
+      status: "UNKNOWN",
+      me: null,
+      endpoints: await getEndpointStatuses(supabaseAdmin, [context.endpoint]),
     });
   }
 
@@ -410,6 +547,10 @@ async function handler(req: Request) {
 
   if (action === "start") {
     return jsonResponse(await ensureSessionStarted(context.endpoint, context.session, context.apiKey));
+  }
+
+  if (action === "restart") {
+    return jsonResponse(await restartSession(context.endpoint, context.session, context.apiKey));
   }
 
   const status = await ensureSessionStarted(context.endpoint, context.session, context.apiKey);

--- a/supabase/functions/waha-session/index.ts
+++ b/supabase/functions/waha-session/index.ts
@@ -169,7 +169,7 @@ function assertAllowedEndpoint(endpoint: string) {
   const host = new URL(endpoint).host.toLowerCase();
   const allowedHosts = getAllowedEndpointHosts();
 
-  if (allowedHosts.has(host) || /^waha\d*\.sector-pro\.work$/i.test(host)) {
+  if (allowedHosts.has(host)) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add a generated WAHA endpoint directory so the settings dropdown includes `waha6.sector-pro.work` and can grow from Edge Function configuration instead of frontend code changes.
- Show per-endpoint WAHA status in settings, including the selected endpoint badge and endpoint list state.
- Add restart support for the configured WAHA session through the `waha-session` Edge Function.

## Risk Assessment
Low to medium. The UI change is isolated to the WAHA settings panel, while the Edge Function now calls endpoint status and restart APIs. Production needs the updated `waha-session` function deployed so the new `endpoints` and `restart` actions are available.

## Impact Checklist
- User-facing settings UI changes only.
- No database schema or RLS changes.
- No dependency changes.
- Backward compatible with existing saved endpoints.

## Rollback Plan
Revert this PR and redeploy the previous `waha-session` Edge Function version. The existing saved `waha_endpoint` profile value remains compatible.

## Migration Impact
No Supabase migrations are included. The Edge Function supports `WAHA_ENDPOINT_FAMILY_MAX` and `WAHA_ALLOWED_ENDPOINTS` for future endpoint growth without frontend redeploys.

## Validation
- `npx vitest run src/components/settings/__tests__/WahaEndpointSettings.test.tsx`
- `npm run lint:app`
- `npm run lint:functions`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- GitHub CI checks on PR #785
