### PR TITLE
Remove ReactQuill wrapper dependency

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,29 +20,36 @@
 
 ## Known Vulnerabilities (Cannot Fix)
 
-### react-quill/quill - Cross-site Scripting (MODERATE)
+### Quill HTML export - Cross-site Scripting (LOW)
 - **Status**: ⚠️ ACCEPTED RISK
-- **CVE**: GHSA-4943-9vgg-gr5r
-- **Severity**: Moderate (CVSS 4.2)
-- **Affected**: react-quill@2.0.0 bundles quill@1.3.7
+- **CVE**: GHSA-v3m3-f69x-jf25
+- **Severity**: Low
+- **Affected**: quill@2.0.3
 - **Mitigation**:
-  - Application directly uses quill@2.0.3 (not vulnerable)
-  - react-quill has not been updated since Aug 2022
-  - XSS requires authenticated user with low privileges (AC:H - High Attack Complexity)
-  - Consider replacing react-quill with alternative editor in future
-- **Why not fixed**: No updated version of react-quill available that uses quill 2.x
+  - ReactQuill and its nested quill@1.3.7 copy have been removed.
+  - Corporate email sanitizes editor HTML with DOMPurify before sending.
+  - Do not render Quill HTML output outside a DOMPurify-sanitized flow.
+- **Why not fixed**: No patched Quill 2.x release is available. `npm audit fix` suggests downgrading to quill@2.0.2, which should be treated as a planned dependency change with editor regression testing.
 
-### esbuild - Development Server Request Vulnerability (MODERATE)
-- **Status**: ⚠️ ACCEPTED RISK (DEV ONLY)
-- **CVE**: GHSA-67mh-4wv8-2f99
-- **Severity**: Moderate (CVSS 5.3)
-- **Affected**: esbuild@0.24.2 (via vitest@2.1.9)
+### ExcelJS/uuid - Buffer Bounds Check (MODERATE)
+- **Status**: ⚠️ ACCEPTED RISK
+- **CVE**: GHSA-w5hq-g745-h8pq
+- **Severity**: Moderate
+- **Affected**: exceljs@4.4.0 -> uuid@8.3.2
 - **Mitigation**:
-  - Only affects development environment
-  - Not present in production builds
-  - Requires high attack complexity (AC:H)
-  - Upgrading vitest to 4.x would require major changes and testing
-- **Why not fixed**: Would require vitest major version upgrade (2.x → 4.x) which needs extensive testing
+  - ExcelJS is used for generated spreadsheet exports.
+  - The application does not pass caller-controlled buffers to uuid v3/v5/v6 through ExcelJS.
+- **Why not fixed**: `npm audit fix` requires downgrading ExcelJS to 3.4.0, which would undo the SheetJS replacement and requires a dedicated export regression pass. Revisit when ExcelJS publishes a compatible uuid update.
+
+### Capacitor assets toolchain - tar/minimatch/uuid (HIGH)
+- **Status**: ⚠️ ACCEPTED RISK (BUILD TOOLING)
+- **CVE**: GHSA-34x7-hfp2-rc4v, GHSA-8qq5-rm4j-mr97, GHSA-83g3-92jg-28cx, GHSA-qffp-2rhf-9h96, GHSA-9ppj-qmqm-q256, GHSA-r6q2-hw4h-h46w, GHSA-vmf3-w455-68vh, GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74, GHSA-w5hq-g745-h8pq
+- **Severity**: High
+- **Affected**: @capacitor/assets@3.0.5 -> @capacitor/cli/tar and @trapezedev/project/replace/minimatch/xcode/uuid
+- **Mitigation**:
+  - Build-time only; these packages are not part of the production browser bundle.
+  - Capacitor asset generation runs on controlled repository assets, not on untrusted archives or glob patterns.
+- **Why not fixed**: `npm audit` reports no compatible fix for @capacitor/assets. Revisit when @capacitor/assets or @trapezedev/project publishes a patched dependency chain.
 
 ## Security Best Practices
 
