### PR TITLE
feat: offline mode for festivals with manual sync

### DIFF
--- a/docs/festival-offline-mode.md
+++ b/docs/festival-offline-mode.md
@@ -36,11 +36,12 @@ Crear, editar y eliminar artistas funciona sin conexión:
 Con conexión, el menú Offline muestra **Sincronizar cambios** (solo roles de edición). El motor (`src/lib/offline/festival-sync.ts`):
 
 1. Aplica los cambios encolados en orden cronológico.
-2. Antes de cada update/delete compara el `updated_at` del servidor con el observado al descargar:
-   - Si coinciden → aplica el cambio.
-   - Si difieren o la fila fue borrada → lo reporta como **conflicto** y lo deja encolado.
-3. Los conflictos pueden resolverse con **Forzar sincronización** (sobrescribe el servidor) o **Descartar cambios pendientes**.
+2. Cada update/delete se escribe de forma condicional (filtrado por el `updated_at` observado al descargar), por lo que la detección de conflictos es atómica:
+   - Si la escritura afecta a la fila → aplicado.
+   - Si no afecta a ninguna fila (modificada o borrada en el servidor) → se reporta como **conflicto** y queda encolado.
+3. Los conflictos pueden resolverse con **Forzar sincronización** (sobrescribe el servidor) o **Descartar cambios pendientes** (requiere conexión: primero restaura la instantánea desde el servidor y solo entonces vacía la cola).
 4. Tras una sincronización limpia se re-descarga la instantánea para alinear la copia local.
+5. Mientras haya cambios pendientes no se permite **Actualizar copia offline**, para no sobrescribir las ediciones locales con datos del servidor.
 
 ## Arquitectura
 

--- a/docs/festival-offline-mode.md
+++ b/docs/festival-offline-mode.md
@@ -1,0 +1,68 @@
+# Modo Offline de Festivales
+
+Permite descargar el dataset completo de un festival para consultarlo (cualquier rol) y editarlo (roles con permiso de edición) sin conexión, sincronizando los cambios manualmente al recuperar la red.
+
+## Cómo funciona
+
+### Descarga (cualquier rol)
+
+Desde la cabecera de **Gestión de Festival** o de **Gestión de Artistas**, el botón **Offline** abre un menú con "Descargar para uso offline". Se guarda en IndexedDB (`sector-pro-offline`) una instantánea completa del festival:
+
+- Trabajo (`jobs`), ajustes (`festival_settings`), tipos de fecha (`job_date_types`)
+- Escenarios (`festival_stages`), setups de equipo (`festival_gear_setups`, `festival_stage_gear_setups`)
+- Artistas (`festival_artists`), envíos de formularios (`festival_artist_form_submissions`), metadatos de riders (`festival_artist_files`)
+- Turnos (`festival_shifts`, `festival_shift_assignments`)
+- Logos y documentos del trabajo (metadatos), venue (`hoja_de_ruta` + `locations`)
+
+Las consultas se paginan (1000 filas por página), por lo que festivales grandes se capturan completos.
+
+> El app shell y los chunks JS ya se cachean vía service worker (`public/sw.js`); la instantánea cubre la capa de datos.
+
+### Lectura offline
+
+Cuando `navigator.onLine` es `false` (o la petición de red falla), las páginas de gestión de festival y de artistas sirven la instantánea local. Un banner ámbar indica que se está viendo la copia offline. Las queries afectadas usan `networkMode: "always"` para que React Query ejecute el `queryFn` sin conexión.
+
+### Edición offline (roles con `canEditJobs`)
+
+Crear, editar y eliminar artistas funciona sin conexión:
+
+- Los cambios se aplican inmediatamente a la instantánea local (lectura consistente).
+- Cada cambio se encola en IndexedDB con el `updated_at` base del registro (detección de conflictos).
+- Los cambios sobre un mismo registro se fusionan (insert+update → insert; insert+delete → nada; update+delete → delete).
+- Las altas offline generan un UUID de cliente que se conserva al sincronizar.
+
+### Sincronización manual
+
+Con conexión, el menú Offline muestra **Sincronizar cambios** (solo roles de edición). El motor (`src/lib/offline/festival-sync.ts`):
+
+1. Aplica los cambios encolados en orden cronológico.
+2. Antes de cada update/delete compara el `updated_at` del servidor con el observado al descargar:
+   - Si coinciden → aplica el cambio.
+   - Si difieren o la fila fue borrada → lo reporta como **conflicto** y lo deja encolado.
+3. Los conflictos pueden resolverse con **Forzar sincronización** (sobrescribe el servidor) o **Descartar cambios pendientes**.
+4. Tras una sincronización limpia se re-descarga la instantánea para alinear la copia local.
+
+## Arquitectura
+
+| Pieza | Ruta |
+|---|---|
+| Almacén IndexedDB (fallback en memoria para tests) | `src/lib/offline/offline-db.ts` |
+| Descarga/lectura de instantáneas | `src/lib/offline/festival-snapshot.ts` |
+| Cola de cambios + coalescing | `src/lib/offline/festival-offline-queue.ts` |
+| Motor de sincronización + conflictos | `src/lib/offline/festival-sync.ts` |
+| Hook de estado/acciones | `src/hooks/festival/useOfflineFestival.ts` |
+| UI (menú Offline) | `src/components/festival/FestivalOfflineControls.tsx` |
+| Tests | `src/lib/offline/__tests__/` |
+
+### Puntos de integración
+
+- `src/hooks/useArtistsQuery.ts` — lectura de artistas con fallback offline + borrado encolado.
+- `src/hooks/useArtistMutations.ts` — creación/edición encoladas offline.
+- `src/features/festival-management/queries.ts` — detalles del festival y documentos desde la instantánea.
+- `src/pages/FestivalArtistManagement.tsx` — contexto (ajustes, tipos de fecha, escenarios) desde la instantánea + banner offline.
+
+## Limitaciones actuales
+
+- La edición offline cubre **artistas** (la superficie principal de trabajo en campo). Turnos y setups de equipo se descargan para consulta; su edición offline puede añadirse extendiendo `OfflineSyncableTable` y encolando en sus mutaciones.
+- Los archivos binarios (riders PDF, logos) no se descargan; solo sus metadatos.
+- La resolución de conflictos es por registro (último en escribir gana al forzar), no por campo.

