### PR TITLE
Fix CodeQL remote property injection findings

### DIFF
--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -232,13 +232,10 @@ export function TechnicianArtistReadOnlyModal({
     enabled: !!job?.id,
   });
 
-  const stageNames = useMemo(() => {
-    const names: Record<number, string> = {};
-    festivalStages.forEach((stage) => {
-      names[stage.number] = stage.name;
-    });
-    return names;
-  }, [festivalStages]);
+  const stageNames = useMemo(
+    () => Object.fromEntries(festivalStages.map((stage) => [stage.number, stage.name])) as Record<number, string>,
+    [festivalStages],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -253,22 +250,21 @@ export function TechnicianArtistReadOnlyModal({
         return;
       }
 
-      const nextUrls: Record<string, string> = {};
-      await Promise.all(
-        artistsWithPlot.map(async (artist) => {
-          if (!artist.stage_plot_file_path) return;
+      const signedUrlEntries = await Promise.all(
+        artistsWithPlot.map(async (artist): Promise<[string, string] | null> => {
+          if (!artist.stage_plot_file_path) return null;
           const { data, error } = await dataLayerClient.storage
             .from("festival_artist_files")
             .createSignedUrl(artist.stage_plot_file_path, 60 * 60);
 
-          if (!error && data?.signedUrl) {
-            nextUrls[artist.id] = data.signedUrl;
-          }
+          return !error && data?.signedUrl ? [artist.id, data.signedUrl] : null;
         })
       );
 
       if (!cancelled) {
-        setStagePlotUrls(nextUrls);
+        setStagePlotUrls(
+          Object.fromEntries(signedUrlEntries.filter((entry): entry is [string, string] => entry !== null)),
+        );
       }
     };
 
@@ -278,7 +274,6 @@ export function TechnicianArtistReadOnlyModal({
       cancelled = true;
     };
   }, [artists]);
-
 
   useEffect(() => {
     let cancelled = false;
@@ -292,18 +287,19 @@ export function TechnicianArtistReadOnlyModal({
     };
 
     const groupRiderFiles = (files: RiderFileRow[]) => {
-      const grouped: Record<string, MobileArtistRiderFile[]> = {};
+      const grouped = new Map<string, MobileArtistRiderFile[]>();
       files.forEach((file) => {
         if (!file.artist_id) return;
-        if (!grouped[file.artist_id]) grouped[file.artist_id] = [];
-        grouped[file.artist_id].push({
+        const artistFiles = grouped.get(file.artist_id) ?? [];
+        artistFiles.push({
           id: file.id,
           file_name: file.file_name,
           file_path: file.file_path,
           uploaded_at: file.uploaded_at,
         });
+        grouped.set(file.artist_id, artistFiles);
       });
-      return grouped;
+      return Object.fromEntries(grouped);
     };
 
     const loadOfflineRiderFiles = async (): Promise<Record<string, MobileArtistRiderFile[]> | null> => {

--- a/src/lib/offline/festival-snapshot.ts
+++ b/src/lib/offline/festival-snapshot.ts
@@ -222,17 +222,15 @@ export const getOfflineFestivalContext = async (jobId: string): Promise<OfflineF
   const snapshot = await getFestivalSnapshot(jobId);
   if (!snapshot) return null;
 
-  const dateTypes: Record<string, string> = {};
-  snapshot.data.jobDateTypes.forEach((item) => {
-    dateTypes[`${jobId}-${item.date as string}`] = item.type as string;
-  });
+  const dateTypes = Object.fromEntries(
+    snapshot.data.jobDateTypes.map((item) => [`${jobId}-${item.date as string}`, item.type as string]),
+  );
 
-  const stageNames: Record<number, string> = {};
-  snapshot.data.stages.forEach((stage) => {
-    if (typeof stage.number === "number") {
-      stageNames[stage.number] = (stage.name as string) ?? `Escenario ${stage.number}`;
-    }
-  });
+  const stageNames = Object.fromEntries(
+    snapshot.data.stages
+      .filter((stage) => typeof stage.number === "number")
+      .map((stage) => [stage.number as number, (stage.name as string) ?? `Escenario ${stage.number as number}`]),
+  ) as Record<number, string>;
 
   const latestGearSetup = [...snapshot.data.gearSetups].sort((a, b) =>
     compareTimeStrings(b.created_at, a.created_at),

--- a/src/lib/offline/festival-sync.ts
+++ b/src/lib/offline/festival-sync.ts
@@ -22,15 +22,11 @@ const CLIENT_ONLY_FIELDS: Record<OfflineSyncableTable, ReadonlySet<string>> = {
 
 const sanitizePayload = (table: OfflineSyncableTable, payload: Row | null): Row => {
   const excluded = CLIENT_ONLY_FIELDS[table];
-  const clean: Row = {};
-  Object.entries(payload ?? {}).forEach(([key, value]) => {
-    if (!excluded.has(key)) {
-      clean[key] = value;
-    }
-  });
+  const clean = Object.fromEntries(
+    Object.entries(payload ?? {}).filter(([key]) => key !== "updated_at" && !excluded.has(key)),
+  );
   // updated_at is maintained by the server; sending the stale local value
   // would defeat conflict detection for later syncs.
-  delete clean.updated_at;
   return clean;
 };
 


### PR DESCRIPTION
### Motivation
- CodeQL reported remote property injection risks where object properties were assigned using dynamic keys derived from external data, which can allow untrusted input to control property writes.
- The offline snapshot and sync logic, and the technician modal grouping/signed-URL mapping, used patterns that triggered the finding and should be made more explicit and safe.

### Description
- Replaced dynamic bracket-assignment for stage/name maps with `Object.fromEntries` to build `stageNames` in `src/components/technician/TechnicianArtistReadOnlyModal.tsx` and `src/lib/offline/festival-snapshot.ts`.
- Reworked signed-URL population to produce an entries array and call `Object.fromEntries` instead of mutating a result object with dynamic keys in `TechnicianArtistReadOnlyModal.tsx`.
- Switched rider-file grouping to use a `Map` during accumulation and convert to a plain object after grouping to avoid dynamic property writes in `TechnicianArtistReadOnlyModal.tsx`.
- Sanitized offline sync payload construction in `src/lib/offline/festival-sync.ts` by filtering `Object.entries` and using `Object.fromEntries` to produce a safe payload (dropping `updated_at` and client-only fields) instead of assigning `clean[key] = value`.

### Testing
- Ran linting with `npm run lint -- --quiet`; the run completed successfully with repository warnings but no lint errors reported for the changes.
- Ran type checking with `npm run typecheck`; the TypeScript check completed successfully with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46b686dfc8832f90b1c96e5f8967f1)