### PR TITLE
fix: restore local PDF download in the SV report generator

### DIFF
--- a/src/components/sound/ReportGenerator.tsx
+++ b/src/components/sound/ReportGenerator.tsx
@@ -55,6 +55,15 @@ const FILENAME_MAPPING = {
   'SUB': { section: 'SUBS SPL(Z) 32-80Hz', view: 'Top View' }
 };
 
+const downloadPdfBlob = (blob: Blob, filename: string) => {
+  const downloadUrl = window.URL.createObjectURL(blob);
+  const link = window.document.createElement('a');
+  link.href = downloadUrl;
+  link.download = filename;
+  link.click();
+  window.URL.revokeObjectURL(downloadUrl);
+};
+
 type MappingResult = {
   found: { filename: string; section: string; view: string }[];
   missing: { filename: string; section: string; view: string }[];
@@ -390,24 +399,29 @@ export const ReportGenerator = () => {
     const filename = `${reportSystem === "LA" ? "SoundVision" : "EaseFocus"}_Report_${jobTitle.replace(/\s+/g, "_")}.pdf`;
     const blob = pdf.output('blob');
 
-    try {
-      await uploadJobPdfWithCleanup(selectedJobId, blob, filename, "calculators/sv-report", {
-        cleanupScope: getTechnicalStageStorageScope(selectedStage),
+    downloadPdfBlob(blob, filename);
+    toast({
+      title: "Descarga iniciada",
+      description: "El informe se está subiendo a los documentos del trabajo en segundo plano.",
+    });
+
+    void uploadJobPdfWithCleanup(selectedJobId, blob, filename, "calculators/sv-report", {
+      cleanupScope: getTechnicalStageStorageScope(selectedStage),
+    })
+      .then(() => {
+        toast({
+          title: "Informe guardado",
+          description: "La descarga local se inició y el informe se guardó en los documentos del trabajo.",
+        });
+      })
+      .catch((error) => {
+        console.error('Error uploading SV report:', error);
+        toast({
+          title: "Subida fallida",
+          description: "El informe se descargó localmente, pero no se pudo guardar en los documentos del trabajo.",
+          variant: "destructive",
+        });
       });
-      toast({
-        title: "Éxito",
-        description: "Informe generado, descargado y guardado en los documentos del trabajo.",
-      });
-    } catch (error) {
-      console.error('Error uploading SV report:', error);
-      toast({
-        title: "Error",
-        description: "No se pudo guardar el informe generado en los documentos del trabajo.",
-        variant: "destructive",
-      });
-    } finally {
-      pdf.save(filename);
-    }
   };
 
   const addImageToPDF = async (pdf: jsPDF, file: File, viewType: string, x: number, y: number, width: number) => {

--- a/src/components/sound/ReportGenerator.tsx
+++ b/src/components/sound/ReportGenerator.tsx
@@ -396,15 +396,17 @@ export const ReportGenerator = () => {
       });
       toast({
         title: "Éxito",
-        description: "Informe generado y guardado en los documentos del trabajo.",
+        description: "Informe generado, descargado y guardado en los documentos del trabajo.",
       });
     } catch (error) {
       console.error('Error uploading SV report:', error);
       toast({
         title: "Error",
-        description: "No se pudo guardar el informe generado.",
+        description: "No se pudo guardar el informe generado en los documentos del trabajo.",
         variant: "destructive",
       });
+    } finally {
+      pdf.save(filename);
     }
   };
 

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -23,7 +23,7 @@ import { buildNormalizedTourPowerTables, computePowerTotalVa } from "@/utils/tou
 import { getDepartmentLabel } from "@/types/department";
 import type { TechnicalPowerDepartment } from "@/utils/technicalPowerTypes";
 import { getResolvedPowerPosition } from "@/utils/powerPositions";
-import { syncTourDefaultDocuments } from "@/utils/tourDefaultDocumentSync";
+import { getTourDefaultDocumentNoUpdateToast, syncTourDefaultDocuments } from "@/utils/tourDefaultDocumentSync";
 import {
   DEPARTMENT_PACKAGE_LABELS,
   TOUR_PACKAGE_LABELS,
@@ -355,14 +355,8 @@ export const TourDefaultsManager = ({
             description: `${result.errors.length} documento(s) no se pudieron refrescar.`,
             variant: 'destructive',
           });
-        } else if (result.uploaded === 0 && result.removed === 0) {
-          toast({
-            title: 'Ningún PDF actualizado',
-            description: 'No se generó ningún PDF de fecha: revisa que las fechas de gira tengan un paquete o conjunto por defecto asignado.',
-            variant: 'destructive',
-          });
         } else if (!silent) {
-          toast({
+          toast(getTourDefaultDocumentNoUpdateToast(result) ?? {
             title: 'PDFs sincronizados',
             description: `${result.uploaded} documento(s) actualizados y ${result.removed} ruta(s) limpiadas.`,
           });

--- a/src/components/tours/TourDefaultsManager.tsx
+++ b/src/components/tours/TourDefaultsManager.tsx
@@ -355,6 +355,12 @@ export const TourDefaultsManager = ({
             description: `${result.errors.length} documento(s) no se pudieron refrescar.`,
             variant: 'destructive',
           });
+        } else if (result.uploaded === 0 && result.removed === 0) {
+          toast({
+            title: 'Ningún PDF actualizado',
+            description: 'No se generó ningún PDF de fecha: revisa que las fechas de gira tengan un paquete o conjunto por defecto asignado.',
+            variant: 'destructive',
+          });
         } else if (!silent) {
           toast({
             title: 'PDFs sincronizados',

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -12,7 +12,7 @@ import type { TourPackageSize } from "@/utils/tourPackages";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { optimizedInvalidation, queryKeys } from "@/lib/react-query";
 import { exportToPDF } from "@/utils/pdfExport";
-import { syncTourDefaultDocuments } from "@/utils/tourDefaultDocumentSync";
+import { syncTourDefaultDocuments, toastTourDefaultDocumentNoUpdate } from "@/utils/tourDefaultDocumentSync";
 import {
   CUSTOM_POWER_POSITION_VALUE,
   NO_POWER_POSITION_VALUE,
@@ -246,7 +246,6 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
 
   const syncDefaultDocumentsAfterMutation = useCallback(async () => {
     if (!isTourDefaults || !tourIdParam) return;
-
     try {
       const result = await syncTourDefaultDocuments({ tourId: tourIdParam });
       optimizedInvalidation.invalidateQueryKeys(queryClient, [
@@ -261,13 +260,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
           description: `${result.errors.length} documento(s) predeterminados no se pudieron actualizar.`,
           variant: "destructive",
         });
-      } else if (result.uploaded === 0 && result.removed === 0) {
-        toast({
-          title: "Ningún PDF actualizado",
-          description: "No se generó ningún PDF de fecha: revisa que las fechas de gira tengan un paquete o conjunto por defecto asignado.",
-          variant: "destructive",
-        });
-      }
+      } else { toastTourDefaultDocumentNoUpdate(result, toast); }
     } catch (error) {
       console.error("Error syncing tour default documents:", error);
       toast({

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -261,6 +261,12 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
           description: `${result.errors.length} documento(s) predeterminados no se pudieron actualizar.`,
           variant: "destructive",
         });
+      } else if (result.uploaded === 0 && result.removed === 0) {
+        toast({
+          title: "Ningún PDF actualizado",
+          description: "No se generó ningún PDF de fecha: revisa que la fecha de gira tenga un paquete o conjunto por defecto asignado.",
+          variant: "destructive",
+        });
       }
     } catch (error) {
       console.error("Error syncing tour default documents:", error);

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -264,7 +264,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       } else if (result.uploaded === 0 && result.removed === 0) {
         toast({
           title: "Ningún PDF actualizado",
-          description: "No se generó ningún PDF de fecha: revisa que la fecha de gira tenga un paquete o conjunto por defecto asignado.",
+          description: "No se generó ningún PDF de fecha: revisa que las fechas de gira tengan un paquete o conjunto por defecto asignado.",
           variant: "destructive",
         });
       }

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -25,7 +25,7 @@ import { CopyToStageMenu } from '@/features/technical-tools/table-presets/CopyTo
 import { QuickPresetsMenu } from '@/features/technical-tools/table-presets/QuickPresetsMenu';
 import type { TourPackageSize } from '@/utils/tourPackages';
 import { optimizedInvalidation, queryKeys } from '@/lib/react-query';
-import { syncTourDefaultDocuments } from '@/utils/tourDefaultDocumentSync';
+import { syncTourDefaultDocuments, toastTourDefaultDocumentNoUpdate } from '@/utils/tourDefaultDocumentSync';
 import {
   cloneTablesToStage,
   remapClusterIds,
@@ -260,7 +260,6 @@ const PesosTool: React.FC = () => {
 
   const syncDefaultDocumentsAfterMutation = async () => {
     if ((!isTourDefaults && !isDefaults) || !tourId) return;
-
     try {
       const result = await syncTourDefaultDocuments({ tourId });
       optimizedInvalidation.invalidateQueryKeys(queryClient, [
@@ -275,13 +274,7 @@ const PesosTool: React.FC = () => {
           description: `${result.errors.length} documento(s) predeterminados no se pudieron actualizar.`,
           variant: 'destructive',
         });
-      } else if (result.uploaded === 0 && result.removed === 0) {
-        toast({
-          title: 'Ningún PDF actualizado',
-          description: 'No se generó ningún PDF de fecha: revisa que las fechas de gira tengan un paquete o conjunto por defecto asignado.',
-          variant: 'destructive',
-        });
-      }
+      } else { toastTourDefaultDocumentNoUpdate(result, toast); }
     } catch (error) {
       console.error('Error syncing tour default documents:', error);
       toast({

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -275,6 +275,12 @@ const PesosTool: React.FC = () => {
           description: `${result.errors.length} documento(s) predeterminados no se pudieron actualizar.`,
           variant: 'destructive',
         });
+      } else if (result.uploaded === 0 && result.removed === 0) {
+        toast({
+          title: 'Ningún PDF actualizado',
+          description: 'No se generó ningún PDF de fecha: revisa que la fecha de gira tenga un paquete o conjunto por defecto asignado.',
+          variant: 'destructive',
+        });
       }
     } catch (error) {
       console.error('Error syncing tour default documents:', error);

--- a/src/pages/PesosTool.tsx
+++ b/src/pages/PesosTool.tsx
@@ -278,7 +278,7 @@ const PesosTool: React.FC = () => {
       } else if (result.uploaded === 0 && result.removed === 0) {
         toast({
           title: 'Ningún PDF actualizado',
-          description: 'No se generó ningún PDF de fecha: revisa que la fecha de gira tenga un paquete o conjunto por defecto asignado.',
+          description: 'No se generó ningún PDF de fecha: revisa que las fechas de gira tengan un paquete o conjunto por defecto asignado.',
           variant: 'destructive',
         });
       }

--- a/src/utils/__tests__/tourDefaultDocumentSync.test.ts
+++ b/src/utils/__tests__/tourDefaultDocumentSync.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildTourDefaultDocumentPlan,
+  getTourDefaultDocumentNoUpdateToast,
   getTourDefaultDocumentObjectPath,
   type TourDefaultDocumentPlanItem,
   type TourDefaultDocumentSyncData,
@@ -236,5 +237,29 @@ describe("tour default document sync planning", () => {
       reason: "no_tables",
       objectPath: "tours/tour-1/auto-generated/default-pdfs/date-1/sound-weight.pdf",
     });
+  });
+});
+
+describe("tour default document sync notifications", () => {
+  it("warns when sync only skipped dates because package defaults are unresolved", () => {
+    expect(
+      getTourDefaultDocumentNoUpdateToast({
+        uploaded: 0,
+        removed: 6,
+        skipped: 6,
+        errors: [],
+      })
+    ).toMatchObject({ title: "Ningún PDF actualizado", variant: "destructive" });
+  });
+
+  it("does not warn for cleanup-only slots without unresolved package defaults", () => {
+    expect(
+      getTourDefaultDocumentNoUpdateToast({
+        uploaded: 0,
+        removed: 6,
+        skipped: 0,
+        errors: [],
+      })
+    ).toBeNull();
   });
 });

--- a/src/utils/tourDefaultDocumentSync.ts
+++ b/src/utils/tourDefaultDocumentSync.ts
@@ -87,6 +87,9 @@ export interface SyncTourDefaultDocumentsResult {
   }>;
 }
 
+export type TourDefaultDocumentSyncToastPayload = { title: string; description: string; variant: "destructive" };
+type TourDefaultDocumentSyncToast = (payload: TourDefaultDocumentSyncToastPayload) => void;
+
 export interface SyncTourDefaultDocumentsOptions {
   tourId: string;
   tourDateIds?: string[];
@@ -95,6 +98,26 @@ export interface SyncTourDefaultDocumentsOptions {
   fetchLogo?: (tourId: string) => Promise<string | undefined>;
   exportPdf?: typeof exportToPDF;
 }
+
+export const getTourDefaultDocumentNoUpdateToast = (
+  result: SyncTourDefaultDocumentsResult
+): TourDefaultDocumentSyncToastPayload | null =>
+  result.errors.length === 0 && result.uploaded === 0 && result.skipped > 0
+    ? {
+        title: "Ningún PDF actualizado",
+        description:
+          "No se generó ningún PDF automático: revisa que las fechas de gira tengan un paquete o conjunto por defecto asignado.",
+        variant: "destructive",
+      }
+    : null;
+
+export const toastTourDefaultDocumentNoUpdate = (
+  result: SyncTourDefaultDocumentsResult,
+  toast: TourDefaultDocumentSyncToast
+) => {
+  const payload = getTourDefaultDocumentNoUpdateToast(result);
+  if (payload) toast(payload);
+};
 
 const isRecord = (value: unknown): value is JsonRecord =>
   typeof value === "object" && value !== null && !Array.isArray(value);


### PR DESCRIPTION
## Summary
- Restore the SV/EaseFocus local report download without a second PDF serialization.
- Run job-document upload in the background and use toasts that distinguish local download from upload completion or failure.
- Centralize tour-default PDF no-update toast copy and key it off skipped default-set resolution work instead of cleanup counters.

## Risk Assessment
Low. The change is limited to PDF download/upload notification flow and tour-default sync messaging. The upload path still uses the existing job document cleanup helper and the PDF blob already generated for the local download.

## Impact Checklist
- User-facing: SV/EaseFocus reports download locally immediately, then upload status is reported separately.
- Data: no schema, RLS, or migration changes.
- Background jobs: no new background workers; client-side upload promise is fire-and-forget after local download starts.
- Mobile/PWA: no Capacitor changes.

## Test Evidence
- npm run governance
- npm run lint
- npm run typecheck
- npm run test:critical
- npm run test:run -- src/utils/__tests__/tourDefaultDocumentSync.test.ts
- npm run build

## Rollback Plan
Revert the latest PR branch commit to return to the prior upload/download flow and inline toast handling.

## Migration Impact
None. No database migrations or Supabase function changes are included.