### PR TITLE
fix: gate festival feed soundcheck/line check pushes on their enabled flags

### DIFF
--- a/supabase/functions/push/__tests__/festivalFeedUtils.test.ts
+++ b/supabase/functions/push/__tests__/festivalFeedUtils.test.ts
@@ -54,6 +54,40 @@ describe("festival feed event generation", () => {
     expect(events[0].eventKey).toContain("artist:artist-1:soundcheck_15:");
   });
 
+  it("skips soundcheck moments when the soundcheck flag is off despite a stale start time", () => {
+    const events = buildFestivalFeedArtistEvents([
+      {
+        ...artistBase,
+        soundcheck: false,
+        soundcheck_start: "09:30:00",
+      },
+    ]);
+
+    expect(events.map((event) => event.eventKind)).toEqual([
+      "linecheck_15",
+      "linecheck_now",
+      "show_15",
+      "show_now",
+    ]);
+  });
+
+  it("skips line check moments when the line check flag is off despite a stale start time", () => {
+    const events = buildFestivalFeedArtistEvents([
+      {
+        ...artistBase,
+        line_check: false,
+        line_check_start: "21:30:00",
+      },
+    ]);
+
+    expect(events.map((event) => event.eventKind)).toEqual([
+      "soundcheck_15",
+      "soundcheck_now",
+      "show_15",
+      "show_now",
+    ]);
+  });
+
   it("uses Madrid timezone and moves line check/show after midnight to the next civil day", () => {
     const events = buildFestivalFeedArtistEvents([
       {

--- a/supabase/functions/push/festivalFeedUtils.ts
+++ b/supabase/functions/push/festivalFeedUtils.ts
@@ -194,8 +194,10 @@ const normalizeStageLabel = (jobId: string, stage: number | null, stageNames?: M
 };
 
 const getArtistMomentTime = (artist: FestivalFeedArtist, source: ArtistMomentConfig["source"]): string | null => {
-  if (source === "soundcheck") return artist.soundcheck_start;
-  if (source === "linecheck") return artist.line_check_start;
+  // soundcheck_start/line_check_start can hold stale values after the artist is
+  // toggled off in the form, so the enabled flag is the source of truth.
+  if (source === "soundcheck") return artist.soundcheck ? artist.soundcheck_start : null;
+  if (source === "linecheck") return artist.line_check ? artist.line_check_start : null;
   return artist.show_start;
 };
 


### PR DESCRIPTION
Artist rows keep stale soundcheck_start/line_check_start values after the
corresponding toggle is switched off in the artist form, and the push feed
built notification moments from any non-null time. This fired soundcheck
pushes (e.g. at 09:30) for artists that only have a line check after
midnight. Only build those moments when the artist's soundcheck/line_check
flag is on, matching what the UI displays.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQmKBqWqvf6sttALwmWEjt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed festival feed timing so soundcheck and line check moments no longer appear when those checks are disabled, even if older start times are still present.
  * Show timing behavior remains unchanged.
  
* **Tests**
  * Added coverage to verify disabled check moments are excluded from the generated event list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->