--- a/src/components/festival/ArtistPageActions.tsx
+++ b/src/components/festival/ArtistPageActions.tsx
@@ -1,0 +1,106 @@
+import { Copy, Menu, Plus, Printer } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+
+type ArtistPageActionsProps = {
+  showArtistControls: boolean;
+  isFullSchedulePrinting: boolean;
+  selectedDate: string;
+  onAddArtist: () => void;
+  onCopyArtists: () => void;
+  onPrintFullSchedule: () => void;
+  onOpenPrintDialog: (date: string) => void;
+};
+
+const AddArtistButton = ({
+  showArtistControls,
+  onAddArtist,
+  className = "",
+}: Pick<ArtistPageActionsProps, "showArtistControls" | "onAddArtist"> & { className?: string }) => (
+  <Button
+    onClick={showArtistControls ? onAddArtist : undefined}
+    disabled={!showArtistControls}
+    title={showArtistControls ? undefined : "Los artistas solo se pueden añadir en fechas de show"}
+    className={className}
+  >
+    <Plus className="h-4 w-4 mr-2" />
+    Añadir Artista
+  </Button>
+);
+
+export const ArtistPageActions = ({
+  showArtistControls,
+  isFullSchedulePrinting,
+  selectedDate,
+  onAddArtist,
+  onCopyArtists,
+  onPrintFullSchedule,
+  onOpenPrintDialog,
+}: ArtistPageActionsProps) => {
+  const printFullLabel = isFullSchedulePrinting ? "Generando..." : "Imprimir Horario Completo";
+  const openDailyPrint = () => onOpenPrintDialog(selectedDate);
+
+  return (
+    <>
+      <div className="hidden lg:flex items-center gap-2">
+        {showArtistControls && (
+          <Button variant="outline" onClick={onCopyArtists}>
+            <Copy className="h-4 w-4 mr-2" />
+            Copiar Artistas
+          </Button>
+        )}
+        <Button variant="outline" onClick={onPrintFullSchedule} disabled={isFullSchedulePrinting}>
+          <Printer className="h-4 w-4 mr-2" />
+          {printFullLabel}
+        </Button>
+        <Button onClick={openDailyPrint}>
+          <Printer className="h-4 w-4 mr-2" />
+          Imprimir Horario del Día
+        </Button>
+        <AddArtistButton showArtistControls={showArtistControls} onAddArtist={onAddArtist} />
+      </div>
+
+      <div className="flex lg:hidden items-center gap-2 w-full sm:w-auto">
+        <AddArtistButton
+          showArtistControls={showArtistControls}
+          onAddArtist={onAddArtist}
+          className="flex-1 sm:flex-initial"
+        />
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline" size="icon">
+              <Menu className="h-4 w-4" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="right" className="w-[300px] sm:w-[400px]">
+            <SheetHeader>
+              <SheetTitle>Acciones</SheetTitle>
+            </SheetHeader>
+            <div className="flex flex-col gap-3 mt-6">
+              {showArtistControls && (
+                <Button variant="outline" onClick={onCopyArtists} className="justify-start w-full">
+                  <Copy className="h-4 w-4 mr-2" />
+                  Copiar Artistas
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                onClick={onPrintFullSchedule}
+                disabled={isFullSchedulePrinting}
+                className="justify-start w-full"
+              >
+                <Printer className="h-4 w-4 mr-2" />
+                {printFullLabel}
+              </Button>
+              <Button variant="outline" onClick={openDailyPrint} className="justify-start w-full">
+                <Printer className="h-4 w-4 mr-2" />
+                Imprimir Horario del Día
+              </Button>
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </>
+  );
+};

--- a/src/components/festival/FestivalOfflineBanner.tsx
+++ b/src/components/festival/FestivalOfflineBanner.tsx
@@ -1,0 +1,10 @@
+import { CloudOff } from "lucide-react";
+
+export const FestivalOfflineBanner = () => (
+  <div className="mt-3 flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200">
+    <CloudOff className="h-4 w-4 shrink-0" />
+    <span>
+      Estás viendo la copia offline de este festival. Los cambios se guardarán localmente y podrás sincronizarlos cuando vuelvas a tener conexión.
+    </span>
+  </div>
+);

--- a/src/components/festival/FestivalOfflineControls.tsx
+++ b/src/components/festival/FestivalOfflineControls.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useOfflineFestival } from "@/hooks/festival/useOfflineFestival";
+import { cn } from "@/lib/utils";
 
 interface FestivalOfflineControlsProps {
   jobId?: string;
@@ -59,7 +60,7 @@ export const FestivalOfflineControls = ({ jobId, canEdit, className }: FestivalO
         <Button
           variant="outline"
           size="sm"
-          className={`relative flex items-center gap-2 hover:bg-accent/50 transition-all ${className ?? ""}`}
+          className={cn("relative flex items-center gap-2 hover:bg-accent/50 transition-all", className)}
         >
           {busy ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -106,10 +107,15 @@ export const FestivalOfflineControls = ({ jobId, canEdit, className }: FestivalO
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
 
-        <DropdownMenuItem disabled={!isOnline || busy} onSelect={() => download()}>
+        <DropdownMenuItem disabled={!isOnline || busy || pendingCount > 0} onSelect={() => download()}>
           <CloudDownload className="h-4 w-4 mr-2" />
           {hasSnapshot ? "Actualizar copia offline" : "Descargar para uso offline"}
         </DropdownMenuItem>
+        {pendingCount > 0 && (
+          <div className="px-2 pb-1 text-xs text-muted-foreground">
+            Sincroniza o descarta los cambios pendientes antes de actualizar la copia.
+          </div>
+        )}
 
         {canEdit && (
           <DropdownMenuItem disabled={!isOnline || busy || pendingCount === 0} onSelect={() => sync()}>
@@ -129,24 +135,22 @@ export const FestivalOfflineControls = ({ jobId, canEdit, className }: FestivalO
           </DropdownMenuItem>
         )}
 
+        {(hasSnapshot || pendingCount > 0) && <DropdownMenuSeparator />}
+        {pendingCount > 0 && (
+          <DropdownMenuItem disabled={busy || !isOnline} onSelect={() => discardChanges()}>
+            <Undo2 className="h-4 w-4 mr-2" />
+            Descartar cambios pendientes
+          </DropdownMenuItem>
+        )}
         {hasSnapshot && (
-          <>
-            <DropdownMenuSeparator />
-            {pendingCount > 0 && (
-              <DropdownMenuItem disabled={busy} onSelect={() => discardChanges()}>
-                <Undo2 className="h-4 w-4 mr-2" />
-                Descartar cambios pendientes
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuItem
-              disabled={busy}
-              onSelect={() => removeOfflineCopy()}
-              className="text-destructive focus:text-destructive"
-            >
-              <Trash2 className="h-4 w-4 mr-2" />
-              Eliminar copia offline
-            </DropdownMenuItem>
-          </>
+          <DropdownMenuItem
+            disabled={busy}
+            onSelect={() => removeOfflineCopy()}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Eliminar copia offline
+          </DropdownMenuItem>
         )}
 
         {hasSnapshot && isOnline && (

--- a/src/components/festival/FestivalOfflineControls.tsx
+++ b/src/components/festival/FestivalOfflineControls.tsx
@@ -1,0 +1,164 @@
+import { format } from "date-fns";
+import {
+  AlertTriangle,
+  CloudDownload,
+  CloudOff,
+  HardDrive,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  Undo2,
+  UploadCloud,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useOfflineFestival } from "@/hooks/festival/useOfflineFestival";
+
+interface FestivalOfflineControlsProps {
+  jobId?: string;
+  /** Whether the current user can push offline edits back to the server */
+  canEdit: boolean;
+  className?: string;
+}
+
+/**
+ * Offline dataset controls for a festival: download/refresh the local copy
+ * (any role) and manually sync queued edits back to the server (edit roles).
+ */
+export const FestivalOfflineControls = ({ jobId, canEdit, className }: FestivalOfflineControlsProps) => {
+  const {
+    isOnline,
+    hasSnapshot,
+    snapshotMeta,
+    pendingCount,
+    hasConflicts,
+    isDownloading,
+    isSyncing,
+    download,
+    sync,
+    removeOfflineCopy,
+    discardChanges,
+  } = useOfflineFestival(jobId);
+
+  if (!jobId) return null;
+
+  const busy = isDownloading || isSyncing;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={`relative flex items-center gap-2 hover:bg-accent/50 transition-all ${className ?? ""}`}
+        >
+          {busy ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : isOnline ? (
+            <HardDrive className="h-4 w-4" />
+          ) : (
+            <CloudOff className="h-4 w-4 text-amber-500" />
+          )}
+          <span className="hidden sm:inline">Offline</span>
+          {pendingCount > 0 && (
+            <Badge
+              variant="destructive"
+              className="absolute -top-2 -right-2 h-5 min-w-5 px-1 flex items-center justify-center text-[10px]"
+            >
+              {pendingCount}
+            </Badge>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-72">
+        <DropdownMenuLabel className="space-y-1">
+          <div>Modo offline</div>
+          {hasSnapshot && snapshotMeta ? (
+            <div className="text-xs font-normal text-muted-foreground">
+              Descargado el {format(new Date(snapshotMeta.downloadedAt), "dd/MM/yyyy HH:mm")} ·{" "}
+              {snapshotMeta.artistCount} artistas
+            </div>
+          ) : (
+            <div className="text-xs font-normal text-muted-foreground">
+              Sin copia offline de este festival
+            </div>
+          )}
+          {!isOnline && (
+            <div className="text-xs font-normal text-amber-600 flex items-center gap-1">
+              <CloudOff className="h-3 w-3" /> Sin conexión
+            </div>
+          )}
+          {pendingCount > 0 && (
+            <div className="text-xs font-normal text-muted-foreground">
+              {pendingCount} cambio{pendingCount === 1 ? "" : "s"} pendiente{pendingCount === 1 ? "" : "s"} de
+              sincronizar
+            </div>
+          )}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem disabled={!isOnline || busy} onSelect={() => download()}>
+          <CloudDownload className="h-4 w-4 mr-2" />
+          {hasSnapshot ? "Actualizar copia offline" : "Descargar para uso offline"}
+        </DropdownMenuItem>
+
+        {canEdit && (
+          <DropdownMenuItem disabled={!isOnline || busy || pendingCount === 0} onSelect={() => sync()}>
+            <UploadCloud className="h-4 w-4 mr-2" />
+            Sincronizar cambios
+          </DropdownMenuItem>
+        )}
+
+        {canEdit && hasConflicts && (
+          <DropdownMenuItem
+            disabled={!isOnline || busy || pendingCount === 0}
+            onSelect={() => sync({ force: true })}
+            className="text-amber-600 focus:text-amber-600"
+          >
+            <AlertTriangle className="h-4 w-4 mr-2" />
+            Forzar sincronización
+          </DropdownMenuItem>
+        )}
+
+        {hasSnapshot && (
+          <>
+            <DropdownMenuSeparator />
+            {pendingCount > 0 && (
+              <DropdownMenuItem disabled={busy} onSelect={() => discardChanges()}>
+                <Undo2 className="h-4 w-4 mr-2" />
+                Descartar cambios pendientes
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              disabled={busy}
+              onSelect={() => removeOfflineCopy()}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Eliminar copia offline
+            </DropdownMenuItem>
+          </>
+        )}
+
+        {hasSnapshot && isOnline && (
+          <>
+            <DropdownMenuSeparator />
+            <div className="px-2 py-1.5 text-xs text-muted-foreground flex items-center gap-1">
+              <RefreshCw className="h-3 w-3" />
+              Actualiza la copia antes de trabajar sin conexión
+            </div>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -232,13 +232,10 @@ export function TechnicianArtistReadOnlyModal({
     enabled: !!job?.id,
   });
 
-  const stageNames = useMemo(() => {
-    const names: Record<number, string> = {};
-    festivalStages.forEach((stage) => {
-      names[stage.number] = stage.name;
-    });
-    return names;
-  }, [festivalStages]);
+  const stageNames = useMemo(
+    () => Object.fromEntries(festivalStages.map((stage) => [stage.number, stage.name])) as Record<number, string>,
+    [festivalStages],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -253,22 +250,21 @@ export function TechnicianArtistReadOnlyModal({
         return;
       }
 
-      const nextUrls: Record<string, string> = {};
-      await Promise.all(
-        artistsWithPlot.map(async (artist) => {
-          if (!artist.stage_plot_file_path) return;
+      const signedUrlEntries = await Promise.all(
+        artistsWithPlot.map(async (artist): Promise<[string, string] | null> => {
+          if (!artist.stage_plot_file_path) return null;
           const { data, error } = await dataLayerClient.storage
             .from("festival_artist_files")
             .createSignedUrl(artist.stage_plot_file_path, 60 * 60);
 
-          if (!error && data?.signedUrl) {
-            nextUrls[artist.id] = data.signedUrl;
-          }
+          return !error && data?.signedUrl ? [artist.id, data.signedUrl] : null;
         })
       );
 
       if (!cancelled) {
-        setStagePlotUrls(nextUrls);
+        setStagePlotUrls(
+          Object.fromEntries(signedUrlEntries.filter((entry): entry is [string, string] => entry !== null)),
+        );
       }
     };
 
@@ -278,7 +274,6 @@ export function TechnicianArtistReadOnlyModal({
       cancelled = true;
     };
   }, [artists]);
-
 
   useEffect(() => {
     let cancelled = false;
@@ -292,18 +287,19 @@ export function TechnicianArtistReadOnlyModal({
     };
 
     const groupRiderFiles = (files: RiderFileRow[]) => {
-      const grouped: Record<string, MobileArtistRiderFile[]> = {};
+      const grouped = new Map<string, MobileArtistRiderFile[]>();
       files.forEach((file) => {
         if (!file.artist_id) return;
-        if (!grouped[file.artist_id]) grouped[file.artist_id] = [];
-        grouped[file.artist_id].push({
+        const artistFiles = grouped.get(file.artist_id) ?? [];
+        artistFiles.push({
           id: file.id,
           file_name: file.file_name,
           file_path: file.file_path,
           uploaded_at: file.uploaded_at,
         });
+        grouped.set(file.artist_id, artistFiles);
       });
-      return grouped;
+      return Object.fromEntries(grouped);
     };
 
     const loadOfflineRiderFiles = async (): Promise<Record<string, MobileArtistRiderFile[]> | null> => {

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -447,10 +447,10 @@ export function TechnicianArtistReadOnlyModal({
 
   return (
     <div
-      className={`fixed inset-0 z-50 flex items-center justify-center ${theme.modalOverlay} px-4 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200`}
+      className={`fixed inset-0 z-50 flex items-center justify-center ${theme.modalOverlay} pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))] pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] animate-in fade-in duration-200`}
     >
       <div
-        className={`w-full max-w-md md:max-w-lg lg:max-w-xl h-[85vh] ${isDark ? "bg-[#0f1219]" : "bg-white"} rounded-2xl border ${theme.divider} shadow-2xl flex flex-col overflow-hidden overflow-x-hidden animate-in zoom-in-95 duration-200`}
+        className={`w-full max-w-md md:max-w-lg lg:max-w-xl h-[85vh] supports-[height:1dvh]:h-[85dvh] max-h-full ${isDark ? "bg-[#0f1219]" : "bg-white"} rounded-2xl border ${theme.divider} shadow-2xl flex flex-col overflow-hidden overflow-x-hidden animate-in zoom-in-95 duration-200`}
       >
         <div className={`p-4 border-b ${theme.divider} flex justify-between items-center shrink-0`}>
           <div className="flex items-center gap-2 min-w-0">

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -12,8 +12,12 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { MobileArtistList } from "@/components/festival/mobile/MobileArtistList";
 import type { MobileArtistRiderFile } from "@/components/festival/mobile/MobileArtistCard";
+import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
 import { Theme } from "./types";
 import { createQueryKey } from "@/lib/optimized-react-query";
+import { getFestivalSnapshot, isBrowserOnline } from "@/lib/offline";
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
+import { canEditJobs } from "@/utils/permissions";
 import type { Tables } from "@/integrations/supabase/types";
 
 type TechnicianArtistReadOnlyModalProps = {
@@ -140,6 +144,22 @@ const mapRawToReadOnlyArtist = (artist: FestivalArtistRow): ReadOnlyArtist => ({
   wired_mics: asArray<ReadOnlyWiredMic>(artist.wired_mics),
 });
 
+const sortReadOnlyArtists = (rows: ReadOnlyArtist[]): ReadOnlyArtist[] =>
+  [...rows].sort((left, right) => {
+    const leftDate = String(left.date || "");
+    const rightDate = String(right.date || "");
+    if (leftDate !== rightDate) return leftDate.localeCompare(rightDate);
+    return String(left.show_start || "").localeCompare(String(right.show_start || ""));
+  });
+
+const fetchOfflineReadOnlyArtists = async (jobId: string): Promise<ReadOnlyArtist[] | null> => {
+  const snapshot = await getFestivalSnapshot(jobId);
+  if (!snapshot) return null;
+  return sortReadOnlyArtists(
+    snapshot.data.artists.map((row) => mapRawToReadOnlyArtist(row as unknown as FestivalArtistRow)),
+  );
+};
+
 export function TechnicianArtistReadOnlyModal({
   theme,
   isDark,
@@ -151,35 +171,61 @@ export function TechnicianArtistReadOnlyModal({
   const [filtersOpen, setFiltersOpen] = useState<boolean>(false);
   const [stagePlotUrls, setStagePlotUrls] = useState<Record<string, string>>({});
   const [riderFilesByArtistId, setRiderFilesByArtistId] = useState<Record<string, MobileArtistRiderFile[]>>({});
+  const { userRole } = useOptimizedAuth();
 
   const { data: artists = [], isLoading: artistsLoading } = useQuery({
     queryKey: createQueryKey.technician.technicianReadonlyArtists(job?.id),
+    networkMode: "always", // the queryFn serves the offline snapshot when disconnected
     queryFn: async () => {
-      const { data, error } = await dataLayerClient.from("festival_artists")
-        .select("*")
-        .eq("job_id", job?.id)
-        .order("date", { ascending: true });
+      if (!isBrowserOnline()) {
+        const offlineArtists = await fetchOfflineReadOnlyArtists(job.id);
+        if (offlineArtists) return offlineArtists;
+        throw new Error("Sin conexión y sin copia offline de este festival");
+      }
 
-      if (error) throw error;
-      return (data || []).map(mapRawToReadOnlyArtist).sort((left, right) => {
-        const leftDate = String(left.date || "");
-        const rightDate = String(right.date || "");
-        if (leftDate !== rightDate) return leftDate.localeCompare(rightDate);
-        return String(left.show_start || "").localeCompare(String(right.show_start || ""));
-      });
+      try {
+        const { data, error } = await dataLayerClient.from("festival_artists")
+          .select("*")
+          .eq("job_id", job?.id)
+          .order("date", { ascending: true });
+
+        if (error) throw error;
+        return sortReadOnlyArtists((data || []).map(mapRawToReadOnlyArtist));
+      } catch (fetchError) {
+        // Network dropped mid-request: fall back to the offline copy if available
+        const offlineArtists = await fetchOfflineReadOnlyArtists(job.id);
+        if (offlineArtists) return offlineArtists;
+        throw fetchError;
+      }
     },
     enabled: !!job?.id,
   });
 
   const { data: festivalStages = [] } = useQuery({
     queryKey: createQueryKey.technician.technicianReadonlyFestivalStages(job?.id),
+    networkMode: "always",
     queryFn: async () => {
+      const readOfflineStages = async (): Promise<FestivalStage[] | null> => {
+        const snapshot = await getFestivalSnapshot(job.id);
+        if (!snapshot) return null;
+        return snapshot.data.stages
+          .filter((stage) => typeof stage.number === "number")
+          .map((stage) => ({
+            number: stage.number as number,
+            name: (stage.name as string) ?? `Escenario ${stage.number as number}`,
+          }));
+      };
+
+      if (!isBrowserOnline()) {
+        return (await readOfflineStages()) ?? [];
+      }
+
       const { data, error } = await dataLayerClient.from("festival_stages")
         .select("number, name")
         .eq("job_id", job?.id);
       if (error) {
         console.warn("TechnicianArtistReadOnlyModal: failed loading stage names", error);
-        return [];
+        return (await readOfflineStages()) ?? [];
       }
       return (data || []) as FestivalStage[];
     },
@@ -200,7 +246,9 @@ export function TechnicianArtistReadOnlyModal({
     const loadStagePlotUrls = async () => {
       const artistsWithPlot = artists.filter((artist) => Boolean(artist.stage_plot_file_path));
 
-      if (artistsWithPlot.length === 0) {
+      // Signed URLs require a connection; binary files are not part of the
+      // offline snapshot.
+      if (artistsWithPlot.length === 0 || !isBrowserOnline()) {
         if (!cancelled) setStagePlotUrls({});
         return;
       }
@@ -235,10 +283,48 @@ export function TechnicianArtistReadOnlyModal({
   useEffect(() => {
     let cancelled = false;
 
+    type RiderFileRow = {
+      id: string;
+      file_name: string;
+      file_path: string;
+      uploaded_at: string;
+      artist_id: string | null;
+    };
+
+    const groupRiderFiles = (files: RiderFileRow[]) => {
+      const grouped: Record<string, MobileArtistRiderFile[]> = {};
+      files.forEach((file) => {
+        if (!file.artist_id) return;
+        if (!grouped[file.artist_id]) grouped[file.artist_id] = [];
+        grouped[file.artist_id].push({
+          id: file.id,
+          file_name: file.file_name,
+          file_path: file.file_path,
+          uploaded_at: file.uploaded_at,
+        });
+      });
+      return grouped;
+    };
+
+    const loadOfflineRiderFiles = async (): Promise<Record<string, MobileArtistRiderFile[]> | null> => {
+      const snapshot = await getFestivalSnapshot(job.id);
+      if (!snapshot) return null;
+      const files = [...snapshot.data.artistFiles].sort((a, b) =>
+        String(b.uploaded_at ?? "").localeCompare(String(a.uploaded_at ?? "")),
+      );
+      return groupRiderFiles(files as unknown as RiderFileRow[]);
+    };
+
     const loadRiderFiles = async () => {
       const artistIds = artists.map((artist) => artist.id).filter(Boolean);
       if (artistIds.length === 0) {
         if (!cancelled) setRiderFilesByArtistId({});
+        return;
+      }
+
+      if (!isBrowserOnline()) {
+        const offlineFiles = await loadOfflineRiderFiles();
+        if (!cancelled) setRiderFilesByArtistId(offlineFiles ?? {});
         return;
       }
 
@@ -256,23 +342,12 @@ export function TechnicianArtistReadOnlyModal({
       const { data, error } = await query;
       if (error) {
         console.warn("TechnicianArtistReadOnlyModal: failed loading rider files", error);
-        if (!cancelled) setRiderFilesByArtistId({});
+        const offlineFiles = await loadOfflineRiderFiles();
+        if (!cancelled) setRiderFilesByArtistId(offlineFiles ?? {});
         return;
       }
 
-      const grouped: Record<string, MobileArtistRiderFile[]> = {};
-      (data || []).forEach((file) => {
-        if (!file.artist_id) return;
-        if (!grouped[file.artist_id]) grouped[file.artist_id] = [];
-        grouped[file.artist_id].push({
-          id: file.id,
-          file_name: file.file_name,
-          file_path: file.file_path,
-          uploaded_at: file.uploaded_at,
-        });
-      });
-
-      if (!cancelled) setRiderFilesByArtistId(grouped);
+      if (!cancelled) setRiderFilesByArtistId(groupRiderFiles(data || []));
     };
 
     void loadRiderFiles();
@@ -280,7 +355,7 @@ export function TechnicianArtistReadOnlyModal({
     return () => {
       cancelled = true;
     };
-  }, [artists]);
+  }, [artists, job.id]);
 
   const handleDownloadRiderFile = async (file: { file_path: string; file_name: string }) => {
     try {
@@ -384,13 +459,16 @@ export function TechnicianArtistReadOnlyModal({
               Artistas · {job?.title || "Trabajo"}
             </h2>
           </div>
-          <button
-            onClick={onClose}
-            className={`p-2 ${theme.textMuted} hover:${theme.textMain} rounded-full transition-colors`}
-            aria-label="Cerrar"
-          >
-            <X size={20} />
-          </button>
+          <div className="flex items-center gap-1 shrink-0">
+            <FestivalOfflineControls jobId={job?.id} canEdit={canEditJobs(userRole)} />
+            <button
+              onClick={onClose}
+              className={`p-2 ${theme.textMuted} hover:${theme.textMain} rounded-full transition-colors`}
+              aria-label="Cerrar"
+            >
+              <X size={20} />
+            </button>
+          </div>
         </div>
 
         <div className={`px-4 py-3 border-b ${theme.divider} shrink-0`}>

--- a/src/features/festival-management/hooks/useFestivalDocuments.ts
+++ b/src/features/festival-management/hooks/useFestivalDocuments.ts
@@ -40,6 +40,7 @@ export const useFestivalDocuments = ({ jobId, toast }: { jobId?: string; toast: 
     queryKey: documentsQueryKey,
     enabled: Boolean(jobId),
     staleTime: 1000 * 60 * 2,
+    networkMode: "always", // the queryFn serves the offline snapshot when disconnected
     queryFn: () => {
       if (!jobId) {
         return Promise.resolve({ artistRiderFiles: [], jobDocuments: [] });

--- a/src/features/festival-management/hooks/useFestivalJobData.ts
+++ b/src/features/festival-management/hooks/useFestivalJobData.ts
@@ -14,6 +14,7 @@ export const useFestivalJobData = ({ jobId, toast }: { jobId?: string; toast: To
     queryKey: jobDetailsQueryKey,
     enabled: Boolean(jobId),
     staleTime: 1000 * 60 * 2,
+    networkMode: "always", // the queryFn serves the offline snapshot when disconnected
     queryFn: () => {
       if (!jobId) {
         throw new Error("Missing festival job id");

--- a/src/features/festival-management/queries.ts
+++ b/src/features/festival-management/queries.ts
@@ -3,6 +3,7 @@ import {
   buildFallbackStageOptions,
   buildFestivalStageOptions,
   buildJobDates,
+  type JobDateTypeRow,
 } from "@/features/festival-management/selectors";
 import { getFestivalSnapshot, isBrowserOnline } from "@/lib/offline";
 import {
@@ -143,7 +144,7 @@ const buildOfflineJobDetails = async (jobId: string): Promise<FestivalJobDetails
     artistCount: snapshot.data.artists.length,
     festivalStageOptions: stageData.options,
     job,
-    jobDates: buildJobDates(job, snapshot.data.jobDateTypes as never),
+    jobDates: buildJobDates(job, snapshot.data.jobDateTypes as JobDateTypeRow[]),
     maxStages,
     venueData: resolveFestivalVenueData(
       snapshot.data.hojaVenue as HojaVenueRow | null,
@@ -152,24 +153,11 @@ const buildOfflineJobDetails = async (jobId: string): Promise<FestivalJobDetails
   };
 };
 
-export const fetchFestivalJobDetails = async (jobId: string): Promise<FestivalJobDetailsData> => {
-  console.log("Fetching job details for jobId:", jobId);
-
-  if (!isBrowserOnline()) {
-    const offlineDetails = await buildOfflineJobDetails(jobId);
-    if (offlineDetails) {
-      return offlineDetails;
-    }
-  }
-
+const fetchFestivalJobDetailsOnline = async (jobId: string): Promise<FestivalJobDetailsData> => {
   const { data: jobData, error: jobError } = await supabase.from("jobs").select("*").eq("id", jobId).single();
 
   if (jobError) {
     console.error("Error fetching job data:", jobError);
-    const offlineDetails = await buildOfflineJobDetails(jobId);
-    if (offlineDetails) {
-      return offlineDetails;
-    }
     throw jobError;
   }
 
@@ -231,6 +219,29 @@ export const fetchFestivalJobDetails = async (jobId: string): Promise<FestivalJo
   };
 };
 
+export const fetchFestivalJobDetails = async (jobId: string): Promise<FestivalJobDetailsData> => {
+  console.log("Fetching job details for jobId:", jobId);
+
+  if (!isBrowserOnline()) {
+    const offlineDetails = await buildOfflineJobDetails(jobId);
+    if (offlineDetails) {
+      return offlineDetails;
+    }
+  }
+
+  try {
+    return await fetchFestivalJobDetailsOnline(jobId);
+  } catch (error) {
+    // Any failure while assembling the online response (job, artist count,
+    // venue, dates) falls back to the offline snapshot when available.
+    const offlineDetails = await buildOfflineJobDetails(jobId);
+    if (offlineDetails) {
+      return offlineDetails;
+    }
+    throw error;
+  }
+};
+
 const buildOfflineDocuments = async (jobId: string): Promise<FestivalDocumentsData | null> => {
   const snapshot = await getFestivalSnapshot(jobId);
   if (!snapshot) {
@@ -258,14 +269,7 @@ const buildOfflineDocuments = async (jobId: string): Promise<FestivalDocumentsDa
   return { artistRiderFiles, jobDocuments };
 };
 
-export const fetchFestivalDocuments = async (jobId: string): Promise<FestivalDocumentsData> => {
-  if (!isBrowserOnline()) {
-    const offlineDocuments = await buildOfflineDocuments(jobId);
-    if (offlineDocuments) {
-      return offlineDocuments;
-    }
-  }
-
+const fetchFestivalDocumentsOnline = async (jobId: string): Promise<FestivalDocumentsData> => {
   const { data: jobDocs, error: jobDocsError } = await supabase
     .from("job_documents")
     .select("id, file_name, file_path, uploaded_at, read_only, template_type")
@@ -318,4 +322,24 @@ export const fetchFestivalDocuments = async (jobId: string): Promise<FestivalDoc
     artistRiderFiles: riderData,
     jobDocuments: (jobDocs || []) as JobDocumentEntry[],
   };
+};
+
+export const fetchFestivalDocuments = async (jobId: string): Promise<FestivalDocumentsData> => {
+  if (!isBrowserOnline()) {
+    const offlineDocuments = await buildOfflineDocuments(jobId);
+    if (offlineDocuments) {
+      return offlineDocuments;
+    }
+  }
+
+  try {
+    return await fetchFestivalDocumentsOnline(jobId);
+  } catch (error) {
+    // Online fetch failed mid-request: serve the snapshot when available.
+    const offlineDocuments = await buildOfflineDocuments(jobId);
+    if (offlineDocuments) {
+      return offlineDocuments;
+    }
+    throw error;
+  }
 };

--- a/src/features/festival-management/queries.ts
+++ b/src/features/festival-management/queries.ts
@@ -4,6 +4,7 @@ import {
   buildFestivalStageOptions,
   buildJobDates,
 } from "@/features/festival-management/selectors";
+import { getFestivalSnapshot, isBrowserOnline } from "@/lib/offline";
 import {
   normalizeVenueCoordinates,
   resolveHojaVenue,
@@ -114,13 +115,61 @@ const fetchJobDates = async (jobId: string, job: FestivalJob) => {
   return [new Date()];
 };
 
+const buildOfflineJobDetails = async (jobId: string): Promise<FestivalJobDetailsData | null> => {
+  const snapshot = await getFestivalSnapshot(jobId);
+  if (!snapshot?.data.job) {
+    return null;
+  }
+
+  const jobRow = snapshot.data.job as Record<string, unknown>;
+  const job = {
+    ...jobRow,
+    location_id: (jobRow.location_id as string | null) ?? undefined,
+    tour_date_id: (jobRow.tour_date_id as string | null) ?? undefined,
+  } as FestivalJob;
+
+  const latestGearSetup = [...snapshot.data.gearSetups].sort((a, b) =>
+    String(b.created_at ?? "").localeCompare(String(a.created_at ?? "")),
+  )[0];
+  let maxStages = Math.max(Number(latestGearSetup?.max_stages) || 1, 1);
+
+  const stageRows = snapshot.data.stages
+    .map((stage) => ({ number: stage.number as number, name: (stage.name as string) ?? null }))
+    .sort((a, b) => a.number - b.number);
+  const stageData = buildFestivalStageOptions(stageRows, maxStages);
+  maxStages = stageData.maxStages;
+
+  return {
+    artistCount: snapshot.data.artists.length,
+    festivalStageOptions: stageData.options,
+    job,
+    jobDates: buildJobDates(job, snapshot.data.jobDateTypes as never),
+    maxStages,
+    venueData: resolveFestivalVenueData(
+      snapshot.data.hojaVenue as HojaVenueRow | null,
+      snapshot.data.location as LocationRow | null,
+    ),
+  };
+};
+
 export const fetchFestivalJobDetails = async (jobId: string): Promise<FestivalJobDetailsData> => {
   console.log("Fetching job details for jobId:", jobId);
+
+  if (!isBrowserOnline()) {
+    const offlineDetails = await buildOfflineJobDetails(jobId);
+    if (offlineDetails) {
+      return offlineDetails;
+    }
+  }
 
   const { data: jobData, error: jobError } = await supabase.from("jobs").select("*").eq("id", jobId).single();
 
   if (jobError) {
     console.error("Error fetching job data:", jobError);
+    const offlineDetails = await buildOfflineJobDetails(jobId);
+    if (offlineDetails) {
+      return offlineDetails;
+    }
     throw jobError;
   }
 
@@ -182,7 +231,41 @@ export const fetchFestivalJobDetails = async (jobId: string): Promise<FestivalJo
   };
 };
 
+const buildOfflineDocuments = async (jobId: string): Promise<FestivalDocumentsData | null> => {
+  const snapshot = await getFestivalSnapshot(jobId);
+  if (!snapshot) {
+    return null;
+  }
+
+  const artistNames = new Map(
+    snapshot.data.artists.map((artist) => [artist.id as string, (artist.name as string) || "Unknown"]),
+  );
+
+  const artistRiderFiles = snapshot.data.artistFiles
+    .map((file) => ({
+      ...(file as unknown as ArtistRiderFile),
+      festival_artists: {
+        id: file.artist_id as string,
+        name: artistNames.get(file.artist_id as string) || "Unknown",
+      },
+    }))
+    .sort((a, b) => String(b.uploaded_at ?? "").localeCompare(String(a.uploaded_at ?? "")));
+
+  const jobDocuments = [...snapshot.data.jobDocuments].sort((a, b) =>
+    String(b.uploaded_at ?? "").localeCompare(String(a.uploaded_at ?? "")),
+  ) as unknown as JobDocumentEntry[];
+
+  return { artistRiderFiles, jobDocuments };
+};
+
 export const fetchFestivalDocuments = async (jobId: string): Promise<FestivalDocumentsData> => {
+  if (!isBrowserOnline()) {
+    const offlineDocuments = await buildOfflineDocuments(jobId);
+    if (offlineDocuments) {
+      return offlineDocuments;
+    }
+  }
+
   const { data: jobDocs, error: jobDocsError } = await supabase
     .from("job_documents")
     .select("id, file_name, file_path, uploaded_at, read_only, template_type")

--- a/src/features/festival-management/selectors.ts
+++ b/src/features/festival-management/selectors.ts
@@ -16,7 +16,7 @@ type StageRow = {
   number?: number | null;
 };
 
-type JobDateTypeRow = {
+export type JobDateTypeRow = {
   date?: string | null;
 };
 

--- a/src/hooks/festival/useOfflineFestival.ts
+++ b/src/hooks/festival/useOfflineFestival.ts
@@ -77,6 +77,14 @@ export const useOfflineFestival = (jobId?: string) => {
       toast.error("Sin conexión", { description: "Conéctate a internet para descargar los datos del festival." });
       return;
     }
+    // A refresh overwrites the local snapshot with server data, which would
+    // hide queued edits while they remain pending sync.
+    if ((await countPendingChanges(jobId)) > 0) {
+      toast.error("Cambios pendientes", {
+        description: "Sincroniza o descarta los cambios pendientes antes de actualizar la copia offline.",
+      });
+      return;
+    }
     setIsDownloading(true);
     try {
       const snapshot = await downloadFestivalSnapshot(jobId);
@@ -110,21 +118,29 @@ export const useOfflineFestival = (jobId?: string) => {
                 ? `${result.applied} cambio${result.applied === 1 ? "" : "s"} enviado${result.applied === 1 ? "" : "s"} al servidor.`
                 : "No había cambios pendientes.",
           });
-        } else if (result.conflicts.length > 0) {
-          const names = result.conflicts
-            .map((conflict) => conflict.label)
-            .filter(Boolean)
-            .slice(0, 3)
-            .join(", ");
-          toast.warning("Sincronización con conflictos", {
-            description: `${result.applied} aplicados, ${result.conflicts.length} en conflicto${
-              names ? ` (${names})` : ""
-            }. Usa "Forzar sincronización" para sobrescribir o descarta los cambios.`,
-            duration: 8000,
-          });
         } else {
-          toast.error("Error de sincronización", {
-            description: `${result.failed.length} cambio${result.failed.length === 1 ? "" : "s"} no se pudieron enviar: ${result.failed[0]?.message ?? ""}`,
+          // Report conflicts and failures together so neither gets hidden
+          const parts = [`${result.applied} aplicados`];
+          if (result.conflicts.length > 0) {
+            const names = result.conflicts
+              .map((conflict) => conflict.label)
+              .filter(Boolean)
+              .slice(0, 3)
+              .join(", ");
+            parts.push(`${result.conflicts.length} en conflicto${names ? ` (${names})` : ""}`);
+          }
+          if (result.failed.length > 0) {
+            parts.push(
+              `${result.failed.length} con error${result.failed[0]?.message ? ` (${result.failed[0].message})` : ""}`,
+            );
+          }
+          const hint =
+            result.conflicts.length > 0
+              ? ' Usa "Forzar sincronización" para sobrescribir o descarta los cambios.'
+              : "";
+          const showToast = result.failed.length > 0 ? toast.error : toast.warning;
+          showToast("Sincronización incompleta", {
+            description: `${parts.join(", ")}.${hint}`,
             duration: 8000,
           });
         }
@@ -149,16 +165,26 @@ export const useOfflineFestival = (jobId?: string) => {
 
   const discardChanges = useCallback(async () => {
     if (!jobId) return;
+    if (!isBrowserOnline()) {
+      toast.error("Sin conexión", {
+        description: "Conéctate a internet para descartar los cambios y restaurar la copia offline.",
+      });
+      return;
+    }
+    // Restore the snapshot from the server BEFORE dropping the queue: if the
+    // download fails the queue stays intact, so the local copy never shows
+    // edits that can no longer be synchronized or discarded cleanly.
+    try {
+      await downloadFestivalSnapshot(jobId);
+    } catch (error) {
+      console.error("No se pudo restaurar la copia offline antes de descartar cambios:", error);
+      toast.error("Error", {
+        description: "No se pudo restaurar la copia offline. Los cambios pendientes se mantienen.",
+      });
+      return;
+    }
     const discarded = await discardPendingChanges(jobId);
     setLastSyncResult(null);
-    if (isBrowserOnline()) {
-      // Re-download so the local copy no longer shows the discarded edits.
-      try {
-        await downloadFestivalSnapshot(jobId);
-      } catch (error) {
-        console.warn("No se pudo refrescar la copia offline tras descartar cambios:", error);
-      }
-    }
     toast.success("Cambios descartados", {
       description: `${discarded} cambio${discarded === 1 ? "" : "s"} pendiente${discarded === 1 ? "" : "s"} eliminado${discarded === 1 ? "" : "s"}.`,
     });

--- a/src/hooks/festival/useOfflineFestival.ts
+++ b/src/hooks/festival/useOfflineFestival.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  countPendingChanges,
+  deleteFestivalSnapshot,
+  discardPendingChanges,
+  downloadFestivalSnapshot,
+  getFestivalSnapshot,
+  isBrowserOnline,
+  subscribeOfflineFestivalChanged,
+  syncFestivalPendingChanges,
+  type OfflineSyncResult,
+} from "@/lib/offline";
+
+export interface OfflineSnapshotMeta {
+  downloadedAt: string;
+  jobTitle: string;
+  artistCount: number;
+}
+
+/**
+ * State + actions for the offline copy of a festival: download/refresh the
+ * dataset, track queued offline edits and push them manually to the server.
+ */
+export const useOfflineFestival = (jobId?: string) => {
+  const [isOnline, setIsOnline] = useState(isBrowserOnline());
+  const [snapshotMeta, setSnapshotMeta] = useState<OfflineSnapshotMeta | null>(null);
+  const [pendingCount, setPendingCount] = useState(0);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [lastSyncResult, setLastSyncResult] = useState<OfflineSyncResult | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!jobId) {
+      setSnapshotMeta(null);
+      setPendingCount(0);
+      return;
+    }
+    const [snapshot, count] = await Promise.all([getFestivalSnapshot(jobId), countPendingChanges(jobId)]);
+    setSnapshotMeta(
+      snapshot
+        ? {
+            downloadedAt: snapshot.downloadedAt,
+            jobTitle: snapshot.jobTitle,
+            artistCount: snapshot.data.artists.length,
+          }
+        : null,
+    );
+    setPendingCount(count);
+  }, [jobId]);
+
+  useEffect(() => {
+    refresh().catch((error) => console.error("Error leyendo estado offline del festival:", error));
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    const unsubscribe = jobId
+      ? subscribeOfflineFestivalChanged(jobId, () => {
+          refresh().catch((error) => console.error("Error refrescando estado offline:", error));
+        })
+      : () => {};
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+      unsubscribe();
+    };
+  }, [jobId, refresh]);
+
+  const download = useCallback(async () => {
+    if (!jobId) return;
+    if (!isBrowserOnline()) {
+      toast.error("Sin conexión", { description: "Conéctate a internet para descargar los datos del festival." });
+      return;
+    }
+    setIsDownloading(true);
+    try {
+      const snapshot = await downloadFestivalSnapshot(jobId);
+      toast.success("Datos offline descargados", {
+        description: `${snapshot.data.artists.length} artistas disponibles sin conexión.`,
+      });
+    } catch (error) {
+      console.error("Error descargando datos offline:", error);
+      toast.error("Error", { description: "No se pudieron descargar los datos para uso offline." });
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [jobId]);
+
+  const sync = useCallback(
+    async (options?: { force?: boolean }) => {
+      if (!jobId) return null;
+      if (!isBrowserOnline()) {
+        toast.error("Sin conexión", { description: "Conéctate a internet para sincronizar los cambios." });
+        return null;
+      }
+      setIsSyncing(true);
+      try {
+        const result = await syncFestivalPendingChanges(jobId, { force: options?.force });
+        setLastSyncResult(result);
+
+        if (result.conflicts.length === 0 && result.failed.length === 0) {
+          toast.success("Sincronización completada", {
+            description:
+              result.applied > 0
+                ? `${result.applied} cambio${result.applied === 1 ? "" : "s"} enviado${result.applied === 1 ? "" : "s"} al servidor.`
+                : "No había cambios pendientes.",
+          });
+        } else if (result.conflicts.length > 0) {
+          const names = result.conflicts
+            .map((conflict) => conflict.label)
+            .filter(Boolean)
+            .slice(0, 3)
+            .join(", ");
+          toast.warning("Sincronización con conflictos", {
+            description: `${result.applied} aplicados, ${result.conflicts.length} en conflicto${
+              names ? ` (${names})` : ""
+            }. Usa "Forzar sincronización" para sobrescribir o descarta los cambios.`,
+            duration: 8000,
+          });
+        } else {
+          toast.error("Error de sincronización", {
+            description: `${result.failed.length} cambio${result.failed.length === 1 ? "" : "s"} no se pudieron enviar: ${result.failed[0]?.message ?? ""}`,
+            duration: 8000,
+          });
+        }
+        return result;
+      } catch (error) {
+        console.error("Error sincronizando cambios offline:", error);
+        toast.error("Error", { description: "No se pudieron sincronizar los cambios offline." });
+        return null;
+      } finally {
+        setIsSyncing(false);
+      }
+    },
+    [jobId],
+  );
+
+  const removeOfflineCopy = useCallback(async () => {
+    if (!jobId) return;
+    await deleteFestivalSnapshot(jobId);
+    setLastSyncResult(null);
+    toast.success("Copia offline eliminada");
+  }, [jobId]);
+
+  const discardChanges = useCallback(async () => {
+    if (!jobId) return;
+    const discarded = await discardPendingChanges(jobId);
+    setLastSyncResult(null);
+    if (isBrowserOnline()) {
+      // Re-download so the local copy no longer shows the discarded edits.
+      try {
+        await downloadFestivalSnapshot(jobId);
+      } catch (error) {
+        console.warn("No se pudo refrescar la copia offline tras descartar cambios:", error);
+      }
+    }
+    toast.success("Cambios descartados", {
+      description: `${discarded} cambio${discarded === 1 ? "" : "s"} pendiente${discarded === 1 ? "" : "s"} eliminado${discarded === 1 ? "" : "s"}.`,
+    });
+  }, [jobId]);
+
+  return {
+    isOnline,
+    hasSnapshot: snapshotMeta !== null,
+    snapshotMeta,
+    pendingCount,
+    hasConflicts: (lastSyncResult?.conflicts.length ?? 0) > 0,
+    lastSyncResult,
+    isDownloading,
+    isSyncing,
+    download,
+    sync,
+    removeOfflineCopy,
+    discardChanges,
+  };
+};

--- a/src/hooks/useArtistMutations.ts
+++ b/src/hooks/useArtistMutations.ts
@@ -2,6 +2,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/hooks/use-toast";
 import type { Database } from "@/integrations/supabase/types";
+import {
+  generateOfflineId,
+  getFestivalSnapshot,
+  isBrowserOnline,
+  queueFestivalChange,
+} from "@/lib/offline";
 
 import { queryKeys } from "@/lib/react-query";
 
@@ -64,8 +70,28 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
   const { toast } = useToast();
 
   const createArtistMutation = useMutation({
+    networkMode: "always",
     mutationFn: async (artistData: FestivalArtistInsert) => {
       const dataToInsert = formatArtistTimeData({ ...artistData, job_id: jobId });
+
+      // Offline: store the new artist in the local snapshot and queue it
+      if (!isBrowserOnline() && jobId) {
+        const snapshot = await getFestivalSnapshot(jobId);
+        if (!snapshot) {
+          throw new Error("Sin conexión y sin copia offline de este festival");
+        }
+        const offlineId = generateOfflineId();
+        await queueFestivalChange({
+          jobId,
+          table: "festival_artists",
+          operation: "insert",
+          recordId: offlineId,
+          payload: dataToInsert as Record<string, unknown>,
+          label: (dataToInsert as { name?: string }).name,
+        });
+        return { ...dataToInsert, id: offlineId, __offline: true };
+      }
+
       const { data, error } = await supabase
         .from("festival_artists")
         .insert([dataToInsert])
@@ -75,11 +101,14 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
       if (error) throw error;
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId, selectedDate) });
+      const savedOffline = Boolean((data as { __offline?: boolean })?.__offline);
       toast({
-        title: "Success",
-        description: "Artist created successfully",
+        title: savedOffline ? "Guardado offline" : "Success",
+        description: savedOffline
+          ? "Artista guardado localmente. Sincroniza cuando vuelvas a tener conexión."
+          : "Artist created successfully",
       });
     },
     onError: (error: unknown) => {
@@ -93,8 +122,29 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
   });
 
   const updateArtistMutation = useMutation({
+    networkMode: "always",
     mutationFn: async ({ id, ...updateData }: FestivalArtistUpdatePayload) => {
       const dataToUpdate = formatArtistTimeData(updateData);
+
+      // Offline: apply to the local snapshot and queue for manual sync
+      if (!isBrowserOnline() && jobId) {
+        const snapshot = await getFestivalSnapshot(jobId);
+        if (!snapshot) {
+          throw new Error("Sin conexión y sin copia offline de este festival");
+        }
+        const existing = snapshot.data.artists.find((row) => row.id === id);
+        await queueFestivalChange({
+          jobId,
+          table: "festival_artists",
+          operation: "update",
+          recordId: id,
+          payload: dataToUpdate as Record<string, unknown>,
+          baseUpdatedAt: (existing?.updated_at as string | null) ?? null,
+          label: (dataToUpdate as { name?: string }).name ?? ((existing?.name as string | undefined) ?? undefined),
+        });
+        return { ...existing, ...dataToUpdate, id, __offline: true };
+      }
+
       const { data, error } = await supabase
         .from("festival_artists")
         .update(dataToUpdate)
@@ -105,11 +155,14 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
       if (error) throw error;
       return data;
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId, selectedDate) });
+      const savedOffline = Boolean((data as { __offline?: boolean })?.__offline);
       toast({
-        title: "Success",
-        description: "Artist updated successfully",
+        title: savedOffline ? "Guardado offline" : "Success",
+        description: savedOffline
+          ? "Cambios guardados localmente. Sincroniza cuando vuelvas a tener conexión."
+          : "Artist updated successfully",
       });
     },
     onError: (error: unknown) => {

--- a/src/hooks/useArtistMutations.ts
+++ b/src/hooks/useArtistMutations.ts
@@ -133,6 +133,9 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
           throw new Error("Sin conexión y sin copia offline de este festival");
         }
         const existing = snapshot.data.artists.find((row) => row.id === id);
+        if (!existing) {
+          throw new Error("El artista no existe en la copia offline de este festival");
+        }
         await queueFestivalChange({
           jobId,
           table: "festival_artists",

--- a/src/hooks/useArtistsQuery.ts
+++ b/src/hooks/useArtistsQuery.ts
@@ -1,13 +1,72 @@
 
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
+import {
+  getFestivalSnapshot,
+  getOfflineArtistsForDate,
+  isBrowserOnline,
+  queueFestivalChange,
+} from "@/lib/offline";
 
 
 import { queryKeys } from "@/lib/react-query";
 export const useArtistsQuery = (jobId: string | undefined, selectedDate: string, dayStartTime: string = "07:00") => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const [isOfflineData, setIsOfflineData] = useState(false);
+
+  const fetchArtistsOnline = async () => {
+    const { data, error } = await supabase
+      .from("festival_artists")
+      .select(`
+        *,
+        festival_artist_form_submissions!left (
+          id,
+          status
+        )
+      `)
+      .eq("job_id", jobId)
+      .eq("date", selectedDate)
+      .order("show_start", { ascending: true });
+
+    if (error) throw error;
+
+    // Process artists for after midnight logic
+    const processedArtists = data?.map((artist) => {
+      const artistWithSubmissions = artist as typeof artist & {
+        festival_artist_form_submissions?: Array<{ status?: string | null }> | null;
+        artist_submitted?: boolean;
+      };
+      const submissions = artistWithSubmissions.festival_artist_form_submissions;
+      const artistSubmitted = Array.isArray(submissions)
+        ? submissions.some((submission) => submission?.status === "submitted")
+        : false;
+
+      const cleanedArtist = {
+        ...artist,
+        artist_submitted: artistSubmitted,
+      };
+
+      if (artist.isaftermidnight !== undefined) {
+        return cleanedArtist;
+      }
+
+      if (!artist.show_start) return cleanedArtist;
+
+      const [hours] = artist.show_start.split(':').map(Number);
+      const [startHour] = dayStartTime.split(':').map(Number);
+      const isAfterMidnight = hours < startHour;
+
+      return {
+        ...cleanedArtist,
+        isaftermidnight: isAfterMidnight
+      };
+    }) || [];
+
+    return processedArtists;
+  };
 
   // Query for fetching artists
   const {
@@ -20,75 +79,73 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
     queryFn: async () => {
       if (!jobId || !selectedDate) return [];
 
-      const { data, error } = await supabase
-        .from("festival_artists")
-        .select(`
-          *,
-          festival_artist_form_submissions!left (
-            id,
-            status
-          )
-        `)
-        .eq("job_id", jobId)
-        .eq("date", selectedDate)
-        .order("show_start", { ascending: true });
-
-      if (error) throw error;
-
-      // Process artists for after midnight logic
-      const processedArtists = data?.map((artist) => {
-        const artistWithSubmissions = artist as typeof artist & {
-          festival_artist_form_submissions?: Array<{ status?: string | null }> | null;
-          artist_submitted?: boolean;
-        };
-        const submissions = artistWithSubmissions.festival_artist_form_submissions;
-        const artistSubmitted = Array.isArray(submissions)
-          ? submissions.some((submission) => submission?.status === "submitted")
-          : false;
-
-        const cleanedArtist = {
-          ...artist,
-          artist_submitted: artistSubmitted,
-        };
-
-        if (artist.isaftermidnight !== undefined) {
-          return cleanedArtist;
+      // Offline: serve the downloaded snapshot (with local edits applied)
+      if (!isBrowserOnline()) {
+        const offlineArtists = await getOfflineArtistsForDate(jobId, selectedDate, dayStartTime);
+        if (offlineArtists) {
+          setIsOfflineData(true);
+          return offlineArtists;
         }
-        
-        if (!artist.show_start) return cleanedArtist;
-        
-        const [hours] = artist.show_start.split(':').map(Number);
-        const [startHour] = dayStartTime.split(':').map(Number);
-        const isAfterMidnight = hours < startHour;
-        
-        return {
-          ...cleanedArtist,
-          isaftermidnight: isAfterMidnight
-        };
-      }) || [];
+        throw new Error("Sin conexión y sin copia offline de este festival");
+      }
 
-      return processedArtists;
+      try {
+        const onlineArtists = await fetchArtistsOnline();
+        setIsOfflineData(false);
+        return onlineArtists;
+      } catch (fetchError) {
+        // Network dropped mid-request: fall back to the offline copy if available
+        const offlineArtists = await getOfflineArtistsForDate(jobId, selectedDate, dayStartTime);
+        if (offlineArtists) {
+          setIsOfflineData(true);
+          return offlineArtists;
+        }
+        throw fetchError;
+      }
     },
     enabled: !!jobId && !!selectedDate,
     staleTime: 1000 * 60 * 2, // 2 minutes
     refetchOnWindowFocus: true,
+    networkMode: "always", // run the queryFn even offline so the snapshot can be served
   });
 
   // Mutation for deleting artists
   const deleteArtistMutation = useMutation({
+    networkMode: "always",
     mutationFn: async (artistId: string) => {
+      // Offline: queue the deletion for manual sync
+      if (!isBrowserOnline() && jobId) {
+        const snapshot = await getFestivalSnapshot(jobId);
+        if (!snapshot) {
+          throw new Error("Sin conexión y sin copia offline de este festival");
+        }
+        const artist = snapshot.data.artists.find((row) => row.id === artistId);
+        await queueFestivalChange({
+          jobId,
+          table: "festival_artists",
+          operation: "delete",
+          recordId: artistId,
+          baseUpdatedAt: (artist?.updated_at as string | null) ?? null,
+          label: (artist?.name as string | undefined) ?? undefined,
+        });
+        return { offline: true };
+      }
+
       const { error } = await supabase
         .from("festival_artists")
         .delete()
         .eq("id", artistId);
 
       if (error) throw error;
+      return { offline: false };
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId, selectedDate) });
       toast({
-        title: "Success",
-        description: "Artist deleted successfully",
+        title: result?.offline ? "Guardado offline" : "Success",
+        description: result?.offline
+          ? "Eliminación guardada. Sincroniza cuando vuelvas a tener conexión."
+          : "Artist deleted successfully",
       });
     },
     onError: (error: any) => {
@@ -113,6 +170,7 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
     refetch,
     deleteArtist: deleteArtistMutation.mutate,
     isDeletingArtist: deleteArtistMutation.isPending,
-    invalidateArtists
+    invalidateArtists,
+    isOfflineData
   };
 };

--- a/src/hooks/useArtistsQuery.ts
+++ b/src/hooks/useArtistsQuery.ts
@@ -1,5 +1,4 @@
 
-import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
@@ -15,7 +14,6 @@ import { queryKeys } from "@/lib/react-query";
 export const useArtistsQuery = (jobId: string | undefined, selectedDate: string, dayStartTime: string = "07:00") => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
-  const [isOfflineData, setIsOfflineData] = useState(false);
 
   const fetchArtistsOnline = async () => {
     const { data, error } = await supabase
@@ -68,37 +66,35 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
     return processedArtists;
   };
 
-  // Query for fetching artists
+  // Query for fetching artists. The result carries an `isOffline` marker so
+  // the flag always matches the cached payload (a separate useState could
+  // desync when React Query reuses cached data across remounts).
   const {
-    data: artists = [],
+    data: artistsResult,
     isLoading,
     error,
     refetch
   } = useQuery({
     queryKey: queryKeys.scope('festival-artists', jobId, selectedDate),
     queryFn: async () => {
-      if (!jobId || !selectedDate) return [];
+      if (!jobId || !selectedDate) return { rows: [], isOffline: false };
 
       // Offline: serve the downloaded snapshot (with local edits applied)
       if (!isBrowserOnline()) {
         const offlineArtists = await getOfflineArtistsForDate(jobId, selectedDate, dayStartTime);
         if (offlineArtists) {
-          setIsOfflineData(true);
-          return offlineArtists;
+          return { rows: offlineArtists, isOffline: true };
         }
         throw new Error("Sin conexión y sin copia offline de este festival");
       }
 
       try {
-        const onlineArtists = await fetchArtistsOnline();
-        setIsOfflineData(false);
-        return onlineArtists;
+        return { rows: await fetchArtistsOnline(), isOffline: false };
       } catch (fetchError) {
         // Network dropped mid-request: fall back to the offline copy if available
         const offlineArtists = await getOfflineArtistsForDate(jobId, selectedDate, dayStartTime);
         if (offlineArtists) {
-          setIsOfflineData(true);
-          return offlineArtists;
+          return { rows: offlineArtists, isOffline: true };
         }
         throw fetchError;
       }
@@ -108,6 +104,9 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
     refetchOnWindowFocus: true,
     networkMode: "always", // run the queryFn even offline so the snapshot can be served
   });
+
+  const artists = artistsResult?.rows ?? [];
+  const isOfflineData = artistsResult?.isOffline ?? false;
 
   // Mutation for deleting artists
   const deleteArtistMutation = useMutation({
@@ -120,13 +119,16 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
           throw new Error("Sin conexión y sin copia offline de este festival");
         }
         const artist = snapshot.data.artists.find((row) => row.id === artistId);
+        if (!artist) {
+          throw new Error("El artista no existe en la copia offline de este festival");
+        }
         await queueFestivalChange({
           jobId,
           table: "festival_artists",
           operation: "delete",
           recordId: artistId,
-          baseUpdatedAt: (artist?.updated_at as string | null) ?? null,
-          label: (artist?.name as string | undefined) ?? undefined,
+          baseUpdatedAt: (artist.updated_at as string | null) ?? null,
+          label: (artist.name as string | undefined) ?? undefined,
         });
         return { offline: true };
       }

--- a/src/lib/offline/__tests__/festival-offline-queue.test.ts
+++ b/src/lib/offline/__tests__/festival-offline-queue.test.ts
@@ -165,6 +165,34 @@ describe("festival offline queue", () => {
     expect(snapshot?.data.artists.map((artist) => artist.id)).not.toContain("artist-1");
   });
 
+  it("serializes concurrent changes so coalescing and snapshot writes are not lost", async () => {
+    await Promise.all([
+      queueFestivalChange({
+        jobId: JOB_ID,
+        table: "festival_artists",
+        operation: "update",
+        recordId: "artist-1",
+        payload: { stage: 2 },
+        baseUpdatedAt: "2026-07-01T10:00:00Z",
+      }),
+      queueFestivalChange({
+        jobId: JOB_ID,
+        table: "festival_artists",
+        operation: "update",
+        recordId: "artist-1",
+        payload: { notes: "concurrente" },
+      }),
+    ]);
+
+    const pending = await getPendingChanges(JOB_ID);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].payload).toMatchObject({ stage: 2, notes: "concurrente" });
+
+    const snapshot = await getFestivalSnapshot(JOB_ID);
+    const artist = snapshot?.data.artists.find((row) => row.id === "artist-1");
+    expect(artist).toMatchObject({ stage: 2, notes: "concurrente" });
+  });
+
   it("discards every pending change of the festival", async () => {
     await queueFestivalChange({
       jobId: JOB_ID,

--- a/src/lib/offline/__tests__/festival-offline-queue.test.ts
+++ b/src/lib/offline/__tests__/festival-offline-queue.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabase,
+}));
+
+import { offlineDb, SNAPSHOT_STORE, __resetOfflineDbForTests } from "../offline-db";
+import { getFestivalSnapshot } from "../festival-snapshot";
+import {
+  discardPendingChanges,
+  getPendingChanges,
+  queueFestivalChange,
+} from "../festival-offline-queue";
+import { OFFLINE_SNAPSHOT_SCHEMA_VERSION, type OfflineFestivalSnapshot } from "../types";
+
+const JOB_ID = "job-1";
+
+const buildSnapshot = (): OfflineFestivalSnapshot => ({
+  jobId: JOB_ID,
+  jobTitle: "Festival Test",
+  schemaVersion: OFFLINE_SNAPSHOT_SCHEMA_VERSION,
+  downloadedAt: new Date().toISOString(),
+  downloadedBy: null,
+  data: {
+    job: { id: JOB_ID, title: "Festival Test" },
+    festivalSettings: null,
+    jobDateTypes: [],
+    stages: [],
+    gearSetups: [],
+    stageGearSetups: [],
+    artists: [
+      { id: "artist-1", name: "Banda Uno", date: "2026-07-10", updated_at: "2026-07-01T10:00:00Z" },
+    ],
+    artistFormSubmissions: [],
+    artistFiles: [],
+    shifts: [],
+    shiftAssignments: [],
+    logos: [],
+    jobDocuments: [],
+    hojaVenue: null,
+    location: null,
+  },
+});
+
+describe("festival offline queue", () => {
+  beforeEach(async () => {
+    __resetOfflineDbForTests();
+    resetMockSupabase();
+    await offlineDb.put(SNAPSHOT_STORE, buildSnapshot());
+  });
+
+  it("queues an insert and reflects it in the snapshot", async () => {
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "insert",
+      recordId: "artist-new",
+      payload: { name: "Banda Nueva", date: "2026-07-10", job_id: JOB_ID },
+      label: "Banda Nueva",
+    });
+
+    const pending = await getPendingChanges(JOB_ID);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({ operation: "insert", recordId: "artist-new" });
+
+    const snapshot = await getFestivalSnapshot(JOB_ID);
+    expect(snapshot?.data.artists.map((artist) => artist.id)).toContain("artist-new");
+  });
+
+  it("coalesces insert + update into a single insert with merged payload", async () => {
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "insert",
+      recordId: "artist-new",
+      payload: { name: "Banda Nueva", stage: 1 },
+    });
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "update",
+      recordId: "artist-new",
+      payload: { stage: 2 },
+    });
+
+    const pending = await getPendingChanges(JOB_ID);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].operation).toBe("insert");
+    expect(pending[0].payload).toMatchObject({ name: "Banda Nueva", stage: 2 });
+  });
+
+  it("drops the queue entry entirely when an offline insert is deleted", async () => {
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "insert",
+      recordId: "artist-new",
+      payload: { name: "Banda Nueva", date: "2026-07-10" },
+    });
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "delete",
+      recordId: "artist-new",
+    });
+
+    expect(await getPendingChanges(JOB_ID)).toHaveLength(0);
+    const snapshot = await getFestivalSnapshot(JOB_ID);
+    expect(snapshot?.data.artists.map((artist) => artist.id)).not.toContain("artist-new");
+  });
+
+  it("merges consecutive updates and keeps the original baseUpdatedAt", async () => {
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "update",
+      recordId: "artist-1",
+      payload: { stage: 2 },
+      baseUpdatedAt: "2026-07-01T10:00:00Z",
+    });
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "update",
+      recordId: "artist-1",
+      payload: { notes: "cambio offline" },
+      baseUpdatedAt: "irrelevant-second-value",
+    });
+
+    const pending = await getPendingChanges(JOB_ID);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].operation).toBe("update");
+    expect(pending[0].payload).toMatchObject({ stage: 2, notes: "cambio offline" });
+    expect(pending[0].baseUpdatedAt).toBe("2026-07-01T10:00:00Z");
+
+    const snapshot = await getFestivalSnapshot(JOB_ID);
+    const artist = snapshot?.data.artists.find((row) => row.id === "artist-1");
+    expect(artist).toMatchObject({ stage: 2, notes: "cambio offline" });
+  });
+
+  it("collapses update + delete into a delete that keeps the original baseUpdatedAt", async () => {
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "update",
+      recordId: "artist-1",
+      payload: { stage: 2 },
+      baseUpdatedAt: "2026-07-01T10:00:00Z",
+    });
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "delete",
+      recordId: "artist-1",
+    });
+
+    const pending = await getPendingChanges(JOB_ID);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].operation).toBe("delete");
+    expect(pending[0].baseUpdatedAt).toBe("2026-07-01T10:00:00Z");
+
+    const snapshot = await getFestivalSnapshot(JOB_ID);
+    expect(snapshot?.data.artists.map((artist) => artist.id)).not.toContain("artist-1");
+  });
+
+  it("discards every pending change of the festival", async () => {
+    await queueFestivalChange({
+      jobId: JOB_ID,
+      table: "festival_artists",
+      operation: "update",
+      recordId: "artist-1",
+      payload: { stage: 3 },
+    });
+
+    const discarded = await discardPendingChanges(JOB_ID);
+    expect(discarded).toBe(1);
+    expect(await getPendingChanges(JOB_ID)).toHaveLength(0);
+  });
+});

--- a/src/lib/offline/__tests__/festival-sync.test.ts
+++ b/src/lib/offline/__tests__/festival-sync.test.ts
@@ -68,12 +68,9 @@ describe("syncFestivalPendingChanges", () => {
   it("applies an update when the server row is unchanged", async () => {
     await seedChange({ operation: "update", baseUpdatedAt: "2026-07-01T10:00:00Z" });
 
-    const selectBuilder = createMockQueryBuilder({
-      data: { id: "artist-1", updated_at: "2026-07-01T10:00:00Z" },
-      error: null,
-    });
-    const updateBuilder = createMockQueryBuilder({ data: null, error: null });
-    mockSupabase.from.mockReturnValueOnce(selectBuilder).mockReturnValueOnce(updateBuilder);
+    // Conditional write matched the row: one row returned
+    const updateBuilder = createMockQueryBuilder({ data: [{ id: "artist-1" }], error: null });
+    mockSupabase.from.mockReturnValueOnce(updateBuilder);
 
     const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
 
@@ -81,17 +78,20 @@ describe("syncFestivalPendingChanges", () => {
     expect(result.conflicts).toHaveLength(0);
     expect(result.failed).toHaveLength(0);
     expect(updateBuilder.update).toHaveBeenCalledWith(expect.objectContaining({ stage: 2 }));
+    expect(updateBuilder.eq).toHaveBeenCalledWith("updated_at", "2026-07-01T10:00:00Z");
     expect(await getPendingChanges(JOB_ID)).toHaveLength(0);
   });
 
   it("reports a conflict when the server row changed since download", async () => {
     await seedChange({ operation: "update", baseUpdatedAt: "2026-07-01T10:00:00Z", label: "Banda Uno" });
 
+    // Conditional write matched zero rows; the follow-up read finds the row
+    const updateBuilder = createMockQueryBuilder({ data: [], error: null });
     const selectBuilder = createMockQueryBuilder({
       data: { id: "artist-1", updated_at: "2026-07-02T09:00:00Z" },
       error: null,
     });
-    mockSupabase.from.mockReturnValueOnce(selectBuilder);
+    mockSupabase.from.mockReturnValueOnce(updateBuilder).mockReturnValueOnce(selectBuilder);
 
     const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
 
@@ -109,25 +109,24 @@ describe("syncFestivalPendingChanges", () => {
   it("applies a conflicting update when force is enabled", async () => {
     await seedChange({ operation: "update", baseUpdatedAt: "2026-07-01T10:00:00Z" });
 
-    const selectBuilder = createMockQueryBuilder({
-      data: { id: "artist-1", updated_at: "2026-07-02T09:00:00Z" },
-      error: null,
-    });
-    const updateBuilder = createMockQueryBuilder({ data: null, error: null });
-    mockSupabase.from.mockReturnValueOnce(selectBuilder).mockReturnValueOnce(updateBuilder);
+    const updateBuilder = createMockQueryBuilder({ data: [{ id: "artist-1" }], error: null });
+    mockSupabase.from.mockReturnValueOnce(updateBuilder);
 
     const result = await syncFestivalPendingChanges(JOB_ID, { force: true, skipSnapshotRefresh: true });
 
     expect(result.applied).toBe(1);
     expect(result.conflicts).toHaveLength(0);
+    // Force skips the updated_at guard so modified rows are overwritten
+    expect(updateBuilder.eq).not.toHaveBeenCalledWith("updated_at", "2026-07-01T10:00:00Z");
     expect(await getPendingChanges(JOB_ID)).toHaveLength(0);
   });
 
   it("reports a conflict when the record was deleted on the server", async () => {
     await seedChange({ operation: "update" });
 
+    const updateBuilder = createMockQueryBuilder({ data: [], error: null });
     const selectBuilder = createMockQueryBuilder({ data: null, error: null });
-    mockSupabase.from.mockReturnValueOnce(selectBuilder);
+    mockSupabase.from.mockReturnValueOnce(updateBuilder).mockReturnValueOnce(selectBuilder);
 
     const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
 
@@ -138,14 +137,33 @@ describe("syncFestivalPendingChanges", () => {
   it("treats deleting an already-deleted record as applied", async () => {
     await seedChange({ operation: "delete", payload: null });
 
+    const deleteBuilder = createMockQueryBuilder({ data: [], error: null });
     const selectBuilder = createMockQueryBuilder({ data: null, error: null });
-    mockSupabase.from.mockReturnValueOnce(selectBuilder);
+    mockSupabase.from.mockReturnValueOnce(deleteBuilder).mockReturnValueOnce(selectBuilder);
 
     const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
 
     expect(result.applied).toBe(1);
     expect(result.conflicts).toHaveLength(0);
     expect(await getPendingChanges(JOB_ID)).toHaveLength(0);
+  });
+
+  it("reports a delete conflict when the server row changed since download", async () => {
+    await seedChange({ operation: "delete", payload: null, baseUpdatedAt: "2026-07-01T10:00:00Z" });
+
+    const deleteBuilder = createMockQueryBuilder({ data: [], error: null });
+    const selectBuilder = createMockQueryBuilder({
+      data: { id: "artist-1", updated_at: "2026-07-02T09:00:00Z" },
+      error: null,
+    });
+    mockSupabase.from.mockReturnValueOnce(deleteBuilder).mockReturnValueOnce(selectBuilder);
+
+    const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
+
+    expect(result.applied).toBe(0);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].reason).toBe("modified_on_server");
+    expect(await getPendingChanges(JOB_ID)).toHaveLength(1);
   });
 
   it("inserts offline-created rows with their client-generated id and strips client-only fields", async () => {
@@ -175,14 +193,9 @@ describe("syncFestivalPendingChanges", () => {
   it("keeps failed changes queued and reports the error", async () => {
     await seedChange({ operation: "update" });
 
-    const selectBuilder = createMockQueryBuilder({
-      data: { id: "artist-1", updated_at: "2026-07-01T10:00:00Z" },
-      error: null,
-    });
-    const updateBuilder = createMockQueryBuilder({ data: null, error: { message: "RLS denied" } });
     // The thenable builder resolves with { error }, which festival-sync turns into a throw
-    updateBuilder.__setResult({ data: null, error: new Error("RLS denied") });
-    mockSupabase.from.mockReturnValueOnce(selectBuilder).mockReturnValueOnce(updateBuilder);
+    const updateBuilder = createMockQueryBuilder({ data: null, error: new Error("RLS denied") });
+    mockSupabase.from.mockReturnValueOnce(updateBuilder);
 
     const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
 

--- a/src/lib/offline/__tests__/festival-sync.test.ts
+++ b/src/lib/offline/__tests__/festival-sync.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabase,
+}));
+
+import { offlineDb, QUEUE_STORE, SNAPSHOT_STORE, __resetOfflineDbForTests } from "../offline-db";
+import { getPendingChanges } from "../festival-offline-queue";
+import { syncFestivalPendingChanges } from "../festival-sync";
+import {
+  OFFLINE_SNAPSHOT_SCHEMA_VERSION,
+  type OfflineFestivalSnapshot,
+  type OfflinePendingChange,
+} from "../types";
+
+const JOB_ID = "job-1";
+
+const buildSnapshot = (): OfflineFestivalSnapshot => ({
+  jobId: JOB_ID,
+  jobTitle: "Festival Test",
+  schemaVersion: OFFLINE_SNAPSHOT_SCHEMA_VERSION,
+  downloadedAt: new Date().toISOString(),
+  downloadedBy: null,
+  data: {
+    job: { id: JOB_ID, title: "Festival Test" },
+    festivalSettings: null,
+    jobDateTypes: [],
+    stages: [],
+    gearSetups: [],
+    stageGearSetups: [],
+    artists: [],
+    artistFormSubmissions: [],
+    artistFiles: [],
+    shifts: [],
+    shiftAssignments: [],
+    logos: [],
+    jobDocuments: [],
+    hojaVenue: null,
+    location: null,
+  },
+});
+
+const seedChange = async (change: Partial<OfflinePendingChange>): Promise<OfflinePendingChange> => {
+  const full: OfflinePendingChange = {
+    id: change.id ?? `change-${Math.random().toString(16).slice(2)}`,
+    jobId: JOB_ID,
+    table: "festival_artists",
+    operation: "update",
+    recordId: "artist-1",
+    payload: { stage: 2 },
+    baseUpdatedAt: "2026-07-01T10:00:00Z",
+    createdAt: new Date().toISOString(),
+    ...change,
+  };
+  await offlineDb.put(QUEUE_STORE, full);
+  return full;
+};
+
+describe("syncFestivalPendingChanges", () => {
+  beforeEach(async () => {
+    __resetOfflineDbForTests();
+    resetMockSupabase();
+    await offlineDb.put(SNAPSHOT_STORE, buildSnapshot());
+  });
+
+  it("applies an update when the server row is unchanged", async () => {
+    await seedChange({ operation: "update", baseUpdatedAt: "2026-07-01T10:00:00Z" });
+
+    const selectBuilder = createMockQueryBuilder({
+      data: { id: "artist-1", updated_at: "2026-07-01T10:00:00Z" },
+      error: null,
+    });
+    const updateBuilder = createMockQueryBuilder({ data: null, error: null });
+    mockSupabase.from.mockReturnValueOnce(selectBuilder).mockReturnValueOnce(updateBuilder);
+
+    const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
+
+    expect(result.applied).toBe(1);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.failed).toHaveLength(0);
+    expect(updateBuilder.update).toHaveBeenCalledWith(expect.objectContaining({ stage: 2 }));
+    expect(await getPendingChanges(JOB_ID)).toHaveLength(0);
+  });
+
+  it("reports a conflict when the server row changed since download", async () => {
+    await seedChange({ operation: "update", baseUpdatedAt: "2026-07-01T10:00:00Z", label: "Banda Uno" });
+
+    const selectBuilder = createMockQueryBuilder({
+      data: { id: "artist-1", updated_at: "2026-07-02T09:00:00Z" },
+      error: null,
+    });
+    mockSupabase.from.mockReturnValueOnce(selectBuilder);
+
+    const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
+
+    expect(result.applied).toBe(0);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toMatchObject({
+      reason: "modified_on_server",
+      recordId: "artist-1",
+      label: "Banda Uno",
+    });
+    // The conflicting change stays queued for force/discard
+    expect(await getPendingChanges(JOB_ID)).toHaveLength(1);
+  });
+
+  it("applies a conflicting update when force is enabled", async () => {
+    await seedChange({ operation: "update", baseUpdatedAt: "2026-07-01T10:00:00Z" });
+
+    const selectBuilder = createMockQueryBuilder({
+      data: { id: "artist-1", updated_at: "2026-07-02T09:00:00Z" },
+      error: null,
+    });
+    const updateBuilder = createMockQueryBuilder({ data: null, error: null });
+    mockSupabase.from.mockReturnValueOnce(selectBuilder).mockReturnValueOnce(updateBuilder);
+
+    const result = await syncFestivalPendingChanges(JOB_ID, { force: true, skipSnapshotRefresh: true });
+
+    expect(result.applied).toBe(1);
+    expect(result.conflicts).toHaveLength(0);
+    expect(await getPendingChanges(JOB_ID)).toHaveLength(0);
+  });
+
+  it("reports a conflict when the record was deleted on the server", async () => {
+    await seedChange({ operation: "update" });
+
+    const selectBuilder = createMockQueryBuilder({ data: null, error: null });
+    mockSupabase.from.mockReturnValueOnce(selectBuilder);
+
+    const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].reason).toBe("deleted_on_server");
+  });
+
+  it("treats deleting an already-deleted record as applied", async () => {
+    await seedChange({ operation: "delete", payload: null });
+
+    const selectBuilder = createMockQueryBuilder({ data: null, error: null });
+    mockSupabase.from.mockReturnValueOnce(selectBuilder);
+
+    const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
+
+    expect(result.applied).toBe(1);
+    expect(result.conflicts).toHaveLength(0);
+    expect(await getPendingChanges(JOB_ID)).toHaveLength(0);
+  });
+
+  it("inserts offline-created rows with their client-generated id and strips client-only fields", async () => {
+    await seedChange({
+      operation: "insert",
+      recordId: "offline-uuid",
+      payload: {
+        name: "Banda Nueva",
+        artist_submitted: true,
+        festival_artist_form_submissions: [],
+        updated_at: "stale",
+      },
+      baseUpdatedAt: null,
+    });
+
+    const insertBuilder = createMockQueryBuilder({ data: null, error: null });
+    mockSupabase.from.mockReturnValueOnce(insertBuilder);
+
+    const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
+
+    expect(result.applied).toBe(1);
+    expect(insertBuilder.insert).toHaveBeenCalledWith([
+      { name: "Banda Nueva", id: "offline-uuid" },
+    ]);
+  });
+
+  it("keeps failed changes queued and reports the error", async () => {
+    await seedChange({ operation: "update" });
+
+    const selectBuilder = createMockQueryBuilder({
+      data: { id: "artist-1", updated_at: "2026-07-01T10:00:00Z" },
+      error: null,
+    });
+    const updateBuilder = createMockQueryBuilder({ data: null, error: { message: "RLS denied" } });
+    // The thenable builder resolves with { error }, which festival-sync turns into a throw
+    updateBuilder.__setResult({ data: null, error: new Error("RLS denied") });
+    mockSupabase.from.mockReturnValueOnce(selectBuilder).mockReturnValueOnce(updateBuilder);
+
+    const result = await syncFestivalPendingChanges(JOB_ID, { skipSnapshotRefresh: true });
+
+    expect(result.applied).toBe(0);
+    expect(result.failed).toHaveLength(1);
+    expect(await getPendingChanges(JOB_ID)).toHaveLength(1);
+  });
+});

--- a/src/lib/offline/festival-offline-queue.ts
+++ b/src/lib/offline/festival-offline-queue.ts
@@ -13,9 +13,41 @@ export const generateOfflineId = (): string => {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
   }
-  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}-${Math.random()
-    .toString(16)
-    .slice(2, 10)}`;
+  // RFC 4122 v4 fallback: the id becomes the row's uuid primary key on
+  // sync, so it must be a valid UUID even in older WebViews.
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i += 1) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
+// Serializes queue/snapshot writes per festival so concurrent
+// queueFestivalChange calls can't interleave their read-modify-write
+// cycles (stale queue coalescing or lost snapshot mutations).
+const jobWriteLocks = new Map<string, Promise<void>>();
+
+const withJobWriteLock = <T>(jobId: string, fn: () => Promise<T>): Promise<T> => {
+  const previous = jobWriteLocks.get(jobId) ?? Promise.resolve();
+  const result = previous.then(fn, fn);
+  const tail = result.then(
+    (): void => undefined,
+    (): void => undefined,
+  );
+  jobWriteLocks.set(jobId, tail);
+  tail.then(() => {
+    if (jobWriteLocks.get(jobId) === tail) {
+      jobWriteLocks.delete(jobId);
+    }
+  });
+  return result;
 };
 
 export const getPendingChanges = async (jobId?: string): Promise<OfflinePendingChange[]> => {
@@ -120,35 +152,37 @@ export interface QueueFestivalChangeInput {
 
 /**
  * Queues an offline mutation and reflects it immediately in the local
- * snapshot so offline reads show the edited data.
+ * snapshot so offline reads show the edited data. Writes for the same
+ * festival are serialized to avoid stale read-modify-write races.
  */
-export const queueFestivalChange = async (input: QueueFestivalChangeInput): Promise<void> => {
-  const incoming: OfflinePendingChange = {
-    id: generateOfflineId(),
-    jobId: input.jobId,
-    table: input.table,
-    operation: input.operation,
-    recordId: input.recordId,
-    payload: input.payload ?? null,
-    baseUpdatedAt: input.baseUpdatedAt ?? null,
-    createdAt: new Date().toISOString(),
-    label: input.label,
-  };
+export const queueFestivalChange = (input: QueueFestivalChangeInput): Promise<void> =>
+  withJobWriteLock(input.jobId, async () => {
+    const incoming: OfflinePendingChange = {
+      id: generateOfflineId(),
+      jobId: input.jobId,
+      table: input.table,
+      operation: input.operation,
+      recordId: input.recordId,
+      payload: input.payload ?? null,
+      baseUpdatedAt: input.baseUpdatedAt ?? null,
+      createdAt: new Date().toISOString(),
+      label: input.label,
+    };
 
-  const pending = await getPendingChanges(input.jobId);
-  const existing = pending.find(
-    (change) => change.table === input.table && change.recordId === input.recordId,
-  );
+    const pending = await getPendingChanges(input.jobId);
+    const existing = pending.find(
+      (change) => change.table === input.table && change.recordId === input.recordId,
+    );
 
-  const merged = coalesce(existing, incoming);
+    const merged = coalesce(existing, incoming);
 
-  if (existing && (!merged || merged.id !== existing.id)) {
-    await offlineDb.remove(QUEUE_STORE, existing.id);
-  }
-  if (merged) {
-    await offlineDb.put(QUEUE_STORE, merged);
-  }
+    if (existing && (!merged || merged.id !== existing.id)) {
+      await offlineDb.remove(QUEUE_STORE, existing.id);
+    }
+    if (merged) {
+      await offlineDb.put(QUEUE_STORE, merged);
+    }
 
-  await mutateSnapshot(incoming);
-  notifyOfflineFestivalChanged(input.jobId);
-};
+    await mutateSnapshot(incoming);
+    notifyOfflineFestivalChanged(input.jobId);
+  });

--- a/src/lib/offline/festival-offline-queue.ts
+++ b/src/lib/offline/festival-offline-queue.ts
@@ -1,0 +1,154 @@
+import { offlineDb, QUEUE_STORE } from "./offline-db";
+import { notifyOfflineFestivalChanged } from "./offline-events";
+import { getFestivalSnapshot, saveFestivalSnapshot } from "./festival-snapshot";
+import type {
+  OfflineChangeOperation,
+  OfflinePendingChange,
+  OfflineSyncableTable,
+} from "./types";
+
+type Row = Record<string, unknown>;
+
+export const generateOfflineId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}-${Math.random()
+    .toString(16)
+    .slice(2, 10)}`;
+};
+
+export const getPendingChanges = async (jobId?: string): Promise<OfflinePendingChange[]> => {
+  const changes = await offlineDb.getAll<OfflinePendingChange>(QUEUE_STORE);
+  return changes
+    .filter((change) => !jobId || change.jobId === jobId)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+};
+
+export const countPendingChanges = async (jobId: string): Promise<number> =>
+  (await getPendingChanges(jobId)).length;
+
+export const removePendingChange = async (changeId: string): Promise<void> => {
+  await offlineDb.remove(QUEUE_STORE, changeId);
+};
+
+/**
+ * Drops every queued change of a festival. The local snapshot may still
+ * contain the discarded edits, so callers should re-download it afterwards
+ * when a connection is available.
+ */
+export const discardPendingChanges = async (jobId: string): Promise<number> => {
+  const changes = await getPendingChanges(jobId);
+  await Promise.all(changes.map((change) => offlineDb.remove(QUEUE_STORE, change.id)));
+  notifyOfflineFestivalChanged(jobId);
+  return changes.length;
+};
+
+const applyChangeToSnapshotArtists = (artists: Row[], change: OfflinePendingChange): Row[] => {
+  switch (change.operation) {
+    case "insert":
+      return [...artists, { ...(change.payload ?? {}), id: change.recordId }];
+    case "update":
+      return artists.map((artist) =>
+        artist.id === change.recordId ? { ...artist, ...(change.payload ?? {}) } : artist,
+      );
+    case "delete":
+      return artists.filter((artist) => artist.id !== change.recordId);
+    default:
+      return artists;
+  }
+};
+
+const mutateSnapshot = async (change: OfflinePendingChange): Promise<void> => {
+  const snapshot = await getFestivalSnapshot(change.jobId);
+  if (!snapshot) return;
+
+  if (change.table === "festival_artists") {
+    snapshot.data.artists = applyChangeToSnapshotArtists(snapshot.data.artists, change);
+  }
+
+  await saveFestivalSnapshot(snapshot);
+};
+
+/**
+ * Coalesces a new operation with a previously queued one for the same
+ * record so sync sends the minimum set of writes:
+ *   insert + update -> insert (merged payload)
+ *   insert + delete -> nothing
+ *   update + update -> update (merged payload, original baseUpdatedAt)
+ *   update + delete -> delete (original baseUpdatedAt)
+ */
+const coalesce = (
+  existing: OfflinePendingChange | undefined,
+  incoming: OfflinePendingChange,
+): OfflinePendingChange | null => {
+  if (!existing) return incoming;
+
+  if (existing.operation === "insert") {
+    if (incoming.operation === "delete") return null;
+    return {
+      ...existing,
+      payload: { ...(existing.payload ?? {}), ...(incoming.payload ?? {}) },
+      label: incoming.label ?? existing.label,
+    };
+  }
+
+  if (existing.operation === "update") {
+    if (incoming.operation === "delete") {
+      return { ...incoming, id: existing.id, createdAt: existing.createdAt, baseUpdatedAt: existing.baseUpdatedAt };
+    }
+    return {
+      ...existing,
+      payload: { ...(existing.payload ?? {}), ...(incoming.payload ?? {}) },
+      label: incoming.label ?? existing.label,
+    };
+  }
+
+  // existing delete followed by anything else: keep the latest intent
+  return incoming;
+};
+
+export interface QueueFestivalChangeInput {
+  jobId: string;
+  table: OfflineSyncableTable;
+  operation: OfflineChangeOperation;
+  recordId: string;
+  payload?: Row | null;
+  baseUpdatedAt?: string | null;
+  label?: string;
+}
+
+/**
+ * Queues an offline mutation and reflects it immediately in the local
+ * snapshot so offline reads show the edited data.
+ */
+export const queueFestivalChange = async (input: QueueFestivalChangeInput): Promise<void> => {
+  const incoming: OfflinePendingChange = {
+    id: generateOfflineId(),
+    jobId: input.jobId,
+    table: input.table,
+    operation: input.operation,
+    recordId: input.recordId,
+    payload: input.payload ?? null,
+    baseUpdatedAt: input.baseUpdatedAt ?? null,
+    createdAt: new Date().toISOString(),
+    label: input.label,
+  };
+
+  const pending = await getPendingChanges(input.jobId);
+  const existing = pending.find(
+    (change) => change.table === input.table && change.recordId === input.recordId,
+  );
+
+  const merged = coalesce(existing, incoming);
+
+  if (existing && (!merged || merged.id !== existing.id)) {
+    await offlineDb.remove(QUEUE_STORE, existing.id);
+  }
+  if (merged) {
+    await offlineDb.put(QUEUE_STORE, merged);
+  }
+
+  await mutateSnapshot(incoming);
+  notifyOfflineFestivalChanged(input.jobId);
+};

--- a/src/lib/offline/festival-snapshot.ts
+++ b/src/lib/offline/festival-snapshot.ts
@@ -222,17 +222,15 @@ export const getOfflineFestivalContext = async (jobId: string): Promise<OfflineF
   const snapshot = await getFestivalSnapshot(jobId);
   if (!snapshot) return null;
 
-  const dateTypes: Record<string, string> = {};
-  snapshot.data.jobDateTypes.forEach((item) => {
-    dateTypes[`${jobId}-${item.date as string}`] = item.type as string;
-  });
+  const dateTypes = Object.fromEntries(
+    snapshot.data.jobDateTypes.map((item) => [`${jobId}-${item.date as string}`, item.type as string]),
+  );
 
-  const stageNames: Record<number, string> = {};
-  snapshot.data.stages.forEach((stage) => {
-    if (typeof stage.number === "number") {
-      stageNames[stage.number] = (stage.name as string) ?? `Escenario ${stage.number}`;
-    }
-  });
+  const stageNames = Object.fromEntries(
+    snapshot.data.stages
+      .filter((stage) => typeof stage.number === "number")
+      .map((stage) => [stage.number as number, (stage.name as string) ?? `Escenario ${stage.number as number}`]),
+  ) as Record<number, string>;
 
   const latestGearSetup = [...snapshot.data.gearSetups].sort((a, b) =>
     compareTimeStrings(b.created_at, a.created_at),

--- a/src/lib/offline/festival-snapshot.ts
+++ b/src/lib/offline/festival-snapshot.ts
@@ -1,0 +1,250 @@
+import { supabase } from "@/integrations/supabase/client";
+
+import { offlineDb, QUEUE_STORE, SNAPSHOT_STORE } from "./offline-db";
+import { notifyOfflineFestivalChanged } from "./offline-events";
+import {
+  OFFLINE_SNAPSHOT_SCHEMA_VERSION,
+  type OfflineFestivalSnapshot,
+  type OfflineFestivalSnapshotData,
+  type OfflinePendingChange,
+} from "./types";
+
+type Row = Record<string, unknown>;
+
+const PAGE_SIZE = 1000;
+
+/**
+ * Fetches every row matching a filter, paginating past the PostgREST
+ * 1000-row default so large festivals are captured completely.
+ */
+const fetchAllRows = async (
+  table: string,
+  filterColumn: string,
+  filterValue: string | string[],
+): Promise<Row[]> => {
+  const rows: Row[] = [];
+  let from = 0;
+
+  for (;;) {
+    let query = supabase.from(table as never).select("*").range(from, from + PAGE_SIZE - 1);
+    query = Array.isArray(filterValue)
+      ? query.in(filterColumn as never, filterValue as never)
+      : query.eq(filterColumn as never, filterValue as never);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const page = (data ?? []) as Row[];
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+
+  return rows;
+};
+
+const fetchMaybeSingle = async (table: string, filterColumn: string, filterValue: string): Promise<Row | null> => {
+  const { data, error } = await supabase
+    .from(table as never)
+    .select("*")
+    .eq(filterColumn as never, filterValue as never)
+    .maybeSingle();
+  if (error) throw error;
+  return (data as Row | null) ?? null;
+};
+
+/**
+ * Downloads the full dataset of a festival (job, settings, dates, stages,
+ * gear, artists, riders metadata, shifts, documents) and persists it to
+ * IndexedDB so the festival can be consulted and edited without connection.
+ */
+export const downloadFestivalSnapshot = async (jobId: string): Promise<OfflineFestivalSnapshot> => {
+  const { data: job, error: jobError } = await supabase.from("jobs").select("*").eq("id", jobId).single();
+  if (jobError) throw jobError;
+
+  const [
+    festivalSettings,
+    jobDateTypes,
+    stages,
+    gearSetups,
+    artists,
+    shifts,
+    logos,
+    jobDocuments,
+    hojaVenue,
+  ] = await Promise.all([
+    fetchMaybeSingle("festival_settings", "job_id", jobId),
+    fetchAllRows("job_date_types", "job_id", jobId),
+    fetchAllRows("festival_stages", "job_id", jobId),
+    fetchAllRows("festival_gear_setups", "job_id", jobId),
+    fetchAllRows("festival_artists", "job_id", jobId),
+    fetchAllRows("festival_shifts", "job_id", jobId),
+    fetchAllRows("festival_logos", "job_id", jobId),
+    fetchAllRows("job_documents", "job_id", jobId),
+    fetchMaybeSingle("hoja_de_ruta", "job_id", jobId),
+  ]);
+
+  const gearSetupIds = gearSetups.map((setup) => setup.id as string).filter(Boolean);
+  const artistIds = artists.map((artist) => artist.id as string).filter(Boolean);
+  const shiftIds = shifts.map((shift) => shift.id as string).filter(Boolean);
+  const locationId = (job as Row).location_id as string | null;
+
+  const [stageGearSetups, artistFormSubmissions, artistFiles, shiftAssignments, location] = await Promise.all([
+    gearSetupIds.length ? fetchAllRows("festival_stage_gear_setups", "gear_setup_id", gearSetupIds) : Promise.resolve([]),
+    artistIds.length ? fetchAllRows("festival_artist_form_submissions", "artist_id", artistIds) : Promise.resolve([]),
+    artistIds.length ? fetchAllRows("festival_artist_files", "artist_id", artistIds) : Promise.resolve([]),
+    shiftIds.length ? fetchAllRows("festival_shift_assignments", "shift_id", shiftIds) : Promise.resolve([]),
+    locationId ? fetchMaybeSingle("locations", "id", locationId) : Promise.resolve(null),
+  ]);
+
+  const { data: sessionData } = await supabase.auth.getSession();
+
+  const snapshot: OfflineFestivalSnapshot = {
+    jobId,
+    jobTitle: ((job as Row).title as string) || "Festival",
+    schemaVersion: OFFLINE_SNAPSHOT_SCHEMA_VERSION,
+    downloadedAt: new Date().toISOString(),
+    downloadedBy: sessionData?.session?.user?.id ?? null,
+    data: {
+      job: job as Row,
+      festivalSettings,
+      jobDateTypes,
+      stages,
+      gearSetups,
+      stageGearSetups,
+      artists,
+      artistFormSubmissions,
+      artistFiles,
+      shifts,
+      shiftAssignments,
+      logos,
+      jobDocuments,
+      hojaVenue,
+      location,
+    },
+  };
+
+  await offlineDb.put(SNAPSHOT_STORE, snapshot);
+  notifyOfflineFestivalChanged(jobId);
+  return snapshot;
+};
+
+export const getFestivalSnapshot = async (jobId: string): Promise<OfflineFestivalSnapshot | null> => {
+  const snapshot = await offlineDb.get<OfflineFestivalSnapshot>(SNAPSHOT_STORE, jobId);
+  if (!snapshot || snapshot.schemaVersion !== OFFLINE_SNAPSHOT_SCHEMA_VERSION) {
+    return null;
+  }
+  return snapshot;
+};
+
+export const saveFestivalSnapshot = async (snapshot: OfflineFestivalSnapshot): Promise<void> => {
+  await offlineDb.put(SNAPSHOT_STORE, snapshot);
+  notifyOfflineFestivalChanged(snapshot.jobId);
+};
+
+/** Removes the offline copy and any pending changes queued against it. */
+export const deleteFestivalSnapshot = async (jobId: string): Promise<void> => {
+  await offlineDb.remove(SNAPSHOT_STORE, jobId);
+  const pending = await offlineDb.getAll<OfflinePendingChange>(QUEUE_STORE);
+  await Promise.all(pending.filter((change) => change.jobId === jobId).map((change) => offlineDb.remove(QUEUE_STORE, change.id)));
+  notifyOfflineFestivalChanged(jobId);
+};
+
+const compareTimeStrings = (a: unknown, b: unknown): number => {
+  const left = typeof a === "string" ? a : "";
+  const right = typeof b === "string" ? b : "";
+  return left.localeCompare(right);
+};
+
+/**
+ * Returns the artists of one festival date exactly as the online
+ * `useArtistsQuery` would (submission flag + after-midnight processing),
+ * or null when no snapshot exists.
+ */
+export const getOfflineArtistsForDate = async (
+  jobId: string,
+  selectedDate: string,
+  dayStartTime = "07:00",
+): Promise<Row[] | null> => {
+  const snapshot = await getFestivalSnapshot(jobId);
+  if (!snapshot) return null;
+
+  const submittedArtistIds = new Set(
+    snapshot.data.artistFormSubmissions
+      .filter((submission) => submission.status === "submitted")
+      .map((submission) => submission.artist_id as string),
+  );
+
+  return snapshot.data.artists
+    .filter((artist) => artist.date === selectedDate)
+    .map((artist) => {
+      const processed: Row = {
+        ...artist,
+        artist_submitted: submittedArtistIds.has(artist.id as string),
+      };
+
+      if (processed.isaftermidnight === undefined || processed.isaftermidnight === null) {
+        const showStart = processed.show_start;
+        if (typeof showStart === "string" && showStart) {
+          const [hours] = showStart.split(":").map(Number);
+          const [startHour] = dayStartTime.split(":").map(Number);
+          processed.isaftermidnight = hours < startHour;
+        }
+      }
+
+      return processed;
+    })
+    .sort((a, b) => compareTimeStrings(a.show_start, b.show_start));
+};
+
+export interface OfflineFestivalContext {
+  job: Row | null;
+  festivalSettings: Row | null;
+  dateTypes: Record<string, string>;
+  stageNames: Record<number, string>;
+  stages: Array<Record<string, unknown>>;
+  maxStages: number;
+  artistCount: number;
+  downloadedAt: string;
+}
+
+/**
+ * Snapshot-backed replacement for the small context queries of the
+ * festival pages (settings, date types, stage names, job row).
+ */
+export const getOfflineFestivalContext = async (jobId: string): Promise<OfflineFestivalContext | null> => {
+  const snapshot = await getFestivalSnapshot(jobId);
+  if (!snapshot) return null;
+
+  const dateTypes: Record<string, string> = {};
+  snapshot.data.jobDateTypes.forEach((item) => {
+    dateTypes[`${jobId}-${item.date as string}`] = item.type as string;
+  });
+
+  const stageNames: Record<number, string> = {};
+  snapshot.data.stages.forEach((stage) => {
+    if (typeof stage.number === "number") {
+      stageNames[stage.number] = (stage.name as string) ?? `Escenario ${stage.number}`;
+    }
+  });
+
+  const latestGearSetup = [...snapshot.data.gearSetups].sort((a, b) =>
+    compareTimeStrings(b.created_at, a.created_at),
+  )[0];
+  const gearMaxStages = Math.max(Number(latestGearSetup?.max_stages) || 1, 1);
+  const stageNumbers = snapshot.data.stages
+    .map((stage) => stage.number)
+    .filter((value): value is number => typeof value === "number");
+  const maxStages = Math.max(gearMaxStages, ...(stageNumbers.length ? stageNumbers : [1]));
+
+  return {
+    job: snapshot.data.job,
+    festivalSettings: snapshot.data.festivalSettings,
+    dateTypes,
+    stageNames,
+    stages: snapshot.data.stages,
+    maxStages,
+    artistCount: snapshot.data.artists.length,
+    downloadedAt: snapshot.downloadedAt,
+  };
+};

--- a/src/lib/offline/festival-snapshot.ts
+++ b/src/lib/offline/festival-snapshot.ts
@@ -16,6 +16,8 @@ const PAGE_SIZE = 1000;
 /**
  * Fetches every row matching a filter, paginating past the PostgREST
  * 1000-row default so large festivals are captured completely.
+ * Pages are ordered by the unique `id` column so pagination is stable
+ * (no skipped or duplicated rows between pages).
  */
 const fetchAllRows = async (
   table: string,
@@ -26,7 +28,11 @@ const fetchAllRows = async (
   let from = 0;
 
   for (;;) {
-    let query = supabase.from(table as never).select("*").range(from, from + PAGE_SIZE - 1);
+    let query = supabase
+      .from(table as never)
+      .select("*")
+      .order("id" as never, { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
     query = Array.isArray(filterValue)
       ? query.in(filterColumn as never, filterValue as never)
       : query.eq(filterColumn as never, filterValue as never);

--- a/src/lib/offline/festival-sync.ts
+++ b/src/lib/offline/festival-sync.ts
@@ -1,0 +1,163 @@
+import { supabase } from "@/integrations/supabase/client";
+
+import { downloadFestivalSnapshot } from "./festival-snapshot";
+import { getPendingChanges, removePendingChange } from "./festival-offline-queue";
+import { isBrowserOnline, notifyOfflineFestivalChanged } from "./offline-events";
+import type {
+  OfflinePendingChange,
+  OfflineSyncConflictReason,
+  OfflineSyncResult,
+} from "./types";
+
+type Row = Record<string, unknown>;
+
+/**
+ * Columns that exist only on the client (joins/derived flags) and must be
+ * stripped before writing a row back to the server.
+ */
+const CLIENT_ONLY_FIELDS = new Set([
+  "artist_submitted",
+  "festival_artist_form_submissions",
+]);
+
+const sanitizePayload = (payload: Row | null): Row => {
+  const clean: Row = {};
+  Object.entries(payload ?? {}).forEach(([key, value]) => {
+    if (!CLIENT_ONLY_FIELDS.has(key)) {
+      clean[key] = value;
+    }
+  });
+  // updated_at is maintained by the server; sending the stale local value
+  // would defeat conflict detection for later syncs.
+  delete clean.updated_at;
+  return clean;
+};
+
+type ApplyOutcome =
+  | { status: "applied" }
+  | { status: "conflict"; reason: OfflineSyncConflictReason };
+
+const fetchServerUpdatedAt = async (
+  change: OfflinePendingChange,
+): Promise<{ exists: boolean; updatedAt: string | null }> => {
+  const { data, error } = await supabase
+    .from(change.table)
+    .select("id, updated_at")
+    .eq("id", change.recordId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return { exists: false, updatedAt: null };
+  return { exists: true, updatedAt: (data as Row).updated_at as string | null };
+};
+
+const applyChange = async (change: OfflinePendingChange, force: boolean): Promise<ApplyOutcome> => {
+  if (change.operation === "insert") {
+    const payload = sanitizePayload(change.payload);
+    payload.id = change.recordId;
+    const { error } = await supabase.from(change.table).insert([payload as never]);
+    if (error) {
+      if (error.code === "23505") {
+        return { status: "conflict", reason: "duplicate_on_server" };
+      }
+      throw error;
+    }
+    return { status: "applied" };
+  }
+
+  const server = await fetchServerUpdatedAt(change);
+
+  if (change.operation === "update") {
+    if (!server.exists) {
+      return { status: "conflict", reason: "deleted_on_server" };
+    }
+    if (!force && change.baseUpdatedAt && server.updatedAt && server.updatedAt !== change.baseUpdatedAt) {
+      return { status: "conflict", reason: "modified_on_server" };
+    }
+    const { error } = await supabase
+      .from(change.table)
+      .update(sanitizePayload(change.payload) as never)
+      .eq("id", change.recordId);
+    if (error) throw error;
+    return { status: "applied" };
+  }
+
+  // delete
+  if (!server.exists) {
+    // Already gone on the server: nothing to do.
+    return { status: "applied" };
+  }
+  if (!force && change.baseUpdatedAt && server.updatedAt && server.updatedAt !== change.baseUpdatedAt) {
+    return { status: "conflict", reason: "modified_on_server" };
+  }
+  const { error } = await supabase.from(change.table).delete().eq("id", change.recordId);
+  if (error) throw error;
+  return { status: "applied" };
+};
+
+export interface SyncOptions {
+  /** Apply changes even when the server row changed since download. */
+  force?: boolean;
+  /** Skip the snapshot refresh after a clean sync (used by tests). */
+  skipSnapshotRefresh?: boolean;
+}
+
+/**
+ * Pushes the queued offline changes of a festival to the server, in the
+ * order they were made. Changes whose server row was modified (or deleted)
+ * since the download are reported as conflicts and stay queued so the user
+ * can retry with `force` or discard them. After a fully clean sync the
+ * snapshot is re-downloaded so local data matches the server again.
+ */
+export const syncFestivalPendingChanges = async (
+  jobId: string,
+  options: SyncOptions = {},
+): Promise<OfflineSyncResult> => {
+  if (!isBrowserOnline()) {
+    throw new Error("Sin conexión: no se pueden sincronizar los cambios");
+  }
+
+  const changes = await getPendingChanges(jobId);
+  const result: OfflineSyncResult = { applied: 0, conflicts: [], failed: [] };
+
+  for (const change of changes) {
+    try {
+      const outcome = await applyChange(change, options.force ?? false);
+      if (outcome.status === "applied") {
+        await removePendingChange(change.id);
+        result.applied += 1;
+      } else {
+        result.conflicts.push({
+          changeId: change.id,
+          table: change.table,
+          operation: change.operation,
+          recordId: change.recordId,
+          label: change.label,
+          reason: outcome.reason,
+        });
+      }
+    } catch (error) {
+      result.failed.push({
+        changeId: change.id,
+        table: change.table,
+        operation: change.operation,
+        recordId: change.recordId,
+        label: change.label,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (!options.skipSnapshotRefresh && result.conflicts.length === 0 && result.failed.length === 0) {
+    try {
+      await downloadFestivalSnapshot(jobId);
+    } catch (error) {
+      // The sync itself succeeded; a failed refresh only leaves the local
+      // copy slightly stale, so report it without failing the operation.
+      console.warn("No se pudo actualizar la copia offline tras la sincronización:", error);
+    }
+  }
+
+  notifyOfflineFestivalChanged(jobId);
+  return result;
+};

--- a/src/lib/offline/festival-sync.ts
+++ b/src/lib/offline/festival-sync.ts
@@ -5,6 +5,7 @@ import { getPendingChanges, removePendingChange } from "./festival-offline-queue
 import { isBrowserOnline, notifyOfflineFestivalChanged } from "./offline-events";
 import type {
   OfflinePendingChange,
+  OfflineSyncableTable,
   OfflineSyncConflictReason,
   OfflineSyncResult,
 } from "./types";
@@ -13,17 +14,17 @@ type Row = Record<string, unknown>;
 
 /**
  * Columns that exist only on the client (joins/derived flags) and must be
- * stripped before writing a row back to the server.
+ * stripped before writing a row back to the server, per syncable table.
  */
-const CLIENT_ONLY_FIELDS = new Set([
-  "artist_submitted",
-  "festival_artist_form_submissions",
-]);
+const CLIENT_ONLY_FIELDS: Record<OfflineSyncableTable, ReadonlySet<string>> = {
+  festival_artists: new Set(["artist_submitted", "festival_artist_form_submissions"]),
+};
 
-const sanitizePayload = (payload: Row | null): Row => {
+const sanitizePayload = (table: OfflineSyncableTable, payload: Row | null): Row => {
+  const excluded = CLIENT_ONLY_FIELDS[table];
   const clean: Row = {};
   Object.entries(payload ?? {}).forEach(([key, value]) => {
-    if (!CLIENT_ONLY_FIELDS.has(key)) {
+    if (!excluded.has(key)) {
       clean[key] = value;
     }
   });
@@ -53,7 +54,7 @@ const fetchServerUpdatedAt = async (
 
 const applyChange = async (change: OfflinePendingChange, force: boolean): Promise<ApplyOutcome> => {
   if (change.operation === "insert") {
-    const payload = sanitizePayload(change.payload);
+    const payload = sanitizePayload(change.table, change.payload);
     payload.id = change.recordId;
     const { error } = await supabase.from(change.table).insert([payload as never]);
     if (error) {
@@ -65,34 +66,50 @@ const applyChange = async (change: OfflinePendingChange, force: boolean): Promis
     return { status: "applied" };
   }
 
-  const server = await fetchServerUpdatedAt(change);
+  // Conflict detection is done atomically: the write is filtered by the
+  // updated_at observed at download time, so a row modified on the server
+  // between check and write simply matches zero rows. The follow-up read
+  // only distinguishes deleted_on_server from modified_on_server.
+  const guardByBase = !force && Boolean(change.baseUpdatedAt);
 
   if (change.operation === "update") {
+    let query = supabase
+      .from(change.table)
+      .update(sanitizePayload(change.table, change.payload) as never)
+      .eq("id", change.recordId);
+    if (guardByBase) {
+      query = query.eq("updated_at", change.baseUpdatedAt as string);
+    }
+    const { data, error } = await query.select("id");
+    if (error) throw error;
+    if ((data ?? []).length > 0) {
+      return { status: "applied" };
+    }
+
+    const server = await fetchServerUpdatedAt(change);
     if (!server.exists) {
       return { status: "conflict", reason: "deleted_on_server" };
     }
-    if (!force && change.baseUpdatedAt && server.updatedAt && server.updatedAt !== change.baseUpdatedAt) {
-      return { status: "conflict", reason: "modified_on_server" };
-    }
-    const { error } = await supabase
-      .from(change.table)
-      .update(sanitizePayload(change.payload) as never)
-      .eq("id", change.recordId);
-    if (error) throw error;
-    return { status: "applied" };
+    return { status: "conflict", reason: "modified_on_server" };
   }
 
   // delete
+  let query = supabase.from(change.table).delete().eq("id", change.recordId);
+  if (guardByBase) {
+    query = query.eq("updated_at", change.baseUpdatedAt as string);
+  }
+  const { data, error } = await query.select("id");
+  if (error) throw error;
+  if ((data ?? []).length > 0) {
+    return { status: "applied" };
+  }
+
+  const server = await fetchServerUpdatedAt(change);
   if (!server.exists) {
     // Already gone on the server: nothing to do.
     return { status: "applied" };
   }
-  if (!force && change.baseUpdatedAt && server.updatedAt && server.updatedAt !== change.baseUpdatedAt) {
-    return { status: "conflict", reason: "modified_on_server" };
-  }
-  const { error } = await supabase.from(change.table).delete().eq("id", change.recordId);
-  if (error) throw error;
-  return { status: "applied" };
+  return { status: "conflict", reason: "modified_on_server" };
 };
 
 export interface SyncOptions {

--- a/src/lib/offline/festival-sync.ts
+++ b/src/lib/offline/festival-sync.ts
@@ -22,15 +22,11 @@ const CLIENT_ONLY_FIELDS: Record<OfflineSyncableTable, ReadonlySet<string>> = {
 
 const sanitizePayload = (table: OfflineSyncableTable, payload: Row | null): Row => {
   const excluded = CLIENT_ONLY_FIELDS[table];
-  const clean: Row = {};
-  Object.entries(payload ?? {}).forEach(([key, value]) => {
-    if (!excluded.has(key)) {
-      clean[key] = value;
-    }
-  });
+  const clean = Object.fromEntries(
+    Object.entries(payload ?? {}).filter(([key]) => key !== "updated_at" && !excluded.has(key)),
+  );
   // updated_at is maintained by the server; sending the stale local value
   // would defeat conflict detection for later syncs.
-  delete clean.updated_at;
   return clean;
 };
 

--- a/src/lib/offline/index.ts
+++ b/src/lib/offline/index.ts
@@ -1,0 +1,18 @@
+export * from "./types";
+export * from "./offline-events";
+export {
+  downloadFestivalSnapshot,
+  getFestivalSnapshot,
+  deleteFestivalSnapshot,
+  getOfflineArtistsForDate,
+  getOfflineFestivalContext,
+  type OfflineFestivalContext,
+} from "./festival-snapshot";
+export {
+  queueFestivalChange,
+  getPendingChanges,
+  countPendingChanges,
+  discardPendingChanges,
+  generateOfflineId,
+} from "./festival-offline-queue";
+export { syncFestivalPendingChanges, type SyncOptions } from "./festival-sync";

--- a/src/lib/offline/offline-db.ts
+++ b/src/lib/offline/offline-db.ts
@@ -1,0 +1,138 @@
+/**
+ * Minimal IndexedDB key-value layer for offline festival data.
+ *
+ * Falls back to an in-memory store when IndexedDB is unavailable
+ * (unit tests under Node, private browsing edge cases). The in-memory
+ * fallback keeps the same API so callers never need to branch.
+ */
+
+export const SNAPSHOT_STORE = "festival-snapshots";
+export const QUEUE_STORE = "festival-pending-changes";
+
+export type OfflineStoreName = typeof SNAPSHOT_STORE | typeof QUEUE_STORE;
+
+const DB_NAME = "sector-pro-offline";
+const DB_VERSION = 1;
+
+const STORE_KEY_PATHS: Record<OfflineStoreName, string> = {
+  [SNAPSHOT_STORE]: "jobId",
+  [QUEUE_STORE]: "id",
+};
+
+const hasIndexedDb = () => typeof indexedDB !== "undefined";
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+const memoryStores: Record<OfflineStoreName, Map<string, unknown>> = {
+  [SNAPSHOT_STORE]: new Map(),
+  [QUEUE_STORE]: new Map(),
+};
+
+const openDb = (): Promise<IDBDatabase> => {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        (Object.keys(STORE_KEY_PATHS) as OfflineStoreName[]).forEach((store) => {
+          if (!db.objectStoreNames.contains(store)) {
+            db.createObjectStore(store, { keyPath: STORE_KEY_PATHS[store] });
+          }
+        });
+      };
+
+      request.onsuccess = () => {
+        const db = request.result;
+        // If the connection is closed elsewhere (e.g. version change from
+        // another tab), reopen lazily on next access.
+        db.onclose = () => {
+          dbPromise = null;
+        };
+        db.onversionchange = () => {
+          db.close();
+          dbPromise = null;
+        };
+        resolve(db);
+      };
+
+      request.onerror = () => {
+        dbPromise = null;
+        reject(request.error ?? new Error("No se pudo abrir la base de datos offline"));
+      };
+    });
+  }
+
+  return dbPromise;
+};
+
+const runTransaction = async <T>(
+  store: OfflineStoreName,
+  mode: IDBTransactionMode,
+  operation: (objectStore: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> => {
+  const db = await openDb();
+  return new Promise<T>((resolve, reject) => {
+    const transaction = db.transaction(store, mode);
+    const request = operation(transaction.objectStore(store));
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Error en la base de datos offline"));
+  });
+};
+
+const getRecordKey = (store: OfflineStoreName, value: unknown): string => {
+  const key = (value as Record<string, unknown>)[STORE_KEY_PATHS[store]];
+  if (typeof key !== "string" || !key) {
+    throw new Error(`Registro offline sin clave "${STORE_KEY_PATHS[store]}"`);
+  }
+  return key;
+};
+
+// Structured clone keeps the in-memory fallback behaviour consistent with
+// IndexedDB (stored values are detached from caller mutations).
+const cloneValue = <T>(value: T): T => {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+export const offlineDb = {
+  async get<T>(store: OfflineStoreName, key: string): Promise<T | null> {
+    if (!hasIndexedDb()) {
+      const value = memoryStores[store].get(key);
+      return value === undefined ? null : cloneValue(value as T);
+    }
+    const result = await runTransaction<T | undefined>(store, "readonly", (os) => os.get(key) as IDBRequest<T | undefined>);
+    return result ?? null;
+  },
+
+  async getAll<T>(store: OfflineStoreName): Promise<T[]> {
+    if (!hasIndexedDb()) {
+      return Array.from(memoryStores[store].values()).map((value) => cloneValue(value as T));
+    }
+    return runTransaction<T[]>(store, "readonly", (os) => os.getAll() as IDBRequest<T[]>);
+  },
+
+  async put(store: OfflineStoreName, value: unknown): Promise<void> {
+    if (!hasIndexedDb()) {
+      memoryStores[store].set(getRecordKey(store, value), cloneValue(value));
+      return;
+    }
+    await runTransaction(store, "readwrite", (os) => os.put(value));
+  },
+
+  async remove(store: OfflineStoreName, key: string): Promise<void> {
+    if (!hasIndexedDb()) {
+      memoryStores[store].delete(key);
+      return;
+    }
+    await runTransaction(store, "readwrite", (os) => os.delete(key));
+  },
+};
+
+/** Test-only helper: wipes the in-memory fallback stores. */
+export const __resetOfflineDbForTests = () => {
+  memoryStores[SNAPSHOT_STORE].clear();
+  memoryStores[QUEUE_STORE].clear();
+};

--- a/src/lib/offline/offline-db.ts
+++ b/src/lib/offline/offline-db.ts
@@ -60,6 +60,13 @@ const openDb = (): Promise<IDBDatabase> => {
         dbPromise = null;
         reject(request.error ?? new Error("No se pudo abrir la base de datos offline"));
       };
+
+      // Another tab holds an older connection open and blocks the upgrade;
+      // settle instead of hanging forever, and retry on the next access.
+      request.onblocked = () => {
+        dbPromise = null;
+        reject(new Error("La base de datos offline está bloqueada por otra pestaña"));
+      };
     });
   }
 

--- a/src/lib/offline/offline-events.ts
+++ b/src/lib/offline/offline-events.ts
@@ -1,0 +1,42 @@
+/**
+ * Lightweight notification channel so every component showing offline
+ * festival state (controls, banners, artist table) refreshes when the
+ * snapshot or the pending-change queue mutates.
+ */
+
+export const OFFLINE_FESTIVAL_CHANGED_EVENT = "offline-festival-changed";
+
+export interface OfflineFestivalChangedDetail {
+  jobId: string;
+}
+
+export const notifyOfflineFestivalChanged = (jobId: string) => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<OfflineFestivalChangedDetail>(OFFLINE_FESTIVAL_CHANGED_EVENT, { detail: { jobId } }),
+  );
+};
+
+export const subscribeOfflineFestivalChanged = (
+  jobId: string,
+  callback: () => void,
+): (() => void) => {
+  if (typeof window === "undefined") return () => {};
+
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<OfflineFestivalChangedDetail>).detail;
+    if (!detail || detail.jobId === jobId) {
+      callback();
+    }
+  };
+
+  window.addEventListener(OFFLINE_FESTIVAL_CHANGED_EVENT, handler);
+  return () => window.removeEventListener(OFFLINE_FESTIVAL_CHANGED_EVENT, handler);
+};
+
+export const isBrowserOnline = (): boolean => {
+  if (typeof navigator === "undefined" || typeof navigator.onLine !== "boolean") {
+    return true;
+  }
+  return navigator.onLine;
+};

--- a/src/lib/offline/types.ts
+++ b/src/lib/offline/types.ts
@@ -1,0 +1,86 @@
+import type { Database } from "@/integrations/supabase/types";
+
+export type FestivalArtistRow = Database["public"]["Tables"]["festival_artists"]["Row"];
+
+/**
+ * Schema version of the snapshot payload. Bump when the shape of
+ * OfflineFestivalSnapshot["data"] changes so stale snapshots are discarded.
+ */
+export const OFFLINE_SNAPSHOT_SCHEMA_VERSION = 1;
+
+export interface OfflineFestivalSnapshotData {
+  job: Record<string, unknown> | null;
+  festivalSettings: Record<string, unknown> | null;
+  jobDateTypes: Array<Record<string, unknown>>;
+  stages: Array<Record<string, unknown>>;
+  gearSetups: Array<Record<string, unknown>>;
+  stageGearSetups: Array<Record<string, unknown>>;
+  artists: Array<Record<string, unknown>>;
+  artistFormSubmissions: Array<Record<string, unknown>>;
+  artistFiles: Array<Record<string, unknown>>;
+  shifts: Array<Record<string, unknown>>;
+  shiftAssignments: Array<Record<string, unknown>>;
+  logos: Array<Record<string, unknown>>;
+  jobDocuments: Array<Record<string, unknown>>;
+  hojaVenue: Record<string, unknown> | null;
+  location: Record<string, unknown> | null;
+}
+
+export interface OfflineFestivalSnapshot {
+  jobId: string;
+  jobTitle: string;
+  schemaVersion: number;
+  downloadedAt: string;
+  downloadedBy: string | null;
+  data: OfflineFestivalSnapshotData;
+}
+
+export type OfflineChangeOperation = "insert" | "update" | "delete";
+
+export type OfflineSyncableTable = "festival_artists";
+
+export interface OfflinePendingChange {
+  /** Unique id of the queue entry */
+  id: string;
+  jobId: string;
+  table: OfflineSyncableTable;
+  operation: OfflineChangeOperation;
+  /** Primary key of the affected record (client-generated uuid for inserts) */
+  recordId: string;
+  /** Row payload for insert/update operations */
+  payload: Record<string, unknown> | null;
+  /** Server updated_at observed when the record was downloaded/edited (conflict detection) */
+  baseUpdatedAt: string | null;
+  createdAt: string;
+  /** Human-readable label for conflict/sync reporting (e.g. artist name) */
+  label?: string;
+}
+
+export type OfflineSyncConflictReason =
+  | "modified_on_server"
+  | "deleted_on_server"
+  | "duplicate_on_server";
+
+export interface OfflineSyncConflict {
+  changeId: string;
+  table: OfflineSyncableTable;
+  operation: OfflineChangeOperation;
+  recordId: string;
+  label?: string;
+  reason: OfflineSyncConflictReason;
+}
+
+export interface OfflineSyncFailure {
+  changeId: string;
+  table: OfflineSyncableTable;
+  operation: OfflineChangeOperation;
+  recordId: string;
+  label?: string;
+  message: string;
+}
+
+export interface OfflineSyncResult {
+  applied: number;
+  conflicts: OfflineSyncConflict[];
+  failed: OfflineSyncFailure[];
+}

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ComponentProps } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Plus, ArrowLeft, Printer, Info, Copy, Menu } from "lucide-react";
+import { ArrowLeft, Info } from "lucide-react";
 import { ArtistTable } from "@/components/festival/ArtistTable";
 import { ArtistManagementDialog } from "@/components/festival/ArtistManagementDialog";
 import { ArtistTableFilters } from "@/components/festival/ArtistTableFilters";
@@ -20,7 +20,6 @@ import { useArtistsQuery } from "@/hooks/useArtistsQuery";
 import { combineWavesDisplay } from "@/constants/wavesModels";
 import { CopyArtistsDialog } from "@/components/festival/CopyArtistsDialog";
 import { exportFullFestivalSchedulePDF, FullFestivalSchedulePdfData } from "@/utils/fullFestivalSchedulePdfExport";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { buildReadableFilename, formatDateForFilename } from "@/utils/fileName";
 import { getEffectiveFestivalDateType } from "@/constants/dateTypes";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
@@ -28,7 +27,8 @@ import { canCreateFestivalArtistExtras, canDeleteFestivalArtists, canEditJobs } 
 import { queryKeys } from "@/lib/react-query";
 import { getOfflineFestivalContext, isBrowserOnline } from "@/lib/offline";
 import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
-import { CloudOff } from "lucide-react";
+import { FestivalOfflineBanner } from "@/components/festival/FestivalOfflineBanner";
+import { ArtistPageActions } from "@/components/festival/ArtistPageActions";
 const DAY_START_HOUR = 7; // Festival day starts at 7:00 AM
 
 const FestivalArtistManagement = () => {
@@ -629,15 +629,7 @@ const FestivalArtistManagement = () => {
             <ConnectionIndicator />
           </div>
         </div>
-        {isOfflineData && (
-          <div className="mt-3 flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200">
-            <CloudOff className="h-4 w-4 shrink-0" />
-            <span>
-              Estás viendo la copia offline de este festival. Los cambios se guardarán localmente y podrás
-              sincronizarlos cuando vuelvas a tener conexión.
-            </span>
-          </div>
-        )}
+        {isOfflineData && <FestivalOfflineBanner />}
       </div>
 
       <Card className="mx-4 md:mx-6">
@@ -659,104 +651,18 @@ const FestivalArtistManagement = () => {
             </TooltipProvider>
           </CardTitle>
           
-          {/* Desktop buttons */}
-          <div className="hidden lg:flex items-center gap-2">
-            {showArtistControls && (
-              <Button
-                variant="outline"
-                onClick={() => setIsCopyDialogOpen(true)}
-              >
-                <Copy className="h-4 w-4 mr-2" />
-                Copiar Artistas
-              </Button>
-            )}
-            <Button
-              variant="outline"
-              onClick={handlePrintFullSchedule}
-              disabled={isFullSchedulePrinting}
-            >
-              <Printer className="h-4 w-4 mr-2" />
-              {isFullSchedulePrinting ? "Generando..." : "Imprimir Horario Completo"}
-            </Button>
-            <Button onClick={() => {
-              setPrintDate(selectedDate);
+          <ArtistPageActions
+            showArtistControls={showArtistControls}
+            isFullSchedulePrinting={isFullSchedulePrinting}
+            selectedDate={selectedDate}
+            onAddArtist={handleAddArtist}
+            onCopyArtists={() => setIsCopyDialogOpen(true)}
+            onPrintFullSchedule={handlePrintFullSchedule}
+            onOpenPrintDialog={(date) => {
+              setPrintDate(date);
               setIsPrintDialogOpen(true);
-            }}>
-              <Printer className="h-4 w-4 mr-2" />
-              Imprimir Horario del Día
-            </Button>
-            {showArtistControls ? (
-              <Button onClick={handleAddArtist}>
-                <Plus className="h-4 w-4 mr-2" />
-                Añadir Artista
-              </Button>
-            ) : (
-              <Button disabled title="Los artistas solo se pueden añadir en fechas de show">
-                <Plus className="h-4 w-4 mr-2" />
-                Añadir Artista
-              </Button>
-            )}
-          </div>
-
-          {/* Mobile - Primary action + menu */}
-          <div className="flex lg:hidden items-center gap-2 w-full sm:w-auto">
-            {showArtistControls ? (
-              <Button onClick={handleAddArtist} className="flex-1 sm:flex-initial">
-                <Plus className="h-4 w-4 mr-2" />
-                Añadir Artista
-              </Button>
-            ) : (
-              <Button disabled title="Los artistas solo se pueden añadir en fechas de show" className="flex-1 sm:flex-initial">
-                <Plus className="h-4 w-4 mr-2" />
-                Añadir Artista
-              </Button>
-            )}
-
-            <Sheet>
-              <SheetTrigger asChild>
-                <Button variant="outline" size="icon">
-                  <Menu className="h-4 w-4" />
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="right" className="w-[300px] sm:w-[400px]">
-                <SheetHeader>
-                  <SheetTitle>Acciones</SheetTitle>
-                </SheetHeader>
-                <div className="flex flex-col gap-3 mt-6">
-                  {showArtistControls && (
-                    <Button
-                      variant="outline"
-                      onClick={() => setIsCopyDialogOpen(true)}
-                      className="justify-start w-full"
-                    >
-                      <Copy className="h-4 w-4 mr-2" />
-                      Copiar Artistas
-                    </Button>
-                  )}
-                  <Button
-                    variant="outline"
-                    onClick={handlePrintFullSchedule}
-                    disabled={isFullSchedulePrinting}
-                    className="justify-start w-full"
-                  >
-                    <Printer className="h-4 w-4 mr-2" />
-                    {isFullSchedulePrinting ? "Generando..." : "Imprimir Horario Completo"}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() => {
-                      setPrintDate(selectedDate);
-                      setIsPrintDialogOpen(true);
-                    }}
-                    className="justify-start w-full"
-                  >
-                    <Printer className="h-4 w-4 mr-2" />
-                    Imprimir Horario del Día
-                  </Button>
-                </div>
-              </SheetContent>
-            </Sheet>
-          </div>
+            }}
+          />
         </CardHeader>
         <CardContent className="p-0">
           <div className="space-y-4 p-6">

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -180,6 +180,18 @@ const FestivalArtistManagement = () => {
   });
 
   useEffect(() => {
+    const applyJobDateRange = (startTime: string, endTime: string) => {
+      const startDate = new Date(startTime);
+      const endDate = new Date(endTime);
+      if (!isValid(startDate) || !isValid(endDate)) return;
+      const dates = eachDayOfInterval({ start: startDate, end: endDate });
+      setJobDates(dates);
+      const routeDateExists = routeDate
+        ? dates.some((festivalDate) => format(festivalDate, "yyyy-MM-dd") === routeDate)
+        : false;
+      setSelectedDate(routeDateExists ? routeDate : format(dates[0], "yyyy-MM-dd"));
+    };
+
     const applyOfflineJobDetails = async () => {
       if (!jobId) return false;
       const offlineContext = await getOfflineFestivalContext(jobId);
@@ -187,16 +199,7 @@ const FestivalArtistManagement = () => {
       if (!offlineJob) return false;
 
       setJobTitle((offlineJob.title as string) || "");
-      const startDate = new Date(offlineJob.start_time as string);
-      const endDate = new Date(offlineJob.end_time as string);
-      if (isValid(startDate) && isValid(endDate)) {
-        const dates = eachDayOfInterval({ start: startDate, end: endDate });
-        setJobDates(dates);
-        const routeDateExists = routeDate
-          ? dates.some((festivalDate) => format(festivalDate, "yyyy-MM-dd") === routeDate)
-          : false;
-        setSelectedDate(routeDateExists ? routeDate : format(dates[0], "yyyy-MM-dd"));
-      }
+      applyJobDateRange(offlineJob.start_time as string, offlineJob.end_time as string);
       setMaxStages(offlineContext.maxStages || 3);
       return true;
     };
@@ -217,17 +220,7 @@ const FestivalArtistManagement = () => {
         await applyOfflineJobDetails();
       } else {
         setJobTitle(data.title);
-        const startDate = new Date(data.start_time);
-        const endDate = new Date(data.end_time);
-        if (isValid(startDate) && isValid(endDate)) {
-          const dates = eachDayOfInterval({ start: startDate, end: endDate });
-          setJobDates(dates);
-          const routeDateExists = routeDate
-            ? dates.some((festivalDate) => format(festivalDate, "yyyy-MM-dd") === routeDate)
-            : false;
-          const initialDate = routeDateExists ? routeDate : format(dates[0], "yyyy-MM-dd");
-          setSelectedDate(initialDate);
-        }
+        applyJobDateRange(data.start_time, data.end_time);
       }
 
       const { data: gearSetups, error: gearError } = await supabase

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -24,8 +24,11 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/co
 import { buildReadableFilename, formatDateForFilename } from "@/utils/fileName";
 import { getEffectiveFestivalDateType } from "@/constants/dateTypes";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
-import { canCreateFestivalArtistExtras, canDeleteFestivalArtists } from "@/utils/permissions";
+import { canCreateFestivalArtistExtras, canDeleteFestivalArtists, canEditJobs } from "@/utils/permissions";
 import { queryKeys } from "@/lib/react-query";
+import { getOfflineFestivalContext, isBrowserOnline } from "@/lib/offline";
+import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
+import { CloudOff } from "lucide-react";
 const DAY_START_HOUR = 7; // Festival day starts at 7:00 AM
 
 const FestivalArtistManagement = () => {
@@ -57,14 +60,19 @@ const FestivalArtistManagement = () => {
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState(false);
   const [isFullSchedulePrinting, setIsFullSchedulePrinting] = useState(false);
 
-  const { artists, isLoading: artistsLoading, deleteArtist, invalidateArtists } = useArtistsQuery(jobId, selectedDate, dayStartTime);
+  const { artists, isLoading: artistsLoading, deleteArtist, invalidateArtists, isOfflineData } = useArtistsQuery(jobId, selectedDate, dayStartTime);
   const artistRows = artists as unknown as ComponentProps<typeof ArtistTable>["artists"];
   const {
     data: festivalSettings
   } = useQuery({
     queryKey: queryKeys.scope('festival-settings', jobId),
+    networkMode: "always",
     queryFn: async () => {
       if (!jobId) return null;
+      if (!isBrowserOnline()) {
+        const offlineContext = await getOfflineFestivalContext(jobId);
+        return offlineContext?.festivalSettings ?? null;
+      }
       const {
         data: existingSettings,
         error: fetchError
@@ -101,8 +109,13 @@ const FestivalArtistManagement = () => {
     refetch: refetchDateTypes
   } = useQuery({
     queryKey: queryKeys.scope('job-date-types', jobId),
+    networkMode: "always",
     queryFn: async () => {
       if (!jobId) return {};
+      if (!isBrowserOnline()) {
+        const offlineContext = await getOfflineFestivalContext(jobId);
+        return offlineContext?.dateTypes ?? {};
+      }
       const {
         data,
         error
@@ -127,9 +140,14 @@ const FestivalArtistManagement = () => {
 
   const { data: stageNamesData } = useQuery({
     queryKey: queryKeys.scope('festival-stages', jobId),
+    networkMode: "always",
     queryFn: async () => {
       if (!jobId) return {};
-      
+      if (!isBrowserOnline()) {
+        const offlineContext = await getOfflineFestivalContext(jobId);
+        return offlineContext?.stageNames ?? {};
+      }
+
       const { data: stages, error } = await supabase
         .from('festival_stages')
         .select('number, name')
@@ -162,8 +180,33 @@ const FestivalArtistManagement = () => {
   });
 
   useEffect(() => {
+    const applyOfflineJobDetails = async () => {
+      if (!jobId) return false;
+      const offlineContext = await getOfflineFestivalContext(jobId);
+      const offlineJob = offlineContext?.job;
+      if (!offlineJob) return false;
+
+      setJobTitle((offlineJob.title as string) || "");
+      const startDate = new Date(offlineJob.start_time as string);
+      const endDate = new Date(offlineJob.end_time as string);
+      if (isValid(startDate) && isValid(endDate)) {
+        const dates = eachDayOfInterval({ start: startDate, end: endDate });
+        setJobDates(dates);
+        const routeDateExists = routeDate
+          ? dates.some((festivalDate) => format(festivalDate, "yyyy-MM-dd") === routeDate)
+          : false;
+        setSelectedDate(routeDateExists ? routeDate : format(dates[0], "yyyy-MM-dd"));
+      }
+      setMaxStages(offlineContext.maxStages || 3);
+      return true;
+    };
+
     const fetchJobDetails = async () => {
       if (!jobId) return;
+      if (!isBrowserOnline()) {
+        const applied = await applyOfflineJobDetails();
+        if (applied) return;
+      }
       const { data, error } = await supabase
         .from("jobs")
         .select("title, start_time, end_time")
@@ -171,6 +214,7 @@ const FestivalArtistManagement = () => {
         .single();
       if (error) {
         console.error("Error fetching job details:", error);
+        await applyOfflineJobDetails();
       } else {
         setJobTitle(data.title);
         const startDate = new Date(data.start_time);
@@ -587,8 +631,20 @@ const FestivalArtistManagement = () => {
         </Button>
         <div className="flex items-center justify-between gap-2">
           <h1 className="text-xl md:text-2xl font-bold truncate">{jobTitle}</h1>
-          <ConnectionIndicator />
+          <div className="flex items-center gap-2">
+            <FestivalOfflineControls jobId={jobId} canEdit={canEditJobs(userRole)} />
+            <ConnectionIndicator />
+          </div>
         </div>
+        {isOfflineData && (
+          <div className="mt-3 flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200">
+            <CloudOff className="h-4 w-4 shrink-0" />
+            <span>
+              Estás viendo la copia offline de este festival. Los cambios se guardarán localmente y podrás
+              sincronizarlos cuando vuelvas a tener conexión.
+            </span>
+          </div>
+        )}
       </div>
 
       <Card className="mx-4 md:mx-6">

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -124,7 +124,6 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
 
   return (
     <div className="max-w-[1920px] mx-auto px-4 py-4 md:py-6 space-y-4 md:space-y-6">
-      {/* Modern Header Card with Gradient */}
       <Card className="border-0 shadow-lg bg-gradient-to-br from-background via-background to-accent/5">
         <CardHeader className="pb-4">
           <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-4">
@@ -161,7 +160,6 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                 )}
               </div>
 
-              {/* Venue Map Preview */}
               {(venueData.address || venueData.coordinates) && (
                 <div className="mt-3">
                   {isMapLoading ? (

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -26,6 +26,7 @@ import {
 
 import createFolderIcon from "@/assets/icons/icon.png";
 import { FestivalLogoManager } from "@/components/festival/FestivalLogoManager";
+import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
 import { FestivalWeatherSection } from "@/components/festival/FestivalWeatherSection";
 import { TechnicianIncidentReportDialog } from "@/components/incident-reports/TechnicianIncidentReportDialog";
 import { CrewCallLinkerDialog } from "@/components/jobs/CrewCallLinker";
@@ -200,6 +201,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
 
             {/* Action Buttons */}
             <div className="flex flex-wrap gap-2 items-start">
+              <FestivalOfflineControls jobId={jobId} canEdit={canEdit} />
               {canEdit && (
                 <>
                   <Button


### PR DESCRIPTION
Any role can download a festival's full dataset (job, settings, dates,
stages, gear setups, artists, rider/file metadata, shifts, documents,
venue) to IndexedDB and keep consulting it without connection. Edit
roles can create/update/delete artists offline; changes are queued
locally, coalesced per record, and pushed manually via the new Offline
menu, with updated_at-based conflict detection plus force/discard
resolution.

- New offline core in src/lib/offline (IndexedDB store with in-memory
  fallback, snapshot download with pagination, pending-change queue,
  sync engine)
- useOfflineFestival hook + FestivalOfflineControls dropdown in the
  festival management and artist management headers
- Offline read fallbacks in useArtistsQuery, festival job details,
  documents, settings, date types and stage queries (networkMode
  "always" so React Query runs them while disconnected)
- Offline write queueing in useArtistMutations and artist deletion
- Unit tests for queue coalescing and sync conflict handling
- Feature doc in docs/festival-offline-mode.md

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01222enZXwgEKQd1xDYPpQCt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline festival mode with full snapshot download and offline rendering of job details, documents, and artist data.
  * Added offline UI (banner + controls) to download, sync queued edits, handle conflicts, and remove/discard offline changes.
  * Enabled offline-first updates for artists (create/update/delete) with queued sync on reconnect.
* **Bug Fixes**
  * Festival pages now reliably fall back to the saved offline snapshot when disconnected or when online assembly fails.
* **Documentation**
  * Added an offline-mode guide covering download, queued edits, manual sync, and current editing limitations.
* **Tests**
  * Added coverage for offline queue coalescing and sync conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->