### PR TITLE
fix: mobile navbar unstick on iOS PWA resume and job document upload bucket mismatch

### DIFF
--- a/src/components/layout/MobileNavBar.test.tsx
+++ b/src/components/layout/MobileNavBar.test.tsx
@@ -136,4 +136,34 @@ describe("MobileNavBar", () => {
 
     await waitFor(() => expect(nav.style.bottom).toBe(""))
   })
+
+  it("recomputes the offset on visibilitychange when iOS resumes a backgrounded PWA without firing resize", async () => {
+    mockVisualViewport({
+      height: 700,
+      innerHeight: 760,
+      offsetTop: 0,
+    })
+
+    renderMobileNav()
+
+    const nav = screen.getByRole("navigation", { name: /navegación principal/i })
+
+    await waitFor(() => expect(nav.style.bottom).toBe("60px"))
+
+    // Simulate the viewport settling back to full height while backgrounded,
+    // without any "resize" event firing on resume (the iOS PWA behavior this
+    // guards against).
+    ;(window.visualViewport as unknown as { height: number }).height = 760
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    })
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+
+    await waitFor(() => expect(nav.style.bottom).toBe(""))
+  })
 })

--- a/src/components/layout/MobileNavBar.test.tsx
+++ b/src/components/layout/MobileNavBar.test.tsx
@@ -104,6 +104,44 @@ function mockVisualViewport({
   }
 }
 
+/**
+ * Replaces requestAnimationFrame with a manually-flushed queue so tests can
+ * assert on the rAF-deferred follow-up recomputes without relying on real
+ * frame timing.
+ */
+function mockRequestAnimationFrame() {
+  const originalRaf = window.requestAnimationFrame
+  const originalCaf = window.cancelAnimationFrame
+  let nextId = 1
+  const callbacks = new Map<number, FrameRequestCallback>()
+
+  window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+    const id = nextId++
+    callbacks.set(id, callback)
+    return id
+  }) as typeof window.requestAnimationFrame
+
+  window.cancelAnimationFrame = vi.fn((id: number) => {
+    callbacks.delete(id)
+  }) as typeof window.cancelAnimationFrame
+
+  return {
+    // Drains every queued frame, including ones scheduled by callbacks that
+    // run during the flush (e.g. the nested second rAF).
+    flush() {
+      while (callbacks.size > 0) {
+        const [id, callback] = callbacks.entries().next().value as [number, FrameRequestCallback]
+        callbacks.delete(id)
+        callback(0)
+      }
+    },
+    restore() {
+      window.requestAnimationFrame = originalRaf
+      window.cancelAnimationFrame = originalCaf
+    },
+  }
+}
+
 describe("MobileNavBar", () => {
   it("renders the fixed nav in a body portal", () => {
     const { container } = renderMobileNav()
@@ -143,27 +181,40 @@ describe("MobileNavBar", () => {
       innerHeight: 760,
       offsetTop: 0,
     })
+    const raf = mockRequestAnimationFrame()
 
-    renderMobileNav()
+    try {
+      renderMobileNav()
 
-    const nav = screen.getByRole("navigation", { name: /navegación principal/i })
+      const nav = screen.getByRole("navigation", { name: /navegación principal/i })
 
-    await waitFor(() => expect(nav.style.bottom).toBe("60px"))
+      await waitFor(() => expect(nav.style.bottom).toBe("60px"))
 
-    // Simulate the viewport settling back to full height while backgrounded,
-    // without any "resize" event firing on resume (the iOS PWA behavior this
-    // guards against).
-    ;(window.visualViewport as unknown as { height: number }).height = 760
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      })
 
-    Object.defineProperty(document, "visibilityState", {
-      configurable: true,
-      value: "visible",
-    })
+      // Dispatch while the viewport is still reporting the stale (backgrounded)
+      // height, mirroring WebKit reporting old values for a frame or two after
+      // resume. The immediate recompute should see no change yet.
+      act(() => {
+        document.dispatchEvent(new Event("visibilitychange"))
+      })
+      expect(nav.style.bottom).toBe("60px")
 
-    act(() => {
-      document.dispatchEvent(new Event("visibilitychange"))
-    })
+      // The corrected height only becomes available a frame later, without any
+      // "resize" event firing on resume (the iOS PWA behavior this guards
+      // against).
+      ;(window.visualViewport as unknown as { height: number }).height = 760
 
-    await waitFor(() => expect(nav.style.bottom).toBe(""))
+      act(() => {
+        raf.flush()
+      })
+
+      expect(nav.style.bottom).toBe("")
+    } finally {
+      raf.restore()
+    }
   })
 })

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -54,6 +54,28 @@ function useVisualViewportBottomOffset() {
 
     updateBottomOffset()
 
+    // iOS often resumes a backgrounded/minimized PWA without firing a "resize"
+    // event even though the WebKit-reported viewport offsets were stale at the
+    // moment it was backgrounded (e.g. mid-keyboard-dismiss or mid-chrome
+    // animation). Without a recompute on resume, the fixed nav stays pinned to
+    // that stale offset and visibly "unsticks" from the bottom. Recompute on
+    // the visibility/pageshow signals below, with a couple of rAF-deferred
+    // follow-ups since WebKit can report the old viewport values for a frame
+    // or two right after resume.
+    const recomputeOnResume = () => {
+      updateBottomOffset()
+      requestAnimationFrame(() => {
+        updateBottomOffset()
+        requestAnimationFrame(updateBottomOffset)
+      })
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        recomputeOnResume()
+      }
+    }
+
     const visualViewport = window.visualViewport
     window.addEventListener("resize", updateBottomOffset)
     window.addEventListener("orientationchange", updateBottomOffset)
