### PR TITLE
[codex] fix large storage uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "sonner": "^1.7.2",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
+        "tus-js-client": "^4.3.1",
         "vaul": "^0.9.3",
         "ws": "^8.18.3",
         "zod": "^3.23.8",
@@ -6633,6 +6634,12 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
@@ -7033,6 +7040,15 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combine-errors": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/combine-errors/-/combine-errors-3.0.3.tgz",
+      "integrity": "sha512-C8ikRNRMygCwaTx+Ek3Yr+OuZzgZjduCOfSQBjbM8V3MfgcjSTeto/GXP6PAwKvJz/v15b7GHZvx5rOlczFw/Q==",
+      "dependencies": {
+        "custom-error-instance": "2.1.1",
+        "lodash.uniqby": "4.5.0"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -7521,6 +7537,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/custom-error-instance": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
+      "integrity": "sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==",
+      "license": "ISC"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -10027,6 +10049,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
+      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10426,6 +10454,52 @@
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
+    "node_modules/lodash._baseiteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
+      "integrity": "sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._stringtopath": "~4.8.0"
+      }
+    },
+    "node_modules/lodash._basetostring": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+      "integrity": "sha512-SwcRIbyxnN6CFEEK4K1y+zuApvWdpQdBHM/swxP962s8HIxPO3alBH5t3m/dl+f4CMUug6sJb7Pww8d13/9WSw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._baseuniq": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+      "integrity": "sha512-Ja1YevpHZctlI5beLA7oc5KNDhGcPixFhcqSiORHNsp/1QTv7amAXzw+gu4YOvErqVlMVyIJGgtzeepCnnur0A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "node_modules/lodash._createset": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+      "integrity": "sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._stringtopath": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
+      "integrity": "sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basetostring": "~4.12.0"
+      }
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -10513,6 +10587,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
@@ -10524,6 +10604,16 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
+    },
+    "node_modules/lodash.uniqby": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz",
+      "integrity": "sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._baseiteratee": "~4.7.0",
+        "lodash._baseuniq": "~4.6.0"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -12873,6 +12963,17 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -13050,6 +13151,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -14167,6 +14274,12 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -14187,6 +14300,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -15709,6 +15831,36 @@
         "node": "*"
       }
     },
+    "node_modules/tus-js-client": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-4.3.1.tgz",
+      "integrity": "sha512-ZLeYmjrkaU1fUsKbIi8JML52uAocjEZtBx4DKjRrqzrZa0O4MYwT6db+oqePlspV+FxXJAyFBc/L5gwUi2OFsg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.1.2",
+        "combine-errors": "^3.0.3",
+        "is-stream": "^2.0.0",
+        "js-base64": "^3.7.2",
+        "lodash.throttle": "^4.1.1",
+        "proper-lockfile": "^4.1.2",
+        "url-parse": "^1.5.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tus-js-client/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -16023,6 +16175,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "sonner": "^1.7.2",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "tus-js-client": "^4.3.1",
     "vaul": "^0.9.3",
     "ws": "^8.18.3",
     "zod": "^3.23.8",

