### PR TITLE
fix: reactivate push toast navigates properly and artist search spans all dates

### DIFF
--- a/src/components/festival/ArtistManagementForm.tsx
+++ b/src/components/festival/ArtistManagementForm.tsx
@@ -105,7 +105,7 @@ export const ArtistManagementForm = ({
     return {
       name: artistData?.name || "",
       stage: artistData?.stage || 1,
-      date: selectedDate,
+      date: artistData?.date || selectedDate,
       show_start: artistData?.show_start || "20:00",
       show_end: artistData?.show_end || "21:00",
       soundcheck: artistData?.soundcheck || false,

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -6,6 +6,7 @@ import { Loading } from "@/components/ui/loading";
 import { Badge } from "@/components/ui/badge";
 import { ArrowUpDown, ExternalLink, ImageOff, ImagePlus, Loader2 } from "lucide-react";
 import { format, parseISO, isAfter, setHours, setMinutes } from "date-fns";
+import { es } from "date-fns/locale";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -118,6 +119,8 @@ interface ArtistTableProps {
   dayStartTime: string;
   jobId?: string;
   selectedDate?: string;
+  /** True while the search box is matching artists across every festival date, not just `selectedDate`. */
+  crossDateSearch?: boolean;
   onArtistStagePlotUpdated?: () => void;
   canDelete: boolean;
   canCreateExtras: boolean;
@@ -134,6 +137,7 @@ export const ArtistTable = ({
   dayStartTime,
   jobId,
   selectedDate,
+  crossDateSearch = false,
   onArtistStagePlotUpdated,
   canDelete,
   canCreateExtras
@@ -794,6 +798,11 @@ export const ArtistTable = ({
                         <div className="space-y-1">
                           <div className="font-medium text-sm break-words">{artist.name}</div>
                           <div className="flex flex-wrap gap-1">
+                            {crossDateSearch && artist.date && (
+                              <Badge variant="secondary" className="text-[10px] px-1 py-0">
+                                {format(parseISO(artist.date), "d MMM", { locale: es })}
+                              </Badge>
+                            )}
                             <Badge variant="outline" className="text-[10px] px-1 py-0">{getStageDisplayName(artist.stage)}</Badge>
                             {artist.artist_submitted && (
                               <Badge variant="outline" className="text-[10px] px-1 py-0 bg-amber-100 text-amber-900 border-amber-300" title="Enviado por artista mediante formulario público">
@@ -1062,6 +1071,7 @@ export const ArtistTable = ({
               gearComparisons={gearComparisons}
               jobId={jobId || ""}
               selectedDate={selectedDate || ""}
+              crossDateSearch={crossDateSearch}
               onEditArtist={onEditArtist}
               onDeleteArtist={handleDeleteClick}
               onGenerateLink={handleGenerateLink}

--- a/src/components/festival/ArtistTableFilters.tsx
+++ b/src/components/festival/ArtistTableFilters.tsx
@@ -31,7 +31,7 @@ export const ArtistTableFilters = ({
           <Label htmlFor="search" className="text-sm">Buscar artista</Label>
           <Input
             id="search"
-            placeholder="Buscar por nombre..."
+            placeholder="Buscar por nombre en todas las fechas..."
             value={searchTerm}
             onChange={(e) => onSearchChange(e.target.value)}
             className="h-10"

--- a/src/components/festival/mobile/MobileArtistCard.tsx
+++ b/src/components/festival/mobile/MobileArtistCard.tsx
@@ -1,3 +1,5 @@
+import { format, parseISO } from "date-fns";
+import { es } from "date-fns/locale";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -223,6 +225,8 @@ interface MobileArtistCardProps {
   stageName: string;
   stagePlotUrl?: string;
   gearComparison?: ArtistGearComparison;
+  /** True while the search box is matching artists across every festival date, not just the selected one. */
+  showDateBadge?: boolean;
   mode?: 'edit' | 'readonly';
   onEditCategory: (artistId: string, category: MobileConfigCategory) => void;
   onEditArtist: (artist: Artist) => void;
@@ -248,6 +252,7 @@ export const MobileArtistCard = ({
   stageName,
   stagePlotUrl,
   gearComparison,
+  showDateBadge = false,
   mode = 'edit',
   onEditCategory,
   onEditArtist,
@@ -283,6 +288,11 @@ export const MobileArtistCard = ({
               {artist.artist_submitted && (
                 <Badge variant="outline" className="text-[10px] bg-amber-100 text-amber-900 border-amber-300">
                   Enviado
+                </Badge>
+              )}
+              {showDateBadge && artist.date && (
+                <Badge variant="secondary" className="text-[10px]">
+                  {format(parseISO(artist.date), "d MMM", { locale: es })}
                 </Badge>
               )}
               <Badge variant="outline" className="text-[10px]">{stageName}</Badge>

--- a/src/components/festival/mobile/MobileArtistFormSheet.tsx
+++ b/src/components/festival/mobile/MobileArtistFormSheet.tsx
@@ -68,7 +68,7 @@ function buildFormData(artistData?: any, selectedDate?: string) {
   return {
     name: artistData?.name || "",
     stage: artistData?.stage || 1,
-    date: selectedDate || artistData?.date || "",
+    date: artistData?.date || selectedDate || "",
     show_start: artistData?.show_start || "20:00",
     show_end: artistData?.show_end || "21:00",
     soundcheck: artistData?.soundcheck || false,

--- a/src/components/festival/mobile/MobileArtistList.tsx
+++ b/src/components/festival/mobile/MobileArtistList.tsx
@@ -76,6 +76,8 @@ interface MobileArtistListProps {
   gearComparisons: Record<string, ArtistGearComparison>;
   jobId: string;
   selectedDate: string;
+  /** True while the search box is matching artists across every festival date, not just `selectedDate`. */
+  crossDateSearch?: boolean;
   onEditArtist: (artist: Artist) => void;
   onDeleteArtist: (artist: Artist) => void;
   onGenerateLink: (artist: Artist) => void;
@@ -104,6 +106,7 @@ export const MobileArtistList = ({
   gearComparisons,
   jobId,
   selectedDate,
+  crossDateSearch = false,
   onEditArtist,
   onDeleteArtist,
   onGenerateLink,
@@ -202,6 +205,7 @@ export const MobileArtistList = ({
             stageName={stageNames[artist.stage] || `Stage ${artist.stage}`}
             stagePlotUrl={stagePlotUrls[artist.id]}
             gearComparison={gearComparisons[artist.id]}
+            showDateBadge={crossDateSearch}
             mode={mode}
             onEditCategory={handleEditCategory}
             onEditArtist={onEditArtist}

--- a/src/hooks/useArtistMutations.ts
+++ b/src/hooks/useArtistMutations.ts
@@ -102,7 +102,10 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
       return data;
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId, selectedDate) });
+      // Prefix match invalidates every cached date bucket (and the
+      // "search all dates" bucket) for this job — the edited artist may have
+      // been found via cross-date search rather than the current tab's date.
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId) });
       const savedOffline = Boolean((data as { __offline?: boolean })?.__offline);
       toast({
         title: savedOffline ? "Guardado offline" : "Success",
@@ -159,7 +162,10 @@ export const useArtistMutations = (jobId: string | undefined, selectedDate: stri
       return data;
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId, selectedDate) });
+      // Prefix match invalidates every cached date bucket (and the
+      // "search all dates" bucket) for this job — the edited artist may have
+      // been found via cross-date search rather than the current tab's date.
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId) });
       const savedOffline = Boolean((data as { __offline?: boolean })?.__offline);
       toast({
         title: savedOffline ? "Guardado offline" : "Success",

--- a/src/hooks/useArtistsQuery.ts
+++ b/src/hooks/useArtistsQuery.ts
@@ -6,18 +6,31 @@ import {
   fetchWithOfflineFallback,
   getFestivalSnapshot,
   getOfflineArtistsForDate,
+  getOfflineArtistsForJob,
   isBrowserOnline,
   queueFestivalChange,
 } from "@/lib/offline";
 
 
 import { queryKeys } from "@/lib/react-query";
-export const useArtistsQuery = (jobId: string | undefined, selectedDate: string, dayStartTime: string = "07:00") => {
+
+interface UseArtistsQueryOptions {
+  /** When true, fetches artists across every festival date instead of just `selectedDate` (used by the "search all dates" mode). */
+  searchAllDates?: boolean;
+}
+
+export const useArtistsQuery = (
+  jobId: string | undefined,
+  selectedDate: string,
+  dayStartTime: string = "07:00",
+  options: UseArtistsQueryOptions = {},
+) => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const { searchAllDates = false } = options;
 
   const fetchArtistsOnline = async () => {
-    const { data, error } = await supabase
+    let query = supabase
       .from("festival_artists")
       .select(`
         *,
@@ -26,8 +39,14 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
           status
         )
       `)
-      .eq("job_id", jobId)
-      .eq("date", selectedDate)
+      .eq("job_id", jobId);
+
+    if (!searchAllDates) {
+      query = query.eq("date", selectedDate);
+    }
+
+    const { data, error } = await query
+      .order("date", { ascending: true })
       .order("show_start", { ascending: true });
 
     if (error) throw error;
@@ -76,7 +95,9 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
     error,
     refetch
   } = useQuery({
-    queryKey: queryKeys.scope('festival-artists', jobId, selectedDate),
+    queryKey: searchAllDates
+      ? queryKeys.scope('festival-artists', jobId, 'all-dates')
+      : queryKeys.scope('festival-artists', jobId, selectedDate),
     queryFn: async () => {
       if (!jobId || !selectedDate) return { rows: [], isOffline: false };
 
@@ -84,7 +105,9 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
       // the network is too slow to answer (weak festival-site connectivity).
       const result = await fetchWithOfflineFallback({
         online: fetchArtistsOnline,
-        offline: () => getOfflineArtistsForDate(jobId, selectedDate, dayStartTime),
+        offline: () => searchAllDates
+          ? getOfflineArtistsForJob(jobId, dayStartTime)
+          : getOfflineArtistsForDate(jobId, selectedDate, dayStartTime),
       });
       return { rows: result.data, isOffline: result.fromOffline };
     },
@@ -131,7 +154,10 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
       return { offline: false };
     },
     onSuccess: (result) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId, selectedDate) });
+      // Prefix match invalidates every cached date bucket (and the
+      // "search all dates" bucket) for this job, not just `selectedDate` —
+      // needed since the deleted artist may have been found via cross-date search.
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId) });
       toast({
         title: result?.offline ? "Guardado offline" : "Success",
         description: result?.offline
@@ -149,9 +175,10 @@ export const useArtistsQuery = (jobId: string | undefined, selectedDate: string,
     }
   });
 
-  // Function to invalidate and refetch artists
+  // Function to invalidate and refetch artists. Prefix match covers every
+  // cached date bucket plus the "search all dates" bucket for this job.
   const invalidateArtists = () => {
-    queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId, selectedDate) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('festival-artists', jobId) });
   };
 
   return {

--- a/src/hooks/usePushSubscriptionRecovery.ts
+++ b/src/hooks/usePushSubscriptionRecovery.ts
@@ -83,7 +83,7 @@ export function usePushSubscriptionRecovery() {
             onClick: () => {
               // Navigate to notifications settings
               // User will need to manually re-enable
-              window.location.hash = '#/profile'; // or wherever your push settings are
+              window.location.href = '/profile';
             },
           },
           cancel: {

--- a/src/lib/offline/festival-snapshot.ts
+++ b/src/lib/offline/festival-snapshot.ts
@@ -260,6 +260,48 @@ export const getOfflineArtistsForDate = async (
     .sort((a, b) => compareTimeStrings(a.show_start, b.show_start));
 };
 
+/**
+ * Returns every artist across all festival dates (used when the artist
+ * search box searches beyond the currently selected date), processed the
+ * same way as `getOfflineArtistsForDate`, or null when no snapshot exists.
+ */
+export const getOfflineArtistsForJob = async (
+  jobId: string,
+  dayStartTime = "07:00",
+): Promise<Row[] | null> => {
+  const snapshot = await getFestivalSnapshot(jobId);
+  if (!snapshot) return null;
+
+  const submittedArtistIds = new Set(
+    snapshot.data.artistFormSubmissions
+      .filter((submission) => submission.status === "submitted")
+      .map((submission) => submission.artist_id as string),
+  );
+
+  return snapshot.data.artists
+    .map((artist) => {
+      const processed: Row = {
+        ...artist,
+        artist_submitted: submittedArtistIds.has(artist.id as string),
+      };
+
+      if (processed.isaftermidnight === undefined || processed.isaftermidnight === null) {
+        const showStart = processed.show_start;
+        if (typeof showStart === "string" && showStart) {
+          const [hours] = showStart.split(":").map(Number);
+          const [startHour] = dayStartTime.split(":").map(Number);
+          processed.isaftermidnight = hours < startHour;
+        }
+      }
+
+      return processed;
+    })
+    .sort((a, b) => {
+      const dateCompare = compareTimeStrings(a.date, b.date);
+      return dateCompare !== 0 ? dateCompare : compareTimeStrings(a.show_start, b.show_start);
+    });
+};
+
 export interface OfflineFestivalContext {
   job: Row | null;
   festivalSettings: Row | null;

--- a/src/lib/offline/index.ts
+++ b/src/lib/offline/index.ts
@@ -6,6 +6,7 @@ export {
   getFestivalSnapshot,
   deleteFestivalSnapshot,
   getOfflineArtistsForDate,
+  getOfflineArtistsForJob,
   getOfflineFestivalContext,
   type OfflineFestivalContext,
   type FestivalSnapshotDownloadResult,

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -217,7 +217,7 @@ const FestivalArtistManagement = () => {
   useRealtimeSubscription({
     table: "festival_artists",
     filter: `job_id=eq.${jobId}`,
-    queryKey: queryKeys.scope("festival-artists", jobId, selectedDate)
+    queryKey: queryKeys.scope("festival-artists", jobId) // Broader key for prefix matching both per-date and 'all-dates' cache entries
   });
 
   useEffect(() => {

--- a/src/pages/FestivalArtistManagement.tsx
+++ b/src/pages/FestivalArtistManagement.tsx
@@ -63,7 +63,9 @@ const FestivalArtistManagement = () => {
   const { jobTitle, jobDates, selectedDate, setSelectedDate, maxStages } =
     useFestivalArtistJobDetails(jobId, routeDate);
 
-  const { artists, isLoading: artistsLoading, deleteArtist, invalidateArtists, isOfflineData } = useArtistsQuery(jobId, selectedDate, dayStartTime);
+  // A non-empty search term searches every festival date instead of just the selected one.
+  const isCrossDateSearch = searchTerm.trim().length > 0;
+  const { artists, isLoading: artistsLoading, deleteArtist, invalidateArtists, isOfflineData } = useArtistsQuery(jobId, selectedDate, dayStartTime, { searchAllDates: isCrossDateSearch });
   const artistRows = artists as unknown as ComponentProps<typeof ArtistTable>["artists"];
   const {
     data: festivalSettings
@@ -698,17 +700,18 @@ const FestivalArtistManagement = () => {
             {selectedDate && (
               isShowDate(new Date(selectedDate)) ? (
                 <div className="w-full">
-                  <ArtistTable 
+                  <ArtistTable
                     artists={artistRows}
-                    isLoading={artistsLoading} 
-                    onEditArtist={handleEditArtist} 
-                    onDeleteArtist={handleDeleteArtist} 
+                    isLoading={artistsLoading}
+                    onEditArtist={handleEditArtist}
+                    onDeleteArtist={handleDeleteArtist}
                     searchTerm={searchTerm}
                     stageFilter={stageFilter}
                     riderFilter={riderFilter}
                     dayStartTime={dayStartTime}
                     jobId={jobId}
                     selectedDate={selectedDate}
+                    crossDateSearch={isCrossDateSearch}
                     onArtistStagePlotUpdated={invalidateArtists}
                     {...artistActionPermissions}
                   />


### PR DESCRIPTION
The push subscription recovery toast set window.location.hash to '#/profile',
which is a no-op under the app's BrowserRouter (no route reads the hash) —
clicking "Reactivar" did nothing. It now navigates via window.location.href.

The festival artist search box only matched artists on the currently
selected date. useArtistsQuery now supports a searchAllDates mode used
whenever the search box has a term, so results span every festival date
(shown with a date badge). Fixed a latent date-overwrite bug this exposed:
editing an artist unconditionally stamped the form's date field with the
page's selected tab instead of the artist's own date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artist search can now span all festival dates, not just the selected day.
  * Artist lists and cards can show each artist’s date when cross-date search is active.
  * Offline artist browsing now includes results from every festival date.
  * Form data now keeps the artist’s saved date when available.

* **Bug Fixes**
  * Search and delete actions now refresh artist lists across all date views more reliably.
  * The push-permission recovery action now opens the profile page directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->