### PR TITLE
fix: allow .mvr file uploads across document upload surfaces

### DIFF
--- a/src/lib/enhanced-security-config.ts
+++ b/src/lib/enhanced-security-config.ts
@@ -88,6 +88,7 @@ const DOCUMENT_UPLOAD_ALLOWED_EXTENSIONS = new Set([
   'dwg',
   'dfx',
   'dxf',
+  'mvr',
 ]);
 
 const DOCUMENT_UPLOAD_ALLOWED_MIME_TYPES = new Set([
@@ -113,6 +114,9 @@ const DOCUMENT_UPLOAD_ALLOWED_MIME_TYPES = new Set([
   'application/vnd.dxf',
   'image/vnd.dxf',
   'drawing/x-dxf',
+  'application/zip',
+  'application/x-zip-compressed',
+  'application/x-mvr',
 ]);
 
 /**

--- a/src/utils/__tests__/documentUploadValidation.test.ts
+++ b/src/utils/__tests__/documentUploadValidation.test.ts
@@ -14,7 +14,7 @@ const createFile = (name: string, type = "") =>
   new File(["technical file"], name, { type });
 
 describe("document upload validation", () => {
-  const technicalExtensions = [".xmlp", ".xmlc", ".xmls", ".nwm", ".dwg", ".dfx", ".dxf"];
+  const technicalExtensions = [".xmlp", ".xmlc", ".xmls", ".nwm", ".dwg", ".dfx", ".dxf", ".mvr"];
 
   it("exposes technical and CAD formats in the shared accept string", () => {
     for (const extension of technicalExtensions) {
@@ -32,6 +32,7 @@ describe("document upload validation", () => {
       createFile("legacy.dfx"),
       createFile("cad-export.dxf", "application/dxf"),
       createFile("stage-plot.webp", "image/webp"),
+      createFile("rig.mvr", "application/zip"),
     ];
 
     expect(getDocumentUploadValidationError(files)).toBeNull();
@@ -45,7 +46,7 @@ describe("document upload validation", () => {
 
 describe("SoundVision file validation", () => {
   it("accepts the SoundVision and CAD formats used by technical teams", () => {
-    for (const extension of [".xmlp", ".xmlc", ".xmls", ".nwm", ".dwg", ".dfx", ".dxf"]) {
+    for (const extension of [".xmlp", ".xmlc", ".xmls", ".nwm", ".dwg", ".dfx", ".dxf", ".mvr"]) {
       expect(SOUNDVISION_ALLOWED_FILE_TYPES).toContain(extension);
       expect(validateSoundVisionFile(createFile(`venue${extension}`, "application/octet-stream"))).toEqual({
         valid: true,

--- a/src/utils/documentUploadValidation.ts
+++ b/src/utils/documentUploadValidation.ts
@@ -1,6 +1,6 @@
 import { validateFileUpload } from "@/lib/enhanced-security-config";
 
-export const DOCUMENT_UPLOAD_ACCEPT = ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.webp,.txt,.xmlp,.xmlc,.xmls,.nwm,.dwg,.dfx,.dxf";
+export const DOCUMENT_UPLOAD_ACCEPT = ".pdf,.doc,.docx,.jpg,.jpeg,.png,.gif,.webp,.txt,.xmlp,.xmlc,.xmls,.nwm,.dwg,.dfx,.dxf,.mvr";
 
 export const getDocumentUploadValidationError = (files: File[]) => {
   for (const file of files) {

--- a/src/utils/soundvisionFileValidation.ts
+++ b/src/utils/soundvisionFileValidation.ts
@@ -6,7 +6,8 @@
 // .xmlc - Archivo de configuración (exportaciones como posiciones de altavoces)
 // .nwm - Archivo de modelo NWM usado como referencia técnica
 // .dwg/.dxf/.dfx - Planos CAD usados como referencia técnica
-export const ALLOWED_FILE_TYPES = ['.xmlp', '.xmls', '.xmlc', '.nwm', '.dwg', '.dxf', '.dfx'];
+// .mvr - My Virtual Rig (formato GDTF, contenedor ZIP con datos 3D de escenario)
+export const ALLOWED_FILE_TYPES = ['.xmlp', '.xmls', '.xmlc', '.nwm', '.dwg', '.dxf', '.dfx', '.mvr'];
 export const ALLOWED_MIME_TYPES = [
   'application/xml',
   'text/xml',
@@ -22,6 +23,9 @@ export const ALLOWED_MIME_TYPES = [
   'application/vnd.dxf',
   'image/vnd.dxf',
   'drawing/x-dxf',
+  'application/zip', // MVR files are ZIP containers
+  'application/x-zip-compressed',
+  'application/x-mvr',
 ];
 export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB in bytes
 

--- a/supabase/functions/upload-public-artist-rider/index.ts
+++ b/supabase/functions/upload-public-artist-rider/index.ts
@@ -31,6 +31,7 @@ const ALLOWED_EXTENSIONS = new Set([
   "dwg",
   "dfx",
   "dxf",
+  "mvr",
 ]);
 const ALLOWED_MIME_TYPES = new Set([
   "application/pdf",
@@ -54,6 +55,9 @@ const ALLOWED_MIME_TYPES = new Set([
   "application/vnd.dxf",
   "image/vnd.dxf",
   "drawing/x-dxf",
+  "application/zip",
+  "application/x-zip-compressed",
+  "application/x-mvr",
 ]);
 
 type UploadFormRow = {


### PR DESCRIPTION
## Summary
- MVR (My Virtual Rig) files were rejected everywhere the shared document-upload allowlists are enforced, since `.mvr` wasn't a recognized extension or MIME type.
- Added `.mvr` (and the ZIP-based MIME types it's commonly reported with — `application/zip`, `application/x-zip-compressed`, `application/x-mvr`) to:
  - `src/lib/enhanced-security-config.ts` — the shared `validateFileUpload` check used by job document uploads (`useJobCard.ts`, `useOptimizedJobCard.ts`)
  - `src/utils/documentUploadValidation.ts` — the shared `DOCUMENT_UPLOAD_ACCEPT` string used by the tour document uploader and artist rider form
  - `src/utils/soundvisionFileValidation.ts` — the SoundVision/technical file validator
  - `supabase/functions/upload-public-artist-rider/index.ts` — server-side validation for the public (unauthenticated) artist rider upload endpoint
- Extended `src/utils/__tests__/documentUploadValidation.test.ts` to cover `.mvr` in the accept string and both client-side validators.

## Test plan
- [x] `npm test -- --run src/utils/__tests__/documentUploadValidation.test.ts`
- [x] `npm run typecheck`

Fixes #788


---
_Generated by [Claude Code](https://claude.ai/code/session_01DLzfCAXcSSByfh3RYou83Q)_