--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -140,6 +140,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       fetchFiles();
     } catch (error: any) {
       console.error("Error uploading file:", error);
+      const uploadErrorMessage = error instanceof Error ? error.message : "";
       try {
         if (insertedIds.length > 0) {
           await dataLayerClient.from('festival_artist_files').delete().in('id', insertedIds);
@@ -152,7 +153,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       }
       toast({
         title: "Error",
-        description: "No se pudo completar la carga. Se han revertido los archivos de esta tanda.",
+        description: uploadErrorMessage || "No se pudo completar la carga. Se han revertido los archivos de esta tanda.",
         variant: "destructive",
       });
     } finally {

--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -13,6 +13,7 @@ import {
   getDocumentUploadValidationError,
 } from "@/utils/documentUploadValidation";
 import { optimizeImageForUpload } from "@/utils/imageOptimization";
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 
 interface ArtistFileDialogProps {
   open: boolean;
@@ -92,16 +93,17 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
         const fileExt = uploadFile.name.split('.').pop();
         const filePath = `${artistId}/${crypto.randomUUID()}.${fileExt}`;
 
-        // First upload the file to storage
-        const { error: uploadError } = await dataLayerClient.storage
-          .from('festival_artist_files')
-          .upload(filePath, uploadFile, {
-            contentType: uploadFile.type || file.type,
+        // First upload the file to storage. Large CAD/rider files use resumable chunks.
+        try {
+          await uploadStorageObject(dataLayerClient, {
+            bucket: 'festival_artist_files',
+            path: filePath,
+            file: uploadFile,
+            contentType: uploadFile.type || file.type || 'application/octet-stream',
           });
-
-        if (uploadError) {
+        } catch (uploadError) {
           console.error("Storage upload error:", uploadError);
-          throw uploadError;
+          throw new Error(getStorageUploadErrorMessage(uploadError, uploadFile));
         }
         uploadedPaths.push(filePath);
 

--- a/src/components/festival/ArtistRequirementsForm.tsx
+++ b/src/components/festival/ArtistRequirementsForm.tsx
@@ -760,9 +760,10 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
         });
       } catch (error) {
         console.error("Error uploading rider file:", error);
+        const uploadErrorMessage = error instanceof Error ? error.message : "";
         toast({
           title: tx("Error", "Error"),
-          description: tx(
+          description: uploadErrorMessage || tx(
             "No se pudo cargar el rider. Inténtalo de nuevo.",
             "Could not upload rider file. Please try again."
           ),

--- a/src/components/festival/ArtistRequirementsForm.tsx
+++ b/src/components/festival/ArtistRequirementsForm.tsx
@@ -20,6 +20,10 @@ import { Download, Eye, FileText, Loader2, Printer, Trash2 } from "lucide-react"
 import { normalizeWirelessSystem, normalizeWirelessSystems } from "@/lib/wirelessSystemNormalizer";
 import { mapFestivalGearSetup } from "@/utils/festivalGearMappers";
 import { DOCUMENT_UPLOAD_ACCEPT } from "@/utils/documentUploadValidation";
+import {
+  type PublicRiderFileRecord,
+  uploadPublicArtistRiderFiles,
+} from "@/utils/publicArtistRiderUpload";
 
 interface ArtistRequirementsFormProps {
   isBlank?: boolean;
@@ -42,16 +46,7 @@ interface PublicSubmitResponse {
 }
 
 type ArtistFormState = ArtistSectionProps["formData"];
-type RiderFileRecord = {
-  id: string;
-  file_name: string;
-  file_path: string;
-  file_type: string | null;
-  file_size: number | null;
-  uploaded_at: string | null;
-  uploaded_by: string | null;
-  uploaded_by_name: string | null;
-};
+type RiderFileRecord = PublicRiderFileRecord;
 
 const makeBlankWirelessSystem = () =>
   normalizeWirelessSystem(
@@ -749,51 +744,7 @@ export const ArtistRequirementsForm = ({ isBlank = false }: ArtistRequirementsFo
       setIsUploadingRider(true);
 
       try {
-        const payload = new FormData();
-        payload.append("token", token);
-        selectedFiles.forEach((file) => payload.append("files", file));
-
-        const { data, error } = await dataLayerClient.functions.invoke("upload-public-artist-rider", {
-          body: payload,
-        });
-
-        if (error) {
-          throw error;
-        }
-
-        const response = data as {
-          ok?: boolean;
-          error?: string;
-          file?: Record<string, unknown> | null;
-          files?: Array<Record<string, unknown>>;
-        } | null;
-        if (!response?.ok) {
-          throw new Error(response?.error || "upload_failed");
-        }
-
-        const uploadedRaw =
-          Array.isArray(response.files) && response.files.length > 0
-            ? response.files
-            : response.file
-              ? [response.file]
-              : [];
-
-        const uploaded = uploadedRaw
-          .map((file) => ({
-            id: asString(file.id),
-            file_name: asString(file.file_name),
-            file_path: asString(file.file_path),
-            file_type: asString(file.file_type) || null,
-            file_size: typeof file.file_size === "number" ? file.file_size : null,
-            uploaded_at: asString(file.uploaded_at) || null,
-            uploaded_by: asString(file.uploaded_by) || null,
-            uploaded_by_name: asString(file.uploaded_by_name) || null,
-          }))
-          .filter((file) => file.id && file.file_path);
-
-        if (uploaded.length === 0) {
-          throw new Error("invalid_upload_response");
-        }
+        const uploaded = await uploadPublicArtistRiderFiles(token, selectedFiles);
 
         setRiderFiles((prev) => {
           const deduped = prev.filter((existing) => !uploaded.some((nextFile) => nextFile.id === existing.id));

--- a/src/components/lights/LightMemoriaTecnica.tsx
+++ b/src/components/lights/LightMemoriaTecnica.tsx
@@ -10,6 +10,7 @@ import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useLogoOptions, LogoOption } from "@/hooks/useLogoOptions";
+import { uploadStorageObject } from "@/utils/storageUpload";
 
 interface PDFFile {
   file: File;
@@ -120,11 +121,12 @@ export const LightMemoriaTecnica = () => {
   };
 
   const uploadToStorage = async (file: File, path: string) => {
-    const { error: uploadError, data } = await dataLayerClient.storage
-      .from('lights-memoria-tecnica')
-      .upload(path, file);
-
-    if (uploadError) throw uploadError;
+    await uploadStorageObject(dataLayerClient, {
+      bucket: 'lights-memoria-tecnica',
+      path,
+      file,
+      contentType: file.type || 'application/octet-stream',
+    });
 
     const { data: { publicUrl } } = dataLayerClient.storage
       .from('lights-memoria-tecnica')

--- a/src/components/lights/LightsTaskDialog.tsx
+++ b/src/components/lights/LightsTaskDialog.tsx
@@ -22,6 +22,7 @@ import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
 import { TASK_TYPES } from "@/constants/taskTypes";
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 import {
   Table as UITable,
   TableBody,
@@ -156,11 +157,16 @@ export const LightsTaskDialog = ({ jobId, open, onOpenChange }: LightsTaskDialog
       for (const file of files) {
         const filePath = `${taskId}/${crypto.randomUUID()}-${file.name}`;
         
-        const { error: uploadError } = await dataLayerClient.storage
-          .from('task_documents')
-          .upload(filePath, file);
-
-        if (uploadError) throw uploadError;
+        try {
+          await uploadStorageObject(dataLayerClient, {
+            bucket: 'task_documents',
+            path: filePath,
+            file,
+            contentType: file.type || 'application/octet-stream',
+          });
+        } catch (uploadError) {
+          throw new Error(getStorageUploadErrorMessage(uploadError, file));
+        }
         uploadedPaths.push(filePath);
 
         const { data: insertedDocument, error: dbError } = await dataLayerClient.from('task_documents')

--- a/src/components/sound/MemoriaTecnica.tsx
+++ b/src/components/sound/MemoriaTecnica.tsx
@@ -11,6 +11,7 @@ import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useLogoOptions, LogoOption } from "@/hooks/useLogoOptions";
+import { uploadStorageObject } from "@/utils/storageUpload";
 
 interface PDFFile {
   file: File;
@@ -127,10 +128,13 @@ export const MemoriaTecnica = () => {
     let lastErr: Error | null = null;
     for (const bucket of STORAGE_BUCKET_CANDIDATES) {
       try {
-        const { error: uploadError } = await dataLayerClient.storage
-          .from(bucket)
-          .upload(safePath, file, { upsert: true });
-        if (uploadError) throw uploadError;
+        await uploadStorageObject(dataLayerClient, {
+          bucket,
+          path: safePath,
+          file,
+          contentType: file.type || "application/octet-stream",
+          upsert: true,
+        });
 
         const { data: signedUrlData, error: signUrlError } = await dataLayerClient.storage
           .from(bucket)

--- a/src/components/sound/MemoriaTecnica.tsx
+++ b/src/components/sound/MemoriaTecnica.tsx
@@ -11,7 +11,7 @@ import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useLogoOptions, LogoOption } from "@/hooks/useLogoOptions";
-import { uploadStorageObject } from "@/utils/storageUpload";
+import { isStorageNotFoundError, uploadStorageObject } from "@/utils/storageUpload";
 
 interface PDFFile {
   file: File;
@@ -144,8 +144,7 @@ export const MemoriaTecnica = () => {
       } catch (err) {
         lastErr = err as Error;
         // Try next candidate on 404 bucket not found; otherwise rethrow
-        const msg = (err && ((err as Error).message || (err as { error?: string }).error || '')) + '';
-        if (!msg.toLowerCase().includes('bucket not found') && !((err as { statusCode?: string })?.statusCode === '404')) {
+        if (!isStorageNotFoundError(err)) {
           throw err;
         }
       }

--- a/src/components/sound/SoundTaskDialog.tsx
+++ b/src/components/sound/SoundTaskDialog.tsx
@@ -23,6 +23,7 @@ import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { useState, useEffect } from "react";
 import { TASK_TYPES } from "@/constants/taskTypes";
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 import {
   Table as UITable,
   TableBody,
@@ -238,13 +239,18 @@ export const SoundTaskDialog = ({ jobId, open, onOpenChange }: SoundTaskDialogPr
         const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
         const filePath = `${taskId}/${Date.now()}-${crypto.randomUUID()}_${sanitizedFileName}`;
 
-        const { error: uploadError } = await dataLayerClient.storage
-          .from('task_documents')
-          .upload(filePath, file, {
+        try {
+          await uploadStorageObject(dataLayerClient, {
+            bucket: 'task_documents',
+            path: filePath,
+            file,
             cacheControl: '3600',
-            upsert: false
+            contentType: file.type || 'application/octet-stream',
+            upsert: false,
           });
-        if (uploadError) throw uploadError;
+        } catch (uploadError) {
+          throw new Error(getStorageUploadErrorMessage(uploadError, file));
+        }
         uploadedPaths.push(filePath);
 
         const { data: insertedDocument, error: dbError } = await dataLayerClient.from('task_documents')

--- a/src/components/video/VideoMemoriaTecnica.tsx
+++ b/src/components/video/VideoMemoriaTecnica.tsx
@@ -10,6 +10,7 @@ import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useLogoOptions, LogoOption } from "@/hooks/useLogoOptions";
+import { uploadStorageObject } from "@/utils/storageUpload";
 
 interface PDFFile {
   file: File;
@@ -119,11 +120,12 @@ export const VideoMemoriaTecnica = () => {
   };
 
   const uploadToStorage = async (file: File, path: string) => {
-    const { error: uploadError, data } = await dataLayerClient.storage
-      .from('video-memoria-tecnica')
-      .upload(path, file);
-
-    if (uploadError) throw uploadError;
+    await uploadStorageObject(dataLayerClient, {
+      bucket: 'video-memoria-tecnica',
+      path,
+      file,
+      contentType: file.type || 'application/octet-stream',
+    });
 
     const { data: { publicUrl } } = dataLayerClient.storage
       .from('video-memoria-tecnica')

--- a/src/components/video/VideoTaskDialog.tsx
+++ b/src/components/video/VideoTaskDialog.tsx
@@ -22,6 +22,7 @@ import { dataLayerClient } from "@/services/dataLayerClient";
 import { useToast } from "@/hooks/use-toast";
 import { useState } from "react";
 import { TASK_TYPES } from "@/constants/taskTypes";
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 import {
   Table as UITable,
   TableBody,
@@ -157,11 +158,16 @@ export const VideoTaskDialog = ({ jobId, open, onOpenChange }: VideoTaskDialogPr
       for (const file of files) {
         const filePath = `${taskId}/${crypto.randomUUID()}-${file.name}`;
         
-        const { error: uploadError } = await dataLayerClient.storage
-          .from('task_documents')
-          .upload(filePath, file);
-
-        if (uploadError) throw uploadError;
+        try {
+          await uploadStorageObject(dataLayerClient, {
+            bucket: 'task_documents',
+            path: filePath,
+            file,
+            contentType: file.type || 'application/octet-stream',
+          });
+        } catch (uploadError) {
+          throw new Error(getStorageUploadErrorMessage(uploadError, file));
+        }
         uploadedPaths.push(filePath);
 
         const taskDocument: TaskDocumentInsert = {

--- a/src/features/festival-management/commands.ts
+++ b/src/features/festival-management/commands.ts
@@ -18,6 +18,7 @@ import { resolveJobDocLocation } from "@/utils/jobDocuments";
 import { generateAndMergeFestivalPDFs, type FestivalPdfProgress } from "@/utils/pdf/festivalPdfGenerator";
 import { generateIndividualStagePDFs } from "@/utils/pdf/individualStagePdfGenerator";
 import { optimizeImageForUpload } from "@/utils/imageOptimization";
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 
 export const getJobDocumentSignedUrl = async (docEntry: JobDocumentEntry) => {
@@ -69,11 +70,17 @@ export const uploadJobDocument = async ({ file, jobId }: { file: File; jobId: st
     outputFormat: "image/webp",
   });
   const filePath = `${jobId}/${uploadFile.name}`;
-  const { error: uploadError } = await supabase.storage.from("job_documents").upload(filePath, uploadFile, {
-    contentType: uploadFile.type || file.type,
-  });
 
-  if (uploadError) throw uploadError;
+  try {
+    await uploadStorageObject(supabase, {
+      bucket: "job_documents",
+      path: filePath,
+      file: uploadFile,
+      contentType: uploadFile.type || file.type || "application/octet-stream",
+    });
+  } catch (uploadError) {
+    throw new Error(getStorageUploadErrorMessage(uploadError, uploadFile));
+  }
 
   const { error: dbError } = await supabase.from("job_documents").insert({
     job_id: jobId,

--- a/src/features/lights/LightsRiggingPlanner.tsx
+++ b/src/features/lights/LightsRiggingPlanner.tsx
@@ -11,6 +11,7 @@ import { AlertTriangle, FileText, Plus, Trash2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { exportToPDF } from "@/utils/pdfExport";
 import { supabase } from "@/lib/supabase";
+import { uploadStorageObject } from "@/utils/storageUpload";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useJobSelection } from "@/hooks/useJobSelection";
 
@@ -264,7 +265,12 @@ const LightsRiggingPlanner: React.FC = () => {
       if (!isTourDefaults && selectedJobId) {
         const file = new File([pdfBlob], fileName, { type: "application/pdf" });
         const filePath = `lights/${selectedJobId}/${crypto.randomUUID()}.pdf`;
-        await supabase.storage.from("task_documents").upload(filePath, file);
+        await uploadStorageObject(supabase, {
+          bucket: "task_documents",
+          path: filePath,
+          file,
+          contentType: "application/pdf",
+        });
       }
 
       toast({ title: "Success", description: "PDF generated." });

--- a/src/features/lights/LightsRiggingPlanner.tsx
+++ b/src/features/lights/LightsRiggingPlanner.tsx
@@ -11,7 +11,7 @@ import { AlertTriangle, FileText, Plus, Trash2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { exportToPDF } from "@/utils/pdfExport";
 import { supabase } from "@/lib/supabase";
-import { uploadStorageObject } from "@/utils/storageUpload";
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useJobSelection } from "@/hooks/useJobSelection";
 
@@ -265,12 +265,16 @@ const LightsRiggingPlanner: React.FC = () => {
       if (!isTourDefaults && selectedJobId) {
         const file = new File([pdfBlob], fileName, { type: "application/pdf" });
         const filePath = `lights/${selectedJobId}/${crypto.randomUUID()}.pdf`;
-        await uploadStorageObject(supabase, {
-          bucket: "task_documents",
-          path: filePath,
-          file,
-          contentType: "application/pdf",
-        });
+        try {
+          await uploadStorageObject(supabase, {
+            bucket: "task_documents",
+            path: filePath,
+            file,
+            contentType: "application/pdf",
+          });
+        } catch (uploadError) {
+          throw new Error(getStorageUploadErrorMessage(uploadError, file));
+        }
       }
 
       toast({ title: "Success", description: "PDF generated." });

--- a/src/hooks/useGlobalTaskMutations.ts
+++ b/src/hooks/useGlobalTaskMutations.ts
@@ -4,6 +4,7 @@ import type { Database } from '@/integrations/supabase/types';
 import { type Dept } from '@/utils/tasks';
 import { isTaskAssigneeUniqueConflict } from '@/utils/taskAssignment';
 import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
+import { uploadTaskStorageObject } from '@/utils/taskStorageUpload';
 
 type SoundTaskUpdate = Database['public']['Tables']['sound_job_tasks']['Update'];
 type LightsTaskUpdate = Database['public']['Tables']['lights_job_tasks']['Update'];
@@ -691,7 +692,7 @@ export function useGlobalTaskMutations(department: Dept) {
 
     if (jobId) {
       const destPath = `${department}/${jobId}/task-${taskId}/${safeName}`;
-      await supabase.storage.from('job_documents').upload(destPath, blob, { upsert: true });
+      await uploadTaskStorageObject(supabase, { bucket: 'job_documents', path: destPath, file: blob, upsert: true });
       // Idempotent: delete any existing row first, then insert
       await supabase.from('job_documents').delete().eq('file_path', destPath);
       await supabase.from('job_documents').insert({
@@ -704,7 +705,7 @@ export function useGlobalTaskMutations(department: Dept) {
 
     if (tourId) {
       const destPath = `schedules/${tourId}/task-${taskId}/${safeName}`;
-      await supabase.storage.from('tour-documents').upload(destPath, blob, { upsert: true });
+      await uploadTaskStorageObject(supabase, { bucket: 'tour-documents', path: destPath, file: blob, upsert: true });
       await supabase.from('tour_documents').delete().eq('file_path', destPath);
       await supabase.from('tour_documents').insert({
         tour_id: tourId,
@@ -738,10 +739,7 @@ export function useGlobalTaskMutations(department: Dept) {
 
     // 1. Always store in task_documents bucket + table
     const taskKey = `${taskId}/${Date.now()}_${safeName}`;
-    const { error: upErr } = await supabase.storage
-      .from('task_documents')
-      .upload(taskKey, file, { upsert: false });
-    if (upErr) throw upErr;
+    await uploadTaskStorageObject(supabase, { bucket: 'task_documents', path: taskKey, file, upsert: false });
 
     const taskDocumentInsert: TaskDocumentInsert = {
       file_name: file.name,
@@ -762,7 +760,7 @@ export function useGlobalTaskMutations(department: Dept) {
     // 2. Mirror to job bucket if linked (idempotent: delete-before-insert)
     if (jobId) {
       const jobPath = `${department}/${jobId}/task-${taskId}/${safeName}`;
-      await supabase.storage.from('job_documents').upload(jobPath, file, { upsert: true });
+      await uploadTaskStorageObject(supabase, { bucket: 'job_documents', path: jobPath, file, upsert: true });
       // Remove any existing row to avoid duplicates
       await supabase.from('job_documents').delete().eq('file_path', jobPath);
       await supabase.from('job_documents').insert({
@@ -776,7 +774,7 @@ export function useGlobalTaskMutations(department: Dept) {
     // 3. Mirror to tour bucket if linked (idempotent: delete-before-insert)
     if (tourId) {
       const tourPath = `schedules/${tourId}/task-${taskId}/${safeName}`;
-      await supabase.storage.from('tour-documents').upload(tourPath, file, { upsert: true });
+      await uploadTaskStorageObject(supabase, { bucket: 'tour-documents', path: tourPath, file, upsert: true });
       // Remove any existing row to avoid duplicates
       await supabase.from('tour_documents').delete().eq('file_path', tourPath);
       await supabase.from('tour_documents').insert({

--- a/src/hooks/useJobCard.ts
+++ b/src/hooks/useJobCard.ts
@@ -15,6 +15,7 @@ import {
   canUploadDocuments as canUploadDocumentsForRole,
 } from '@/utils/permissions';
 import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
+import { getStorageUploadErrorMessage, uploadStorageObject } from '@/utils/storageUpload';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -192,10 +193,16 @@ export const useJobCard = (job: any, department: Department, userRole: string | 
         const fileExt = file.name.split(".").pop();
         const filePath = `${department}/${job.id}/${crypto.randomUUID()}.${fileExt}`;
 
-        const { error: uploadError } = await supabase.storage
-          .from("job_documents")
-          .upload(filePath, file);
-        if (uploadError) throw uploadError;
+        try {
+          await uploadStorageObject(supabase, {
+            bucket: "job_documents",
+            path: filePath,
+            file,
+            contentType: file.type || "application/octet-stream",
+          });
+        } catch (uploadError) {
+          throw new Error(getStorageUploadErrorMessage(uploadError, file));
+        }
 
         const { error: dbError } = await supabase
           .from("job_documents")

--- a/src/hooks/useOptimizedJobCard.ts
+++ b/src/hooks/useOptimizedJobCard.ts
@@ -16,6 +16,7 @@ import {
   canUploadDocuments as canUploadDocumentsForRole,
 } from '@/utils/permissions';
 import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
+import { getStorageUploadErrorMessage, uploadStorageObject } from '@/utils/storageUpload';
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -430,10 +431,16 @@ export const useOptimizedJobCard = (
         const fileExt = file.name.split('.').pop();
         const filePath = `${department}/${job.id}/${crypto.randomUUID()}.${fileExt}`;
 
-        const { error: uploadError } = await supabase.storage
-          .from('job_documents')
-          .upload(filePath, file);
-        if (uploadError) throw uploadError;
+        try {
+          await uploadStorageObject(supabase, {
+            bucket: 'job_documents',
+            path: filePath,
+            file,
+            contentType: file.type || 'application/octet-stream',
+          });
+        } catch (uploadError) {
+          throw new Error(getStorageUploadErrorMessage(uploadError, file));
+        }
 
         const { data: inserted, error: dbError } = await supabase
           .from('job_documents')

--- a/src/hooks/useSoundVisionUpload.ts
+++ b/src/hooks/useSoundVisionUpload.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { validateFile, generateStoragePath } from '@/utils/soundvisionFileValidation';
+import { getStorageUploadErrorMessage, uploadStorageObject } from '@/utils/storageUpload';
 import { VenueMetadata, useUpsertVenue } from './useVenues';
 
 
@@ -40,15 +41,22 @@ export const useSoundVisionUpload = () => {
       const storagePath = generateStoragePath(venueId, file.name);
       setProgress(40);
 
-      // Upload file to storage
-      const { error: uploadError } = await supabase.storage
-        .from('soundvision-files')
-        .upload(storagePath, file, {
+      // Upload file to storage. Large CAD/SoundVision files use resumable chunks.
+      try {
+        await uploadStorageObject(supabase, {
+          bucket: 'soundvision-files',
+          path: storagePath,
+          file,
           cacheControl: '3600',
+          contentType: file.type || 'application/octet-stream',
           upsert: false,
+          onProgress: ({ percentage }) => {
+            setProgress(40 + Math.round((percentage / 100) * 30));
+          },
         });
-
-      if (uploadError) throw uploadError;
+      } catch (uploadError) {
+        throw new Error(getStorageUploadErrorMessage(uploadError, file));
+      }
       setProgress(70);
 
       // Get current user

--- a/src/hooks/useTaskMutations.ts
+++ b/src/hooks/useTaskMutations.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/lib/supabase';
 import { completeTask, revertTask, Department } from '@/services/taskCompletion';
 import { getDocumentUploadValidationError } from '@/utils/documentUploadValidation';
+import { getStorageUploadErrorMessage, uploadStorageObject } from '@/utils/storageUpload';
 
 type Dept = 'sound'|'lights'|'video';
 type TaskUpdateFields = Record<string, unknown>;
@@ -350,8 +351,17 @@ export function useTaskMutations(jobId?: string, department?: Dept, tourId?: str
 
     const sanitized = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
     const key = `${taskId}/${Date.now()}_${sanitized}`;
-    const { error: upErr } = await supabase.storage.from('task_documents').upload(key, file, { upsert: false });
-    if (upErr) throw upErr;
+    try {
+      await uploadStorageObject(supabase, {
+        bucket: 'task_documents',
+        path: key,
+        file,
+        contentType: file.type || 'application/octet-stream',
+        upsert: false,
+      });
+    } catch (upErr) {
+      throw new Error(getStorageUploadErrorMessage(upErr, file));
+    }
     const { error: insErr } = await supabase.from('task_documents').insert({ [docFk]: taskId, file_name: file.name, file_path: key });
     if (insErr) {
       const { error: cleanupError } = await supabase.storage.from('task_documents').remove([key]);

--- a/src/hooks/useTourDocuments.ts
+++ b/src/hooks/useTourDocuments.ts
@@ -9,6 +9,7 @@ import {
   canUploadTourDocuments,
   isManagementRole,
 } from "@/utils/permissions";
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -75,14 +76,17 @@ export const useTourDocuments = (tourId: string) => {
 
       console.log('Uploading file:', finalFileName, 'to path:', filePath);
 
-      // Upload file to storage
-      const { error: uploadError } = await supabase.storage
-        .from('tour-documents')
-        .upload(filePath, file);
-
-      if (uploadError) {
+      // Upload file to storage. Large CAD documents use resumable chunks.
+      try {
+        await uploadStorageObject(supabase, {
+          bucket: 'tour-documents',
+          path: filePath,
+          file,
+          contentType: file.type || 'application/octet-stream',
+        });
+      } catch (uploadError) {
         console.error('Storage upload error:', uploadError);
-        throw uploadError;
+        throw new Error(getStorageUploadErrorMessage(uploadError, file));
       }
 
       // Save document record

--- a/src/utils/__tests__/storageUpload.test.ts
+++ b/src/utils/__tests__/storageUpload.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockTusOptions = {
+  endpoint: string;
+  retryDelays: number[];
+  headers: Record<string, string>;
+  metadata: Record<string, string>;
+  chunkSize: number;
+  uploadDataDuringCreation: boolean;
+  removeFingerprintOnSuccess: boolean;
+  fingerprint?: (file: Blob) => Promise<string>;
+  onProgress?: (bytesUploaded: number, bytesTotal: number) => void;
+  onSuccess?: () => void;
+  onError?: (error: Error) => void;
+};
+
+const mocks = vi.hoisted(() => {
+  const uploadInstances: Array<{
+    file: Blob;
+    options: MockTusOptions;
+    findPreviousUploads: ReturnType<typeof vi.fn>;
+    resumeFromPreviousUpload: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  class MockUpload {
+    file: Blob;
+    options: MockTusOptions;
+    findPreviousUploads = vi.fn(() => Promise.resolve([]));
+    resumeFromPreviousUpload = vi.fn();
+    start = vi.fn(() => {
+      this.options.onProgress?.(this.file.size, this.file.size);
+      this.options.onSuccess?.();
+    });
+
+    constructor(file: Blob, options: MockTusOptions) {
+      this.file = file;
+      this.options = options;
+      uploadInstances.push(this);
+    }
+  }
+
+  return {
+    authGetSession: vi.fn(),
+    storageFrom: vi.fn(),
+    storageUpload: vi.fn(),
+    uploadInstances,
+    MockUpload,
+  };
+});
+
+vi.mock("@/lib/api-config", () => ({
+  SUPABASE_URL: "https://project-ref.supabase.co",
+  SUPABASE_ANON_KEY: "anon-key",
+}));
+
+vi.mock("tus-js-client", () => ({
+  Upload: mocks.MockUpload,
+}));
+
+import {
+  RESUMABLE_UPLOAD_THRESHOLD_BYTES,
+  uploadStorageObject,
+} from "@/utils/storageUpload";
+
+const makeSupabase = () => ({
+  auth: {
+    getSession: mocks.authGetSession,
+  },
+  storage: {
+    from: mocks.storageFrom,
+  },
+}) as unknown as Parameters<typeof uploadStorageObject>[0];
+
+const makeNamedBlob = (size: number, name: string, type = "application/octet-stream") =>
+  Object.assign(new Blob([new Uint8Array(size)], { type }), {
+    name,
+    lastModified: 1234,
+  });
+
+describe("storageUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.uploadInstances.length = 0;
+    mocks.authGetSession.mockResolvedValue({
+      data: { session: { access_token: "session-token" } },
+      error: null,
+    });
+    mocks.storageFrom.mockReturnValue({
+      upload: mocks.storageUpload,
+    });
+    mocks.storageUpload.mockResolvedValue({ error: null });
+  });
+
+  it("uses the normal Supabase upload API below the resumable threshold", async () => {
+    const file = makeNamedBlob(1024, "small.dwg", "application/acad");
+    const onProgress = vi.fn();
+
+    await uploadStorageObject(makeSupabase(), {
+      bucket: "plans",
+      path: "jobs/job-1/small.dwg",
+      file,
+      contentType: "application/dwg",
+      onProgress,
+    });
+
+    expect(mocks.storageFrom).toHaveBeenCalledWith("plans");
+    expect(mocks.storageUpload).toHaveBeenCalledWith("jobs/job-1/small.dwg", file, {
+      cacheControl: "3600",
+      contentType: "application/dwg",
+      upsert: false,
+    });
+    expect(mocks.uploadInstances).toHaveLength(0);
+    expect(onProgress).toHaveBeenCalledWith({
+      bytesUploaded: file.size,
+      bytesTotal: file.size,
+      percentage: 100,
+    });
+  });
+
+  it("uses Supabase resumable uploads for large authenticated files", async () => {
+    const file = makeNamedBlob(RESUMABLE_UPLOAD_THRESHOLD_BYTES, "large.dwg", "application/acad");
+    const onProgress = vi.fn();
+
+    await uploadStorageObject(makeSupabase(), {
+      bucket: "plans",
+      path: "jobs/job-1/large.dwg",
+      file,
+      upsert: true,
+      onProgress,
+    });
+
+    expect(mocks.storageUpload).not.toHaveBeenCalled();
+    expect(mocks.authGetSession).toHaveBeenCalledTimes(1);
+    expect(mocks.uploadInstances).toHaveLength(1);
+
+    const { options } = mocks.uploadInstances[0];
+    expect(options.endpoint).toBe("https://project-ref.storage.supabase.co/storage/v1/upload/resumable");
+    expect(options.headers).toMatchObject({
+      apikey: "anon-key",
+      authorization: "Bearer session-token",
+      "x-upsert": "true",
+    });
+    expect(options.metadata).toMatchObject({
+      bucketName: "plans",
+      objectName: "jobs/job-1/large.dwg",
+      contentType: "application/acad",
+      cacheControl: "3600",
+    });
+    expect(options.chunkSize).toBe(6 * 1024 * 1024);
+    expect(options.uploadDataDuringCreation).toBe(true);
+    expect(options.removeFingerprintOnSuccess).toBe(true);
+    expect(onProgress).toHaveBeenCalledWith({
+      bytesUploaded: file.size,
+      bytesTotal: file.size,
+      percentage: 100,
+    });
+  });
+
+  it("uses signed resumable uploads without requiring an authenticated session", async () => {
+    const file = makeNamedBlob(RESUMABLE_UPLOAD_THRESHOLD_BYTES, "public-rider.dwg", "application/acad");
+
+    await uploadStorageObject(makeSupabase(), {
+      bucket: "festival_artist_files",
+      path: "artist-1/public-rider.dwg",
+      file,
+      signedUploadToken: "signed-token",
+    });
+
+    expect(mocks.authGetSession).not.toHaveBeenCalled();
+    expect(mocks.uploadInstances).toHaveLength(1);
+
+    const { options } = mocks.uploadInstances[0];
+    expect(options.endpoint).toBe("https://project-ref.supabase.co/storage/v1/upload/resumable/sign");
+    expect(options.headers).toEqual({
+      apikey: "anon-key",
+      "x-signature": "signed-token",
+    });
+    await expect(options.fingerprint?.(file)).resolves.toContain("artist-1/public-rider.dwg");
+  });
+});

--- a/src/utils/__tests__/storageUpload.test.ts
+++ b/src/utils/__tests__/storageUpload.test.ts
@@ -15,6 +15,7 @@ type MockTusOptions = {
 };
 
 const mocks = vi.hoisted(() => {
+  let tusStartError: Error | null = null;
   const uploadInstances: Array<{
     file: Blob;
     options: MockTusOptions;
@@ -29,6 +30,10 @@ const mocks = vi.hoisted(() => {
     findPreviousUploads = vi.fn(() => Promise.resolve([]));
     resumeFromPreviousUpload = vi.fn();
     start = vi.fn(() => {
+      if (tusStartError) {
+        this.options.onError?.(tusStartError);
+        return;
+      }
       this.options.onProgress?.(this.file.size, this.file.size);
       this.options.onSuccess?.();
     });
@@ -45,6 +50,9 @@ const mocks = vi.hoisted(() => {
     storageFrom: vi.fn(),
     storageUpload: vi.fn(),
     uploadInstances,
+    setTusStartError: (error: Error | null) => {
+      tusStartError = error;
+    },
     MockUpload,
   };
 });
@@ -82,6 +90,7 @@ describe("storageUpload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.uploadInstances.length = 0;
+    mocks.setTusStartError(null);
     mocks.authGetSession.mockResolvedValue({
       data: { session: { access_token: "session-token" } },
       error: null,
@@ -177,5 +186,47 @@ describe("storageUpload", () => {
       "x-signature": "signed-token",
     });
     await expect(options.fingerprint?.(file)).resolves.toContain("artist-1/public-rider.dwg");
+  });
+
+  it("surfaces errors from the normal Supabase upload API", async () => {
+    const file = makeNamedBlob(1024, "small.dwg", "application/acad");
+    mocks.storageUpload.mockResolvedValue({ error: new Error("standard upload failed") });
+
+    await expect(
+      uploadStorageObject(makeSupabase(), {
+        bucket: "plans",
+        path: "jobs/job-1/small.dwg",
+        file,
+      }),
+    ).rejects.toThrow("standard upload failed");
+  });
+
+  it("requires an authenticated session for large non-signed resumable uploads", async () => {
+    const file = makeNamedBlob(RESUMABLE_UPLOAD_THRESHOLD_BYTES, "large.dwg", "application/acad");
+    mocks.authGetSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    await expect(
+      uploadStorageObject(makeSupabase(), {
+        bucket: "plans",
+        path: "jobs/job-1/large.dwg",
+        file,
+      }),
+    ).rejects.toThrow("Usuario no autenticado");
+  });
+
+  it("rejects when the resumable tus upload reports an error", async () => {
+    const file = makeNamedBlob(RESUMABLE_UPLOAD_THRESHOLD_BYTES, "large.dwg", "application/acad");
+    mocks.setTusStartError(new Error("tus upload failed"));
+
+    await expect(
+      uploadStorageObject(makeSupabase(), {
+        bucket: "plans",
+        path: "jobs/job-1/large.dwg",
+        file,
+      }),
+    ).rejects.toThrow("tus upload failed");
   });
 });

--- a/src/utils/publicArtistRiderUpload.ts
+++ b/src/utils/publicArtistRiderUpload.ts
@@ -1,0 +1,156 @@
+import { dataLayerClient } from "@/services/dataLayerClient";
+import { getDocumentUploadValidationError } from "@/utils/documentUploadValidation";
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
+
+export type PublicRiderFileRecord = {
+  id: string;
+  file_name: string;
+  file_path: string;
+  file_type: string | null;
+  file_size: number | null;
+  uploaded_at: string | null;
+  uploaded_by: string | null;
+  uploaded_by_name: string | null;
+};
+
+type PreparedRiderUpload = {
+  client_id: string;
+  file_name: string;
+  file_path: string;
+  file_type: string | null;
+  file_size: number;
+  upload_token: string;
+};
+
+const asString = (value: unknown) => (typeof value === "string" ? value : "");
+
+const parsePreparedUploads = (files: Array<Record<string, unknown>>, expectedCount: number) => {
+  const preparedUploads = files
+    .map((file) => ({
+      client_id: asString(file.client_id),
+      file_name: asString(file.file_name),
+      file_path: asString(file.file_path),
+      file_type: asString(file.file_type) || null,
+      file_size: typeof file.file_size === "number" ? file.file_size : 0,
+      upload_token: asString(file.upload_token),
+    }))
+    .filter((file): file is PreparedRiderUpload =>
+      Boolean(file.client_id && file.file_name && file.file_path && file.file_size > 0 && file.upload_token)
+    );
+
+  if (preparedUploads.length !== expectedCount) {
+    throw new Error("invalid_upload_response");
+  }
+
+  return preparedUploads;
+};
+
+const parseUploadedRiderFiles = (response: {
+  file?: Record<string, unknown> | null;
+  files?: Array<Record<string, unknown>>;
+}) => {
+  const uploadedRaw =
+    Array.isArray(response.files) && response.files.length > 0
+      ? response.files
+      : response.file
+        ? [response.file]
+        : [];
+
+  const uploaded = uploadedRaw
+    .map((file) => ({
+      id: asString(file.id),
+      file_name: asString(file.file_name),
+      file_path: asString(file.file_path),
+      file_type: asString(file.file_type) || null,
+      file_size: typeof file.file_size === "number" ? file.file_size : null,
+      uploaded_at: asString(file.uploaded_at) || null,
+      uploaded_by: asString(file.uploaded_by) || null,
+      uploaded_by_name: asString(file.uploaded_by_name) || null,
+    }))
+    .filter((file) => file.id && file.file_path);
+
+  if (uploaded.length === 0) {
+    throw new Error("invalid_upload_response");
+  }
+
+  return uploaded;
+};
+
+export async function uploadPublicArtistRiderFiles(token: string, selectedFiles: File[]) {
+  const validationError = getDocumentUploadValidationError(selectedFiles);
+  if (validationError) {
+    throw new Error(validationError);
+  }
+
+  const { data: prepareData, error: prepareError } = await dataLayerClient.functions.invoke("upload-public-artist-rider", {
+    body: {
+      action: "prepare",
+      token,
+      files: selectedFiles.map((file, index) => ({
+        client_id: String(index),
+        name: file.name,
+        type: file.type || null,
+        size: file.size,
+      })),
+    },
+  });
+
+  if (prepareError) throw prepareError;
+
+  const prepareResponse = prepareData as {
+    ok?: boolean;
+    error?: string;
+    files?: Array<Record<string, unknown>>;
+  } | null;
+  if (!prepareResponse?.ok || !Array.isArray(prepareResponse.files)) {
+    throw new Error(prepareResponse?.error || "upload_prepare_failed");
+  }
+
+  const preparedUploads = parsePreparedUploads(prepareResponse.files, selectedFiles.length);
+
+  for (const preparedUpload of preparedUploads) {
+    const sourceFile = selectedFiles[Number(preparedUpload.client_id)];
+    if (!sourceFile) {
+      throw new Error("invalid_upload_response");
+    }
+
+    try {
+      await uploadStorageObject(dataLayerClient, {
+        bucket: "festival_artist_files",
+        path: preparedUpload.file_path,
+        file: sourceFile,
+        contentType: sourceFile.type || preparedUpload.file_type || "application/octet-stream",
+        signedUploadToken: preparedUpload.upload_token,
+      });
+    } catch (uploadError) {
+      throw new Error(getStorageUploadErrorMessage(uploadError, sourceFile));
+    }
+  }
+
+  const { data: completeData, error: completeError } = await dataLayerClient.functions.invoke("upload-public-artist-rider", {
+    body: {
+      action: "complete",
+      token,
+      files: preparedUploads.map((file) => ({
+        file_name: file.file_name,
+        file_path: file.file_path,
+        file_type: file.file_type,
+        file_size: file.file_size,
+      })),
+    },
+  });
+
+  if (completeError) throw completeError;
+
+  const completeResponse = completeData as {
+    ok?: boolean;
+    error?: string;
+    file?: Record<string, unknown> | null;
+    files?: Array<Record<string, unknown>>;
+  } | null;
+  if (!completeResponse?.ok) {
+    throw new Error(completeResponse?.error || "upload_failed");
+  }
+
+  return parseUploadedRiderFiles(completeResponse);
+}

--- a/src/utils/storageUpload.ts
+++ b/src/utils/storageUpload.ts
@@ -1,0 +1,150 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import * as tus from "tus-js-client";
+
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "@/lib/api-config";
+
+export const RESUMABLE_UPLOAD_THRESHOLD_BYTES = 6 * 1024 * 1024;
+const TUS_CHUNK_SIZE_BYTES = 6 * 1024 * 1024;
+
+type UploadableFile = Blob & {
+  name?: string;
+  type?: string;
+  size: number;
+};
+
+type StorageUploadOptions = {
+  bucket: string;
+  path: string;
+  file: UploadableFile;
+  cacheControl?: string;
+  contentType?: string;
+  signedUploadToken?: string;
+  upsert?: boolean;
+  onProgress?: (progress: { bytesUploaded: number; bytesTotal: number; percentage: number }) => void;
+};
+
+type SupabaseStorageClient = Pick<SupabaseClient, "auth" | "storage">;
+
+function getResumableUploadEndpoint() {
+  const url = new URL(SUPABASE_URL);
+  const [projectRef] = url.hostname.split(".");
+
+  if (projectRef && url.hostname.endsWith(".supabase.co")) {
+    return `${url.protocol}//${projectRef}.storage.supabase.co/storage/v1/upload/resumable`;
+  }
+
+  return `${url.origin}/storage/v1/upload/resumable`;
+}
+
+function getSignedResumableUploadEndpoint() {
+  const url = new URL(SUPABASE_URL);
+  return `${url.origin}/storage/v1/upload/resumable/sign`;
+}
+
+function getUploadContentType(file: UploadableFile, override?: string) {
+  return override || file.type || "application/octet-stream";
+}
+
+export function shouldUseResumableUpload(file: UploadableFile) {
+  return file.size >= RESUMABLE_UPLOAD_THRESHOLD_BYTES;
+}
+
+export async function uploadStorageObject(
+  supabase: SupabaseStorageClient,
+  options: StorageUploadOptions,
+): Promise<void> {
+  const { bucket, path, file, cacheControl = "3600", contentType, upsert = false, onProgress } = options;
+
+  if (!options.signedUploadToken && !shouldUseResumableUpload(file)) {
+    const { error } = await supabase.storage.from(bucket).upload(path, file, {
+      cacheControl,
+      contentType: getUploadContentType(file, contentType),
+      upsert,
+    });
+
+    if (error) throw error;
+    onProgress?.({ bytesUploaded: file.size, bytesTotal: file.size, percentage: 100 });
+    return;
+  }
+
+  let endpoint = getResumableUploadEndpoint();
+  let headers: Record<string, string> = {
+    apikey: SUPABASE_ANON_KEY,
+    "x-upsert": String(upsert),
+  };
+
+  if (options.signedUploadToken) {
+    endpoint = getSignedResumableUploadEndpoint();
+    headers = {
+      apikey: SUPABASE_ANON_KEY,
+      "x-signature": options.signedUploadToken,
+    };
+  } else {
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabase.auth.getSession();
+
+    if (sessionError) throw sessionError;
+    if (!session?.access_token) {
+      throw new Error("Usuario no autenticado");
+    }
+
+    headers.authorization = `Bearer ${session.access_token}`;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const upload = new tus.Upload(file, {
+      endpoint,
+      retryDelays: [0, 3000, 5000, 10000, 20000],
+      headers,
+      metadata: {
+        bucketName: bucket,
+        objectName: path,
+        contentType: getUploadContentType(file, contentType),
+        cacheControl,
+      },
+      fingerprint: async (uploadFile) => {
+        const namedFile = uploadFile as UploadableFile & { lastModified?: number };
+        return [
+          endpoint,
+          bucket,
+          path,
+          namedFile.name ?? "blob",
+          namedFile.size,
+          namedFile.type ?? "",
+          namedFile.lastModified ?? "",
+        ].join(":");
+      },
+      chunkSize: TUS_CHUNK_SIZE_BYTES,
+      uploadDataDuringCreation: true,
+      removeFingerprintOnSuccess: true,
+      onProgress: (bytesUploaded, bytesTotal) => {
+        const percentage = bytesTotal > 0 ? (bytesUploaded / bytesTotal) * 100 : 0;
+        onProgress?.({ bytesUploaded, bytesTotal, percentage });
+      },
+      onError: reject,
+      onSuccess: () => resolve(),
+    });
+
+    upload.findPreviousUploads()
+      .then((previousUploads) => {
+        const [previousUpload] = previousUploads;
+        if (previousUpload) {
+          upload.resumeFromPreviousUpload(previousUpload);
+        }
+        upload.start();
+      })
+      .catch(reject);
+  });
+}
+
+export function getStorageUploadErrorMessage(error: unknown, file?: UploadableFile) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (file && shouldUseResumableUpload(file) && /failed to fetch|networkerror|load failed/i.test(message)) {
+    return "No se pudo completar la subida del archivo grande. Revisa la conexion e intentalo de nuevo; la subida se enviara por partes.";
+  }
+
+  return message || "No se pudo subir el archivo";
+}

--- a/src/utils/storageUpload.ts
+++ b/src/utils/storageUpload.ts
@@ -24,6 +24,20 @@ type StorageUploadOptions = {
 };
 
 type SupabaseStorageClient = Pick<SupabaseClient, "auth" | "storage">;
+type UploadErrorWithStatus = {
+  status?: unknown;
+  statusCode?: unknown;
+  originalResponse?: {
+    getStatus?: () => unknown;
+    status?: unknown;
+    statusCode?: unknown;
+  };
+};
+
+function normalizeStatusCode(value: unknown) {
+  const numeric = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  return Number.isFinite(numeric) ? numeric : null;
+}
 
 function getResumableUploadEndpoint() {
   const url = new URL(SUPABASE_URL);
@@ -147,4 +161,28 @@ export function getStorageUploadErrorMessage(error: unknown, file?: UploadableFi
   }
 
   return message || "No se pudo subir el archivo";
+}
+
+export function getStorageUploadStatusCode(error: unknown) {
+  const errorWithStatus = error as UploadErrorWithStatus;
+  const response = errorWithStatus.originalResponse;
+  const candidates = [
+    errorWithStatus.status,
+    errorWithStatus.statusCode,
+    response?.status,
+    response?.statusCode,
+    response?.getStatus?.(),
+  ];
+
+  for (const candidate of candidates) {
+    const statusCode = normalizeStatusCode(candidate);
+    if (statusCode !== null) return statusCode;
+  }
+
+  return null;
+}
+
+export function isStorageNotFoundError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return getStorageUploadStatusCode(error) === 404 || /bucket not found/i.test(message);
 }

--- a/src/utils/taskDocuments.ts
+++ b/src/utils/taskDocuments.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/lib/supabase";
+import { uploadStorageObject } from "@/utils/storageUpload";
 
 export type SignedUrlResult = { signedUrl: string | null };
 
@@ -24,6 +25,16 @@ export async function remove(bucket: string, filePath: string): Promise<boolean>
 }
 
 export async function upload(bucket: string, filePath: string, file: File | Blob): Promise<boolean> {
-  const { error } = await supabase.storage.from(bucket).upload(filePath, file, { upsert: true });
-  return !error;
+  try {
+    await uploadStorageObject(supabase, {
+      bucket,
+      path: filePath,
+      file,
+      contentType: file.type || "application/octet-stream",
+      upsert: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/utils/taskStorageUpload.ts
+++ b/src/utils/taskStorageUpload.ts
@@ -1,0 +1,28 @@
+import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
+
+type UploadClient = Parameters<typeof uploadStorageObject>[0];
+type UploadFile = Parameters<typeof uploadStorageObject>[1]["file"];
+
+type TaskStorageUploadOptions = {
+  bucket: string;
+  path: string;
+  file: UploadFile;
+  upsert: boolean;
+};
+
+export async function uploadTaskStorageObject(
+  supabase: UploadClient,
+  { bucket, path, file, upsert }: TaskStorageUploadOptions,
+) {
+  try {
+    await uploadStorageObject(supabase, {
+      bucket,
+      path,
+      file,
+      contentType: file.type || "application/octet-stream",
+      upsert,
+    });
+  } catch (error) {
+    throw new Error(getStorageUploadErrorMessage(error, file));
+  }
+}

--- a/supabase/functions/upload-public-artist-rider/index.ts
+++ b/supabase/functions/upload-public-artist-rider/index.ts
@@ -8,7 +8,7 @@ import {
 } from "../_shared/http.ts";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
 
-const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 const MAX_FILES_PER_REQUEST = 10;
 const MAX_MULTIPART_BODY_BYTES = MAX_FILES_PER_REQUEST * MAX_FILE_SIZE_BYTES + 1024 * 1024;
 const INGRESS_RATE_LIMIT_WINDOW_SECONDS = 60;
@@ -74,6 +74,26 @@ type JobTitleRow = {
   title: string | null;
 };
 
+type FileDescriptor = {
+  name?: unknown;
+  type?: unknown;
+  size?: unknown;
+};
+
+type PreparedUploadTarget = {
+  client_id: string;
+  file_name: string;
+  file_path: string;
+  file_type: string | null;
+  file_size: number;
+  upload_token: string;
+};
+
+type UploadContext = {
+  formRow: UploadFormRow;
+  artistContext: ArtistLookupRow | null;
+};
+
 const sanitizeFileName = (value: string) => {
   const trimmed = value.trim();
   const cleaned = trimmed
@@ -110,6 +130,276 @@ const buildArtistTableUrl = (jobId?: string | null, artistDate?: string | null) 
   return `/festival-management/${normalizedJobId}/artists?date=${encodeURIComponent(normalizedDate)}`;
 };
 
+const buildRiderFilePath = (artistId: string, sanitizedName: string) => {
+  const timestampPrefix = new Date().toISOString().replace(/[:.]/g, "-");
+  return `${artistId}/${timestampPrefix}-${crypto.randomUUID()}-${sanitizedName}`;
+};
+
+const getFileValidationStatus = (errorCode: string) =>
+  errorCode === "file_too_large"
+    ? 413
+    : errorCode === "empty_file" ||
+        errorCode === "invalid_file_extension" ||
+        errorCode === "invalid_file_type" ||
+        errorCode === "invalid_file_name" ||
+        errorCode === "invalid_file_size"
+      ? 400
+      : 500;
+
+const validateFileDescriptor = (descriptor: FileDescriptor) => {
+  const fileName = typeof descriptor.name === "string" ? descriptor.name : "";
+  const fileType = typeof descriptor.type === "string" ? descriptor.type : "";
+  const fileSize =
+    typeof descriptor.size === "number"
+      ? descriptor.size
+      : typeof descriptor.size === "string"
+        ? Number(descriptor.size)
+        : Number.NaN;
+
+  if (!fileName.trim()) {
+    throw new Error("invalid_file_name");
+  }
+
+  if (!Number.isFinite(fileSize)) {
+    throw new Error("invalid_file_size");
+  }
+
+  if (fileSize <= 0) {
+    throw new Error("empty_file");
+  }
+
+  if (fileSize > MAX_FILE_SIZE_BYTES) {
+    throw new Error("file_too_large");
+  }
+
+  const sanitizedName = sanitizeFileName(fileName);
+  const extension = getFileExtension(sanitizedName);
+  if (!extension || !ALLOWED_EXTENSIONS.has(extension)) {
+    throw new Error("invalid_file_extension");
+  }
+
+  if (fileType && !ALLOWED_MIME_TYPES.has(fileType)) {
+    throw new Error("invalid_file_type");
+  }
+
+  return {
+    sanitizedName,
+    fileType: fileType || null,
+    fileSize,
+  };
+};
+
+async function loadUploadContext(
+  req: Request,
+  supabaseAdmin: ReturnType<typeof createClient>,
+  token: string,
+  rateLimitSalt: string,
+): Promise<UploadContext | Response> {
+  if (!token) {
+    return jsonResponse({ ok: false, error: "missing_token" }, { status: 400 });
+  }
+
+  const tokenRateLimit = await checkEdgeRateLimit({
+    req,
+    supabase: supabaseAdmin,
+    scope: "upload-public-artist-rider",
+    identifierParts: [token],
+    windowSeconds: TOKEN_RATE_LIMIT_WINDOW_SECONDS,
+    maxRequests: TOKEN_RATE_LIMIT_MAX_REQUESTS,
+    includeIp: false,
+    includeUserAgent: false,
+    salt: rateLimitSalt,
+  });
+
+  if (!tokenRateLimit.allowed) {
+    return jsonResponse(
+      { ok: false, error: "rate_limited" },
+      { status: 429, headers: rateLimitHeaders(tokenRateLimit) },
+    );
+  }
+
+  const { data: formRow, error: formError } = await supabaseAdmin
+    .from("festival_artist_forms")
+    .select("id, artist_id, status, expires_at")
+    .eq("token", token)
+    .maybeSingle<UploadFormRow>();
+
+  if (formError) {
+    console.error("[upload-public-artist-rider] token lookup error", formError);
+    return jsonResponse({ ok: false, error: "token_lookup_failed" }, { status: 500 });
+  }
+
+  if (!formRow) {
+    return jsonResponse({ ok: false, error: "invalid_token" }, { status: 404 });
+  }
+
+  let artistContext: ArtistLookupRow | null = null;
+  const { data: artistRow, error: artistError } = await supabaseAdmin
+    .from("festival_artists")
+    .select("id, job_id, name, date")
+    .eq("id", formRow.artist_id)
+    .maybeSingle<ArtistLookupRow>();
+
+  if (artistError) {
+    console.error("[upload-public-artist-rider] artist lookup error", artistError);
+  } else if (artistRow) {
+    artistContext = artistRow;
+  }
+
+  if (formRow.status !== "pending") {
+    return jsonResponse({ ok: false, error: "form_not_pending", status: formRow.status }, { status: 409 });
+  }
+
+  if (new Date(formRow.expires_at).getTime() <= Date.now()) {
+    await supabaseAdmin
+      .from("festival_artist_forms")
+      .update({ status: "expired", updated_at: new Date().toISOString() })
+      .eq("id", formRow.id);
+
+    return jsonResponse({ ok: false, error: "form_expired", status: "expired" }, { status: 410 });
+  }
+
+  const { data: submittedRow, error: submittedError } = await supabaseAdmin
+    .from("festival_artist_form_submissions")
+    .select("id")
+    .eq("artist_id", formRow.artist_id)
+    .eq("status", "submitted")
+    .maybeSingle();
+
+  if (submittedError && submittedError.code !== "PGRST116") {
+    console.error("[upload-public-artist-rider] submission lookup error", submittedError);
+    return jsonResponse({ ok: false, error: "submission_lookup_failed" }, { status: 500 });
+  }
+
+  if (submittedRow) {
+    await supabaseAdmin
+      .from("festival_artist_forms")
+      .update({ status: "submitted", updated_at: new Date().toISOString() })
+      .eq("id", formRow.id);
+
+    return jsonResponse({ ok: false, error: "already_submitted", status: "submitted" }, { status: 409 });
+  }
+
+  return { formRow, artistContext };
+}
+
+async function notifyRiderUpload(
+  supabaseAdmin: ReturnType<typeof createClient>,
+  context: UploadContext,
+  insertedFiles: Array<Record<string, unknown>>,
+) {
+  if (insertedFiles.length === 0) return;
+
+  let jobTitle: string | null = null;
+  if (context.artistContext?.job_id) {
+    const { data: jobRow, error: jobError } = await supabaseAdmin
+      .from("jobs")
+      .select("title")
+      .eq("id", context.artistContext.job_id)
+      .maybeSingle<JobTitleRow>();
+
+    if (jobError) {
+      console.error("[upload-public-artist-rider] job lookup error", jobError);
+    } else {
+      jobTitle = jobRow?.title ?? null;
+    }
+  }
+
+  const artistUrl = buildArtistTableUrl(context.artistContext?.job_id, context.artistContext?.date);
+  const { error: pushError } = await supabaseAdmin.functions.invoke("push", {
+    body: {
+      action: "broadcast",
+      type: "festival.public_rider.uploaded",
+      job_id: context.artistContext?.job_id ?? undefined,
+      job_title: jobTitle ?? undefined,
+      artist_id: context.artistContext?.id ?? context.formRow.artist_id,
+      artist_name: context.artistContext?.name ?? undefined,
+      artist_date: context.artistContext?.date ?? undefined,
+      file_name:
+        insertedFiles.length === 1
+          ? String(insertedFiles[0].file_name ?? "")
+          : `${String(insertedFiles[0].file_name ?? "rider")} (+${insertedFiles.length - 1})`,
+      url: artistUrl,
+    },
+  });
+
+  if (pushError) {
+    console.error("[upload-public-artist-rider] push invoke error", pushError);
+  }
+}
+
+async function insertUploadedRiderFiles(
+  supabaseAdmin: ReturnType<typeof createClient>,
+  context: UploadContext,
+  files: Array<{ file_name: string; file_path: string; file_type: string | null; file_size: number }>,
+) {
+  const insertedFiles: Array<Record<string, unknown>> = [];
+
+  try {
+    for (const file of files) {
+      if (!file.file_path.startsWith(`${context.formRow.artist_id}/`)) {
+        throw new Error("invalid_file_path");
+      }
+
+      const folder = context.formRow.artist_id;
+      const objectName = file.file_path.slice(folder.length + 1);
+      const { data: storedFiles, error: listError } = await supabaseAdmin.storage
+        .from("festival_artist_files")
+        .list(folder, { limit: 1, search: objectName });
+
+      if (listError) {
+        console.error("[upload-public-artist-rider] storage list error", listError);
+        throw new Error("storage_lookup_failed");
+      }
+
+      if (!storedFiles?.some((storedFile) => storedFile.name === objectName)) {
+        throw new Error("uploaded_file_missing");
+      }
+
+      const { data: insertedFile, error: insertError } = await supabaseAdmin
+        .from("festival_artist_files")
+        .insert({
+          artist_id: context.formRow.artist_id,
+          file_name: file.file_name,
+          file_path: file.file_path,
+          file_type: file.file_type,
+          file_size: file.file_size,
+        })
+        .select("id, file_name, file_path, file_type, file_size, uploaded_at, uploaded_by")
+        .single();
+
+      if (insertError || !insertedFile) {
+        console.error("[upload-public-artist-rider] file metadata insert error", insertError);
+        throw new Error("metadata_insert_failed");
+      }
+
+      insertedFiles.push(insertedFile as Record<string, unknown>);
+    }
+  } catch (error) {
+    if (insertedFiles.length > 0) {
+      const insertedIds = insertedFiles
+        .map((file) => String(file.id ?? ""))
+        .filter((id) => id.length > 0);
+      if (insertedIds.length > 0) {
+        await supabaseAdmin.from("festival_artist_files").delete().in("id", insertedIds);
+      }
+    }
+    throw error;
+  }
+
+  await notifyRiderUpload(supabaseAdmin, context, insertedFiles);
+
+  return {
+    ok: true,
+    file: insertedFiles[0] ? { ...insertedFiles[0], uploaded_by_name: null } : null,
+    files: insertedFiles.map((file) => ({
+      ...file,
+      uploaded_by_name: null,
+    })),
+    count: insertedFiles.length,
+  };
+}
+
 serve(createHttpHandler(async (req) => {
   try {
     const {
@@ -133,6 +423,115 @@ serve(createHttpHandler(async (req) => {
         { ok: false, error: "rate_limited" },
         { status: 429, headers: rateLimitHeaders(ingressRateLimit) },
       );
+    }
+
+    const contentType = req.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      let body: Record<string, unknown>;
+      try {
+        body = await req.json() as Record<string, unknown>;
+      } catch {
+        return jsonResponse({ ok: false, error: "invalid_json" }, { status: 400 });
+      }
+
+      const action = typeof body.action === "string" ? body.action : "";
+      const token = typeof body.token === "string" ? body.token.trim() : "";
+
+      if (action === "prepare") {
+        const files = Array.isArray(body.files) ? body.files : [];
+        if (files.length === 0) {
+          return jsonResponse({ ok: false, error: "missing_file" }, { status: 400 });
+        }
+        if (files.length > MAX_FILES_PER_REQUEST) {
+          return jsonResponse({ ok: false, error: "too_many_files" }, { status: 400 });
+        }
+
+        const contextOrResponse = await loadUploadContext(req, supabaseAdmin, token, rateLimitSalt);
+        if (contextOrResponse instanceof Response) return contextOrResponse;
+
+        const targets: PreparedUploadTarget[] = [];
+
+        try {
+          for (const [index, rawFile] of files.entries()) {
+            if (!rawFile || typeof rawFile !== "object" || Array.isArray(rawFile)) {
+              throw new Error("invalid_file");
+            }
+
+            const descriptor = rawFile as FileDescriptor & { client_id?: unknown };
+            const validated = validateFileDescriptor(descriptor);
+            const filePath = buildRiderFilePath(contextOrResponse.formRow.artist_id, validated.sanitizedName);
+            const { data: signedUpload, error: signedUploadError } = await supabaseAdmin.storage
+              .from("festival_artist_files")
+              .createSignedUploadUrl(filePath);
+
+            if (signedUploadError || !signedUpload?.token) {
+              console.error("[upload-public-artist-rider] signed upload error", signedUploadError);
+              throw new Error("signed_upload_failed");
+            }
+
+            targets.push({
+              client_id: typeof descriptor.client_id === "string" ? descriptor.client_id : String(index),
+              file_name: validated.sanitizedName,
+              file_path: filePath,
+              file_type: validated.fileType,
+              file_size: validated.fileSize,
+              upload_token: signedUpload.token,
+            });
+          }
+        } catch (error) {
+          const errorCode = error instanceof Error ? error.message : "internal_error";
+          return jsonResponse({ ok: false, error: errorCode }, { status: getFileValidationStatus(errorCode) });
+        }
+
+        return jsonResponse({ ok: true, files: targets }, { status: 200 });
+      }
+
+      if (action === "complete") {
+        const files = Array.isArray(body.files) ? body.files : [];
+        if (files.length === 0) {
+          return jsonResponse({ ok: false, error: "missing_file" }, { status: 400 });
+        }
+        if (files.length > MAX_FILES_PER_REQUEST) {
+          return jsonResponse({ ok: false, error: "too_many_files" }, { status: 400 });
+        }
+
+        const contextOrResponse = await loadUploadContext(req, supabaseAdmin, token, rateLimitSalt);
+        if (contextOrResponse instanceof Response) return contextOrResponse;
+
+        try {
+          const completedFiles = files.map((rawFile) => {
+            if (!rawFile || typeof rawFile !== "object" || Array.isArray(rawFile)) {
+              throw new Error("invalid_file");
+            }
+
+            const fileRecord = rawFile as Record<string, unknown>;
+            const validated = validateFileDescriptor({
+              name: fileRecord.file_name,
+              type: fileRecord.file_type,
+              size: fileRecord.file_size,
+            });
+            const filePath = typeof fileRecord.file_path === "string" ? fileRecord.file_path : "";
+
+            return {
+              file_name: validated.sanitizedName,
+              file_path: filePath,
+              file_type: validated.fileType,
+              file_size: validated.fileSize,
+            };
+          });
+
+          const result = await insertUploadedRiderFiles(supabaseAdmin, contextOrResponse, completedFiles);
+          return jsonResponse(result, { status: 201 });
+        } catch (error) {
+          const errorCode = error instanceof Error ? error.message : "internal_error";
+          const status = errorCode === "invalid_file_path" || errorCode === "uploaded_file_missing"
+            ? 400
+            : getFileValidationStatus(errorCode);
+          return jsonResponse({ ok: false, error: errorCode }, { status });
+        }
+      }
+
+      return jsonResponse({ ok: false, error: "invalid_action" }, { status: 400 });
     }
 
     const contentLength = Number.parseInt(req.headers.get("content-length") ?? "", 10);
@@ -162,30 +561,20 @@ serve(createHttpHandler(async (req) => {
       return jsonResponse({ ok: false, error: "too_many_files" }, { status: 400 });
     }
 
-    const validatedFiles = fileEntries.map((entry) => {
-      if (entry.size <= 0) {
-        throw new Error("empty_file");
-      }
-
-      if (entry.size > MAX_FILE_SIZE_BYTES) {
-        throw new Error("file_too_large");
-      }
-
-      const sanitizedName = sanitizeFileName(entry.name || "rider");
-      const extension = getFileExtension(sanitizedName);
-      if (!extension || !ALLOWED_EXTENSIONS.has(extension)) {
-        throw new Error("invalid_file_extension");
-      }
-
-      if (entry.type && !ALLOWED_MIME_TYPES.has(entry.type)) {
-        throw new Error("invalid_file_type");
-      }
-
-      return {
+    let validatedFiles: Array<{ file: File; sanitizedName: string }>;
+    try {
+      validatedFiles = fileEntries.map((entry) => ({
         file: entry,
-        sanitizedName,
-      };
-    });
+        sanitizedName: validateFileDescriptor({
+          name: entry.name || "rider",
+          type: entry.type,
+          size: entry.size,
+        }).sanitizedName,
+      }));
+    } catch (validationError) {
+      const errorCode = validationError instanceof Error ? validationError.message : "internal_error";
+      return jsonResponse({ ok: false, error: errorCode }, { status: getFileValidationStatus(errorCode) });
+    }
 
     const tokenRateLimit = await checkEdgeRateLimit({
       req,
@@ -273,8 +662,7 @@ serve(createHttpHandler(async (req) => {
 
     try {
       for (const entry of validatedFiles) {
-        const timestampPrefix = new Date().toISOString().replace(/[:.]/g, "-");
-        const filePath = `${formRow.artist_id}/${timestampPrefix}-${crypto.randomUUID()}-${entry.sanitizedName}`;
+        const filePath = buildRiderFilePath(formRow.artist_id, entry.sanitizedName);
 
         const { error: storageError } = await supabaseAdmin.storage
           .from("festival_artist_files")

--- a/supabase/functions/upload-public-artist-rider/index.ts
+++ b/supabase/functions/upload-public-artist-rider/index.ts
@@ -94,6 +94,11 @@ type UploadContext = {
   artistContext: ArtistLookupRow | null;
 };
 
+type StorageListFile = {
+  name: string;
+  metadata?: Record<string, unknown> | null;
+};
+
 const sanitizeFileName = (value: string) => {
   const trimmed = value.trim();
   const cleaned = trimmed
@@ -186,6 +191,33 @@ const validateFileDescriptor = (descriptor: FileDescriptor) => {
     sanitizedName,
     fileType: fileType || null,
     fileSize,
+  };
+};
+
+const readMetadataNumber = (metadata: Record<string, unknown>, keys: string[]) => {
+  for (const key of keys) {
+    const value = metadata[key];
+    const numeric = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return null;
+};
+
+const readMetadataString = (metadata: Record<string, unknown>, keys: string[]) => {
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+};
+
+const normalizeMimeType = (value: string | null) => value?.trim().toLowerCase() || null;
+
+const readStoredFileMetadata = (storedFile: StorageListFile) => {
+  const metadata = storedFile.metadata && typeof storedFile.metadata === "object" ? storedFile.metadata : {};
+  return {
+    size: readMetadataNumber(metadata, ["size", "content_length", "contentLength"]),
+    mimeType: readMetadataString(metadata, ["mimetype", "mime_type", "contentType", "content-type"]),
   };
 };
 
@@ -352,8 +384,21 @@ async function insertUploadedRiderFiles(
         throw new Error("storage_lookup_failed");
       }
 
-      if (!storedFiles?.some((storedFile) => storedFile.name === objectName)) {
+      const storedFile = (storedFiles as StorageListFile[] | null | undefined)
+        ?.find((candidate) => candidate.name === objectName);
+      if (!storedFile) {
         throw new Error("uploaded_file_missing");
+      }
+
+      const storedMetadata = readStoredFileMetadata(storedFile);
+      if (storedMetadata.size !== null && storedMetadata.size !== file.file_size) {
+        throw new Error("uploaded_file_size_mismatch");
+      }
+
+      const storedMimeType = normalizeMimeType(storedMetadata.mimeType);
+      const submittedMimeType = normalizeMimeType(file.file_type);
+      if (storedMimeType && submittedMimeType && storedMimeType !== submittedMimeType) {
+        throw new Error("uploaded_file_type_mismatch");
       }
 
       const { data: insertedFile, error: insertError } = await supabaseAdmin
@@ -362,8 +407,8 @@ async function insertUploadedRiderFiles(
           artist_id: context.formRow.artist_id,
           file_name: file.file_name,
           file_path: file.file_path,
-          file_type: file.file_type,
-          file_size: file.file_size,
+          file_type: storedMetadata.mimeType || file.file_type,
+          file_size: storedMetadata.size ?? file.file_size,
         })
         .select("id, file_name, file_path, file_type, file_size, uploaded_at, uploaded_by")
         .single();
@@ -524,9 +569,13 @@ serve(createHttpHandler(async (req) => {
           return jsonResponse(result, { status: 201 });
         } catch (error) {
           const errorCode = error instanceof Error ? error.message : "internal_error";
-          const status = errorCode === "invalid_file_path" || errorCode === "uploaded_file_missing"
-            ? 400
-            : getFileValidationStatus(errorCode);
+          const status =
+            errorCode === "invalid_file_path" ||
+            errorCode === "uploaded_file_missing" ||
+            errorCode === "uploaded_file_size_mismatch" ||
+            errorCode === "uploaded_file_type_mismatch"
+              ? 400
+              : getFileValidationStatus(errorCode);
           return jsonResponse({ ok: false, error: errorCode }, { status });
         }
       }


### PR DESCRIPTION
## Summary
- Add a shared Supabase Storage resumable upload helper using `tus-js-client` for files at or above 6 MB.
- Route DWG/document upload paths through the helper so large files upload in 6 MB chunks instead of one large request.
- Change public artist rider uploads from multipart Edge Function upload to prepare/signed-upload/complete, and align the function limit with the 50 MB UI validator.
- Add focused tests for normal, authenticated resumable, signed resumable, and error-path storage uploads.

## Root Cause
A 29 MB DWG could exceed the existing public rider Edge Function's 25 MB file cap and several client upload paths still used one-shot Storage uploads. Depending on the browser/network path, that surfaced as a generic `Failed to fetch` instead of a useful file-size or upload error.

## User Impact
Large DWG/CAD and rider uploads now use Supabase resumable uploads, which reduces failed single-request uploads and preserves clearer validation/storage messages when an upload still fails.

## Risk Assessment
- Medium: upload behavior is shared across job, task, tour, festival, and public rider document paths.
- Mitigation: small files still use the existing Supabase `.upload(...)` path; large files switch to Supabase's documented TUS path with 6 MB chunks.
- Public rider completion now verifies uploaded object metadata before inserting database rows.

## Impact Checklist
- [x] App storage uploads for large documents use chunked resumable uploads.
- [x] Public artist rider uploads avoid multipart Edge Function bodies for large files.
- [x] Existing small-file upload behavior is preserved.
- [x] No database schema or RLS changes.
- [x] No production migration required.

## Migration Impact
No database migration is included. The `upload-public-artist-rider` Edge Function must be deployed with this application release so the public prepare/complete flow is available in production.

## Rollback Plan
Revert this PR and redeploy the previous `upload-public-artist-rider` Edge Function version. Existing uploaded files and file metadata remain compatible because storage paths and database rows keep the same shape.

## Validation
- `npm ci --legacy-peer-deps`
- `npm run typecheck`
- `npm run lint:all` (0 errors; existing warnings remain)
- `npm run governance`
- `npm run test:critical`
- `npm run test:run` (213 files, 1165 tests)
- `npm run build`
- `npm run budget:bundle`
