### PR TITLE
fix: cache festival files offline and stop slow-network hangs

### DIFF
--- a/docs/festival-offline-mode.md
+++ b/docs/festival-offline-mode.md
@@ -16,11 +16,19 @@ Desde la cabecera de **Gestión de Festival** o de **Gestión de Artistas**, el 
 
 Las consultas se paginan (1000 filas por página), por lo que festivales grandes se capturan completos.
 
+Tras los metadatos se descargan también los **archivos binarios**: riders (PDF), stage plots y documentos del trabajo. Se guardan como blobs en IndexedDB (`festival-files`) y los fallos individuales no abortan la descarga (se reportan en el toast).
+
 > El app shell y los chunks JS ya se cachean vía service worker (`public/sw.js`); la instantánea cubre la capa de datos.
 
 ### Lectura offline
 
-Cuando `navigator.onLine` es `false` (o la petición de red falla), las páginas de gestión de festival y de artistas sirven la instantánea local. Un banner ámbar indica que se está viendo la copia offline. Las queries afectadas usan `networkMode: "always"` para que React Query ejecute el `queryFn` sin conexión.
+Las páginas de gestión de festival, la de artistas y el modal de artistas del tech app sirven la instantánea local cuando:
+
+- el navegador reporta sin conexión (`navigator.onLine === false`),
+- la petición de red falla, o
+- la red tarda más de ~4 s en responder (`fetchWithOfflineFallback` — `navigator.onLine` suele reportar `true` en recintos con cobertura inutilizable, así que las lecturas nunca esperan a la red indefinidamente).
+
+Un banner ámbar indica que se está viendo la copia offline. Las queries afectadas usan `networkMode: "always"` para que React Query ejecute el `queryFn` sin conexión. Los riders, stage plots y documentos se sirven desde los blobs cacheados (también con conexión, para abrirlos al instante).
 
 ### Edición offline (roles con `canEditJobs`)
 
