### PR TITLE
[codex] Use readable Flex report filenames

### DIFF
--- a/src/components/jobs/cards/job-card-actions/PrintFlexReportAction.tsx
+++ b/src/components/jobs/cards/job-card-actions/PrintFlexReportAction.tsx
@@ -98,6 +98,18 @@ const REPORT_COPY: Record<FlexMaterialReportType, {
   },
 };
 
+const ReportAvailabilityLight = ({ available }: { available: boolean }) => (
+  <span
+    aria-hidden="true"
+    className={[
+      "h-2.5 w-2.5 shrink-0 rounded-full border ring-2",
+      available
+        ? "border-emerald-500 bg-emerald-400 ring-emerald-400/25"
+        : "border-slate-300 bg-slate-300 ring-slate-300/20",
+    ].join(" ")}
+  />
+);
+
 export const PrintFlexReportAction = ({
   job,
   department,
@@ -178,6 +190,7 @@ export const PrintFlexReportAction = ({
             : copy.unavailableScopedTitle(scopedDepartmentOption.label)
         }
       >
+        <ReportAvailabilityLight available={isAvailable} />
         {loadingDepartment ? (
           <Loader2 className="h-4 w-4 animate-spin" />
         ) : (
@@ -198,6 +211,7 @@ export const PrintFlexReportAction = ({
           disabled={!!loadingDepartment || !hasAnyQuote}
           title={hasAnyQuote ? copy.dropdownTitle : copy.unavailableDropdownTitle}
         >
+          <ReportAvailabilityLight available={hasAnyQuote} />
           {loadingDepartment ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
@@ -213,12 +227,14 @@ export const PrintFlexReportAction = ({
         {MATERIAL_LIST_DEPARTMENTS.map(({ department, label }) => (
           <DropdownMenuItem
             key={department}
+            className="gap-2"
             disabled={!quoteAvailability.get(department)}
             onSelect={(event) => {
               event.preventDefault();
               void handlePrintReport(department, label);
             }}
           >
+            <ReportAvailabilityLight available={quoteAvailability.get(department) ?? false} />
             {label}
           </DropdownMenuItem>
         ))}

--- a/supabase/functions/fetch-flex-material-report/index.ts
+++ b/supabase/functions/fetch-flex-material-report/index.ts
@@ -282,7 +282,7 @@ serve(createHttpHandler(async (req: Request) => {
 
   const { error: uploadError } = await supabase.storage
     .from(bucket)
-    .upload(objectPath, pdfBytes, { contentType: "application/pdf", upsert: true });
+    .upload(objectPath, pdfBytes, { contentType: "application/pdf", cacheControl: "0", upsert: true });
   if (uploadError) {
     throw new HttpError(500, `Failed to store the generated ${reportDefinition.displayName}`, {
       code: "storage_upload_failed",
@@ -309,7 +309,7 @@ serve(createHttpHandler(async (req: Request) => {
 
   const { data: signedUrlData, error: signError } = await supabase.storage
     .from(bucket)
-    .createSignedUrl(objectPath, 3600);
+    .createSignedUrl(objectPath, 3600, { cacheNonce: crypto.randomUUID() });
   if (signError || !signedUrlData) {
     throw new HttpError(500, `Failed to sign the generated ${reportDefinition.displayName} URL`, {
       code: "sign_url_failed",

--- a/supabase/functions/fetch-flex-material-report/index.ts
+++ b/supabase/functions/fetch-flex-material-report/index.ts
@@ -261,7 +261,7 @@ serve(createHttpHandler(async (req: Request) => {
   const stageScope = stageNumber ? getTechnicalStageStorageScope(stageNumber, stageName) : null;
   const baseFolder = stageScope ? `${category}/${jobId}/${stageScope}` : `${category}/${jobId}`;
   const fileName = `${reportDefinition.fileNamePrefix} - ${sanitizeFileNameSegment(department)}.pdf`;
-  const objectPath = `${baseFolder}/${crypto.randomUUID()}-${sanitizeFileNameSegment(fileName)}`;
+  const objectPath = `${baseFolder}/${fileName}`;
 
   // Clean up any previous auto-fetched report for this exact job/department/stage
   // scope before writing the new one. Scope both the storage removal and the
@@ -282,7 +282,7 @@ serve(createHttpHandler(async (req: Request) => {
 
   const { error: uploadError } = await supabase.storage
     .from(bucket)
-    .upload(objectPath, pdfBytes, { contentType: "application/pdf", upsert: false });
+    .upload(objectPath, pdfBytes, { contentType: "application/pdf", upsert: true });
   if (uploadError) {
     throw new HttpError(500, `Failed to store the generated ${reportDefinition.displayName}`, {
       code: "storage_upload_failed",


### PR DESCRIPTION
## Summary
- store generated Flex material-list and quote PDFs with the returned report filename instead of a UUID-prefixed object basename
- keep the existing cleanup path and make the deterministic storage upload idempotent
- add availability indicator lights to Flex material-list and quote actions, including production dropdown options

## Affected Feature(s)
- Sound/Lights/Production Flex material-list and quote PDF generation via `fetch-flex-material-report`
- Project management Flex report action buttons

## Risk
- Low. Storage path basename changes for newly generated reports only; existing UUID-prefixed reports are removed by the existing cleanup before the next generated report is written. Indicator lights are visual only and preserve existing disabled/title behavior.

## Migration Impact
- None. No database migrations.

## Rollback / Backout
- Revert this PR to restore UUID-prefixed generated report object names and remove the Flex report indicator lights.

## Validation
- `npm run lint:functions`
- `npm run test:run -- src/components/jobs/cards/__tests__/JobCardActions.test.tsx`
- `npm run lint`
- `npm run typecheck`
- `npm run governance`
- `npm run test:critical`
- `npm run test:run`
- `npm run build`
- `npm run budget:bundle`