@@ -125,7 +132,7 @@
 ### Medium Priority (Next Month)
 - [ ] Implement automated security scanning in CI/CD (npm audit, Snyk, or OWASP)
 - [ ] Set up Dependabot or Renovate for automated dependency PRs
-- [ ] Consider replacing react-quill with maintained alternative (TipTap, Lexical, Slate)
+- [ ] Track a patched Quill 2.x release or schedule a tested downgrade from quill@2.0.3 to quill@2.0.2
 - [ ] Document security testing procedures in test suite
 
 ### Long-term (Next Quarter)

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
         "react-markdown": "^10.1.0",
-        "react-quill": "^2.0.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
         "react-signature-canvas": "^1.1.0-alpha.2",
@@ -5322,21 +5321,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/quill": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
-      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
-      "license": "MIT",
-      "dependencies": {
-        "parchment": "^1.1.2"
-      }
-    },
-    "node_modules/@types/quill/node_modules/parchment": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@types/raf": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
@@ -6667,53 +6651,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -6963,15 +6900,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -7829,26 +7757,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arguments": "^1.1.1",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.5.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -7866,23 +7774,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -7890,23 +7781,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dequal": {
@@ -8075,20 +7949,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -8226,19 +8086,11 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8250,18 +8102,6 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -9009,15 +8849,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9030,30 +8862,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-nonce": {
@@ -9157,19 +8965,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/git-raw-commits": {
@@ -9312,18 +9107,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -9385,49 +9168,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9729,22 +9474,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -9773,22 +9502,6 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9900,24 +9613,6 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-stream": {
       "version": "3.0.0",
@@ -10755,15 +10450,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -12206,31 +11892,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -13350,67 +13011,6 @@
         "react": ">=18"
       }
     },
