### PR TITLE
[codex] Add scoped Flex report buttons

### DIFF
--- a/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
+++ b/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
@@ -1004,6 +1004,134 @@ describe('JobCardActions', () => {
       );
     });
 
+    it('prints a scoped Flex material list directly from the sound project tab', async () => {
+      const user = userEvent.setup();
+      dataLayerFunctionsInvokeMock.mockResolvedValueOnce({
+        data: {
+          url: 'https://example.test/sound-material-list.pdf',
+          fileName: 'Listado de Material - sound.pdf',
+          elementId: 'sound-quote-element',
+          folderType: 'comercial_presupuesto',
+          elementValidated: true,
+          elementJobMismatch: false,
+          reportType: 'material-list',
+        },
+        error: null,
+      });
+
+      const props = {
+        ...defaultProps,
+        department: 'sound',
+        job: {
+          ...defaultProps.job,
+          flex_folders: [
+            {
+              id: 'sound-quote-folder',
+              department: 'sound',
+              element_id: 'sound-quote-element',
+              folder_type: 'comercial_presupuesto',
+            },
+            {
+              id: 'lights-quote-folder',
+              department: 'lights',
+              element_id: 'lights-quote-element',
+              folder_type: 'comercial_presupuesto',
+            },
+          ],
+        },
+      };
+
+      render(<JobCardActions {...props} />);
+
+      const materialButton = screen.getByRole('button', { name: /Lista Material/i });
+      expect(materialButton).toHaveAttribute('title', 'Imprimir lista de material de Sonido desde Flex');
+      expect(screen.queryByText('Sonido')).toBeNull();
+
+      await user.click(materialButton);
+
+      await waitFor(() => {
+        expect(dataLayerFunctionsInvokeMock).toHaveBeenCalledWith(
+          'fetch-flex-material-report',
+          expect.objectContaining({
+            body: expect.objectContaining({
+              jobId: 'test-job-id',
+              department: 'sound',
+              reportType: 'material-list',
+            }),
+          })
+        );
+      });
+      expect(window.open).toHaveBeenCalledWith(
+        'https://example.test/sound-material-list.pdf',
+        '_blank',
+        'noopener,noreferrer'
+      );
+    });
+
+    it('prints a scoped Flex quote directly from the lights project tab', async () => {
+      const user = userEvent.setup();
+      dataLayerFunctionsInvokeMock.mockResolvedValueOnce({
+        data: {
+          url: 'https://example.test/lights-quote.pdf',
+          fileName: 'Presupuesto - lights.pdf',
+          elementId: 'lights-quote-element',
+          folderType: 'presupuestos_recibidos',
+          elementValidated: true,
+          elementJobMismatch: false,
+          reportType: 'quote',
+        },
+        error: null,
+      });
+
+      const props = {
+        ...defaultProps,
+        department: 'lights',
+        job: {
+          ...defaultProps.job,
+          flex_folders: [
+            {
+              id: 'sound-quote-folder',
+              department: 'sound',
+              element_id: 'sound-quote-element',
+              folder_type: 'comercial_presupuesto',
+            },
+            {
+              id: 'lights-quote-folder',
+              department: 'lights',
+              element_id: 'lights-quote-element',
+              folder_type: 'presupuestos_recibidos',
+            },
+          ],
+        },
+      };
+
+      render(<JobCardActions {...props} />);
+
+      const quoteButton = screen.getByRole('button', { name: /Presupuesto/i });
+      expect(quoteButton).toHaveAttribute('title', 'Imprimir presupuesto de Iluminación desde Flex');
+      expect(screen.queryByText('Iluminación')).toBeNull();
+
+      await user.click(quoteButton);
+
+      await waitFor(() => {
+        expect(dataLayerFunctionsInvokeMock).toHaveBeenCalledWith(
+          'fetch-flex-material-report',
+          expect.objectContaining({
+            body: expect.objectContaining({
+              jobId: 'test-job-id',
+              department: 'lights',
+              reportType: 'quote',
+            }),
+          })
+        );
+      });
+      expect(window.open).toHaveBeenCalledWith(
+        'https://example.test/lights-quote.pdf',
+        '_blank',
+        'noopener,noreferrer'
+      );
+    });
+
     it('should render the technical power summary button for project management managers', () => {
       render(<JobCardActions {...defaultProps} />);
 

--- a/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
+++ b/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
@@ -1075,7 +1075,7 @@ describe('JobCardActions', () => {
           url: 'https://example.test/lights-quote.pdf',
           fileName: 'Presupuesto - lights.pdf',
           elementId: 'lights-quote-element',
-          folderType: 'presupuestos_recibidos',
+          folderType: 'comercial_presupuesto',
           elementValidated: true,
           elementJobMismatch: false,
           reportType: 'quote',
@@ -1099,7 +1099,7 @@ describe('JobCardActions', () => {
               id: 'lights-quote-folder',
               department: 'lights',
               element_id: 'lights-quote-element',
-              folder_type: 'presupuestos_recibidos',
+              folder_type: 'comercial_presupuesto',
             },
           ],
         },
@@ -1130,6 +1130,30 @@ describe('JobCardActions', () => {
         '_blank',
         'noopener,noreferrer'
       );
+    });
+
+    it('does not enable scoped quote printing from a Presupuestos Recibidos container', () => {
+      const props = {
+        ...defaultProps,
+        department: 'lights',
+        job: {
+          ...defaultProps.job,
+          flex_folders: [
+            {
+              id: 'lights-pr-folder',
+              department: 'lights',
+              element_id: 'lights-pr-element',
+              folder_type: 'presupuestos_recibidos',
+            },
+          ],
+        },
+      };
+
+      render(<JobCardActions {...props} />);
+
+      expect(screen.getByRole('button', { name: /Lista Material/i })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: /Presupuesto/i })).toBeDisabled();
+      expect(screen.getByTitle('No hay presupuesto de Iluminación en Flex')).toBeTruthy();
     });
 
     it('should render the technical power summary button for project management managers', () => {

--- a/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
+++ b/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
@@ -171,6 +171,7 @@ export const JobCardActionButtons = ({
   whatsappRequest,
 }: JobCardActionButtonsProps) => {
   const isProductionDepartment = department === "production";
+  const flexReportDepartment = department === "sound" || department === "lights" ? department : null;
   const normalizedJobType = String(job.job_type || "").toLowerCase();
   const canOpenTimesheets = !["dryhire", "dry_hire"].includes(normalizedJobType) && (
     normalizedJobType !== "tourdate" || hasPrepDayDateType(job.job_date_types)
@@ -390,6 +391,20 @@ export const JobCardActionButtons = ({
           <FileStack className="h-4 w-4" />
           <span className="hidden sm:inline">Memoria</span>
         </Button>
+      </>
+    )}
+    {flexReportDepartment && isProjectManagementPage && isManagementUser && (
+      <>
+        <PrintFlexReportAction
+          job={job}
+          department={flexReportDepartment}
+          reportType="material-list"
+        />
+        <PrintFlexReportAction
+          job={job}
+          department={flexReportDepartment}
+          reportType="quote"
+        />
       </>
     )}
     {technicalPower.canGenerateTechnicalPowerPack && allowedJobType && (

--- a/src/components/jobs/cards/job-card-actions/PrintFlexReportAction.tsx
+++ b/src/components/jobs/cards/job-card-actions/PrintFlexReportAction.tsx
@@ -13,6 +13,7 @@ import type { JobCardJob } from "@/components/jobs/cards/job-card-actions/types"
 import {
   fetchFlexMaterialReport,
   type FlexMaterialReportDepartment,
+  type FlexMaterialReportType,
 } from "@/utils/flexMaterialReport";
 
 type PrintableDepartment = Extract<FlexMaterialReportDepartment, "sound" | "lights">;
@@ -30,6 +31,8 @@ const QUOTE_FOLDER_TYPES = new Set([
 
 type PrintFlexReportActionProps = {
   job: JobCardJob;
+  department?: PrintableDepartment;
+  reportType?: FlexMaterialReportType;
 };
 
 const getFolderElementId = (folder: NonNullable<JobCardJob["flex_folders"]>[number]) =>
@@ -43,9 +46,56 @@ const hasQuoteForDepartment = (job: JobCardJob, department: PrintableDepartment)
     Boolean(getFolderElementId(folder))
   );
 
-export const PrintFlexReportAction = ({ job }: PrintFlexReportActionProps) => {
+const REPORT_COPY: Record<FlexMaterialReportType, {
+  buttonLabel: string;
+  dropdownTitle: string;
+  errorTitle: string;
+  fallbackError: string;
+  loadingLabel: (label: string) => string;
+  scopedTitle: (label: string) => string;
+  successDescription: (label: string) => string;
+  successTitle: string;
+  unavailableDropdownTitle: string;
+  unavailableScopedTitle: (label: string) => string;
+}> = {
+  "material-list": {
+    buttonLabel: "Lista Material",
+    dropdownTitle: "Imprimir lista de material de Flex",
+    errorTitle: "No se pudo imprimir la lista",
+    fallbackError: "No se pudo obtener la lista de material de Flex.",
+    loadingLabel: (label) => `Lista ${label}`,
+    scopedTitle: (label) => `Imprimir lista de material de ${label} desde Flex`,
+    successDescription: (label) => `Se ha abierto la lista de material de ${label}.`,
+    successTitle: "Lista de material generada",
+    unavailableDropdownTitle: "No hay presupuesto de sonido o iluminación en Flex",
+    unavailableScopedTitle: (label) => `No hay presupuesto de ${label} en Flex`,
+  },
+  quote: {
+    buttonLabel: "Presupuesto",
+    dropdownTitle: "Imprimir presupuesto de Flex",
+    errorTitle: "No se pudo imprimir el presupuesto",
+    fallbackError: "No se pudo obtener el presupuesto de Flex.",
+    loadingLabel: (label) => `Presupuesto ${label}`,
+    scopedTitle: (label) => `Imprimir presupuesto de ${label} desde Flex`,
+    successDescription: (label) => `Se ha abierto el presupuesto de ${label}.`,
+    successTitle: "Presupuesto generado",
+    unavailableDropdownTitle: "No hay presupuesto de sonido o iluminación en Flex",
+    unavailableScopedTitle: (label) => `No hay presupuesto de ${label} en Flex`,
+  },
+};
+
+export const PrintFlexReportAction = ({
+  job,
+  department,
+  reportType = "material-list",
+}: PrintFlexReportActionProps) => {
   const { toast } = useToast();
   const [loadingDepartment, setLoadingDepartment] = React.useState<PrintableDepartment | null>(null);
+  const copy = REPORT_COPY[reportType];
+  const scopedDepartmentOption = React.useMemo(
+    () => MATERIAL_LIST_DEPARTMENTS.find((option) => option.department === department) ?? null,
+    [department]
+  );
   const quoteAvailability = React.useMemo(
     () => new Map(
       MATERIAL_LIST_DEPARTMENTS.map(({ department }) => [
@@ -57,7 +107,7 @@ export const PrintFlexReportAction = ({ job }: PrintFlexReportActionProps) => {
   );
   const hasAnyQuote = Array.from(quoteAvailability.values()).some(Boolean);
 
-  const handlePrintMaterialList = React.useCallback(async (department: PrintableDepartment, label: string) => {
+  const handlePrintReport = React.useCallback(async (department: PrintableDepartment, label: string) => {
     if (!job.id || loadingDepartment || !quoteAvailability.get(department)) return;
 
     setLoadingDepartment(department);
@@ -70,7 +120,7 @@ export const PrintFlexReportAction = ({ job }: PrintFlexReportActionProps) => {
         department,
         undefined,
         null,
-        "material-list"
+        reportType
       );
 
       if (reportWindow) {
@@ -80,24 +130,49 @@ export const PrintFlexReportAction = ({ job }: PrintFlexReportActionProps) => {
         window.open(result.url, "_blank", "noopener,noreferrer");
       }
       toast({
-        title: "Lista de material generada",
-        description: `Se ha abierto la lista de material de ${label}.`,
+        title: copy.successTitle,
+        description: copy.successDescription(label),
       });
     } catch (error: unknown) {
       reportWindow?.close();
       toast({
-        title: "No se pudo imprimir la lista",
-        description: error instanceof Error ? error.message : "No se pudo obtener la lista de material de Flex.",
+        title: copy.errorTitle,
+        description: error instanceof Error ? error.message : copy.fallbackError,
         variant: "destructive",
       });
     } finally {
       setLoadingDepartment(null);
     }
-  }, [job.id, loadingDepartment, quoteAvailability, toast]);
+  }, [copy, job.id, loadingDepartment, quoteAvailability, reportType, toast]);
 
   const loadingLabel = MATERIAL_LIST_DEPARTMENTS.find(
     (option) => option.department === loadingDepartment
   )?.label;
+
+  if (scopedDepartmentOption) {
+    const isAvailable = quoteAvailability.get(scopedDepartmentOption.department) ?? false;
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-2"
+        disabled={!!loadingDepartment || !isAvailable}
+        onClick={() => void handlePrintReport(scopedDepartmentOption.department, scopedDepartmentOption.label)}
+        title={
+          isAvailable
+            ? copy.scopedTitle(scopedDepartmentOption.label)
+            : copy.unavailableScopedTitle(scopedDepartmentOption.label)
+        }
+      >
+        {loadingDepartment ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Printer className="h-4 w-4" />
+        )}
+        <span className="hidden sm:inline">{copy.buttonLabel}</span>
+      </Button>
+    );
+  }
 
   return (
     <DropdownMenu>
@@ -107,7 +182,7 @@ export const PrintFlexReportAction = ({ job }: PrintFlexReportActionProps) => {
           size="sm"
           className="gap-2"
           disabled={!!loadingDepartment || !hasAnyQuote}
-          title={hasAnyQuote ? "Imprimir lista de material de Flex" : "No hay presupuesto de sonido o iluminación en Flex"}
+          title={hasAnyQuote ? copy.dropdownTitle : copy.unavailableDropdownTitle}
         >
           {loadingDepartment ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -115,7 +190,7 @@ export const PrintFlexReportAction = ({ job }: PrintFlexReportActionProps) => {
             <Printer className="h-4 w-4" />
           )}
           <span className="hidden sm:inline">
-            {loadingLabel ? `Lista ${loadingLabel}` : "Lista Material"}
+            {loadingLabel ? copy.loadingLabel(loadingLabel) : copy.buttonLabel}
           </span>
           {!loadingDepartment && <ChevronDown className="h-3.5 w-3.5" />}
         </Button>
@@ -127,7 +202,7 @@ export const PrintFlexReportAction = ({ job }: PrintFlexReportActionProps) => {
             disabled={!quoteAvailability.get(department)}
             onSelect={(event) => {
               event.preventDefault();
-              void handlePrintMaterialList(department, label);
+              void handlePrintReport(department, label);
             }}
           >
             {label}

--- a/src/components/jobs/cards/job-card-actions/PrintFlexReportAction.tsx
+++ b/src/components/jobs/cards/job-card-actions/PrintFlexReportAction.tsx
@@ -23,10 +23,15 @@ const MATERIAL_LIST_DEPARTMENTS: Array<{ department: PrintableDepartment; label:
   { department: "lights", label: "Iluminación" },
 ];
 
-const QUOTE_FOLDER_TYPES = new Set([
+const MATERIAL_LIST_FOLDER_TYPES = new Set([
   "comercial_presupuesto",
   "dryhire_presupuesto",
   "presupuestos_recibidos",
+]);
+
+const PRINTABLE_QUOTE_FOLDER_TYPES = new Set([
+  "comercial_presupuesto",
+  "dryhire_presupuesto",
 ]);
 
 type PrintFlexReportActionProps = {
@@ -38,13 +43,22 @@ type PrintFlexReportActionProps = {
 const getFolderElementId = (folder: NonNullable<JobCardJob["flex_folders"]>[number]) =>
   folder.element_id || folder.elementId || null;
 
-const hasQuoteForDepartment = (job: JobCardJob, department: PrintableDepartment) =>
-  (job.flex_folders || []).some((folder) =>
+const getReportFolderTypes = (reportType: FlexMaterialReportType) =>
+  reportType === "quote" ? PRINTABLE_QUOTE_FOLDER_TYPES : MATERIAL_LIST_FOLDER_TYPES;
+
+const hasReportForDepartment = (
+  job: JobCardJob,
+  department: PrintableDepartment,
+  reportType: FlexMaterialReportType
+) => {
+  const folderTypes = getReportFolderTypes(reportType);
+  return (job.flex_folders || []).some((folder) =>
     folder.department === department &&
     typeof folder.folder_type === "string" &&
-    QUOTE_FOLDER_TYPES.has(folder.folder_type) &&
+    folderTypes.has(folder.folder_type) &&
     Boolean(getFolderElementId(folder))
   );
+};
 
 const REPORT_COPY: Record<FlexMaterialReportType, {
   buttonLabel: string;
@@ -98,12 +112,12 @@ export const PrintFlexReportAction = ({
   );
   const quoteAvailability = React.useMemo(
     () => new Map(
-      MATERIAL_LIST_DEPARTMENTS.map(({ department }) => [
-        department,
-        hasQuoteForDepartment(job, department),
+      MATERIAL_LIST_DEPARTMENTS.map(({ department: optionDepartment }) => [
+        optionDepartment,
+        hasReportForDepartment(job, optionDepartment, reportType),
       ])
     ),
-    [job]
+    [job, reportType]
   );
   const hasAnyQuote = Array.from(quoteAvailability.values()).some(Boolean);
 

--- a/supabase/functions/fetch-flex-material-report/index.ts
+++ b/supabase/functions/fetch-flex-material-report/index.ts
@@ -48,8 +48,13 @@ const isFlexReportType = (value: string): value is FlexReportType =>
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const VALID_DEPARTMENTS = new Set(["sound", "lights", "video", "production"]);
 const UNVERIFIED_OVERRIDE_ROLES = new Set(["admin", "management"]);
-// Preference order when a job/department has multiple quote-type folders.
-const QUOTE_FOLDER_TYPES = ["comercial_presupuesto", "dryhire_presupuesto", "presupuestos_recibidos"];
+// Preference order when a job/department has multiple report-capable folders.
+// `presupuestos_recibidos` is a container used by the material-list workflow,
+// but quote printing must resolve to a real presupuesto element.
+const REPORT_FOLDER_TYPES: Record<FlexReportType, string[]> = {
+  "material-list": ["comercial_presupuesto", "dryhire_presupuesto", "presupuestos_recibidos"],
+  quote: ["comercial_presupuesto", "dryhire_presupuesto"],
+};
 
 interface FetchFlexMaterialReportBody extends Record<string, unknown> {
   jobId?: unknown;
@@ -160,12 +165,13 @@ serve(createHttpHandler(async (req: Request) => {
       });
     }
   } else {
+    const reportFolderTypes = REPORT_FOLDER_TYPES[reportType];
     const { data: folders, error: folderError } = await supabase
       .from("flex_folders")
       .select("element_id, folder_type, created_at")
       .eq("job_id", jobId)
       .eq("department", department)
-      .in("folder_type", QUOTE_FOLDER_TYPES)
+      .in("folder_type", reportFolderTypes)
       .order("created_at", { ascending: false });
 
     if (folderError) {
@@ -176,7 +182,7 @@ serve(createHttpHandler(async (req: Request) => {
     }
 
     const ranked = (folders || []).slice().sort((a, b) => {
-      const rankDiff = QUOTE_FOLDER_TYPES.indexOf(a.folder_type) - QUOTE_FOLDER_TYPES.indexOf(b.folder_type);
+      const rankDiff = reportFolderTypes.indexOf(a.folder_type) - reportFolderTypes.indexOf(b.folder_type);
       return rankDiff !== 0 ? rankDiff : 0;
     });
 


### PR DESCRIPTION
## Summary
- Adds department-scoped Flex report buttons to Sound and Lights project-management job cards.
- Reuses the existing `fetch-flex-material-report` path for both `material-list` and `quote` report types.
- Keeps Production unchanged: the existing Lista Material dropdown still lets production choose the target department.
- Gates quote printing to real presupuesto folders in both the UI and edge function so `Presupuestos Recibidos` containers do not enable the quote PDF action.

## Affected Route / Feature
- Project Management job cards for the Sound and Lights department tabs.
- Shared Flex material/quote report generation via `fetch-flex-material-report`.

## Why
The shared report action already had the proven Flex edge-function path, but project-management department tabs only exposed the production material-list workflow. Sound and Lights needed direct buttons that are already scoped to their tab department so users do not have to pick a department again.

## Impact
- Sound tab managers can print `Lista Material` and `Presupuesto` for Sound directly.
- Lights tab managers can print `Lista Material` and `Presupuesto` for Lights directly.
- Material-list buttons preserve the existing production-compatible folder matching.
- Quote buttons stay disabled unless a matching real presupuesto folder exists for the scoped department.
- Production keeps its existing material-list department selector behavior.

## Risk Assessment
- Low to moderate: change is limited to job-card action rendering and report folder resolution.
- Main behavioral risk is accidentally enabling quote printing for a Flex container rather than a presupuesto element; this is guarded in both UI and edge function and covered by regression tests.

## Migration Impact
- No database migrations.
- No Supabase production database push required.
- Edge function code changes deploy through the normal application release path.

## Rollback / Backout
- Revert this PR to remove the Sound/Light scoped buttons and restore the previous report folder resolver behavior.
- No data backfill or schema rollback is needed.

## Test Results
- `npm run lint` passed with existing warnings only.
- `npm run lint:functions` passed with existing warnings only.
- `npm run typecheck` passed.
- `npm run test:run -- src/components/jobs/cards/__tests__/JobCardActions.test.tsx` passed: 45 tests.
- `npm run test:run` passed: 223 files / 1239 tests.
- `npm run build` passed.
- `npm run governance` passed.
- `npm run test:critical` passed.
- `npm run budget:bundle` passed.

## PR Checks
- GitHub CI: passing.
- Security / CodeQL: passing.
- Supabase CI jobs: passing.
- Cloudflare Pages preview: passing.
- CodeRabbit: passing.