@@ -62,11 +84,15 @@ function useVisualViewportBottomOffset() {
     // fires continuously during momentum/rubber-band scrolling with transient
     // offsets, which made the fixed bottom bar chase the viewport and visibly
     // "unstick". Keyboard and browser-chrome changes still arrive via "resize".
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    window.addEventListener("pageshow", recomputeOnResume)
 
     return () => {
       window.removeEventListener("resize", updateBottomOffset)
       window.removeEventListener("orientationchange", updateBottomOffset)
       visualViewport?.removeEventListener("resize", updateBottomOffset)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+      window.removeEventListener("pageshow", recomputeOnResume)
     }
   }, [])
 

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -62,12 +62,22 @@ function useVisualViewportBottomOffset() {
     // the visibility/pageshow signals below, with a couple of rAF-deferred
     // follow-ups since WebKit can report the old viewport values for a frame
     // or two right after resume.
+    let pendingFrames: number[] = []
+
+    const cancelPendingFrames = () => {
+      pendingFrames.forEach((frameId) => cancelAnimationFrame(frameId))
+      pendingFrames = []
+    }
+
     const recomputeOnResume = () => {
+      cancelPendingFrames()
       updateBottomOffset()
-      requestAnimationFrame(() => {
+      const firstFrame = requestAnimationFrame(() => {
         updateBottomOffset()
-        requestAnimationFrame(updateBottomOffset)
+        const secondFrame = requestAnimationFrame(updateBottomOffset)
+        pendingFrames.push(secondFrame)
       })
+      pendingFrames.push(firstFrame)
     }
 
     const handleVisibilityChange = () => {
@@ -93,6 +103,7 @@ function useVisualViewportBottomOffset() {
       visualViewport?.removeEventListener("resize", updateBottomOffset)
       document.removeEventListener("visibilitychange", handleVisibilityChange)
       window.removeEventListener("pageshow", recomputeOnResume)
+      cancelPendingFrames()
     }
   }, [])
 

--- a/src/features/festival-management/__tests__/commands.test.ts
+++ b/src/features/festival-management/__tests__/commands.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  dbInsert: vi.fn(),
+  storageFrom: vi.fn(),
+  storageRemove: vi.fn(),
+  storageUpload: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      insert: mocks.dbInsert,
+    })),
+    storage: {
+      from: mocks.storageFrom,
+    },
+  },
+}));
+
+import { resolveJobDocLocation } from "@/utils/jobDocuments";
+import { uploadJobDocument } from "@/features/festival-management/commands";
+
+describe("uploadJobDocument", () => {
+  it("uploads to the same bucket resolveJobDocLocation resolves for the stored path", async () => {
+    mocks.storageFrom.mockReturnValue({
+      upload: mocks.storageUpload,
+      remove: mocks.storageRemove,
+    });
+    mocks.storageUpload.mockResolvedValue({ error: null });
+    mocks.dbInsert.mockResolvedValue({ error: null });
+
+    const file = new File(["contenido"], "rider.pdf", { type: "application/pdf" });
+
+    await uploadJobDocument({ file, jobId: "job-1" });
+
+    const [uploadBucket] = mocks.storageFrom.mock.calls[0];
+    const [objectPath] = mocks.storageUpload.mock.calls[0];
+
+    expect(objectPath).toBe("job-1/rider.pdf");
+    expect(uploadBucket).toBe("job-documents");
+
+    // Any later view/download/delete of this row resolves its bucket from the
+    // stored file_path alone. If the upload bucket ever drifts from what this
+    // resolves to, re-uploading a deleted file's name fails forever because
+    // the real object never gets cleaned up from the bucket it actually lives in.
+    expect(resolveJobDocLocation(objectPath).bucket).toBe(uploadBucket);
+  });
+});

--- a/src/features/festival-management/commands.ts
+++ b/src/features/festival-management/commands.ts
@@ -73,7 +73,7 @@ export const uploadJobDocument = async ({ file, jobId }: { file: File; jobId: st
 
   try {
     await uploadStorageObject(supabase, {
-      bucket: "job_documents",
+      bucket: "job-documents",
       path: filePath,
       file: uploadFile,
       contentType: uploadFile.type || file.type || "application/octet-stream",
@@ -89,7 +89,7 @@ export const uploadJobDocument = async ({ file, jobId }: { file: File; jobId: st
   });
 
   if (dbError) {
-    const { error: cleanupError } = await supabase.storage.from("job_documents").remove([filePath]);
+    const { error: cleanupError } = await supabase.storage.from("job-documents").remove([filePath]);
     if (cleanupError) {
       console.error("Failed to remove uploaded job document after database insert error:", cleanupError);
     }


### PR DESCRIPTION
MobileNavBar only recomputed its visual-viewport bottom offset on
resize/orientationchange. iOS often resumes a backgrounded/minimized PWA
without firing resize even though the offset was stale when backgrounded,
leaving the fixed nav detached from the bottom. Recompute on
visibilitychange/pageshow (with rAF-deferred follow-ups) to catch that case.

uploadJobDocument (festival job documents) uploaded to the "job_documents"
storage bucket, but resolveJobDocLocation - used by every viewer/downloader/
deleter for the same file_path - resolves non-department-prefixed paths to
the "job-documents" bucket. Deleting one of these documents therefore only
removed the DB row; the real object stayed orphaned in "job_documents".
Re-uploading a file with the same name then always collided with that
orphan, so the "duplicate name" upload error persisted even after the
document appeared deleted. Fixed the upload to target "job-documents" to
match the resolver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation positioning so it refreshes correctly when returning to the app or switching back to a visible tab, including on iOS PWAs.
  * Fixed job document uploads to use the updated storage path, helping prevent upload issues and cleanup inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->