### PR TITLE
[codex] add festival push notification feed

### DIFF
--- a/src/components/festival/FestivalPushFeedButton.tsx
+++ b/src/components/festival/FestivalPushFeedButton.tsx
@@ -11,6 +11,7 @@ import { Switch } from "@/components/ui/switch";
 import { useFestivalPushSubscription } from "@/hooks/festival/useFestivalPushSubscription";
 import { usePushNotifications } from "@/hooks/usePushNotifications";
 import { cn } from "@/lib/utils";
+import { normalizeFestivalStages } from "@/utils/festivalPushStages";
 
 type FestivalPushFeedButtonProps = {
   jobId?: string;
@@ -21,9 +22,6 @@ type FestivalPushFeedButtonProps = {
 
 const sameStages = (left: number[], right: number[]) =>
   left.length === right.length && left.every((stage, index) => stage === right[index]);
-
-const normalizeStages = (stages: number[]) =>
-  Array.from(new Set(stages)).sort((left, right) => left - right);
 
 export const FestivalPushFeedButton = ({
   jobId,
@@ -39,7 +37,11 @@ export const FestivalPushFeedButton = ({
   const [draftStages, setDraftStages] = useState<number[]>([]);
 
   const hasDevicePush = Boolean(push.subscription);
-  const selectedStages = useMemo(() => normalizeStages(feed.selectedStages), [feed.selectedStages]);
+  const selectedStageKey = normalizeFestivalStages(feed.selectedStages).join(",");
+  const selectedStages = useMemo(
+    () => selectedStageKey ? selectedStageKey.split(",").map(Number) : [],
+    [selectedStageKey],
+  );
 
   useEffect(() => {
     setDraftEnabled(feed.subscription?.enabled ?? false);
@@ -53,11 +55,11 @@ export const FestivalPushFeedButton = ({
   const isActive = hasDevicePush && feed.isSubscribed;
   const isDirty =
     draftEnabled !== (feed.subscription?.enabled ?? false) ||
-    !sameStages(normalizeStages(draftStages), selectedStages);
+    !sameStages(normalizeFestivalStages(draftStages), selectedStages);
 
   const handleToggleStage = (stage: number, checked: boolean) => {
     setDraftStages((current) => {
-      if (checked) return normalizeStages([...current, stage]);
+      if (checked) return normalizeFestivalStages([...current, stage]);
       return current.filter((item) => item !== stage);
     });
   };
@@ -72,11 +74,15 @@ export const FestivalPushFeedButton = ({
   };
 
   const handleSave = async () => {
-    await feed.save({
-      enabled: draftEnabled,
-      stages: draftStages,
-    });
-    setOpen(false);
+    try {
+      await feed.save({
+        enabled: draftEnabled,
+        stages: draftStages,
+      });
+      setOpen(false);
+    } catch {
+      // The mutation already shows the Spanish error toast.
+    }
   };
 
   const triggerIcon = isBusy ? (

--- a/src/components/festival/FestivalPushFeedButton.tsx
+++ b/src/components/festival/FestivalPushFeedButton.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Bell, BellOff, Check, Loader2, Settings } from "lucide-react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { useFestivalPushSubscription } from "@/hooks/festival/useFestivalPushSubscription";
+import { usePushNotifications } from "@/hooks/usePushNotifications";
+import { cn } from "@/lib/utils";
+
+type FestivalPushFeedButtonProps = {
+  jobId?: string;
+  className?: string;
+  compact?: boolean;
+  onActivatePushClick?: () => void;
+};
+
+const sameStages = (left: number[], right: number[]) =>
+  left.length === right.length && left.every((stage, index) => stage === right[index]);
+
+const normalizeStages = (stages: number[]) =>
+  Array.from(new Set(stages)).sort((left, right) => left - right);
+
+export const FestivalPushFeedButton = ({
+  jobId,
+  className,
+  compact = false,
+  onActivatePushClick,
+}: FestivalPushFeedButtonProps) => {
+  const navigate = useNavigate();
+  const push = usePushNotifications();
+  const feed = useFestivalPushSubscription(jobId);
+  const [open, setOpen] = useState(false);
+  const [draftEnabled, setDraftEnabled] = useState(false);
+  const [draftStages, setDraftStages] = useState<number[]>([]);
+
+  const hasDevicePush = Boolean(push.subscription);
+  const selectedStages = useMemo(() => normalizeStages(feed.selectedStages), [feed.selectedStages]);
+
+  useEffect(() => {
+    setDraftEnabled(feed.subscription?.enabled ?? false);
+    setDraftStages(selectedStages);
+  }, [feed.subscription?.enabled, selectedStages]);
+
+  if (!jobId) return null;
+
+  const stageCount = feed.stageOptions.length;
+  const isBusy = feed.isLoading || push.isInitializing;
+  const isActive = hasDevicePush && feed.isSubscribed;
+  const isDirty =
+    draftEnabled !== (feed.subscription?.enabled ?? false) ||
+    !sameStages(normalizeStages(draftStages), selectedStages);
+
+  const handleToggleStage = (stage: number, checked: boolean) => {
+    setDraftStages((current) => {
+      if (checked) return normalizeStages([...current, stage]);
+      return current.filter((item) => item !== stage);
+    });
+  };
+
+  const handleProfileClick = () => {
+    setOpen(false);
+    if (onActivatePushClick) {
+      onActivatePushClick();
+      return;
+    }
+    navigate("/profile");
+  };
+
+  const handleSave = async () => {
+    await feed.save({
+      enabled: draftEnabled,
+      stages: draftStages,
+    });
+    setOpen(false);
+  };
+
+  const triggerIcon = isBusy ? (
+    <Loader2 className="h-4 w-4 animate-spin" />
+  ) : isActive ? (
+    <Bell className="h-4 w-4" />
+  ) : (
+    <BellOff className="h-4 w-4" />
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant={isActive ? "default" : "outline"}
+          size="sm"
+          className={cn("relative flex items-center gap-2 hover:bg-accent/50 transition-all", className)}
+          aria-label="Feed de avisos del festival"
+        >
+          {triggerIcon}
+          {!compact && <span className="hidden sm:inline">Avisos</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        <div className="p-4 space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-sm font-semibold">Feed de avisos</div>
+              <div className="text-xs text-muted-foreground">
+                Notificaciones por escenario y horario
+              </div>
+            </div>
+            <Bell className="h-4 w-4 text-muted-foreground" />
+          </div>
+
+          {!hasDevicePush ? (
+            <Alert>
+              <Settings className="h-4 w-4" />
+              <AlertDescription className="space-y-3">
+                <span className="block">
+                  Activa las notificaciones push en Perfil para suscribirte a este feed.
+                </span>
+                <Button type="button" size="sm" onClick={handleProfileClick}>
+                  Ir a Perfil
+                </Button>
+              </AlertDescription>
+            </Alert>
+          ) : isBusy ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Cargando estado del feed...
+            </div>
+          ) : stageCount === 0 ? (
+            <Alert>
+              <AlertDescription>
+                {feed.canChooseAnyStage
+                  ? "No hay escenarios configurados para este festival."
+                  : "No tienes escenarios asignados para este festival."}
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              <div className="flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+                <div>
+                  <div className="text-sm font-medium">Feed activo</div>
+                  <div className="text-xs text-muted-foreground">
+                    Recibir avisos del festival
+                  </div>
+                </div>
+                <Switch checked={draftEnabled} onCheckedChange={setDraftEnabled} />
+              </div>
+
+              <div className="space-y-2">
+                <div className="text-xs font-semibold uppercase text-muted-foreground">
+                  Escenarios
+                </div>
+                <div className="space-y-2">
+                  {feed.stageOptions.map((stage) => {
+                    const checked = draftStages.includes(stage.number);
+                    return (
+                      <label
+                        key={stage.number}
+                        className="flex items-center gap-3 rounded-md border px-3 py-2 text-sm"
+                      >
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={(value) => handleToggleStage(stage.number, value === true)}
+                        />
+                        <span className="min-w-0 flex-1 truncate">{stage.label}</span>
+                        {checked && <Check className="h-4 w-4 text-primary" />}
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {!feed.canChooseAnyStage && (
+                <div className="text-xs text-muted-foreground">
+                  Solo puedes suscribirte a escenarios donde tienes turno asignado.
+                </div>
+              )}
+
+              <Separator />
+
+              <div className="flex items-center justify-end gap-2">
+                <Button type="button" variant="ghost" size="sm" onClick={() => setOpen(false)}>
+                  Cancelar
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={feed.isSaving || !isDirty || (draftEnabled && draftStages.length === 0)}
+                >
+                  {feed.isSaving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+                  Guardar
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/festival/__tests__/FestivalPushFeedButton.test.tsx
+++ b/src/components/festival/__tests__/FestivalPushFeedButton.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FestivalPushFeedButton } from "@/components/festival/FestivalPushFeedButton";
+
+const { pushStateMock, feedStateMock } = vi.hoisted(() => ({
+  pushStateMock: vi.fn(),
+  feedStateMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePushNotifications", () => ({
+  usePushNotifications: () => pushStateMock(),
+}));
+
+vi.mock("@/hooks/festival/useFestivalPushSubscription", () => ({
+  useFestivalPushSubscription: () => feedStateMock(),
+}));
+
+const renderButton = (onActivatePushClick = vi.fn()) =>
+  render(
+    <MemoryRouter>
+      <FestivalPushFeedButton jobId="job-1" onActivatePushClick={onActivatePushClick} />
+    </MemoryRouter>,
+  );
+
+describe("FestivalPushFeedButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pushStateMock.mockReturnValue({
+      subscription: { endpoint: "https://push.example/sub" },
+      isInitializing: false,
+    });
+    feedStateMock.mockReturnValue({
+      subscription: { enabled: false, stages: [] },
+      isSubscribed: false,
+      selectedStages: [],
+      stageOptions: [
+        { number: 1, label: "Escenario Norte", assigned: true },
+        { number: 2, label: "Escenario Sur", assigned: true },
+      ],
+      canChooseAnyStage: false,
+      isLoading: false,
+      isSaving: false,
+      error: null,
+      save: vi.fn().mockResolvedValue({ enabled: true, stages: [1, 2] }),
+    });
+  });
+
+  it("shows Spanish guidance when device push is inactive", async () => {
+    const user = userEvent.setup();
+    const onActivatePushClick = vi.fn();
+    pushStateMock.mockReturnValue({
+      subscription: null,
+      isInitializing: false,
+    });
+
+    renderButton(onActivatePushClick);
+
+    await user.click(screen.getByRole("button", { name: /feed de avisos del festival/i }));
+
+    expect(screen.getByText("Activa las notificaciones push en Perfil para suscribirte a este feed."))
+      .toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /ir a perfil/i }));
+    expect(onActivatePushClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves multiple selected stages", async () => {
+    const user = userEvent.setup();
+    const save = vi.fn().mockResolvedValue({ enabled: true, stages: [1, 2] });
+    feedStateMock.mockReturnValue({
+      subscription: { enabled: false, stages: [] },
+      isSubscribed: false,
+      selectedStages: [],
+      stageOptions: [
+        { number: 1, label: "Escenario Norte", assigned: true },
+        { number: 2, label: "Escenario Sur", assigned: true },
+      ],
+      canChooseAnyStage: true,
+      isLoading: false,
+      isSaving: false,
+      error: null,
+      save,
+    });
+
+    renderButton();
+
+    await user.click(screen.getByRole("button", { name: /feed de avisos del festival/i }));
+    await user.click(screen.getByText("Escenario Norte"));
+    await user.click(screen.getByText("Escenario Sur"));
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: /guardar/i }));
+
+    expect(save).toHaveBeenCalledWith({
+      enabled: true,
+      stages: [1, 2],
+    });
+  });
+});

--- a/src/components/festival/__tests__/FestivalPushFeedButton.test.tsx
+++ b/src/components/festival/__tests__/FestivalPushFeedButton.test.tsx
@@ -27,6 +27,24 @@ const renderButton = (onActivatePushClick = vi.fn()) =>
     </MemoryRouter>,
   );
 
+const defaultStageOptions = [
+  { number: 1, label: "Escenario Norte", assigned: true },
+  { number: 2, label: "Escenario Sur", assigned: true },
+];
+
+const createFeedState = (overrides = {}) => ({
+  subscription: { enabled: false, stages: [] as number[] },
+  isSubscribed: false,
+  selectedStages: [] as number[],
+  stageOptions: defaultStageOptions.map((stage) => ({ ...stage })),
+  canChooseAnyStage: false,
+  isLoading: false,
+  isSaving: false,
+  error: null as Error | null,
+  save: vi.fn().mockResolvedValue({ enabled: true, stages: [1, 2] }),
+  ...overrides,
+});
+
 describe("FestivalPushFeedButton", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,20 +52,7 @@ describe("FestivalPushFeedButton", () => {
       subscription: { endpoint: "https://push.example/sub" },
       isInitializing: false,
     });
-    feedStateMock.mockReturnValue({
-      subscription: { enabled: false, stages: [] },
-      isSubscribed: false,
-      selectedStages: [],
-      stageOptions: [
-        { number: 1, label: "Escenario Norte", assigned: true },
-        { number: 2, label: "Escenario Sur", assigned: true },
-      ],
-      canChooseAnyStage: false,
-      isLoading: false,
-      isSaving: false,
-      error: null,
-      save: vi.fn().mockResolvedValue({ enabled: true, stages: [1, 2] }),
-    });
+    feedStateMock.mockImplementation(() => createFeedState());
   });
 
   it("shows Spanish guidance when device push is inactive", async () => {
@@ -72,20 +77,7 @@ describe("FestivalPushFeedButton", () => {
   it("saves multiple selected stages", async () => {
     const user = userEvent.setup();
     const save = vi.fn().mockResolvedValue({ enabled: true, stages: [1, 2] });
-    feedStateMock.mockReturnValue({
-      subscription: { enabled: false, stages: [] },
-      isSubscribed: false,
-      selectedStages: [],
-      stageOptions: [
-        { number: 1, label: "Escenario Norte", assigned: true },
-        { number: 2, label: "Escenario Sur", assigned: true },
-      ],
-      canChooseAnyStage: true,
-      isLoading: false,
-      isSaving: false,
-      error: null,
-      save,
-    });
+    feedStateMock.mockImplementation(() => createFeedState({ canChooseAnyStage: true, save }));
 
     renderButton();
 
@@ -98,6 +90,31 @@ describe("FestivalPushFeedButton", () => {
     expect(save).toHaveBeenCalledWith({
       enabled: true,
       stages: [1, 2],
+    });
+  });
+
+  it("keeps draft stage choices when the hook returns fresh references", async () => {
+    const user = userEvent.setup();
+    const save = vi.fn().mockResolvedValue({ enabled: true, stages: [1] });
+    feedStateMock.mockImplementation(() => createFeedState({ canChooseAnyStage: true, save }));
+
+    const view = renderButton();
+
+    await user.click(screen.getByRole("button", { name: /feed de avisos del festival/i }));
+    await user.click(screen.getByText("Escenario Norte"));
+
+    view.rerender(
+      <MemoryRouter>
+        <FestivalPushFeedButton jobId="job-1" />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: /guardar/i }));
+
+    expect(save).toHaveBeenCalledWith({
+      enabled: true,
+      stages: [1],
     });
   });
 });

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -430,6 +430,14 @@ export function TechnicianArtistReadOnlyModal({
     }));
   }, [artists, stageNames]);
 
+  useEffect(() => {
+    if (artistsLoading) return;
+    if (selectedStage === "all") return;
+    if (!stageOptions.some((option) => option.value === selectedStage)) {
+      setSelectedStage("all");
+    }
+  }, [artistsLoading, selectedStage, stageOptions]);
+
   const stageFilteredArtists = useMemo(() => {
     if (selectedStage === "all") return artists;
     return artists.filter((artist) => String(artist.stage) === selectedStage);
@@ -448,11 +456,12 @@ export function TechnicianArtistReadOnlyModal({
   }, [stageFilteredArtists]);
 
   useEffect(() => {
+    if (artistsLoading) return;
     if (selectedDay === "all") return;
     if (!dayOptions.some((option) => option.value === selectedDay)) {
       setSelectedDay("all");
     }
-  }, [dayOptions, selectedDay]);
+  }, [artistsLoading, dayOptions, selectedDay]);
 
   const filteredArtists = useMemo(() => {
     if (selectedDay === "all") return stageFilteredArtists;

--- a/src/components/technician/TechnicianArtistReadOnlyModal.tsx
+++ b/src/components/technician/TechnicianArtistReadOnlyModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { format, parseISO } from "date-fns";
 import { es } from "date-fns/locale";
@@ -33,6 +33,9 @@ type TechnicianArtistReadOnlyModalProps = {
     title?: string;
   };
   onClose: () => void;
+  initialDate?: string | null;
+  initialStage?: string | null;
+  headerAction?: ReactNode;
 };
 
 type ReadOnlyArtist = {
@@ -170,9 +173,12 @@ export function TechnicianArtistReadOnlyModal({
   isDark,
   job,
   onClose,
+  initialDate,
+  initialStage,
+  headerAction,
 }: TechnicianArtistReadOnlyModalProps) {
-  const [selectedStage, setSelectedStage] = useState<string>("all");
-  const [selectedDay, setSelectedDay] = useState<string>("all");
+  const [selectedStage, setSelectedStage] = useState<string>(initialStage || "all");
+  const [selectedDay, setSelectedDay] = useState<string>(initialDate || "all");
   const [filtersOpen, setFiltersOpen] = useState<boolean>(false);
   const [stagePlotUrls, setStagePlotUrls] = useState<Record<string, string>>({});
   const [riderFilesByArtistId, setRiderFilesByArtistId] = useState<Record<string, MobileArtistRiderFile[]>>({});
@@ -244,6 +250,14 @@ export function TechnicianArtistReadOnlyModal({
     () => Object.fromEntries(festivalStages.map((stage) => [stage.number, stage.name])) as Record<number, string>,
     [festivalStages],
   );
+
+  useEffect(() => {
+    if (initialStage) setSelectedStage(initialStage);
+  }, [initialStage]);
+
+  useEffect(() => {
+    if (initialDate) setSelectedDay(initialDate);
+  }, [initialDate]);
 
   useEffect(() => {
     let cancelled = false;
@@ -487,6 +501,7 @@ export function TechnicianArtistReadOnlyModal({
             </h2>
           </div>
           <div className="flex items-center gap-1 shrink-0">
+            {headerAction}
             <FestivalOfflineControls jobId={job?.id} canEdit={canEditJobs(userRole)} />
             <button
               onClick={onClose}

--- a/src/hooks/festival/useFestivalPushSubscription.ts
+++ b/src/hooks/festival/useFestivalPushSubscription.ts
@@ -1,0 +1,205 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
+import { queryKeys } from "@/lib/react-query";
+import { dataLayerClient } from "@/services/dataLayerClient";
+
+export type FestivalPushStageOption = {
+  number: number;
+  label: string;
+  assigned: boolean;
+};
+
+type FestivalPushSubscriptionRow = {
+  id: string;
+  user_id: string;
+  job_id: string;
+  enabled: boolean;
+  stages: number[];
+};
+
+type SaveFestivalPushSubscriptionInput = {
+  enabled: boolean;
+  stages: number[];
+};
+
+const isManagementSubscriber = (role: string | null | undefined) =>
+  role === "admin" || role === "management";
+
+const normalizeStages = (stages: number[]) =>
+  Array.from(new Set(stages.filter((stage) => Number.isInteger(stage) && stage > 0)))
+    .sort((left, right) => left - right);
+
+export const useFestivalPushSubscription = (jobId?: string) => {
+  const { user, userRole } = useOptimizedAuth();
+  const queryClient = useQueryClient();
+  const canChooseAnyStage = isManagementSubscriber(userRole);
+
+  const subscriptionKey = queryKeys.scope("festival-push-subscription", jobId, user?.id);
+  const stagesKey = queryKeys.scope("festival-push-stages", jobId, user?.id, userRole);
+
+  const subscriptionQuery = useQuery({
+    queryKey: subscriptionKey,
+    queryFn: async (): Promise<FestivalPushSubscriptionRow | null> => {
+      if (!jobId || !user?.id) return null;
+
+      const { data, error } = await dataLayerClient
+        .from("festival_push_subscriptions")
+        .select("id, user_id, job_id, enabled, stages")
+        .eq("job_id", jobId)
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      if (error) throw error;
+      return data ?? null;
+    },
+    enabled: Boolean(jobId && user?.id),
+  });
+
+  const stagesQuery = useQuery({
+    queryKey: stagesKey,
+    queryFn: async (): Promise<FestivalPushStageOption[]> => {
+      if (!jobId || !user?.id) return [];
+
+      const [stageRows, gearRows, artistRows, shiftRows] = await Promise.all([
+        dataLayerClient
+          .from("festival_stages")
+          .select("number, name")
+          .eq("job_id", jobId),
+        dataLayerClient
+          .from("festival_gear_setups")
+          .select("max_stages")
+          .eq("job_id", jobId)
+          .order("created_at", { ascending: false })
+          .limit(1),
+        dataLayerClient
+          .from("festival_artists")
+          .select("stage")
+          .eq("job_id", jobId)
+          .not("stage", "is", null),
+        dataLayerClient
+          .from("festival_shifts")
+          .select("id, stage")
+          .eq("job_id", jobId),
+      ]);
+
+      if (stageRows.error) throw stageRows.error;
+      if (gearRows.error) throw gearRows.error;
+      if (artistRows.error) throw artistRows.error;
+      if (shiftRows.error) throw shiftRows.error;
+
+      const labels = new Map<number, string>();
+      const stageNumbers = new Set<number>();
+
+      for (const stage of stageRows.data ?? []) {
+        if (typeof stage.number !== "number") continue;
+        stageNumbers.add(stage.number);
+        labels.set(stage.number, stage.name || `Escenario ${stage.number}`);
+      }
+
+      const maxStages = gearRows.data?.[0]?.max_stages ?? 0;
+      for (let stage = 1; stage <= maxStages; stage += 1) {
+        stageNumbers.add(stage);
+      }
+
+      for (const artist of artistRows.data ?? []) {
+        if (typeof artist.stage === "number") stageNumbers.add(artist.stage);
+      }
+
+      const shiftIdToStage = new Map<string, number>();
+      for (const shift of shiftRows.data ?? []) {
+        if (shift.id && typeof shift.stage === "number") {
+          shiftIdToStage.set(shift.id, shift.stage);
+          stageNumbers.add(shift.stage);
+        }
+      }
+
+      let assignedStages = new Set<number>();
+      if (!canChooseAnyStage && shiftIdToStage.size > 0) {
+        const { data, error } = await dataLayerClient
+          .from("festival_shift_assignments")
+          .select("shift_id")
+          .eq("technician_id", user.id)
+          .in("shift_id", Array.from(shiftIdToStage.keys()));
+
+        if (error) throw error;
+
+        assignedStages = new Set(
+          (data ?? [])
+            .map((assignment) => assignment.shift_id ? shiftIdToStage.get(assignment.shift_id) : undefined)
+            .filter((stage): stage is number => typeof stage === "number"),
+        );
+      }
+
+      const effectiveStages = canChooseAnyStage ? stageNumbers : assignedStages;
+
+      return Array.from(effectiveStages)
+        .sort((left, right) => left - right)
+        .map((stageNumber) => ({
+          number: stageNumber,
+          label: labels.get(stageNumber) || `Escenario ${stageNumber}`,
+          assigned: assignedStages.has(stageNumber),
+        }));
+    },
+    enabled: Boolean(jobId && user?.id),
+  });
+
+  const selectableStageNumbers = useMemo(
+    () => new Set((stagesQuery.data ?? []).map((stage) => stage.number)),
+    [stagesQuery.data],
+  );
+
+  const saveMutation = useMutation({
+    mutationFn: async ({ enabled, stages }: SaveFestivalPushSubscriptionInput) => {
+      if (!jobId || !user?.id) throw new Error("No se pudo identificar el festival o el usuario.");
+
+      const normalizedStages = normalizeStages(stages)
+        .filter((stage) => selectableStageNumbers.has(stage));
+
+      if (enabled && normalizedStages.length === 0) {
+        throw new Error("Selecciona al menos un escenario para activar el feed.");
+      }
+
+      const { data, error } = await dataLayerClient
+        .from("festival_push_subscriptions")
+        .upsert(
+          {
+            user_id: user.id,
+            job_id: jobId,
+            enabled,
+            stages: normalizedStages,
+          },
+          { onConflict: "user_id,job_id" },
+        )
+        .select("id, user_id, job_id, enabled, stages")
+        .single();
+
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: async (row) => {
+      queryClient.setQueryData(subscriptionKey, row);
+      await queryClient.invalidateQueries({ queryKey: subscriptionKey });
+      toast.success(row.enabled ? "Feed de avisos activado" : "Feed de avisos pausado");
+    },
+    onError: (error) => {
+      toast.error("No se pudo guardar el feed", {
+        description: error instanceof Error ? error.message : "Inténtalo de nuevo.",
+      });
+    },
+  });
+
+  return {
+    subscription: subscriptionQuery.data ?? null,
+    isSubscribed: Boolean(subscriptionQuery.data?.enabled && (subscriptionQuery.data.stages ?? []).length > 0),
+    selectedStages: normalizeStages(subscriptionQuery.data?.stages ?? []),
+    stageOptions: stagesQuery.data ?? [],
+    canChooseAnyStage,
+    isLoading: subscriptionQuery.isLoading || stagesQuery.isLoading,
+    isSaving: saveMutation.isPending,
+    error: subscriptionQuery.error || stagesQuery.error,
+    save: saveMutation.mutateAsync,
+  };
+};

--- a/src/hooks/festival/useFestivalPushSubscription.ts
+++ b/src/hooks/festival/useFestivalPushSubscription.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { queryKeys } from "@/lib/react-query";
 import { dataLayerClient } from "@/services/dataLayerClient";
+import { normalizeFestivalStages } from "@/utils/festivalPushStages";
 
 export type FestivalPushStageOption = {
   number: number;
@@ -27,10 +28,6 @@ type SaveFestivalPushSubscriptionInput = {
 
 const isManagementSubscriber = (role: string | null | undefined) =>
   role === "admin" || role === "management";
-
-const normalizeStages = (stages: number[]) =>
-  Array.from(new Set(stages.filter((stage) => Number.isInteger(stage) && stage > 0)))
-    .sort((left, right) => left - right);
 
 export const useFestivalPushSubscription = (jobId?: string) => {
   const { user, userRole } = useOptimizedAuth();
@@ -155,7 +152,7 @@ export const useFestivalPushSubscription = (jobId?: string) => {
     mutationFn: async ({ enabled, stages }: SaveFestivalPushSubscriptionInput) => {
       if (!jobId || !user?.id) throw new Error("No se pudo identificar el festival o el usuario.");
 
-      const normalizedStages = normalizeStages(stages)
+      const normalizedStages = normalizeFestivalStages(stages)
         .filter((stage) => selectableStageNumbers.has(stage));
 
       if (enabled && normalizedStages.length === 0) {
@@ -194,7 +191,7 @@ export const useFestivalPushSubscription = (jobId?: string) => {
   return {
     subscription: subscriptionQuery.data ?? null,
     isSubscribed: Boolean(subscriptionQuery.data?.enabled && (subscriptionQuery.data.stages ?? []).length > 0),
-    selectedStages: normalizeStages(subscriptionQuery.data?.stages ?? []),
+    selectedStages: normalizeFestivalStages(subscriptionQuery.data?.stages ?? []),
     stageOptions: stagesQuery.data ?? [],
     canChooseAnyStage,
     isLoading: subscriptionQuery.isLoading || stagesQuery.isLoading,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1872,6 +1872,130 @@ export type Database = {
           },
         ]
       }
+      festival_push_delivery_log: {
+        Row: {
+          created_at: string
+          due_at: string
+          event_key: string
+          event_kind: string
+          id: string
+          job_id: string
+          payload: Json
+          sent_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          due_at: string
+          event_key: string
+          event_kind: string
+          id?: string
+          job_id: string
+          payload?: Json
+          sent_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          due_at?: string
+          event_key?: string
+          event_kind?: string
+          id?: string
+          job_id?: string
+          payload?: Json
+          sent_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "festival_push_delivery_log_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "festival_push_delivery_log_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "v_job_staffing_summary"
+            referencedColumns: ["job_id"]
+          },
+          {
+            foreignKeyName: "festival_push_delivery_log_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "festival_push_delivery_log_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      festival_push_subscriptions: {
+        Row: {
+          created_at: string
+          enabled: boolean
+          id: string
+          job_id: string
+          stages: number[]
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          enabled?: boolean
+          id?: string
+          job_id: string
+          stages?: number[]
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          enabled?: boolean
+          id?: string
+          job_id?: string
+          stages?: number[]
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "festival_push_subscriptions_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "festival_push_subscriptions_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "v_job_staffing_summary"
+            referencedColumns: ["job_id"]
+          },
+          {
+            foreignKeyName: "festival_push_subscriptions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "festival_push_subscriptions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "wallboard_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       festival_gear_setups: {
         Row: {
           available_analog_runs: number | null

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -30,6 +30,7 @@ import { useFestivalArtistJobDetails } from "@/hooks/festival/useFestivalArtistJ
 import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
 import { FestivalOfflineBanner } from "@/components/festival/FestivalOfflineBanner";
 import { ArtistPageActions } from "@/components/festival/ArtistPageActions";
+import { FestivalPushFeedButton } from "@/components/festival/FestivalPushFeedButton";
 const DAY_START_HOUR = 7; // Festival day starts at 7:00 AM
 
 const FestivalArtistManagement = () => {
@@ -40,11 +41,13 @@ const FestivalArtistManagement = () => {
   const { userRole } = useOptimizedAuth();
   const artistActionPermissions = { canDelete: canDeleteFestivalArtists(userRole), canCreateExtras: canCreateFestivalArtistExtras(userRole) };
   const routeDate = searchParams.get("date") || "";
+  const routeStage = searchParams.get("stage") || "all";
+  const normalizedRouteStage = routeStage && routeStage !== "all" ? routeStage : "all";
   
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [selectedArtist, setSelectedArtist] = useState<any>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const [stageFilter, setStageFilter] = useState("all");
+  const [stageFilter, setStageFilter] = useState(normalizedRouteStage);
   const [riderFilter, setRiderFilter] = useState("all");
   const [isPrintDialogOpen, setIsPrintDialogOpen] = useState(false);
   const [isPrinting, setIsPrinting] = useState(false);
@@ -226,6 +229,26 @@ const FestivalArtistManagement = () => {
       return nextParams;
     }, { replace: true });
   }, [selectedDate, setSearchParams]);
+
+  useEffect(() => {
+    setStageFilter((current) => (current === normalizedRouteStage ? current : normalizedRouteStage));
+  }, [normalizedRouteStage]);
+
+  useEffect(() => {
+    setSearchParams((previousParams) => {
+      const currentStage = previousParams.get("stage") || "all";
+      if (currentStage === stageFilter || (!previousParams.has("stage") && stageFilter === "all")) {
+        return previousParams;
+      }
+      const nextParams = new URLSearchParams(previousParams);
+      if (stageFilter === "all") {
+        nextParams.delete("stage");
+      } else {
+        nextParams.set("stage", stageFilter);
+      }
+      return nextParams;
+    }, { replace: true });
+  }, [stageFilter, setSearchParams]);
 
   const { data: logoData } = useQuery({
     queryKey: queryKeys.scope('festival-logo', jobId),
@@ -603,6 +626,7 @@ const FestivalArtistManagement = () => {
           <h1 className="text-xl md:text-2xl font-bold truncate">{jobTitle}</h1>
           <div className="flex items-center gap-2">
             <FestivalOfflineControls jobId={jobId} canEdit={canEditJobs(userRole)} />
+            <FestivalPushFeedButton jobId={jobId} />
             <ConnectionIndicator />
           </div>
         </div>

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -31,6 +31,7 @@ import { SoundVisionModal } from '@/components/technician/SoundVisionModal';
 import { TechnicianTourRates } from '@/components/dashboard/TechnicianTourRates';
 import { TechnicianArtistReadOnlyModal } from '@/components/technician/TechnicianArtistReadOnlyModal';
 import { TechnicianRfTableModal } from '@/components/technician/TechnicianRfTableModal';
+import { FestivalPushFeedButton } from '@/components/festival/FestivalPushFeedButton';
 
 // Type definitions
 interface TechnicianJobData {
@@ -397,6 +398,13 @@ const TechnicianDashboard = () => {
           isDark={isDark}
           job={selectedJob}
           onClose={() => setActiveModal(null)}
+          headerAction={
+            <FestivalPushFeedButton
+              jobId={selectedJob.id}
+              compact
+              onActivatePushClick={() => setTab('profile')}
+            />
+          }
         />
       )}
       {activeModal === 'rf-table' && selectedJob && (

--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useTheme } from 'next-themes';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
@@ -57,6 +57,7 @@ import { DetailsModal } from '@/components/technician/DetailsModal';
 import { AboutModal } from '@/components/technician/AboutModal';
 import { TechnicianArtistReadOnlyModal } from '@/components/technician/TechnicianArtistReadOnlyModal';
 import { TechnicianRfTableModal } from '@/components/technician/TechnicianRfTableModal';
+import { FestivalPushFeedButton } from '@/components/festival/FestivalPushFeedButton';
 import type { JobWithLocationAndDocs } from '@/types/job';
 
 
@@ -140,6 +141,8 @@ export default function TechnicianSuperApp() {
   const [showRatesModal, setShowRatesModal] = useState(false);
   const [showMessagesModal, setShowMessagesModal] = useState(false);
   const [showAboutModal, setShowAboutModal] = useState(false);
+  const [artistDeepLinkFilters, setArtistDeepLinkFilters] = useState<{ date?: string; stage?: string }>({});
+  const handledArtistDeepLinkRef = useRef<string | null>(null);
 
   // Handle deeplink to open About modal via URL param
   useEffect(() => {
@@ -150,6 +153,13 @@ export default function TechnicianSuperApp() {
       setSearchParams(searchParams, { replace: true });
     }
   }, [searchParams, setSearchParams]);
+
+  useEffect(() => {
+    const routeTab = searchParams.get('tab');
+    if (routeTab && ['dashboard', 'jobs', 'availability', 'profile'].includes(routeTab)) {
+      setTab(routeTab);
+    }
+  }, [searchParams]);
 
   // Set up real-time subscriptions
   useTechnicianDashboardSubscriptions();
@@ -342,8 +352,145 @@ export default function TechnicianSuperApp() {
 
   const handleOpenAction = (action: string, jobData?: TechnicianJobData) => {
     // TechJobCard already extracts job data before calling onAction
+    if (action === 'artists') {
+      setArtistDeepLinkFilters({});
+    }
     setSelectedJob(jobData || null);
     setActiveModal(action);
+  };
+
+  useEffect(() => {
+    const openTarget = searchParams.get('open');
+    const jobIdParam = searchParams.get('jobId');
+    if (openTarget !== 'artists' || !jobIdParam || !user?.id || isLoading) return;
+
+    const dateParam = searchParams.get('date') || undefined;
+    const stageParam = searchParams.get('stage') || undefined;
+    const deepLinkKey = `${jobIdParam}:${dateParam || ''}:${stageParam || ''}`;
+    if (handledArtistDeepLinkRef.current === deepLinkKey) return;
+
+    let cancelled = false;
+
+    const openArtistModal = async () => {
+      const assignedJob = (assignments as TechnicianAssignment[]).find(
+        (assignment) => assignment.job_id === jobIdParam || assignment.jobs?.id === jobIdParam,
+      );
+
+      if (assignedJob?.jobs) {
+        if (cancelled) return;
+        setSelectedJob(assignedJob.jobs);
+        setArtistDeepLinkFilters({ date: dateParam, stage: stageParam });
+        setActiveModal('artists');
+        handledArtistDeepLinkRef.current = deepLinkKey;
+        return;
+      }
+
+      const { data: shifts, error: shiftsError } = await dataLayerClient
+        .from('festival_shifts')
+        .select('id')
+        .eq('job_id', jobIdParam);
+
+      if (shiftsError) {
+        console.error('Error resolving festival artist deep link shifts:', shiftsError);
+        return;
+      }
+
+      const shiftIds = (shifts || []).map((shift) => shift.id).filter(Boolean);
+      if (shiftIds.length === 0) {
+        toast.error('No tienes acceso a los artistas de este festival');
+        handledArtistDeepLinkRef.current = deepLinkKey;
+        return;
+      }
+
+      const { data: shiftAssignments, error: assignmentError } = await dataLayerClient
+        .from('festival_shift_assignments')
+        .select('shift_id')
+        .eq('technician_id', user.id)
+        .in('shift_id', shiftIds)
+        .limit(1);
+
+      if (assignmentError) {
+        console.error('Error resolving festival artist deep link assignments:', assignmentError);
+        return;
+      }
+
+      if (!shiftAssignments || shiftAssignments.length === 0) {
+        toast.error('No tienes acceso a los artistas de este festival');
+        handledArtistDeepLinkRef.current = deepLinkKey;
+        return;
+      }
+
+      const { data: jobData, error: jobError } = await dataLayerClient
+        .from('jobs')
+        .select(`
+          id,
+          title,
+          description,
+          start_time,
+          end_time,
+          created_at,
+          timezone,
+          location_id,
+          job_type,
+          color,
+          status,
+          preventive_resource_technician_id,
+          location:locations(name),
+          job_date_types(date, type),
+          job_documents(
+            id,
+            file_name,
+            file_path,
+            visible_to_tech,
+            uploaded_at,
+            read_only,
+            template_type
+          )
+        `)
+        .eq('id', jobIdParam)
+        .maybeSingle();
+
+      if (jobError || !jobData) {
+        console.error('Error resolving festival artist deep link job:', jobError);
+        toast.error('No se pudo abrir el festival');
+        handledArtistDeepLinkRef.current = deepLinkKey;
+        return;
+      }
+
+      if (cancelled) return;
+
+      const resolvedJob = {
+        ...jobData,
+        created_at: jobData.created_at || '',
+        job_type: jobData.job_type || 'festival',
+        artist_count: 0,
+      } as TechnicianJobData;
+
+      setSelectedJob(resolvedJob);
+      setArtistDeepLinkFilters({ date: dateParam, stage: stageParam });
+      setActiveModal('artists');
+      handledArtistDeepLinkRef.current = deepLinkKey;
+    };
+
+    void openArtistModal();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [assignments, isLoading, searchParams, user?.id]);
+
+  const closeArtistsModal = () => {
+    setActiveModal(null);
+    setArtistDeepLinkFilters({});
+
+    if (searchParams.get('open') === 'artists') {
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.delete('open');
+      nextParams.delete('jobId');
+      nextParams.delete('date');
+      nextParams.delete('stage');
+      setSearchParams(nextParams, { replace: true });
+    }
   };
 
   const userName = userProfile?.first_name && userProfile?.last_name
@@ -437,7 +584,16 @@ export default function TechnicianSuperApp() {
           theme={t}
           isDark={isDark}
           job={selectedJob}
-          onClose={() => setActiveModal(null)}
+          onClose={closeArtistsModal}
+          initialDate={artistDeepLinkFilters.date}
+          initialStage={artistDeepLinkFilters.stage}
+          headerAction={
+            <FestivalPushFeedButton
+              jobId={selectedJob.id}
+              compact
+              onActivatePushClick={() => setTab('profile')}
+            />
+          }
         />
       )}
       {activeModal === 'rf-table' && selectedJob && (

--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -390,8 +390,11 @@ export default function TechnicianSuperApp() {
         .select('id')
         .eq('job_id', jobIdParam);
 
+      if (cancelled) return;
+
       if (shiftsError) {
         console.error('Error resolving festival artist deep link shifts:', shiftsError);
+        handledArtistDeepLinkRef.current = deepLinkKey;
         return;
       }
 
@@ -409,8 +412,11 @@ export default function TechnicianSuperApp() {
         .in('shift_id', shiftIds)
         .limit(1);
 
+      if (cancelled) return;
+
       if (assignmentError) {
         console.error('Error resolving festival artist deep link assignments:', assignmentError);
+        handledArtistDeepLinkRef.current = deepLinkKey;
         return;
       }
 
@@ -450,14 +456,14 @@ export default function TechnicianSuperApp() {
         .eq('id', jobIdParam)
         .maybeSingle();
 
+      if (cancelled) return;
+
       if (jobError || !jobData) {
         console.error('Error resolving festival artist deep link job:', jobError);
         toast.error('No se pudo abrir el festival');
         handledArtistDeepLinkRef.current = deepLinkKey;
         return;
       }
-
-      if (cancelled) return;
 
       const resolvedJob = {
         ...jobData,
@@ -482,6 +488,7 @@ export default function TechnicianSuperApp() {
   const closeArtistsModal = () => {
     setActiveModal(null);
     setArtistDeepLinkFilters({});
+    handledArtistDeepLinkRef.current = null;
 
     if (searchParams.get('open') === 'artists') {
       const nextParams = new URLSearchParams(searchParams);

--- a/src/pages/__tests__/FestivalArtistManagement.stage.test.tsx
+++ b/src/pages/__tests__/FestivalArtistManagement.stage.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+import { renderWithProviders } from "@/test/renderWithProviders";
+import FestivalArtistManagement from "../FestivalArtistManagement";
+
+const { useOptimizedAuthMock } = vi.hoisted(() => ({
+  useOptimizedAuthMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/useOptimizedAuth", () => ({
+  useOptimizedAuth: () => useOptimizedAuthMock(),
+}));
+
+vi.mock("@/lib/enhanced-supabase-client", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: mockSupabase,
+}));
+
+vi.mock("@/hooks/useRealtimeSubscription", () => ({
+  useRealtimeSubscription: vi.fn(),
+}));
+
+vi.mock("@/hooks/useArtistsQuery", () => ({
+  useArtistsQuery: () => ({
+    artists: [] as unknown[],
+    isLoading: false,
+    deleteArtist: vi.fn(),
+    invalidateArtists: vi.fn(),
+    isOfflineData: false,
+  }),
+}));
+
+vi.mock("@/hooks/festival/useFestivalArtistJobDetails", () => ({
+  useFestivalArtistJobDetails: () => ({
+    jobTitle: "Festival Uno",
+    jobDates: [new Date("2026-07-03T00:00:00Z")],
+    selectedDate: "2026-07-03",
+    setSelectedDate: vi.fn(),
+    maxStages: 4,
+  }),
+}));
+
+vi.mock("@/components/festival/FestivalDateNavigation", () => ({
+  FestivalDateNavigation: ({
+    selectedStage,
+    onStageChange,
+  }: {
+    selectedStage: string;
+    onStageChange: (stage: string) => void;
+  }) => (
+    <div>
+      <div data-testid="selected-stage">{selectedStage}</div>
+      <button type="button" onClick={() => onStageChange("3")}>
+        Cambiar a stage 3
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/festival/FestivalOfflineControls", () => ({
+  FestivalOfflineControls: (): null => null,
+}));
+
+vi.mock("@/components/festival/FestivalPushFeedButton", () => ({
+  FestivalPushFeedButton: (): null => null,
+}));
+
+vi.mock("@/components/ui/connection-indicator", () => ({
+  ConnectionIndicator: (): null => null,
+}));
+
+vi.mock("@/components/festival/ArtistPageActions", () => ({
+  ArtistPageActions: (): null => null,
+}));
+
+vi.mock("@/components/festival/ArtistTable", () => ({
+  ArtistTable: (): null => null,
+}));
+
+vi.mock("@/components/festival/ArtistTableFilters", () => ({
+  ArtistTableFilters: (): null => null,
+}));
+
+vi.mock("@/components/festival/FestivalOfflineBanner", () => ({
+  FestivalOfflineBanner: (): null => null,
+}));
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="location-probe">{location.pathname}{location.search}</div>;
+};
+
+describe("FestivalArtistManagement stage query sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    useOptimizedAuthMock.mockReturnValue({ userRole: "management" });
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "festival_settings") {
+        return createMockQueryBuilder({ data: { day_start_time: "07:00" }, error: null });
+      }
+      if (table === "job_date_types") {
+        return createMockQueryBuilder({ data: [{ date: "2026-07-03", type: "show" }], error: null });
+      }
+      if (table === "festival_stages") {
+        return createMockQueryBuilder({ data: [{ number: 2, name: "Escenario Norte" }], error: null });
+      }
+      if (table === "festival_logos") {
+        return createMockQueryBuilder({ data: null, error: null });
+      }
+      return createMockQueryBuilder();
+    });
+  });
+
+  it("initializes from stage query param and writes stage changes back to the URL", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <>
+        <Routes>
+          <Route path="/festival-management/:jobId/artists" element={<FestivalArtistManagement />} />
+        </Routes>
+        <LocationProbe />
+      </>,
+      { route: "/festival-management/job-1/artists?date=2026-07-03&stage=2" },
+    );
+
+    expect(await screen.findByTestId("selected-stage")).toHaveTextContent("2");
+
+    await user.click(screen.getByRole("button", { name: /cambiar a stage 3/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location-probe")).toHaveTextContent("stage=3");
+      expect(screen.getByTestId("location-probe")).toHaveTextContent("date=2026-07-03");
+    });
+  });
+});

--- a/src/pages/__tests__/TechnicianSuperApp.test.tsx
+++ b/src/pages/__tests__/TechnicianSuperApp.test.tsx
@@ -102,11 +102,27 @@ vi.mock("@/components/technician/DetailsModal", () => ({
 }));
 
 vi.mock("@/components/technician/TechnicianArtistReadOnlyModal", () => ({
-  TechnicianArtistReadOnlyModal: (): null => null,
+  TechnicianArtistReadOnlyModal: ({
+    job,
+    initialDate,
+    initialStage,
+  }: {
+    job: { id: string; title?: string };
+    initialDate?: string;
+    initialStage?: string;
+  }) => (
+    <div data-testid="artist-modal">
+      Artistas {job.id} {initialDate} {initialStage}
+    </div>
+  ),
 }));
 
 vi.mock("@/components/technician/TechnicianRfTableModal", () => ({
   TechnicianRfTableModal: (): null => null,
+}));
+
+vi.mock("@/components/festival/FestivalPushFeedButton", () => ({
+  FestivalPushFeedButton: (): null => null,
 }));
 
 vi.mock("@/components/incident-reports/TechnicianIncidentReportDialog", () => ({
@@ -274,5 +290,46 @@ describe("TechnicianSuperApp", () => {
     expect(setThemeMock).toHaveBeenCalledWith("dark");
     expect(window.localStorage.getItem(APP_THEME_STORAGE_KEY)).toBe("dark");
     expect(window.localStorage.getItem("theme-preference")).toBe("dark");
+  });
+
+  it("opens technician artist deep links with date and stage filters", async () => {
+    const profileBuilder = createMockQueryBuilder({
+      data: createTechnicianProfile({ id: "technician-user", role: "technician", department: "sound" }),
+      error: null,
+    });
+    const assignmentBuilder = createMockQueryBuilder({
+      data: [],
+      error: null,
+    });
+    const shiftsBuilder = createMockQueryBuilder({
+      data: [{ id: "festival-shift-1" }],
+      error: null,
+    });
+    const shiftAssignmentsBuilder = createMockQueryBuilder({
+      data: [{ shift_id: "festival-shift-1" }],
+      error: null,
+    });
+    const jobBuilder = createMockQueryBuilder({
+      data: createJob({ id: "festival-job-1", title: "Festival Uno", job_type: "festival" }),
+      error: null,
+    });
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "profiles") return profileBuilder;
+      if (table === "job_assignments") return assignmentBuilder;
+      if (table === "festival_shifts") return shiftsBuilder;
+      if (table === "festival_shift_assignments") return shiftAssignmentsBuilder;
+      if (table === "jobs") return jobBuilder;
+      return createMockQueryBuilder();
+    });
+
+    renderWithProviders(<TechnicianSuperApp />, {
+      route: "/tech-app?open=artists&jobId=festival-job-1&date=2026-07-03&stage=2",
+    });
+
+    expect(await screen.findByTestId("artist-modal"))
+      .toHaveTextContent("Artistas festival-job-1 2026-07-03 2");
+    expect(shiftsBuilder.eq).toHaveBeenCalledWith("job_id", "festival-job-1");
+    expect(shiftAssignmentsBuilder.eq).toHaveBeenCalledWith("technician_id", "technician-user");
   });
 });

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -27,6 +27,7 @@ import {
 import createFolderIcon from "@/assets/icons/icon.png";
 import { FestivalLogoManager } from "@/components/festival/FestivalLogoManager";
 import { FestivalOfflineControls } from "@/components/festival/FestivalOfflineControls";
+import { FestivalPushFeedButton } from "@/components/festival/FestivalPushFeedButton";
 import { FestivalWeatherSection } from "@/components/festival/FestivalWeatherSection";
 import { TechnicianIncidentReportDialog } from "@/components/incident-reports/TechnicianIncidentReportDialog";
 import { CrewCallLinkerDialog } from "@/components/jobs/CrewCallLinker";
@@ -50,11 +51,9 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
     isSchedulingRoute,
     isArtistRoute,
     isGearRoute,
-
     venueData,
     mapPreviewUrl,
     isMapLoading,
-
     handlePrintButtonClick,
     isPrinting,
 
@@ -200,6 +199,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
             {/* Action Buttons */}
             <div className="flex flex-wrap gap-2 items-start">
               <FestivalOfflineControls jobId={jobId} canEdit={canEdit} />
+              <FestivalPushFeedButton jobId={jobId} />
               {canEdit && (
                 <>
                   <Button

--- a/src/utils/festivalPushStages.ts
+++ b/src/utils/festivalPushStages.ts
@@ -1,0 +1,3 @@
+export const normalizeFestivalStages = (stages: number[]) =>
+  Array.from(new Set(stages.filter((stage) => Number.isInteger(stage) && stage > 0)))
+    .sort((left, right) => left - right);

--- a/supabase/functions/push/__tests__/festivalFeedUtils.test.ts
+++ b/supabase/functions/push/__tests__/festivalFeedUtils.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAssignedStagesByUserJob,
+  buildAssignedUsersByShift,
+  buildFestivalFeedArtistEvents,
+  buildFestivalFeedPayload,
+  buildFestivalFeedShiftEvents,
+  buildFestivalFeedUrl,
+  isDueInWindow,
+  resolveArtistRecipients,
+  resolveShiftRecipients,
+  zonedDateTimeToUtc,
+  type FestivalFeedArtist,
+  type FestivalFeedShift,
+  type FestivalFeedShiftAssignment,
+  type FestivalFeedSubscription,
+} from "../festivalFeedUtils.ts";
+
+const artistBase: FestivalFeedArtist = {
+  id: "artist-1",
+  job_id: "job-1",
+  name: "La Banda",
+  date: "2026-07-03",
+  stage: 2,
+  show_start: "22:00:00",
+  soundcheck: true,
+  soundcheck_start: "18:00:00",
+  line_check: true,
+  line_check_start: "21:30:00",
+  timezone: "Europe/Madrid",
+  isaftermidnight: false,
+};
+
+describe("festival feed event generation", () => {
+  it("builds soundcheck, line check, and show artist moments with Spanish copy", () => {
+    const stageNames = new Map([["job-1:2", "Escenario Norte"]]);
+    const events = buildFestivalFeedArtistEvents([artistBase], stageNames);
+
+    expect(events).toHaveLength(6);
+    expect(events.map((event) => event.eventKind)).toEqual([
+      "soundcheck_15",
+      "soundcheck_now",
+      "linecheck_15",
+      "linecheck_now",
+      "show_15",
+      "show_now",
+    ]);
+    expect(events.find((event) => event.eventKind === "linecheck_15")).toMatchObject({
+      title: "Line check en 15 min",
+      body: "En 15 min empieza el line check de La Banda en Escenario Norte.",
+    });
+    expect(events.find((event) => event.eventKind === "show_15")?.body)
+      .toContain("Próximo artista en Escenario Norte");
+    expect(events[0].eventKey).toContain("artist:artist-1:soundcheck_15:");
+  });
+
+  it("uses Madrid timezone and moves line check/show after midnight to the next civil day", () => {
+    const events = buildFestivalFeedArtistEvents([
+      {
+        ...artistBase,
+        soundcheck_start: "20:00:00",
+        line_check_start: "00:30:00",
+        show_start: "01:00:00",
+        isaftermidnight: true,
+      },
+    ]);
+
+    expect(events.find((event) => event.eventKind === "soundcheck_now")?.dueAt.toISOString())
+      .toBe("2026-07-03T18:00:00.000Z");
+    expect(events.find((event) => event.eventKind === "linecheck_now")?.dueAt.toISOString())
+      .toBe("2026-07-03T22:30:00.000Z");
+    expect(events.find((event) => event.eventKind === "show_15")?.dueAt.toISOString())
+      .toBe("2026-07-03T22:45:00.000Z");
+    expect(events.find((event) => event.eventKind === "show_now")?.urlDate)
+      .toBe("2026-07-03");
+  });
+
+  it("builds shift start/end/ended moments across midnight", () => {
+    const shift: FestivalFeedShift = {
+      id: "shift-1",
+      job_id: "job-1",
+      date: "2026-07-03",
+      stage: 2,
+      name: "Turno escenario norte",
+      start_time: "23:30:00",
+      end_time: "01:30:00",
+    };
+
+    const events = buildFestivalFeedShiftEvents([shift], new Map([["job-1:2", "Escenario Norte"]]));
+
+    expect(events.map((event) => event.eventKind)).toEqual([
+      "shift_start_15",
+      "shift_end_15",
+      "shift_end_now",
+    ]);
+    expect(events.find((event) => event.eventKind === "shift_start_15")?.dueAt.toISOString())
+      .toBe("2026-07-03T21:15:00.000Z");
+    expect(events.find((event) => event.eventKind === "shift_end_now")?.dueAt.toISOString())
+      .toBe("2026-07-03T23:30:00.000Z");
+    expect(events.find((event) => event.eventKind === "shift_end_now")?.body)
+      .toBe("Tu turno ha acabado, muchas gracias por el trabajo y no olvides firmar tus horas.");
+  });
+
+  it("matches due events inside the scheduler tolerance window", () => {
+    const now = new Date("2026-07-03T20:00:00.000Z");
+    expect(isDueInWindow(new Date("2026-07-03T19:59:00.000Z"), now)).toBe(true);
+    expect(isDueInWindow(new Date("2026-07-03T20:00:04.000Z"), now)).toBe(true);
+    expect(isDueInWindow(new Date("2026-07-03T19:58:54.000Z"), now)).toBe(false);
+  });
+
+  it("converts Madrid local datetimes to UTC across summer time", () => {
+    expect(zonedDateTimeToUtc("2026-07-03", "18:00:00", "Europe/Madrid")?.toISOString())
+      .toBe("2026-07-03T16:00:00.000Z");
+  });
+});
+
+describe("festival feed recipient targeting", () => {
+  const subscriptions: FestivalFeedSubscription[] = [
+    { user_id: "admin-1", job_id: "job-1", enabled: true, stages: [2], role: "admin" },
+    { user_id: "manager-1", job_id: "job-1", enabled: true, stages: [2], role: "management" },
+    { user_id: "tech-1", job_id: "job-1", enabled: true, stages: [2], role: "technician" },
+    { user_id: "house-1", job_id: "job-1", enabled: true, stages: [2], role: "house_tech" },
+    { user_id: "tech-disabled", job_id: "job-1", enabled: false, stages: [2], role: "technician" },
+  ];
+
+  it("allows admin/management unassigned artist subscriptions but keeps technician/house_tech stage-strict", () => {
+    const [event] = buildFestivalFeedArtistEvents([artistBase]);
+    const assignments: FestivalFeedShiftAssignment[] = [
+      { shift_id: "shift-stage-2", technician_id: "tech-1" },
+      { shift_id: "shift-stage-1", technician_id: "house-1" },
+    ];
+    const shifts: FestivalFeedShift[] = [
+      {
+        id: "shift-stage-2",
+        job_id: "job-1",
+        date: "2026-07-03",
+        stage: 2,
+        name: "Stage 2",
+        start_time: "18:00:00",
+        end_time: "23:00:00",
+      },
+      {
+        id: "shift-stage-1",
+        job_id: "job-1",
+        date: "2026-07-03",
+        stage: 1,
+        name: "Stage 1",
+        start_time: "18:00:00",
+        end_time: "23:00:00",
+      },
+    ];
+
+    const recipients = resolveArtistRecipients(
+      event,
+      subscriptions,
+      buildAssignedStagesByUserJob(shifts, assignments),
+    );
+
+    expect(recipients.map((recipient) => recipient.user_id)).toEqual([
+      "admin-1",
+      "manager-1",
+      "tech-1",
+    ]);
+  });
+
+  it("sends shift reminders only to users assigned to the exact shift", () => {
+    const [event] = buildFestivalFeedShiftEvents([
+      {
+        id: "shift-1",
+        job_id: "job-1",
+        date: "2026-07-03",
+        stage: 2,
+        name: "Stage 2",
+        start_time: "18:00:00",
+        end_time: "23:00:00",
+      },
+    ]);
+    const assignments: FestivalFeedShiftAssignment[] = [
+      { shift_id: "shift-1", technician_id: "tech-1" },
+      { shift_id: "shift-1", technician_id: null },
+      { shift_id: "other-shift", technician_id: "admin-1" },
+    ];
+
+    const recipients = resolveShiftRecipients(
+      event,
+      subscriptions,
+      buildAssignedUsersByShift(assignments),
+    );
+
+    expect(recipients.map((recipient) => recipient.user_id)).toEqual(["tech-1"]);
+  });
+});
+
+describe("festival feed deep links", () => {
+  it("routes technicians through TechSuperApp with date and stage filters", () => {
+    expect(buildFestivalFeedUrl("technician", "job-1", "2026-07-03", 2))
+      .toBe("/tech-app?open=artists&jobId=job-1&date=2026-07-03&stage=2");
+  });
+
+  it("routes admin, management, and house tech through festival management artist filters", () => {
+    expect(buildFestivalFeedUrl("admin", "job-1", "2026-07-03", 2))
+      .toBe("/festival-management/job-1/artists?date=2026-07-03&stage=2");
+    expect(buildFestivalFeedUrl("house_tech", "job-1", "2026-07-03", 2))
+      .toBe("/festival-management/job-1/artists?date=2026-07-03&stage=2");
+  });
+
+  it("puts dedupe metadata in the payload", () => {
+    const [event] = buildFestivalFeedArtistEvents([artistBase]);
+    const payload = buildFestivalFeedPayload(event, {
+      user_id: "tech-1",
+      job_id: "job-1",
+      enabled: true,
+      stages: [2],
+      role: "technician",
+    });
+
+    expect(payload.meta).toMatchObject({
+      eventKey: event.eventKey,
+      eventKind: event.eventKind,
+      jobId: "job-1",
+      artistId: "artist-1",
+      stage: 2,
+    });
+  });
+});

--- a/supabase/functions/push/config.ts
+++ b/supabase/functions/push/config.ts
@@ -91,6 +91,7 @@ export const EVENT_TYPES = {
 
   // Scheduled notifications
   DAILY_MORNING_SUMMARY: 'daily.morning.summary',
+  FESTIVAL_FEED_TICK: 'festival.feed.tick',
 } as const;
 
 // Push notification configuration

--- a/supabase/functions/push/festivalFeed.ts
+++ b/supabase/functions/push/festivalFeed.ts
@@ -1,0 +1,287 @@
+import type { createClient } from "./deps.ts";
+import { EVENT_TYPES } from "./config.ts";
+import { jsonResponse } from "./http.ts";
+import { sendPayloadToUsers } from "./broadcast/delivery.ts";
+import type { PushPayload } from "./types.ts";
+import {
+  buildAssignedStagesByUserJob,
+  buildAssignedUsersByShift,
+  buildFestivalFeedArtistEvents,
+  buildFestivalFeedPayload,
+  buildFestivalFeedShiftEvents,
+  formatDateKeyInTimeZone,
+  addDaysToDateKey,
+  isDueInWindow,
+  resolveArtistRecipients,
+  resolveShiftRecipients,
+  type FestivalFeedArtist,
+  type FestivalFeedShift,
+  type FestivalFeedShiftAssignment,
+  type FestivalFeedSubscription,
+} from "./festivalFeedUtils.ts";
+
+type FestivalFeedClient = ReturnType<typeof createClient>;
+
+type FestivalPushSubscriptionRow = {
+  user_id: string;
+  job_id: string;
+  enabled: boolean;
+  stages: number[] | null;
+};
+
+type ProfileRoleRow = {
+  id: string;
+  role: string | null;
+};
+
+type FestivalStageRow = {
+  job_id: string | null;
+  number: number;
+  name: string;
+};
+
+type PostgrestErrorLike = {
+  code?: string;
+  message?: string;
+};
+
+const asErrorCode = (error: unknown): string | null => {
+  if (typeof error !== "object" || error === null) return null;
+  const candidate = error as PostgrestErrorLike;
+  return typeof candidate.code === "string" ? candidate.code : null;
+};
+
+const buildStageNames = (rows: FestivalStageRow[] | null | undefined): Map<string, string> => {
+  const stageNames = new Map<string, string>();
+  for (const row of rows ?? []) {
+    if (!row.job_id || typeof row.number !== "number") continue;
+    stageNames.set(`${row.job_id}:${row.number}`, row.name);
+    stageNames.set(String(row.number), row.name);
+  }
+  return stageNames;
+};
+
+const getTargetDateRange = (now: Date) => {
+  const today = formatDateKeyInTimeZone(now);
+  return {
+    start: addDaysToDateKey(today, -1),
+    end: addDaysToDateKey(today, 1),
+  };
+};
+
+const loadProfilesById = async (
+  client: FestivalFeedClient,
+  userIds: string[],
+): Promise<Map<string, string | null>> => {
+  if (userIds.length === 0) return new Map();
+
+  const { data, error } = await client
+    .from("profiles")
+    .select("id, role")
+    .in("id", userIds)
+    .returns<ProfileRoleRow[]>();
+
+  if (error) {
+    console.error("festival feed failed loading profile roles", error);
+    return new Map();
+  }
+
+  return new Map((data ?? []).map((row) => [row.id, row.role]));
+};
+
+const loadFestivalFeedData = async (
+  client: FestivalFeedClient,
+  jobIds: string[],
+  now: Date,
+) => {
+  const { start, end } = getTargetDateRange(now);
+
+  const [artistsResult, shiftsResult, stagesResult] = await Promise.all([
+    client
+      .from("festival_artists")
+      .select(
+        "id, job_id, name, date, stage, show_start, soundcheck, soundcheck_start, line_check, line_check_start, timezone, isaftermidnight",
+      )
+      .in("job_id", jobIds)
+      .gte("date", start)
+      .lte("date", end)
+      .returns<FestivalFeedArtist[]>(),
+    client
+      .from("festival_shifts")
+      .select("id, job_id, date, stage, name, start_time, end_time")
+      .in("job_id", jobIds)
+      .gte("date", start)
+      .lte("date", end)
+      .returns<FestivalFeedShift[]>(),
+    client
+      .from("festival_stages")
+      .select("job_id, number, name")
+      .in("job_id", jobIds)
+      .returns<FestivalStageRow[]>(),
+  ]);
+
+  if (artistsResult.error) {
+    throw new Error(`Failed to load festival artists: ${artistsResult.error.message}`);
+  }
+  if (shiftsResult.error) {
+    throw new Error(`Failed to load festival shifts: ${shiftsResult.error.message}`);
+  }
+  if (stagesResult.error) {
+    console.warn("festival feed failed loading stage names", stagesResult.error);
+  }
+
+  const shifts = shiftsResult.data ?? [];
+  const shiftIds = shifts.map((shift) => shift.id).filter(Boolean);
+  let assignments: FestivalFeedShiftAssignment[] = [];
+
+  if (shiftIds.length > 0) {
+    const { data, error } = await client
+      .from("festival_shift_assignments")
+      .select("shift_id, technician_id")
+      .in("shift_id", shiftIds)
+      .not("technician_id", "is", null)
+      .returns<FestivalFeedShiftAssignment[]>();
+
+    if (error) {
+      throw new Error(`Failed to load festival shift assignments: ${error.message}`);
+    }
+    assignments = data ?? [];
+  }
+
+  return {
+    artists: artistsResult.data ?? [],
+    shifts,
+    assignments,
+    stageNames: buildStageNames(stagesResult.data),
+  };
+};
+
+const insertDeliveryLog = async (
+  client: FestivalFeedClient,
+  userId: string,
+  event: ReturnType<typeof buildFestivalFeedArtistEvents>[number],
+  payload: PushPayload,
+): Promise<"inserted" | "duplicate" | "failed"> => {
+  const { error } = await client
+    .from("festival_push_delivery_log")
+    .insert({
+      user_id: userId,
+      job_id: event.jobId,
+      event_key: event.eventKey,
+      event_kind: event.eventKind,
+      due_at: event.dueAt.toISOString(),
+      payload: JSON.parse(JSON.stringify(payload)),
+    });
+
+  if (!error) return "inserted";
+  if (asErrorCode(error) === "23505") return "duplicate";
+
+  console.error("festival feed failed inserting delivery log", {
+    userId,
+    eventKey: event.eventKey,
+    error,
+  });
+  return "failed";
+};
+
+export async function handleFestivalFeedTick(
+  client: FestivalFeedClient,
+  now = new Date(),
+) {
+  const { data, error } = await client
+    .from("festival_push_subscriptions")
+    .select("user_id, job_id, enabled, stages")
+    .eq("enabled", true)
+    .returns<FestivalPushSubscriptionRow[]>();
+
+  if (error) {
+    console.error("festival feed failed loading subscriptions", error);
+    return jsonResponse({ error: "Failed to load festival feed subscriptions" }, 500);
+  }
+
+  const rawSubscriptions = (data ?? []).filter((row) => (row.stages ?? []).length > 0);
+  if (rawSubscriptions.length === 0) {
+    return jsonResponse({ status: "skipped", reason: "No users subscribed" });
+  }
+
+  const profileRoles = await loadProfilesById(
+    client,
+    Array.from(new Set(rawSubscriptions.map((row) => row.user_id))),
+  );
+
+  const subscriptions: FestivalFeedSubscription[] = rawSubscriptions.map((row) => ({
+    user_id: row.user_id,
+    job_id: row.job_id,
+    enabled: row.enabled,
+    stages: Array.from(new Set(row.stages ?? [])).sort((a, b) => a - b),
+    role: profileRoles.get(row.user_id) ?? null,
+  }));
+
+  const jobIds = Array.from(new Set(subscriptions.map((row) => row.job_id)));
+  if (jobIds.length === 0) {
+    return jsonResponse({ status: "skipped", reason: "No subscribed jobs" });
+  }
+
+  let feedData: Awaited<ReturnType<typeof loadFestivalFeedData>>;
+  try {
+    feedData = await loadFestivalFeedData(client, jobIds, now);
+  } catch (loadError) {
+    console.error("festival feed failed loading data", loadError);
+    return jsonResponse({ error: "Failed to load festival feed data" }, 500);
+  }
+
+  const assignedStagesByUserJob = buildAssignedStagesByUserJob(feedData.shifts, feedData.assignments);
+  const assignedUsersByShift = buildAssignedUsersByShift(feedData.assignments);
+
+  const artistEvents = buildFestivalFeedArtistEvents(feedData.artists, feedData.stageNames)
+    .filter((event) => isDueInWindow(event.dueAt, now));
+  const shiftEvents = buildFestivalFeedShiftEvents(feedData.shifts, feedData.stageNames)
+    .filter((event) => isDueInWindow(event.dueAt, now));
+
+  const dueEvents = [...artistEvents, ...shiftEvents].sort(
+    (left, right) => left.dueAt.getTime() - right.dueAt.getTime(),
+  );
+
+  if (dueEvents.length === 0) {
+    return jsonResponse({ status: "skipped", reason: "No due festival feed events" });
+  }
+
+  let attemptedUsers = 0;
+  let duplicateUsers = 0;
+  let deliveredCount = 0;
+  let failedLogInserts = 0;
+
+  for (const event of dueEvents) {
+    const recipients = event.shiftId
+      ? resolveShiftRecipients(event, subscriptions, assignedUsersByShift)
+      : resolveArtistRecipients(event, subscriptions, assignedStagesByUserJob);
+
+    for (const recipient of recipients) {
+      const payload = buildFestivalFeedPayload(event, recipient);
+      const logStatus = await insertDeliveryLog(client, recipient.user_id, event, payload);
+
+      if (logStatus === "duplicate") {
+        duplicateUsers++;
+        continue;
+      }
+      if (logStatus === "failed") {
+        failedLogInserts++;
+        continue;
+      }
+
+      attemptedUsers++;
+      const results = await sendPayloadToUsers(client, [recipient.user_id], payload);
+      deliveredCount += results.filter((result) => result.ok).length;
+    }
+  }
+
+  return jsonResponse({
+    status: "sent",
+    type: EVENT_TYPES.FESTIVAL_FEED_TICK,
+    dueEvents: dueEvents.length,
+    attemptedUsers,
+    duplicateUsers,
+    failedLogInserts,
+    deliveredCount,
+  });
+}

--- a/supabase/functions/push/festivalFeedUtils.ts
+++ b/supabase/functions/push/festivalFeedUtils.ts
@@ -1,0 +1,515 @@
+import type { PushPayload } from "./types.ts";
+
+export const FESTIVAL_FEED_EVENT_TYPE = "festival.feed.tick";
+export const FESTIVAL_FEED_TIMEZONE = "Europe/Madrid";
+
+export type FestivalFeedRole = string | null;
+
+export type FestivalFeedSubscription = {
+  user_id: string;
+  job_id: string;
+  enabled: boolean;
+  stages: number[];
+  role: FestivalFeedRole;
+};
+
+export type FestivalFeedArtist = {
+  id: string;
+  job_id: string | null;
+  name: string;
+  date: string | null;
+  stage: number | null;
+  show_start: string | null;
+  soundcheck: boolean | null;
+  soundcheck_start: string | null;
+  line_check: boolean | null;
+  line_check_start: string | null;
+  timezone: string | null;
+  isaftermidnight: boolean | null;
+};
+
+export type FestivalFeedShift = {
+  id: string;
+  job_id: string | null;
+  date: string;
+  stage: number | null;
+  name: string;
+  start_time: string;
+  end_time: string;
+};
+
+export type FestivalFeedShiftAssignment = {
+  shift_id: string | null;
+  technician_id: string | null;
+};
+
+export type FestivalFeedEventKind =
+  | "soundcheck_15"
+  | "soundcheck_now"
+  | "linecheck_15"
+  | "linecheck_now"
+  | "show_15"
+  | "show_now"
+  | "shift_start_15"
+  | "shift_end_15"
+  | "shift_end_now";
+
+export type FestivalFeedEvent = {
+  eventKey: string;
+  eventKind: FestivalFeedEventKind;
+  jobId: string;
+  dueAt: Date;
+  date: string;
+  urlDate: string;
+  stage: number | null;
+  title: string;
+  body: string;
+  artistId?: string;
+  artistName?: string;
+  shiftId?: string;
+  shiftName?: string;
+};
+
+type ArtistMomentConfig = {
+  kind: FestivalFeedEventKind;
+  source: "soundcheck" | "linecheck" | "show";
+  leadMinutes: number;
+};
+
+const ARTIST_MOMENTS: ArtistMomentConfig[] = [
+  { kind: "soundcheck_15", source: "soundcheck", leadMinutes: 15 },
+  { kind: "soundcheck_now", source: "soundcheck", leadMinutes: 0 },
+  { kind: "linecheck_15", source: "linecheck", leadMinutes: 15 },
+  { kind: "linecheck_now", source: "linecheck", leadMinutes: 0 },
+  { kind: "show_15", source: "show", leadMinutes: 15 },
+  { kind: "show_now", source: "show", leadMinutes: 0 },
+];
+
+const pad2 = (value: number) => String(value).padStart(2, "0");
+
+const parseDateKey = (dateKey: string) => {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  if (!year || !month || !day) return null;
+  return { year, month, day };
+};
+
+const parseTime = (time: string | null | undefined) => {
+  if (!time) return null;
+  const [hours, minutes = "0", seconds = "0"] = time.split(":");
+  const hour = Number(hours);
+  const minute = Number(minutes);
+  const second = Number(seconds);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute) || !Number.isFinite(second)) {
+    return null;
+  }
+  return { hour, minute, second };
+};
+
+const getTimeZoneOffsetMs = (date: Date, timeZone: string): number => {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "shortOffset",
+  });
+  const timeZoneName = formatter
+    .formatToParts(date)
+    .find((part) => part.type === "timeZoneName")?.value;
+
+  if (!timeZoneName || timeZoneName === "GMT" || timeZoneName === "UTC") {
+    return 0;
+  }
+
+  const match = timeZoneName.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/);
+  if (!match) return 0;
+
+  const sign = match[1] === "-" ? -1 : 1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? "0");
+  return sign * ((hours * 60 + minutes) * 60 * 1000);
+};
+
+export const zonedDateTimeToUtc = (
+  dateKey: string,
+  time: string,
+  timeZone = FESTIVAL_FEED_TIMEZONE,
+): Date | null => {
+  const parsedDate = parseDateKey(dateKey);
+  const parsedTime = parseTime(time);
+  if (!parsedDate || !parsedTime) return null;
+
+  const utcGuess = new Date(Date.UTC(
+    parsedDate.year,
+    parsedDate.month - 1,
+    parsedDate.day,
+    parsedTime.hour,
+    parsedTime.minute,
+    parsedTime.second,
+  ));
+  const firstOffset = getTimeZoneOffsetMs(utcGuess, timeZone);
+  const firstCandidate = new Date(utcGuess.getTime() - firstOffset);
+  const correctedOffset = getTimeZoneOffsetMs(firstCandidate, timeZone);
+
+  return new Date(utcGuess.getTime() - correctedOffset);
+};
+
+export const formatDateKeyInTimeZone = (
+  date: Date,
+  timeZone = FESTIVAL_FEED_TIMEZONE,
+): string => {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = formatter.formatToParts(date);
+  const year = parts.find((part) => part.type === "year")?.value ?? "1970";
+  const month = parts.find((part) => part.type === "month")?.value ?? "01";
+  const day = parts.find((part) => part.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
+};
+
+export const addDaysToDateKey = (dateKey: string, days: number): string => {
+  const parsedDate = parseDateKey(dateKey);
+  if (!parsedDate) return dateKey;
+  const date = new Date(Date.UTC(parsedDate.year, parsedDate.month - 1, parsedDate.day + days));
+  return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())}`;
+};
+
+const subtractMinutes = (date: Date, minutes: number): Date =>
+  new Date(date.getTime() - minutes * 60 * 1000);
+
+export const isDueInWindow = (
+  dueAt: Date,
+  now: Date,
+  lookbackMs = 65_000,
+  lookaheadMs = 5_000,
+): boolean => {
+  const deltaMs = dueAt.getTime() - now.getTime();
+  return deltaMs >= -lookbackMs && deltaMs <= lookaheadMs;
+};
+
+const normalizeStageLabel = (jobId: string, stage: number | null, stageNames?: Map<string, string>) => {
+  if (stage === null) return "";
+  return stageNames?.get(`${jobId}:${stage}`) || stageNames?.get(String(stage)) || `Escenario ${stage}`;
+};
+
+const getArtistMomentTime = (artist: FestivalFeedArtist, source: ArtistMomentConfig["source"]): string | null => {
+  if (source === "soundcheck") return artist.soundcheck_start;
+  if (source === "linecheck") return artist.line_check_start;
+  return artist.show_start;
+};
+
+const getArtistMomentDateKey = (
+  artist: FestivalFeedArtist,
+  source: ArtistMomentConfig["source"],
+): string | null => {
+  if (!artist.date) return null;
+  if ((source === "linecheck" || source === "show") && artist.isaftermidnight) {
+    return addDaysToDateKey(artist.date, 1);
+  }
+  return artist.date;
+};
+
+const buildArtistMessage = (
+  artistName: string,
+  stageLabel: string,
+  eventKind: FestivalFeedEventKind,
+  eventTime: string,
+) => {
+  if (eventKind === "soundcheck_15") {
+    return {
+      title: "Prueba de sonido en 15 min",
+      body: `En 15 min empieza la prueba de sonido de ${artistName} en ${stageLabel}.`,
+    };
+  }
+
+  if (eventKind === "soundcheck_now") {
+    return {
+      title: "Prueba de sonido ahora",
+      body: `Empieza ahora la prueba de sonido de ${artistName} en ${stageLabel}.`,
+    };
+  }
+
+  if (eventKind === "linecheck_15") {
+    return {
+      title: "Line check en 15 min",
+      body: `En 15 min empieza el line check de ${artistName} en ${stageLabel}.`,
+    };
+  }
+
+  if (eventKind === "linecheck_now") {
+    return {
+      title: "Line check ahora",
+      body: `Empieza ahora el line check de ${artistName} en ${stageLabel}.`,
+    };
+  }
+
+  if (eventKind === "show_15") {
+    return {
+      title: "Show en 15 min",
+      body: `Próximo artista en ${stageLabel}: ${artistName} a las ${eventTime.slice(0, 5)}.`,
+    };
+  }
+
+  return {
+    title: "Empieza el show",
+    body: `${artistName} empieza ahora en ${stageLabel}.`,
+  };
+};
+
+export const buildFestivalFeedArtistEvents = (
+  artists: FestivalFeedArtist[],
+  stageNames?: Map<string, string>,
+): FestivalFeedEvent[] => {
+  const events: FestivalFeedEvent[] = [];
+
+  for (const artist of artists) {
+    if (!artist.id || !artist.job_id || !artist.date || typeof artist.stage !== "number") {
+      continue;
+    }
+
+    for (const moment of ARTIST_MOMENTS) {
+      const time = getArtistMomentTime(artist, moment.source);
+      if (!time) continue;
+
+      const localDate = getArtistMomentDateKey(artist, moment.source);
+      if (!localDate) continue;
+
+      const dueBase = zonedDateTimeToUtc(localDate, time, artist.timezone || FESTIVAL_FEED_TIMEZONE);
+      if (!dueBase) continue;
+
+      const dueAt = subtractMinutes(dueBase, moment.leadMinutes);
+      const stageLabel = normalizeStageLabel(artist.job_id, artist.stage, stageNames);
+      const message = buildArtistMessage(artist.name, stageLabel, moment.kind, time);
+
+      events.push({
+        eventKey: `artist:${artist.id}:${moment.kind}:${dueAt.toISOString()}`,
+        eventKind: moment.kind,
+        jobId: artist.job_id,
+        dueAt,
+        date: localDate,
+        urlDate: artist.date,
+        stage: artist.stage,
+        title: message.title,
+        body: message.body,
+        artistId: artist.id,
+        artistName: artist.name,
+      });
+    }
+  }
+
+  return events;
+};
+
+const isTimeBeforeOrEqual = (left: string, right: string): boolean => {
+  const leftTime = parseTime(left);
+  const rightTime = parseTime(right);
+  if (!leftTime || !rightTime) return false;
+  const leftSeconds = leftTime.hour * 3600 + leftTime.minute * 60 + leftTime.second;
+  const rightSeconds = rightTime.hour * 3600 + rightTime.minute * 60 + rightTime.second;
+  return leftSeconds <= rightSeconds;
+};
+
+const buildShiftMessage = (
+  shift: FestivalFeedShift,
+  stageLabel: string,
+  eventKind: FestivalFeedEventKind,
+) => {
+  const stageSuffix = stageLabel ? ` en ${stageLabel}` : "";
+
+  if (eventKind === "shift_start_15") {
+    return {
+      title: "Tu turno empieza en 15 min",
+      body: `${shift.name} empieza a las ${shift.start_time.slice(0, 5)}${stageSuffix}.`,
+    };
+  }
+
+  if (eventKind === "shift_end_15") {
+    return {
+      title: "Tu turno acaba en 15 min",
+      body: `${shift.name} acaba a las ${shift.end_time.slice(0, 5)}${stageSuffix}.`,
+    };
+  }
+
+  return {
+    title: "Turno finalizado",
+    body: "Tu turno ha acabado, muchas gracias por el trabajo y no olvides firmar tus horas.",
+  };
+};
+
+export const buildFestivalFeedShiftEvents = (
+  shifts: FestivalFeedShift[],
+  stageNames?: Map<string, string>,
+): FestivalFeedEvent[] => {
+  const events: FestivalFeedEvent[] = [];
+
+  for (const shift of shifts) {
+    if (!shift.id || !shift.job_id || !shift.date || !shift.start_time || !shift.end_time) {
+      continue;
+    }
+
+    const shiftStart = zonedDateTimeToUtc(shift.date, shift.start_time, FESTIVAL_FEED_TIMEZONE);
+    const endDate = isTimeBeforeOrEqual(shift.end_time, shift.start_time)
+      ? addDaysToDateKey(shift.date, 1)
+      : shift.date;
+    const shiftEnd = zonedDateTimeToUtc(endDate, shift.end_time, FESTIVAL_FEED_TIMEZONE);
+    if (!shiftStart || !shiftEnd) continue;
+
+    const stageLabel = normalizeStageLabel(shift.job_id, shift.stage, stageNames);
+    const moments: Array<{ kind: FestivalFeedEventKind; dueAt: Date }> = [
+      { kind: "shift_start_15", dueAt: subtractMinutes(shiftStart, 15) },
+      { kind: "shift_end_15", dueAt: subtractMinutes(shiftEnd, 15) },
+      { kind: "shift_end_now", dueAt: shiftEnd },
+    ];
+
+    for (const moment of moments) {
+      const message = buildShiftMessage(shift, stageLabel, moment.kind);
+      events.push({
+        eventKey: `shift:${shift.id}:${moment.kind}:${moment.dueAt.toISOString()}`,
+        eventKind: moment.kind,
+        jobId: shift.job_id,
+        dueAt: moment.dueAt,
+        date: moment.kind === "shift_start_15" ? shift.date : endDate,
+        urlDate: shift.date,
+        stage: shift.stage,
+        title: message.title,
+        body: message.body,
+        shiftId: shift.id,
+        shiftName: shift.name,
+      });
+    }
+  }
+
+  return events;
+};
+
+export const buildAssignedStagesByUserJob = (
+  shifts: FestivalFeedShift[],
+  assignments: FestivalFeedShiftAssignment[],
+): Map<string, Set<number>> => {
+  const shiftById = new Map(shifts.map((shift) => [shift.id, shift]));
+  const assignedStages = new Map<string, Set<number>>();
+
+  for (const assignment of assignments) {
+    if (!assignment.shift_id || !assignment.technician_id) continue;
+    const shift = shiftById.get(assignment.shift_id);
+    if (!shift?.job_id || !shift.date || typeof shift.stage !== "number") continue;
+
+    const key = `${assignment.technician_id}:${shift.job_id}:${shift.date}`;
+    const stages = assignedStages.get(key) ?? new Set<number>();
+    stages.add(shift.stage);
+    assignedStages.set(key, stages);
+  }
+
+  return assignedStages;
+};
+
+export const buildAssignedUsersByShift = (
+  assignments: FestivalFeedShiftAssignment[],
+): Map<string, Set<string>> => {
+  const usersByShift = new Map<string, Set<string>>();
+
+  for (const assignment of assignments) {
+    if (!assignment.shift_id || !assignment.technician_id) continue;
+    const users = usersByShift.get(assignment.shift_id) ?? new Set<string>();
+    users.add(assignment.technician_id);
+    usersByShift.set(assignment.shift_id, users);
+  }
+
+  return usersByShift;
+};
+
+const isAdminOrManagement = (role: FestivalFeedRole): boolean =>
+  role === "admin" || role === "management";
+
+const isStrictAssignedRole = (role: FestivalFeedRole): boolean =>
+  role === "technician" || role === "house_tech";
+
+export const resolveArtistRecipients = (
+  event: FestivalFeedEvent,
+  subscriptions: FestivalFeedSubscription[],
+  assignedStagesByUserJob: Map<string, Set<number>>,
+): FestivalFeedSubscription[] => {
+  if (typeof event.stage !== "number") return [];
+
+  return subscriptions.filter((subscription) => {
+    if (!subscription.enabled || subscription.job_id !== event.jobId) return false;
+    if (!subscription.stages.includes(event.stage as number)) return false;
+
+    if (isAdminOrManagement(subscription.role)) {
+      return true;
+    }
+
+    if (isStrictAssignedRole(subscription.role)) {
+      return assignedStagesByUserJob
+        .get(`${subscription.user_id}:${event.jobId}:${event.urlDate}`)
+        ?.has(event.stage as number) === true;
+    }
+
+    return false;
+  });
+};
+
+export const resolveShiftRecipients = (
+  event: FestivalFeedEvent,
+  subscriptions: FestivalFeedSubscription[],
+  assignedUsersByShift: Map<string, Set<string>>,
+): FestivalFeedSubscription[] => {
+  if (!event.shiftId) return [];
+  const assignedUsers = assignedUsersByShift.get(event.shiftId);
+  if (!assignedUsers || assignedUsers.size === 0) return [];
+
+  return subscriptions.filter((subscription) => {
+    if (!subscription.enabled || subscription.job_id !== event.jobId) return false;
+    if (!assignedUsers.has(subscription.user_id)) return false;
+    if (typeof event.stage === "number" && !subscription.stages.includes(event.stage)) return false;
+    return true;
+  });
+};
+
+export const buildFestivalFeedUrl = (
+  role: FestivalFeedRole,
+  jobId: string,
+  date: string,
+  stage: number | null,
+): string => {
+  const params = new URLSearchParams({ date });
+  if (typeof stage === "number") {
+    params.set("stage", String(stage));
+  }
+
+  if (role === "technician") {
+    params.set("open", "artists");
+    params.set("jobId", jobId);
+    const ordered = new URLSearchParams();
+    ordered.set("open", "artists");
+    ordered.set("jobId", jobId);
+    ordered.set("date", date);
+    if (typeof stage === "number") ordered.set("stage", String(stage));
+    return `/tech-app?${ordered.toString()}`;
+  }
+
+  return `/festival-management/${jobId}/artists?${params.toString()}`;
+};
+
+export const buildFestivalFeedPayload = (
+  event: FestivalFeedEvent,
+  subscription: FestivalFeedSubscription,
+): PushPayload => ({
+  title: event.title,
+  body: event.body,
+  url: buildFestivalFeedUrl(subscription.role, event.jobId, event.urlDate, event.stage),
+  type: FESTIVAL_FEED_EVENT_TYPE,
+  meta: {
+    eventKey: event.eventKey,
+    eventKind: event.eventKind,
+    jobId: event.jobId,
+    artistId: event.artistId,
+    artistName: event.artistName,
+    shiftId: event.shiftId,
+    shiftName: event.shiftName,
+    date: event.urlDate,
+    stage: event.stage,
+    dueAt: event.dueAt.toISOString(),
+  },
+});

--- a/supabase/functions/push/scheduled.ts
+++ b/supabase/functions/push/scheduled.ts
@@ -3,6 +3,7 @@ import { EVENT_TYPES } from "./config.ts";
 import { jsonResponse } from "./http.ts";
 import { sendNativePushNotification } from "./apns.ts";
 import { sendPushNotification } from "./webpush.ts";
+import { handleFestivalFeedTick } from "./festivalFeed.ts";
 import type {
   CheckScheduledBody,
   NativePushTokenRow,
@@ -586,6 +587,10 @@ export async function handleCheckScheduled(
 ) {
   const type = body.type;
   console.log(`🔍 Checking scheduled notification: ${type}`);
+
+  if (type === EVENT_TYPES.FESTIVAL_FEED_TICK) {
+    return handleFestivalFeedTick(client);
+  }
 
   // Check if it's time to send
   const { shouldSend, config } = await checkAndGetScheduleConfig(client, type, body.force);

--- a/supabase/migrations/20260703120000_add_festival_push_feed.sql
+++ b/supabase/migrations/20260703120000_add_festival_push_feed.sql
@@ -1,0 +1,218 @@
+-- Festival push feed subscriptions and delivery dedupe.
+
+CREATE TABLE IF NOT EXISTS public.festival_push_subscriptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  job_id uuid NOT NULL REFERENCES public.jobs(id) ON DELETE CASCADE,
+  enabled boolean NOT NULL DEFAULT true,
+  stages integer[] NOT NULL DEFAULT '{}'::integer[],
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT festival_push_subscriptions_user_job_key UNIQUE (user_id, job_id),
+  CONSTRAINT festival_push_subscriptions_stages_valid CHECK (
+    stages IS NOT NULL
+    AND array_position(stages, NULL) IS NULL
+    AND stages <@ ARRAY[
+      1, 2, 3, 4, 5, 6, 7, 8,
+      9, 10, 11, 12, 13, 14, 15, 16,
+      17, 18, 19, 20, 21, 22, 23, 24,
+      25, 26, 27, 28, 29, 30, 31, 32,
+      33, 34, 35, 36, 37, 38, 39, 40,
+      41, 42, 43, 44, 45, 46, 47, 48,
+      49, 50, 51, 52, 53, 54, 55, 56,
+      57, 58, 59, 60, 61, 62, 63, 64
+    ]::integer[]
+  )
+);
+
+COMMENT ON TABLE public.festival_push_subscriptions IS
+  'Opt-in festival timing push feed. Admin/management may subscribe to selected stages; technician/house_tech subscriptions are constrained to assigned festival shift stages.';
+COMMENT ON COLUMN public.festival_push_subscriptions.stages IS
+  'Stage numbers included in the feed for this job. Empty arrays are only useful for disabled rows.';
+
+CREATE INDEX IF NOT EXISTS idx_festival_push_subscriptions_job_enabled
+  ON public.festival_push_subscriptions (job_id, enabled);
+
+CREATE INDEX IF NOT EXISTS idx_festival_push_subscriptions_user
+  ON public.festival_push_subscriptions (user_id);
+
+CREATE TABLE IF NOT EXISTS public.festival_push_delivery_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  job_id uuid NOT NULL REFERENCES public.jobs(id) ON DELETE CASCADE,
+  event_key text NOT NULL,
+  event_kind text NOT NULL,
+  due_at timestamptz NOT NULL,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  sent_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT festival_push_delivery_log_user_event_key UNIQUE (user_id, event_key)
+);
+
+COMMENT ON TABLE public.festival_push_delivery_log IS
+  'Service-role dedupe log for the scheduled festival push feed.';
+
+CREATE INDEX IF NOT EXISTS idx_festival_push_delivery_log_job_due
+  ON public.festival_push_delivery_log (job_id, due_at);
+
+CREATE INDEX IF NOT EXISTS idx_festival_push_delivery_log_event_kind
+  ON public.festival_push_delivery_log (event_kind);
+
+CREATE OR REPLACE FUNCTION public.get_festival_assigned_stages(
+  p_user_id uuid,
+  p_job_id uuid
+)
+RETURNS integer[]
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT COALESCE(array_agg(DISTINCT fs.stage ORDER BY fs.stage), '{}'::integer[])
+  FROM public.festival_shifts fs
+  JOIN public.festival_shift_assignments fsa
+    ON fsa.shift_id = fs.id
+  WHERE fsa.technician_id = p_user_id
+    AND fs.job_id = p_job_id
+    AND fs.stage IS NOT NULL;
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_manage_festival_push_subscription(
+  p_user_id uuid,
+  p_job_id uuid,
+  p_enabled boolean,
+  p_stages integer[]
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_role text;
+  v_assigned_stages integer[];
+BEGIN
+  IF auth.uid() IS NULL OR p_user_id IS DISTINCT FROM auth.uid() OR p_job_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  IF p_stages IS NULL OR array_position(p_stages, NULL) IS NOT NULL THEN
+    RETURN false;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM unnest(p_stages) AS stage_number
+    WHERE stage_number < 1 OR stage_number > 64
+  ) THEN
+    RETURN false;
+  END IF;
+
+  -- Let users disable their own row even when assignments or stages changed.
+  IF COALESCE(p_enabled, false) = false THEN
+    RETURN true;
+  END IF;
+
+  IF COALESCE(array_length(p_stages, 1), 0) = 0 THEN
+    RETURN false;
+  END IF;
+
+  v_role := public.current_user_role();
+
+  IF v_role = ANY (ARRAY['admin'::text, 'management'::text]) THEN
+    RETURN true;
+  END IF;
+
+  IF v_role = ANY (ARRAY['technician'::text, 'house_tech'::text]) THEN
+    v_assigned_stages := public.get_festival_assigned_stages(p_user_id, p_job_id);
+    RETURN COALESCE(array_length(v_assigned_stages, 1), 0) > 0
+      AND p_stages <@ v_assigned_stages;
+  END IF;
+
+  RETURN false;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_festival_assigned_stages(uuid, uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.get_festival_assigned_stages(uuid, uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_festival_assigned_stages(uuid, uuid) TO service_role;
+
+REVOKE ALL ON FUNCTION public.can_manage_festival_push_subscription(uuid, uuid, boolean, integer[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.can_manage_festival_push_subscription(uuid, uuid, boolean, integer[]) TO authenticated, service_role;
+
+DROP TRIGGER IF EXISTS set_festival_push_subscriptions_updated_at
+  ON public.festival_push_subscriptions;
+CREATE TRIGGER set_festival_push_subscriptions_updated_at
+  BEFORE UPDATE ON public.festival_push_subscriptions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+ALTER TABLE public.festival_push_subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.festival_push_delivery_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS festival_push_subscriptions_select_own
+  ON public.festival_push_subscriptions;
+CREATE POLICY festival_push_subscriptions_select_own
+  ON public.festival_push_subscriptions
+  FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS festival_push_subscriptions_insert_own
+  ON public.festival_push_subscriptions;
+CREATE POLICY festival_push_subscriptions_insert_own
+  ON public.festival_push_subscriptions
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.can_manage_festival_push_subscription(user_id, job_id, enabled, stages)
+  );
+
+DROP POLICY IF EXISTS festival_push_subscriptions_update_own
+  ON public.festival_push_subscriptions;
+CREATE POLICY festival_push_subscriptions_update_own
+  ON public.festival_push_subscriptions
+  FOR UPDATE
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (
+    public.can_manage_festival_push_subscription(user_id, job_id, enabled, stages)
+  );
+
+DROP POLICY IF EXISTS festival_push_subscriptions_delete_own
+  ON public.festival_push_subscriptions;
+CREATE POLICY festival_push_subscriptions_delete_own
+  ON public.festival_push_subscriptions
+  FOR DELETE
+  TO authenticated
+  USING (user_id = auth.uid());
+
+REVOKE ALL ON TABLE public.festival_push_delivery_log FROM anon, authenticated;
+GRANT ALL ON TABLE public.festival_push_delivery_log TO service_role;
+
+REVOKE ALL ON TABLE public.festival_push_subscriptions FROM PUBLIC, anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.festival_push_subscriptions TO authenticated;
+GRANT ALL ON TABLE public.festival_push_subscriptions TO service_role;
+
+DO $cron$
+BEGIN
+  IF to_regnamespace('cron') IS NULL THEN
+    RAISE WARNING 'cron schema not available; festival push feed cron was not scheduled';
+    RETURN;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM cron.job
+    WHERE jobname = 'festival-push-feed-tick'
+  ) THEN
+    PERFORM cron.unschedule('festival-push-feed-tick');
+  END IF;
+
+  PERFORM cron.schedule(
+    'festival-push-feed-tick',
+    '* * * * *',
+    $$SELECT public.invoke_scheduled_push_notification('festival.feed.tick')$$
+  );
+END $cron$;

--- a/supabase/migrations/20260703120000_add_festival_push_feed.sql
+++ b/supabase/migrations/20260703120000_add_festival_push_feed.sql
@@ -58,6 +58,9 @@ CREATE INDEX IF NOT EXISTS idx_festival_push_delivery_log_job_due
 CREATE INDEX IF NOT EXISTS idx_festival_push_delivery_log_event_kind
   ON public.festival_push_delivery_log (event_kind);
 
+CREATE INDEX IF NOT EXISTS idx_festival_push_delivery_log_sent_at
+  ON public.festival_push_delivery_log (sent_at);
+
 CREATE OR REPLACE FUNCTION public.get_festival_assigned_stages(
   p_user_id uuid,
   p_job_id uuid
@@ -214,5 +217,19 @@ BEGIN
     'festival-push-feed-tick',
     '* * * * *',
     $$SELECT public.invoke_scheduled_push_notification('festival.feed.tick')$$
+  );
+
+  IF EXISTS (
+    SELECT 1
+    FROM cron.job
+    WHERE jobname = 'festival-push-delivery-log-cleanup'
+  ) THEN
+    PERFORM cron.unschedule('festival-push-delivery-log-cleanup');
+  END IF;
+
+  PERFORM cron.schedule(
+    'festival-push-delivery-log-cleanup',
+    '17 4 * * *',
+    $$DELETE FROM public.festival_push_delivery_log WHERE sent_at < now() - interval '14 days'$$
   );
 END $cron$;

--- a/supabase/tests/database/festival_push_feed_permissions.sql
+++ b/supabase/tests/database/festival_push_feed_permissions.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(30);
+SELECT plan(32);
 
 SELECT has_table('public', 'festival_push_subscriptions', 'festival push subscriptions table exists');
 SELECT has_table('public', 'festival_push_delivery_log', 'festival push delivery log table exists');
@@ -189,6 +189,29 @@ SELECT ok(
       AND indexname = 'idx_festival_push_delivery_log_job_due'
   ),
   'festival push delivery log has a job/due index'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_push_delivery_log'
+      AND indexname = 'idx_festival_push_delivery_log_sent_at'
+  ),
+  'festival push delivery log has a sent_at cleanup index'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM cron.job
+    WHERE jobname = 'festival-push-delivery-log-cleanup'
+      AND schedule = '17 4 * * *'
+      AND command ILIKE '%festival_push_delivery_log%'
+      AND command ILIKE '%14 days%'
+  ),
+  'festival push delivery log has a scheduled retention cleanup'
 );
 
 SELECT set_config('request.jwt.claim.role', 'service_role', false);

--- a/supabase/tests/database/festival_push_feed_permissions.sql
+++ b/supabase/tests/database/festival_push_feed_permissions.sql
@@ -1,0 +1,489 @@
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+SET search_path TO public, extensions;
+
+SELECT plan(30);
+
+SELECT has_table('public', 'festival_push_subscriptions', 'festival push subscriptions table exists');
+SELECT has_table('public', 'festival_push_delivery_log', 'festival push delivery log table exists');
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.festival_push_subscriptions'::regclass
+      AND conname = 'festival_push_subscriptions_user_job_key'
+  ),
+  'festival push subscriptions are unique per user/job'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.festival_push_delivery_log'::regclass
+      AND conname = 'festival_push_delivery_log_user_event_key'
+  ),
+  'festival push delivery log dedupes per user/event'
+);
+
+SELECT ok(
+  to_regprocedure('public.get_festival_assigned_stages(uuid,uuid)') IS NOT NULL,
+  'assigned festival stages helper exists'
+);
+
+SELECT ok(
+  COALESCE((
+    SELECT proconfig @> ARRAY['search_path=pg_catalog, public']::text[]
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.get_festival_assigned_stages(uuid,uuid)')
+  ), false),
+  'assigned festival stages helper pins pg_catalog/public search_path'
+);
+
+SELECT ok(
+  NOT has_function_privilege('authenticated', 'public.get_festival_assigned_stages(uuid,uuid)', 'EXECUTE')
+  AND has_function_privilege('service_role', 'public.get_festival_assigned_stages(uuid,uuid)', 'EXECUTE'),
+  'direct assigned-stage helper is service-role only'
+);
+
+SELECT ok(
+  to_regprocedure('public.can_manage_festival_push_subscription(uuid,uuid,boolean,integer[])') IS NOT NULL,
+  'festival push subscription authorization helper exists'
+);
+
+SELECT ok(
+  COALESCE((
+    SELECT proconfig @> ARRAY['search_path=pg_catalog, public']::text[]
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.can_manage_festival_push_subscription(uuid,uuid,boolean,integer[])')
+  ), false),
+  'festival push subscription authorization helper pins pg_catalog/public search_path'
+);
+
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.can_manage_festival_push_subscription(uuid,uuid,boolean,integer[])', 'EXECUTE')
+  AND has_function_privilege('authenticated', 'public.can_manage_festival_push_subscription(uuid,uuid,boolean,integer[])', 'EXECUTE'),
+  'festival push subscription helper is available to authenticated users only'
+);
+
+SELECT ok(
+  NOT has_table_privilege('anon', 'public.festival_push_subscriptions', 'SELECT')
+  AND has_table_privilege('authenticated', 'public.festival_push_subscriptions', 'SELECT'),
+  'anonymous users cannot select festival push subscriptions'
+);
+
+SELECT ok(
+  NOT has_table_privilege('anon', 'public.festival_push_delivery_log', 'SELECT')
+  AND NOT has_table_privilege('authenticated', 'public.festival_push_delivery_log', 'SELECT')
+  AND has_table_privilege('service_role', 'public.festival_push_delivery_log', 'INSERT'),
+  'festival push delivery log is service-role only'
+);
+
+SELECT ok(
+  (
+    SELECT count(*)
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_push_subscriptions'
+      AND policyname IN (
+        'festival_push_subscriptions_select_own',
+        'festival_push_subscriptions_insert_own',
+        'festival_push_subscriptions_update_own',
+        'festival_push_subscriptions_delete_own'
+      )
+  ) = 4,
+  'festival push subscriptions have the four scoped policies'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_push_subscriptions'
+      AND cmd = 'INSERT'
+      AND with_check ILIKE '%can_manage_festival_push_subscription%'
+  ),
+  'subscription inserts call the authorization helper'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_push_subscriptions'
+      AND cmd = 'UPDATE'
+      AND qual ILIKE '%auth.uid%'
+      AND with_check ILIKE '%can_manage_festival_push_subscription%'
+  ),
+  'subscription updates are self-scoped and call the authorization helper'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.can_manage_festival_push_subscription(uuid,uuid,boolean,integer[])')
+      AND pg_get_functiondef(oid) ILIKE '%admin%'
+      AND pg_get_functiondef(oid) ILIKE '%management%'
+      AND pg_get_functiondef(oid) ILIKE '%technician%'
+      AND pg_get_functiondef(oid) ILIKE '%house_tech%'
+      AND pg_get_functiondef(oid) ILIKE '%get_festival_assigned_stages%'
+  ),
+  'authorization helper preserves admin/management and assigned technician/house_tech paths'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.can_manage_festival_push_subscription(uuid,uuid,boolean,integer[])')
+      AND pg_get_functiondef(oid) ILIKE '%array_length%'
+      AND pg_get_functiondef(oid) ILIKE '%p_stages <@ v_assigned_stages%'
+  ),
+  'authorization helper requires non-empty enabled stage arrays and assigned-stage containment'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.get_festival_assigned_stages(uuid,uuid)')
+      AND pg_get_functiondef(oid) ILIKE '%festival_shift_assignments%'
+      AND pg_get_functiondef(oid) ILIKE '%technician_id%'
+      AND pg_get_functiondef(oid) ILIKE '%fs.stage IS NOT NULL%'
+  ),
+  'assigned-stage helper uses festival shift assignments and ignores external-only rows'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.festival_push_subscriptions'::regclass
+      AND conname = 'festival_push_subscriptions_stages_valid'
+      AND pg_get_constraintdef(oid) ILIKE '%<@ ARRAY%'
+  ),
+  'subscription stages are constrained to positive stage numbers'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_push_subscriptions'
+      AND indexname = 'idx_festival_push_subscriptions_job_enabled'
+  ),
+  'festival push scheduler has a job/enabled subscription index'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_push_delivery_log'
+      AND indexname = 'idx_festival_push_delivery_log_job_due'
+  ),
+  'festival push delivery log has a job/due index'
+);
+
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  aud,
+  role
+) VALUES
+  (
+    '10000000-0000-0000-0000-000000000001'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'festival-feed-admin@test.local',
+    'test',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    'authenticated',
+    'authenticated'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000002'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'festival-feed-manager@test.local',
+    'test',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    'authenticated',
+    'authenticated'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000003'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'festival-feed-tech@test.local',
+    'test',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    'authenticated',
+    'authenticated'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000004'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'festival-feed-house@test.local',
+    'test',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    'authenticated',
+    'authenticated'
+  ),
+  (
+    '10000000-0000-0000-0000-000000000005'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'festival-feed-unassigned-tech@test.local',
+    'test',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    'authenticated',
+    'authenticated'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.profiles (id, email, first_name, last_name, role, department)
+VALUES
+  ('10000000-0000-0000-0000-000000000001'::uuid, 'festival-feed-admin@test.local', 'Feed', 'Admin', 'admin', 'sound'),
+  ('10000000-0000-0000-0000-000000000002'::uuid, 'festival-feed-manager@test.local', 'Feed', 'Manager', 'management', 'sound'),
+  ('10000000-0000-0000-0000-000000000003'::uuid, 'festival-feed-tech@test.local', 'Feed', 'Tech', 'technician', 'sound'),
+  ('10000000-0000-0000-0000-000000000004'::uuid, 'festival-feed-house@test.local', 'Feed', 'House', 'house_tech', 'sound'),
+  ('10000000-0000-0000-0000-000000000005'::uuid, 'festival-feed-unassigned-tech@test.local', 'Feed', 'Unassigned', 'technician', 'sound')
+ON CONFLICT (id) DO UPDATE
+SET email = excluded.email,
+    first_name = excluded.first_name,
+    last_name = excluded.last_name,
+    role = excluded.role,
+    department = excluded.department;
+
+INSERT INTO public.activity_catalog (code, label, default_visibility, severity, toast_enabled)
+VALUES ('job.created', 'Job created', 'management', 'info', false)
+ON CONFLICT (code) DO UPDATE
+SET label = excluded.label,
+    default_visibility = excluded.default_visibility,
+    severity = excluded.severity,
+    toast_enabled = excluded.toast_enabled;
+
+INSERT INTO public.jobs (id, title, start_time, end_time, job_type)
+VALUES (
+  '20000000-0000-0000-0000-000000000001'::uuid,
+  'Festival Feed RLS Test',
+  '2026-07-03 08:00:00+02'::timestamptz,
+  '2026-07-04 02:00:00+02'::timestamptz,
+  'festival'
+)
+ON CONFLICT (id) DO UPDATE
+SET title = excluded.title,
+    start_time = excluded.start_time,
+    end_time = excluded.end_time,
+    job_type = excluded.job_type;
+
+INSERT INTO public.festival_shifts (id, job_id, date, start_time, end_time, name, stage, department)
+VALUES
+  (
+    '30000000-0000-0000-0000-000000000001'::uuid,
+    '20000000-0000-0000-0000-000000000001'::uuid,
+    '2026-07-03'::date,
+    '09:00'::time,
+    '13:00'::time,
+    'Stage 2 shift',
+    2,
+    'sound'
+  ),
+  (
+    '30000000-0000-0000-0000-000000000002'::uuid,
+    '20000000-0000-0000-0000-000000000001'::uuid,
+    '2026-07-03'::date,
+    '14:00'::time,
+    '18:00'::time,
+    'Stage 3 shift',
+    3,
+    'sound'
+  )
+ON CONFLICT (id) DO UPDATE
+SET job_id = excluded.job_id,
+    date = excluded.date,
+    start_time = excluded.start_time,
+    end_time = excluded.end_time,
+    name = excluded.name,
+    stage = excluded.stage,
+    department = excluded.department;
+
+INSERT INTO public.festival_shift_assignments (id, shift_id, technician_id, role, external_technician_name)
+VALUES
+  (
+    '40000000-0000-0000-0000-000000000001'::uuid,
+    '30000000-0000-0000-0000-000000000001'::uuid,
+    '10000000-0000-0000-0000-000000000003'::uuid,
+    'foh',
+    NULL
+  ),
+  (
+    '40000000-0000-0000-0000-000000000002'::uuid,
+    '30000000-0000-0000-0000-000000000002'::uuid,
+    '10000000-0000-0000-0000-000000000004'::uuid,
+    'house',
+    NULL
+  ),
+  (
+    '40000000-0000-0000-0000-000000000003'::uuid,
+    '30000000-0000-0000-0000-000000000001'::uuid,
+    NULL,
+    'external',
+    'External Tech'
+  )
+ON CONFLICT (id) DO UPDATE
+SET shift_id = excluded.shift_id,
+    technician_id = excluded.technician_id,
+    role = excluded.role,
+    external_technician_name = excluded.external_technician_name;
+
+CREATE OR REPLACE FUNCTION public.__test_upsert_festival_push_subscription(
+  p_user_id uuid,
+  p_enabled boolean,
+  p_stages integer[]
+)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  INSERT INTO public.festival_push_subscriptions (user_id, job_id, enabled, stages)
+  VALUES (
+    p_user_id,
+    '20000000-0000-0000-0000-000000000001'::uuid,
+    p_enabled,
+    p_stages
+  )
+  ON CONFLICT (user_id, job_id) DO UPDATE
+  SET enabled = excluded.enabled,
+      stages = excluded.stages;
+
+  RETURN true;
+EXCEPTION WHEN others THEN
+  RETURN false;
+END;
+$$;
+
+SET ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000001', false);
+SELECT ok(
+  public.__test_upsert_festival_push_subscription(
+    '10000000-0000-0000-0000-000000000001'::uuid,
+    true,
+    ARRAY[1, 2]
+  ),
+  'admin can subscribe to multiple unassigned festival stages'
+);
+
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000002', false);
+SELECT ok(
+  public.__test_upsert_festival_push_subscription(
+    '10000000-0000-0000-0000-000000000002'::uuid,
+    true,
+    ARRAY[3]
+  ),
+  'management can subscribe without a festival shift assignment'
+);
+
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000003', false);
+SELECT ok(
+  public.__test_upsert_festival_push_subscription(
+    '10000000-0000-0000-0000-000000000003'::uuid,
+    true,
+    ARRAY[2]
+  ),
+  'technician can subscribe to an assigned stage'
+);
+SELECT ok(
+  NOT public.__test_upsert_festival_push_subscription(
+    '10000000-0000-0000-0000-000000000003'::uuid,
+    true,
+    ARRAY[3]
+  ),
+  'technician cannot subscribe to an unassigned stage'
+);
+SELECT ok(
+  NOT public.__test_upsert_festival_push_subscription(
+    '10000000-0000-0000-0000-000000000003'::uuid,
+    true,
+    ARRAY[2, 3]
+  ),
+  'technician cannot add an unassigned stage to a multi-stage subscription'
+);
+
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000004', false);
+SELECT ok(
+  public.__test_upsert_festival_push_subscription(
+    '10000000-0000-0000-0000-000000000004'::uuid,
+    true,
+    ARRAY[3]
+  ),
+  'house tech can subscribe to an assigned stage'
+);
+SELECT ok(
+  NOT public.__test_upsert_festival_push_subscription(
+    '10000000-0000-0000-0000-000000000004'::uuid,
+    true,
+    ARRAY[2]
+  ),
+  'house tech cannot subscribe to an unassigned stage'
+);
+
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000005', false);
+SELECT ok(
+  public.__test_upsert_festival_push_subscription(
+    '10000000-0000-0000-0000-000000000005'::uuid,
+    false,
+    ARRAY[]::integer[]
+  ),
+  'unassigned technician can save a disabled empty subscription row'
+);
+
+SELECT set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000003', false);
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.festival_push_subscriptions
+    WHERE job_id = '20000000-0000-0000-0000-000000000001'::uuid
+  ),
+  1,
+  'authenticated users only select their own festival feed subscription rows'
+);
+
+RESET ROLE;
+DROP FUNCTION public.__test_upsert_festival_push_subscription(uuid, boolean, integer[]);
+
+SELECT * FROM finish();


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Affected route/feature: festival management artists, TechSuperApp Artistas modal, scheduled push notifications, Supabase RLS.

Adds an opt-in festival push notification feed using the existing scheduled push path.

- Adds `festival_push_subscriptions` and `festival_push_delivery_log` with RLS and service-side dedupe.
- Adds the `festival.feed.tick` scheduled push event, generated every minute through `invoke_scheduled_push_notification`.
- Sends Spanish artist and shift timing notifications for soundcheck, line check, show, and assigned shift moments.
- Enforces stage targeting: technicians and house techs only receive assigned stages/shifts; admins and management can subscribe to selected stages without job assignment.
- Adds stage-aware deep links for management and TechSuperApp artist views.
- Adds subscription UI next to festival offline controls and in the technician read-only Artistas flow.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: medium
- Main risks: scheduled notification volume/spam if dedupe regresses; incorrect stage targeting if RLS or recipient resolution regresses; production migration/cron rollout ordering.
- [x] If this touches database, auth, CI/CD, dependency, security, or production-header paths, I requested CODEOWNER review.
- [ ] If risk level is high, I requested two independent approvals before merge.

## Impact Checklist
- [x] Migration impact assessed.
- [x] Realtime/subscription impact assessed.
- [x] RLS/security impact assessed.
- [x] Performance impact assessed.

Notes: no realtime channel changes. The feed uses the existing scheduled push function path. Delivery log retention is limited by a daily cleanup job and indexed `sent_at`. The new subscription table is protected by RLS; admins/management can choose festival stages, while technicians and house techs are limited to assigned stages.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `git diff --check`
  - `npm run lint`
  - `npm run lint:functions`
  - `npm run typecheck`
  - `npm run governance`
  - `npm run test:critical`
  - `npm run test:run`
  - `npm run build`
  - `npm run budget:bundle`
  - `npm run ci:db:migrations`
  - `npx vitest run src/components/festival/__tests__/FestivalPushFeedButton.test.tsx src/pages/__tests__/TechnicianSuperApp.test.tsx src/pages/__tests__/FestivalArtistManagement.stage.test.tsx supabase/functions/push/__tests__/festivalFeedUtils.test.ts`
  - `npx supabase db reset --local --no-seed`
  - `npx supabase db lint --local --fail-on error --schema public,auth`
  - `npx supabase test db supabase/tests/database`
- Results: all local checks pass. Lint has 0 errors with existing warnings. `npm run test:run` passed 222 files / 1214 tests. Database tests passed 5 files / 126 tests. Build passed with existing large-chunk warnings. Supabase db lint passes at error level with existing unrelated warnings.

## Rollback Plan
- [x] I documented how to safely revert this change.
- [x] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert this PR. For an urgent stop before revert/deploy completes, disable the scheduled feed jobs with `cron.unschedule('festival-push-feed-tick')` and `cron.unschedule('festival-push-delivery-log-cleanup')`. If the schema must be backed out, drop the new feed tables, helper functions, policies, indexes, and cron jobs in a rollback migration after confirming no retained subscription data is needed.

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: yes
- If yes, describe migration, impact, and backout plan: adds `festival_push_subscriptions`, `festival_push_delivery_log`, helper authorization functions, RLS policies, indexes, and two pg_cron jobs. No backfill is required. Production workflow requires linked Supabase dry run, applying the pending migration to production, then a follow-up dry run confirming the remote DB is up to date before merge.