@@ -65,5 +73,5 @@ Con conexión, el menú Offline muestra **Sincronizar cambios** (solo roles de e
 ## Limitaciones actuales
 
 - La edición offline cubre **artistas** (la superficie principal de trabajo en campo). Turnos y setups de equipo se descargan para consulta; su edición offline puede añadirse extendiendo `OfflineSyncableTable` y encolando en sus mutaciones.
-- Los archivos binarios (riders PDF, logos) no se descargan; solo sus metadatos.
+- Los logos del festival no se cachean como blob (solo riders, stage plots y documentos del trabajo).
 - La resolución de conflictos es por registro (último en escribir gana al forzar), no por campo.

--- a/docs/festival-offline-mode.md
+++ b/docs/festival-offline-mode.md
@@ -26,7 +26,7 @@ Las páginas de gestión de festival, la de artistas y el modal de artistas del 
 
 - el navegador reporta sin conexión (`navigator.onLine === false`),
 - la petición de red falla, o
-- la red tarda más de ~4 s en responder (`fetchWithOfflineFallback` — `navigator.onLine` suele reportar `true` en recintos con cobertura inutilizable, así que las lecturas nunca esperan a la red indefinidamente).
+- la red tarda más de ~4 s en responder: si hay copia offline se sirve; si no la hay, la lectura sigue esperando a la red (`fetchWithOfflineFallback` — `navigator.onLine` suele reportar `true` en recintos con cobertura inutilizable).
 
 Un banner ámbar indica que se está viendo la copia offline. Las queries afectadas usan `networkMode: "always"` para que React Query ejecute el `queryFn` sin conexión. Los riders, stage plots y documentos se sirven desde los blobs cacheados (también con conexión, para abrirlos al instante).
 

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -26,6 +26,7 @@ import { dataLayerClient } from "@/services/dataLayerClient";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { compareArtistRequirements, ArtistGearComparison } from "@/utils/gearComparisonService";
+import { getOfflineFileBlob, isBrowserOnline } from "@/lib/offline";
 import { GearMismatchIndicator } from "./GearMismatchIndicator";
 import { FestivalGearSetup, StageGearSetup } from "@/types/festival";
 import { mapFestivalGearSetup, mapStageGearSetups } from "@/utils/festivalGearMappers";
@@ -288,6 +289,7 @@ export const ArtistTable = ({
 
   useEffect(() => {
     let isCancelled = false;
+    const objectUrls: string[] = [];
 
     const loadStagePlotUrls = async () => {
       const artistsWithPlot = artists.filter((artist) => Boolean(artist.stage_plot_file_path));
@@ -304,6 +306,18 @@ export const ArtistTable = ({
       await Promise.all(
         artistsWithPlot.map(async (artist) => {
           if (!artist.stage_plot_file_path) return;
+
+          // Cached blob first: renders offline and skips the signed-URL
+          // round-trip when the festival was downloaded.
+          const cachedBlob = await getOfflineFileBlob("festival_artist_files", artist.stage_plot_file_path);
+          if (cachedBlob) {
+            const objectUrl = URL.createObjectURL(cachedBlob);
+            objectUrls.push(objectUrl);
+            nextUrls[artist.id] = objectUrl;
+            return;
+          }
+
+          if (!isBrowserOnline()) return;
           const { data, error } = await dataLayerClient.storage
             .from("festival_artist_files")
             .createSignedUrl(artist.stage_plot_file_path, 60 * 60);
@@ -323,6 +337,7 @@ export const ArtistTable = ({
 
     return () => {
       isCancelled = true;
+      objectUrls.forEach((url) => URL.revokeObjectURL(url));
     };
   }, [artists]);
 
@@ -1071,11 +1086,12 @@ export const ArtistTable = ({
         </div>
       </TooltipProvider>
 
+      {/* No `capture` attribute: mobile browsers then offer the chooser
+          (camera roll / take photo / files) instead of forcing the camera */}
       <input
         ref={stagePlotInputRef}
         type="file"
         accept="image/*"
-        capture="environment"
         className="hidden"
         onChange={handleStagePlotUpload}
       />

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -310,6 +310,9 @@ export const ArtistTable = ({
           // Cached blob first: renders offline and skips the signed-URL
           // round-trip when the festival was downloaded.
           const cachedBlob = await getOfflineFileBlob("festival_artist_files", artist.stage_plot_file_path);
+          // Cleanup may have already revoked the tracked URLs; creating one
+          // now would leak it
+          if (isCancelled) return;
           if (cachedBlob) {
             const objectUrl = URL.createObjectURL(cachedBlob);
             objectUrls.push(objectUrl);

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -15,7 +15,12 @@ import type { MobileArtistRiderFile } from "@/components/festival/mobile/MobileA
 import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
 import { Theme } from "./types";
 import { createQueryKey } from "@/lib/optimized-react-query";
-import { getFestivalSnapshot, isBrowserOnline } from "@/lib/offline";
+import {
+  fetchWithOfflineFallback,
+  getFestivalSnapshot,
+  getOfflineFileBlob,
+  isBrowserOnline,
+} from "@/lib/offline";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { canEditJobs } from "@/utils/permissions";
 import type { Tables } from "@/integrations/supabase/types";
@@ -177,13 +182,7 @@ export function TechnicianArtistReadOnlyModal({
     queryKey: createQueryKey.technician.technicianReadonlyArtists(job?.id),
     networkMode: "always", // the queryFn serves the offline snapshot when disconnected
     queryFn: async () => {
-      if (!isBrowserOnline()) {
-        const offlineArtists = await fetchOfflineReadOnlyArtists(job.id);
-        if (offlineArtists) return offlineArtists;
-        throw new Error("Sin conexión y sin copia offline de este festival");
-      }
-
-      try {
+      const fetchArtistsOnline = async () => {
         const { data, error } = await dataLayerClient.from("festival_artists")
           .select("*")
           .eq("job_id", job?.id)
@@ -191,12 +190,15 @@ export function TechnicianArtistReadOnlyModal({
 
         if (error) throw error;
         return sortReadOnlyArtists((data || []).map(mapRawToReadOnlyArtist));
-      } catch (fetchError) {
-        // Network dropped mid-request: fall back to the offline copy if available
-        const offlineArtists = await fetchOfflineReadOnlyArtists(job.id);
-        if (offlineArtists) return offlineArtists;
-        throw fetchError;
-      }
+      };
+
+      // Snapshot fallback covers browser-offline, fetch failures and
+      // slow/unresponsive networks (timeout-raced).
+      const result = await fetchWithOfflineFallback({
+        online: fetchArtistsOnline,
+        offline: () => fetchOfflineReadOnlyArtists(job.id),
+      });
+      return result.data;
     },
     enabled: !!job?.id,
   });
@@ -216,18 +218,24 @@ export function TechnicianArtistReadOnlyModal({
           }));
       };
 
-      if (!isBrowserOnline()) {
-        return (await readOfflineStages()) ?? [];
-      }
+      const fetchStagesOnline = async () => {
+        const { data, error } = await dataLayerClient.from("festival_stages")
+          .select("number, name")
+          .eq("job_id", job?.id);
+        if (error) throw error;
+        return (data || []) as FestivalStage[];
+      };
 
-      const { data, error } = await dataLayerClient.from("festival_stages")
-        .select("number, name")
-        .eq("job_id", job?.id);
-      if (error) {
+      try {
+        const result = await fetchWithOfflineFallback({
+          online: fetchStagesOnline,
+          offline: readOfflineStages,
+        });
+        return result.data;
+      } catch (error) {
         console.warn("TechnicianArtistReadOnlyModal: failed loading stage names", error);
-        return (await readOfflineStages()) ?? [];
+        return [];
       }
-      return (data || []) as FestivalStage[];
     },
     enabled: !!job?.id,
   });
@@ -239,20 +247,30 @@ export function TechnicianArtistReadOnlyModal({
 
   useEffect(() => {
     let cancelled = false;
+    const objectUrls: string[] = [];
 
     const loadStagePlotUrls = async () => {
       const artistsWithPlot = artists.filter((artist) => Boolean(artist.stage_plot_file_path));
 
-      // Signed URLs require a connection; binary files are not part of the
-      // offline snapshot.
-      if (artistsWithPlot.length === 0 || !isBrowserOnline()) {
+      if (artistsWithPlot.length === 0) {
         if (!cancelled) setStagePlotUrls({});
         return;
       }
 
-      const signedUrlEntries = await Promise.all(
+      const urlEntries = await Promise.all(
         artistsWithPlot.map(async (artist): Promise<[string, string] | null> => {
           if (!artist.stage_plot_file_path) return null;
+
+          // Cached blob first: renders offline and skips the signed-URL
+          // round-trip when the festival was downloaded.
+          const cachedBlob = await getOfflineFileBlob("festival_artist_files", artist.stage_plot_file_path);
+          if (cachedBlob) {
+            const objectUrl = URL.createObjectURL(cachedBlob);
+            objectUrls.push(objectUrl);
+            return [artist.id, objectUrl];
+          }
+
+          if (!isBrowserOnline()) return null;
           const { data, error } = await dataLayerClient.storage
             .from("festival_artist_files")
             .createSignedUrl(artist.stage_plot_file_path, 60 * 60);
@@ -263,7 +281,7 @@ export function TechnicianArtistReadOnlyModal({
 
       if (!cancelled) {
         setStagePlotUrls(
-          Object.fromEntries(signedUrlEntries.filter((entry): entry is [string, string] => entry !== null)),
+          Object.fromEntries(urlEntries.filter((entry): entry is [string, string] => entry !== null)),
         );
       }
     };
@@ -272,6 +290,7 @@ export function TechnicianArtistReadOnlyModal({
 
     return () => {
       cancelled = true;
+      objectUrls.forEach((url) => URL.revokeObjectURL(url));
     };
   }, [artists]);
 
@@ -355,12 +374,21 @@ export function TechnicianArtistReadOnlyModal({
 
   const handleDownloadRiderFile = async (file: { file_path: string; file_name: string }) => {
     try {
-      const { data, error } = await dataLayerClient.storage.from("festival_artist_files").download(file.file_path);
-      if (error || !data) {
-        toast.error("Error al descargar el archivo", { description: error?.message || "No se pudo obtener el archivo" });
-        return;
+      // Cached copy first so riders open offline (and instantly when cached)
+      let blob = await getOfflineFileBlob("festival_artist_files", file.file_path);
+      if (!blob) {
+        const { data, error } = await dataLayerClient.storage.from("festival_artist_files").download(file.file_path);
+        if (error || !data) {
+          toast.error("Error al descargar el archivo", {
+            description: !isBrowserOnline()
+              ? "Sin conexión y sin copia offline de este archivo. Actualiza la copia offline con conexión."
+              : error?.message || "No se pudo obtener el archivo",
+          });
+          return;
+        }
+        blob = data;
       }
-      const url = window.URL.createObjectURL(data);
+      const url = window.URL.createObjectURL(blob);
       const link = window.document.createElement("a");
       link.href = url;
       link.download = file.file_name;

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -264,6 +264,9 @@ export function TechnicianArtistReadOnlyModal({
           // Cached blob first: renders offline and skips the signed-URL
           // round-trip when the festival was downloaded.
           const cachedBlob = await getOfflineFileBlob("festival_artist_files", artist.stage_plot_file_path);
+          // Cleanup may have already revoked the tracked URLs; creating one
+          // now would leak it
+          if (cancelled) return null;
           if (cachedBlob) {
             const objectUrl = URL.createObjectURL(cachedBlob);
             objectUrls.push(objectUrl);

--- a/src/features/festival-management/commands.ts
+++ b/src/features/festival-management/commands.ts
@@ -12,6 +12,7 @@ import type {
 } from "@/features/festival-management/types";
 import { supabase } from "@/integrations/supabase/client";
 import { getStaticMapUrlForLocation } from "@/lib/mapbox/mapboxClient";
+import { getOfflineFileBlob } from "@/lib/offline";
 import type { CreateFoldersOptions } from "@/utils/flex-folders";
 import { createAllFoldersForJob, openFlexElement } from "@/utils/flex-folders";
 import { resolveJobDocLocation } from "@/utils/jobDocuments";
@@ -23,6 +24,11 @@ import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 
 export const getJobDocumentSignedUrl = async (docEntry: JobDocumentEntry) => {
   const { bucket, path } = resolveJobDocLocation(docEntry.file_path);
+
+  // Cached copy first so documents open offline (and instantly when cached)
+  const cachedBlob = await getOfflineFileBlob(bucket, path);
+  if (cachedBlob) return URL.createObjectURL(cachedBlob);
+
   const { data, error } = await supabase.storage.from(bucket).createSignedUrl(path, 3600);
 
   if (error) throw error;
@@ -31,6 +37,10 @@ export const getJobDocumentSignedUrl = async (docEntry: JobDocumentEntry) => {
 
 export const downloadJobDocumentBlob = async (docEntry: JobDocumentEntry) => {
   const { bucket, path } = resolveJobDocLocation(docEntry.file_path);
+
+  const cachedBlob = await getOfflineFileBlob(bucket, path);
+  if (cachedBlob) return cachedBlob;
+
   const { data, error } = await supabase.storage.from(bucket).download(path);
 
   if (error) throw error;
@@ -38,6 +48,9 @@ export const downloadJobDocumentBlob = async (docEntry: JobDocumentEntry) => {
 };
 
 export const getRiderSignedUrl = async (file: ArtistRiderFile) => {
+  const cachedBlob = await getOfflineFileBlob("festival_artist_files", file.file_path);
+  if (cachedBlob) return URL.createObjectURL(cachedBlob);
+
   const { data, error } = await supabase.storage.from("festival_artist_files").createSignedUrl(file.file_path, 3600);
 
   if (error) throw error;
@@ -45,6 +58,9 @@ export const getRiderSignedUrl = async (file: ArtistRiderFile) => {
 };
 
 export const downloadRiderBlob = async (file: ArtistRiderFile) => {
+  const cachedBlob = await getOfflineFileBlob("festival_artist_files", file.file_path);
+  if (cachedBlob) return cachedBlob;
+
   const { data, error } = await supabase.storage.from("festival_artist_files").download(file.file_path);
 
   if (error) throw error;

--- a/src/features/festival-management/commands.ts
+++ b/src/features/festival-management/commands.ts
@@ -22,12 +22,18 @@ import { optimizeImageForUpload } from "@/utils/imageOptimization";
 import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 
-export const getJobDocumentSignedUrl = async (docEntry: JobDocumentEntry) => {
-  const { bucket, path } = resolveJobDocLocation(docEntry.file_path);
+// Blob object URLs created for offline-cached files stay valid long enough
+// for the viewer tab to load, then get revoked to release the memory.
+const OFFLINE_OBJECT_URL_TTL_MS = 60_000;
 
-  // Cached copy first so documents open offline (and instantly when cached)
+// Cached copy first so files open offline (and instantly when cached)
+const getViewableUrl = async (bucket: string, path: string) => {
   const cachedBlob = await getOfflineFileBlob(bucket, path);
-  if (cachedBlob) return URL.createObjectURL(cachedBlob);
+  if (cachedBlob) {
+    const objectUrl = URL.createObjectURL(cachedBlob);
+    setTimeout(() => URL.revokeObjectURL(objectUrl), OFFLINE_OBJECT_URL_TTL_MS);
+    return objectUrl;
+  }
 
   const { data, error } = await supabase.storage.from(bucket).createSignedUrl(path, 3600);
 
@@ -35,9 +41,7 @@ export const getJobDocumentSignedUrl = async (docEntry: JobDocumentEntry) => {
   return data?.signedUrl ?? null;
 };
 
-export const downloadJobDocumentBlob = async (docEntry: JobDocumentEntry) => {
-  const { bucket, path } = resolveJobDocLocation(docEntry.file_path);
-
+const getDownloadableBlob = async (bucket: string, path: string) => {
   const cachedBlob = await getOfflineFileBlob(bucket, path);
   if (cachedBlob) return cachedBlob;
 
@@ -47,25 +51,21 @@ export const downloadJobDocumentBlob = async (docEntry: JobDocumentEntry) => {
   return data;
 };
 
-export const getRiderSignedUrl = async (file: ArtistRiderFile) => {
-  const cachedBlob = await getOfflineFileBlob("festival_artist_files", file.file_path);
-  if (cachedBlob) return URL.createObjectURL(cachedBlob);
-
-  const { data, error } = await supabase.storage.from("festival_artist_files").createSignedUrl(file.file_path, 3600);
-
-  if (error) throw error;
-  return data?.signedUrl ?? null;
+export const getJobDocumentSignedUrl = async (docEntry: JobDocumentEntry) => {
+  const { bucket, path } = resolveJobDocLocation(docEntry.file_path);
+  return getViewableUrl(bucket, path);
 };
 
-export const downloadRiderBlob = async (file: ArtistRiderFile) => {
-  const cachedBlob = await getOfflineFileBlob("festival_artist_files", file.file_path);
-  if (cachedBlob) return cachedBlob;
-
-  const { data, error } = await supabase.storage.from("festival_artist_files").download(file.file_path);
-
-  if (error) throw error;
-  return data;
+export const downloadJobDocumentBlob = async (docEntry: JobDocumentEntry) => {
+  const { bucket, path } = resolveJobDocLocation(docEntry.file_path);
+  return getDownloadableBlob(bucket, path);
 };
+
+export const getRiderSignedUrl = async (file: ArtistRiderFile) =>
+  getViewableUrl("festival_artist_files", file.file_path);
+
+export const downloadRiderBlob = async (file: ArtistRiderFile) =>
+  getDownloadableBlob("festival_artist_files", file.file_path);
 
 export const downloadBlobInBrowser = (blob: Blob, fileName: string) => {
   const url = window.URL.createObjectURL(blob);

--- a/src/features/festival-management/queries.ts
+++ b/src/features/festival-management/queries.ts
@@ -5,7 +5,7 @@ import {
   buildJobDates,
   type JobDateTypeRow,
 } from "@/features/festival-management/selectors";
-import { getFestivalSnapshot, isBrowserOnline } from "@/lib/offline";
+import { fetchWithOfflineFallback, getFestivalSnapshot } from "@/lib/offline";
 import {
   normalizeVenueCoordinates,
   resolveHojaVenue,
@@ -222,24 +222,13 @@ const fetchFestivalJobDetailsOnline = async (jobId: string): Promise<FestivalJob
 export const fetchFestivalJobDetails = async (jobId: string): Promise<FestivalJobDetailsData> => {
   console.log("Fetching job details for jobId:", jobId);
 
-  if (!isBrowserOnline()) {
-    const offlineDetails = await buildOfflineJobDetails(jobId);
-    if (offlineDetails) {
-      return offlineDetails;
-    }
-  }
-
-  try {
-    return await fetchFestivalJobDetailsOnline(jobId);
-  } catch (error) {
-    // Any failure while assembling the online response (job, artist count,
-    // venue, dates) falls back to the offline snapshot when available.
-    const offlineDetails = await buildOfflineJobDetails(jobId);
-    if (offlineDetails) {
-      return offlineDetails;
-    }
-    throw error;
-  }
+  // Snapshot fallback covers browser-offline, online failures and
+  // slow/unresponsive networks (timeout-raced).
+  const result = await fetchWithOfflineFallback({
+    online: () => fetchFestivalJobDetailsOnline(jobId),
+    offline: () => buildOfflineJobDetails(jobId),
+  });
+  return result.data;
 };
 
 const buildOfflineDocuments = async (jobId: string): Promise<FestivalDocumentsData | null> => {
@@ -325,21 +314,9 @@ const fetchFestivalDocumentsOnline = async (jobId: string): Promise<FestivalDocu
 };
 
 export const fetchFestivalDocuments = async (jobId: string): Promise<FestivalDocumentsData> => {
-  if (!isBrowserOnline()) {
-    const offlineDocuments = await buildOfflineDocuments(jobId);
-    if (offlineDocuments) {
-      return offlineDocuments;
-    }
-  }
-
-  try {
-    return await fetchFestivalDocumentsOnline(jobId);
-  } catch (error) {
-    // Online fetch failed mid-request: serve the snapshot when available.
-    const offlineDocuments = await buildOfflineDocuments(jobId);
-    if (offlineDocuments) {
-      return offlineDocuments;
-    }
-    throw error;
-  }
+  const result = await fetchWithOfflineFallback({
+    online: () => fetchFestivalDocumentsOnline(jobId),
+    offline: () => buildOfflineDocuments(jobId),
+  });
+  return result.data;
 };

--- a/src/hooks/festival/useFestivalArtistJobDetails.ts
+++ b/src/hooks/festival/useFestivalArtistJobDetails.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import { eachDayOfInterval, format, isValid } from "date-fns";
+
+import { supabase } from "@/lib/enhanced-supabase-client";
+import { fetchWithOfflineFallback, getOfflineFestivalContext } from "@/lib/offline";
+
+type JobHeaderDetails = {
+  title: string;
+  startTime: string;
+  endTime: string;
+  maxStages: number | null;
+};
+
+/**
+ * Job header data for the festival artist management page: title, festival
+ * dates (with route-date preselection) and max stages. Races the network
+ * against the offline snapshot so a weak connection never leaves the page
+ * stuck on "Cargando". The fetchers only RETURN data; state is applied once
+ * for whichever side wins, so a timed-out online fetch that resolves later
+ * cannot overwrite the snapshot's values with mixed context.
+ */
+export const useFestivalArtistJobDetails = (jobId: string | undefined, routeDate: string) => {
+  const [jobTitle, setJobTitle] = useState("");
+  const [jobDates, setJobDates] = useState<Date[]>([]);
+  const [selectedDate, setSelectedDate] = useState<string>("");
+  const [maxStages, setMaxStages] = useState(3);
+
+  useEffect(() => {
+    const applyJobDateRange = (startTime: string, endTime: string) => {
+      const startDate = new Date(startTime);
+      const endDate = new Date(endTime);
+      if (!isValid(startDate) || !isValid(endDate)) return;
+      const dates = eachDayOfInterval({ start: startDate, end: endDate });
+      setJobDates(dates);
+      const routeDateExists = routeDate
+        ? dates.some((festivalDate) => format(festivalDate, "yyyy-MM-dd") === routeDate)
+        : false;
+      setSelectedDate(routeDateExists ? routeDate : format(dates[0], "yyyy-MM-dd"));
+    };
+
+    const readOfflineJobDetails = async (): Promise<JobHeaderDetails | null> => {
+      if (!jobId) return null;
+      const offlineContext = await getOfflineFestivalContext(jobId);
+      const offlineJob = offlineContext?.job;
+      if (!offlineJob) return null;
+
+      return {
+        title: (offlineJob.title as string) || "",
+        startTime: offlineJob.start_time as string,
+        endTime: offlineJob.end_time as string,
+        maxStages: offlineContext.maxStages || 3,
+      };
+    };
+
+    const fetchJobDetailsOnline = async (): Promise<JobHeaderDetails> => {
+      const { data, error } = await supabase
+        .from("jobs")
+        .select("title, start_time, end_time")
+        .eq("id", jobId)
+        .single();
+      if (error) throw error;
+
+      let maxStagesValue: number | null = null;
+      const { data: gearSetups, error: gearError } = await supabase
+        .from("festival_gear_setups")
+        .select("max_stages")
+        .eq("job_id", jobId)
+        .order("created_at", { ascending: false })
+        .limit(1);
+      if (gearError) {
+        console.error("Error fetching gear setup:", gearError);
+      } else if (gearSetups && gearSetups.length > 0) {
+        maxStagesValue = gearSetups[0].max_stages || 3;
+      }
+
+      return { title: data.title, startTime: data.start_time, endTime: data.end_time, maxStages: maxStagesValue };
+    };
+
+    let cancelled = false;
+
+    const fetchJobDetails = async () => {
+      if (!jobId) return;
+      try {
+        const result = await fetchWithOfflineFallback({
+          online: fetchJobDetailsOnline,
+          offline: readOfflineJobDetails,
+        });
+        if (cancelled) return;
+
+        const details = result.data;
+        setJobTitle(details.title);
+        applyJobDateRange(details.startTime, details.endTime);
+        if (details.maxStages !== null) {
+          setMaxStages(details.maxStages);
+        }
+      } catch (error) {
+        console.error("Error fetching job details:", error);
+      }
+    };
+    fetchJobDetails();
+
+    return () => {
+      cancelled = true;
+    };
+    // routeDate is intentionally read at fetch time only: it tracks
+    // selectedDate via the URL, and re-running on every date change would
+    // refetch the job for nothing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jobId]);
+
+  return { jobTitle, jobDates, selectedDate, setSelectedDate, maxStages };
+};

--- a/src/hooks/festival/useFestivalArtistJobDetails.ts
+++ b/src/hooks/festival/useFestivalArtistJobDetails.ts
@@ -8,7 +8,7 @@ type JobHeaderDetails = {
   title: string;
   startTime: string;
   endTime: string;
-  maxStages: number | null;
+  maxStages: number;
 };
 
 /**
@@ -60,7 +60,9 @@ export const useFestivalArtistJobDetails = (jobId: string | undefined, routeDate
         .single();
       if (error) throw error;
 
-      let maxStagesValue: number | null = null;
+      // Default to 3 so a job without gear setup (or a gear-query error)
+      // resets the previous job's stage count instead of letting it persist
+      let maxStagesValue = 3;
       const { data: gearSetups, error: gearError } = await supabase
         .from("festival_gear_setups")
         .select("max_stages")
@@ -90,9 +92,7 @@ export const useFestivalArtistJobDetails = (jobId: string | undefined, routeDate
         const details = result.data;
         setJobTitle(details.title);
         applyJobDateRange(details.startTime, details.endTime);
-        if (details.maxStages !== null) {
-          setMaxStages(details.maxStages);
-        }
+        setMaxStages(details.maxStages);
       } catch (error) {
         console.error("Error fetching job details:", error);
       }
@@ -104,9 +104,23 @@ export const useFestivalArtistJobDetails = (jobId: string | undefined, routeDate
     };
     // routeDate is intentionally read at fetch time only: it tracks
     // selectedDate via the URL, and re-running on every date change would
-    // refetch the job for nothing.
+    // refetch the job for nothing. URL -> state sync for later routeDate
+    // changes is handled by the effect below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [jobId]);
+
+  // Keep selectedDate in sync when ?date= changes for the same job (e.g.
+  // browser back/forward), without refetching the job. In-app date picks
+  // round-trip through the URL and land here as a no-op.
+  useEffect(() => {
+    if (!routeDate || jobDates.length === 0) return;
+    const routeDateExists = jobDates.some(
+      (festivalDate) => format(festivalDate, "yyyy-MM-dd") === routeDate,
+    );
+    if (routeDateExists) {
+      setSelectedDate((current) => (current === routeDate ? current : routeDate));
+    }
+  }, [routeDate, jobDates]);
 
   return { jobTitle, jobDates, selectedDate, setSelectedDate, maxStages };
 };

--- a/src/hooks/festival/useOfflineFestival.ts
+++ b/src/hooks/festival/useOfflineFestival.ts
@@ -5,7 +5,7 @@ import {
   countPendingChanges,
   deleteFestivalSnapshot,
   discardPendingChanges,
-  downloadFestivalSnapshot,
+  downloadFestivalSnapshotWithFiles,
   getFestivalSnapshot,
   isBrowserOnline,
   subscribeOfflineFestivalChanged,
@@ -87,10 +87,21 @@ export const useOfflineFestival = (jobId?: string) => {
     }
     setIsDownloading(true);
     try {
-      const snapshot = await downloadFestivalSnapshot(jobId);
-      toast.success("Datos offline descargados", {
-        description: `${snapshot.data.artists.length} artistas disponibles sin conexión.`,
-      });
+      const { snapshot, files } = await downloadFestivalSnapshotWithFiles(jobId);
+      const fileSummary =
+        files.total > 0
+          ? ` y ${files.downloaded} de ${files.total} archivos (riders, planos, documentos)`
+          : "";
+      if (files.failed > 0) {
+        toast.warning("Datos offline descargados con avisos", {
+          description: `${snapshot.data.artists.length} artistas${fileSummary}. ${files.failed} archivo${files.failed === 1 ? "" : "s"} no se pudieron descargar.`,
+          duration: 8000,
+        });
+      } else {
+        toast.success("Datos offline descargados", {
+          description: `${snapshot.data.artists.length} artistas${fileSummary} disponibles sin conexión.`,
+        });
+      }
     } catch (error) {
       console.error("Error descargando datos offline:", error);
       toast.error("Error", { description: "No se pudieron descargar los datos para uso offline." });
@@ -175,7 +186,7 @@ export const useOfflineFestival = (jobId?: string) => {
     // download fails the queue stays intact, so the local copy never shows
     // edits that can no longer be synchronized or discarded cleanly.
     try {
-      await downloadFestivalSnapshot(jobId);
+      await downloadFestivalSnapshotWithFiles(jobId);
     } catch (error) {
       console.error("No se pudo restaurar la copia offline antes de descartar cambios:", error);
       toast.error("Error", {

--- a/src/hooks/festival/useOfflineFestival.ts
+++ b/src/hooks/festival/useOfflineFestival.ts
@@ -186,7 +186,13 @@ export const useOfflineFestival = (jobId?: string) => {
     // download fails the queue stays intact, so the local copy never shows
     // edits that can no longer be synchronized or discarded cleanly.
     try {
-      await downloadFestivalSnapshotWithFiles(jobId);
+      const { files } = await downloadFestivalSnapshotWithFiles(jobId);
+      if (files.failed > 0) {
+        toast.warning("Copia restaurada con avisos", {
+          description: `${files.failed} archivo${files.failed === 1 ? "" : "s"} no se pudieron restaurar.`,
+          duration: 8000,
+        });
+      }
     } catch (error) {
       console.error("No se pudo restaurar la copia offline antes de descartar cambios:", error);
       toast.error("Error", {

--- a/src/hooks/useArtistsQuery.ts
+++ b/src/hooks/useArtistsQuery.ts
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 import {
+  fetchWithOfflineFallback,
   getFestivalSnapshot,
   getOfflineArtistsForDate,
   isBrowserOnline,
@@ -79,25 +80,13 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
     queryFn: async () => {
       if (!jobId || !selectedDate) return { rows: [], isOffline: false };
 
-      // Offline: serve the downloaded snapshot (with local edits applied)
-      if (!isBrowserOnline()) {
-        const offlineArtists = await getOfflineArtistsForDate(jobId, selectedDate, dayStartTime);
-        if (offlineArtists) {
-          return { rows: offlineArtists, isOffline: true };
-        }
-        throw new Error("Sin conexión y sin copia offline de este festival");
-      }
-
-      try {
-        return { rows: await fetchArtistsOnline(), isOffline: false };
-      } catch (fetchError) {
-        // Network dropped mid-request: fall back to the offline copy if available
-        const offlineArtists = await getOfflineArtistsForDate(jobId, selectedDate, dayStartTime);
-        if (offlineArtists) {
-          return { rows: offlineArtists, isOffline: true };
-        }
-        throw fetchError;
-      }
+      // Serves the snapshot when the browser is offline, the fetch fails, or
+      // the network is too slow to answer (weak festival-site connectivity).
+      const result = await fetchWithOfflineFallback({
+        online: fetchArtistsOnline,
+        offline: () => getOfflineArtistsForDate(jobId, selectedDate, dayStartTime),
+      });
+      return { rows: result.data, isOffline: result.fromOffline };
     },
     enabled: !!jobId && !!selectedDate,
     staleTime: 1000 * 60 * 2, // 2 minutes

--- a/src/lib/offline/__tests__/festival-files.test.ts
+++ b/src/lib/offline/__tests__/festival-files.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: mockSupabase,
+}));
+
+import { __resetOfflineDbForTests } from "../offline-db";
+import {
+  deleteOfflineFilesForJob,
+  downloadFestivalFiles,
+  getOfflineFileBlob,
+} from "../festival-files";
+
+const JOB_ID = "job-1";
+
+const mockStorageDownload = (failPaths: string[] = []) => {
+  mockSupabase.storage.from.mockImplementation(() => ({
+    download: vi.fn(async (path: string) =>
+      failPaths.includes(path)
+        ? { data: null, error: new Error("storage error") }
+        : { data: new Blob([`contenido de ${path}`]), error: null },
+    ),
+    upload: vi.fn(),
+    createSignedUrl: vi.fn(),
+    remove: vi.fn(),
+    getPublicUrl: vi.fn(),
+  }));
+};
+
+describe("festival offline files", () => {
+  beforeEach(() => {
+    __resetOfflineDbForTests();
+    resetMockSupabase();
+  });
+
+  it("downloads and stores the referenced files", async () => {
+    mockStorageDownload();
+
+    const stats = await downloadFestivalFiles(JOB_ID, [
+      { bucket: "festival_artist_files", path: "riders/a.pdf", fileName: "a.pdf" },
+      { bucket: "job-documents", path: "docs/b.pdf", fileName: "b.pdf" },
+    ]);
+
+    expect(stats).toEqual({ total: 2, downloaded: 2, failed: 0 });
+    expect(await getOfflineFileBlob("festival_artist_files", "riders/a.pdf")).not.toBeNull();
+    expect(await getOfflineFileBlob("job-documents", "docs/b.pdf")).not.toBeNull();
+  });
+
+  it("counts failures without aborting the rest of the batch", async () => {
+    mockStorageDownload(["riders/broken.pdf"]);
+
+    const stats = await downloadFestivalFiles(JOB_ID, [
+      { bucket: "festival_artist_files", path: "riders/broken.pdf", fileName: "broken.pdf" },
+      { bucket: "festival_artist_files", path: "riders/ok.pdf", fileName: "ok.pdf" },
+    ]);
+
+    expect(stats).toEqual({ total: 2, downloaded: 1, failed: 1 });
+    expect(await getOfflineFileBlob("festival_artist_files", "riders/ok.pdf")).not.toBeNull();
+    expect(await getOfflineFileBlob("festival_artist_files", "riders/broken.pdf")).toBeNull();
+  });
+
+  it("prunes files that no longer belong to the festival on refresh", async () => {
+    mockStorageDownload();
+
+    await downloadFestivalFiles(JOB_ID, [
+      { bucket: "festival_artist_files", path: "riders/old.pdf", fileName: "old.pdf" },
+    ]);
+    await downloadFestivalFiles(JOB_ID, [
+      { bucket: "festival_artist_files", path: "riders/new.pdf", fileName: "new.pdf" },
+    ]);
+
+    expect(await getOfflineFileBlob("festival_artist_files", "riders/old.pdf")).toBeNull();
+    expect(await getOfflineFileBlob("festival_artist_files", "riders/new.pdf")).not.toBeNull();
+  });
+
+  it("removes every cached file of a festival", async () => {
+    mockStorageDownload();
+
+    await downloadFestivalFiles(JOB_ID, [
+      { bucket: "festival_artist_files", path: "riders/a.pdf", fileName: "a.pdf" },
+    ]);
+    await deleteOfflineFilesForJob(JOB_ID);
+
+    expect(await getOfflineFileBlob("festival_artist_files", "riders/a.pdf")).toBeNull();
+  });
+});

--- a/src/lib/offline/__tests__/festival-files.test.ts
+++ b/src/lib/offline/__tests__/festival-files.test.ts
@@ -61,6 +61,21 @@ describe("festival offline files", () => {
     expect(await getOfflineFileBlob("festival_artist_files", "riders/broken.pdf")).toBeNull();
   });
 
+  it("keeps a previously cached file when a re-download fails", async () => {
+    mockStorageDownload();
+    await downloadFestivalFiles(JOB_ID, [
+      { bucket: "festival_artist_files", path: "riders/a.pdf", fileName: "a.pdf" },
+    ]);
+
+    mockStorageDownload(["riders/a.pdf"]);
+    const stats = await downloadFestivalFiles(JOB_ID, [
+      { bucket: "festival_artist_files", path: "riders/a.pdf", fileName: "a.pdf" },
+    ]);
+
+    expect(stats).toEqual({ total: 1, downloaded: 0, failed: 1 });
+    expect(await getOfflineFileBlob("festival_artist_files", "riders/a.pdf")).not.toBeNull();
+  });
+
   it("prunes files that no longer belong to the festival on refresh", async () => {
     mockStorageDownload();
 

--- a/src/lib/offline/__tests__/with-offline-fallback.test.ts
+++ b/src/lib/offline/__tests__/with-offline-fallback.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { fetchWithOfflineFallback } from "../with-offline-fallback";
+
+// Node has no navigator, so isBrowserOnline() reports online here; the
+// browser-offline branch is exercised indirectly via the error paths.
+
+const never = () => new Promise<string>(() => {});
+
+describe("fetchWithOfflineFallback", () => {
+  it("returns online data when the fetch answers in time", async () => {
+    const result = await fetchWithOfflineFallback({
+      online: async () => "online",
+      offline: async () => "offline",
+      timeoutMs: 50,
+    });
+    expect(result).toEqual({ data: "online", fromOffline: false });
+  });
+
+  it("serves the snapshot when the online fetch exceeds the timeout", async () => {
+    const result = await fetchWithOfflineFallback({
+      online: never,
+      offline: async () => "offline",
+      timeoutMs: 20,
+    });
+    expect(result).toEqual({ data: "offline", fromOffline: true });
+  });
+
+  it("keeps waiting for the network on timeout when there is no snapshot", async () => {
+    const result = await fetchWithOfflineFallback({
+      online: () => new Promise<string>((resolve) => setTimeout(() => resolve("slow-online"), 40)),
+      offline: async (): Promise<string | null> => null,
+      timeoutMs: 10,
+    });
+    expect(result).toEqual({ data: "slow-online", fromOffline: false });
+  });
+
+  it("serves the snapshot when the online fetch fails", async () => {
+    const result = await fetchWithOfflineFallback({
+      online: async (): Promise<string> => {
+        throw new Error("network down");
+      },
+      offline: async () => "offline",
+      timeoutMs: 50,
+    });
+    expect(result).toEqual({ data: "offline", fromOffline: true });
+  });
+
+  it("rethrows the online error when there is no snapshot", async () => {
+    await expect(
+      fetchWithOfflineFallback({
+        online: async () => {
+          throw new Error("network down");
+        },
+        offline: async (): Promise<string | null> => null,
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow("network down");
+  });
+});

--- a/src/lib/offline/__tests__/with-offline-fallback.test.ts
+++ b/src/lib/offline/__tests__/with-offline-fallback.test.ts
@@ -1,13 +1,40 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { fetchWithOfflineFallback } from "../with-offline-fallback";
 
-// Node has no navigator, so isBrowserOnline() reports online here; the
-// browser-offline branch is exercised indirectly via the error paths.
+// Node has no navigator by default, so isBrowserOnline() reports online;
+// the browser-offline branch is exercised by stubbing navigator below.
 
 const never = () => new Promise<string>(() => {});
 
 describe("fetchWithOfflineFallback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("serves the snapshot immediately when the browser is offline", async () => {
+    vi.stubGlobal("navigator", { onLine: false });
+
+    const online = vi.fn(async () => "online");
+    const result = await fetchWithOfflineFallback({
+      online,
+      offline: async () => "offline",
+    });
+
+    expect(result).toEqual({ data: "offline", fromOffline: true });
+    expect(online).not.toHaveBeenCalled();
+  });
+
+  it("throws immediately when the browser is offline and there is no snapshot", async () => {
+    vi.stubGlobal("navigator", { onLine: false });
+
+    await expect(
+      fetchWithOfflineFallback({
+        online: async () => "online",
+        offline: async (): Promise<string | null> => null,
+      }),
+    ).rejects.toThrow("Sin conexión y sin copia offline de este festival");
+  });
   it("returns online data when the fetch answers in time", async () => {
     const result = await fetchWithOfflineFallback({
       online: async () => "online",

--- a/src/lib/offline/festival-files.ts
+++ b/src/lib/offline/festival-files.ts
@@ -33,18 +33,36 @@ export interface OfflineFileDownloadStats {
 const fileKey = (bucket: string, path: string) => `${bucket}/${path}`;
 
 const DOWNLOAD_CONCURRENCY = 4;
+const FILE_DOWNLOAD_TIMEOUT_MS = 30_000;
 
-export const getOfflineFile = async (bucket: string, path: string): Promise<OfflineStoredFile | null> =>
-  offlineDb.get<OfflineStoredFile>(FILES_STORE, fileKey(bucket, path));
+/**
+ * Cache lookups never throw: callers use them as a fast path before the
+ * network, so a blocked/broken IndexedDB must degrade to "not cached".
+ */
+export const getOfflineFile = async (bucket: string, path: string): Promise<OfflineStoredFile | null> => {
+  try {
+    return await offlineDb.get<OfflineStoredFile>(FILES_STORE, fileKey(bucket, path));
+  } catch (error) {
+    console.warn("No se pudo leer el archivo offline:", error);
+    return null;
+  }
+};
 
 export const getOfflineFileBlob = async (bucket: string, path: string): Promise<Blob | null> =>
   (await getOfflineFile(bucket, path))?.blob ?? null;
 
 export const deleteOfflineFilesForJob = async (jobId: string): Promise<void> => {
-  const files = await offlineDb.getAll<OfflineStoredFile>(FILES_STORE);
-  await Promise.all(
-    files.filter((file) => file.jobId === jobId).map((file) => offlineDb.remove(FILES_STORE, file.key)),
-  );
+  const keys = await offlineDb.getKeysByIndex(FILES_STORE, "jobId", jobId);
+  await Promise.all(keys.map((key) => offlineDb.remove(FILES_STORE, key)));
+};
+
+// Storage downloads get their own abort timeout: one request that never
+// settles would otherwise pin a worker and block the whole snapshot download.
+const downloadWithTimeout = (bucket: string, path: string) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FILE_DOWNLOAD_TIMEOUT_MS);
+  const request = supabase.storage.from(bucket).download(path, undefined, { signal: controller.signal });
+  return Promise.resolve(request).finally(() => clearTimeout(timer));
 };
 
 /**
@@ -68,7 +86,7 @@ export const downloadFestivalFiles = async (
       if (!ref) return;
       const key = fileKey(ref.bucket, ref.path);
       try {
-        const { data, error } = await supabase.storage.from(ref.bucket).download(ref.path);
+        const { data, error } = await downloadWithTimeout(ref.bucket, ref.path);
         if (error || !data) throw error ?? new Error("empty download");
         const stored: OfflineStoredFile = {
           key,
@@ -97,11 +115,9 @@ export const downloadFestivalFiles = async (
   await Promise.all(Array.from({ length: DOWNLOAD_CONCURRENCY }, worker));
 
   // Drop files that no longer belong to the festival (deleted riders, etc.)
-  const existing = await offlineDb.getAll<OfflineStoredFile>(FILES_STORE);
+  const existingKeys = await offlineDb.getKeysByIndex(FILES_STORE, "jobId", jobId);
   await Promise.all(
-    existing
-      .filter((file) => file.jobId === jobId && !keptKeys.has(file.key))
-      .map((file) => offlineDb.remove(FILES_STORE, file.key)),
+    existingKeys.filter((key) => !keptKeys.has(key)).map((key) => offlineDb.remove(FILES_STORE, key)),
   );
 
   return stats;

--- a/src/lib/offline/festival-files.ts
+++ b/src/lib/offline/festival-files.ts
@@ -1,0 +1,108 @@
+import { supabase } from "@/integrations/supabase/client";
+
+import { FILES_STORE, offlineDb } from "./offline-db";
+
+/**
+ * Binary files (rider PDFs, stage plots, job documents) cached alongside a
+ * festival snapshot so they can be viewed without connection.
+ */
+export interface OfflineStoredFile {
+  /** `${bucket}/${path}` */
+  key: string;
+  jobId: string;
+  bucket: string;
+  path: string;
+  fileName: string;
+  size: number;
+  downloadedAt: string;
+  blob: Blob;
+}
+
+export interface OfflineFileRef {
+  bucket: string;
+  path: string;
+  fileName: string;
+}
+
+export interface OfflineFileDownloadStats {
+  total: number;
+  downloaded: number;
+  failed: number;
+}
+
+const fileKey = (bucket: string, path: string) => `${bucket}/${path}`;
+
+const DOWNLOAD_CONCURRENCY = 4;
+
+export const getOfflineFile = async (bucket: string, path: string): Promise<OfflineStoredFile | null> =>
+  offlineDb.get<OfflineStoredFile>(FILES_STORE, fileKey(bucket, path));
+
+export const getOfflineFileBlob = async (bucket: string, path: string): Promise<Blob | null> =>
+  (await getOfflineFile(bucket, path))?.blob ?? null;
+
+export const deleteOfflineFilesForJob = async (jobId: string): Promise<void> => {
+  const files = await offlineDb.getAll<OfflineStoredFile>(FILES_STORE);
+  await Promise.all(
+    files.filter((file) => file.jobId === jobId).map((file) => offlineDb.remove(FILES_STORE, file.key)),
+  );
+};
+
+/**
+ * Downloads the referenced storage objects and stores them in IndexedDB,
+ * replacing the festival's previous file set. Individual download failures
+ * are counted but never abort the batch — a festival with one broken rider
+ * still gets everything else cached.
+ */
+export const downloadFestivalFiles = async (
+  jobId: string,
+  refs: OfflineFileRef[],
+): Promise<OfflineFileDownloadStats> => {
+  const uniqueRefs = Array.from(new Map(refs.map((ref) => [fileKey(ref.bucket, ref.path), ref])).values());
+  const stats: OfflineFileDownloadStats = { total: uniqueRefs.length, downloaded: 0, failed: 0 };
+  const keptKeys = new Set<string>();
+
+  const queue = [...uniqueRefs];
+  const worker = async () => {
+    for (;;) {
+      const ref = queue.shift();
+      if (!ref) return;
+      const key = fileKey(ref.bucket, ref.path);
+      try {
+        const { data, error } = await supabase.storage.from(ref.bucket).download(ref.path);
+        if (error || !data) throw error ?? new Error("empty download");
+        const stored: OfflineStoredFile = {
+          key,
+          jobId,
+          bucket: ref.bucket,
+          path: ref.path,
+          fileName: ref.fileName,
+          size: data.size,
+          downloadedAt: new Date().toISOString(),
+          blob: data,
+        };
+        await offlineDb.put(FILES_STORE, stored);
+        keptKeys.add(key);
+        stats.downloaded += 1;
+      } catch (error) {
+        console.warn(`No se pudo descargar el archivo offline ${key}:`, error);
+        stats.failed += 1;
+        // Keep a previously cached copy if we have one rather than dropping it
+        if (await getOfflineFile(ref.bucket, ref.path)) {
+          keptKeys.add(key);
+        }
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: DOWNLOAD_CONCURRENCY }, worker));
+
+  // Drop files that no longer belong to the festival (deleted riders, etc.)
+  const existing = await offlineDb.getAll<OfflineStoredFile>(FILES_STORE);
+  await Promise.all(
+    existing
+      .filter((file) => file.jobId === jobId && !keptKeys.has(file.key))
+      .map((file) => offlineDb.remove(FILES_STORE, file.key)),
+  );
+
+  return stats;
+};

--- a/src/lib/offline/festival-snapshot.ts
+++ b/src/lib/offline/festival-snapshot.ts
@@ -1,5 +1,12 @@
 import { supabase } from "@/integrations/supabase/client";
+import { resolveJobDocLocation } from "@/utils/jobDocuments";
 
+import {
+  deleteOfflineFilesForJob,
+  downloadFestivalFiles,
+  type OfflineFileDownloadStats,
+  type OfflineFileRef,
+} from "./festival-files";
 import { offlineDb, QUEUE_STORE, SNAPSHOT_STORE } from "./offline-db";
 import { notifyOfflineFestivalChanged } from "./offline-events";
 import {
@@ -59,11 +66,60 @@ const fetchMaybeSingle = async (table: string, filterColumn: string, filterValue
   return (data as Row | null) ?? null;
 };
 
+export interface FestivalSnapshotDownloadResult {
+  snapshot: OfflineFestivalSnapshot;
+  files: OfflineFileDownloadStats;
+}
+
+const collectSnapshotFileRefs = (data: OfflineFestivalSnapshotData): OfflineFileRef[] => {
+  const refs: OfflineFileRef[] = [];
+
+  data.artistFiles.forEach((file) => {
+    if (typeof file.file_path === "string" && file.file_path) {
+      refs.push({
+        bucket: "festival_artist_files",
+        path: file.file_path,
+        fileName: (file.file_name as string) || "rider",
+      });
+    }
+  });
+
+  data.artists.forEach((artist) => {
+    if (typeof artist.stage_plot_file_path === "string" && artist.stage_plot_file_path) {
+      refs.push({
+        bucket: "festival_artist_files",
+        path: artist.stage_plot_file_path,
+        fileName: (artist.stage_plot_file_name as string) || "stage-plot",
+      });
+    }
+  });
+
+  data.jobDocuments.forEach((doc) => {
+    if (typeof doc.file_path === "string" && doc.file_path) {
+      const { bucket, path } = resolveJobDocLocation(doc.file_path);
+      refs.push({ bucket, path, fileName: (doc.file_name as string) || "documento" });
+    }
+  });
+
+  return refs;
+};
+
 /**
  * Downloads the full dataset of a festival (job, settings, dates, stages,
- * gear, artists, riders metadata, shifts, documents) and persists it to
+ * gear, artists, riders, stage plots, shifts, documents) and persists it to
  * IndexedDB so the festival can be consulted and edited without connection.
+ * Binary files download after the metadata; per-file failures are reported
+ * in the result but never abort the snapshot.
  */
+export const downloadFestivalSnapshotWithFiles = async (
+  jobId: string,
+): Promise<FestivalSnapshotDownloadResult> => {
+  const snapshot = await downloadFestivalSnapshot(jobId);
+  const files = await downloadFestivalFiles(jobId, collectSnapshotFileRefs(snapshot.data));
+  notifyOfflineFestivalChanged(jobId);
+  return { snapshot, files };
+};
+
 export const downloadFestivalSnapshot = async (jobId: string): Promise<OfflineFestivalSnapshot> => {
   const { data: job, error: jobError } = await supabase.from("jobs").select("*").eq("id", jobId).single();
   if (jobError) throw jobError;
@@ -148,11 +204,12 @@ export const saveFestivalSnapshot = async (snapshot: OfflineFestivalSnapshot): P
   notifyOfflineFestivalChanged(snapshot.jobId);
 };
 
-/** Removes the offline copy and any pending changes queued against it. */
+/** Removes the offline copy, its cached files and any pending changes. */
 export const deleteFestivalSnapshot = async (jobId: string): Promise<void> => {
   await offlineDb.remove(SNAPSHOT_STORE, jobId);
   const pending = await offlineDb.getAll<OfflinePendingChange>(QUEUE_STORE);
   await Promise.all(pending.filter((change) => change.jobId === jobId).map((change) => offlineDb.remove(QUEUE_STORE, change.id)));
+  await deleteOfflineFilesForJob(jobId);
   notifyOfflineFestivalChanged(jobId);
 };
 

--- a/src/lib/offline/index.ts
+++ b/src/lib/offline/index.ts
@@ -2,12 +2,21 @@ export * from "./types";
 export * from "./offline-events";
 export {
   downloadFestivalSnapshot,
+  downloadFestivalSnapshotWithFiles,
   getFestivalSnapshot,
   deleteFestivalSnapshot,
   getOfflineArtistsForDate,
   getOfflineFestivalContext,
   type OfflineFestivalContext,
+  type FestivalSnapshotDownloadResult,
 } from "./festival-snapshot";
+export {
+  getOfflineFile,
+  getOfflineFileBlob,
+  type OfflineFileDownloadStats,
+  type OfflineStoredFile,
+} from "./festival-files";
+export { fetchWithOfflineFallback, ONLINE_FETCH_TIMEOUT_MS } from "./with-offline-fallback";
 export {
   queueFestivalChange,
   getPendingChanges,

--- a/src/lib/offline/offline-db.ts
+++ b/src/lib/offline/offline-db.ts
@@ -14,12 +14,18 @@ export type OfflineStoreName = typeof SNAPSHOT_STORE | typeof QUEUE_STORE | type
 
 const DB_NAME = "sector-pro-offline";
 // v2: adds the festival-files store (binary blobs for riders/stage plots/documents)
-const DB_VERSION = 2;
+// v3: adds the jobId index on festival-files so per-festival deletes/prunes
+//     don't materialize every cached blob
+const DB_VERSION = 3;
 
 const STORE_KEY_PATHS: Record<OfflineStoreName, string> = {
   [SNAPSHOT_STORE]: "jobId",
   [QUEUE_STORE]: "id",
   [FILES_STORE]: "key",
+};
+
+const STORE_INDEXES: Partial<Record<OfflineStoreName, string[]>> = {
+  [FILES_STORE]: ["jobId"],
 };
 
 const hasIndexedDb = () => typeof indexedDB !== "undefined";
@@ -39,10 +45,17 @@ const openDb = (): Promise<IDBDatabase> => {
 
       request.onupgradeneeded = () => {
         const db = request.result;
+        const upgradeTransaction = request.transaction;
         (Object.keys(STORE_KEY_PATHS) as OfflineStoreName[]).forEach((store) => {
-          if (!db.objectStoreNames.contains(store)) {
-            db.createObjectStore(store, { keyPath: STORE_KEY_PATHS[store] });
-          }
+          const objectStore = db.objectStoreNames.contains(store)
+            ? upgradeTransaction?.objectStore(store)
+            : db.createObjectStore(store, { keyPath: STORE_KEY_PATHS[store] });
+          if (!objectStore) return;
+          (STORE_INDEXES[store] ?? []).forEach((indexName) => {
+            if (!objectStore.indexNames.contains(indexName)) {
+              objectStore.createIndex(indexName, indexName);
+            }
+          });
         });
       };
 
@@ -123,6 +136,22 @@ export const offlineDb = {
       return Array.from(memoryStores[store].values()).map((value) => cloneValue(value as T));
     }
     return runTransaction<T[]>(store, "readonly", (os) => os.getAll() as IDBRequest<T[]>);
+  },
+
+  /**
+   * Primary keys of records whose indexed field equals `value`. Reads only
+   * the index, so record payloads (e.g. cached blobs) are never loaded.
+   */
+  async getKeysByIndex(store: OfflineStoreName, indexName: string, value: string): Promise<string[]> {
+    if (!hasIndexedDb()) {
+      return Array.from(memoryStores[store].entries())
+        .filter(([, record]) => (record as Record<string, unknown>)[indexName] === value)
+        .map(([key]) => key);
+    }
+    const keys = await runTransaction<IDBValidKey[]>(store, "readonly", (os) =>
+      os.index(indexName).getAllKeys(IDBKeyRange.only(value)),
+    );
+    return keys.map((key) => String(key));
   },
 
   async put(store: OfflineStoreName, value: unknown): Promise<void> {

--- a/src/lib/offline/offline-db.ts
+++ b/src/lib/offline/offline-db.ts
@@ -8,15 +8,18 @@
 
 export const SNAPSHOT_STORE = "festival-snapshots";
 export const QUEUE_STORE = "festival-pending-changes";
+export const FILES_STORE = "festival-files";
 
-export type OfflineStoreName = typeof SNAPSHOT_STORE | typeof QUEUE_STORE;
+export type OfflineStoreName = typeof SNAPSHOT_STORE | typeof QUEUE_STORE | typeof FILES_STORE;
 
 const DB_NAME = "sector-pro-offline";
-const DB_VERSION = 1;
+// v2: adds the festival-files store (binary blobs for riders/stage plots/documents)
+const DB_VERSION = 2;
 
 const STORE_KEY_PATHS: Record<OfflineStoreName, string> = {
   [SNAPSHOT_STORE]: "jobId",
   [QUEUE_STORE]: "id",
+  [FILES_STORE]: "key",
 };
 
 const hasIndexedDb = () => typeof indexedDB !== "undefined";
@@ -26,6 +29,7 @@ let dbPromise: Promise<IDBDatabase> | null = null;
 const memoryStores: Record<OfflineStoreName, Map<string, unknown>> = {
   [SNAPSHOT_STORE]: new Map(),
   [QUEUE_STORE]: new Map(),
+  [FILES_STORE]: new Map(),
 };
 
 const openDb = (): Promise<IDBDatabase> => {
@@ -142,4 +146,5 @@ export const offlineDb = {
 export const __resetOfflineDbForTests = () => {
   memoryStores[SNAPSHOT_STORE].clear();
   memoryStores[QUEUE_STORE].clear();
+  memoryStores[FILES_STORE].clear();
 };

--- a/src/lib/offline/with-offline-fallback.ts
+++ b/src/lib/offline/with-offline-fallback.ts
@@ -1,0 +1,71 @@
+import { isBrowserOnline } from "./offline-events";
+
+/**
+ * How long an online fetch may take before the snapshot is served instead.
+ * navigator.onLine regularly reports true on connections that cannot
+ * actually move data (festival sites, captive portals, one signal bar), so
+ * offline-capable reads must never wait on the network indefinitely.
+ */
+export const ONLINE_FETCH_TIMEOUT_MS = 4000;
+
+const TIMEOUT = Symbol("online-timeout");
+
+export interface OfflineFallbackResult<T> {
+  data: T;
+  /** true when the data came from the offline snapshot */
+  fromOffline: boolean;
+}
+
+/**
+ * Runs an online fetch with a snapshot fallback:
+ *  - browser reports offline  -> snapshot immediately (throw if none)
+ *  - online fetch errors      -> snapshot if available, else rethrow
+ *  - online fetch exceeds the timeout -> snapshot if available, otherwise
+ *    keep waiting for the network
+ *
+ * The offline reader returns null when no snapshot exists.
+ */
+export const fetchWithOfflineFallback = async <T>(options: {
+  online: () => Promise<T>;
+  offline: () => Promise<T | null>;
+  timeoutMs?: number;
+}): Promise<OfflineFallbackResult<T>> => {
+  const { online, offline, timeoutMs = ONLINE_FETCH_TIMEOUT_MS } = options;
+
+  if (!isBrowserOnline()) {
+    const offlineData = await offline();
+    if (offlineData !== null) {
+      return { data: offlineData, fromOffline: true };
+    }
+    throw new Error("Sin conexión y sin copia offline de este festival");
+  }
+
+  const onlinePromise = online();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<typeof TIMEOUT>((resolve) => {
+    timer = setTimeout(() => resolve(TIMEOUT), timeoutMs);
+  });
+
+  try {
+    const winner = await Promise.race([onlinePromise, timeoutPromise]);
+    if (winner !== TIMEOUT) {
+      return { data: winner as T, fromOffline: false };
+    }
+
+    const offlineData = await offline();
+    if (offlineData !== null) {
+      // Ignore the eventual outcome of the abandoned online fetch
+      onlinePromise.catch(() => {});
+      return { data: offlineData, fromOffline: true };
+    }
+    return { data: await onlinePromise, fromOffline: false };
+  } catch (error) {
+    const offlineData = await offline();
+    if (offlineData !== null) {
+      return { data: offlineData, fromOffline: true };
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -70,15 +70,15 @@ const FestivalArtistManagement = () => {
     queryFn: async () => {
       if (!jobId) return null;
 
+      // Throws on Supabase errors so fetchWithOfflineFallback can serve the
+      // snapshot; resolving a default here would mask the failure as fresh
+      // online data.
       const fetchSettingsOnline = async () => {
         const {
           data: existingSettings,
           error: fetchError
         } = await supabase.from('festival_settings').select('*').eq('job_id', jobId).maybeSingle();
-        if (fetchError) {
-          console.error('Error fetching festival settings:', fetchError);
-          return { settings: null };
-        }
+        if (fetchError) throw fetchError;
         if (existingSettings) {
           return { settings: existingSettings };
         }
@@ -89,21 +89,24 @@ const FestivalArtistManagement = () => {
           job_id: jobId,
           day_start_time: "07:00"
         }).select().single();
-        if (createError) {
-          console.error('Error creating festival settings:', createError);
-          return { settings: null };
-        }
+        if (createError) throw createError;
         return { settings: newSettings };
       };
 
-      const result = await fetchWithOfflineFallback({
-        online: fetchSettingsOnline,
-        offline: async () => {
-          const offlineContext = await getOfflineFestivalContext(jobId);
-          return offlineContext ? { settings: offlineContext.festivalSettings } : null;
-        },
-      });
-      return result.data.settings;
+      try {
+        const result = await fetchWithOfflineFallback({
+          online: fetchSettingsOnline,
+          offline: async () => {
+            const offlineContext = await getOfflineFestivalContext(jobId);
+            return offlineContext ? { settings: offlineContext.festivalSettings } : null;
+          },
+        });
+        return result.data.settings;
+      } catch (error) {
+        // No snapshot to fall back to: keep the previous default behaviour
+        console.error('Error fetching festival settings:', error);
+        return null;
+      }
     },
     enabled: !!jobId
   });
@@ -121,15 +124,14 @@ const FestivalArtistManagement = () => {
     queryFn: async () => {
       if (!jobId) return {};
 
+      // Throws on error so the snapshot fallback kicks in — an empty map
+      // would silently mark every festival date as a show day.
       const fetchDateTypesOnline = async () => {
         const {
           data,
           error
         } = await supabase.from('job_date_types').select('*').eq('job_id', jobId);
-        if (error) {
-          console.error('Error fetching date types:', error);
-          return {};
-        }
+        if (error) throw error;
         const dateTypeMap: Record<string, string> = {};
         data.forEach(item => {
           dateTypeMap[`${jobId}-${item.date}`] = item.type;
@@ -137,11 +139,16 @@ const FestivalArtistManagement = () => {
         return dateTypeMap;
       };
 
-      const result = await fetchWithOfflineFallback({
-        online: fetchDateTypesOnline,
-        offline: async () => (await getOfflineFestivalContext(jobId))?.dateTypes ?? null,
-      });
-      return result.data;
+      try {
+        const result = await fetchWithOfflineFallback({
+          online: fetchDateTypesOnline,
+          offline: async () => (await getOfflineFestivalContext(jobId))?.dateTypes ?? null,
+        });
+        return result.data;
+      } catch (error) {
+        console.error('Error fetching date types:', error);
+        return {};
+      }
     },
     enabled: !!jobId
   });
@@ -157,16 +164,14 @@ const FestivalArtistManagement = () => {
     queryFn: async () => {
       if (!jobId) return {};
 
+      // Throws on error so the snapshot fallback kicks in
       const fetchStageNamesOnline = async () => {
         const { data: stages, error } = await supabase
           .from('festival_stages')
           .select('number, name')
           .eq('job_id', jobId);
 
-        if (error) {
-          console.error('Error fetching stage names:', error);
-          return {};
-        }
+        if (error) throw error;
 
         const stageMap: Record<number, string> = {};
         stages?.forEach(stage => {
@@ -175,11 +180,16 @@ const FestivalArtistManagement = () => {
         return stageMap;
       };
 
-      const result = await fetchWithOfflineFallback({
-        online: fetchStageNamesOnline,
-        offline: async () => (await getOfflineFestivalContext(jobId))?.stageNames ?? null,
-      });
-      return result.data;
+      try {
+        const result = await fetchWithOfflineFallback({
+          online: fetchStageNamesOnline,
+          offline: async () => (await getOfflineFestivalContext(jobId))?.stageNames ?? null,
+        });
+        return result.data;
+      } catch (error) {
+        console.error('Error fetching stage names:', error);
+        return {};
+      }
     },
     enabled: !!jobId
   });
@@ -209,19 +219,31 @@ const FestivalArtistManagement = () => {
       setSelectedDate(routeDateExists ? routeDate : format(dates[0], "yyyy-MM-dd"));
     };
 
-    const applyOfflineJobDetails = async () => {
-      if (!jobId) return false;
-      const offlineContext = await getOfflineFestivalContext(jobId);
-      const offlineJob = offlineContext?.job;
-      if (!offlineJob) return false;
-
-      setJobTitle((offlineJob.title as string) || "");
-      applyJobDateRange(offlineJob.start_time as string, offlineJob.end_time as string);
-      setMaxStages(offlineContext.maxStages || 3);
-      return true;
+    // The fetchers only RETURN data; state is applied once for whichever
+    // side wins the race. A timed-out online fetch that resolves later must
+    // not overwrite the snapshot's title/dates/maxStages with mixed context.
+    type JobHeaderDetails = {
+      title: string;
+      startTime: string;
+      endTime: string;
+      maxStages: number | null;
     };
 
-    const fetchJobDetailsOnline = async () => {
+    const readOfflineJobDetails = async (): Promise<JobHeaderDetails | null> => {
+      if (!jobId) return null;
+      const offlineContext = await getOfflineFestivalContext(jobId);
+      const offlineJob = offlineContext?.job;
+      if (!offlineJob) return null;
+
+      return {
+        title: (offlineJob.title as string) || "",
+        startTime: offlineJob.start_time as string,
+        endTime: offlineJob.end_time as string,
+        maxStages: offlineContext.maxStages || 3,
+      };
+    };
+
+    const fetchJobDetailsOnline = async (): Promise<JobHeaderDetails> => {
       const { data, error } = await supabase
         .from("jobs")
         .select("title, start_time, end_time")
@@ -229,9 +251,7 @@ const FestivalArtistManagement = () => {
         .single();
       if (error) throw error;
 
-      setJobTitle(data.title);
-      applyJobDateRange(data.start_time, data.end_time);
-
+      let maxStagesValue: number | null = null;
       const { data: gearSetups, error: gearError } = await supabase
         .from("festival_gear_setups")
         .select("max_stages")
@@ -241,25 +261,40 @@ const FestivalArtistManagement = () => {
       if (gearError) {
         console.error("Error fetching gear setup:", gearError);
       } else if (gearSetups && gearSetups.length > 0) {
-        setMaxStages(gearSetups[0].max_stages || 3);
+        maxStagesValue = gearSetups[0].max_stages || 3;
       }
-      return true;
+
+      return { title: data.title, startTime: data.start_time, endTime: data.end_time, maxStages: maxStagesValue };
     };
+
+    let cancelled = false;
 
     const fetchJobDetails = async () => {
       if (!jobId) return;
       try {
         // Race the network against the snapshot so a weak connection never
         // leaves the page stuck on "Cargando".
-        await fetchWithOfflineFallback({
+        const result = await fetchWithOfflineFallback({
           online: fetchJobDetailsOnline,
-          offline: async () => ((await applyOfflineJobDetails()) ? true : null),
+          offline: readOfflineJobDetails,
         });
+        if (cancelled) return;
+
+        const details = result.data;
+        setJobTitle(details.title);
+        applyJobDateRange(details.startTime, details.endTime);
+        if (details.maxStages !== null) {
+          setMaxStages(details.maxStages);
+        }
       } catch (error) {
         console.error("Error fetching job details:", error);
       }
     };
     fetchJobDetails();
+
+    return () => {
+      cancelled = true;
+    };
   }, [jobId]);
 
   useEffect(() => {

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -11,7 +11,7 @@ import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/lib/enhanced-supabase-client";
 import { ConnectionIndicator } from "@/components/ui/connection-indicator";
 import { useRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
-import { format, eachDayOfInterval, isValid, addDays, parseISO, setHours, setMinutes } from "date-fns";
+import { format } from "date-fns";
 import { ArtistTablePrintDialog } from "@/components/festival/ArtistTablePrintDialog";
 import { exportArtistTablePDF } from "@/utils/artistTablePdfExport";
 import { useQuery } from "@tanstack/react-query";
@@ -26,6 +26,7 @@ import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { canCreateFestivalArtistExtras, canDeleteFestivalArtists, canEditJobs } from "@/utils/permissions";
 import { queryKeys } from "@/lib/react-query";
 import { fetchWithOfflineFallback, getOfflineFestivalContext } from "@/lib/offline";
+import { useFestivalArtistJobDetails } from "@/hooks/festival/useFestivalArtistJobDetails";
 import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
 import { FestivalOfflineBanner } from "@/components/festival/FestivalOfflineBanner";
 import { ArtistPageActions } from "@/components/festival/ArtistPageActions";
@@ -42,9 +43,6 @@ const FestivalArtistManagement = () => {
   
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [selectedArtist, setSelectedArtist] = useState<any>(null);
-  const [jobTitle, setJobTitle] = useState("");
-  const [jobDates, setJobDates] = useState<Date[]>([]);
-  const [selectedDate, setSelectedDate] = useState<string>("");
   const [searchTerm, setSearchTerm] = useState("");
   const [stageFilter, setStageFilter] = useState("all");
   const [riderFilter, setRiderFilter] = useState("all");
@@ -55,10 +53,12 @@ const FestivalArtistManagement = () => {
   const [dateTypes, setDateTypes] = useState<Record<string, string>>({});
   const [dayStartTime, setDayStartTime] = useState<string>("07:00");
   const [logoUrl, setLogoUrl] = useState("");
-  const [maxStages, setMaxStages] = useState(3);
   const [stageNames, setStageNames] = useState<Record<number, string>>({});
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState(false);
   const [isFullSchedulePrinting, setIsFullSchedulePrinting] = useState(false);
+
+  const { jobTitle, jobDates, selectedDate, setSelectedDate, maxStages } =
+    useFestivalArtistJobDetails(jobId, routeDate);
 
   const { artists, isLoading: artistsLoading, deleteArtist, invalidateArtists, isOfflineData } = useArtistsQuery(jobId, selectedDate, dayStartTime);
   const artistRows = artists as unknown as ComponentProps<typeof ArtistTable>["artists"];
@@ -205,97 +205,6 @@ const FestivalArtistManagement = () => {
     filter: `job_id=eq.${jobId}`,
     queryKey: queryKeys.scope("festival-artists", jobId, selectedDate)
   });
-
-  useEffect(() => {
-    const applyJobDateRange = (startTime: string, endTime: string) => {
-      const startDate = new Date(startTime);
-      const endDate = new Date(endTime);
-      if (!isValid(startDate) || !isValid(endDate)) return;
-      const dates = eachDayOfInterval({ start: startDate, end: endDate });
-      setJobDates(dates);
-      const routeDateExists = routeDate
-        ? dates.some((festivalDate) => format(festivalDate, "yyyy-MM-dd") === routeDate)
-        : false;
-      setSelectedDate(routeDateExists ? routeDate : format(dates[0], "yyyy-MM-dd"));
-    };
-
-    // The fetchers only RETURN data; state is applied once for whichever
-    // side wins the race. A timed-out online fetch that resolves later must
-    // not overwrite the snapshot's title/dates/maxStages with mixed context.
-    type JobHeaderDetails = {
-      title: string;
-      startTime: string;
-      endTime: string;
-      maxStages: number | null;
-    };
-
-    const readOfflineJobDetails = async (): Promise<JobHeaderDetails | null> => {
-      if (!jobId) return null;
-      const offlineContext = await getOfflineFestivalContext(jobId);
-      const offlineJob = offlineContext?.job;
-      if (!offlineJob) return null;
-
-      return {
-        title: (offlineJob.title as string) || "",
-        startTime: offlineJob.start_time as string,
-        endTime: offlineJob.end_time as string,
-        maxStages: offlineContext.maxStages || 3,
-      };
-    };
-
-    const fetchJobDetailsOnline = async (): Promise<JobHeaderDetails> => {
-      const { data, error } = await supabase
-        .from("jobs")
-        .select("title, start_time, end_time")
-        .eq("id", jobId)
-        .single();
-      if (error) throw error;
-
-      let maxStagesValue: number | null = null;
-      const { data: gearSetups, error: gearError } = await supabase
-        .from("festival_gear_setups")
-        .select("max_stages")
-        .eq("job_id", jobId)
-        .order("created_at", { ascending: false })
-        .limit(1);
-      if (gearError) {
-        console.error("Error fetching gear setup:", gearError);
-      } else if (gearSetups && gearSetups.length > 0) {
-        maxStagesValue = gearSetups[0].max_stages || 3;
-      }
-
-      return { title: data.title, startTime: data.start_time, endTime: data.end_time, maxStages: maxStagesValue };
-    };
-
-    let cancelled = false;
-
-    const fetchJobDetails = async () => {
-      if (!jobId) return;
-      try {
-        // Race the network against the snapshot so a weak connection never
-        // leaves the page stuck on "Cargando".
-        const result = await fetchWithOfflineFallback({
-          online: fetchJobDetailsOnline,
-          offline: readOfflineJobDetails,
-        });
-        if (cancelled) return;
-
-        const details = result.data;
-        setJobTitle(details.title);
-        applyJobDateRange(details.startTime, details.endTime);
-        if (details.maxStages !== null) {
-          setMaxStages(details.maxStages);
-        }
-      } catch (error) {
-        console.error("Error fetching job details:", error);
-      }
-    };
-    fetchJobDetails();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [jobId]);
 
   useEffect(() => {
     if (!selectedDate) return;

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -70,27 +70,16 @@ const FestivalArtistManagement = () => {
     queryFn: async () => {
       if (!jobId) return null;
 
-      // Throws on Supabase errors so fetchWithOfflineFallback can serve the
-      // snapshot; resolving a default here would mask the failure as fresh
-      // online data.
+      // Read-only inside the fallback race: a timed-out online promise is
+      // abandoned, so it must never write. Throws on Supabase errors so
+      // fetchWithOfflineFallback can serve the snapshot.
       const fetchSettingsOnline = async () => {
         const {
           data: existingSettings,
           error: fetchError
         } = await supabase.from('festival_settings').select('*').eq('job_id', jobId).maybeSingle();
         if (fetchError) throw fetchError;
-        if (existingSettings) {
-          return { settings: existingSettings };
-        }
-        const {
-          data: newSettings,
-          error: createError
-        } = await supabase.from('festival_settings').insert({
-          job_id: jobId,
-          day_start_time: "07:00"
-        }).select().single();
-        if (createError) throw createError;
-        return { settings: newSettings };
+        return { settings: existingSettings ?? null };
       };
 
       try {
@@ -101,7 +90,24 @@ const FestivalArtistManagement = () => {
             return offlineContext ? { settings: offlineContext.festivalSettings } : null;
           },
         });
-        return result.data.settings;
+        if (result.fromOffline || result.data.settings) {
+          return result.data.settings;
+        }
+
+        // Row confirmed missing by a live online read: create the defaults
+        // here, outside the race, where the write is awaited (never abandoned)
+        const {
+          data: newSettings,
+          error: createError
+        } = await supabase.from('festival_settings').insert({
+          job_id: jobId,
+          day_start_time: "07:00"
+        }).select().single();
+        if (createError) {
+          console.error('Error creating festival settings:', createError);
+          return null;
+        }
+        return newSettings;
       } catch (error) {
         // No snapshot to fall back to: keep the previous default behaviour
         console.error('Error fetching festival settings:', error);
@@ -146,8 +152,11 @@ const FestivalArtistManagement = () => {
         });
         return result.data;
       } catch (error) {
+        // Return null (not {}) so previously loaded date types are kept:
+        // the state effect skips null, while an empty map would silently
+        // mark every festival date as a show day.
         console.error('Error fetching date types:', error);
-        return {};
+        return null;
       }
     },
     enabled: !!jobId

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -25,7 +25,7 @@ import { getEffectiveFestivalDateType } from "@/constants/dateTypes";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { canCreateFestivalArtistExtras, canDeleteFestivalArtists, canEditJobs } from "@/utils/permissions";
 import { queryKeys } from "@/lib/react-query";
-import { getOfflineFestivalContext, isBrowserOnline } from "@/lib/offline";
+import { fetchWithOfflineFallback, getOfflineFestivalContext } from "@/lib/offline";
 import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
 import { FestivalOfflineBanner } from "@/components/festival/FestivalOfflineBanner";
 import { ArtistPageActions } from "@/components/festival/ArtistPageActions";
@@ -69,33 +69,41 @@ const FestivalArtistManagement = () => {
     networkMode: "always",
     queryFn: async () => {
       if (!jobId) return null;
-      if (!isBrowserOnline()) {
-        const offlineContext = await getOfflineFestivalContext(jobId);
-        return offlineContext?.festivalSettings ?? null;
-      }
-      const {
-        data: existingSettings,
-        error: fetchError
-      } = await supabase.from('festival_settings').select('*').eq('job_id', jobId).maybeSingle();
-      if (fetchError) {
-        console.error('Error fetching festival settings:', fetchError);
-        return null;
-      }
-      if (existingSettings) {
-        return existingSettings;
-      }
-      const {
-        data: newSettings,
-        error: createError
-      } = await supabase.from('festival_settings').insert({
-        job_id: jobId,
-        day_start_time: "07:00"
-      }).select().single();
-      if (createError) {
-        console.error('Error creating festival settings:', createError);
-        return null;
-      }
-      return newSettings;
+
+      const fetchSettingsOnline = async () => {
+        const {
+          data: existingSettings,
+          error: fetchError
+        } = await supabase.from('festival_settings').select('*').eq('job_id', jobId).maybeSingle();
+        if (fetchError) {
+          console.error('Error fetching festival settings:', fetchError);
+          return { settings: null };
+        }
+        if (existingSettings) {
+          return { settings: existingSettings };
+        }
+        const {
+          data: newSettings,
+          error: createError
+        } = await supabase.from('festival_settings').insert({
+          job_id: jobId,
+          day_start_time: "07:00"
+        }).select().single();
+        if (createError) {
+          console.error('Error creating festival settings:', createError);
+          return { settings: null };
+        }
+        return { settings: newSettings };
+      };
+
+      const result = await fetchWithOfflineFallback({
+        online: fetchSettingsOnline,
+        offline: async () => {
+          const offlineContext = await getOfflineFestivalContext(jobId);
+          return offlineContext ? { settings: offlineContext.festivalSettings } : null;
+        },
+      });
+      return result.data.settings;
     },
     enabled: !!jobId
   });
@@ -112,23 +120,28 @@ const FestivalArtistManagement = () => {
     networkMode: "always",
     queryFn: async () => {
       if (!jobId) return {};
-      if (!isBrowserOnline()) {
-        const offlineContext = await getOfflineFestivalContext(jobId);
-        return offlineContext?.dateTypes ?? {};
-      }
-      const {
-        data,
-        error
-      } = await supabase.from('job_date_types').select('*').eq('job_id', jobId);
-      if (error) {
-        console.error('Error fetching date types:', error);
-        return {};
-      }
-      const dateTypeMap: Record<string, string> = {};
-      data.forEach(item => {
-        dateTypeMap[`${jobId}-${item.date}`] = item.type;
+
+      const fetchDateTypesOnline = async () => {
+        const {
+          data,
+          error
+        } = await supabase.from('job_date_types').select('*').eq('job_id', jobId);
+        if (error) {
+          console.error('Error fetching date types:', error);
+          return {};
+        }
+        const dateTypeMap: Record<string, string> = {};
+        data.forEach(item => {
+          dateTypeMap[`${jobId}-${item.date}`] = item.type;
+        });
+        return dateTypeMap;
+      };
+
+      const result = await fetchWithOfflineFallback({
+        online: fetchDateTypesOnline,
+        offline: async () => (await getOfflineFestivalContext(jobId))?.dateTypes ?? null,
       });
-      return dateTypeMap;
+      return result.data;
     },
     enabled: !!jobId
   });
@@ -143,26 +156,30 @@ const FestivalArtistManagement = () => {
     networkMode: "always",
     queryFn: async () => {
       if (!jobId) return {};
-      if (!isBrowserOnline()) {
-        const offlineContext = await getOfflineFestivalContext(jobId);
-        return offlineContext?.stageNames ?? {};
-      }
 
-      const { data: stages, error } = await supabase
-        .from('festival_stages')
-        .select('number, name')
-        .eq('job_id', jobId);
-        
-      if (error) {
-        console.error('Error fetching stage names:', error);
-        return {};
-      }
-      
-      const stageMap: Record<number, string> = {};
-      stages?.forEach(stage => {
-        stageMap[stage.number] = stage.name;
+      const fetchStageNamesOnline = async () => {
+        const { data: stages, error } = await supabase
+          .from('festival_stages')
+          .select('number, name')
+          .eq('job_id', jobId);
+
+        if (error) {
+          console.error('Error fetching stage names:', error);
+          return {};
+        }
+
+        const stageMap: Record<number, string> = {};
+        stages?.forEach(stage => {
+          stageMap[stage.number] = stage.name;
+        });
+        return stageMap;
+      };
+
+      const result = await fetchWithOfflineFallback({
+        online: fetchStageNamesOnline,
+        offline: async () => (await getOfflineFestivalContext(jobId))?.stageNames ?? null,
       });
-      return stageMap;
+      return result.data;
     },
     enabled: !!jobId
   });
@@ -204,24 +221,16 @@ const FestivalArtistManagement = () => {
       return true;
     };
 
-    const fetchJobDetails = async () => {
-      if (!jobId) return;
-      if (!isBrowserOnline()) {
-        const applied = await applyOfflineJobDetails();
-        if (applied) return;
-      }
+    const fetchJobDetailsOnline = async () => {
       const { data, error } = await supabase
         .from("jobs")
         .select("title, start_time, end_time")
         .eq("id", jobId)
         .single();
-      if (error) {
-        console.error("Error fetching job details:", error);
-        await applyOfflineJobDetails();
-      } else {
-        setJobTitle(data.title);
-        applyJobDateRange(data.start_time, data.end_time);
-      }
+      if (error) throw error;
+
+      setJobTitle(data.title);
+      applyJobDateRange(data.start_time, data.end_time);
 
       const { data: gearSetups, error: gearError } = await supabase
         .from("festival_gear_setups")
@@ -233,6 +242,21 @@ const FestivalArtistManagement = () => {
         console.error("Error fetching gear setup:", gearError);
       } else if (gearSetups && gearSetups.length > 0) {
         setMaxStages(gearSetups[0].max_stages || 3);
+      }
+      return true;
+    };
+
+    const fetchJobDetails = async () => {
+      if (!jobId) return;
+      try {
+        // Race the network against the snapshot so a weak connection never
+        // leaves the page stuck on "Cargando".
+        await fetchWithOfflineFallback({
+          online: fetchJobDetailsOnline,
+          offline: async () => ((await applyOfflineJobDetails()) ? true : null),
+        });
+      } catch (error) {
+        console.error("Error fetching job details:", error);
       }
     };
     fetchJobDetails();


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Affected route/feature: Festival offline mode (`/festival-management/:jobId`, `/festival-management/:jobId/artists`, technician super-app artists modal)

Field testing after #798 surfaced three problems: screens hang on weak connectivity, stage plots don't render offline, and riders are not accessible offline. This PR fixes all three:

- **Binary files cached offline**: downloading a festival now also stores rider PDFs, stage plots, and job documents as blobs in a new IndexedDB store (`festival-files`, DB v2). Downloads run 4-at-a-time; per-file failures are reported in the toast but never abort the snapshot, and stale files are pruned on refresh/delete.
- **Offline-first file access**: stage plots and rider/document opens read the cached blob first (works offline, instant when online), falling back to signed URLs / network only when not cached.
- **No more slow-network hangs**: new `fetchWithOfflineFallback` races the online fetch against a 4s timeout and serves the snapshot when the fetch fails or stalls — `navigator.onLine` regularly reports `true` on unusable festival-site connections, so offline-capable reads no longer wait on the network indefinitely. Applied to the artists query, job details, documents, settings, date types, stage names, and the technician artists modal.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: medium
- Main risks:
  - IndexedDB schema bump (v1 → v2) — additive store creation only; existing snapshots and queues survive the upgrade.
  - The 4s timeout can serve snapshot data on a slow-but-working connection; this is intentional (stale-tolerant field usage) and only applies when an offline copy exists.
  - Larger initial download for festivals with many/large rider PDFs (surfaced in the download toast).
- [ ] If this touches database, auth, CI/CD, dependency, security, or production-header paths, I requested CODEOWNER review. <!-- not applicable: client-side only -->
- [ ] If risk level is high, I requested two independent approvals before merge. <!-- risk level is medium -->

## Impact Checklist
- [x] Migration impact assessed. (none — no schema/function changes; IndexedDB versioning is client-side)
- [x] Realtime/subscription impact assessed. (none — no subscription changes)
- [x] RLS/security impact assessed. (file blobs are fetched through the authenticated storage client under existing bucket policies; cached data lives in the user's own IndexedDB)
- [x] Performance impact assessed. (cached-blob-first file access removes signed-URL round-trips; timeout race bounds worst-case read latency at ~4s when a snapshot exists)

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run typecheck`
  - `npm run governance:filesize`
  - `npx eslint` on all touched files
  - `npx vitest run src/lib/offline src/features/festival-management src/components/festival src/hooks/festival src/pages/__tests__/TechnicianSuperApp.test.tsx`
  - `npm run build`
- Results: typecheck clean; file-size gate passes (44 files over threshold vs baseline 45); lint shows only pre-existing baseline warnings; 46 tests pass (9 new covering the file cache and the timeout race); production build succeeds.

## Rollback Plan
- [x] I documented how to safely revert this change.
- [ ] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert the single commit (`git revert fc39c79`) and redeploy — client-side only, no server state to unwind. Devices that already upgraded to IndexedDB v2 keep the extra (unused) `festival-files` store harmlessly; re-downloading the offline copy restores metadata-only behavior.

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no
- If yes, describe migration, impact, and backout plan: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01222enZXwgEKQd1xDYPpQCt

---
_Generated by [Claude Code](https://claude.ai/code/session_01222enZXwgEKQd1xDYPpQCt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Festival offline mode now caches binary assets (riders PDFs, stage plots, work documents) and serves them directly from offline storage when available.
* **Bug Fixes**
  * Improved offline fallback: automatically switches to saved data when requests fail, exceed a ~4s timeout, or error mid-fetch.
  * Stage-plot offline rendering now creates/revokes temporary image URLs to prevent leaks.
  * Partial downloads fail gracefully with warnings, while successful files remain cached.
  * Cached offline files are more consistently pruned when snapshots are refreshed/removed.
* **Documentation**
  * Updated offline mode documentation and clarified that festival logos are not cached as blobs.
* **Tests**
  * Added coverage for offline file caching and offline fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->