### PR TITLE
feat: add programa push notifications for non-festival jobs

### DIFF
--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -1,15 +1,12 @@
 
 import React, { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
@@ -23,8 +20,6 @@ import {
   Hotel,
   Image,
   Settings,
-  Save,
-  Download,
   Upload,
   Sparkles,
   CheckCircle2,
@@ -39,14 +34,11 @@ import {
   Bed,
   Activity,
   Palette,
-  Globe,
-  MoreHorizontal,
   RefreshCw,
   Database,
   UtensilsCrossed,
   AlertCircle,
   FileDown,
-  Loader2,
   CloudSun
 } from "lucide-react";
 
@@ -65,6 +57,10 @@ import { ModernLogisticsSection } from "./sections/ModernLogisticsSection";
 import { ModernScheduleSection } from "./sections/ModernScheduleSection";
 import { ModernStatusIndicator } from "./components/ModernStatusIndicator";
 import { ModernProgressTracker } from "./components/ModernProgressTracker";
+import { HojaDeRutaHeaderActions } from "./components/HojaDeRutaHeaderActions";
+import { MobileSectionSwitcher } from "./components/MobileSectionSwitcher";
+import { MobileSaveBar } from "./components/MobileSaveBar";
+import { QuickNavigationSidebar } from "./components/QuickNavigationSidebar";
 import { ModernWeatherSection } from "./sections/ModernWeatherSection";
 import { ModernRestaurantSection } from "./sections/ModernRestaurantSection";
 import {
@@ -734,96 +730,18 @@ export const ModernHojaDeRuta = ({ jobId, embedded = false }: ModernHojaDeRutaPr
               </div>
 
               {/* Action Buttons */}
-              {isMobile ? (
-                // Guardar lives in the sticky bottom bar on mobile (thumb-reachable);
-                // the header only keeps a compact overflow menu for the secondary actions.
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      aria-label="Más acciones"
-                      className="h-11 w-11 shrink-0"
-                    >
-                      <MoreHorizontal className="w-4 h-4" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent align="end" className="w-48 p-1">
-                    <PopoverClose asChild>
-                      <button
-                        type="button"
-                        onClick={() => { void handlePreviewPDF(); }}
-                        disabled={!selectedJobId || !isInitialized || isSaving || isGenerating || isPreviewing}
-                        className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
-                      >
-                        <Eye className="w-4 h-4 mr-2" />
-                        Vista previa
-                      </button>
-                    </PopoverClose>
-                    <PopoverClose asChild>
-                      <button
-                        type="button"
-                        onClick={() => setShowPrintDialog(true)}
-                        disabled={!selectedJobId}
-                        className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
-                      >
-                        <Download className="w-4 h-4 mr-2" />
-                        Exportar
-                      </button>
-                    </PopoverClose>
-                  </PopoverContent>
-                </Popover>
-              ) : (
-                <>
-                  {/* Simplified Save Button - Always enabled when job is selected */}
-                  <Button
-                    onClick={handleSave}
-                    disabled={!selectedJobId || !isInitialized || isSaving}
-                    variant="outline"
-                    size="sm"
-                    aria-label="Guardar hoja de ruta"
-                    className="h-11 min-w-[44px] border-2 border-green-500 text-green-600 hover:bg-green-50"
-                  >
-                    {isSaving ? (
-                      <>
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                        Guardando...
-                      </>
-                    ) : (
-                      <>
-                        <Save className="w-4 h-4 mr-2" />
-                        <span className="hidden sm:inline">Guardar</span>
-                      </>
-                    )}
-                  </Button>
-
-                  <Button
-                    onClick={() => { void handlePreviewPDF(); }}
-                    disabled={!selectedJobId || !isInitialized || isSaving || isGenerating || isPreviewing}
-                    variant="outline"
-                    size="sm"
-                    aria-label="Vista previa PDF"
-                    className="h-11 min-w-[44px] border-2 border-blue-500 text-blue-600 hover:bg-blue-50"
-                  >
-                    {isPreviewing && previewingTarget === "full" ? (
-                      <Loader2 className="w-4 h-4 sm:mr-2 animate-spin" />
-                    ) : (
-                      <Eye className="w-4 h-4 sm:mr-2" />
-                    )}
-                    <span className="hidden sm:inline">Vista previa</span>
-                  </Button>
-
-                  <Button
-                    onClick={() => setShowPrintDialog(true)}
-                    disabled={!selectedJobId}
-                    aria-label="Exportar"
-                    className="h-11 min-w-[44px] bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70"
-                  >
-                    <Download className="w-4 h-4 mr-2" />
-                    <span className="hidden sm:inline">Exportar</span>
-                  </Button>
-                </>
-              )}
+              <HojaDeRutaHeaderActions
+                isMobile={isMobile}
+                selectedJobId={selectedJobId}
+                isInitialized={isInitialized}
+                isSaving={isSaving}
+                isGenerating={isGenerating}
+                isPreviewing={isPreviewing}
+                previewingTarget={previewingTarget}
+                onSave={handleSave}
+                onPreviewPDF={() => { void handlePreviewPDF(); }}
+                onExport={() => setShowPrintDialog(true)}
+              />
             </div>
           </div>
 
@@ -862,37 +780,12 @@ export const ModernHojaDeRuta = ({ jobId, embedded = false }: ModernHojaDeRutaPr
       <div className={cn(embedded && "flex-1 overflow-y-auto")}>
       <div className={cn("max-w-screen-2xl mx-auto px-4 md:px-6 py-4 md:py-8", isMobile && "pb-24")}>
         <div className="grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-6">
-          {/* Sidebar with Templates (hidden on mobile, replaced by horizontal nav) */}
-          <div className="hidden md:block md:col-span-3">
-            <div className={cn("sticky space-y-4", embedded ? "top-0" : "top-24")}>
-              {/* Quick Navigation */}
-              <Card className="border-2">
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-sm font-medium flex items-center gap-2">
-                    <Globe className="w-4 h-4" />
-                    Navegación Rápida
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  {tabConfig.map((tab) => {
-                    const Icon = tab.icon;
-                    return (
-                      <Button
-                        key={tab.id}
-                        variant={activeTab === tab.id ? "default" : "ghost"}
-                        size="sm"
-                        onClick={() => setActiveTab(tab.id)}
-                        className={`w-full justify-start ${activeTab === tab.id ? 'bg-primary text-primary-foreground' : ''}`}
-                      >
-                        <Icon className={`w-4 h-4 mr-2 ${tab.color}`} />
-                        {tab.label}
-                      </Button>
-                    );
-                  })}
-                </CardContent>
-              </Card>
-            </div>
-          </div>
+          <QuickNavigationSidebar
+            tabConfig={tabConfig}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            embedded={embedded}
+          />
 
           {/* Main Content Area */}
           <div className="md:col-span-9">
@@ -901,46 +794,13 @@ export const ModernHojaDeRuta = ({ jobId, embedded = false }: ModernHojaDeRutaPr
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.1 }}
             >
-              {/* Mobile section switcher */}
-              <div
-                className={cn(
-                  "md:hidden -mx-4 px-4 mb-3 sticky z-40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b border-border/40 py-2 space-y-2",
-                  // When embedded, the page header lives outside the scroll region (flex `shrink-0`),
-                  // so this only needs to clear the scroll container's own top, not the header's height.
-                  embedded ? "top-0" : "top-[68px]"
-                )}
-              >
-                <Select value={activeTab} onValueChange={setActiveTab}>
-                  <SelectTrigger className="w-full h-11" aria-label="Seleccionar sección">
-                    <SelectValue>
-                      {(() => {
-                        const current = tabConfig.find((tab) => tab.id === activeTab) ?? tabConfig[0];
-                        const Icon = current.icon;
-                        return (
-                          <span className="flex items-center gap-2">
-                            <Icon className={`w-4 h-4 ${current.color}`} />
-                            {current.label}
-                          </span>
-                        );
-                      })()}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {tabConfig.map((tab) => {
-                      const Icon = tab.icon;
-                      return (
-                        <SelectItem key={tab.id} value={tab.id}>
-                          <span className="flex items-center gap-2">
-                            <Icon className={`w-4 h-4 ${tab.color}`} />
-                            {tab.label}
-                          </span>
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectContent>
-                </Select>
-                <ModernProgressTracker progress={completionProgress} />
-              </div>
+              <MobileSectionSwitcher
+                tabConfig={tabConfig}
+                activeTab={activeTab}
+                onTabChange={setActiveTab}
+                progress={completionProgress}
+                embedded={embedded}
+              />
 
               <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
                 {/* Tab Contents */}
@@ -1094,26 +954,11 @@ export const ModernHojaDeRuta = ({ jobId, embedded = false }: ModernHojaDeRutaPr
       </div>
 
       {isMobile && (
-        <div className="fixed inset-x-0 bottom-0 z-50 shrink-0 border-t bg-background/95 backdrop-blur px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
-          <Button
-            onClick={handleSave}
-            disabled={!selectedJobId || !isInitialized || isSaving}
-            variant="outline"
-            className="w-full h-11 border-2 border-green-500 text-green-600 hover:bg-green-50"
-          >
-            {isSaving ? (
-              <>
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                Guardando...
-              </>
-            ) : (
-              <>
-                <Save className="w-4 h-4 mr-2" />
-                Guardar
-              </>
-            )}
-          </Button>
-        </div>
+        <MobileSaveBar
+          onSave={handleSave}
+          disabled={!selectedJobId || !isInitialized || isSaving}
+          isSaving={isSaving}
+        />
       )}
 
       <HojaDeRutaPrintDialog

--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -57,10 +57,10 @@ import { ModernLogisticsSection } from "./sections/ModernLogisticsSection";
 import { ModernScheduleSection } from "./sections/ModernScheduleSection";
 import { ModernStatusIndicator } from "./components/ModernStatusIndicator";
 import { ModernProgressTracker } from "./components/ModernProgressTracker";
-import { HojaDeRutaHeaderActions } from "./components/HojaDeRutaHeaderActions";
-import { MobileSectionSwitcher } from "./components/MobileSectionSwitcher";
-import { MobileSaveBar } from "./components/MobileSaveBar";
-import { QuickNavigationSidebar } from "./components/QuickNavigationSidebar";
+import { HojaDeRutaHeaderActions } from "@/components/hoja-de-ruta/components/HojaDeRutaHeaderActions";
+import { MobileSectionSwitcher } from "@/components/hoja-de-ruta/components/MobileSectionSwitcher";
+import { MobileSaveBar } from "@/components/hoja-de-ruta/components/MobileSaveBar";
+import { QuickNavigationSidebar } from "@/components/hoja-de-ruta/components/QuickNavigationSidebar";
 import { ModernWeatherSection } from "./sections/ModernWeatherSection";
 import { ModernRestaurantSection } from "./sections/ModernRestaurantSection";
 import {
@@ -81,6 +81,7 @@ import {
 } from "@/utils/hoja-de-ruta/pdf";
 import type { EventData, HojaDeRutaMetadata } from "@/types/hoja-de-ruta";
 import type { LucideIcon } from "lucide-react";
+import type { HojaDeRutaTabOption } from "@/components/hoja-de-ruta/types";
 
 type ModernHojaDeRutaProps = {
   jobId?: string;
@@ -642,7 +643,7 @@ export const ModernHojaDeRuta = ({ jobId, embedded = false }: ModernHojaDeRutaPr
     { id: "restaurants", icon: UtensilsCrossed, color: "text-emerald-600" },
   ];
 
-  const tabConfig: Array<{ id: HojaDeRutaPdfSectionId; label: string; icon: LucideIcon; color: string }> = tabPresentationConfig.map((section) => ({
+  const tabConfig: HojaDeRutaTabOption[] = tabPresentationConfig.map((section) => ({
     ...section,
     label: getHojaDeRutaPdfSectionLabel(section.id),
   }));

--- a/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
+++ b/src/components/hoja-de-ruta/ModernHojaDeRuta.tsx
@@ -8,7 +8,11 @@ import { Progress } from "@/components/ui/progress";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   FileText,
@@ -84,10 +88,15 @@ import type { LucideIcon } from "lucide-react";
 
 type ModernHojaDeRutaProps = {
   jobId?: string;
+  // Set when rendered inside a Dialog (e.g. JobCardNewView's "Hoja de Ruta" modal)
+  // instead of the standalone /hoja-de-ruta page — switches the root layout from
+  // page-flow (min-h-screen) to a flex column that stretches to fill its parent.
+  embedded?: boolean;
 };
 
-export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
+export const ModernHojaDeRuta = ({ jobId, embedded = false }: ModernHojaDeRutaProps) => {
   const { toast } = useToast();
+  const isMobile = useIsMobile();
   const [searchParams] = useSearchParams();
   const routedJobId = jobId ?? searchParams.get("jobId") ?? searchParams.get("openHojaDeRuta") ?? undefined;
   const [activeTab, setActiveTab] = useState("event");
@@ -671,12 +680,17 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
   const DataSourceIcon = dataSourceInfo.icon;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
+    <div
+      className={cn(
+        "bg-gradient-to-br from-background via-background to-muted/20",
+        embedded ? "h-full flex flex-col overflow-hidden" : "min-h-screen"
+      )}
+    >
       {/* Modern Header */}
       <motion.div
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="sticky top-0 z-50 bg-background/95 backdrop-blur-lg border-b border-border/40"
+        className="shrink-0 sticky top-0 z-50 bg-background/95 backdrop-blur-lg border-b border-border/40"
       >
         {/* Use custom max width + responsive padding to avoid double container padding and overflow on mobile */}
         <div className="max-w-screen-2xl mx-auto px-4 md:px-6 py-3 md:py-4">
@@ -718,56 +732,98 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
               <div className="hidden md:block">
                 <ModernProgressTracker progress={completionProgress} />
               </div>
-              
+
               {/* Action Buttons */}
+              {isMobile ? (
+                // Guardar lives in the sticky bottom bar on mobile (thumb-reachable);
+                // the header only keeps a compact overflow menu for the secondary actions.
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      aria-label="Más acciones"
+                      className="h-11 w-11 shrink-0"
+                    >
+                      <MoreHorizontal className="w-4 h-4" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent align="end" className="w-48 p-1">
+                    <PopoverClose asChild>
+                      <button
+                        type="button"
+                        onClick={() => { void handlePreviewPDF(); }}
+                        disabled={!selectedJobId || !isInitialized || isSaving || isGenerating || isPreviewing}
+                        className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+                      >
+                        <Eye className="w-4 h-4 mr-2" />
+                        Vista previa
+                      </button>
+                    </PopoverClose>
+                    <PopoverClose asChild>
+                      <button
+                        type="button"
+                        onClick={() => setShowPrintDialog(true)}
+                        disabled={!selectedJobId}
+                        className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+                      >
+                        <Download className="w-4 h-4 mr-2" />
+                        Exportar
+                      </button>
+                    </PopoverClose>
+                  </PopoverContent>
+                </Popover>
+              ) : (
+                <>
+                  {/* Simplified Save Button - Always enabled when job is selected */}
+                  <Button
+                    onClick={handleSave}
+                    disabled={!selectedJobId || !isInitialized || isSaving}
+                    variant="outline"
+                    size="sm"
+                    aria-label="Guardar hoja de ruta"
+                    className="h-11 min-w-[44px] border-2 border-green-500 text-green-600 hover:bg-green-50"
+                  >
+                    {isSaving ? (
+                      <>
+                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        Guardando...
+                      </>
+                    ) : (
+                      <>
+                        <Save className="w-4 h-4 mr-2" />
+                        <span className="hidden sm:inline">Guardar</span>
+                      </>
+                    )}
+                  </Button>
 
-              {/* Simplified Save Button - Always enabled when job is selected */}
-              <Button
-                onClick={handleSave}
-                disabled={!selectedJobId || !isInitialized || isSaving}
-                variant="outline"
-                size="sm"
-                aria-label="Guardar hoja de ruta"
-                className="h-11 min-w-[44px] border-2 border-green-500 text-green-600 hover:bg-green-50"
-              >
-                {isSaving ? (
-                  <>
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    Guardando...
-                  </>
-                ) : (
-                  <>
-                    <Save className="w-4 h-4 mr-2" />
-                    <span className="hidden sm:inline">Guardar</span>
-                  </>
-                )}
-              </Button>
+                  <Button
+                    onClick={() => { void handlePreviewPDF(); }}
+                    disabled={!selectedJobId || !isInitialized || isSaving || isGenerating || isPreviewing}
+                    variant="outline"
+                    size="sm"
+                    aria-label="Vista previa PDF"
+                    className="h-11 min-w-[44px] border-2 border-blue-500 text-blue-600 hover:bg-blue-50"
+                  >
+                    {isPreviewing && previewingTarget === "full" ? (
+                      <Loader2 className="w-4 h-4 sm:mr-2 animate-spin" />
+                    ) : (
+                      <Eye className="w-4 h-4 sm:mr-2" />
+                    )}
+                    <span className="hidden sm:inline">Vista previa</span>
+                  </Button>
 
-              <Button
-                onClick={() => { void handlePreviewPDF(); }}
-                disabled={!selectedJobId || !isInitialized || isSaving || isGenerating || isPreviewing}
-                variant="outline"
-                size="sm"
-                aria-label="Vista previa PDF"
-                className="h-11 min-w-[44px] border-2 border-blue-500 text-blue-600 hover:bg-blue-50"
-              >
-                {isPreviewing && previewingTarget === "full" ? (
-                  <Loader2 className="w-4 h-4 sm:mr-2 animate-spin" />
-                ) : (
-                  <Eye className="w-4 h-4 sm:mr-2" />
-                )}
-                <span className="hidden sm:inline">Vista previa</span>
-              </Button>
-
-              <Button
-                onClick={() => setShowPrintDialog(true)}
-                disabled={!selectedJobId}
-                aria-label="Exportar"
-                className="h-11 min-w-[44px] bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70"
-              >
-                <Download className="w-4 h-4 mr-2" />
-                <span className="hidden sm:inline">Exportar</span>
-              </Button>
+                  <Button
+                    onClick={() => setShowPrintDialog(true)}
+                    disabled={!selectedJobId}
+                    aria-label="Exportar"
+                    className="h-11 min-w-[44px] bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70"
+                  >
+                    <Download className="w-4 h-4 mr-2" />
+                    <span className="hidden sm:inline">Exportar</span>
+                  </Button>
+                </>
+              )}
             </div>
           </div>
 
@@ -803,11 +859,12 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
       </motion.div>
 
       {/* Main Content */}
-      <div className="max-w-screen-2xl mx-auto px-4 md:px-6 py-4 md:py-8">
+      <div className={cn(embedded && "flex-1 overflow-y-auto")}>
+      <div className={cn("max-w-screen-2xl mx-auto px-4 md:px-6 py-4 md:py-8", isMobile && "pb-24")}>
         <div className="grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-6">
           {/* Sidebar with Templates (hidden on mobile, replaced by horizontal nav) */}
           <div className="hidden md:block md:col-span-3">
-            <div className="sticky top-24 space-y-4">
+            <div className={cn("sticky space-y-4", embedded ? "top-0" : "top-24")}>
               {/* Quick Navigation */}
               <Card className="border-2">
                 <CardHeader className="pb-3">
@@ -844,36 +901,45 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.1 }}
             >
-              {/* Mobile horizontal section tabs */}
-              <div className="md:hidden -mx-4 px-4 mb-3 sticky top-[68px] z-40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b border-border/40">
-                <nav aria-label="Secciones de Hoja de Ruta" role="tablist" className="flex items-center gap-2.5 py-2 overflow-x-auto whitespace-nowrap [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-                  {tabConfig.map((tab) => {
-                    const Icon = tab.icon;
-                    const active = activeTab === tab.id;
-                    const iconClass = active ? 'text-primary-foreground' : 'text-foreground/70';
-                    return (
-                      <button
-                        key={tab.id}
-                        role="tab"
-                        aria-selected={active}
-                        aria-controls={`panel-${tab.id}`}
-                        onClick={() => setActiveTab(tab.id)}
-                        className={`shrink-0 inline-flex items-center h-9 px-3 rounded-full border text-[13px] leading-none min-w-[44px] transition-colors ${
-                          active
-                            ? 'bg-primary text-primary-foreground border-primary shadow-sm'
-                            : 'bg-muted/60 text-foreground border-border/60 hover:bg-muted'
-                        }`}
-                      >
-                        <Icon className={`w-4 h-4 mr-1.5 ${iconClass}`} />
-                        {tab.label}
-                      </button>
-                    );
-                  })}
-                </nav>
-                {/* Mobile progress below tabs */}
-                <div className="py-2">
-                  <ModernProgressTracker progress={completionProgress} />
-                </div>
+              {/* Mobile section switcher */}
+              <div
+                className={cn(
+                  "md:hidden -mx-4 px-4 mb-3 sticky z-40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b border-border/40 py-2 space-y-2",
+                  // When embedded, the page header lives outside the scroll region (flex `shrink-0`),
+                  // so this only needs to clear the scroll container's own top, not the header's height.
+                  embedded ? "top-0" : "top-[68px]"
+                )}
+              >
+                <Select value={activeTab} onValueChange={setActiveTab}>
+                  <SelectTrigger className="w-full h-11" aria-label="Seleccionar sección">
+                    <SelectValue>
+                      {(() => {
+                        const current = tabConfig.find((tab) => tab.id === activeTab) ?? tabConfig[0];
+                        const Icon = current.icon;
+                        return (
+                          <span className="flex items-center gap-2">
+                            <Icon className={`w-4 h-4 ${current.color}`} />
+                            {current.label}
+                          </span>
+                        );
+                      })()}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {tabConfig.map((tab) => {
+                      const Icon = tab.icon;
+                      return (
+                        <SelectItem key={tab.id} value={tab.id}>
+                          <span className="flex items-center gap-2">
+                            <Icon className={`w-4 h-4 ${tab.color}`} />
+                            {tab.label}
+                          </span>
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+                <ModernProgressTracker progress={completionProgress} />
               </div>
 
               <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
@@ -1025,6 +1091,30 @@ export const ModernHojaDeRuta = ({ jobId }: ModernHojaDeRutaProps) => {
           </div>
         </div>
       </div>
+      </div>
+
+      {isMobile && (
+        <div className="fixed inset-x-0 bottom-0 z-50 shrink-0 border-t bg-background/95 backdrop-blur px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+          <Button
+            onClick={handleSave}
+            disabled={!selectedJobId || !isInitialized || isSaving}
+            variant="outline"
+            className="w-full h-11 border-2 border-green-500 text-green-600 hover:bg-green-50"
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Guardando...
+              </>
+            ) : (
+              <>
+                <Save className="w-4 h-4 mr-2" />
+                Guardar
+              </>
+            )}
+          </Button>
+        </div>
+      )}
 
       <HojaDeRutaPrintDialog
         showDialog={showPrintDialog}

--- a/src/components/hoja-de-ruta/components/HojaDeRutaHeaderActions.tsx
+++ b/src/components/hoja-de-ruta/components/HojaDeRutaHeaderActions.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Download, Eye, Loader2, MoreHorizontal, Save } from "lucide-react";
-import type { HojaDeRutaPrintPreviewTarget } from "../HojaDeRutaPrintDialog";
+import type { HojaDeRutaPrintPreviewTarget } from "@/components/hoja-de-ruta/HojaDeRutaPrintDialog";
 
 type HojaDeRutaHeaderActionsProps = {
   isMobile: boolean;

--- a/src/components/hoja-de-ruta/components/HojaDeRutaHeaderActions.tsx
+++ b/src/components/hoja-de-ruta/components/HojaDeRutaHeaderActions.tsx
@@ -1,0 +1,124 @@
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Download, Eye, Loader2, MoreHorizontal, Save } from "lucide-react";
+import type { HojaDeRutaPrintPreviewTarget } from "../HojaDeRutaPrintDialog";
+
+type HojaDeRutaHeaderActionsProps = {
+  isMobile: boolean;
+  selectedJobId?: string | null;
+  isInitialized: boolean;
+  isSaving: boolean;
+  isGenerating: boolean;
+  isPreviewing: boolean;
+  previewingTarget: HojaDeRutaPrintPreviewTarget;
+  onSave: () => void;
+  onPreviewPDF: () => void;
+  onExport: () => void;
+};
+
+// Mobile keeps Guardar in a sticky bottom bar (thumb-reachable) — the header only
+// needs a compact overflow menu for the secondary actions. Desktop keeps all three
+// buttons inline. A Popover (not DropdownMenu) is used for the overflow menu because
+// the shared DropdownMenuContent forces `position: fixed`, which breaks Radix's
+// Popper alignment inside a fullscreen mobile dialog.
+export const HojaDeRutaHeaderActions = ({
+  isMobile,
+  selectedJobId,
+  isInitialized,
+  isSaving,
+  isGenerating,
+  isPreviewing,
+  previewingTarget,
+  onSave,
+  onPreviewPDF,
+  onExport,
+}: HojaDeRutaHeaderActionsProps) => {
+  if (isMobile) {
+    return (
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline" size="icon" aria-label="Más acciones" className="h-11 w-11 shrink-0">
+            <MoreHorizontal className="w-4 h-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-48 p-1">
+          <PopoverClose asChild>
+            <button
+              type="button"
+              onClick={onPreviewPDF}
+              disabled={!selectedJobId || !isInitialized || isSaving || isGenerating || isPreviewing}
+              className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+            >
+              <Eye className="w-4 h-4 mr-2" />
+              Vista previa
+            </button>
+          </PopoverClose>
+          <PopoverClose asChild>
+            <button
+              type="button"
+              onClick={onExport}
+              disabled={!selectedJobId}
+              className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+            >
+              <Download className="w-4 h-4 mr-2" />
+              Exportar
+            </button>
+          </PopoverClose>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        onClick={onSave}
+        disabled={!selectedJobId || !isInitialized || isSaving}
+        variant="outline"
+        size="sm"
+        aria-label="Guardar hoja de ruta"
+        className="h-11 min-w-[44px] border-2 border-green-500 text-green-600 hover:bg-green-50"
+      >
+        {isSaving ? (
+          <>
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            Guardando...
+          </>
+        ) : (
+          <>
+            <Save className="w-4 h-4 mr-2" />
+            <span className="hidden sm:inline">Guardar</span>
+          </>
+        )}
+      </Button>
+
+      <Button
+        onClick={onPreviewPDF}
+        disabled={!selectedJobId || !isInitialized || isSaving || isGenerating || isPreviewing}
+        variant="outline"
+        size="sm"
+        aria-label="Vista previa PDF"
+        className="h-11 min-w-[44px] border-2 border-blue-500 text-blue-600 hover:bg-blue-50"
+      >
+        {isPreviewing && previewingTarget === "full" ? (
+          <Loader2 className="w-4 h-4 sm:mr-2 animate-spin" />
+        ) : (
+          <Eye className="w-4 h-4 sm:mr-2" />
+        )}
+        <span className="hidden sm:inline">Vista previa</span>
+      </Button>
+
+      <Button
+        onClick={onExport}
+        disabled={!selectedJobId}
+        aria-label="Exportar"
+        className="h-11 min-w-[44px] bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70"
+      >
+        <Download className="w-4 h-4 mr-2" />
+        <span className="hidden sm:inline">Exportar</span>
+      </Button>
+    </>
+  );
+};
+
+export default HojaDeRutaHeaderActions;

--- a/src/components/hoja-de-ruta/components/MobileSaveBar.tsx
+++ b/src/components/hoja-de-ruta/components/MobileSaveBar.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@/components/ui/button";
+import { Loader2, Save } from "lucide-react";
+
+type MobileSaveBarProps = {
+  onSave: () => void;
+  disabled: boolean;
+  isSaving: boolean;
+};
+
+// Sticky, thumb-reachable Guardar bar for mobile — keeps the primary action
+// accessible without competing with the header's title/overflow menu for space.
+export const MobileSaveBar = ({ onSave, disabled, isSaving }: MobileSaveBarProps) => (
+  <div className="fixed inset-x-0 bottom-0 z-50 shrink-0 border-t bg-background/95 backdrop-blur px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+    <Button
+      onClick={onSave}
+      disabled={disabled}
+      variant="outline"
+      className="w-full h-11 border-2 border-green-500 text-green-600 hover:bg-green-50"
+    >
+      {isSaving ? (
+        <>
+          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+          Guardando...
+        </>
+      ) : (
+        <>
+          <Save className="w-4 h-4 mr-2" />
+          Guardar
+        </>
+      )}
+    </Button>
+  </div>
+);
+
+export default MobileSaveBar;

--- a/src/components/hoja-de-ruta/components/MobileSectionSwitcher.tsx
+++ b/src/components/hoja-de-ruta/components/MobileSectionSwitcher.tsx
@@ -1,12 +1,10 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import { ModernProgressTracker } from "./ModernProgressTracker";
-import type { LucideIcon } from "lucide-react";
-
-type TabOption = { id: string; label: string; icon: LucideIcon; color: string };
+import { ModernProgressTracker } from "@/components/hoja-de-ruta/components/ModernProgressTracker";
+import type { HojaDeRutaTabOption } from "@/components/hoja-de-ruta/types";
 
 type MobileSectionSwitcherProps = {
-  tabConfig: TabOption[];
+  tabConfig: HojaDeRutaTabOption[];
   activeTab: string;
   onTabChange: (tabId: string) => void;
   progress: number;

--- a/src/components/hoja-de-ruta/components/MobileSectionSwitcher.tsx
+++ b/src/components/hoja-de-ruta/components/MobileSectionSwitcher.tsx
@@ -1,0 +1,65 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { ModernProgressTracker } from "./ModernProgressTracker";
+import type { LucideIcon } from "lucide-react";
+
+type TabOption = { id: string; label: string; icon: LucideIcon; color: string };
+
+type MobileSectionSwitcherProps = {
+  tabConfig: TabOption[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  progress: number;
+  embedded: boolean;
+};
+
+// Replaces an 11-item horizontally-scrolling pill strip (no scroll affordance, never
+// comfortably fit) with a single dropdown showing the active section.
+export const MobileSectionSwitcher = ({
+  tabConfig,
+  activeTab,
+  onTabChange,
+  progress,
+  embedded,
+}: MobileSectionSwitcherProps) => {
+  const current = tabConfig.find((tab) => tab.id === activeTab) ?? tabConfig[0];
+  const CurrentIcon = current.icon;
+
+  return (
+    <div
+      className={cn(
+        "md:hidden -mx-4 px-4 mb-3 sticky z-40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b border-border/40 py-2 space-y-2",
+        // When embedded, the page header lives outside the scroll region (flex `shrink-0`),
+        // so this only needs to clear the scroll container's own top, not the header's height.
+        embedded ? "top-0" : "top-[68px]"
+      )}
+    >
+      <Select value={activeTab} onValueChange={onTabChange}>
+        <SelectTrigger className="w-full h-11" aria-label="Seleccionar sección">
+          <SelectValue>
+            <span className="flex items-center gap-2">
+              <CurrentIcon className={`w-4 h-4 ${current.color}`} />
+              {current.label}
+            </span>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {tabConfig.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <SelectItem key={tab.id} value={tab.id}>
+                <span className="flex items-center gap-2">
+                  <Icon className={`w-4 h-4 ${tab.color}`} />
+                  {tab.label}
+                </span>
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+      <ModernProgressTracker progress={progress} />
+    </div>
+  );
+};
+
+export default MobileSectionSwitcher;

--- a/src/components/hoja-de-ruta/components/QuickNavigationSidebar.tsx
+++ b/src/components/hoja-de-ruta/components/QuickNavigationSidebar.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { Globe } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+type TabOption = { id: string; label: string; icon: LucideIcon; color: string };
+
+type QuickNavigationSidebarProps = {
+  tabConfig: TabOption[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  embedded: boolean;
+};
+
+// Desktop-only section nav (hidden on mobile, replaced by MobileSectionSwitcher).
+export const QuickNavigationSidebar = ({
+  tabConfig,
+  activeTab,
+  onTabChange,
+  embedded,
+}: QuickNavigationSidebarProps) => (
+  <div className="hidden md:block md:col-span-3">
+    <div className={cn("sticky space-y-4", embedded ? "top-0" : "top-24")}>
+      <Card className="border-2">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm font-medium flex items-center gap-2">
+            <Globe className="w-4 h-4" />
+            Navegación Rápida
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {tabConfig.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <Button
+                key={tab.id}
+                variant={activeTab === tab.id ? "default" : "ghost"}
+                size="sm"
+                onClick={() => onTabChange(tab.id)}
+                className={`w-full justify-start ${activeTab === tab.id ? "bg-primary text-primary-foreground" : ""}`}
+              >
+                <Icon className={`w-4 h-4 mr-2 ${tab.color}`} />
+                {tab.label}
+              </Button>
+            );
+          })}
+        </CardContent>
+      </Card>
+    </div>
+  </div>
+);
+
+export default QuickNavigationSidebar;

--- a/src/components/hoja-de-ruta/components/QuickNavigationSidebar.tsx
+++ b/src/components/hoja-de-ruta/components/QuickNavigationSidebar.tsx
@@ -2,12 +2,10 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { Globe } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
-
-type TabOption = { id: string; label: string; icon: LucideIcon; color: string };
+import type { HojaDeRutaTabOption } from "@/components/hoja-de-ruta/types";
 
 type QuickNavigationSidebarProps = {
-  tabConfig: TabOption[];
+  tabConfig: HojaDeRutaTabOption[];
   activeTab: string;
   onTabChange: (tabId: string) => void;
   embedded: boolean;

--- a/src/components/hoja-de-ruta/hojaDeRutaDialogClassName.ts
+++ b/src/components/hoja-de-ruta/hojaDeRutaDialogClassName.ts
@@ -1,0 +1,7 @@
+// Mobile: true fullscreen (matches ArtistManagementDialog's convention). Desktop:
+// w-96vw/h-85vh — matches what dialog.tsx's own base classes actually allow
+// (md:max-h-[85vh]), so the two don't fight over the box's rendered height.
+export const getHojaDeRutaDialogClassName = (isMobile: boolean): string =>
+  isMobile
+    ? "flex h-dvh max-h-dvh w-[100vw] max-w-[100vw] flex-col gap-0 overflow-hidden rounded-none p-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
+    : "flex w-[96vw] max-w-[96vw] h-[85vh] max-h-[85vh] flex-col gap-0 overflow-hidden p-0";

--- a/src/components/hoja-de-ruta/sections/ModernAccommodationSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernAccommodationSection.tsx
@@ -216,7 +216,7 @@ export const ModernAccommodationSection: React.FC<ModernAccommodationSectionProp
                             </Button>
                           </div>
 
-                          <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                             <div className="space-y-2">
                               <Label className="text-sm font-medium">Tipo de Habitación</Label>
                               <Select

--- a/src/components/hoja-de-ruta/sections/ModernContactsSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernContactsSection.tsx
@@ -67,7 +67,7 @@ export const ModernContactsSection: React.FC<ModernContactsSectionProps> = ({
                   exit={{ opacity: 0, x: 20 }}
                   className="p-4 border-2 border-gray-200 rounded-lg bg-gradient-to-r from-purple-50 to-transparent"
                 >
-                  <div className="grid grid-cols-3 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                     <div className="space-y-2">
                       <Label className="text-sm font-medium flex items-center gap-2">
                         <User className="w-4 h-4" />

--- a/src/components/hoja-de-ruta/sections/ModernEventSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernEventSection.tsx
@@ -136,7 +136,7 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="job-select">Trabajo Base</Label>
                   <Select value={selectedJobId} onValueChange={setSelectedJobId}>
@@ -174,7 +174,7 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
                   animate={{ opacity: 1, height: "auto" }}
                   className="mt-4 p-4 bg-blue-50 rounded-lg border border-blue-200"
                 >
-                  <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                     <div>
                       <span className="font-medium text-blue-700">Fechas:</span>
                       <p className="text-blue-600">
@@ -215,7 +215,7 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
             </div>
           </CardHeader>
           <CardContent className="space-y-6">
-            <div className="grid grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
                 <Label htmlFor="event-name" className="text-sm font-medium">
                   Nombre del Evento *
@@ -243,7 +243,7 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
                 <Label htmlFor="venue-name" className="text-sm font-medium">
                   Nombre del Venue *

--- a/src/components/hoja-de-ruta/sections/ModernStaffSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernStaffSection.tsx
@@ -106,7 +106,7 @@ export const ModernStaffSection: React.FC<ModernStaffSectionProps> = ({
                   exit={{ opacity: 0, x: 20 }}
                   className="p-4 border-2 border-gray-200 rounded-lg bg-gradient-to-r from-orange-50 to-transparent"
                 >
-                  <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+                  <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
                     <div className="space-y-2">
                       <Label className="text-sm font-medium flex items-center gap-2">
                         <User className="w-4 h-4" />

--- a/src/components/hoja-de-ruta/sections/ModernTravelSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernTravelSection.tsx
@@ -147,7 +147,7 @@ export const ModernTravelSection: React.FC<ModernTravelSectionProps> = ({
                       </Button>
                     </div>
 
-                    <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                       <div className="space-y-2">
                         <Label className="text-sm font-medium">
                           Tipo de Transporte

--- a/src/components/hoja-de-ruta/sections/ModernVenueSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernVenueSection.tsx
@@ -192,7 +192,7 @@ export const ModernVenueSection: React.FC<ModernVenueSectionProps> = ({
 
             {/* Image Gallery */}
             {imagePreviews.venue.length > 0 && (
-              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <AnimatePresence>
                   {imagePreviews.venue.map((preview, index) => (
                     <motion.div

--- a/src/components/hoja-de-ruta/types.ts
+++ b/src/components/hoja-de-ruta/types.ts
@@ -1,0 +1,9 @@
+import type { LucideIcon } from "lucide-react";
+import type { HojaDeRutaPdfSectionId } from "@/utils/hoja-de-ruta/pdf";
+
+export type HojaDeRutaTabOption = {
+  id: HojaDeRutaPdfSectionId;
+  label: string;
+  icon: LucideIcon;
+  color: string;
+};

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -10,6 +10,7 @@ import { Card } from "@/components/ui/card";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { ModernHojaDeRuta } from "@/components/hoja-de-ruta/ModernHojaDeRuta";
+import { getHojaDeRutaDialogClassName } from "@/components/hoja-de-ruta/hojaDeRutaDialogClassName";
 import { FlexSyncLogDialog } from "@/components/jobs/FlexSyncLogDialog";
 import { JobAssignmentDialog } from "@/components/jobs/JobAssignmentDialog";
 import { JobDetailsDialog } from "@/components/jobs/JobDetailsDialog";
@@ -34,7 +35,6 @@ import { JobCardHeader } from "../JobCardHeader";
 import { JobCardProgress } from "../JobCardProgress";
 import { ConfettiBurst } from "@/components/ui/celebration/ConfettiBurst";
 import { isManagementRole } from "@/utils/permissions";
-
 
 import { queryKeys } from "@/lib/react-query";
 export interface JobCardNewViewProps {
@@ -675,13 +675,7 @@ export function JobCardNewView({
           {isProjectManagementPage && (
             <>
               <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
-                <DialogContent
-                  className={
-                    isMobile
-                      ? "flex h-dvh max-h-dvh w-[100vw] max-w-[100vw] flex-col gap-0 overflow-hidden rounded-none p-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
-                      : "flex w-[96vw] max-w-[96vw] h-[85vh] max-h-[85vh] flex-col gap-0 overflow-hidden p-0"
-                  }
-                >
+                <DialogContent className={getHojaDeRutaDialogClassName(isMobile)}>
                   <ModernHojaDeRuta jobId={job.id} embedded />
                 </DialogContent>
               </Dialog>

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { ModernHojaDeRuta } from "@/components/hoja-de-ruta/ModernHojaDeRuta";
 import { FlexSyncLogDialog } from "@/components/jobs/FlexSyncLogDialog";
 import { JobAssignmentDialog } from "@/components/jobs/JobAssignmentDialog";
@@ -271,6 +272,7 @@ export function JobCardNewView({
   handleFlexPickerConfirm,
 }: JobCardNewViewProps) {
   const reducedMotion = useReducedMotion();
+  const isMobile = useIsMobile();
   const canManageTransportRequests = userDepartment === "logistics" || isManagementRole(userRole);
   const isAndreaWeddingJob = job?.id === "eeb00e4d-7d38-4687-9d04-31471b89adfc";
   const [celebrateSeed, setCelebrateSeed] = React.useState(0);
@@ -673,10 +675,14 @@ export function JobCardNewView({
           {isProjectManagementPage && (
             <>
               <Dialog open={routeSheetOpen} onOpenChange={setRouteSheetOpen}>
-                <DialogContent className="max-w-[96vw] w-[96vw] h-[96vh] p-0 overflow-hidden">
-                  <div className="h-full overflow-auto">
-                    <ModernHojaDeRuta jobId={job.id} />
-                  </div>
+                <DialogContent
+                  className={
+                    isMobile
+                      ? "flex h-dvh max-h-dvh w-[100vw] max-w-[100vw] flex-col gap-0 overflow-hidden rounded-none p-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
+                      : "flex w-[96vw] max-w-[96vw] h-[85vh] max-h-[85vh] flex-col gap-0 overflow-hidden p-0"
+                  }
+                >
+                  <ModernHojaDeRuta jobId={job.id} embedded />
                 </DialogContent>
               </Dialog>
               <ProjectNotesDialog

--- a/src/components/schedule/MultiDayScheduleBuilder.tsx
+++ b/src/components/schedule/MultiDayScheduleBuilder.tsx
@@ -52,7 +52,7 @@ export const MultiDayScheduleBuilder: React.FC<MultiDayScheduleBuilderProps> = (
       const clone: ProgramDay = {
         label: `${src.label || `Día ${index + 1}`} (copia)`,
         date: src.date,
-        rows: src.rows.map((r) => ({ ...r } as ProgramRow)),
+        rows: src.rows.map((r) => ({ ...r, id: crypto.randomUUID() } as ProgramRow)),
       };
       return [...d, clone];
     });

--- a/src/components/schedule/ScheduleBuilder.tsx
+++ b/src/components/schedule/ScheduleBuilder.tsx
@@ -24,15 +24,15 @@ type ScheduleBuilderProps = {
 };
 
 const defaultPresets: Array<Pick<ProgramRow, 'item' | 'dept' | 'notes'>> = [
-  { item: 'Venue Access', dept: 'PM/Venue', notes: '' },
-  { item: 'Load-In', dept: 'All Depts', notes: '' },
-  { item: 'Lighting Focus', dept: 'Lighting', notes: '' },
-  { item: 'Soundcheck', dept: 'Audio', notes: '' },
-  { item: 'Video Check', dept: 'Video', notes: '' },
-  { item: 'Meal Break', dept: 'Hospitality', notes: '' },
-  { item: 'Doors', dept: 'FOH/Security', notes: '' },
-  { item: 'Show Start', dept: 'Stage', notes: '' },
-  { item: 'Load-Out', dept: 'All Depts', notes: '' },
+  { item: 'Acceso al recinto', dept: 'PM/Recinto', notes: '' },
+  { item: 'Montaje', dept: 'Todos los deptos.', notes: '' },
+  { item: 'Enfoque de iluminación', dept: 'Iluminación', notes: '' },
+  { item: 'Prueba de sonido', dept: 'Sonido', notes: '' },
+  { item: 'Prueba de vídeo', dept: 'Vídeo', notes: '' },
+  { item: 'Comida', dept: 'Hostelería', notes: '' },
+  { item: 'Apertura de puertas', dept: 'FOH/Seguridad', notes: '' },
+  { item: 'Inicio del show', dept: 'Escenario', notes: '' },
+  { item: 'Desmontaje', dept: 'Todos los deptos.', notes: '' },
 ];
 
 export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
@@ -187,7 +187,7 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
           <span>Constructor de Programa</span>
           <div className="flex items-center gap-2">
             {headerControls}
-            <Label className="text-xs text-muted-foreground">Snap</Label>
+            <Label className="text-xs text-muted-foreground">Intervalo</Label>
             <select
               className="border rounded px-2 py-1 text-xs"
               value={snap}
@@ -241,41 +241,42 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
                   step={stepSeconds}
                   value={row.time}
                   onChange={(e) => updateRow(idx, { time: roundToSnap(e.target.value) })}
-                  className="sm:col-span-2"
+                  className="sm:col-span-2 min-w-0"
                 />
                 <Input
                   value={row.item}
                   onChange={(e) => updateRow(idx, { item: e.target.value })}
                   placeholder="Actividad"
-                  className="sm:col-span-4"
+                  className="sm:col-span-4 min-w-0"
                 />
                 <Input
                   value={row.dept || ''}
                   onChange={(e) => updateRow(idx, { dept: e.target.value })}
                   placeholder="Depto/Líder"
-                  className="sm:col-span-3"
+                  className="sm:col-span-3 min-w-0"
                 />
-                <div className="sm:col-span-3 flex items-center gap-2">
-                  <Input
-                    value={row.notes || ''}
-                    onChange={(e) => updateRow(idx, { notes: e.target.value })}
-                    placeholder="Notas"
-                  />
-                  <div className="flex items-center gap-1">
-                    <Button variant="ghost" size="icon" onClick={() => moveRow(idx, -1)} title="Subir">
-                      <ArrowUp className="w-4 h-4" />
-                    </Button>
-                    <Button variant="ghost" size="icon" onClick={() => moveRow(idx, 1)} title="Bajar">
-                      <ArrowDown className="w-4 h-4" />
-                    </Button>
-                    <Button variant="ghost" size="icon" onClick={() => duplicateRow(idx)} title="Duplicar">
-                      <Copy className="w-4 h-4" />
-                    </Button>
-                    <Button variant="ghost" size="icon" onClick={() => deleteRow(idx)} title="Eliminar">
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
-                  </div>
-                </div>
+                <Input
+                  value={row.notes || ''}
+                  onChange={(e) => updateRow(idx, { notes: e.target.value })}
+                  placeholder="Notas"
+                  className="sm:col-span-3 min-w-0"
+                />
+              </div>
+              {/* Row actions live on their own row so Notas always gets full width
+                  instead of being squeezed alongside four icon buttons on narrow screens. */}
+              <div className="flex items-center justify-end gap-1">
+                <Button variant="ghost" size="icon" onClick={() => moveRow(idx, -1)} title="Subir">
+                  <ArrowUp className="w-4 h-4" />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => moveRow(idx, 1)} title="Bajar">
+                  <ArrowDown className="w-4 h-4" />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => duplicateRow(idx)} title="Duplicar">
+                  <Copy className="w-4 h-4" />
+                </Button>
+                <Button variant="ghost" size="icon" onClick={() => deleteRow(idx)} title="Eliminar">
+                  <Trash2 className="w-4 h-4" />
+                </Button>
               </div>
               <div className="flex flex-wrap items-center gap-2 pl-1">
                 <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -290,6 +291,7 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
                   <ToggleGroup
                     type="multiple"
                     size="sm"
+                    className="flex-wrap justify-start"
                     value={row.departments || []}
                     onValueChange={(value) => updateRow(idx, { departments: value as ActiveDepartment[] })}
                   >

--- a/src/components/schedule/ScheduleBuilder.tsx
+++ b/src/components/schedule/ScheduleBuilder.tsx
@@ -3,8 +3,11 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { ProgramRow } from '@/types/hoja-de-ruta';
-import { Plus, Trash2, Copy, ArrowUp, ArrowDown, FileDown } from 'lucide-react';
+import { ACTIVE_DEPARTMENTS, DEPARTMENT_LABELS, type ActiveDepartment } from '@/types/department';
+import { Plus, Trash2, Copy, ArrowUp, ArrowDown, FileDown, Bell } from 'lucide-react';
 
 type TimeFormat = '24h' | '12h';
 
@@ -57,7 +60,9 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
         ra.time !== rb.time ||
         ra.item !== rb.item ||
         (ra.dept || '') !== (rb.dept || '') ||
-        (ra.notes || '') !== (rb.notes || '')
+        (ra.notes || '') !== (rb.notes || '') ||
+        !!ra.notify !== !!rb.notify ||
+        (ra.departments || []).join(',') !== (rb.departments || []).join(',')
       ) {
         return false;
       }
@@ -107,6 +112,7 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
     const lastTime = rows.length ? rows[rows.length - 1].time : '09:00';
     const nextTime = roundToSnap(incrementTime(lastTime, snap));
     const newRow: ProgramRow = {
+      id: crypto.randomUUID(),
       time: nextTime,
       item: preset?.item || '',
       dept: preset?.dept || '',
@@ -135,7 +141,7 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
   const duplicateRow = (index: number) => {
     setRows((r) => {
       const copy = [...r];
-      copy.splice(index + 1, 0, { ...r[index] });
+      copy.splice(index + 1, 0, { ...r[index], id: crypto.randomUUID() });
       return copy;
     });
   };
@@ -226,48 +232,77 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
         </div>
 
         {/* Rows */}
-        <div className="space-y-2">
+        <div className="space-y-3">
           {rows.map((row, idx) => (
-            <div key={idx} className="grid grid-cols-12 gap-2 items-center">
-              <Input
-                type="time"
-                step={stepSeconds}
-                value={row.time}
-                onChange={(e) => updateRow(idx, { time: roundToSnap(e.target.value) })}
-                className="col-span-2"
-              />
-              <Input
-                value={row.item}
-                onChange={(e) => updateRow(idx, { item: e.target.value })}
-                placeholder="Actividad"
-                className="col-span-4"
-              />
-              <Input
-                value={row.dept || ''}
-                onChange={(e) => updateRow(idx, { dept: e.target.value })}
-                placeholder="Depto/Líder"
-                className="col-span-3"
-              />
-              <div className="col-span-3 flex items-center gap-2">
+            <div key={row.id || idx} className="space-y-1.5 rounded-md border border-transparent p-1.5 hover:border-border">
+              <div className="grid grid-cols-12 gap-2 items-center">
                 <Input
-                  value={row.notes || ''}
-                  onChange={(e) => updateRow(idx, { notes: e.target.value })}
-                  placeholder="Notas"
+                  type="time"
+                  step={stepSeconds}
+                  value={row.time}
+                  onChange={(e) => updateRow(idx, { time: roundToSnap(e.target.value) })}
+                  className="col-span-2"
                 />
-                <div className="flex items-center gap-1">
-                  <Button variant="ghost" size="icon" onClick={() => moveRow(idx, -1)} title="Subir">
-                    <ArrowUp className="w-4 h-4" />
-                  </Button>
-                  <Button variant="ghost" size="icon" onClick={() => moveRow(idx, 1)} title="Bajar">
-                    <ArrowDown className="w-4 h-4" />
-                  </Button>
-                  <Button variant="ghost" size="icon" onClick={() => duplicateRow(idx)} title="Duplicar">
-                    <Copy className="w-4 h-4" />
-                  </Button>
-                  <Button variant="ghost" size="icon" onClick={() => deleteRow(idx)} title="Eliminar">
-                    <Trash2 className="w-4 h-4" />
-                  </Button>
+                <Input
+                  value={row.item}
+                  onChange={(e) => updateRow(idx, { item: e.target.value })}
+                  placeholder="Actividad"
+                  className="col-span-4"
+                />
+                <Input
+                  value={row.dept || ''}
+                  onChange={(e) => updateRow(idx, { dept: e.target.value })}
+                  placeholder="Depto/Líder"
+                  className="col-span-3"
+                />
+                <div className="col-span-3 flex items-center gap-2">
+                  <Input
+                    value={row.notes || ''}
+                    onChange={(e) => updateRow(idx, { notes: e.target.value })}
+                    placeholder="Notas"
+                  />
+                  <div className="flex items-center gap-1">
+                    <Button variant="ghost" size="icon" onClick={() => moveRow(idx, -1)} title="Subir">
+                      <ArrowUp className="w-4 h-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon" onClick={() => moveRow(idx, 1)} title="Bajar">
+                      <ArrowDown className="w-4 h-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon" onClick={() => duplicateRow(idx)} title="Duplicar">
+                      <Copy className="w-4 h-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon" onClick={() => deleteRow(idx)} title="Eliminar">
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
                 </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 pl-1">
+                <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Checkbox
+                    checked={!!row.notify}
+                    onCheckedChange={(checked) => updateRow(idx, { notify: checked === true })}
+                  />
+                  <Bell className="w-3.5 h-3.5" />
+                  Notificar a los asignados a esta hora
+                </label>
+                {row.notify && (
+                  <ToggleGroup
+                    type="multiple"
+                    size="sm"
+                    value={row.departments || []}
+                    onValueChange={(value) => updateRow(idx, { departments: value as ActiveDepartment[] })}
+                  >
+                    {ACTIVE_DEPARTMENTS.map((dept) => (
+                      <ToggleGroupItem key={dept} value={dept} className="text-xs px-2 py-1 h-7">
+                        {DEPARTMENT_LABELS[dept]}
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                )}
+                {row.notify && (row.departments || []).length === 0 && (
+                  <span className="text-xs text-muted-foreground">(todos los asignados)</span>
+                )}
               </div>
             </div>
           ))}

--- a/src/components/schedule/ScheduleBuilder.tsx
+++ b/src/components/schedule/ScheduleBuilder.tsx
@@ -223,8 +223,8 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
           </Button>
         </div>
 
-        {/* Grid header */}
-        <div className="grid grid-cols-12 gap-2 text-xs font-medium text-muted-foreground">
+        {/* Grid header (hidden on mobile, where rows stack in a single column) */}
+        <div className="hidden sm:grid grid-cols-12 gap-2 text-xs font-medium text-muted-foreground">
           <div className="col-span-2">Hora</div>
           <div className="col-span-4">Ítem</div>
           <div className="col-span-3">Depto/Líder</div>
@@ -235,27 +235,27 @@ export const ScheduleBuilder: React.FC<ScheduleBuilderProps> = ({
         <div className="space-y-3">
           {rows.map((row, idx) => (
             <div key={row.id || idx} className="space-y-1.5 rounded-md border border-transparent p-1.5 hover:border-border">
-              <div className="grid grid-cols-12 gap-2 items-center">
+              <div className="grid grid-cols-1 sm:grid-cols-12 gap-2 sm:items-center">
                 <Input
                   type="time"
                   step={stepSeconds}
                   value={row.time}
                   onChange={(e) => updateRow(idx, { time: roundToSnap(e.target.value) })}
-                  className="col-span-2"
+                  className="sm:col-span-2"
                 />
                 <Input
                   value={row.item}
                   onChange={(e) => updateRow(idx, { item: e.target.value })}
                   placeholder="Actividad"
-                  className="col-span-4"
+                  className="sm:col-span-4"
                 />
                 <Input
                   value={row.dept || ''}
                   onChange={(e) => updateRow(idx, { dept: e.target.value })}
                   placeholder="Depto/Líder"
-                  className="col-span-3"
+                  className="sm:col-span-3"
                 />
-                <div className="col-span-3 flex items-center gap-2">
+                <div className="sm:col-span-3 flex items-center gap-2">
                   <Input
                     value={row.notes || ''}
                     onChange={(e) => updateRow(idx, { notes: e.target.value })}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -7,6 +7,8 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
+const PopoverClose = PopoverPrimitive.Close
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -26,4 +28,4 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverClose, PopoverContent }

--- a/src/hooks/useHojaDeRutaPersistence.ts
+++ b/src/hooks/useHojaDeRutaPersistence.ts
@@ -7,6 +7,7 @@ import type {
   AuxiliaryMachineryRequirement,
   Transport,
   WeatherData,
+  ProgramDay,
 } from "@/types/hoja-de-ruta";
 import type { Json } from "@/integrations/supabase/types";
 import { useToast } from "@/hooks/use-toast";
@@ -18,6 +19,16 @@ import {
   normalizeVenueCoordinates,
   resolveHojaVenue,
 } from "@/utils/hoja-de-ruta/venue-resolution";
+
+// Older programa rows were saved before `id` existed; backfill so push notifications
+// have a stable dedup key without forcing a one-time data migration.
+const backfillProgramDayIds = (days: ProgramDay[] | undefined): ProgramDay[] | undefined => {
+  if (!Array.isArray(days)) return days;
+  return days.map((day) => ({
+    ...day,
+    rows: (day.rows || []).map((row) => (row.id ? row : { ...row, id: crypto.randomUUID() })),
+  }));
+};
 
 
 
@@ -265,7 +276,7 @@ export const useHojaDeRutaPersistence = (
         })) : [{ name: '', surname1: '', surname2: '', position: '', dni: '' }],
         schedule: mainData.schedule || '',
         // Load multi-day program if available
-        programScheduleDays: (mainData as any).program_schedule_json || undefined,
+        programScheduleDays: backfillProgramDayIds((mainData as any).program_schedule_json || undefined),
         powerRequirements: mainData.power_requirements || '',
         auxiliaryNeeds: mainData.auxiliary_needs || '',
         auxiliaryStaffSetupQty: toSafeNonNegativeInt(mainData.aux_staff_setup_qty),

--- a/src/types/hoja-de-ruta.ts
+++ b/src/types/hoja-de-ruta.ts
@@ -1,5 +1,6 @@
 import type { LogisticsHojaCategory } from "@/constants/logisticsHojaCategories";
 import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf/section-options";
+import type { ActiveDepartment } from "@/types/department";
 
 // Core interfaces - most comprehensive version first
 export interface WeatherData {
@@ -171,6 +172,11 @@ export interface ProgramRow {
   item: string;
   dept?: string;
   notes?: string;
+  id?: string;
+  // When true, assigned technicians (with push enabled) get a push reminder at `time`.
+  notify?: boolean;
+  // Scopes the push to technicians in these departments on this job; empty/undefined = everyone assigned.
+  departments?: ActiveDepartment[];
 }
 
 export interface ProgramDay {

--- a/supabase/functions/push/__tests__/programaFeedUtils.test.ts
+++ b/supabase/functions/push/__tests__/programaFeedUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  backfillMissingRowIds,
   buildProgramaDueEvents,
   buildProgramaMessage,
   buildProgramaPayload,
@@ -153,6 +154,86 @@ describe("programa feed recipient targeting", () => {
       "lx-tech",
       "sound-tech",
     ]);
+  });
+
+  it("normalizes department casing so it matches the lowercased values deriveAssignmentDepartments produces", () => {
+    const [event] = buildProgramaDueEvents(
+      job,
+      [
+        {
+          date: "2026-07-06",
+          rows: [{ id: "row-1", time: "18:00", item: "Lighting Focus", notify: true, departments: [" Lights " as never] }],
+        },
+      ],
+      new Date("2026-07-06T10:00:00.000Z"),
+    );
+
+    expect(event.departments).toEqual(["lights"]);
+
+    const assignments: ProgramaAssignment[] = [
+      { ...baseAssignment, technician_id: "lx-tech", lights_role: "LD" },
+    ];
+    expect(resolveProgramaRecipients(event, assignments).map((r) => r.technician_id)).toEqual(["lx-tech"]);
+  });
+
+  it("broadcasts instead of silently dropping recipients when every stored department value is unrecognized", () => {
+    const [event] = buildProgramaDueEvents(
+      job,
+      [
+        {
+          date: "2026-07-06",
+          rows: [{ id: "row-1", time: "18:00", item: "Legacy row", notify: true, departments: ["FOH/Security" as never] }],
+        },
+      ],
+      new Date("2026-07-06T10:00:00.000Z"),
+    );
+
+    expect(event.departments).toEqual([]);
+
+    const assignments: ProgramaAssignment[] = [
+      { ...baseAssignment, technician_id: "lx-tech", lights_role: "LD" },
+      { ...baseAssignment, technician_id: "sound-tech", sound_role: "FOH" },
+    ];
+    expect(resolveProgramaRecipients(event, assignments).map((r) => r.technician_id)).toEqual([
+      "lx-tech",
+      "sound-tech",
+    ]);
+  });
+});
+
+describe("programa feed legacy row id backfill", () => {
+  it("assigns ids only to rows that are missing one and flags the result as changed", () => {
+    const days: ProgramaProgramDay[] = [
+      {
+        date: "2026-07-06",
+        rows: [
+          { id: "row-1", time: "18:00", item: "Soundcheck" },
+          { time: "19:00", item: "Doors" },
+        ],
+      },
+    ];
+
+    const result = backfillMissingRowIds(days);
+
+    expect(result.changed).toBe(true);
+    expect(result.days[0].rows?.[0].id).toBe("row-1");
+    expect(result.days[0].rows?.[1].id).toEqual(expect.any(String));
+    expect(result.days[0].rows?.[1].id).not.toBe("");
+  });
+
+  it("reports unchanged when every row already has an id", () => {
+    const days: ProgramaProgramDay[] = [
+      { date: "2026-07-06", rows: [{ id: "row-1", time: "18:00", item: "Soundcheck" }] },
+    ];
+
+    const result = backfillMissingRowIds(days);
+    expect(result.changed).toBe(false);
+    expect(result.days).toEqual(days);
+  });
+
+  it("handles missing/non-array input without throwing", () => {
+    expect(backfillMissingRowIds(undefined)).toEqual({ days: [], changed: false });
+    expect(backfillMissingRowIds(null)).toEqual({ days: [], changed: false });
   });
 });
 

--- a/supabase/functions/push/__tests__/programaFeedUtils.test.ts
+++ b/supabase/functions/push/__tests__/programaFeedUtils.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProgramaDueEvents,
+  buildProgramaMessage,
+  buildProgramaPayload,
+  deriveAssignmentDepartments,
+  resolveProgramaRecipients,
+  type ProgramaAssignment,
+  type ProgramaJob,
+  type ProgramaProgramDay,
+} from "../programaFeedUtils.ts";
+
+// Times land at midday UTC (~14:00 Madrid summer time) so the Madrid-timezone
+// date-key conversion never crosses a day boundary in a way that would make the
+// fixture's implied [start, end] range ambiguous.
+const job: ProgramaJob = {
+  id: "job-1",
+  title: "Concierto Sala X",
+  start_time: "2026-07-05T10:00:00.000Z",
+  end_time: "2026-07-08T10:00:00.000Z",
+};
+
+describe("programa feed due-event generation", () => {
+  it("builds one event for a dated day row marked to notify", () => {
+    const days: ProgramaProgramDay[] = [
+      { date: "2026-07-06", rows: [{ id: "row-1", time: "18:00", item: "Soundcheck", notify: true }] },
+    ];
+
+    const events = buildProgramaDueEvents(job, days, new Date("2026-07-06T10:00:00.000Z"));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventKey: "programa:job-1:row-1:2026-07-06",
+      jobId: "job-1",
+      dateKey: "2026-07-06",
+      item: "Soundcheck",
+    });
+    expect(events[0].dueAt.toISOString()).toBe("2026-07-06T16:00:00.000Z");
+  });
+
+  it("ignores rows that are not marked to notify, lack an id, or have an invalid time", () => {
+    const days: ProgramaProgramDay[] = [
+      {
+        date: "2026-07-06",
+        rows: [
+          { id: "row-1", time: "18:00", item: "Lunch" }, // notify not set
+          { time: "18:00", item: "No id", notify: true },
+          { id: "row-2", time: "not-a-time", item: "Bad time", notify: true },
+        ],
+      },
+    ];
+
+    const events = buildProgramaDueEvents(job, days, new Date("2026-07-06T10:00:00.000Z"));
+    expect(events).toHaveLength(0);
+  });
+
+  it("recurs an undated row across every candidate date that falls within the job's run", () => {
+    const days: ProgramaProgramDay[] = [
+      { rows: [{ id: "row-1", time: "21:00", item: "Show Start", notify: true }] },
+    ];
+
+    // "now" sits in the middle of the job's run; candidate window is yesterday/today/tomorrow,
+    // all of which fall inside [2026-07-05, 2026-07-08].
+    const events = buildProgramaDueEvents(job, days, new Date("2026-07-06T12:00:00.000Z"));
+
+    expect(events.map((event) => event.dateKey).sort()).toEqual([
+      "2026-07-05",
+      "2026-07-06",
+      "2026-07-07",
+    ]);
+  });
+
+  it("does not generate an undated recurrence for a candidate date outside the job's run", () => {
+    const days: ProgramaProgramDay[] = [
+      { rows: [{ id: "row-1", time: "21:00", item: "Show Start", notify: true }] },
+    ];
+
+    // "now" is the last day of the run; tomorrow falls outside [2026-07-05, 2026-07-08].
+    const events = buildProgramaDueEvents(job, days, new Date("2026-07-08T12:00:00.000Z"));
+
+    expect(events.map((event) => event.dateKey).sort()).toEqual([
+      "2026-07-07",
+      "2026-07-08",
+    ]);
+  });
+});
+
+describe("programa feed recipient targeting", () => {
+  const baseAssignment: ProgramaAssignment = {
+    technician_id: "tech-1",
+    status: "confirmed",
+    sound_role: null,
+    lights_role: null,
+    video_role: null,
+    production_role: null,
+    department: null,
+    push_notifications_enabled: true,
+  };
+
+  it("derives department from whichever role column is active", () => {
+    expect(deriveAssignmentDepartments({ ...baseAssignment, sound_role: "FOH" })).toEqual(["sound"]);
+    expect(deriveAssignmentDepartments({ ...baseAssignment, lights_role: "none" })).toEqual([]);
+  });
+
+  it("falls back to the technician's profile department when no role column is set", () => {
+    expect(deriveAssignmentDepartments({ ...baseAssignment, department: "logistics" })).toEqual([
+      "logistics",
+    ]);
+  });
+
+  it("excludes assignments that are not confirmed or have push disabled", () => {
+    const [event] = buildProgramaDueEvents(
+      job,
+      [{ date: "2026-07-06", rows: [{ id: "row-1", time: "18:00", item: "Soundcheck", notify: true }] }],
+      new Date("2026-07-06T10:00:00.000Z"),
+    );
+
+    const assignments: ProgramaAssignment[] = [
+      { ...baseAssignment, technician_id: "confirmed-enabled", sound_role: "FOH" },
+      { ...baseAssignment, technician_id: "invited", status: "invited", sound_role: "FOH" },
+      { ...baseAssignment, technician_id: "push-off", push_notifications_enabled: false, sound_role: "FOH" },
+    ];
+
+    const recipients = resolveProgramaRecipients(event, assignments);
+    expect(recipients.map((recipient) => recipient.technician_id)).toEqual(["confirmed-enabled"]);
+  });
+
+  it("scopes recipients to the row's departments when set, and broadcasts when empty", () => {
+    const [event] = buildProgramaDueEvents(
+      job,
+      [
+        {
+          date: "2026-07-06",
+          rows: [{ id: "row-1", time: "18:00", item: "Lighting Focus", notify: true, departments: ["lights"] }],
+        },
+      ],
+      new Date("2026-07-06T10:00:00.000Z"),
+    );
+
+    const assignments: ProgramaAssignment[] = [
+      { ...baseAssignment, technician_id: "lx-tech", lights_role: "LD" },
+      { ...baseAssignment, technician_id: "sound-tech", sound_role: "FOH" },
+    ];
+
+    expect(resolveProgramaRecipients(event, assignments).map((r) => r.technician_id)).toEqual(["lx-tech"]);
+
+    const [undeptEvent] = buildProgramaDueEvents(
+      job,
+      [{ date: "2026-07-06", rows: [{ id: "row-2", time: "19:00", item: "Doors", notify: true }] }],
+      new Date("2026-07-06T10:00:00.000Z"),
+    );
+    expect(resolveProgramaRecipients(undeptEvent, assignments).map((r) => r.technician_id)).toEqual([
+      "lx-tech",
+      "sound-tech",
+    ]);
+  });
+});
+
+describe("programa feed message building", () => {
+  it("builds Spanish reminder copy including the job title, item, and time", () => {
+    const [event] = buildProgramaDueEvents(
+      job,
+      [{ date: "2026-07-06", rows: [{ id: "row-1", time: "18:00", item: "Soundcheck", notify: true, notes: "Traer in-ears" }] }],
+      new Date("2026-07-06T10:00:00.000Z"),
+    );
+
+    const message = buildProgramaMessage(job, event);
+    expect(message.title).toBe("Recordatorio de programa");
+    expect(message.body).toBe("Concierto Sala X: Soundcheck a las 18:00 — Traer in-ears");
+
+    const payload = buildProgramaPayload(job, event);
+    expect(payload.meta).toMatchObject({ eventKey: event.eventKey, jobId: "job-1", rowId: "row-1" });
+  });
+});

--- a/supabase/functions/push/config.ts
+++ b/supabase/functions/push/config.ts
@@ -92,6 +92,7 @@ export const EVENT_TYPES = {
   // Scheduled notifications
   DAILY_MORNING_SUMMARY: 'daily.morning.summary',
   FESTIVAL_FEED_TICK: 'festival.feed.tick',
+  PROGRAMA_FEED_TICK: 'programa.feed.tick',
 } as const;
 
 // Push notification configuration

--- a/supabase/functions/push/programaFeed.ts
+++ b/supabase/functions/push/programaFeed.ts
@@ -1,0 +1,272 @@
+import type { createClient } from "./deps.ts";
+import { EVENT_TYPES } from "./config.ts";
+import { jsonResponse } from "./http.ts";
+import { sendPayloadToUsers } from "./broadcast/delivery.ts";
+import type { PushPayload } from "./types.ts";
+import { addDaysToDateKey, formatDateKeyInTimeZone, isDueInWindow, zonedDateTimeToUtc } from "./festivalFeedUtils.ts";
+import {
+  buildProgramaDueEvents,
+  buildProgramaPayload,
+  PROGRAMA_FEED_TIMEZONE,
+  resolveProgramaRecipients,
+  type ProgramaAssignment,
+  type ProgramaFeedEvent,
+  type ProgramaJob,
+  type ProgramaProgramDay,
+} from "./programaFeedUtils.ts";
+
+type ProgramaFeedClient = ReturnType<typeof createClient>;
+
+type JobRow = {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+};
+
+type HojaDeRutaRow = {
+  job_id: string;
+  program_schedule_json: ProgramaProgramDay[] | null;
+};
+
+type JobAssignmentRow = {
+  job_id: string;
+  technician_id: string;
+  status: string | null;
+  sound_role: string | null;
+  lights_role: string | null;
+  video_role: string | null;
+  production_role: string | null;
+};
+
+type ProfileRow = {
+  id: string;
+  department: string | null;
+  push_notifications_enabled: boolean | null;
+};
+
+type PostgrestErrorLike = { code?: string; message?: string };
+
+const asErrorCode = (error: unknown): string | null => {
+  if (typeof error !== "object" || error === null) return null;
+  const candidate = error as PostgrestErrorLike;
+  return typeof candidate.code === "string" ? candidate.code : null;
+};
+
+// Only festival/dryhire jobs are excluded — every other job_type (single, tour,
+// tourdate, evento, ciclo, and any future addition) is eligible for programa push.
+const EXCLUDED_JOB_TYPES = ["festival", "dryhire"];
+
+const getWindowBounds = (now: Date) => {
+  const today = formatDateKeyInTimeZone(now, PROGRAMA_FEED_TIMEZONE);
+  const start = zonedDateTimeToUtc(addDaysToDateKey(today, -1), "00:00:00", PROGRAMA_FEED_TIMEZONE);
+  const end = zonedDateTimeToUtc(addDaysToDateKey(today, 1), "23:59:59", PROGRAMA_FEED_TIMEZONE);
+  return { start, end };
+};
+
+const loadEligibleJobsWithProgramas = async (
+  client: ProgramaFeedClient,
+  now: Date,
+): Promise<Array<{ job: ProgramaJob; days: ProgramaProgramDay[] }>> => {
+  const { start, end } = getWindowBounds(now);
+  if (!start || !end) return [];
+
+  const { data: jobs, error: jobsError } = await client
+    .from("jobs")
+    .select("id, title, start_time, end_time")
+    .not("job_type", "in", `(${EXCLUDED_JOB_TYPES.join(",")})`)
+    .lte("start_time", end.toISOString())
+    .gte("end_time", start.toISOString())
+    .returns<JobRow[]>();
+
+  if (jobsError) {
+    throw new Error(`Failed to load jobs for programa feed: ${jobsError.message}`);
+  }
+
+  const jobIds = (jobs ?? []).map((job) => job.id);
+  if (jobIds.length === 0) return [];
+
+  const { data: hojas, error: hojasError } = await client
+    .from("hoja_de_ruta")
+    .select("job_id, program_schedule_json")
+    .in("job_id", jobIds)
+    .not("program_schedule_json", "is", null)
+    .returns<HojaDeRutaRow[]>();
+
+  if (hojasError) {
+    throw new Error(`Failed to load hoja de ruta programas: ${hojasError.message}`);
+  }
+
+  const jobById = new Map((jobs ?? []).map((job) => [job.id, job]));
+
+  return (hojas ?? [])
+    .map((hoja) => {
+      const job = jobById.get(hoja.job_id);
+      if (!job || !Array.isArray(hoja.program_schedule_json)) return null;
+      return { job, days: hoja.program_schedule_json };
+    })
+    .filter((entry): entry is { job: ProgramaJob; days: ProgramaProgramDay[] } => entry !== null);
+};
+
+const loadAssignmentsByJob = async (
+  client: ProgramaFeedClient,
+  jobIds: string[],
+): Promise<Map<string, ProgramaAssignment[]>> => {
+  const assignmentsByJob = new Map<string, ProgramaAssignment[]>();
+  if (jobIds.length === 0) return assignmentsByJob;
+
+  const { data: assignments, error: assignmentsError } = await client
+    .from("job_assignments")
+    .select("job_id, technician_id, status, sound_role, lights_role, video_role, production_role")
+    .eq("status", "confirmed")
+    .in("job_id", jobIds)
+    .returns<JobAssignmentRow[]>();
+
+  if (assignmentsError) {
+    console.error("programa feed failed loading job assignments", assignmentsError);
+    return assignmentsByJob;
+  }
+
+  const technicianIds = Array.from(
+    new Set((assignments ?? []).map((row) => row.technician_id).filter(Boolean)),
+  );
+  if (technicianIds.length === 0) return assignmentsByJob;
+
+  const { data: profiles, error: profilesError } = await client
+    .from("profiles")
+    .select("id, department, push_notifications_enabled")
+    .in("id", technicianIds)
+    .eq("push_notifications_enabled", true)
+    .returns<ProfileRow[]>();
+
+  if (profilesError) {
+    console.error("programa feed failed loading profiles", profilesError);
+    return assignmentsByJob;
+  }
+
+  const profileById = new Map((profiles ?? []).map((profile) => [profile.id, profile]));
+
+  for (const row of assignments ?? []) {
+    const profile = profileById.get(row.technician_id);
+    if (!profile) continue; // push disabled or profile missing
+
+    const entry: ProgramaAssignment = {
+      technician_id: row.technician_id,
+      status: row.status,
+      sound_role: row.sound_role,
+      lights_role: row.lights_role,
+      video_role: row.video_role,
+      production_role: row.production_role,
+      department: profile.department,
+      push_notifications_enabled: profile.push_notifications_enabled,
+    };
+
+    const list = assignmentsByJob.get(row.job_id) ?? [];
+    list.push(entry);
+    assignmentsByJob.set(row.job_id, list);
+  }
+
+  return assignmentsByJob;
+};
+
+const insertDeliveryLog = async (
+  client: ProgramaFeedClient,
+  userId: string,
+  event: ProgramaFeedEvent,
+  payload: PushPayload,
+): Promise<"inserted" | "duplicate" | "failed"> => {
+  const { error } = await client
+    .from("programa_push_delivery_log")
+    .insert({
+      user_id: userId,
+      job_id: event.jobId,
+      event_key: event.eventKey,
+      event_kind: "programa_row",
+      due_at: event.dueAt.toISOString(),
+      payload: JSON.parse(JSON.stringify(payload)),
+    });
+
+  if (!error) return "inserted";
+  if (asErrorCode(error) === "23505") return "duplicate";
+
+  console.error("programa feed failed inserting delivery log", {
+    userId,
+    eventKey: event.eventKey,
+    error,
+  });
+  return "failed";
+};
+
+export async function handleProgramaFeedTick(
+  client: ProgramaFeedClient,
+  now = new Date(),
+) {
+  let entries: Array<{ job: ProgramaJob; days: ProgramaProgramDay[] }>;
+  try {
+    entries = await loadEligibleJobsWithProgramas(client, now);
+  } catch (loadError) {
+    console.error("programa feed failed loading jobs/programas", loadError);
+    return jsonResponse({ error: "Failed to load programa feed data" }, 500);
+  }
+
+  if (entries.length === 0) {
+    return jsonResponse({ status: "skipped", reason: "No eligible jobs with programa data" });
+  }
+
+  const jobById = new Map(entries.map((entry) => [entry.job.id, entry.job]));
+
+  const dueEvents = entries
+    .flatMap((entry) => buildProgramaDueEvents(entry.job, entry.days, now))
+    .filter((event) => isDueInWindow(event.dueAt, now))
+    .sort((left, right) => left.dueAt.getTime() - right.dueAt.getTime());
+
+  if (dueEvents.length === 0) {
+    return jsonResponse({ status: "skipped", reason: "No due programa events" });
+  }
+
+  const dueJobIds = Array.from(new Set(dueEvents.map((event) => event.jobId)));
+  const assignmentsByJob = await loadAssignmentsByJob(client, dueJobIds);
+
+  let attemptedUsers = 0;
+  let duplicateUsers = 0;
+  let deliveredCount = 0;
+  let failedLogInserts = 0;
+
+  for (const event of dueEvents) {
+    const job = jobById.get(event.jobId);
+    if (!job) continue;
+
+    const assignments = assignmentsByJob.get(event.jobId) ?? [];
+    const recipients = resolveProgramaRecipients(event, assignments);
+    if (recipients.length === 0) continue;
+
+    const payload = buildProgramaPayload(job, event);
+
+    for (const recipient of recipients) {
+      const logStatus = await insertDeliveryLog(client, recipient.technician_id, event, payload);
+
+      if (logStatus === "duplicate") {
+        duplicateUsers++;
+        continue;
+      }
+      if (logStatus === "failed") {
+        failedLogInserts++;
+        continue;
+      }
+
+      attemptedUsers++;
+      const results = await sendPayloadToUsers(client, [recipient.technician_id], payload);
+      deliveredCount += results.filter((result) => result.ok).length;
+    }
+  }
+
+  return jsonResponse({
+    status: "sent",
+    type: EVENT_TYPES.PROGRAMA_FEED_TICK,
+    dueEvents: dueEvents.length,
+    attemptedUsers,
+    duplicateUsers,
+    failedLogInserts,
+    deliveredCount,
+  });
+}

--- a/supabase/functions/push/programaFeed.ts
+++ b/supabase/functions/push/programaFeed.ts
@@ -5,6 +5,7 @@ import { sendPayloadToUsers } from "./broadcast/delivery.ts";
 import type { PushPayload } from "./types.ts";
 import { addDaysToDateKey, formatDateKeyInTimeZone, isDueInWindow, zonedDateTimeToUtc } from "./festivalFeedUtils.ts";
 import {
+  backfillMissingRowIds,
   buildProgramaDueEvents,
   buildProgramaPayload,
   PROGRAMA_FEED_TIMEZONE,
@@ -99,13 +100,34 @@ const loadEligibleJobsWithProgramas = async (
 
   const jobById = new Map((jobs ?? []).map((job) => [job.id, job]));
 
-  return (hojas ?? [])
-    .map((hoja) => {
-      const job = jobById.get(hoja.job_id);
-      if (!job || !Array.isArray(hoja.program_schedule_json)) return null;
-      return { job, days: hoja.program_schedule_json };
-    })
-    .filter((entry): entry is { job: ProgramaJob; days: ProgramaProgramDay[] } => entry !== null);
+  const entries: Array<{ job: ProgramaJob; days: ProgramaProgramDay[] }> = [];
+
+  for (const hoja of hojas ?? []) {
+    const job = jobById.get(hoja.job_id);
+    if (!job || !Array.isArray(hoja.program_schedule_json)) continue;
+
+    // Rows saved before `notify`/`id` existed only pick up an id once the frontend
+    // re-saves the whole hoja de ruta. Backfill and persist it here so `notify: true`
+    // rows are never silently skipped by buildProgramaDueEvents' `row.id` check.
+    const { days, changed } = backfillMissingRowIds(hoja.program_schedule_json);
+    if (changed) {
+      const { error: updateError } = await client
+        .from("hoja_de_ruta")
+        .update({ program_schedule_json: days })
+        .eq("job_id", hoja.job_id);
+
+      if (updateError) {
+        console.error("programa feed failed persisting backfilled row ids", {
+          jobId: hoja.job_id,
+          error: updateError,
+        });
+      }
+    }
+
+    entries.push({ job, days });
+  }
+
+  return entries;
 };
 
 const loadAssignmentsByJob = async (
@@ -197,6 +219,27 @@ const insertDeliveryLog = async (
   return "failed";
 };
 
+// The delivery log row doubles as a dedupe claim (so two ticks that both see the
+// same due event don't double-send) and a delivery record. If the send ends up
+// delivering to zero devices, release the claim so a later tick — still inside
+// the ~70s due window — can retry instead of the reminder being silently and
+// permanently dropped on a transient failure.
+const releaseDeliveryLogClaim = async (
+  client: ProgramaFeedClient,
+  userId: string,
+  eventKey: string,
+): Promise<void> => {
+  const { error } = await client
+    .from("programa_push_delivery_log")
+    .delete()
+    .eq("user_id", userId)
+    .eq("event_key", eventKey);
+
+  if (error) {
+    console.error("programa feed failed releasing delivery log claim", { userId, eventKey, error });
+  }
+};
+
 export async function handleProgramaFeedTick(
   client: ProgramaFeedClient,
   now = new Date(),
@@ -242,22 +285,29 @@ export async function handleProgramaFeedTick(
 
     const payload = buildProgramaPayload(job, event);
 
-    for (const recipient of recipients) {
+    // Each recipient's claim/send/release is independent (distinct user_id +
+    // event_key), so dispatching the event's recipients concurrently is safe.
+    await Promise.all(recipients.map(async (recipient) => {
       const logStatus = await insertDeliveryLog(client, recipient.technician_id, event, payload);
 
       if (logStatus === "duplicate") {
         duplicateUsers++;
-        continue;
+        return;
       }
       if (logStatus === "failed") {
         failedLogInserts++;
-        continue;
+        return;
       }
 
       attemptedUsers++;
       const results = await sendPayloadToUsers(client, [recipient.technician_id], payload);
-      deliveredCount += results.filter((result) => result.ok).length;
-    }
+      const delivered = results.filter((result) => result.ok).length;
+      deliveredCount += delivered;
+
+      if (delivered === 0) {
+        await releaseDeliveryLogClaim(client, recipient.technician_id, event.eventKey);
+      }
+    }));
   }
 
   return jsonResponse({

--- a/supabase/functions/push/programaFeedUtils.ts
+++ b/supabase/functions/push/programaFeedUtils.ts
@@ -92,6 +92,28 @@ export const deriveAssignmentDepartments = (assignment: ProgramaAssignment): str
   return Array.from(departments);
 };
 
+// Legacy rows (saved before `notify`/`id` existed) only get an `id` once the
+// frontend re-saves the whole hoja de ruta. Rather than depend on that, the
+// edge function backfills+persists ids itself the first time it sees a gap —
+// see handleProgramaFeedTick's write-back after loading each job's programa.
+export const backfillMissingRowIds = (
+  days: ProgramaProgramDay[] | null | undefined,
+): { days: ProgramaProgramDay[]; changed: boolean } => {
+  if (!Array.isArray(days)) return { days: days ?? [], changed: false };
+
+  let changed = false;
+  const backfilled = days.map((day) => ({
+    ...day,
+    rows: (day.rows ?? []).map((row) => {
+      if (row.id) return row;
+      changed = true;
+      return { ...row, id: crypto.randomUUID() };
+    }),
+  }));
+
+  return { days: backfilled, changed };
+};
+
 const TIME_PATTERN = /^\d{2}:\d{2}(:\d{2})?$/;
 
 // Builds due-events for rows marked `notify: true`. Rows tied to a specific day
@@ -133,7 +155,13 @@ export const buildProgramaDueEvents = (
           notes: row.notes ?? null,
           time: row.time,
           departments: Array.isArray(row.departments)
-            ? row.departments.filter((d): d is string => typeof d === "string")
+            ? Array.from(
+              new Set(
+                row.departments
+                  .map((d) => normalizeDepartment(d))
+                  .filter((d): d is string => d !== null),
+              ),
+            )
             : [],
         });
       }

--- a/supabase/functions/push/programaFeedUtils.ts
+++ b/supabase/functions/push/programaFeedUtils.ts
@@ -1,0 +1,190 @@
+import type { PushPayload } from "./types.ts";
+import {
+  addDaysToDateKey,
+  FESTIVAL_FEED_TIMEZONE,
+  formatDateKeyInTimeZone,
+  zonedDateTimeToUtc,
+} from "./festivalFeedUtils.ts";
+
+export const PROGRAMA_FEED_EVENT_TYPE = "programa.feed.tick";
+export const PROGRAMA_FEED_TIMEZONE = FESTIVAL_FEED_TIMEZONE;
+
+export type ProgramaProgramRow = {
+  id?: string | null;
+  time?: string | null;
+  item?: string | null;
+  notes?: string | null;
+  notify?: boolean | null;
+  departments?: string[] | null;
+};
+
+export type ProgramaProgramDay = {
+  date?: string | null;
+  rows?: ProgramaProgramRow[] | null;
+};
+
+export type ProgramaJob = {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+};
+
+export type ProgramaAssignment = {
+  technician_id: string;
+  status: string | null;
+  sound_role: string | null;
+  lights_role: string | null;
+  video_role: string | null;
+  production_role: string | null;
+  department: string | null;
+  push_notifications_enabled: boolean | null;
+};
+
+export type ProgramaFeedEvent = {
+  eventKey: string;
+  jobId: string;
+  dueAt: Date;
+  dateKey: string;
+  rowId: string;
+  item: string;
+  notes: string | null;
+  time: string;
+  departments: string[];
+};
+
+const KNOWN_DEPARTMENTS = new Set([
+  "sound",
+  "lights",
+  "video",
+  "production",
+  "logistics",
+  "administrative",
+]);
+
+const normalizeDepartment = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return KNOWN_DEPARTMENTS.has(normalized) ? normalized : null;
+};
+
+const hasActiveRole = (value: unknown): boolean => {
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 && normalized !== "none";
+};
+
+// Mirrors src/utils/assignmentNotificationDepartments.ts — duplicated rather than shared
+// because edge functions (Deno) can't import from src/ (frontend, Vite/Node-oriented).
+export const deriveAssignmentDepartments = (assignment: ProgramaAssignment): string[] => {
+  const departments = new Set<string>();
+
+  if (hasActiveRole(assignment.sound_role)) departments.add("sound");
+  if (hasActiveRole(assignment.lights_role)) departments.add("lights");
+  if (hasActiveRole(assignment.video_role)) departments.add("video");
+  if (hasActiveRole(assignment.production_role)) departments.add("production");
+
+  if (departments.size === 0) {
+    const fallback = normalizeDepartment(assignment.department);
+    if (fallback) departments.add(fallback);
+  }
+
+  return Array.from(departments);
+};
+
+const TIME_PATTERN = /^\d{2}:\d{2}(:\d{2})?$/;
+
+// Builds due-events for rows marked `notify: true`. Rows tied to a specific day
+// (`day.date` set) only ever fire on that date; undated rows (common on multi-day
+// jobs where staff didn't bother filling in per-day dates) recur on every candidate
+// date within the job's own run, bounded to the same 3-day window the feed polls
+// (yesterday/today/tomorrow) so a single tick never has to enumerate an entire tour.
+export const buildProgramaDueEvents = (
+  job: ProgramaJob,
+  days: ProgramaProgramDay[] | null | undefined,
+  now: Date,
+): ProgramaFeedEvent[] => {
+  const events: ProgramaFeedEvent[] = [];
+  const today = formatDateKeyInTimeZone(now, PROGRAMA_FEED_TIMEZONE);
+  const candidateDates = [addDaysToDateKey(today, -1), today, addDaysToDateKey(today, 1)];
+
+  const jobStartDate = formatDateKeyInTimeZone(new Date(job.start_time), PROGRAMA_FEED_TIMEZONE);
+  const jobEndDate = formatDateKeyInTimeZone(new Date(job.end_time), PROGRAMA_FEED_TIMEZONE);
+
+  for (const day of days ?? []) {
+    for (const row of day.rows ?? []) {
+      if (!row.notify || !row.id || !row.time || !TIME_PATTERN.test(row.time)) continue;
+
+      const datesToCheck = day.date
+        ? [day.date]
+        : candidateDates.filter((dateKey) => dateKey >= jobStartDate && dateKey <= jobEndDate);
+
+      for (const dateKey of datesToCheck) {
+        const dueAt = zonedDateTimeToUtc(dateKey, row.time, PROGRAMA_FEED_TIMEZONE);
+        if (!dueAt) continue;
+
+        events.push({
+          eventKey: `programa:${job.id}:${row.id}:${dateKey}`,
+          jobId: job.id,
+          dueAt,
+          dateKey,
+          rowId: row.id,
+          item: row.item || "",
+          notes: row.notes ?? null,
+          time: row.time,
+          departments: Array.isArray(row.departments)
+            ? row.departments.filter((d): d is string => typeof d === "string")
+            : [],
+        });
+      }
+    }
+  }
+
+  return events;
+};
+
+export const resolveProgramaRecipients = (
+  event: ProgramaFeedEvent,
+  assignments: ProgramaAssignment[],
+): ProgramaAssignment[] => {
+  const eligible = assignments.filter(
+    (assignment) => assignment.status === "confirmed" && assignment.push_notifications_enabled === true,
+  );
+
+  if (event.departments.length === 0) return eligible;
+
+  const wanted = new Set(event.departments);
+  return eligible.filter((assignment) =>
+    deriveAssignmentDepartments(assignment).some((department) => wanted.has(department))
+  );
+};
+
+export const buildProgramaMessage = (
+  job: ProgramaJob,
+  event: ProgramaFeedEvent,
+): { title: string; body: string } => {
+  const timeLabel = event.time.slice(0, 5);
+  const body = event.notes
+    ? `${job.title}: ${event.item} a las ${timeLabel} — ${event.notes}`
+    : `${job.title}: ${event.item} a las ${timeLabel}`;
+
+  return { title: "Recordatorio de programa", body };
+};
+
+export const buildProgramaPayload = (job: ProgramaJob, event: ProgramaFeedEvent): PushPayload => {
+  const message = buildProgramaMessage(job, event);
+
+  return {
+    title: message.title,
+    body: message.body,
+    type: PROGRAMA_FEED_EVENT_TYPE,
+    meta: {
+      eventKey: event.eventKey,
+      jobId: job.id,
+      rowId: event.rowId,
+      time: event.time,
+      date: event.dateKey,
+      departments: event.departments,
+    },
+  };
+};

--- a/supabase/functions/push/scheduled.ts
+++ b/supabase/functions/push/scheduled.ts
@@ -4,6 +4,7 @@ import { jsonResponse } from "./http.ts";
 import { sendNativePushNotification } from "./apns.ts";
 import { sendPushNotification } from "./webpush.ts";
 import { handleFestivalFeedTick } from "./festivalFeed.ts";
+import { handleProgramaFeedTick } from "./programaFeed.ts";
 import type {
   CheckScheduledBody,
   NativePushTokenRow,
@@ -590,6 +591,10 @@ export async function handleCheckScheduled(
 
   if (type === EVENT_TYPES.FESTIVAL_FEED_TICK) {
     return handleFestivalFeedTick(client);
+  }
+
+  if (type === EVENT_TYPES.PROGRAMA_FEED_TICK) {
+    return handleProgramaFeedTick(client);
   }
 
   // Check if it's time to send

--- a/supabase/migrations/20260706120000_add_programa_push_feed.sql
+++ b/supabase/migrations/20260706120000_add_programa_push_feed.sql
@@ -1,0 +1,72 @@
+-- Programa push feed delivery dedupe.
+-- Unlike the festival push feed, this has no separate opt-in subscription table:
+-- recipients are gated by an existing confirmed job_assignments row plus the
+-- existing profiles.push_notifications_enabled toggle. Per-row participation is
+-- controlled entirely in the hoja_de_ruta.program_schedule_json payload itself
+-- (ProgramRow.notify / ProgramRow.departments), read by the edge function.
+
+CREATE TABLE IF NOT EXISTS public.programa_push_delivery_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  job_id uuid NOT NULL REFERENCES public.jobs(id) ON DELETE CASCADE,
+  event_key text NOT NULL,
+  event_kind text NOT NULL DEFAULT 'programa_row',
+  due_at timestamptz NOT NULL,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  sent_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT programa_push_delivery_log_user_event_key UNIQUE (user_id, event_key)
+);
+
+COMMENT ON TABLE public.programa_push_delivery_log IS
+  'Service-role dedupe log for the scheduled hoja de ruta programa push feed (non-festival, non-dryhire jobs).';
+
+CREATE INDEX IF NOT EXISTS idx_programa_push_delivery_log_job_due
+  ON public.programa_push_delivery_log (job_id, due_at);
+
+CREATE INDEX IF NOT EXISTS idx_programa_push_delivery_log_event_kind
+  ON public.programa_push_delivery_log (event_kind);
+
+CREATE INDEX IF NOT EXISTS idx_programa_push_delivery_log_sent_at
+  ON public.programa_push_delivery_log (sent_at);
+
+ALTER TABLE public.programa_push_delivery_log ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.programa_push_delivery_log FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.programa_push_delivery_log TO service_role;
+
+DO $cron$
+BEGIN
+  IF to_regnamespace('cron') IS NULL THEN
+    RAISE WARNING 'cron schema not available; programa push feed cron was not scheduled';
+    RETURN;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM cron.job
+    WHERE jobname = 'programa-push-feed-tick'
+  ) THEN
+    PERFORM cron.unschedule('programa-push-feed-tick');
+  END IF;
+
+  PERFORM cron.schedule(
+    'programa-push-feed-tick',
+    '* * * * *',
+    $$SELECT public.invoke_scheduled_push_notification('programa.feed.tick')$$
+  );
+
+  IF EXISTS (
+    SELECT 1
+    FROM cron.job
+    WHERE jobname = 'programa-push-delivery-log-cleanup'
+  ) THEN
+    PERFORM cron.unschedule('programa-push-delivery-log-cleanup');
+  END IF;
+
+  PERFORM cron.schedule(
+    'programa-push-delivery-log-cleanup',
+    '23 4 * * *',
+    $$DELETE FROM public.programa_push_delivery_log WHERE sent_at < now() - interval '14 days'$$
+  );
+END $cron$;


### PR DESCRIPTION
Extends the existing festival push feed pattern to hoja de ruta programa
schedules: staff can mark individual programa rows to notify, scoped to
one or more departments, and confirmed job assignees with push enabled
get a Spanish-language reminder at the scheduled time. Applies to every
job type except festival and dryhire. No new opt-in subscription table —
gating relies on job_assignments.status = 'confirmed' and the existing
profiles.push_notifications_enabled toggle.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WdmRVGFdCFNeHJ7RV9m5u8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-row reminder options in the schedule builder, including notification toggle and department targeting.
  * Improved “Hoja de Ruta” experience with an embedded mode, mobile actions menu, section dropdown navigation, quick navigation sidebar (desktop), and a fixed mobile save bar.
* **Bug Fixes**
  * Schedule copies/duplicates now create truly independent rows (new unique identifiers).
  * Older saved schedules are upgraded automatically to restore missing row IDs, improving reminder behavior and sync.
  * Notifications are now deduplicated and more reliably delivered within the scheduled window.
* **UI Improvements**
  * Updated responsive layouts across Hoja de Ruta sections and adjusted interval label/preset text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->