### PR TITLE
fix: allow house tech festival uploads

### DIFF
--- a/supabase/migrations/20260701230000_allow_house_tech_festival_uploads.sql
+++ b/supabase/migrations/20260701230000_allow_house_tech_festival_uploads.sql
@@ -1,0 +1,188 @@
+insert into storage.buckets (id, name, public)
+values
+  ('festival_artist_files', 'festival_artist_files', false),
+  ('festival-logos', 'festival-logos', false)
+on conflict (id) do nothing;
+
+drop policy if exists "p_festival_artist_files_public_insert_279f74" on public.festival_artist_files;
+
+create policy "p_festival_artist_files_public_insert_279f74"
+on public.festival_artist_files
+for insert
+to authenticated
+with check (
+  public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+);
+
+drop policy if exists "p_festival_logos_public_insert_4ce816" on public.festival_logos;
+drop policy if exists "p_festival_logos_public_update_bc2a4a" on public.festival_logos;
+
+create policy "p_festival_logos_public_insert_4ce816"
+on public.festival_logos
+for insert
+to authenticated
+with check (
+  public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+);
+
+create policy "p_festival_logos_public_update_bc2a4a"
+on public.festival_logos
+for update
+to authenticated
+using (
+  public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+)
+with check (
+  public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+);
+
+drop policy if exists "p_storage_festival_artist_files_house_tech_select" on storage.objects;
+drop policy if exists "p_storage_festival_artist_files_house_tech_insert" on storage.objects;
+drop policy if exists "p_storage_festival_artist_files_house_tech_update" on storage.objects;
+drop policy if exists "p_storage_festival_artist_files_authorized_select" on storage.objects;
+drop policy if exists "p_storage_festival_artist_files_authorized_insert" on storage.objects;
+drop policy if exists "p_storage_festival_artist_files_authorized_update" on storage.objects;
+drop policy if exists "p_storage_festival_logos_house_tech_select" on storage.objects;
+drop policy if exists "p_storage_festival_logos_house_tech_insert" on storage.objects;
+drop policy if exists "p_storage_festival_logos_house_tech_update" on storage.objects;
+drop policy if exists "p_storage_festival_logos_authorized_select" on storage.objects;
+drop policy if exists "p_storage_festival_logos_authorized_insert" on storage.objects;
+drop policy if exists "p_storage_festival_logos_authorized_update" on storage.objects;
+
+create policy "p_storage_festival_artist_files_authorized_select"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'festival_artist_files'
+  and public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  and exists (
+    select 1
+    from public.festival_artists fa
+    where fa.id = case
+      when split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        then split_part(storage.objects.name, '/', 1)::uuid
+      else null
+    end
+  )
+);
+
+create policy "p_storage_festival_artist_files_authorized_insert"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'festival_artist_files'
+  and public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  and exists (
+    select 1
+    from public.festival_artists fa
+    where fa.id = case
+      when split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        then split_part(storage.objects.name, '/', 1)::uuid
+      else null
+    end
+  )
+);
+
+create policy "p_storage_festival_artist_files_authorized_update"
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'festival_artist_files'
+  and public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  and exists (
+    select 1
+    from public.festival_artists fa
+    where fa.id = case
+      when split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        then split_part(storage.objects.name, '/', 1)::uuid
+      else null
+    end
+  )
+)
+with check (
+  bucket_id = 'festival_artist_files'
+  and public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  and exists (
+    select 1
+    from public.festival_artists fa
+    where fa.id = case
+      when split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        then split_part(storage.objects.name, '/', 1)::uuid
+      else null
+    end
+  )
+);
+
+create policy "p_storage_festival_logos_authorized_select"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'festival-logos'
+  and public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id = case
+      when storage.objects.name ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.[A-Za-z0-9]+$'
+        then split_part(storage.objects.name, '.', 1)::uuid
+      else null
+    end
+      and j.job_type::text in ('festival', 'ciclo')
+  )
+);
+
+create policy "p_storage_festival_logos_authorized_insert"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'festival-logos'
+  and public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id = case
+      when storage.objects.name ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.[A-Za-z0-9]+$'
+        then split_part(storage.objects.name, '.', 1)::uuid
+      else null
+    end
+      and j.job_type::text in ('festival', 'ciclo')
+  )
+);
+
+create policy "p_storage_festival_logos_authorized_update"
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'festival-logos'
+  and public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id = case
+      when storage.objects.name ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.[A-Za-z0-9]+$'
+        then split_part(storage.objects.name, '.', 1)::uuid
+      else null
+    end
+      and j.job_type::text in ('festival', 'ciclo')
+  )
+)
+with check (
+  bucket_id = 'festival-logos'
+  and public.get_current_user_role() = any (array['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  and exists (
+    select 1
+    from public.jobs j
+    where j.id = case
+      when storage.objects.name ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.[A-Za-z0-9]+$'
+        then split_part(storage.objects.name, '.', 1)::uuid
+      else null
+    end
+      and j.job_type::text in ('festival', 'ciclo')
+  )
+);

--- a/supabase/tests/database/festival_artist_permissions.sql
+++ b/supabase/tests/database/festival_artist_permissions.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(6);
+SELECT plan(16);
 
 SELECT is(
   (
@@ -82,6 +82,171 @@ SELECT ok(
       AND qual ILIKE '%house_tech%'
   ),
   'house techs retain festival artist read access'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artist_files'
+      AND cmd = 'INSERT'
+      AND with_check ILIKE '%house_tech%'
+  ),
+  'house techs may insert festival artist file metadata'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_logos'
+      AND cmd = 'INSERT'
+      AND with_check ILIKE '%house_tech%'
+  ),
+  'house techs may insert festival logo metadata'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_logos'
+      AND cmd = 'UPDATE'
+      AND qual ILIKE '%house_tech%'
+      AND with_check ILIKE '%house_tech%'
+  ),
+  'house techs may update festival logo metadata'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'p_storage_festival_artist_files_authorized_select'
+      AND cmd = 'SELECT'
+      AND qual ILIKE '%festival_artist_files%'
+      AND qual ILIKE '%admin%'
+      AND qual ILIKE '%management%'
+      AND qual ILIKE '%logistics%'
+      AND qual ILIKE '%house_tech%'
+      AND qual ILIKE '%festival_artists%'
+  ),
+  'house techs may view festival artist file storage objects'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'p_storage_festival_artist_files_authorized_insert'
+      AND cmd = 'INSERT'
+      AND with_check ILIKE '%festival_artist_files%'
+      AND with_check ILIKE '%admin%'
+      AND with_check ILIKE '%management%'
+      AND with_check ILIKE '%logistics%'
+      AND with_check ILIKE '%house_tech%'
+      AND with_check ILIKE '%festival_artists%'
+  ),
+  'house techs may upload festival artist file storage objects'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'p_storage_festival_artist_files_authorized_update'
+      AND cmd = 'UPDATE'
+      AND qual ILIKE '%festival_artist_files%'
+      AND qual ILIKE '%admin%'
+      AND qual ILIKE '%management%'
+      AND qual ILIKE '%logistics%'
+      AND qual ILIKE '%house_tech%'
+      AND with_check ILIKE '%festival_artist_files%'
+      AND with_check ILIKE '%admin%'
+      AND with_check ILIKE '%management%'
+      AND with_check ILIKE '%logistics%'
+      AND with_check ILIKE '%house_tech%'
+  ),
+  'house techs may upsert festival artist file storage objects'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'p_storage_festival_logos_authorized_select'
+      AND cmd = 'SELECT'
+      AND qual ILIKE '%festival-logos%'
+      AND qual ILIKE '%admin%'
+      AND qual ILIKE '%management%'
+      AND qual ILIKE '%logistics%'
+      AND qual ILIKE '%house_tech%'
+      AND qual ILIKE '%festival%'
+      AND qual ILIKE '%ciclo%'
+  ),
+  'house techs may view festival logo storage objects'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'p_storage_festival_logos_authorized_insert'
+      AND cmd = 'INSERT'
+      AND with_check ILIKE '%festival-logos%'
+      AND with_check ILIKE '%admin%'
+      AND with_check ILIKE '%management%'
+      AND with_check ILIKE '%logistics%'
+      AND with_check ILIKE '%house_tech%'
+      AND with_check ILIKE '%festival%'
+      AND with_check ILIKE '%ciclo%'
+  ),
+  'house techs may upload festival logo storage objects'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'p_storage_festival_logos_authorized_update'
+      AND cmd = 'UPDATE'
+      AND qual ILIKE '%festival-logos%'
+      AND qual ILIKE '%admin%'
+      AND qual ILIKE '%management%'
+      AND qual ILIKE '%logistics%'
+      AND qual ILIKE '%house_tech%'
+      AND with_check ILIKE '%festival-logos%'
+      AND with_check ILIKE '%admin%'
+      AND with_check ILIKE '%management%'
+      AND with_check ILIKE '%logistics%'
+      AND with_check ILIKE '%house_tech%'
+  ),
+  'house techs may upsert festival logo storage objects'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM storage.buckets
+    WHERE id IN ('festival_artist_files', 'festival-logos')
+    HAVING count(*) = 2
+  ),
+  'festival upload buckets are declared by migrations'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
## Summary
- allow house techs to insert festival artist file metadata and upsert festival logo metadata
- add scoped storage RLS for house techs on `festival_artist_files` and `festival-logos` upload/view/upsert paths
- extend database policy tests to cover the file and logo upload permissions

## Root cause
House techs could mutate festival artists after the previous permissions change, but the related file metadata and storage object policies still blocked the upload paths from the festival management interface.

## Validation
- `npm run ci:db:migrations`
- `npx supabase db reset --local --no-seed`
- `npx supabase db lint --local --fail-on error --schema public,auth`
- `npx supabase test db supabase/tests/database`
- `npm run lint`
- `npm run typecheck`
- `npm run governance`
- `npm run test:critical`
- `npm run build`
- `npm run budget:bundle`