-    "node_modules/react-quill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
-      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/quill": "^1.3.10",
-        "lodash": "^4.17.4",
-        "quill": "^1.3.7"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
-      }
-    },
-    "node_modules/react-quill/node_modules/eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
-      "license": "MIT"
-    },
-    "node_modules/react-quill/node_modules/fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/react-quill/node_modules/parchment": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/react-quill/node_modules/quill": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "clone": "^2.1.1",
-        "deep-equal": "^1.0.1",
-        "eventemitter3": "^2.0.3",
-        "extend": "^3.0.2",
-        "parchment": "^1.1.4",
-        "quill-delta": "^3.6.2"
-      }
-    },
-    "node_modules/react-quill/node_modules/quill-delta": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "deep-equal": "^1.0.1",
-        "extend": "^3.0.2",
-        "fast-diff": "1.1.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
@@ -13854,26 +13454,6 @@
       "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/rehype-autolink-headings": {
       "version": "7.1.0",
@@ -14562,38 +14142,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
     "react-markdown": "^10.1.0",
-    "react-quill": "^2.0.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "react-signature-canvas": "^1.1.0-alpha.2",

--- a/scripts/governance/dependency-audit-baseline.json
+++ b/scripts/governance/dependency-audit-baseline.json
@@ -1,9 +1,8 @@
 {
   "version": 1,
-  "generatedAt": "2026-06-12T21:28:10.080Z",
+  "generatedAt": "2026-07-01T21:13:42Z",
   "note": "Current npm audit advisories are grandfathered. CI fails on new advisory IDs or increased severity counts.",
   "advisoryIds": [
-    "1098574",
     "1112659",
     "1113300",
     "1113375",
@@ -15,27 +14,36 @@
     "1114680",
     "1116451",
     "1119441",
-    "1120679",
     "1120782"
   ],
   "exceptions": [
     {
-      "advisoryId": "1120679",
-      "package": "esbuild",
-      "rationale": "The vulnerable Deno module path is not used; this repository consumes esbuild through Node and Vite 6. The patched esbuild 0.28 line breaks Vite 6 target transforms, so remove this exception during the planned Vite major migration."
+      "advisoryId": "1116451",
+      "package": "quill",
+      "rationale": "The direct editor dependency is quill@2.0.3. ReactQuill and its nested quill@1.3.7 copy have been removed. Corporate email sanitizes editor HTML with DOMPurify before send; remove this exception when Quill publishes a patched 2.x release or a tested downgrade to 2.0.2 is approved."
+    },
+    {
+      "advisoryId": "1119441",
+      "package": "uuid",
+      "rationale": "This is pulled through exceljs@4.4.0 and the @capacitor/assets toolchain. The app does not pass caller-controlled buffers to uuid v3/v5/v6 through these libraries, and npm audit's ExcelJS fix path downgrades to 3.4.0; remove this exception when ExcelJS or Capacitor assets publish compatible dependency updates."
     },
     {
       "advisoryId": "1120782",
       "package": "tar",
       "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x. @capacitor/assets is already at its latest release and npm audit reports no fixAvailable path for that nested CLI; remove this exception when @capacitor/assets publishes a compatible release that no longer depends on the vulnerable tar range."
+    },
+    {
+      "advisoryId": "1113459",
+      "package": "minimatch",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @trapezedev/project -> replace. It is used only by local/build tooling on controlled project inputs; remove this exception when @capacitor/assets or @trapezedev/project publishes a compatible release without the vulnerable minimatch range."
     }
   ],
   "vulnerabilityCounts": {
     "info": 0,
-    "low": 0,
-    "moderate": 5,
-    "high": 12,
+    "low": 1,
+    "moderate": 3,
+    "high": 6,
     "critical": 0
   },
-  "total": 17
+  "total": 10
 }

--- a/scripts/governance/dependency-audit-baseline.json
+++ b/scripts/governance/dependency-audit-baseline.json
@@ -18,6 +18,51 @@
   ],
   "exceptions": [
     {
+      "advisoryId": "1112659",
+      "package": "tar",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar. Capacitor asset generation is local/build tooling on controlled project assets, and npm audit reports no compatible fix for @capacitor/assets; remove this exception when that toolchain no longer depends on the vulnerable tar range."
+    },
+    {
+      "advisoryId": "1113300",
+      "package": "tar",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar. Capacitor asset generation is local/build tooling on controlled project assets, and npm audit reports no compatible fix for @capacitor/assets; remove this exception when that toolchain no longer depends on the vulnerable tar range."
+    },
+    {
+      "advisoryId": "1113375",
+      "package": "tar",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar. Capacitor asset generation is local/build tooling on controlled project assets, and npm audit reports no compatible fix for @capacitor/assets; remove this exception when that toolchain no longer depends on the vulnerable tar range."
+    },
+    {
+      "advisoryId": "1113459",
+      "package": "minimatch",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @trapezedev/project -> replace -> minimatch. It is used only by local/build tooling on controlled project inputs; remove this exception when @capacitor/assets or @trapezedev/project publishes a compatible release without the vulnerable minimatch range."
+    },
+    {
+      "advisoryId": "1113538",
+      "package": "minimatch",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @trapezedev/project -> replace -> minimatch. It is used only by local/build tooling on controlled project inputs; remove this exception when @capacitor/assets or @trapezedev/project publishes a compatible release without the vulnerable minimatch range."
+    },
+    {
+      "advisoryId": "1113546",
+      "package": "minimatch",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @trapezedev/project -> replace -> minimatch. It is used only by local/build tooling on controlled project inputs; remove this exception when @capacitor/assets or @trapezedev/project publishes a compatible release without the vulnerable minimatch range."
+    },
+    {
+      "advisoryId": "1114200",
+      "package": "tar",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar. Capacitor asset generation is local/build tooling on controlled project assets, and npm audit reports no compatible fix for @capacitor/assets; remove this exception when that toolchain no longer depends on the vulnerable tar range."
+    },
+    {
+      "advisoryId": "1114302",
+      "package": "tar",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar. Capacitor asset generation is local/build tooling on controlled project assets, and npm audit reports no compatible fix for @capacitor/assets; remove this exception when that toolchain no longer depends on the vulnerable tar range."
+    },
+    {
+      "advisoryId": "1114680",
+      "package": "tar",
+      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar. Capacitor asset generation is local/build tooling on controlled project assets, and npm audit reports no compatible fix for @capacitor/assets; remove this exception when that toolchain no longer depends on the vulnerable tar range."
+    },
+    {
       "advisoryId": "1116451",
       "package": "quill",
       "rationale": "The direct editor dependency is quill@2.0.3. ReactQuill and its nested quill@1.3.7 copy have been removed. Corporate email sanitizes editor HTML with DOMPurify before send; remove this exception when Quill publishes a patched 2.x release or a tested downgrade to 2.0.2 is approved."
@@ -25,17 +70,12 @@
     {
       "advisoryId": "1119441",
       "package": "uuid",
-      "rationale": "This is pulled through exceljs@4.4.0 and the @capacitor/assets toolchain. The app does not pass caller-controlled buffers to uuid v3/v5/v6 through these libraries, and npm audit's ExcelJS fix path downgrades to 3.4.0; remove this exception when ExcelJS or Capacitor assets publish compatible dependency updates."
+      "rationale": "This is pulled through both exceljs@4.4.0 -> uuid@8.3.2 and @capacitor/assets 3.0.5 -> @trapezedev/project -> xcode -> uuid@7.0.3. The app does not pass caller-controlled buffers to uuid v3/v5/v6 through these libraries, and npm audit's ExcelJS fix path downgrades to 3.4.0; remove this exception only after both dependency paths resolve to a non-vulnerable uuid range."
     },
     {
       "advisoryId": "1120782",
       "package": "tar",
       "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x. @capacitor/assets is already at its latest release and npm audit reports no fixAvailable path for that nested CLI; remove this exception when @capacitor/assets publishes a compatible release that no longer depends on the vulnerable tar range."
-    },
-    {
-      "advisoryId": "1113459",
-      "package": "minimatch",
-      "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @trapezedev/project -> replace. It is used only by local/build tooling on controlled project inputs; remove this exception when @capacitor/assets or @trapezedev/project publishes a compatible release without the vulnerable minimatch range."
     }
   ],
   "vulnerabilityCounts": {

--- a/src/components/emails/RichTextEditor.css
+++ b/src/components/emails/RichTextEditor.css
@@ -5,9 +5,6 @@
   border-radius: 0.5rem;
   overflow: hidden;
   background: hsl(var(--background));
-}
-
-.rich-text-editor-wrapper .quill {
   display: flex;
   flex-direction: column;
 }

--- a/src/components/emails/RichTextEditor.tsx
+++ b/src/components/emails/RichTextEditor.tsx
@@ -40,8 +40,64 @@ const EDITOR_FORMATS = [
   "link",
 ];
 
+function normalizeQuillListHtml(html: string): string {
+  if (!html.includes("data-list") && !html.includes("ql-ui")) {
+    return html;
+  }
+
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  template.content.querySelectorAll(".ql-ui").forEach((node) => node.remove());
+
+  template.content.querySelectorAll("ol").forEach((list) => {
+    const childNodes = Array.from(list.childNodes);
+    const hasQuillListItems = childNodes.some((node) => {
+      return node.nodeType === 1
+        && (node as Element).tagName === "LI"
+        && (node as Element).hasAttribute("data-list");
+    });
+
+    if (!hasQuillListItems) {
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    let currentList: HTMLOListElement | HTMLUListElement | null = null;
+    let currentListTagName: "ol" | "ul" | null = null;
+
+    childNodes.forEach((node) => {
+      if (node.nodeType === 3 && !node.textContent?.trim()) {
+        return;
+      }
+
+      if (node.nodeType !== 1 || (node as Element).tagName !== "LI") {
+        currentList = null;
+        currentListTagName = null;
+        fragment.appendChild(node);
+        return;
+      }
+
+      const item = node as HTMLLIElement;
+      const listTagName = item.getAttribute("data-list") === "bullet" ? "ul" : "ol";
+      item.removeAttribute("data-list");
+
+      if (!currentList || currentListTagName !== listTagName) {
+        currentList = document.createElement(listTagName);
+        currentListTagName = listTagName;
+        fragment.appendChild(currentList);
+      }
+
+      currentList.appendChild(item);
+    });
+
+    list.replaceWith(fragment);
+  });
+
+  return template.innerHTML;
+}
+
 function normalizeEditorHtml(html: string): string {
-  return html === EMPTY_EDITOR_HTML ? "" : html;
+  return html === EMPTY_EDITOR_HTML ? "" : normalizeQuillListHtml(html);
 }
 
 export function RichTextEditor({

--- a/src/components/emails/RichTextEditor.tsx
+++ b/src/components/emails/RichTextEditor.tsx
@@ -23,9 +23,6 @@ const EDITOR_MODULES = {
     ["link"],
     ["clean"],
   ],
-  clipboard: {
-    matchVisual: false,
-  },
 };
 
 const EDITOR_FORMATS = [

--- a/src/components/emails/RichTextEditor.tsx
+++ b/src/components/emails/RichTextEditor.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useMemo } from "react";
-import ReactQuill from "react-quill";
-import "react-quill/dist/quill.snow.css";
+import { useEffect, useRef } from "react";
+import Quill from "quill";
+import "quill/dist/quill.snow.css";
 import "./RichTextEditor.css";
 
 interface RichTextEditorProps {
@@ -10,69 +10,114 @@ interface RichTextEditorProps {
   minHeight?: string;
 }
 
+const EMPTY_EDITOR_HTML = "<p><br></p>";
+
+const EDITOR_MODULES = {
+  toolbar: [
+    [{ header: [1, 2, 3, false] }],
+    [{ size: ["small", false, "large", "huge"] }],
+    ["bold", "italic", "underline", "strike"],
+    [{ color: [] as string[] }, { background: [] as string[] }],
+    [{ list: "ordered" }, { list: "bullet" }],
+    [{ align: [] as string[] }],
+    ["link"],
+    ["clean"],
+  ],
+  clipboard: {
+    matchVisual: false,
+  },
+};
+
+const EDITOR_FORMATS = [
+  "header",
+  "size",
+  "bold",
+  "italic",
+  "underline",
+  "strike",
+  "color",
+  "background",
+  "list",
+  "bullet",
+  "align",
+  "link",
+];
+
+function normalizeEditorHtml(html: string): string {
+  return html === EMPTY_EDITOR_HTML ? "" : html;
+}
+
 export function RichTextEditor({
   value,
   onChange,
   placeholder = "Escribe tu mensaje aquí...",
   minHeight = "250px",
 }: RichTextEditorProps) {
-  const quillRef = useRef<ReactQuill>(null);
-
-  // Configure the toolbar with essential formatting options
-  const modules = useMemo(
-    () => ({
-      toolbar: [
-        [{ header: [1, 2, 3, false] }],
-        [{ size: ["small", false, "large", "huge"] }],
-        ["bold", "italic", "underline", "strike"],
-        [{ color: [] as string[] }, { background: [] as string[] }],
-        [{ list: "ordered" }, { list: "bullet" }],
-        [{ align: [] as string[] }],
-        ["link"],
-        ["clean"],
-      ],
-      clipboard: {
-        matchVisual: false,
-      },
-    }),
-    []
-  );
-
-  const formats = [
-    "header",
-    "size",
-    "bold",
-    "italic",
-    "underline",
-    "strike",
-    "color",
-    "background",
-    "list",
-    "bullet",
-    "align",
-    "link",
-  ];
-
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
+  const quillRef = useRef<Quill | null>(null);
+  const valueRef = useRef(value);
+  const onChangeRef = useRef(onChange);
 
   useEffect(() => {
-    // Set CSS custom properties for dynamic styling
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
     if (wrapperRef.current) {
-      wrapperRef.current.style.setProperty('--editor-min-height', minHeight);
+      wrapperRef.current.style.setProperty("--editor-min-height", minHeight);
     }
   }, [minHeight]);
 
+  useEffect(() => {
+    if (!wrapperRef.current || !editorRef.current || quillRef.current) return;
+
+    const wrapperElement = wrapperRef.current;
+    const editorElement = editorRef.current;
+    const quill = new Quill(editorElement, {
+      theme: "snow",
+      modules: EDITOR_MODULES,
+      formats: EDITOR_FORMATS,
+      placeholder,
+    });
+
+    quillRef.current = quill;
+    if (valueRef.current) {
+      quill.clipboard.dangerouslyPasteHTML(valueRef.current, "silent");
+    }
+
+    const handleTextChange = () => {
+      const nextValue = normalizeEditorHtml(quill.root.innerHTML);
+      valueRef.current = nextValue;
+      onChangeRef.current(nextValue);
+    };
+
+    quill.on("text-change", handleTextChange);
+
+    return () => {
+      quill.off("text-change", handleTextChange);
+      quillRef.current = null;
+      Array.from(wrapperElement.children).forEach((child) => {
+        if (child !== editorElement && child.classList.contains("ql-toolbar")) {
+          child.remove();
+        }
+      });
+      editorElement.className = "rich-text-editor";
+      editorElement.replaceChildren();
+    };
+  }, [placeholder]);
+
+  useEffect(() => {
+    const quill = quillRef.current;
+    if (!quill || value === valueRef.current) return;
+
+    valueRef.current = value;
+    quill.clipboard.dangerouslyPasteHTML(value || "", "silent");
+  }, [value]);
+
   return (
     <div className="rich-text-editor-wrapper" ref={wrapperRef}>
-      <ReactQuill
-        ref={quillRef}
-        theme="snow"
-        value={value}
-        onChange={onChange}
-        modules={modules}
-        formats={formats}
-        placeholder={placeholder}
-      />
+      <div ref={editorRef} className="rich-text-editor" />
     </div>
   );
 }

--- a/src/components/emails/__tests__/RichTextEditor.test.tsx
+++ b/src/components/emails/__tests__/RichTextEditor.test.tsx
@@ -1,7 +1,7 @@
 import { act, render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { RichTextEditor } from "../RichTextEditor";
+import { RichTextEditor } from "@/components/emails/RichTextEditor";
 
 type PasteCall = {
   html: string;
@@ -113,5 +113,43 @@ describe("RichTextEditor", () => {
     });
 
     expect(onChange).toHaveBeenLastCalledWith("");
+  });
+
+  it("emits formatted Quill HTML without rewriting it", () => {
+    const onChange = vi.fn();
+    render(<RichTextEditor value="" onChange={onChange} />);
+    const editor = mockQuillInstances[0];
+    const formattedHtml =
+      '<ol><li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>Patch notes</li></ol><p><a href="https://example.com" target="_blank">Details</a></p>';
+
+    act(() => {
+      editor.root.innerHTML = formattedHtml;
+      editor.handlers.get("text-change")?.();
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith(formattedHtml);
+  });
+
+  it("cleans up listeners, toolbar DOM, and editor children on unmount", () => {
+    const onChange = vi.fn();
+    const { container, unmount } = render(
+      <RichTextEditor value="<p>Hello</p>" onChange={onChange} />,
+    );
+    const editor = mockQuillInstances[0];
+    const wrapper = container.querySelector(".rich-text-editor-wrapper");
+    const child = document.createElement("p");
+    child.textContent = "temporary content";
+    editor.element.appendChild(child);
+
+    expect(editor.handlers.has("text-change")).toBe(true);
+    expect(wrapper?.querySelectorAll(".ql-toolbar")).toHaveLength(1);
+    expect(editor.element.childNodes).toHaveLength(1);
+
+    unmount();
+
+    expect(editor.handlers.has("text-change")).toBe(false);
+    expect(wrapper?.querySelectorAll(".ql-toolbar")).toHaveLength(0);
+    expect(editor.element.className).toBe("rich-text-editor");
+    expect(editor.element.childNodes).toHaveLength(0);
   });
 });

--- a/src/components/emails/__tests__/RichTextEditor.test.tsx
+++ b/src/components/emails/__tests__/RichTextEditor.test.tsx
@@ -115,19 +115,21 @@ describe("RichTextEditor", () => {
     expect(onChange).toHaveBeenLastCalledWith("");
   });
 
-  it("emits formatted Quill HTML without rewriting it", () => {
+  it("emits semantic formatted HTML from Quill list markup", () => {
     const onChange = vi.fn();
     render(<RichTextEditor value="" onChange={onChange} />);
     const editor = mockQuillInstances[0];
     const formattedHtml =
       '<ol><li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>Patch notes</li></ol><p><a href="https://example.com" target="_blank">Details</a></p>';
+    const expectedHtml =
+      '<ul><li>Patch notes</li></ul><p><a href="https://example.com" target="_blank">Details</a></p>';
 
     act(() => {
       editor.root.innerHTML = formattedHtml;
       editor.handlers.get("text-change")?.();
     });
 
-    expect(onChange).toHaveBeenLastCalledWith(formattedHtml);
+    expect(onChange).toHaveBeenLastCalledWith(expectedHtml);
   });
 
   it("cleans up listeners, toolbar DOM, and editor children on unmount", () => {

--- a/src/components/emails/__tests__/RichTextEditor.test.tsx
+++ b/src/components/emails/__tests__/RichTextEditor.test.tsx
@@ -1,0 +1,117 @@
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RichTextEditor } from "../RichTextEditor";
+
+type PasteCall = {
+  html: string;
+  source: string;
+};
+
+type TextChangeHandler = () => void;
+
+const { mockQuillInstances, MockQuill } = vi.hoisted(() => {
+  class MockQuillClass {
+    root = { innerHTML: "" };
+    handlers = new Map<string, TextChangeHandler>();
+    pasteCalls: PasteCall[] = [];
+    options: Record<string, unknown>;
+    element: Element;
+
+    clipboard = {
+      dangerouslyPasteHTML: (html: string, source: string) => {
+        this.pasteCalls.push({ html, source });
+        this.root.innerHTML = html || "<p><br></p>";
+      },
+    };
+
+    constructor(element: Element, options: Record<string, unknown>) {
+      this.element = element;
+      this.options = options;
+      element.classList.add("ql-container");
+
+      const toolbar = document.createElement("div");
+      toolbar.className = "ql-toolbar";
+      element.parentElement?.insertBefore(toolbar, element);
+
+      instances.push(this);
+    }
+
+    on(event: string, handler: TextChangeHandler) {
+      this.handlers.set(event, handler);
+    }
+
+    off(event: string, handler: TextChangeHandler) {
+      if (this.handlers.get(event) === handler) {
+        this.handlers.delete(event);
+      }
+    }
+  }
+
+  const instances: MockQuillClass[] = [];
+
+  return {
+    mockQuillInstances: instances,
+    MockQuill: MockQuillClass,
+  };
+});
+
+vi.mock("quill", () => ({
+  default: MockQuill,
+}));
+
+describe("RichTextEditor", () => {
+  beforeEach(() => {
+    mockQuillInstances.length = 0;
+  });
+
+  it("initializes Quill with the supplied value and emits user edits", () => {
+    const onChange = vi.fn();
+
+    render(
+      <RichTextEditor
+        value="<p>Hello</p>"
+        onChange={onChange}
+        placeholder="Body"
+      />,
+    );
+
+    const editor = mockQuillInstances[0];
+    expect(editor.options).toMatchObject({
+      theme: "snow",
+      placeholder: "Body",
+    });
+    expect(editor.pasteCalls).toEqual([
+      { html: "<p>Hello</p>", source: "silent" },
+    ]);
+
+    act(() => {
+      editor.root.innerHTML = "<p>Updated</p>";
+      editor.handlers.get("text-change")?.();
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith("<p>Updated</p>");
+  });
+
+  it("syncs external value changes and normalizes empty Quill HTML", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <RichTextEditor value="" onChange={onChange} />,
+    );
+    const editor = mockQuillInstances[0];
+
+    rerender(<RichTextEditor value="<p>External</p>" onChange={onChange} />);
+
+    expect(editor.pasteCalls).toEqual([
+      { html: "<p>External</p>", source: "silent" },
+    ]);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      editor.root.innerHTML = "<p><br></p>";
+      editor.handlers.get("text-change")?.();
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith("");
+  });
+});


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Affected route/feature: Corporate email rich text composer and dependency/security audit baseline.

This removes the unmaintained `react-quill` wrapper and the nested Quill 1.3.7 dependency tree. `RichTextEditor` now uses the existing direct `quill@2.0.3` dependency, with explicit lifecycle/value-sync handling and regression coverage.

The dependency audit baseline and `SECURITY.md` were refreshed to match the current `npm audit` snapshot: 10 advisories remain documented/accepted, down from 17, with ReactQuill-specific risk removed. The CodeRabbit review notes were addressed by documenting every remaining advisory exception, removing the stale Quill 1 clipboard option, and expanding editor parity/cleanup tests.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: medium
- Main risks: rich text editor initialization/value synchronization/cleanup, corporate email formatting parity, and dependency audit baseline accuracy.
- [x] If this touches database, auth, CI/CD, dependency, security, or production-header paths, I checked CODEOWNER handling. CODEOWNERS names `@jvhtec` for `package*.json` and `scripts/governance/**`; GitHub rejected a separate reviewer request because `@jvhtec` is the PR author. CodeRabbit review is running on the latest push.
- [ ] If risk level is high, I requested two independent approvals before merge.

## Impact Checklist
- [x] Migration impact assessed.
- [x] Realtime/subscription impact assessed.
- [x] RLS/security impact assessed.
- [x] Performance impact assessed.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm ci --legacy-peer-deps` - pass; installs 1128 packages; audit now reports 10 vulnerabilities.
  - `npm run lint` - pass with existing warnings only.
  - `npm run lint:app` - pass with existing warnings only.
  - `npm run typecheck` - pass.
  - `npm run governance` - pass, including `audit:deps` with 1 low / 3 moderate / 6 high / 10 total advisories.
  - `npm run test:critical` - pass, 22 files / 103 tests.
  - `npm run test:run` - pass, 215 files / 1169 tests.
  - `npx vitest run src/components/emails/__tests__/RichTextEditor.test.tsx` - pass, 4 tests.
  - `npm run build` - pass with existing chunk-size warnings.
  - `npm run budget:bundle` - pass.
  - `git diff --check` - pass.
- Results: all relevant local validation passed.

## Rollback Plan
- [x] I documented how to safely revert this change.
- [x] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert this PR to restore the ReactQuill wrapper/dependency and previous audit baseline, then run `npm ci --legacy-peer-deps`, `npm run test:run`, and `npm run build` before redeploying.

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no
- If yes, describe migration, impact, and backout plan: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The rich text editor now uses a more direct editing setup with improved HTML normalization for cleaner saved content.
  * Empty editor content is now handled consistently, and list formatting is preserved in a more standard HTML structure.

* **Bug Fixes**
  * Improved synchronization when editor content changes externally.
  * Reduced leftover editor UI artifacts during cleanup and unmounting.

* **Chores**
  * Updated dependency and security audit records to reflect the latest reviewed risk status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->