### PR TITLE
fix: mobile-responsive dialogs on Tarifas + iOS navbar detach bug

### DIFF
--- a/src/components/dashboard/EmailComposerDialog.tsx
+++ b/src/components/dashboard/EmailComposerDialog.tsx
@@ -13,7 +13,7 @@ interface EmailComposerDialogProps {
 export const EmailComposerDialog = ({ open, onOpenChange }: EmailComposerDialogProps) => {
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto bg-[#0f1219] border-[#1f232e] text-slate-100">
+            <DialogContent className="max-w-3xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto bg-[#0f1219] border-[#1f232e] text-slate-100">
                 <DialogHeader>
                     <DialogTitle>Redactar Email Corporativo</DialogTitle>
                 </DialogHeader>

--- a/src/components/dashboard/EmailComposerDialog.tsx
+++ b/src/components/dashboard/EmailComposerDialog.tsx
@@ -13,7 +13,7 @@ interface EmailComposerDialogProps {
 export const EmailComposerDialog = ({ open, onOpenChange }: EmailComposerDialogProps) => {
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-3xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto bg-[#0f1219] border-[#1f232e] text-slate-100">
+            <DialogContent className="max-w-3xl max-h-[calc(90vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto bg-[#0f1219] border-[#1f232e] text-slate-100">
                 <DialogHeader>
                     <DialogTitle>Redactar Email Corporativo</DialogTitle>
                 </DialogHeader>

--- a/src/components/dashboard/MessagesDialog.tsx
+++ b/src/components/dashboard/MessagesDialog.tsx
@@ -17,7 +17,7 @@ export const MessagesDialog = ({ open, onOpenChange }: MessagesDialogProps) => {
     return (
         <>
             <Dialog open={open} onOpenChange={onOpenChange}>
-                <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto bg-[#0f1219] border-[#1f232e] text-slate-100">
+                <DialogContent className="max-w-2xl max-h-[calc(80vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto bg-[#0f1219] border-[#1f232e] text-slate-100">
                     <DialogHeader className="flex flex-row items-center justify-between">
                         <DialogTitle>Mensajes</DialogTitle>
                         <Button

--- a/src/components/dashboard/MessagesDialog.tsx
+++ b/src/components/dashboard/MessagesDialog.tsx
@@ -17,7 +17,7 @@ export const MessagesDialog = ({ open, onOpenChange }: MessagesDialogProps) => {
     return (
         <>
             <Dialog open={open} onOpenChange={onOpenChange}>
-                <DialogContent className="max-w-2xl max-h-[calc(80vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto bg-[#0f1219] border-[#1f232e] text-slate-100">
+                <DialogContent className="max-w-2xl max-h-[calc(80vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto bg-[#0f1219] border-[#1f232e] text-slate-100">
                     <DialogHeader className="flex flex-row items-center justify-between">
                         <DialogTitle>Mensajes</DialogTitle>
                         <Button

--- a/src/components/disponibilidad/MobileAvailabilityView.tsx
+++ b/src/components/disponibilidad/MobileAvailabilityView.tsx
@@ -84,7 +84,7 @@ export function MobileAvailabilityView({
                                     <Menu className="h-5 w-5" />
                                 </Button>
                             </SheetTrigger>
-                            <SheetContent side="right" className="w-[300px] bg-[#0f1219] border-l border-[#1f232e]">
+                            <SheetContent side="right" className="w-[85vw] max-w-[300px] bg-[#0f1219] border-l border-[#1f232e]">
                                 <SheetHeader className="mb-6">
                                     <SheetTitle className="text-white">Acciones</SheetTitle>
                                 </SheetHeader>

--- a/src/components/festival/ArtistFormLinksDialog.tsx
+++ b/src/components/festival/ArtistFormLinksDialog.tsx
@@ -356,7 +356,7 @@ export const ArtistFormLinksDialog = ({
   const titleDate = dateFilter === ALL_DATES_VALUE ? "Todas las fechas" : formatDateLabel(dateFilter);
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl max-h-[calc(80vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+      <DialogContent className="max-w-3xl max-h-[calc(80vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Enlaces de Formularios de Artistas - {titleDate}</DialogTitle>
         </DialogHeader>

--- a/src/components/festival/ArtistFormLinksDialog.tsx
+++ b/src/components/festival/ArtistFormLinksDialog.tsx
@@ -356,7 +356,7 @@ export const ArtistFormLinksDialog = ({
   const titleDate = dateFilter === ALL_DATES_VALUE ? "Todas las fechas" : formatDateLabel(dateFilter);
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+      <DialogContent className="max-w-3xl max-h-[calc(80vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Enlaces de Formularios de Artistas - {titleDate}</DialogTitle>
         </DialogHeader>
@@ -365,10 +365,10 @@ export const ArtistFormLinksDialog = ({
           <div className="rounded-md border border-muted px-3 py-2 text-sm text-muted-foreground">
             Los enlaces públicos expiran en 7 días. Puedes filtrar por fecha o ver todas las fechas del festival.
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <span className="text-sm text-muted-foreground">Fecha:</span>
             <Select value={dateFilter} onValueChange={setDateFilter}>
-              <SelectTrigger className="w-[240px]">
+              <SelectTrigger className="w-full sm:w-[240px]">
                 <SelectValue placeholder="Selecciona fecha" />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/jobs/CreateJobDialog.tsx
+++ b/src/components/jobs/CreateJobDialog.tsx
@@ -302,7 +302,7 @@ export const CreateJobDialog = ({ open, onOpenChange, currentDepartment, initial
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+      <DialogContent className="max-h-[calc(90vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Crear Nuevo Trabajo</DialogTitle>
         </DialogHeader>

--- a/src/components/jobs/CreateJobDialog.tsx
+++ b/src/components/jobs/CreateJobDialog.tsx
@@ -302,7 +302,7 @@ export const CreateJobDialog = ({ open, onOpenChange, currentDepartment, initial
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Crear Nuevo Trabajo</DialogTitle>
         </DialogHeader>
@@ -439,7 +439,7 @@ export const CreateJobDialog = ({ open, onOpenChange, currentDepartment, initial
 
           <div className="space-y-2">
             <Label>Departamentos</Label>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               {TECHNICAL_DEPARTMENTS.map((department) => (
                 <Button
                   key={department}

--- a/src/components/jobs/EditJobDialog.tsx
+++ b/src/components/jobs/EditJobDialog.tsx
@@ -466,7 +466,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-[95vw] max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-lg max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit Job</DialogTitle>
           </DialogHeader>

--- a/src/components/jobs/EditJobDialog.tsx
+++ b/src/components/jobs/EditJobDialog.tsx
@@ -466,7 +466,7 @@ export const EditJobDialog = ({ open, onOpenChange, job }: EditJobDialogProps) =
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-[95vw] max-w-lg max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-lg max-h-[calc(90vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Edit Job</DialogTitle>
           </DialogHeader>

--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -515,7 +515,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="w-[95vw] max-w-[625px] max-h-[90vh] flex flex-col overflow-hidden">
+      <DialogContent className="w-[95vw] max-w-[625px] max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex flex-col overflow-hidden">
         {isClosureLocked && (
           <Alert className="border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-50">
             <AlertCircle className="h-4 w-4" />

--- a/src/components/jobs/JobAssignmentDialog.tsx
+++ b/src/components/jobs/JobAssignmentDialog.tsx
@@ -515,7 +515,7 @@ export const JobAssignmentDialog = ({ isOpen, onClose, onAssignmentChange, jobId
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="w-[95vw] max-w-[625px] max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex flex-col overflow-hidden">
+      <DialogContent className="w-[95vw] max-w-[625px] max-h-[calc(90vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] flex flex-col overflow-hidden">
         {isClosureLocked && (
           <Alert className="border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-50">
             <AlertCircle className="h-4 w-4" />

--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -200,7 +200,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
   if (isJobLoading) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[90vh] flex flex-col overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex flex-col overflow-y-auto">
           <div className="flex items-center justify-center h-32">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
           </div>
@@ -213,7 +213,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] max-h-[92vh] flex flex-col overflow-y-auto overflow-x-hidden px-3 sm:px-6">
+      <DialogContent className="w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] max-h-[calc(92vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex flex-col overflow-y-auto overflow-x-hidden px-3 sm:px-6">
         <DialogHeader className="flex-shrink-0">
           <DialogTitle className="flex items-center gap-2 text-base md:text-lg">
             <Calendar className="h-4 w-4 md:h-5 md:w-5" />

--- a/src/components/jobs/JobDetailsDialog.tsx
+++ b/src/components/jobs/JobDetailsDialog.tsx
@@ -200,7 +200,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
   if (isJobLoading) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex flex-col overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] flex flex-col overflow-y-auto">
           <div className="flex items-center justify-center h-32">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
           </div>
@@ -213,7 +213,7 @@ const JobDetailsDialogComponent: React.FC<JobDetailsDialogProps> = ({ open, onOp
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] max-h-[calc(92vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex flex-col overflow-y-auto overflow-x-hidden px-3 sm:px-6">
+      <DialogContent className="w-[98vw] sm:w-[96vw] max-w-[1200px] xl:max-w-[1400px] max-h-[calc(92vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] flex flex-col overflow-y-auto overflow-x-hidden px-3 sm:px-6">
         <DialogHeader className="flex-shrink-0">
           <DialogTitle className="flex items-center gap-2 text-base md:text-lg">
             <Calendar className="h-4 w-4 md:h-5 md:w-5" />

--- a/src/components/jobs/PayoutEmailPreview.tsx
+++ b/src/components/jobs/PayoutEmailPreview.tsx
@@ -349,7 +349,7 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-hidden flex flex-col">
+      <DialogContent className="max-w-4xl max-h-[calc(90vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle>Vista Previa - Correo de Pago</DialogTitle>
           <DialogDescription>

--- a/src/components/jobs/PayoutEmailPreview.tsx
+++ b/src/components/jobs/PayoutEmailPreview.tsx
@@ -349,7 +349,7 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+      <DialogContent className="max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle>Vista Previa - Correo de Pago</DialogTitle>
           <DialogDescription>
@@ -376,10 +376,10 @@ export function PayoutEmailPreview({ open, onClose, context, jobTitle }: PayoutE
 
           {/* Preview Content */}
           {selectedAttachment && (
-            <Tabs defaultValue="email" className="flex-1 flex flex-col overflow-hidden">
-              <TabsList>
-                <TabsTrigger value="email">Email HTML</TabsTrigger>
-                <TabsTrigger value="data">Datos</TabsTrigger>
+            <Tabs defaultValue="email" className="flex-1 flex flex-col overflow-hidden min-w-0">
+              <TabsList className="w-full sm:w-auto">
+                <TabsTrigger value="email" className="flex-1 sm:flex-none">Email HTML</TabsTrigger>
+                <TabsTrigger value="data" className="flex-1 sm:flex-none">Datos</TabsTrigger>
               </TabsList>
 
               <TabsContent value="email" className="flex-1 overflow-auto border rounded-md p-4">

--- a/src/components/layout/MobileNavBar.test.tsx
+++ b/src/components/layout/MobileNavBar.test.tsx
@@ -153,7 +153,7 @@ describe("MobileNavBar", () => {
     expect(nav).toHaveClass("fixed", "bottom-0")
   })
 
-  it("offsets the nav to the visual viewport bottom when browser chrome changes visible height", async () => {
+  it("ignores a visualViewport offset when nothing editable is focused", async () => {
     const visualViewport = mockVisualViewport({
       height: 700,
       innerHeight: 760,
@@ -164,6 +164,33 @@ describe("MobileNavBar", () => {
 
     const nav = screen.getByRole("navigation", { name: /navegación principal/i })
 
+    // No input is focused, so even though visualViewport reports a 60px inset
+    // (as if the keyboard/chrome shrank the visible area), the nav must stay
+    // pinned to the true bottom edge.
+    act(() => {
+      visualViewport.dispatch("resize")
+    })
+    expect(nav.style.bottom).toBe("")
+  })
+
+  it("offsets the nav to the visual viewport bottom while an input is focused", async () => {
+    const visualViewport = mockVisualViewport({
+      height: 700,
+      innerHeight: 760,
+      offsetTop: 0,
+    })
+
+    renderMobileNav()
+
+    const nav = screen.getByRole("navigation", { name: /navegación principal/i })
+    const input = document.createElement("input")
+    document.body.appendChild(input)
+
+    act(() => {
+      input.focus()
+      input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }))
+    })
+
     await waitFor(() => expect(nav.style.bottom).toBe("60px"))
 
     ;(window.visualViewport as unknown as { height: number }).height = 760
@@ -173,10 +200,46 @@ describe("MobileNavBar", () => {
     })
 
     await waitFor(() => expect(nav.style.bottom).toBe(""))
+
+    act(() => {
+      input.blur()
+      input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }))
+    })
+    document.body.removeChild(input)
   })
 
-  it("recomputes the offset on visibilitychange when iOS resumes a backgrounded PWA without firing resize", async () => {
-    mockVisualViewport({
+  it("snaps back to bottom:0 the instant focus leaves an input, even if visualViewport still reports an inset", async () => {
+    const visualViewport = mockVisualViewport({
+      height: 700,
+      innerHeight: 760,
+      offsetTop: 0,
+    })
+
+    renderMobileNav()
+
+    const nav = screen.getByRole("navigation", { name: /navegación principal/i })
+    const input = document.createElement("input")
+    document.body.appendChild(input)
+
+    act(() => {
+      input.focus()
+      input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }))
+    })
+    await waitFor(() => expect(nav.style.bottom).toBe("60px"))
+
+    // visualViewport still reports the keyboard-open inset (WebKit can lag
+    // here), but focus has already moved away from the input.
+    act(() => {
+      input.blur()
+      input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }))
+    })
+
+    expect(nav.style.bottom).toBe("")
+    document.body.removeChild(input)
+  })
+
+  it("forces the offset back to 0 on resume even when visualViewport keeps reporting a stale inset and no input is focused", async () => {
+    const visualViewport = mockVisualViewport({
       height: 700,
       innerHeight: 760,
       offsetTop: 0,
@@ -188,30 +251,29 @@ describe("MobileNavBar", () => {
 
       const nav = screen.getByRole("navigation", { name: /navegación principal/i })
 
-      await waitFor(() => expect(nav.style.bottom).toBe("60px"))
+      // Nothing is focused, so the bar must already be pinned to the bottom...
+      expect(nav.style.bottom).toBe("")
 
+      // ...and resuming a backgrounded PWA where WebKit's visualViewport API
+      // keeps misreporting a stale inset (the reported bug: no keyboard was
+      // ever involved) must not pull the bar away from the bottom edge.
       Object.defineProperty(document, "visibilityState", {
         configurable: true,
         value: "visible",
       })
 
-      // Dispatch while the viewport is still reporting the stale (backgrounded)
-      // height, mirroring WebKit reporting old values for a frame or two after
-      // resume. The immediate recompute should see no change yet.
       act(() => {
         document.dispatchEvent(new Event("visibilitychange"))
-      })
-      expect(nav.style.bottom).toBe("60px")
-
-      // The corrected height only becomes available a frame later, without any
-      // "resize" event firing on resume (the iOS PWA behavior this guards
-      // against).
-      ;(window.visualViewport as unknown as { height: number }).height = 760
-
-      act(() => {
         raf.flush()
       })
 
+      expect(nav.style.bottom).toBe("")
+
+      // Even an explicit resize firing with the same stale, nonzero
+      // visualViewport reading must not move the bar while unfocused.
+      act(() => {
+        visualViewport.dispatch("resize")
+      })
       expect(nav.style.bottom).toBe("")
     } finally {
       raf.restore()

--- a/src/components/layout/MobileNavBar.test.tsx
+++ b/src/components/layout/MobileNavBar.test.tsx
@@ -209,7 +209,7 @@ describe("MobileNavBar", () => {
   })
 
   it("snaps back to bottom:0 the instant focus leaves an input, even if visualViewport still reports an inset", async () => {
-    const visualViewport = mockVisualViewport({
+    mockVisualViewport({
       height: 700,
       innerHeight: 760,
       offsetTop: 0,

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -38,7 +38,45 @@ function getVisualViewportBottomOffset() {
 }
 
 /**
- * Tracks browser UI and keyboard viewport changes that can move fixed mobile chrome.
+ * Whether the currently focused element is one that would plausibly bring up
+ * the on-screen keyboard. This is the ONLY legitimate reason the fixed nav
+ * should ever be offset from `bottom: 0`.
+ */
+function isEditableElementFocused() {
+  if (typeof document === "undefined") {
+    return false
+  }
+
+  const active = document.activeElement as HTMLElement | null
+  if (!active) {
+    return false
+  }
+
+  if (active.tagName === "INPUT" || active.tagName === "TEXTAREA") {
+    return true
+  }
+
+  return active.isContentEditable === true
+}
+
+/**
+ * Tracks the on-screen-keyboard inset for fixed mobile chrome.
+ *
+ * iOS standalone PWAs have a well-documented WebKit bug where, after the app
+ * is backgrounded and resumed (even briefly, and with no keyboard ever
+ * involved), `visualViewport.height`/`offsetTop` can come back stale or
+ * simply wrong — and stay wrong until a full reload, i.e. a plain resize/
+ * scroll does NOT self-correct it. An earlier fix here tried to work around
+ * that by recomputing from `visualViewport` on every resume signal, but that
+ * still trusts numbers the browser itself is misreporting, so it can just as
+ * easily "fix" the offset to a wrong nonzero value and pin the nav mid-screen.
+ *
+ * The only time a nonzero offset is ever legitimate is while the on-screen
+ * keyboard is up, which requires a focused text input/textarea/contenteditable.
+ * So we hard-clamp the offset to 0 whenever nothing editable is focused,
+ * regardless of what `visualViewport` reports — including immediately on
+ * resume — and only consult `visualViewport` while an editable element is
+ * genuinely focused.
  */
 function useVisualViewportBottomOffset() {
   const [bottomOffset, setBottomOffset] = useState(0)
@@ -48,20 +86,6 @@ function useVisualViewportBottomOffset() {
       return undefined
     }
 
-    const updateBottomOffset = () => {
-      setBottomOffset(getVisualViewportBottomOffset())
-    }
-
-    updateBottomOffset()
-
-    // iOS often resumes a backgrounded/minimized PWA without firing a "resize"
-    // event even though the WebKit-reported viewport offsets were stale at the
-    // moment it was backgrounded (e.g. mid-keyboard-dismiss or mid-chrome
-    // animation). Without a recompute on resume, the fixed nav stays pinned to
-    // that stale offset and visibly "unsticks" from the bottom. Recompute on
-    // the visibility/pageshow signals below, with a couple of rAF-deferred
-    // follow-ups since WebKit can report the old viewport values for a frame
-    // or two right after resume.
     let pendingFrames: number[] = []
 
     const cancelPendingFrames = () => {
@@ -69,6 +93,15 @@ function useVisualViewportBottomOffset() {
       pendingFrames = []
     }
 
+    const updateBottomOffset = () => {
+      setBottomOffset(isEditableElementFocused() ? getVisualViewportBottomOffset() : 0)
+    }
+
+    updateBottomOffset()
+
+    // Recompute a few times after resume in case an editable element was
+    // already focused (keyboard open) before backgrounding and WebKit needs a
+    // frame or two to report the correct post-resume viewport metrics.
     const recomputeOnResume = () => {
       cancelPendingFrames()
       updateBottomOffset()
@@ -96,6 +129,10 @@ function useVisualViewportBottomOffset() {
     // "unstick". Keyboard and browser-chrome changes still arrive via "resize".
     document.addEventListener("visibilitychange", handleVisibilityChange)
     window.addEventListener("pageshow", recomputeOnResume)
+    // Focus state is what gates whether we trust visualViewport at all, so
+    // transitions in/out of an editable element must recompute immediately.
+    document.addEventListener("focusin", updateBottomOffset)
+    document.addEventListener("focusout", updateBottomOffset)
 
     return () => {
       window.removeEventListener("resize", updateBottomOffset)
@@ -103,6 +140,8 @@ function useVisualViewportBottomOffset() {
       visualViewport?.removeEventListener("resize", updateBottomOffset)
       document.removeEventListener("visibilitychange", handleVisibilityChange)
       window.removeEventListener("pageshow", recomputeOnResume)
+      document.removeEventListener("focusin", updateBottomOffset)
+      document.removeEventListener("focusout", updateBottomOffset)
       cancelPendingFrames()
     }
   }, [])

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -37,6 +37,21 @@ function getVisualViewportBottomOffset() {
   return Math.max(0, Math.round(layoutViewportHeight - visualViewportBottom))
 }
 
+// Input types that bring up a text-style on-screen keyboard. Excludes
+// checkbox/radio/file/range/color/date/time/etc., which either show no
+// keyboard at all or a non-text picker that doesn't resize the viewport the
+// same way — trusting visualViewport while one of those is focused would let
+// a stale WebKit reading detach the nav again with no keyboard in sight.
+const TEXT_ENTRY_INPUT_TYPES = new Set([
+  "text",
+  "search",
+  "email",
+  "url",
+  "tel",
+  "password",
+  "number",
+])
+
 /**
  * Whether the currently focused element is one that would plausibly bring up
  * the on-screen keyboard. This is the ONLY legitimate reason the fixed nav
@@ -52,8 +67,12 @@ function isEditableElementFocused() {
     return false
   }
 
-  if (active.tagName === "INPUT" || active.tagName === "TEXTAREA") {
+  if (active.tagName === "TEXTAREA") {
     return true
+  }
+
+  if (active.tagName === "INPUT") {
+    return TEXT_ENTRY_INPUT_TYPES.has((active as HTMLInputElement).type)
   }
 
   return active.isContentEditable === true

--- a/src/components/matrix/AssignJobDialog.tsx
+++ b/src/components/matrix/AssignJobDialog.tsx
@@ -1145,7 +1145,7 @@ export const AssignJobDialog = ({
           }
         }}
       >
-        <AlertDialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <AlertDialogContent className="max-w-2xl max-h-[calc(80vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
           <AlertDialogHeader>
             <AlertDialogTitle>
               {conflictWarning?.result.hasHardConflict ? '⛔ Conflicto de Horario' : '⚠️ Conflicto Potencial'}

--- a/src/components/matrix/AssignJobDialog.tsx
+++ b/src/components/matrix/AssignJobDialog.tsx
@@ -1145,7 +1145,7 @@ export const AssignJobDialog = ({
           }
         }}
       >
-        <AlertDialogContent className="max-w-2xl max-h-[calc(80vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+        <AlertDialogContent className="max-w-2xl max-h-[calc(80vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto">
           <AlertDialogHeader>
             <AlertDialogTitle>
               {conflictWarning?.result.hasHardConflict ? '⛔ Conflicto de Horario' : '⚠️ Conflicto Potencial'}

--- a/src/components/tasks/PendingTasksModal.tsx
+++ b/src/components/tasks/PendingTasksModal.tsx
@@ -90,7 +90,7 @@ export const PendingTasksModal: React.FC<PendingTasksModalProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl w-[96vw] max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-hidden">
+      <DialogContent className="max-w-5xl w-[96vw] max-h-[calc(90vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             Tareas Pendientes

--- a/src/components/tasks/PendingTasksModal.tsx
+++ b/src/components/tasks/PendingTasksModal.tsx
@@ -90,7 +90,7 @@ export const PendingTasksModal: React.FC<PendingTasksModalProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl w-[96vw] max-h-[90vh] overflow-hidden">
+      <DialogContent className="max-w-5xl w-[96vw] max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             Tareas Pendientes

--- a/src/components/tasks/TaskManagerDialog.tsx
+++ b/src/components/tasks/TaskManagerDialog.tsx
@@ -21,7 +21,7 @@ export const TaskManagerDialog: React.FC<TaskManagerDialogProps> = ({ jobId, tou
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-6xl w-[96vw] max-h-[90vh] overflow-hidden">
+      <DialogContent className="max-w-6xl w-[96vw] max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-hidden">
         <DialogHeader>
           <DialogTitle>Task Manager</DialogTitle>
         </DialogHeader>

--- a/src/components/tasks/TaskManagerDialog.tsx
+++ b/src/components/tasks/TaskManagerDialog.tsx
@@ -21,7 +21,7 @@ export const TaskManagerDialog: React.FC<TaskManagerDialogProps> = ({ jobId, tou
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-6xl w-[96vw] max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-hidden">
+      <DialogContent className="max-w-6xl w-[96vw] max-h-[calc(90vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-hidden">
         <DialogHeader>
           <DialogTitle>Task Manager</DialogTitle>
         </DialogHeader>

--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -277,7 +277,7 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
 
       {/* Expense Dialog */}
       <Dialog open={expenseDialogOpen} onOpenChange={(open) => { setExpenseDialogOpen(open); if (!open) setShowExpenseForm(false); }}>
-        <DialogContent className="max-w-2xl max-h-[calc(85vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+        <DialogContent className="max-w-2xl max-h-[calc(85vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Receipt className="h-5 w-5" />

--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -277,7 +277,7 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
 
       {/* Expense Dialog */}
       <Dialog open={expenseDialogOpen} onOpenChange={(open) => { setExpenseDialogOpen(open); if (!open) setShowExpenseForm(false); }}>
-        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+        <DialogContent className="max-w-2xl max-h-[calc(85vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Receipt className="h-5 w-5" />

--- a/src/components/technician/TechJobCard.tsx
+++ b/src/components/technician/TechJobCard.tsx
@@ -194,7 +194,7 @@ export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techNam
 
             {/* Expense Dialog */}
             <Dialog open={expenseDialogOpen} onOpenChange={(open) => { setExpenseDialogOpen(open); if (!open) setShowExpenseForm(false); }}>
-                <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+                <DialogContent className="max-w-2xl max-h-[calc(85vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
                     <DialogHeader>
                         <DialogTitle className="flex items-center gap-2">
                             <Receipt className="h-5 w-5" />

--- a/src/components/technician/TechJobCard.tsx
+++ b/src/components/technician/TechJobCard.tsx
@@ -194,7 +194,7 @@ export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techNam
 
             {/* Expense Dialog */}
             <Dialog open={expenseDialogOpen} onOpenChange={(open) => { setExpenseDialogOpen(open); if (!open) setShowExpenseForm(false); }}>
-                <DialogContent className="max-w-2xl max-h-[calc(85vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+                <DialogContent className="max-w-2xl max-h-[calc(85vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto">
                     <DialogHeader>
                         <DialogTitle className="flex items-center gap-2">
                             <Receipt className="h-5 w-5" />

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -1681,7 +1681,7 @@ export const TourDefaultsManager = ({
         </DialogHeader>
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="min-w-0">
-          <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4">
+          <TabsList className="grid h-auto w-full grid-cols-2 gap-1 sm:h-10 sm:grid-cols-4 sm:gap-0">
             <TabsTrigger value="sound">Sonido</TabsTrigger>
             <TabsTrigger value="lights">Luces</TabsTrigger>
             <TabsTrigger value="video">Vídeo</TabsTrigger>

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -1675,7 +1675,7 @@ export const TourDefaultsManager = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl w-[95vw] md:w-full max-h-[calc(95vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] md:max-h-[80vh] overflow-y-auto">
+      <DialogContent className="max-w-5xl w-[95vw] md:w-full max-h-[calc(95vh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] md:max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-base md:text-lg truncate">Valores por Defecto de Gira: {tour?.name}</DialogTitle>
         </DialogHeader>

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -1221,12 +1221,12 @@ export const TourDefaultsManager = ({
 
         {/* Power Defaults */}
         <div>
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-4">
             <h4 className="text-lg font-semibold flex items-center gap-2">
               <Calculator className="h-5 w-5" />
               Valores por Defecto de Potencia ({powerTables.length})
             </h4>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <Button
                 variant="outline"
                 size="sm"
@@ -1440,12 +1440,12 @@ export const TourDefaultsManager = ({
 
         {/* Weight Defaults */}
         <div>
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-4">
             <h4 className="text-lg font-semibold flex items-center gap-2">
               <Weight className="h-5 w-5" />
               Valores por Defecto de Peso ({weightTables.length})
             </h4>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <Button
                 variant="outline"
                 size="sm"
@@ -1675,13 +1675,13 @@ export const TourDefaultsManager = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl w-[95vw] md:w-full max-h-[95vh] md:max-h-[80vh] overflow-y-auto">
+      <DialogContent className="max-w-5xl w-[95vw] md:w-full max-h-[calc(95vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] md:max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-base md:text-lg truncate">Valores por Defecto de Gira: {tour?.name}</DialogTitle>
         </DialogHeader>
 
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid w-full grid-cols-4">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="min-w-0">
+          <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4">
             <TabsTrigger value="sound">Sonido</TabsTrigger>
             <TabsTrigger value="lights">Luces</TabsTrigger>
             <TabsTrigger value="video">Vídeo</TabsTrigger>

--- a/src/components/tours/TourManagementDialog.tsx
+++ b/src/components/tours/TourManagementDialog.tsx
@@ -258,7 +258,7 @@ export const TourManagementDialog = ({
             <div className="border-b pb-4">
               <h3 className="text-sm font-medium mb-3">Configuración de Tour Pack</h3>
               <div className="space-y-3">
-                <div className="flex items-center justify-between p-3 bg-blue-50 dark:bg-blue-950 rounded-lg">
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3 bg-blue-50 dark:bg-blue-950 rounded-lg">
                   <div className="flex items-center gap-3">
                     <Package className="h-4 w-4 text-blue-600" />
                     <div>
@@ -266,7 +266,7 @@ export const TourManagementDialog = ({
                       <p className="text-xs text-muted-foreground">Establecer todas las fechas de esta gira como paquete S</p>
                     </div>
                   </div>
-                  <div className="flex gap-2">
+                  <div className="flex flex-wrap gap-2">
                     <Button
                       size="sm"
                       variant="outline"

--- a/src/components/tours/TourRatesManagerDialog.tsx
+++ b/src/components/tours/TourRatesManagerDialog.tsx
@@ -271,14 +271,14 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl max-h-[95vh] md:max-h-[90vh] overflow-y-auto w-[95vw] md:w-full">
+      <DialogContent className="max-w-5xl max-h-[calc(95dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] md:max-h-[90vh] overflow-y-auto w-[95vw] md:w-full">
         <DialogHeader>
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
             <DialogTitle className="flex items-center gap-2 text-base md:text-lg">
               <Euro className="h-4 w-4 md:h-5 md:w-5" />
               Gestor de Tarifas y Extras
             </DialogTitle>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto">
               <Badge variant={approved ? 'default' : 'secondary'} className="hidden sm:inline-flex">
                 {approved ? 'Tarifas base liberadas' : 'Aprobación base pendiente'}
               </Badge>
@@ -380,11 +380,11 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
           </p>
         </DialogHeader>
 
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
-          <TabsList>
-            <TabsTrigger value="by-date">Por fecha</TabsTrigger>
-            <TabsTrigger value="extras">Catálogo de extras</TabsTrigger>
-            <TabsTrigger value="base">Tarifas base</TabsTrigger>
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="min-w-0 space-y-4">
+          <TabsList className="w-full justify-start overflow-x-auto sm:w-auto sm:justify-center sm:overflow-visible">
+            <TabsTrigger value="by-date" className="shrink-0">Por fecha</TabsTrigger>
+            <TabsTrigger value="extras" className="shrink-0">Catálogo de extras</TabsTrigger>
+            <TabsTrigger value="base" className="shrink-0">Tarifas base</TabsTrigger>
           </TabsList>
 
           {/* By Date Tab */}
@@ -397,7 +397,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
               </CardHeader>
               <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
                 <Select value={selectedJobId} onValueChange={(v) => setSelectedJobId(v)}>
-                  <SelectTrigger className="min-w-[260px]"><SelectValue placeholder="Elegir fecha" /></SelectTrigger>
+                  <SelectTrigger className="w-full sm:w-auto sm:min-w-[260px]"><SelectValue placeholder="Elegir fecha" /></SelectTrigger>
                   <SelectContent>
                     {tourJobs.map((j) => (
                       <SelectItem
@@ -413,7 +413,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                     ))}
                   </SelectContent>
                 </Select>
-                <div className="flex items-center gap-2 ml-auto">
+                <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto sm:ml-auto">
                   <Badge variant="outline" className="w-fit">
                     <Users className="h-3 w-3 mr-1" />
                     {quotes.length} asignaciones
@@ -595,7 +595,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                             <span>{errorCode === 'category_missing' && 'Falta categoría'}{errorCode === 'house_rate_missing' && 'Falta tarifa de house tech'}{errorCode === 'tour_base_missing' && 'Falta tarifa base de gira para la categoría'}</span>
                           </div>
                           {errorCode === 'category_missing' && (
-                            <div className="flex items-center gap-2">
+                            <div className="flex flex-wrap items-center gap-2">
                               <Label className="text-xs">Establecer categoría:</Label>
                               <Select onValueChange={(val) => {
                                 if (isTimesheetCategory(val)) {
@@ -615,7 +615,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
                             </div>
                           )}
                           {errorCode === 'house_rate_missing' && (
-                            <div className="flex items-center gap-2">
+                            <div className="flex flex-wrap items-center gap-2">
                               <Label className="text-xs min-w-[120px]">Día base (en plantilla):</Label>
                               <Input
                                 type="number"

--- a/src/components/tours/TourRatesManagerDialog.tsx
+++ b/src/components/tours/TourRatesManagerDialog.tsx
@@ -271,7 +271,7 @@ export function TourRatesManagerDialog({ open, onOpenChange, tourId }: TourRates
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl max-h-[calc(95dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] md:max-h-[90vh] overflow-y-auto w-[95vw] md:w-full">
+      <DialogContent className="max-w-5xl max-h-[calc(95dvh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] md:max-h-[90vh] overflow-y-auto w-[95vw] md:w-full">
         <DialogHeader>
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
             <DialogTitle className="flex items-center gap-2 text-base md:text-lg">

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -36,6 +36,7 @@ const AlertDialogContent = React.forwardRef<
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         "max-h-[calc(90dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto",
+        "pl-[max(1.5rem,calc(env(safe-area-inset-left)+1rem))] pr-[max(1.5rem,calc(env(safe-area-inset-right)+1rem))]",
         className
       )}
       {...props}
@@ -50,7 +51,7 @@ const AlertDialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
+      "flex min-w-0 flex-col space-y-2 text-center sm:text-left",
       className
     )}
     {...props}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -35,7 +35,7 @@ const AlertDialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        "max-h-[calc(90dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto",
+        "max-h-[calc(90dvh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto",
         "pl-[max(1.5rem,calc(env(safe-area-inset-left)+1rem))] pr-[max(1.5rem,calc(env(safe-area-inset-right)+1rem))]",
         className
       )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,6 +38,7 @@ const DialogContent = React.forwardRef<
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         "max-h-[calc(90dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto md:max-h-[85vh]",
+        "pl-[max(1.5rem,calc(env(safe-area-inset-left)+1rem))] pr-[max(1.5rem,calc(env(safe-area-inset-right)+1rem))]",
         className
       )}
       {...props}
@@ -58,7 +59,7 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
+      "flex min-w-0 flex-col space-y-1.5 text-center sm:text-left",
       className
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        "max-h-[calc(90dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto md:max-h-[85vh]",
+        "max-h-[calc(90dvh_-_env(safe-area-inset-top)_-_env(safe-area-inset-bottom))] overflow-y-auto md:max-h-[85vh]",
         "pl-[max(1.5rem,calc(env(safe-area-inset-left)+1rem))] pr-[max(1.5rem,calc(env(safe-area-inset-right)+1rem))]",
         className
       )}

--- a/src/features/rates/components/RatesApprovalsTable.tsx
+++ b/src/features/rates/components/RatesApprovalsTable.tsx
@@ -79,8 +79,8 @@ export function RatesApprovalsTable({ onManageTour }: RatesApprovalsTableProps) 
       <CardHeader>
         <div className="flex items-center justify-between gap-3 flex-wrap">
           <CardTitle className="text-base">Aprobaciones de tarifas</CardTitle>
-          <div className="flex items-center gap-2 w-full md:w-auto">
-            <div className="w-full md:w-64">
+          <div className="flex flex-wrap items-center gap-2 w-full md:w-auto">
+            <div className="w-full sm:flex-1 md:w-64 md:flex-none">
               <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Buscar trabajos o giras" />
             </div>
             <Select value={typeFilter} onValueChange={(v) => setTypeFilter(v as any)}>

--- a/src/pages/GlobalTasks.tsx
+++ b/src/pages/GlobalTasks.tsx
@@ -398,7 +398,7 @@ export default function GlobalTasks() {
             {DEPARTMENT_LABELS[dept] || dept} — tareas de departamento y tareas globales
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Button variant="outline" size="sm" onClick={() => setShowFilters(!showFilters)}>
             <Filter className="h-4 w-4 mr-1" />
             Filtros

--- a/src/pages/RatesCenterPage.tsx
+++ b/src/pages/RatesCenterPage.tsx
@@ -57,10 +57,10 @@ export default function RatesCenterPage() {
 
       <RatesCenterHeader overview={overview} isLoading={isLoading} />
 
-      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof TABS[number]['id'])}>
-        <TabsList className="w-full sm:w-auto">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof TABS[number]['id'])} className="min-w-0">
+        <TabsList className="w-full justify-start overflow-x-auto sm:w-auto sm:justify-center sm:overflow-visible">
           {TABS.map((tab) => (
-            <TabsTrigger key={tab.id} value={tab.id} className="flex-1 sm:flex-none">
+            <TabsTrigger key={tab.id} value={tab.id} className="shrink-0">
               {tab.label}
             </TabsTrigger>
           ))}

--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -491,7 +491,7 @@ const Sound = () => {
       )}
 
       <Dialog open={showReportGenerator} onOpenChange={setShowReportGenerator}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Generador de Reportes</DialogTitle>
           </DialogHeader>
@@ -500,7 +500,7 @@ const Sound = () => {
       </Dialog>
 
       <Dialog open={showAmplifierTool} onOpenChange={setShowAmplifierTool}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Calculadora de Amplificadores</DialogTitle>
           </DialogHeader>
@@ -509,7 +509,7 @@ const Sound = () => {
       </Dialog>
 
       <Dialog open={showMemoriaTecnica} onOpenChange={setShowMemoriaTecnica}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Memoria Técnica</DialogTitle>
           </DialogHeader>
@@ -518,7 +518,7 @@ const Sound = () => {
       </Dialog>
 
       <Dialog open={showIncidentReport} onOpenChange={setShowIncidentReport}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Reporte de Incidencia</DialogTitle>
           </DialogHeader>

--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -491,7 +491,7 @@ const Sound = () => {
       )}
 
       <Dialog open={showReportGenerator} onOpenChange={setShowReportGenerator}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Generador de Reportes</DialogTitle>
           </DialogHeader>
@@ -500,7 +500,7 @@ const Sound = () => {
       </Dialog>
 
       <Dialog open={showAmplifierTool} onOpenChange={setShowAmplifierTool}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Calculadora de Amplificadores</DialogTitle>
           </DialogHeader>
@@ -509,7 +509,7 @@ const Sound = () => {
       </Dialog>
 
       <Dialog open={showMemoriaTecnica} onOpenChange={setShowMemoriaTecnica}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Memoria Técnica</DialogTitle>
           </DialogHeader>
@@ -518,7 +518,7 @@ const Sound = () => {
       </Dialog>
 
       <Dialog open={showIncidentReport} onOpenChange={setShowIncidentReport}>
-        <DialogContent className="w-[95vw] max-w-4xl max-h-[calc(90vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] overflow-y-auto">
+        <DialogContent className="w-[95vw] max-w-4xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Reporte de Incidencia</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Affected route/feature: `/management/rates` (Tarifas) modals and page tabs, ~15 other frequently-used dialogs app-wide, and the global mobile bottom navbar (`MobileNavBar`).

Two separate mobile issues:

1. **Tarifas modals didn't adapt to mobile.** `TourRatesManagerDialog` had a real bug: `DialogContent` uses `display:grid`, and a Radix grid item's "automatic minimum size" let the dialog's own description text/tab row force the grid track wider than the dialog's explicit width — combined with `overflow-y-auto` (which silently flips `overflow-x` to `auto` per spec), this hid content behind an *invisible* internal horizontal scroll instead of visibly overflowing. Also fixed: an overflowing 3-tab strip, non-wrapping header/toolbar buttons, and a `max-h-[95vh]` override that ignored the iOS safe-area (notch/home-indicator). The page's own top-level tab bar had the same equal-width-tabs bug, visibly truncating labels on both edges (verified in a real headless-browser render at 375–390px).
   - Hardened the shared `Dialog`/`AlertDialog` base components (`min-w-0` + safe-area padding) so the fix protects all ~137 dialog usages app-wide, then used a read-only audit to find and fix the same anti-patterns in ~15 other frequently-used dialogs (job details/create/edit/assignment, task manager, Sound.tsx tool dialogs, matrix assign dialog, technician cards, dashboard dialogs, tour defaults/management dialogs, artist form links, a fixed-pixel Sheet width).

2. **Mobile navbar detaching from the bottom after minimizing the iOS PWA.** A prior fix (PR #787) recomputed the nav's `bottom` offset from `visualViewport` on resume, but user testing on a real device showed the bug persists: bar overlaps content, happens with **no keyboard ever involved**, doesn't self-correct on scroll/rotate, and needs a full reload. That signature means WebKit's `visualViewport.height`/`offsetTop` can come back genuinely wrong (not just stale-for-a-frame) after standalone-PWA resume, and the previous fix still trusted that reading. Since the only legitimate reason for a nonzero offset is an open on-screen keyboard, the offset is now hard-clamped to `0` whenever no editable element is focused — regardless of what `visualViewport` reports, including immediately on resume — and `visualViewport` is only consulted while a text input/textarea/contenteditable genuinely has focus.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: low
- Main risks: purely CSS/layout class changes plus one behavioral change in `MobileNavBar`'s viewport-offset gating; no backend, auth, schema, or RLS touched. Small residual risk that some legitimate non-keyboard use of the `visualViewport` offset exists that this change now ignores, but none was found in code or tests, and this app runs primarily as a standalone home-screen PWA where the on-screen keyboard is the only expected source of viewport inset.
- [ ] If this touches database, auth, CI/CD, dependency, security, or production-header paths, I requested CODEOWNER review. — N/A, none touched.
- [ ] If risk level is high, I requested two independent approvals before merge. — N/A, low risk.

## Impact Checklist
- [x] Migration impact assessed. — None; no `supabase/migrations` changes.
- [x] Realtime/subscription impact assessed. — None; no realtime/subscription code touched.
- [x] RLS/security impact assessed. — None; no RLS/security code touched.
- [x] Performance impact assessed. — Negligible; added a couple of `focusin`/`focusout` listeners on `document` in `MobileNavBar`, no new renders in the steady state.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint` — 0 errors (363 pre-existing warnings, none new)
  - `npm run typecheck`
  - `npx vitest run src/components/layout/MobileNavBar.test.tsx src/components/tours/__tests__/TourRatesPanel.autonomo.test.tsx`
  - `npm run build`
  - Manual verification of the Tarifas dialog fix via a real headless-browser render (Playwright, mock-auth harness) at 375–390px viewports, confirming the internal horizontal overflow and tab-label truncation are gone.
- Results: all green. Did not run `npm run governance` / `npm run test:critical` / full `npm run test:run` / `npm run test:e2e` / `npm run ci:db:migrations` in this session — none of the changed files touch edge functions, migrations, workflows, or the critical-flow test list, and the diff is CSS/layout-class + one client-only viewport-offset change.
- Added 3 new regression tests to `MobileNavBar.test.tsx` covering: ignoring a stale visualViewport offset with nothing focused, snapping back to `bottom:0` the instant focus leaves an input, and staying pinned to `bottom:0` through a simulated resume where `visualViewport` keeps misreporting a stale inset.

## Rollback Plan
- [x] I documented how to safely revert this change.
- [ ] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert this PR's commits; both changes are self-contained CSS/class edits and one isolated hook in `MobileNavBar.tsx`, no data or migration to back out.

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no
- If yes, describe migration, impact, and backout plan: N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_018GrQv8poTckXLfq8xjVXpv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog and sheet sizing on mobile so content stays within the visible safe area and scrolls more reliably.
  * Updated the mobile bottom navigation to behave better with the keyboard and focus changes, reducing unwanted jumps.
  * Refined several toolbars, tabs, and button groups to wrap or scroll more cleanly on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->