### PR TITLE
Add rider library import workflow

### DIFF
--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -141,15 +141,18 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
 
       if (artistUpdateError) {
         console.error("Artist rider state update error:", artistUpdateError);
-        throw artistUpdateError;
       }
 
+      const uploadSuccessDescription =
+        selectedFiles.length === 1
+          ? "Archivo cargado correctamente"
+          : `${selectedFiles.length} archivos cargados correctamente`;
+
       toast({
-        title: "Éxito",
-        description:
-          selectedFiles.length === 1
-            ? "Archivo cargado correctamente"
-            : `${selectedFiles.length} archivos cargados correctamente`,
+        title: artistUpdateError ? "Carga completada con aviso" : "Éxito",
+        description: artistUpdateError
+          ? `${uploadSuccessDescription}, pero no se pudo actualizar el estado del rider.`
+          : uploadSuccessDescription,
       });
 
       fetchFiles();
@@ -180,29 +183,25 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
     if (!selectedFile) return;
 
     try {
-      const { count: referenceCount, error: countError } = await dataLayerClient
-        .from('festival_artist_files')
-        .select('id', { count: 'exact', head: true })
-        .eq('file_path', selectedFile.file_path);
-
-      if (countError) {
-        console.error("File reference count error:", countError);
-        throw countError;
-      }
-
-      const { error: dbError } = await dataLayerClient.from('festival_artist_files')
-        .delete()
-        .eq('id', selectedFile.id);
+      const { data: deleteRows, error: dbError } = await dataLayerClient
+        .rpc("delete_festival_artist_file_reference", {
+          p_file_id: selectedFile.id,
+        });
 
       if (dbError) {
         console.error("Database delete error:", dbError);
         throw dbError;
       }
 
-      if ((referenceCount ?? 0) <= 1) {
+      const deleteResult = deleteRows?.[0];
+      if (!deleteResult) {
+        throw new Error("No se recibió confirmación de eliminación.");
+      }
+
+      if (deleteResult.should_delete_storage && deleteResult.file_path) {
         const { error: storageError } = await dataLayerClient.storage
           .from('festival_artist_files')
-          .remove([selectedFile.file_path]);
+          .remove([deleteResult.file_path]);
 
         if (storageError) {
           console.error("Storage delete error:", storageError);

--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -129,6 +129,21 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
         }
       }
 
+      const { error: artistUpdateError } = await dataLayerClient
+        .from("festival_artists")
+        .update({
+          rider_missing: false,
+          rider_outdated: false,
+          rider_copied_from_date: null,
+          rider_outdated_dismissed: false,
+        })
+        .eq("id", artistId);
+
+      if (artistUpdateError) {
+        console.error("Artist rider state update error:", artistUpdateError);
+        throw artistUpdateError;
+      }
+
       toast({
         title: "Éxito",
         description:
@@ -165,17 +180,16 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
     if (!selectedFile) return;
 
     try {
-      // First delete from storage
-      const { error: storageError } = await dataLayerClient.storage
+      const { count: referenceCount, error: countError } = await dataLayerClient
         .from('festival_artist_files')
-        .remove([selectedFile.file_path]);
+        .select('id', { count: 'exact', head: true })
+        .eq('file_path', selectedFile.file_path);
 
-      if (storageError) {
-        console.error("Storage delete error:", storageError);
-        throw storageError;
+      if (countError) {
+        console.error("File reference count error:", countError);
+        throw countError;
       }
 
-      // Then delete the database record
       const { error: dbError } = await dataLayerClient.from('festival_artist_files')
         .delete()
         .eq('id', selectedFile.id);
@@ -183,6 +197,16 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
       if (dbError) {
         console.error("Database delete error:", dbError);
         throw dbError;
+      }
+
+      if ((referenceCount ?? 0) <= 1) {
+        const { error: storageError } = await dataLayerClient.storage
+          .from('festival_artist_files')
+          .remove([selectedFile.file_path]);
+
+        if (storageError) {
+          console.error("Storage delete error:", storageError);
+        }
       }
 
       toast({

--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -38,6 +38,7 @@ import { MobileArtistList } from "./mobile/MobileArtistList";
 import { useCreateExtrasPresupuesto } from "@/hooks/festival/useCreateExtrasPresupuesto";
 import { ArtistActionButtons } from "./ArtistActionButtons";
 import { buildArtistPdfData } from "@/utils/artistPdfDataMapper";
+import { getArtistRiderStatus } from "@/features/festival-management/selectors";
 
 interface Artist {
   id: string;
@@ -79,6 +80,7 @@ interface Artist {
   notes?: string;
   rider_missing?: boolean;
   rider_copied_from_date?: string | null;
+  rider_outdated?: boolean;
   rider_outdated_dismissed?: boolean;
   foh_tech?: boolean;
   mon_tech?: boolean;
@@ -578,7 +580,8 @@ export const ArtistTable = ({
   const filteredArtists = artists.filter(artist => {
     const matchesSearch = artist.name.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesStage = stageFilter === "all" || artist.stage?.toString() === stageFilter;
-    const matchesRider = riderFilter === "all" || riderFilter === "missing" && artist.rider_missing || riderFilter === "complete" && !artist.rider_missing;
+    const riderStatus = getArtistRiderStatus(artist);
+    const matchesRider = riderFilter === "all" || riderStatus === riderFilter;
     return matchesSearch && matchesStage && matchesRider;
   });
 
@@ -1023,7 +1026,7 @@ export const ArtistTable = ({
                       {/* Estado: rider + material */}
                       <TableCell className="px-2 py-2 align-top">
                         <div className="flex flex-col items-start gap-1">
-                          {artist.rider_copied_from_date && !artist.rider_outdated_dismissed ? (
+                          {getArtistRiderStatus(artist) === "outdated" ? (
                             <OutdatedRiderBadge
                               artistId={artist.id}
                               copiedFromDate={artist.rider_copied_from_date}

--- a/src/components/festival/ArtistTableFilters.tsx
+++ b/src/components/festival/ArtistTableFilters.tsx
@@ -64,6 +64,7 @@ export const ArtistTableFilters = ({
             <SelectContent>
               <SelectItem value="all">Todos los riders</SelectItem>
               <SelectItem value="complete">Rider completo</SelectItem>
+              <SelectItem value="outdated">Rider desactualizado</SelectItem>
               <SelectItem value="missing">Rider faltante</SelectItem>
             </SelectContent>
           </Select>

--- a/src/components/festival/CopyArtistsDialog.tsx
+++ b/src/components/festival/CopyArtistsDialog.tsx
@@ -273,6 +273,7 @@ export const CopyArtistsDialog = ({
           // can flag it as "outdated" (vs missing) and prompt for a fresher
           // rider. artistData.date still holds the source date here.
           rider_copied_from_date: artistData.date || null,
+          rider_outdated: true,
           rider_outdated_dismissed: false,
           // Reset times if option is selected
           show_start: copyOptions.resetTimes ? null : artistData.show_start,

--- a/src/components/festival/OutdatedRiderBadge.tsx
+++ b/src/components/festival/OutdatedRiderBadge.tsx
@@ -25,10 +25,10 @@ const formatSourceDate = (date: string | null | undefined): string => {
   return Number.isNaN(parsed.getTime()) ? date : format(parsed, "d 'de' MMMM 'de' yyyy", { locale: es });
 };
 
-// Warns that an artist's rider/specs were copied from a previous show date and
-// may be stale. Details surface on hover (desktop) or tap (mobile); the warning
-// is dismissible per artist ("defeatable"), after which the row falls back to
-// the normal rider status badge.
+// Warns that an artist's rider/specs were imported or copied and may be stale.
+// Details surface on hover (desktop) or tap (mobile); the warning is
+// dismissible per artist, after which the row falls back to the normal rider
+// status badge.
 export const OutdatedRiderBadge = ({ artistId, copiedFromDate, onDismissed, compact = false }: OutdatedRiderBadgeProps) => {
   const isMobile = useIsMobile();
   const [isDismissing, setIsDismissing] = useState(false);
@@ -57,7 +57,7 @@ export const OutdatedRiderBadge = ({ artistId, copiedFromDate, onDismissed, comp
       className={`bg-amber-100 text-amber-900 border-amber-300 ${compact ? "text-[10px] px-1 py-0" : "text-xs"}`}
     >
       <History className={`${compact ? "h-3 w-3" : "h-3.5 w-3.5"} mr-1`} />
-      Rider antiguo
+      Desactualizado
     </Badge>
   );
 
@@ -65,7 +65,9 @@ export const OutdatedRiderBadge = ({ artistId, copiedFromDate, onDismissed, comp
     <div className="max-w-xs space-y-1.5">
       <p className="font-medium text-amber-900">Rider posiblemente desactualizado</p>
       <p className="text-xs text-muted-foreground">
-        Copiado de la fecha {formatSourceDate(copiedFromDate)}.
+        {copiedFromDate
+          ? `Copiado de la fecha ${formatSourceDate(copiedFromDate)}.`
+          : "Importado desde la biblioteca de riders."}
       </p>
       <p className="text-xs text-muted-foreground">
         Solicita un rider más reciente si es posible antes de la producción.

--- a/src/components/festival/RiderLibraryDialog.tsx
+++ b/src/components/festival/RiderLibraryDialog.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { importArtistRiderToJob, getRiderImportErrorMessage } from "@/features/festival-management/commands";
 import { fetchRiderLibrary } from "@/features/festival-management/queries";
 import type { FestivalStageOption, RiderLibraryEntry } from "@/features/festival-management/types";
@@ -33,6 +34,8 @@ type ImportMutationInput = {
   targetDate: string;
   targetStage: number;
 };
+
+const ALL_SOURCE_JOBS_VALUE = "all";
 
 const formatDateValue = (date: Date) => format(date, "yyyy-MM-dd");
 
@@ -69,6 +72,8 @@ const normalizeJobType = (value?: string | null) => {
   return value.replace(/_/g, " ");
 };
 
+const getSourceJobKey = (entry: RiderLibraryEntry) => entry.sourceJobId || `unlinked:${entry.sourceJobTitle}`;
+
 export const RiderLibraryDialog = ({
   canImport,
   initialDate,
@@ -82,6 +87,8 @@ export const RiderLibraryDialog = ({
   const { toast } = useToast();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [libraryMode, setLibraryMode] = useState<"browse" | "search">("browse");
+  const [sourceJobFilter, setSourceJobFilter] = useState(ALL_SOURCE_JOBS_VALUE);
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedDate, setSelectedDate] = useState("");
   const [stageByArtist, setStageByArtist] = useState<Record<string, string>>({});
@@ -102,6 +109,8 @@ export const RiderLibraryDialog = ({
     if (!open) return;
 
     setSearchTerm("");
+    setSourceJobFilter(ALL_SOURCE_JOBS_VALUE);
+    setLibraryMode("browse");
     setStageByArtist({});
 
     if (dateOptions.length === 1) {
@@ -154,10 +163,58 @@ export const RiderLibraryDialog = ({
     },
   });
 
-  const entries = riderLibraryQuery.data ?? [];
+  const entries = useMemo(() => riderLibraryQuery.data ?? [], [riderLibraryQuery.data]);
+  const sourceJobOptions = useMemo(() => {
+    const options = new Map<
+      string,
+      {
+        count: number;
+        files: number;
+        latestUploadedAt: string | null;
+        sourceJobTitle: string;
+        sourceJobType: string;
+      }
+    >();
+
+    entries.forEach((entry) => {
+      const key = getSourceJobKey(entry);
+      const existing = options.get(key);
+      const latestCandidate = entry.latestUploadedAt ? new Date(entry.latestUploadedAt).getTime() : 0;
+      const latestExisting = existing?.latestUploadedAt ? new Date(existing.latestUploadedAt).getTime() : 0;
+
+      if (!existing) {
+        options.set(key, {
+          count: 1,
+          files: entry.files.length,
+          latestUploadedAt: entry.latestUploadedAt,
+          sourceJobTitle: entry.sourceJobTitle,
+          sourceJobType: normalizeJobType(entry.sourceJobType),
+        });
+        return;
+      }
+
+      existing.count += 1;
+      existing.files += entry.files.length;
+      if (latestCandidate > latestExisting) {
+        existing.latestUploadedAt = entry.latestUploadedAt;
+      }
+    });
+
+    return Array.from(options.entries())
+      .map(([value, option]) => ({ value, ...option }))
+      .sort((a, b) => {
+        const latestA = a.latestUploadedAt ? new Date(a.latestUploadedAt).getTime() : 0;
+        const latestB = b.latestUploadedAt ? new Date(b.latestUploadedAt).getTime() : 0;
+        return latestB - latestA || a.sourceJobTitle.localeCompare(b.sourceJobTitle);
+      });
+  }, [entries]);
+  const totalFileCount = entries.reduce((total, entry) => total + entry.files.length, 0);
   const normalizedSearch = searchTerm.trim().toLowerCase();
-  const filteredEntries = normalizedSearch
-    ? entries.filter((entry) => {
+  const filteredEntries =
+    libraryMode === "browse"
+      ? entries.filter((entry) => sourceJobFilter === ALL_SOURCE_JOBS_VALUE || getSourceJobKey(entry) === sourceJobFilter)
+      : normalizedSearch
+        ? entries.filter((entry) => {
         const haystack = [
           entry.artistName,
           entry.sourceJobTitle,
@@ -168,8 +225,8 @@ export const RiderLibraryDialog = ({
           .join(" ")
           .toLowerCase();
         return haystack.includes(normalizedSearch);
-      })
-    : entries;
+        })
+        : entries;
 
   const defaultStageValueFor = (entry: RiderLibraryEntry) => {
     const sourceStage = entry.sourceStage ? String(entry.sourceStage) : "";
@@ -206,19 +263,59 @@ export const RiderLibraryDialog = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-3 border-b px-5 py-4 md:grid-cols-[1fr_220px]">
-          <div className="space-y-2">
-            <Label htmlFor="rider-library-search">Buscar</Label>
-            <div className="relative">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                id="rider-library-search"
-                value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="Artista, trabajo o archivo"
-                className="pl-9"
-              />
-            </div>
+        <div className="grid gap-4 border-b px-5 py-4 md:grid-cols-[1fr_220px]">
+          <div className="min-w-0">
+            <Tabs value={libraryMode} onValueChange={(value) => setLibraryMode(value as "browse" | "search")}>
+              <TabsList className="grid w-full grid-cols-2 sm:w-[260px]">
+                <TabsTrigger value="browse" className="gap-2">
+                  <Library className="h-4 w-4" />
+                  Explorar
+                </TabsTrigger>
+                <TabsTrigger value="search" className="gap-2">
+                  <Search className="h-4 w-4" />
+                  Buscar
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="browse" className="mt-3 space-y-3">
+                <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+                  <div className="space-y-2">
+                    <Label htmlFor="rider-library-source-job">Trabajo origen</Label>
+                    <Select value={sourceJobFilter} onValueChange={setSourceJobFilter}>
+                      <SelectTrigger id="rider-library-source-job">
+                        <SelectValue placeholder="Seleccionar trabajo" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={ALL_SOURCE_JOBS_VALUE}>Todos los trabajos ({entries.length})</SelectItem>
+                        {sourceJobOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.sourceJobTitle} ({option.count})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="secondary">{entries.length} artistas</Badge>
+                    <Badge variant="outline">{totalFileCount} archivos</Badge>
+                  </div>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="search" className="mt-3 space-y-2">
+                <Label htmlFor="rider-library-search">Buscar</Label>
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    id="rider-library-search"
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    placeholder="Artista, trabajo o archivo"
+                    className="pl-9"
+                  />
+                </div>
+              </TabsContent>
+            </Tabs>
           </div>
 
           <div className="space-y-2">
@@ -258,7 +355,7 @@ export const RiderLibraryDialog = ({
               </div>
             ) : filteredEntries.length === 0 ? (
               <div className="rounded-md border p-6 text-center text-sm text-muted-foreground">
-                No hay riders disponibles para los filtros actuales.
+                {entries.length === 0 ? "No hay riders disponibles en la biblioteca." : "No hay riders disponibles para los filtros actuales."}
               </div>
             ) : (
               filteredEntries.map((entry) => {

--- a/src/components/festival/RiderLibraryDialog.tsx
+++ b/src/components/festival/RiderLibraryDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { CalendarDays, FileText, FolderInput, Library, Loader2, Search } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
@@ -36,8 +36,19 @@ type ImportMutationInput = {
 };
 
 const ALL_SOURCE_JOBS_VALUE = "all";
+const FESTIVAL_TIMEZONE = "Europe/Madrid";
 
-const formatDateValue = (date: Date) => format(date, "yyyy-MM-dd");
+const JOB_TYPE_LABELS: Record<string, string> = {
+  ciclo: "Ciclo",
+  dryhire: "Dry hire",
+  evento: "Evento",
+  festival: "Festival",
+  single: "Trabajo único",
+  tour: "Gira",
+  tourdate: "Fecha de gira",
+};
+
+const formatDateValue = (date: Date) => formatInTimeZone(date, FESTIVAL_TIMEZONE, "yyyy-MM-dd");
 
 const formatDisplayDate = (value?: string | null) => {
   if (!value) return "Sin fecha";
@@ -47,7 +58,7 @@ const formatDisplayDate = (value?: string | null) => {
   }
 
   const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? "Sin fecha" : parsed.toLocaleDateString("es-ES");
+  return Number.isNaN(parsed.getTime()) ? "Sin fecha" : formatInTimeZone(parsed, FESTIVAL_TIMEZONE, "dd/MM/yyyy");
 };
 
 const formatUploadDate = (value?: string | null) => {
@@ -55,10 +66,7 @@ const formatUploadDate = (value?: string | null) => {
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return "Sin fecha de subida";
 
-  return parsed.toLocaleString("es-ES", {
-    dateStyle: "short",
-    timeStyle: "short",
-  });
+  return formatInTimeZone(parsed, FESTIVAL_TIMEZONE, "dd/MM/yy, HH:mm");
 };
 
 const formatFileSize = (value?: number | null) => {
@@ -69,6 +77,7 @@ const formatFileSize = (value?: number | null) => {
 
 const normalizeJobType = (value?: string | null) => {
   if (!value) return "Sin tipo";
+  if (JOB_TYPE_LABELS[value]) return JOB_TYPE_LABELS[value];
   return value.replace(/_/g, " ");
 };
 
@@ -100,7 +109,7 @@ export const RiderLibraryDialog = ({
   const resolvedStageOptions = useMemo(() => {
     if (stageOptions.length > 0) return stageOptions;
     return Array.from({ length: Math.max(maxStages, 1) }, (_, index) => ({
-      name: `Stage ${index + 1}`,
+      name: `Escenario ${index + 1}`,
       number: index + 1,
     }));
   }, [maxStages, stageOptions]);
@@ -147,7 +156,7 @@ export const RiderLibraryDialog = ({
 
       toast({
         title: "Rider importado",
-        description: `${entry.artistName} importado a ${formatDisplayDate(targetDate)}, Stage ${targetStage}. ${result.imported_file_count} archivo(s) referenciados.`,
+        description: `${entry.artistName} importado a ${formatDisplayDate(targetDate)}, Escenario ${targetStage}. ${result.imported_file_count} archivo(s) referenciados.`,
         action: {
           label: "Abrir tabla",
           onClick: () => navigate(`/festival-management/${jobId}/artists?date=${targetDate}&stage=${targetStage}`),
@@ -219,7 +228,7 @@ export const RiderLibraryDialog = ({
           entry.artistName,
           entry.sourceJobTitle,
           entry.sourceDate,
-          entry.sourceStage ? `stage ${entry.sourceStage}` : "",
+          entry.sourceStage ? `escenario ${entry.sourceStage} stage ${entry.sourceStage}` : "",
           ...entry.files.map((file) => file.file_name),
         ]
           .join(" ")
@@ -381,16 +390,16 @@ export const RiderLibraryDialog = ({
                           <span>{entry.sourceJobTitle}</span>
                           <span>{normalizeJobType(entry.sourceJobType)}</span>
                           <span>{formatDisplayDate(entry.sourceDate)}</span>
-                          <span>Stage {entry.sourceStage ?? "sin asignar"}</span>
+                          <span>Escenario {entry.sourceStage ?? "sin asignar"}</span>
                         </div>
                       </div>
 
                       <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
                         <div className="w-full sm:w-36">
-                          <Label className="mb-1 block text-xs">Stage destino</Label>
+                          <Label className="mb-1 block text-xs">Escenario destino</Label>
                           {resolvedStageOptions.length <= 1 ? (
                             <div className="flex h-9 items-center rounded-md border px-3 text-sm">
-                              {resolvedStageOptions[0]?.name ?? "Stage 1"}
+                              {resolvedStageOptions[0]?.name ?? "Escenario 1"}
                             </div>
                           ) : (
                             <Select

--- a/src/components/festival/RiderLibraryDialog.tsx
+++ b/src/components/festival/RiderLibraryDialog.tsx
@@ -1,0 +1,365 @@
+import { useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
+import { CalendarDays, FileText, FolderInput, Library, Loader2, Search } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { importArtistRiderToJob, getRiderImportErrorMessage } from "@/features/festival-management/commands";
+import { fetchRiderLibrary } from "@/features/festival-management/queries";
+import type { FestivalStageOption, RiderLibraryEntry } from "@/features/festival-management/types";
+import { useToast } from "@/hooks/use-toast";
+import { queryKeys } from "@/lib/react-query";
+
+type RiderLibraryDialogProps = {
+  canImport: boolean;
+  initialDate?: string | null;
+  jobDates: Date[];
+  jobId: string;
+  maxStages: number;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  stageOptions: FestivalStageOption[];
+};
+
+type ImportMutationInput = {
+  entry: RiderLibraryEntry;
+  targetDate: string;
+  targetStage: number;
+};
+
+const formatDateValue = (date: Date) => format(date, "yyyy-MM-dd");
+
+const formatDisplayDate = (value?: string | null) => {
+  if (!value) return "Sin fecha";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const [year, month, day] = value.split("-");
+    return `${day}/${month}/${year}`;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? "Sin fecha" : parsed.toLocaleDateString("es-ES");
+};
+
+const formatUploadDate = (value?: string | null) => {
+  if (!value) return "Sin fecha de subida";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Sin fecha de subida";
+
+  return parsed.toLocaleString("es-ES", {
+    dateStyle: "short",
+    timeStyle: "short",
+  });
+};
+
+const formatFileSize = (value?: number | null) => {
+  if (!value) return null;
+  if (value < 1024 * 1024) return `${Math.round(value / 1024)} KB`;
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const normalizeJobType = (value?: string | null) => {
+  if (!value) return "Sin tipo";
+  return value.replace(/_/g, " ");
+};
+
+export const RiderLibraryDialog = ({
+  canImport,
+  initialDate,
+  jobDates,
+  jobId,
+  maxStages,
+  onOpenChange,
+  open,
+  stageOptions,
+}: RiderLibraryDialogProps) => {
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedDate, setSelectedDate] = useState("");
+  const [stageByArtist, setStageByArtist] = useState<Record<string, string>>({});
+
+  const dateOptions = useMemo(
+    () => Array.from(new Set(jobDates.map(formatDateValue).filter(Boolean))),
+    [jobDates],
+  );
+  const resolvedStageOptions = useMemo(() => {
+    if (stageOptions.length > 0) return stageOptions;
+    return Array.from({ length: Math.max(maxStages, 1) }, (_, index) => ({
+      name: `Stage ${index + 1}`,
+      number: index + 1,
+    }));
+  }, [maxStages, stageOptions]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setSearchTerm("");
+    setStageByArtist({});
+
+    if (dateOptions.length === 1) {
+      setSelectedDate(dateOptions[0]);
+      return;
+    }
+
+    setSelectedDate(initialDate && dateOptions.includes(initialDate) ? initialDate : "");
+  }, [dateOptions, initialDate, open]);
+
+  const riderLibraryQuery = useQuery({
+    queryKey: queryKeys.scope("rider-library", jobId),
+    queryFn: () => fetchRiderLibrary(jobId),
+    enabled: open && Boolean(jobId),
+  });
+
+  const importMutation = useMutation({
+    mutationFn: async ({ entry, targetDate, targetStage }: ImportMutationInput) => {
+      const result = await importArtistRiderToJob({
+        sourceArtistId: entry.artistId,
+        targetDate,
+        targetJobId: jobId,
+        targetStage,
+      });
+      return { entry, result, targetDate, targetStage };
+    },
+    onSuccess: async ({ entry, result, targetDate, targetStage }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("rider-library", jobId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("festival-artists", jobId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("festival-documents", jobId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.scope("festival-job-details", jobId) }),
+      ]);
+
+      toast({
+        title: "Rider importado",
+        description: `${entry.artistName} importado a ${formatDisplayDate(targetDate)}, Stage ${targetStage}. ${result.imported_file_count} archivo(s) referenciados.`,
+        action: {
+          label: "Abrir tabla",
+          onClick: () => navigate(`/festival-management/${jobId}/artists?date=${targetDate}&stage=${targetStage}`),
+        },
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "No se pudo importar",
+        description: getRiderImportErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const entries = riderLibraryQuery.data ?? [];
+  const normalizedSearch = searchTerm.trim().toLowerCase();
+  const filteredEntries = normalizedSearch
+    ? entries.filter((entry) => {
+        const haystack = [
+          entry.artistName,
+          entry.sourceJobTitle,
+          entry.sourceDate,
+          entry.sourceStage ? `stage ${entry.sourceStage}` : "",
+          ...entry.files.map((file) => file.file_name),
+        ]
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(normalizedSearch);
+      })
+    : entries;
+
+  const defaultStageValueFor = (entry: RiderLibraryEntry) => {
+    const sourceStage = entry.sourceStage ? String(entry.sourceStage) : "";
+    if (sourceStage && resolvedStageOptions.some((option) => String(option.number) === sourceStage)) {
+      return sourceStage;
+    }
+
+    return String(resolvedStageOptions[0]?.number ?? 1);
+  };
+
+  const getTargetStage = (entry: RiderLibraryEntry) => Number(stageByArtist[entry.artistId] || defaultStageValueFor(entry));
+
+  const handleImport = (entry: RiderLibraryEntry) => {
+    const targetStage = getTargetStage(entry);
+    if (!selectedDate || !Number.isFinite(targetStage)) return;
+
+    importMutation.mutate({
+      entry,
+      targetDate: selectedDate,
+      targetStage,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[90vh] max-w-5xl flex-col p-0">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle className="flex items-center gap-2 text-lg">
+            <Library className="h-5 w-5" />
+            Biblioteca de Riders
+          </DialogTitle>
+          <DialogDescription>
+            Importa riders existentes como copia técnica para este trabajo. Los riders importados se marcarán como desactualizados.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 border-b px-5 py-4 md:grid-cols-[1fr_220px]">
+          <div className="space-y-2">
+            <Label htmlFor="rider-library-search">Buscar</Label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="rider-library-search"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Artista, trabajo o archivo"
+                className="pl-9"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="rider-library-date">Fecha destino</Label>
+            {dateOptions.length <= 1 ? (
+              <div className="flex h-10 items-center rounded-md border px-3 text-sm">
+                <CalendarDays className="mr-2 h-4 w-4 text-muted-foreground" />
+                {formatDisplayDate(dateOptions[0])}
+              </div>
+            ) : (
+              <Select value={selectedDate} onValueChange={setSelectedDate}>
+                <SelectTrigger id="rider-library-date">
+                  <SelectValue placeholder="Seleccionar fecha" />
+                </SelectTrigger>
+                <SelectContent>
+                  {dateOptions.map((date) => (
+                    <SelectItem key={date} value={date}>
+                      {formatDisplayDate(date)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+        </div>
+
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="space-y-3 px-5 py-4">
+            {riderLibraryQuery.isLoading ? (
+              <div className="flex min-h-48 items-center justify-center text-sm text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Cargando biblioteca…
+              </div>
+            ) : riderLibraryQuery.isError ? (
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                No se pudo cargar la biblioteca de riders.
+              </div>
+            ) : filteredEntries.length === 0 ? (
+              <div className="rounded-md border p-6 text-center text-sm text-muted-foreground">
+                No hay riders disponibles para los filtros actuales.
+              </div>
+            ) : (
+              filteredEntries.map((entry) => {
+                const selectedStage = String(getTargetStage(entry));
+                const isStageValid = resolvedStageOptions.some((option) => String(option.number) === selectedStage);
+                const isImporting = importMutation.isPending && importMutation.variables?.entry.artistId === entry.artistId;
+                const importDisabled =
+                  !canImport || !selectedDate || !isStageValid || entry.alreadyImported || importMutation.isPending;
+
+                return (
+                  <div key={entry.artistId} className="rounded-md border bg-background p-4">
+                    <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                      <div className="min-w-0 space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="truncate text-base font-semibold">{entry.artistName}</h3>
+                          {entry.alreadyImported ? (
+                            <Badge variant="secondary">Ya referenciado</Badge>
+                          ) : (
+                            <Badge variant="outline">Último: {formatUploadDate(entry.latestUploadedAt)}</Badge>
+                          )}
+                        </div>
+                        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                          <span>{entry.sourceJobTitle}</span>
+                          <span>{normalizeJobType(entry.sourceJobType)}</span>
+                          <span>{formatDisplayDate(entry.sourceDate)}</span>
+                          <span>Stage {entry.sourceStage ?? "sin asignar"}</span>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+                        <div className="w-full sm:w-36">
+                          <Label className="mb-1 block text-xs">Stage destino</Label>
+                          {resolvedStageOptions.length <= 1 ? (
+                            <div className="flex h-9 items-center rounded-md border px-3 text-sm">
+                              {resolvedStageOptions[0]?.name ?? "Stage 1"}
+                            </div>
+                          ) : (
+                            <Select
+                              value={selectedStage}
+                              onValueChange={(value) =>
+                                setStageByArtist((current) => ({ ...current, [entry.artistId]: value }))
+                              }
+                            >
+                              <SelectTrigger className="h-9">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {resolvedStageOptions.map((option) => (
+                                  <SelectItem key={option.number} value={String(option.number)}>
+                                    {option.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
+                        </div>
+                        <Button
+                          onClick={() => handleImport(entry)}
+                          disabled={importDisabled}
+                          className="gap-2 sm:min-w-32"
+                          size="sm"
+                        >
+                          {isImporting ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <FolderInput className="h-4 w-4" />
+                          )}
+                          Importar
+                        </Button>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 space-y-2">
+                      {entry.files.map((file) => {
+                        const fileSize = formatFileSize(file.file_size);
+                        const isDuplicate = entry.duplicateFilePaths.includes(file.file_path);
+                        return (
+                          <div
+                            key={file.id}
+                            className="flex flex-col gap-1 rounded-md bg-muted/40 px-3 py-2 text-xs sm:flex-row sm:items-center sm:justify-between"
+                          >
+                            <span className="flex min-w-0 items-center gap-2">
+                              <FileText className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                              <span className="truncate font-medium">{file.file_name}</span>
+                              {isDuplicate && <Badge variant="outline">Duplicado</Badge>}
+                            </span>
+                            <span className="flex-shrink-0 text-muted-foreground">
+                              {formatUploadDate(file.uploaded_at)}
+                              {fileSize ? ` · ${fileSize}` : ""}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/festival/mobile/MobileArtistCard.tsx
+++ b/src/components/festival/mobile/MobileArtistCard.tsx
@@ -17,6 +17,7 @@ import {
   type FohDrive,
   type ConsolePosition,
 } from "@/constants/consoleDrive";
+import { getArtistRiderStatus } from "@/features/festival-management/selectors";
 
 interface Artist {
   id: string;
@@ -56,6 +57,7 @@ interface Artist {
   notes?: string;
   rider_missing?: boolean;
   rider_copied_from_date?: string | null;
+  rider_outdated?: boolean;
   rider_outdated_dismissed?: boolean;
   foh_tech?: boolean;
   mon_tech?: boolean;
@@ -301,7 +303,7 @@ export const MobileArtistCard = ({
                 </Badge>
               )}
               <Badge variant="outline" className="text-[10px]">{stageName}</Badge>
-              {artist.rider_copied_from_date && !artist.rider_outdated_dismissed ? (
+              {getArtistRiderStatus(artist) === "outdated" ? (
                 <OutdatedRiderBadge
                   artistId={artist.id}
                   copiedFromDate={artist.rider_copied_from_date}

--- a/src/components/festival/mobile/MobileArtistList.tsx
+++ b/src/components/festival/mobile/MobileArtistList.tsx
@@ -45,6 +45,9 @@ interface Artist {
   extras_wired?: string;
   notes?: string;
   rider_missing?: boolean;
+  rider_copied_from_date?: string | null;
+  rider_outdated?: boolean;
+  rider_outdated_dismissed?: boolean;
   foh_tech?: boolean;
   mon_tech?: boolean;
   isaftermidnight?: boolean;

--- a/src/components/festival/pdf/PrintOptionsDialog.tsx
+++ b/src/components/festival/pdf/PrintOptionsDialog.tsx
@@ -274,11 +274,7 @@ export const PrintOptionsDialog = ({
       throw error;
     }
 
-    // Missing riders, plus imported/copied riders flagged outdated (unless dismissed).
-    const missingRiderArtists = artists?.filter(artist =>
-      Boolean(artist.rider_missing) ||
-      ((Boolean(artist.rider_outdated) || Boolean(artist.rider_copied_from_date)) && !artist.rider_outdated_dismissed)
-    ) || [];
+    const missingRiderArtists = artists?.filter(artist => Boolean(artist.rider_missing) || ((Boolean(artist.rider_outdated) || Boolean(artist.rider_copied_from_date)) && !artist.rider_outdated_dismissed)) || [];
 
     const { data: stageRows } = await dataLayerClient.from('festival_stages')
       .select('number, name')

--- a/src/components/festival/pdf/PrintOptionsDialog.tsx
+++ b/src/components/festival/pdf/PrintOptionsDialog.tsx
@@ -274,8 +274,11 @@ export const PrintOptionsDialog = ({
       throw error;
     }
 
-    // Missing riders, plus copied riders flagged outdated (unless dismissed).
-    const missingRiderArtists = artists?.filter(artist => Boolean(artist.rider_missing) || (Boolean(artist.rider_copied_from_date) && !artist.rider_outdated_dismissed)) || [];
+    // Missing riders, plus imported/copied riders flagged outdated (unless dismissed).
+    const missingRiderArtists = artists?.filter(artist =>
+      Boolean(artist.rider_missing) ||
+      ((Boolean(artist.rider_outdated) || Boolean(artist.rider_copied_from_date)) && !artist.rider_outdated_dismissed)
+    ) || [];
 
     const { data: stageRows } = await dataLayerClient.from('festival_stages')
       .select('number, name')

--- a/src/components/festival/pdf/PrintOptionsDialog.tsx
+++ b/src/components/festival/pdf/PrintOptionsDialog.tsx
@@ -19,6 +19,7 @@ import { mergePDFs } from "@/utils/pdf/pdfMerge";
 import { fetchJobLogo, fetchLogoUrl } from "@/utils/pdf/logoUtils";
 import { ensurePublicArtistFormLinks } from "@/utils/publicArtistFormLinks";
 import { buildReadableFilename } from "@/utils/fileName";
+import { getArtistRiderStatus } from "@/features/festival-management/selectors";
 import {
   attachShiftAssignmentsAndProfiles,
   buildArtistTableArtists,
@@ -274,7 +275,7 @@ export const PrintOptionsDialog = ({
       throw error;
     }
 
-    const missingRiderArtists = artists?.filter(artist => Boolean(artist.rider_missing) || ((Boolean(artist.rider_outdated) || Boolean(artist.rider_copied_from_date)) && !artist.rider_outdated_dismissed)) || [];
+    const missingRiderArtists = artists?.filter((artist) => getArtistRiderStatus(artist) !== 'complete') || [];
 
     const { data: stageRows } = await dataLayerClient.from('festival_stages')
       .select('number, name')
@@ -299,19 +300,19 @@ export const PrintOptionsDialog = ({
     const missingRiderData: MissingRiderReportData = {
       jobTitle,
       logoUrl,
-      artists: missingRiderArtists.map(artist => ({
-        id: artist.id,
-        name: artist.name || 'Unnamed Artist',
-        stage: artist.stage || 1,
-        stageName: stageNameByNumber.get(Number(artist.stage || 1)) || `Escenario ${artist.stage || 1}`,
-        date: artist.date || '',
-        showTime: {
-          start: artist.show_start || '',
-          end: artist.show_end || ''
-        },
-        formUrl: publicFormLinksByArtistId[artist.id],
-        status: artist.rider_missing ? 'missing' : 'outdated',
-        copiedFromDate: artist.rider_copied_from_date || undefined,
+      artists: missingRiderArtists.map((artist) => ({
+          id: artist.id,
+          name: artist.name || 'Unnamed Artist',
+          stage: artist.stage || 1,
+          stageName: stageNameByNumber.get(Number(artist.stage || 1)) || `Escenario ${artist.stage || 1}`,
+          date: artist.date || '',
+          showTime: {
+            start: artist.show_start || '',
+            end: artist.show_end || ''
+          },
+          formUrl: publicFormLinksByArtistId[artist.id],
+          status: getArtistRiderStatus(artist) === 'missing' ? 'missing' as const : 'outdated' as const,
+          copiedFromDate: artist.rider_copied_from_date || undefined,
       }))
     };
 

--- a/src/components/festival/scheduling/FestivalScheduling.tsx
+++ b/src/components/festival/scheduling/FestivalScheduling.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { CalendarX, MessageCircle, Plus, RefreshCw } from "lucide-react";
+import { CalendarX, Library, MessageCircle, Plus, RefreshCw } from "lucide-react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Loading } from "@/components/ui/loading";
 import { format } from "date-fns";
@@ -22,9 +22,16 @@ interface FestivalSchedulingProps {
   jobDates: Date[];
   isViewOnly?: boolean;
   onCreateWhatsappGroup?: () => void;
+  onOpenRiderLibrary?: (selectedDate?: string) => void;
 }
 
-export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false, onCreateWhatsappGroup }: FestivalSchedulingProps) => {
+export const FestivalScheduling = ({
+  jobId,
+  jobDates,
+  isViewOnly = false,
+  onCreateWhatsappGroup,
+  onOpenRiderLibrary,
+}: FestivalSchedulingProps) => {
   const [selectedDate, setSelectedDate] = useState<string>("");
   const [isCreateShiftOpen, setIsCreateShiftOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"list" | "table">("table");
@@ -227,6 +234,17 @@ export const FestivalScheduling = ({ jobId, jobDates, isViewOnly = false, onCrea
               >
                 <MessageCircle className="h-4 w-4" />
                 <span className="hidden sm:inline">WhatsApp</span>
+              </Button>
+            )}
+            {!isViewOnly && onOpenRiderLibrary && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onOpenRiderLibrary(selectedDate)}
+                className="flex items-center gap-1"
+              >
+                <Library className="h-4 w-4" />
+                <span className="hidden sm:inline">Riders</span>
               </Button>
             )}
             {!isViewOnly && (

--- a/src/features/festival-management/__tests__/selectors.test.ts
+++ b/src/features/festival-management/__tests__/selectors.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { formatInTimeZone } from "date-fns-tz";
 
 import {
+  buildRiderLibraryEntries,
   buildFestivalStageOptions,
   buildFestivalWhatsappStageOptions,
   buildJobDates,
   formatFestivalDateLabel,
+  getArtistRiderStatus,
   getFestivalFlexStatus,
   groupFestivalRiderFiles,
   normalizeFestivalWhatsappStage,
@@ -70,6 +72,67 @@ describe("festival management selectors", () => {
     ];
 
     expect(groupFestivalRiderFiles(files).map((group) => group.artistName)).toEqual(["Alpha", "Beta"]);
+  });
+
+  it("derives rider status with missing taking priority over outdated", () => {
+    expect(getArtistRiderStatus({ rider_missing: true, rider_outdated: true })).toBe("missing");
+    expect(getArtistRiderStatus({ rider_missing: false, rider_outdated: true })).toBe("outdated");
+    expect(getArtistRiderStatus({ rider_missing: false, rider_copied_from_date: "2026-06-01" })).toBe("outdated");
+    expect(
+      getArtistRiderStatus({
+        rider_missing: false,
+        rider_outdated: true,
+        rider_outdated_dismissed: true,
+      }),
+    ).toBe("complete");
+    expect(getArtistRiderStatus({ rider_missing: false })).toBe("complete");
+  });
+
+  it("builds rider library entries sorted by latest upload and flags duplicate file paths", () => {
+    const entries = buildRiderLibraryEntries({
+      artistsById: {
+        "artist-a": { id: "artist-a", name: "Alpha", job_id: "job-a", date: "2026-06-01", stage: 2 },
+        "artist-b": { id: "artist-b", name: "Beta", job_id: "job-b", date: "2026-05-01", stage: 1 },
+      },
+      files: [
+        {
+          id: "file-old",
+          artist_id: "artist-a",
+          file_name: "alpha-old.pdf",
+          file_path: "riders/alpha-old.pdf",
+          uploaded_at: "2026-05-01T10:00:00.000Z",
+        },
+        {
+          id: "file-new",
+          artist_id: "artist-a",
+          file_name: "alpha-new.pdf",
+          file_path: "riders/alpha-new.pdf",
+          uploaded_at: "2026-06-01T10:00:00.000Z",
+        },
+        {
+          id: "file-beta",
+          artist_id: "artist-b",
+          file_name: "beta.pdf",
+          file_path: "riders/beta.pdf",
+          uploaded_at: "2026-07-01T10:00:00.000Z",
+        },
+      ],
+      jobsById: {
+        "job-a": { id: "job-a", title: "Source A", job_type: "festival" },
+        "job-b": { id: "job-b", title: "Source B", job_type: "tourdate" },
+      },
+      targetFilePaths: ["riders/alpha-new.pdf"],
+    });
+
+    expect(entries.map((entry) => entry.artistName)).toEqual(["Beta", "Alpha"]);
+    expect(entries[1]).toMatchObject({
+      alreadyImported: true,
+      duplicateFilePaths: ["riders/alpha-new.pdf"],
+      latestUploadedAt: "2026-06-01T10:00:00.000Z",
+      sourceJobTitle: "Source A",
+      sourceStage: 2,
+    });
+    expect(entries[1].files.map((file) => file.file_name)).toEqual(["alpha-new.pdf", "alpha-old.pdf"]);
   });
 
   it("normalizes WhatsApp stage state by department and stage count", () => {

--- a/src/features/festival-management/commands.ts
+++ b/src/features/festival-management/commands.ts
@@ -9,6 +9,8 @@ import type {
   FestivalVenueData,
   FestivalWhatsappDepartment,
   JobDocumentEntry,
+  RiderLibraryImportInput,
+  RiderLibraryImportResult,
 } from "@/features/festival-management/types";
 import { supabase } from "@/integrations/supabase/client";
 import { getStaticMapUrlForLocation } from "@/lib/mapbox/mapboxClient";
@@ -66,6 +68,51 @@ export const getRiderSignedUrl = async (file: ArtistRiderFile) =>
 
 export const downloadRiderBlob = async (file: ArtistRiderFile) =>
   getDownloadableBlob("festival_artist_files", file.file_path);
+
+export const getRiderImportErrorMessage = (error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error || "");
+
+  if (message.includes("duplicate_rider_import")) {
+    return "Este trabajo ya referencia al menos uno de los archivos de ese rider.";
+  }
+  if (message.includes("not_authorized")) {
+    return "No tienes permisos para importar riders.";
+  }
+  if (message.includes("source_artist_has_no_riders")) {
+    return "El artista seleccionado no tiene riders para importar.";
+  }
+  if (message.includes("invalid_target_stage")) {
+    return "Selecciona un escenario válido para importar el rider.";
+  }
+  if (message.includes("missing_required_argument")) {
+    return "Selecciona una fecha y escenario antes de importar.";
+  }
+
+  return message || "No se pudo importar el rider.";
+};
+
+export const importArtistRiderToJob = async ({
+  sourceArtistId,
+  targetDate,
+  targetJobId,
+  targetStage,
+}: RiderLibraryImportInput): Promise<RiderLibraryImportResult> => {
+  const { data, error } = await supabase.rpc("import_artist_rider_to_job", {
+    p_source_artist_id: sourceArtistId,
+    p_target_date: targetDate,
+    p_target_job_id: targetJobId,
+    p_target_stage: targetStage,
+  });
+
+  if (error) throw error;
+
+  const result = data?.[0];
+  if (!result) {
+    throw new Error("No se recibió confirmación de importación.");
+  }
+
+  return result as RiderLibraryImportResult;
+};
 
 export const downloadBlobInBrowser = (blob: Blob, fileName: string) => {
   const url = window.URL.createObjectURL(blob);

--- a/src/features/festival-management/commands.ts
+++ b/src/features/festival-management/commands.ts
@@ -87,8 +87,11 @@ export const getRiderImportErrorMessage = (error: unknown) => {
   if (message.includes("missing_required_argument")) {
     return "Selecciona una fecha y escenario antes de importar.";
   }
+  if (message.includes("No se recibió confirmación de importación.")) {
+    return message;
+  }
 
-  return message || "No se pudo importar el rider.";
+  return "No se pudo importar el rider. Inténtalo de nuevo o revisa los permisos del trabajo.";
 };
 
 export const importArtistRiderToJob = async ({

--- a/src/features/festival-management/queries.ts
+++ b/src/features/festival-management/queries.ts
@@ -3,6 +3,7 @@ import {
   buildFallbackStageOptions,
   buildFestivalStageOptions,
   buildJobDates,
+  buildRiderLibraryEntries,
   type JobDateTypeRow,
 } from "@/features/festival-management/selectors";
 import { fetchWithOfflineFallback, getFestivalSnapshot } from "@/lib/offline";
@@ -17,6 +18,10 @@ import type {
   FestivalJobDetailsData,
   FestivalVenueData,
   JobDocumentEntry,
+  RiderLibraryEntry,
+  RiderLibraryFile,
+  RiderLibrarySourceArtist,
+  RiderLibrarySourceJob,
 } from "@/features/festival-management/types";
 
 type LocationRow = {
@@ -319,4 +324,91 @@ export const fetchFestivalDocuments = async (jobId: string): Promise<FestivalDoc
     offline: () => buildOfflineDocuments(jobId),
   });
   return result.data;
+};
+
+const fetchTargetJobRiderFilePaths = async (jobId: string) => {
+  const { data: targetArtists, error: artistError } = await supabase
+    .from("festival_artists")
+    .select("id")
+    .eq("job_id", jobId);
+
+  if (artistError) throw artistError;
+
+  const targetArtistIds = (targetArtists || []).map((artist) => artist.id);
+  if (targetArtistIds.length === 0) return [];
+
+  const { data: targetFiles, error: filesError } = await supabase
+    .from("festival_artist_files")
+    .select("file_path")
+    .in("artist_id", targetArtistIds);
+
+  if (filesError) throw filesError;
+
+  return (targetFiles || []).map((file) => file.file_path).filter((value): value is string => Boolean(value));
+};
+
+export const fetchRiderLibrary = async (targetJobId: string): Promise<RiderLibraryEntry[]> => {
+  const [{ data: filesData, error: filesError }, targetFilePaths] = await Promise.all([
+    supabase
+      .from("festival_artist_files")
+      .select("id, artist_id, file_name, file_path, file_type, file_size, uploaded_by, uploaded_at")
+      .not("artist_id", "is", null)
+      .order("uploaded_at", { ascending: false }),
+    fetchTargetJobRiderFilePaths(targetJobId),
+  ]);
+
+  if (filesError) throw filesError;
+
+  const files: RiderLibraryFile[] = (filesData || [])
+    .filter((file) => Boolean(file.artist_id))
+    .map((file) => ({
+      artist_id: file.artist_id as string,
+      file_name: file.file_name,
+      file_path: file.file_path,
+      file_size: file.file_size,
+      file_type: file.file_type,
+      id: file.id,
+      uploaded_at: file.uploaded_at,
+      uploaded_by: file.uploaded_by,
+    }));
+
+  if (files.length === 0) return [];
+
+  const artistIds = Array.from(new Set(files.map((file) => file.artist_id)));
+  const { data: artistsData, error: artistsError } = await supabase
+    .from("festival_artists")
+    .select("id, name, job_id, date, stage")
+    .in("id", artistIds);
+
+  if (artistsError) throw artistsError;
+
+  const artists: RiderLibrarySourceArtist[] = (artistsData || []).map((artist) => ({
+    date: artist.date,
+    id: artist.id,
+    job_id: artist.job_id,
+    name: artist.name,
+    stage: artist.stage,
+  }));
+
+  const jobIds = Array.from(
+    new Set(artists.map((artist) => artist.job_id).filter((value): value is string => Boolean(value))),
+  );
+  const jobs: RiderLibrarySourceJob[] = [];
+
+  if (jobIds.length > 0) {
+    const { data: jobsData, error: jobsError } = await supabase
+      .from("jobs")
+      .select("id, title, job_type, start_time, end_time")
+      .in("id", jobIds);
+
+    if (jobsError) throw jobsError;
+    jobs.push(...(jobsData || []));
+  }
+
+  return buildRiderLibraryEntries({
+    artistsById: new Map(artists.map((artist) => [artist.id, artist])),
+    files,
+    jobsById: new Map(jobs.map((job) => [job.id, job])),
+    targetFilePaths,
+  });
 };

--- a/src/features/festival-management/queries.ts
+++ b/src/features/festival-management/queries.ts
@@ -38,6 +38,8 @@ type HojaVenueRow = {
   venue_longitude?: number | null;
 };
 
+const RIDER_LIBRARY_FILE_LIMIT = 1000;
+
 export const resolveFestivalVenueData = (
   hojaData: HojaVenueRow | null | undefined,
   location: LocationRow | null | undefined
@@ -353,7 +355,8 @@ export const fetchRiderLibrary = async (targetJobId: string): Promise<RiderLibra
       .from("festival_artist_files")
       .select("id, artist_id, file_name, file_path, file_type, file_size, uploaded_by, uploaded_at")
       .not("artist_id", "is", null)
-      .order("uploaded_at", { ascending: false }),
+      .order("uploaded_at", { ascending: false })
+      .limit(RIDER_LIBRARY_FILE_LIMIT),
     fetchTargetJobRiderFilePaths(targetJobId),
   ]);
 

--- a/src/features/festival-management/selectors.ts
+++ b/src/features/festival-management/selectors.ts
@@ -119,7 +119,7 @@ export const groupFestivalRiderFiles = (artistRiderFiles: ArtistRiderFile[]): Gr
 
   artistRiderFiles.forEach((file) => {
     const artistId = file.artist_id || file.festival_artists?.id || "unknown";
-    const artistName = file.festival_artists?.name || "Unknown Artist";
+    const artistName = file.festival_artists?.name || "Artista desconocido";
 
     if (!map.has(artistId)) {
       map.set(artistId, { artistId, artistName, files: [] });
@@ -148,7 +148,7 @@ export const getArtistRiderStatus = (artist: RiderFreshnessArtist): RiderStatus 
 };
 
 const normalizeRecordMap = <T extends { id: string }>(items: Map<string, T> | Record<string, T>) =>
-  items instanceof Map ? items : new Map(Object.entries(items));
+  items instanceof Map ? items : new Map(Object.values(items).map((item) => [item.id, item] as const));
 
 const toUploadedAtSortValue = (value?: string | null) => {
   if (!value) return 0;
@@ -184,7 +184,7 @@ export const buildRiderLibraryEntries = ({
       entries.set(artist.id, {
         alreadyImported: duplicateFilePaths.length > 0,
         artistId: artist.id,
-        artistName: artist.name || "Unknown Artist",
+        artistName: artist.name || "Artista desconocido",
         duplicateFilePaths,
         files: [file],
         latestUploadedAt: file.uploaded_at ?? null,

--- a/src/features/festival-management/selectors.ts
+++ b/src/features/festival-management/selectors.ts
@@ -8,6 +8,12 @@ import type {
   FestivalStageOption,
   FestivalWhatsappDepartment,
   GroupedRiderFiles,
+  RiderFreshnessArtist,
+  RiderLibraryEntry,
+  RiderLibraryFile,
+  RiderLibrarySourceArtist,
+  RiderLibrarySourceJob,
+  RiderStatus,
 } from "@/features/festival-management/types";
 import type { Department } from "@/types/department";
 
@@ -123,6 +129,98 @@ export const groupFestivalRiderFiles = (artistRiderFiles: ArtistRiderFile[]): Gr
   });
 
   return Array.from(map.values()).sort((a, b) => a.artistName.localeCompare(b.artistName));
+};
+
+export const isArtistRiderOutdated = (artist: RiderFreshnessArtist) =>
+  !artist.rider_outdated_dismissed &&
+  (Boolean(artist.rider_outdated) || Boolean(artist.rider_copied_from_date));
+
+export const getArtistRiderStatus = (artist: RiderFreshnessArtist): RiderStatus => {
+  if (artist.rider_missing) {
+    return "missing";
+  }
+
+  if (isArtistRiderOutdated(artist)) {
+    return "outdated";
+  }
+
+  return "complete";
+};
+
+const normalizeRecordMap = <T extends { id: string }>(items: Map<string, T> | Record<string, T>) =>
+  items instanceof Map ? items : new Map(Object.entries(items));
+
+const toUploadedAtSortValue = (value?: string | null) => {
+  if (!value) return 0;
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+export const buildRiderLibraryEntries = ({
+  artistsById,
+  files,
+  jobsById,
+  targetFilePaths = [],
+}: {
+  artistsById: Map<string, RiderLibrarySourceArtist> | Record<string, RiderLibrarySourceArtist>;
+  files: RiderLibraryFile[];
+  jobsById: Map<string, RiderLibrarySourceJob> | Record<string, RiderLibrarySourceJob>;
+  targetFilePaths?: Iterable<string>;
+}): RiderLibraryEntry[] => {
+  const artistMap = normalizeRecordMap(artistsById);
+  const jobMap = normalizeRecordMap(jobsById);
+  const targetPathSet = new Set(targetFilePaths);
+  const entries = new Map<string, RiderLibraryEntry>();
+
+  files.forEach((file) => {
+    const artist = artistMap.get(file.artist_id);
+    if (!artist) return;
+
+    const job = artist.job_id ? jobMap.get(artist.job_id) : undefined;
+    const duplicateFilePaths = targetPathSet.has(file.file_path) ? [file.file_path] : [];
+    const existingEntry = entries.get(artist.id);
+
+    if (!existingEntry) {
+      entries.set(artist.id, {
+        alreadyImported: duplicateFilePaths.length > 0,
+        artistId: artist.id,
+        artistName: artist.name || "Unknown Artist",
+        duplicateFilePaths,
+        files: [file],
+        latestUploadedAt: file.uploaded_at ?? null,
+        sourceDate: artist.date ?? null,
+        sourceJobId: artist.job_id ?? null,
+        sourceJobTitle: job?.title || "Trabajo sin título",
+        sourceJobType: job?.job_type ?? null,
+        sourceStage: artist.stage ?? null,
+      });
+      return;
+    }
+
+    existingEntry.files.push(file);
+    existingEntry.duplicateFilePaths.push(...duplicateFilePaths);
+    existingEntry.alreadyImported = existingEntry.alreadyImported || duplicateFilePaths.length > 0;
+
+    const latestCurrent = toUploadedAtSortValue(existingEntry.latestUploadedAt);
+    const latestCandidate = toUploadedAtSortValue(file.uploaded_at);
+    if (latestCandidate > latestCurrent) {
+      existingEntry.latestUploadedAt = file.uploaded_at ?? null;
+    }
+  });
+
+  return Array.from(entries.values())
+    .map((entry) => ({
+      ...entry,
+      duplicateFilePaths: Array.from(new Set(entry.duplicateFilePaths)),
+      files: [...entry.files].sort((a, b) => {
+        const byUpload = toUploadedAtSortValue(b.uploaded_at) - toUploadedAtSortValue(a.uploaded_at);
+        return byUpload || a.file_name.localeCompare(b.file_name);
+      }),
+    }))
+    .sort((a, b) => {
+      const byUpload = toUploadedAtSortValue(b.latestUploadedAt) - toUploadedAtSortValue(a.latestUploadedAt);
+      return byUpload || a.artistName.localeCompare(b.artistName);
+    });
 };
 
 export const formatFestivalDateLabel = (value?: string | null) => {

--- a/src/features/festival-management/types.ts
+++ b/src/features/festival-management/types.ts
@@ -53,14 +53,82 @@ export interface ArtistRiderFile {
   id: string;
   file_name: string;
   file_path: string;
+  file_size?: number | null;
+  file_type?: string | null;
   created_at: string;
   uploaded_at?: string | null;
+  uploaded_by?: string | null;
   artist_id?: string;
   festival_artists?: {
     id: string;
     name: string;
   } | null;
 }
+
+export type RiderStatus = "missing" | "outdated" | "complete";
+
+export type RiderFreshnessArtist = {
+  rider_copied_from_date?: string | null;
+  rider_missing?: boolean | null;
+  rider_outdated?: boolean | null;
+  rider_outdated_dismissed?: boolean | null;
+};
+
+export type RiderLibraryFile = {
+  id: string;
+  artist_id: string;
+  created_at?: string | null;
+  file_name: string;
+  file_path: string;
+  file_size?: number | null;
+  file_type?: string | null;
+  uploaded_at?: string | null;
+  uploaded_by?: string | null;
+};
+
+export type RiderLibrarySourceArtist = {
+  id: string;
+  date?: string | null;
+  job_id?: string | null;
+  name: string;
+  stage?: number | null;
+};
+
+export type RiderLibrarySourceJob = {
+  id: string;
+  end_time?: string | null;
+  job_type?: JobType | string | null;
+  start_time?: string | null;
+  title?: string | null;
+};
+
+export type RiderLibraryEntry = {
+  alreadyImported: boolean;
+  artistId: string;
+  artistName: string;
+  duplicateFilePaths: string[];
+  files: RiderLibraryFile[];
+  latestUploadedAt: string | null;
+  sourceDate: string | null;
+  sourceJobId: string | null;
+  sourceJobTitle: string;
+  sourceJobType: JobType | string | null;
+  sourceStage: number | null;
+};
+
+export type RiderLibraryImportInput = {
+  sourceArtistId: string;
+  targetDate: string;
+  targetJobId: string;
+  targetStage: number;
+};
+
+export type RiderLibraryImportResult = {
+  imported_artist_id: string;
+  imported_file_count: number;
+  target_date: string;
+  target_stage: number;
+};
 
 export type FestivalStageOption = {
   number: number;
@@ -135,6 +203,7 @@ type FestivalManagementLocalVm = {
   handleOpenAssignments: () => void;
   handleOpenJobDetails: () => void;
   handleOpenRouteSheet: () => void;
+  handleOpenRiderLibrary: (initialDate?: string | null) => void;
   handleRefreshAll: () => void;
   humanizeDepartment: (department: Department) => string;
   isArtistRoute: boolean;
@@ -148,6 +217,7 @@ type FestivalManagementLocalVm = {
   isManagementUser?: boolean;
   isPlanningViewOnly: boolean;
   isRouteSheetOpen: boolean;
+  isRiderLibraryOpen: boolean;
   isSchedulingRoute: boolean;
   isSingleJobMode: boolean;
   isViewOnly: boolean;
@@ -162,6 +232,8 @@ type FestivalManagementLocalVm = {
   setIsJobDetailsOpen: Dispatch<SetStateAction<boolean>>;
   setIsJobPresetsOpen: Dispatch<SetStateAction<boolean>>;
   setIsRouteSheetOpen: Dispatch<SetStateAction<boolean>>;
+  setIsRiderLibraryOpen: Dispatch<SetStateAction<boolean>>;
+  riderLibraryInitialDate: string | null;
   userRole: string | null | undefined;
   venueData: FestivalVenueData;
 };

--- a/src/features/festival-management/useFestivalManagementVm.ts
+++ b/src/features/festival-management/useFestivalManagementVm.ts
@@ -49,6 +49,8 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
   const [isRouteSheetOpen, setIsRouteSheetOpen] = useState(false);
   const [isJobDetailsOpen, setIsJobDetailsOpen] = useState(false);
   const [isJobPresetsOpen, setIsJobPresetsOpen] = useState(false);
+  const [isRiderLibraryOpen, setIsRiderLibraryOpen] = useState(false);
+  const [riderLibraryInitialDate, setRiderLibraryInitialDate] = useState<string | null>(null);
 
   const flexControls = useFestivalFlexControls({
     fetchDocuments: documents.fetchDocuments,
@@ -141,6 +143,11 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
     setIsRouteSheetOpen(true);
   }, []);
 
+  const handleOpenRiderLibrary = useCallback((initialDate?: string | null) => {
+    setRiderLibraryInitialDate(initialDate ?? null);
+    setIsRiderLibraryOpen(true);
+  }, []);
+
   const handleOpenJobDetails = useCallback(() => {
     if (!jobData.job) return;
     setIsJobDetailsOpen(true);
@@ -211,6 +218,7 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
       handleOpenAssignments,
       handleOpenJobDetails,
       handleOpenRouteSheet,
+      handleOpenRiderLibrary,
       handleRefreshAll,
       navigateToCalculator,
 
@@ -218,6 +226,9 @@ export const useFestivalManagementVm = (): FestivalManagementVmResult => {
       setIsAssignmentDialogOpen,
       isRouteSheetOpen,
       setIsRouteSheetOpen,
+      isRiderLibraryOpen,
+      setIsRiderLibraryOpen,
+      riderLibraryInitialDate,
       isJobDetailsOpen,
       setIsJobDetailsOpen,
       isJobPresetsOpen,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1677,6 +1677,7 @@ export type Database = {
           rf_festival_wireless: number | null
           rider_copied_from_date: string | null
           rider_missing: boolean | null
+          rider_outdated: boolean
           rider_outdated_dismissed: boolean
           show_end: string | null
           show_start: string | null
@@ -1759,6 +1760,7 @@ export type Database = {
           rf_festival_wireless?: number | null
           rider_copied_from_date?: string | null
           rider_missing?: boolean | null
+          rider_outdated?: boolean
           rider_outdated_dismissed?: boolean
           show_end?: string | null
           show_start?: string | null
@@ -1841,6 +1843,7 @@ export type Database = {
           rf_festival_wireless?: number | null
           rider_copied_from_date?: string | null
           rider_missing?: boolean | null
+          rider_outdated?: boolean
           rider_outdated_dismissed?: boolean
           show_end?: string | null
           show_start?: string | null
@@ -10556,6 +10559,20 @@ export type Database = {
         }
       }
       assert_soundvision_access: { Args: never; Returns: boolean }
+      import_artist_rider_to_job: {
+        Args: {
+          p_source_artist_id: string
+          p_target_date: string
+          p_target_job_id: string
+          p_target_stage: number
+        }
+        Returns: {
+          imported_artist_id: string
+          imported_file_count: number
+          target_date: string
+          target_stage: number
+        }[]
+      }
       attempt_whatsapp_send: {
         Args: {
           _actor_id: string

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -10559,6 +10559,14 @@ export type Database = {
         }
       }
       assert_soundvision_access: { Args: never; Returns: boolean }
+      delete_festival_artist_file_reference: {
+        Args: { p_artist_id?: string; p_file_id: string }
+        Returns: {
+          deleted_file_id: string
+          file_path: string
+          should_delete_storage: boolean
+        }[]
+      }
       import_artist_rider_to_job: {
         Args: {
           p_source_artist_id: string

--- a/src/pages/festival-management/FestivalManagementDialogs.tsx
+++ b/src/pages/festival-management/FestivalManagementDialogs.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Textarea } from "@/components/ui/textarea";
 import { FestivalScheduling } from "@/components/festival/scheduling/FestivalScheduling";
 import { PrintOptionsDialog } from "@/components/festival/pdf/PrintOptionsDialog";
+import { RiderLibraryDialog } from "@/components/festival/RiderLibraryDialog";
 import { FlexFolderPicker } from "@/components/flex/FlexFolderPicker";
 import { ModernHojaDeRuta } from "@/components/hoja-de-ruta/ModernHojaDeRuta";
 import { JobAssignmentDialog } from "@/components/jobs/JobAssignmentDialog";
@@ -18,6 +19,7 @@ import {
   requiresFestivalWhatsappStage,
 } from "@/features/festival-management/selectors";
 import type { FestivalManagementVm } from "@/features/festival-management/types";
+import { canEditJobs } from "@/utils/permissions";
 
 export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) => {
   const {
@@ -29,6 +31,7 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
     isPlanningViewOnly,
     isHouseTech,
     isManagementUser,
+    userRole,
 
     isAssignmentDialogOpen,
     setIsAssignmentDialogOpen,
@@ -117,10 +120,15 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
     setIsDeleteDialogOpen,
     isDeleting,
     handleDeleteJob,
+    isRiderLibraryOpen,
+    setIsRiderLibraryOpen,
+    riderLibraryInitialDate,
+    handleOpenRiderLibrary,
   } = vm;
   const festivalWhatsappStageOptions = buildFestivalWhatsappStageOptions(festivalStageOptions, maxStages);
   const requiresStageScopedWhatsapp = requiresFestivalWhatsappStage(maxStages, waDepartment);
   const canUpdateExistingWaGroup = !!waGroup && requiresStageScopedWhatsapp;
+  const canImportRiders = canEditJobs(userRole);
 
   return (
     <>
@@ -169,6 +177,7 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
               jobDates={jobDates}
               isViewOnly={isPlanningViewOnly}
               onCreateWhatsappGroup={isManagementUser ? () => setIsWhatsappDialogOpen(true) : undefined}
+              onOpenRiderLibrary={canImportRiders ? handleOpenRiderLibrary : undefined}
             />
           ) : (
             <Card>
@@ -198,6 +207,17 @@ export const FestivalManagementDialogs = ({ vm }: { vm: FestivalManagementVm }) 
       )}
 
       {jobId && <JobPresetManagerDialog open={isJobPresetsOpen} onOpenChange={setIsJobPresetsOpen} jobId={jobId} />}
+
+      <RiderLibraryDialog
+        canImport={canImportRiders}
+        initialDate={riderLibraryInitialDate}
+        jobDates={jobDates}
+        jobId={jobId}
+        maxStages={maxStages}
+        onOpenChange={setIsRiderLibraryOpen}
+        open={isRiderLibraryOpen}
+        stageOptions={festivalStageOptions}
+      />
 
       <Dialog open={isArchiveDialogOpen} onOpenChange={setIsArchiveDialogOpen}>
         <DialogContent className="sm:max-w-lg">

--- a/src/pages/festival-management/FestivalManagementNavCards.tsx
+++ b/src/pages/festival-management/FestivalManagementNavCards.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 type FestivalManagementNavCardsProps = {
   artistCount: number;
+  canImportRiders: boolean;
   isPlanningViewOnly: boolean;
   isViewOnly: boolean;
   jobId: string;
@@ -14,6 +15,7 @@ type FestivalManagementNavCardsProps = {
 
 export const FestivalManagementNavCards = ({
   artistCount,
+  canImportRiders,
   isPlanningViewOnly,
   isViewOnly,
   jobId,
@@ -109,33 +111,35 @@ export const FestivalManagementNavCards = ({
       </CardContent>
     </Card>
 
-    <Card
-      className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
-      onClick={onOpenRiderLibrary}
-    >
-      <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-3 text-base md:text-lg">
-          <div className="p-2 rounded-lg bg-cyan-500/10 text-cyan-600 group-hover:bg-cyan-500/20 transition-colors">
-            <Library className="h-5 w-5 md:h-6 md:w-6" />
-          </div>
-          <span className="group-hover:text-primary transition-colors">Biblioteca de Riders</span>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">
-          Importa riders existentes como copias técnicas para este trabajo
-        </p>
-        <Button
-          className="w-full group-hover:shadow-md transition-shadow"
-          size="sm"
-          onClick={(event) => {
-            event.stopPropagation();
-            onOpenRiderLibrary();
-          }}
-        >
-          Abrir Biblioteca
-        </Button>
-      </CardContent>
-    </Card>
+    {canImportRiders && (
+      <Card
+        className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
+        onClick={onOpenRiderLibrary}
+      >
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-3 text-base md:text-lg">
+            <div className="p-2 rounded-lg bg-cyan-500/10 text-cyan-600 group-hover:bg-cyan-500/20 transition-colors">
+              <Library className="h-5 w-5 md:h-6 md:w-6" />
+            </div>
+            <span className="group-hover:text-primary transition-colors">Biblioteca de Riders</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">
+            Importa riders existentes como copias técnicas para este trabajo
+          </p>
+          <Button
+            className="w-full group-hover:shadow-md transition-shadow"
+            size="sm"
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpenRiderLibrary();
+            }}
+          >
+            Abrir Biblioteca
+          </Button>
+        </CardContent>
+      </Card>
+    )}
   </div>
 );

--- a/src/pages/festival-management/FestivalManagementNavCards.tsx
+++ b/src/pages/festival-management/FestivalManagementNavCards.tsx
@@ -1,0 +1,141 @@
+import { Calendar, Layout, Library, Users } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type FestivalManagementNavCardsProps = {
+  artistCount: number;
+  isPlanningViewOnly: boolean;
+  isViewOnly: boolean;
+  jobId: string;
+  navigate: (path: string) => void;
+  onOpenRiderLibrary: () => void;
+};
+
+export const FestivalManagementNavCards = ({
+  artistCount,
+  isPlanningViewOnly,
+  isViewOnly,
+  jobId,
+  navigate,
+  onOpenRiderLibrary,
+}: FestivalManagementNavCardsProps) => (
+  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+    <Card
+      className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
+      onClick={() => navigate(`/festival-management/${jobId}/artists`)}
+    >
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-3 text-base md:text-lg">
+          <div className="p-2 rounded-lg bg-blue-500/10 text-blue-500 group-hover:bg-blue-500/20 transition-colors">
+            <Users className="h-5 w-5 md:h-6 md:w-6" />
+          </div>
+          <span className="group-hover:text-primary transition-colors">Artistas</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline gap-2">
+          <p className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-blue-600 to-blue-400 bg-clip-text text-transparent">
+            {artistCount}
+          </p>
+          <p className="text-xs md:text-sm text-muted-foreground">Total de Artistas</p>
+        </div>
+        <Button
+          className="w-full group-hover:shadow-md transition-shadow"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation();
+            navigate(`/festival-management/${jobId}/artists`);
+          }}
+        >
+          {isViewOnly ? "Ver Artistas" : "Gestionar Artistas"}
+        </Button>
+      </CardContent>
+    </Card>
+
+    <Card
+      className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
+      onClick={() => navigate(`/festival-management/${jobId}/gear`)}
+    >
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-3 text-base md:text-lg">
+          <div className="p-2 rounded-lg bg-purple-500/10 text-purple-500 group-hover:bg-purple-500/20 transition-colors">
+            <Layout className="h-5 w-5 md:h-6 md:w-6" />
+          </div>
+          <span className="group-hover:text-primary transition-colors">Escenarios y Equipo</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">Gestiona escenarios y equipo técnico</p>
+        <Button
+          className="w-full group-hover:shadow-md transition-shadow"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation();
+            navigate(`/festival-management/${jobId}/gear`);
+          }}
+        >
+          {isPlanningViewOnly ? "Ver Equipo" : "Gestionar Equipo"}
+        </Button>
+      </CardContent>
+    </Card>
+
+    <Card
+      className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
+      onClick={() => navigate(`/festival-management/${jobId}/scheduling`)}
+    >
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-3 text-base md:text-lg">
+          <div className="p-2 rounded-lg bg-green-500/10 text-green-500 group-hover:bg-green-500/20 transition-colors">
+            <Calendar className="h-5 w-5 md:h-6 md:w-6" />
+          </div>
+          <span className="group-hover:text-primary transition-colors">Planificación</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">
+          Gestiona turnos y asignaciones de personal
+        </p>
+        <Button
+          className="w-full group-hover:shadow-md transition-shadow"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation();
+            navigate(`/festival-management/${jobId}/scheduling`);
+          }}
+        >
+          {isPlanningViewOnly ? "Ver Planificación" : "Gestionar Planificación"}
+        </Button>
+      </CardContent>
+    </Card>
+
+    <Card
+      className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
+      onClick={onOpenRiderLibrary}
+    >
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-3 text-base md:text-lg">
+          <div className="p-2 rounded-lg bg-cyan-500/10 text-cyan-600 group-hover:bg-cyan-500/20 transition-colors">
+            <Library className="h-5 w-5 md:h-6 md:w-6" />
+          </div>
+          <span className="group-hover:text-primary transition-colors">Biblioteca de Riders</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">
+          Importa riders existentes como copias técnicas para este trabajo
+        </p>
+        <Button
+          className="w-full group-hover:shadow-md transition-shadow"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenRiderLibrary();
+          }}
+        >
+          Abrir Biblioteca
+        </Button>
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -8,8 +8,6 @@ import {
   Eye,
   FileText,
   FolderPlus,
-  Layout,
-  Library,
   Link as LinkIcon,
   Loader2,
   MapPin,
@@ -42,6 +40,7 @@ import { DOCUMENT_UPLOAD_ACCEPT } from "@/utils/documentUploadValidation";
 import { canSubmitTechnicianIncidentReports, isDepartmentManagementRole, isManagementRole } from "@/utils/permissions";
 
 import { FestivalManagementDialogs } from "./FestivalManagementDialogs";
+import { FestivalManagementNavCards } from "./FestivalManagementNavCards";
 
 export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => {
   const {
@@ -270,96 +269,14 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
 
       {!isSchedulingRoute && !isArtistRoute && !isGearRoute && (
         <>
-          {/* Modern Navigation Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 md:gap-6">
-            <Card
-              className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
-              onClick={() => navigate(`/festival-management/${jobId}/artists`)}
-            >
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-3 text-base md:text-lg">
-                  <div className="p-2 rounded-lg bg-blue-500/10 text-blue-500 group-hover:bg-blue-500/20 transition-colors">
-                    <Users className="h-5 w-5 md:h-6 md:w-6" />
-                  </div>
-                  <span className="group-hover:text-primary transition-colors">Artistas</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <div className="flex items-baseline gap-2">
-                  <p className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-blue-600 to-blue-400 bg-clip-text text-transparent">
-                    {artistCount}
-                  </p>
-                  <p className="text-xs md:text-sm text-muted-foreground">Total de Artistas</p>
-                </div>
-                <Button
-                  className="w-full group-hover:shadow-md transition-shadow"
-                  size="sm"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigate(`/festival-management/${jobId}/artists`);
-                  }}
-                >
-                  {isViewOnly ? "Ver Artistas" : "Gestionar Artistas"}
-                </Button>
-              </CardContent>
-            </Card>
-
-            <Card
-              className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
-              onClick={() => navigate(`/festival-management/${jobId}/gear`)}
-            >
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-3 text-base md:text-lg">
-                  <div className="p-2 rounded-lg bg-purple-500/10 text-purple-500 group-hover:bg-purple-500/20 transition-colors">
-                    <Layout className="h-5 w-5 md:h-6 md:w-6" />
-                  </div>
-                  <span className="group-hover:text-primary transition-colors">Escenarios y Equipo</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">Gestiona escenarios y equipo técnico</p>
-                <Button
-                  className="w-full group-hover:shadow-md transition-shadow"
-                  size="sm"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigate(`/festival-management/${jobId}/gear`);
-                  }}
-                >
-                  {isPlanningViewOnly ? "Ver Equipo" : "Gestionar Equipo"}
-                </Button>
-              </CardContent>
-            </Card>
-
-            <Card
-              className="group hover:shadow-xl hover:scale-[1.02] transition-all duration-300 cursor-pointer border-2 hover:border-primary/50 bg-gradient-to-br from-background to-accent/5"
-              onClick={() => navigate(`/festival-management/${jobId}/scheduling`)}
-            >
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-3 text-base md:text-lg">
-                  <div className="p-2 rounded-lg bg-green-500/10 text-green-500 group-hover:bg-green-500/20 transition-colors">
-                    <Calendar className="h-5 w-5 md:h-6 md:w-6" />
-                  </div>
-                  <span className="group-hover:text-primary transition-colors">Planificación</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <p className="text-xs md:text-sm text-muted-foreground min-h-[2.5rem]">
-                  Gestiona turnos y asignaciones de personal
-                </p>
-                <Button
-                  className="w-full group-hover:shadow-md transition-shadow"
-                  size="sm"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigate(`/festival-management/${jobId}/scheduling`);
-                  }}
-                >
-                  {isPlanningViewOnly ? "Ver Planificación" : "Gestionar Planificación"}
-                </Button>
-              </CardContent>
-            </Card>
-          </div>
+          <FestivalManagementNavCards
+            artistCount={artistCount}
+            isPlanningViewOnly={isPlanningViewOnly}
+            isViewOnly={isViewOnly}
+            jobId={jobId}
+            navigate={navigate}
+            onOpenRiderLibrary={() => handleOpenRiderLibrary()}
+          />
 
           <Card>
             <CardHeader className="pb-3">
@@ -421,19 +338,6 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                       Abrir
                     </Button>
                   </div>
-                </div>
-
-                <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3">
-                  <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
-                    <Library className="h-4 w-4 flex-shrink-0" />
-                    Biblioteca de Riders
-                  </div>
-                  <p className="text-xs md:text-sm text-muted-foreground">
-                    Importa riders existentes como copias técnicas para este trabajo.
-                  </p>
-                  <Button onClick={() => handleOpenRiderLibrary()} disabled={!jobId} size="sm" className="w-full">
-                    Abrir Biblioteca
-                  </Button>
                 </div>
 
                 <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3">

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   FolderPlus,
   Layout,
+  Library,
   Link as LinkIcon,
   Loader2,
   MapPin,
@@ -80,6 +81,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
     isAssignmentDialogOpen,
     handleNavigateTimesheets,
     handleOpenRouteSheet,
+    handleOpenRiderLibrary,
 
     flexStatus,
     handleCreateFlexFolders,
@@ -419,6 +421,19 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
                       Abrir
                     </Button>
                   </div>
+                </div>
+
+                <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3">
+                  <div className="flex items-center gap-2 text-xs md:text-sm font-semibold text-foreground">
+                    <Library className="h-4 w-4 flex-shrink-0" />
+                    Biblioteca de Riders
+                  </div>
+                  <p className="text-xs md:text-sm text-muted-foreground">
+                    Importa riders existentes como copias técnicas para este trabajo.
+                  </p>
+                  <Button onClick={() => handleOpenRiderLibrary()} disabled={!jobId} size="sm" className="w-full">
+                    Abrir Biblioteca
+                  </Button>
                 </div>
 
                 <div className="rounded-lg border p-3 md:p-4 space-y-2 md:space-y-3">

--- a/src/pages/festival-management/FestivalManagementView.tsx
+++ b/src/pages/festival-management/FestivalManagementView.tsx
@@ -271,6 +271,7 @@ export const FestivalManagementView = ({ vm }: { vm: FestivalManagementVm }) => 
         <>
           <FestivalManagementNavCards
             artistCount={artistCount}
+            canImportRiders={canEdit}
             isPlanningViewOnly={isPlanningViewOnly}
             isViewOnly={isViewOnly}
             jobId={jobId}

--- a/src/utils/pdf/festivalPdfGenerator.ts
+++ b/src/utils/pdf/festivalPdfGenerator.ts
@@ -805,7 +805,7 @@ export const generateAndMergeFestivalPDFs = async (
       if (artists && artists.length > 0) {
         const missingRiderArtists = artists.filter(artist =>
           Boolean(artist.rider_missing) ||
-          (Boolean(artist.rider_copied_from_date) && !artist.rider_outdated_dismissed)
+          ((Boolean(artist.rider_outdated) || Boolean(artist.rider_copied_from_date)) && !artist.rider_outdated_dismissed)
         );
 
         console.log(`Found ${missingRiderArtists.length} artists with missing or outdated riders out of ${artists.length} total artists`);

--- a/src/utils/pdf/festivalPdfGenerator.ts
+++ b/src/utils/pdf/festivalPdfGenerator.ts
@@ -17,6 +17,7 @@ import { generateWeatherPDF, WeatherPdfData } from './weatherPdfGenerator';
 import { ensurePublicArtistFormLinks } from '../publicArtistFormLinks';
 import { buildReadableFilename } from '@/utils/fileName';
 import { combineWavesDisplay } from '@/constants/wavesModels';
+import { getArtistRiderStatus } from '@/features/festival-management/selectors';
 import {
   normalizeVenueCoordinates,
   resolveHojaVenue,
@@ -803,10 +804,7 @@ export const generateAndMergeFestivalPDFs = async (
       console.log("Processing Missing Rider Report generation");
       
       if (artists && artists.length > 0) {
-        const missingRiderArtists = artists.filter(artist =>
-          Boolean(artist.rider_missing) ||
-          ((Boolean(artist.rider_outdated) || Boolean(artist.rider_copied_from_date)) && !artist.rider_outdated_dismissed)
-        );
+        const missingRiderArtists = artists.filter((artist) => getArtistRiderStatus(artist) !== 'complete');
 
         console.log(`Found ${missingRiderArtists.length} artists with missing or outdated riders out of ${artists.length} total artists`);
         
@@ -822,19 +820,19 @@ export const generateAndMergeFestivalPDFs = async (
         const missingRiderData: MissingRiderReportData = {
           jobTitle,
           logoUrl,
-          artists: sortedMissingRiderArtists.map(artist => ({
-            id: artist.id,
-            name: artist.name || 'Unnamed Artist',
-            stage: artist.stage || 1,
-            stageName: getStageNameByNumber(artist.stage || 1),
-            date: artist.date || '',
-            showTime: {
-              start: artist.show_start || '',
-              end: artist.show_end || ''
-            },
-            formUrl: publicFormLinksByArtistId[artist.id],
-            status: artist.rider_missing ? 'missing' as const : 'outdated' as const,
-            copiedFromDate: artist.rider_copied_from_date || undefined,
+          artists: sortedMissingRiderArtists.map((artist) => ({
+              id: artist.id,
+              name: artist.name || 'Unnamed Artist',
+              stage: artist.stage || 1,
+              stageName: getStageNameByNumber(artist.stage || 1),
+              date: artist.date || '',
+              showTime: {
+                start: artist.show_start || '',
+                end: artist.show_end || ''
+              },
+              formUrl: publicFormLinksByArtistId[artist.id],
+              status: getArtistRiderStatus(artist) === 'missing' ? 'missing' as const : 'outdated' as const,
+              copiedFromDate: artist.rider_copied_from_date || undefined,
           }))
         };
 

--- a/supabase/functions/delete-public-artist-rider/index.ts
+++ b/supabase/functions/delete-public-artist-rider/index.ts
@@ -146,38 +146,34 @@ serve(createHttpHandler(async (req) => {
       return jsonResponse({ ok: false, error: "file_not_found" }, { status: 404 });
     }
 
-    const { count: referenceCount, error: referenceCountError } = await supabaseAdmin
-      .from("festival_artist_files")
-      .select("id", { count: "exact", head: true })
-      .eq("file_path", fileRow.file_path);
-
-    if (referenceCountError) {
-      console.error("[delete-public-artist-rider] file reference count error", referenceCountError);
-      return jsonResponse({ ok: false, error: "file_reference_count_failed" }, { status: 500 });
-    }
-
-    const { error: deleteError } = await supabaseAdmin
-      .from("festival_artist_files")
-      .delete()
-      .eq("id", fileRow.id)
-      .eq("artist_id", formRow.artist_id);
+    const { data: deleteRows, error: deleteError } = await supabaseAdmin
+      .rpc("delete_festival_artist_file_reference", {
+        p_artist_id: formRow.artist_id,
+        p_file_id: fileRow.id,
+      });
 
     if (deleteError) {
       console.error("[delete-public-artist-rider] metadata delete error", deleteError);
       return jsonResponse({ ok: false, error: "metadata_delete_failed" }, { status: 500 });
     }
 
-    if ((referenceCount ?? 0) <= 1) {
+    const deleteResult = deleteRows?.[0];
+    if (!deleteResult) {
+      console.error("[delete-public-artist-rider] metadata delete returned no result");
+      return jsonResponse({ ok: false, error: "metadata_delete_failed" }, { status: 500 });
+    }
+
+    if (deleteResult.should_delete_storage && deleteResult.file_path) {
       const { error: storageError } = await supabaseAdmin.storage
         .from("festival_artist_files")
-        .remove([fileRow.file_path]);
+        .remove([deleteResult.file_path]);
 
       if (storageError) {
         console.error("[delete-public-artist-rider] storage remove error", storageError);
       }
     }
 
-    return jsonResponse({ ok: true, deleted_file_id: fileRow.id }, { status: 200 });
+    return jsonResponse({ ok: true, deleted_file_id: deleteResult.deleted_file_id }, { status: 200 });
   } catch (error) {
     if (error instanceof HttpError) throw error;
     console.error("[delete-public-artist-rider] unexpected error", error);

--- a/supabase/functions/delete-public-artist-rider/index.ts
+++ b/supabase/functions/delete-public-artist-rider/index.ts
@@ -146,12 +146,14 @@ serve(createHttpHandler(async (req) => {
       return jsonResponse({ ok: false, error: "file_not_found" }, { status: 404 });
     }
 
-    const { error: storageError } = await supabaseAdmin.storage
+    const { count: referenceCount, error: referenceCountError } = await supabaseAdmin
       .from("festival_artist_files")
-      .remove([fileRow.file_path]);
+      .select("id", { count: "exact", head: true })
+      .eq("file_path", fileRow.file_path);
 
-    if (storageError) {
-      console.error("[delete-public-artist-rider] storage remove error", storageError);
+    if (referenceCountError) {
+      console.error("[delete-public-artist-rider] file reference count error", referenceCountError);
+      return jsonResponse({ ok: false, error: "file_reference_count_failed" }, { status: 500 });
     }
 
     const { error: deleteError } = await supabaseAdmin
@@ -163,6 +165,16 @@ serve(createHttpHandler(async (req) => {
     if (deleteError) {
       console.error("[delete-public-artist-rider] metadata delete error", deleteError);
       return jsonResponse({ ok: false, error: "metadata_delete_failed" }, { status: 500 });
+    }
+
+    if ((referenceCount ?? 0) <= 1) {
+      const { error: storageError } = await supabaseAdmin.storage
+        .from("festival_artist_files")
+        .remove([fileRow.file_path]);
+
+      if (storageError) {
+        console.error("[delete-public-artist-rider] storage remove error", storageError);
+      }
     }
 
     return jsonResponse({ ok: true, deleted_file_id: fileRow.id }, { status: 200 });

--- a/supabase/functions/upload-public-artist-rider/index.ts
+++ b/supabase/functions/upload-public-artist-rider/index.ts
@@ -364,6 +364,26 @@ async function notifyRiderUpload(
   }
 }
 
+async function clearArtistRiderFreshness(
+  supabaseAdmin: ReturnType<typeof createClient>,
+  artistId: string,
+) {
+  const { error } = await supabaseAdmin
+    .from("festival_artists")
+    .update({
+      rider_missing: false,
+      rider_outdated: false,
+      rider_copied_from_date: null,
+      rider_outdated_dismissed: false,
+    })
+    .eq("id", artistId);
+
+  if (error) {
+    console.error("[upload-public-artist-rider] artist rider freshness update error", error);
+    throw new Error("artist_rider_state_update_failed");
+  }
+}
+
 async function insertUploadedRiderFiles(
   supabaseAdmin: ReturnType<typeof createClient>,
   context: UploadContext,
@@ -424,6 +444,8 @@ async function insertUploadedRiderFiles(
 
       insertedFiles.push(insertedFile as Record<string, unknown>);
     }
+
+    await clearArtistRiderFreshness(supabaseAdmin, context.formRow.artist_id);
   } catch (error) {
     if (insertedFiles.length > 0) {
       const insertedIds = insertedFiles
@@ -750,6 +772,8 @@ serve(createHttpHandler(async (req) => {
 
         insertedFiles.push(insertedFile as Record<string, unknown>);
       }
+
+      await clearArtistRiderFreshness(supabaseAdmin, formRow.artist_id);
     } catch (uploadError) {
       if (uploadedPaths.length > 0) {
         await supabaseAdmin.storage.from("festival_artist_files").remove(uploadedPaths);

--- a/supabase/migrations/20260706130000_rider_library_import.sql
+++ b/supabase/migrations/20260706130000_rider_library_import.sql
@@ -51,26 +51,30 @@ BEGIN
   SELECT *
   INTO v_source_artist
   FROM public.festival_artists
-  WHERE id = p_source_artist_id;
+  WHERE id = p_source_artist_id
+  FOR SHARE;
 
   IF NOT FOUND THEN
     RAISE EXCEPTION 'source_artist_not_found'
       USING ERRCODE = 'P0002';
   END IF;
 
-  IF NOT EXISTS (
-    SELECT 1
-    FROM public.jobs
-    WHERE id = p_target_job_id
-  ) THEN
+  PERFORM 1
+  FROM public.jobs
+  WHERE id = p_target_job_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
     RAISE EXCEPTION 'target_job_not_found'
       USING ERRCODE = 'P0002';
   END IF;
 
-  SELECT count(*)::integer
-  INTO v_file_count
+  PERFORM 1
   FROM public.festival_artist_files
-  WHERE artist_id = p_source_artist_id;
+  WHERE artist_id = p_source_artist_id
+  FOR SHARE;
+
+  GET DIAGNOSTICS v_file_count = ROW_COUNT;
 
   IF v_file_count = 0 THEN
     RAISE EXCEPTION 'source_artist_has_no_riders'
@@ -268,3 +272,64 @@ COMMENT ON FUNCTION public.import_artist_rider_to_job(uuid, uuid, date, integer)
 
 REVOKE ALL ON FUNCTION public.import_artist_rider_to_job(uuid, uuid, date, integer) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.import_artist_rider_to_job(uuid, uuid, date, integer) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.delete_festival_artist_file_reference(
+  p_file_id uuid,
+  p_artist_id uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  deleted_file_id uuid,
+  file_path text,
+  should_delete_storage boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_role text;
+  v_file public.festival_artist_files%ROWTYPE;
+  v_remaining_references integer;
+BEGIN
+  v_role := public.get_current_user_role();
+  IF auth.role() <> 'service_role'
+    AND (v_role IS NULL OR v_role <> ALL (ARRAY['admin', 'management', 'logistics'])) THEN
+    RAISE EXCEPTION 'not_authorized'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_file_id IS NULL THEN
+    RAISE EXCEPTION 'missing_required_argument'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT *
+  INTO v_file
+  FROM public.festival_artist_files
+  WHERE id = p_file_id
+    AND (p_artist_id IS NULL OR artist_id = p_artist_id)
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'file_not_found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  DELETE FROM public.festival_artist_files
+  WHERE id = v_file.id;
+
+  SELECT count(*)::integer
+  INTO v_remaining_references
+  FROM public.festival_artist_files remaining_file
+  WHERE remaining_file.file_path = v_file.file_path;
+
+  RETURN QUERY
+  SELECT v_file.id, v_file.file_path, v_remaining_references = 0;
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_festival_artist_file_reference(uuid, uuid) IS
+  'Deletes one rider file metadata reference and reports whether the shared storage object has no remaining references.';
+
+REVOKE ALL ON FUNCTION public.delete_festival_artist_file_reference(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.delete_festival_artist_file_reference(uuid, uuid) TO authenticated, service_role;

--- a/supabase/migrations/20260706130000_rider_library_import.sql
+++ b/supabase/migrations/20260706130000_rider_library_import.sql
@@ -1,0 +1,270 @@
+ALTER TABLE public.festival_artists
+  ADD COLUMN IF NOT EXISTS rider_outdated boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.festival_artists.rider_outdated IS
+  'Explicit rider freshness flag. Imported/copied riders are marked true until a current rider is uploaded for the artist.';
+
+CREATE INDEX IF NOT EXISTS idx_festival_artist_files_uploaded_at
+  ON public.festival_artist_files (uploaded_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_festival_artist_files_file_path
+  ON public.festival_artist_files (file_path);
+
+CREATE OR REPLACE FUNCTION public.import_artist_rider_to_job(
+  p_source_artist_id uuid,
+  p_target_job_id uuid,
+  p_target_date date,
+  p_target_stage integer
+)
+RETURNS TABLE (
+  imported_artist_id uuid,
+  imported_file_count integer,
+  target_date date,
+  target_stage integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_role text;
+  v_source_artist public.festival_artists%ROWTYPE;
+  v_imported_artist_id uuid;
+  v_file_count integer;
+BEGIN
+  v_role := public.get_current_user_role();
+  IF v_role IS NULL OR v_role <> ALL (ARRAY['admin', 'management', 'logistics']) THEN
+    RAISE EXCEPTION 'not_authorized'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_source_artist_id IS NULL OR p_target_job_id IS NULL OR p_target_date IS NULL THEN
+    RAISE EXCEPTION 'missing_required_argument'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_target_stage IS NULL OR p_target_stage < 1 OR p_target_stage > 4 THEN
+    RAISE EXCEPTION 'invalid_target_stage'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT *
+  INTO v_source_artist
+  FROM public.festival_artists
+  WHERE id = p_source_artist_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'source_artist_not_found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.jobs
+    WHERE id = p_target_job_id
+  ) THEN
+    RAISE EXCEPTION 'target_job_not_found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT count(*)::integer
+  INTO v_file_count
+  FROM public.festival_artist_files
+  WHERE artist_id = p_source_artist_id;
+
+  IF v_file_count = 0 THEN
+    RAISE EXCEPTION 'source_artist_has_no_riders'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.festival_artist_files source_file
+    JOIN public.festival_artist_files target_file
+      ON target_file.file_path = source_file.file_path
+    JOIN public.festival_artists target_artist
+      ON target_artist.id = target_file.artist_id
+    WHERE source_file.artist_id = p_source_artist_id
+      AND target_artist.job_id = p_target_job_id
+  ) THEN
+    RAISE EXCEPTION 'duplicate_rider_import'
+      USING ERRCODE = '23505';
+  END IF;
+
+  INSERT INTO public.festival_artists (
+    job_id,
+    name,
+    date,
+    stage,
+    show_start,
+    show_end,
+    soundcheck,
+    soundcheck_start,
+    soundcheck_end,
+    line_check,
+    line_check_start,
+    line_check_end,
+    load_in_time,
+    foh_console,
+    foh_console_provided_by,
+    foh_drive,
+    foh_drive_position,
+    foh_outboard,
+    foh_tech,
+    foh_waves_models,
+    foh_waves_provided_by,
+    mon_console,
+    mon_console_provided_by,
+    mon_position,
+    mon_outboard,
+    mon_tech,
+    mon_waves_models,
+    mon_waves_provided_by,
+    monitors_from_foh,
+    wireless_quantity,
+    wireless_systems,
+    wireless_provided_by,
+    iem_systems,
+    iem_provided_by,
+    monitors_enabled,
+    monitors_quantity,
+    extras_sf,
+    extras_df,
+    extras_djbooth,
+    extras_wired,
+    mic_pack,
+    rf_festival_mics,
+    rf_festival_wireless,
+    rf_festival_url,
+    infra_cat6,
+    infra_cat6_quantity,
+    infra_hma,
+    infra_hma_quantity,
+    infra_coax,
+    infra_coax_quantity,
+    infra_opticalcon_duo,
+    infra_opticalcon_duo_quantity,
+    infra_analog,
+    other_infrastructure,
+    infrastructure_provided_by,
+    notes,
+    crew,
+    timezone,
+    isaftermidnight,
+    rider_missing,
+    rider_copied_from_date,
+    rider_outdated,
+    rider_outdated_dismissed,
+    mic_kit,
+    wired_mics,
+    form_language,
+    stage_plot_file_path,
+    stage_plot_file_name,
+    stage_plot_file_type,
+    stage_plot_uploaded_at
+  )
+  VALUES (
+    p_target_job_id,
+    v_source_artist.name,
+    p_target_date,
+    p_target_stage,
+    NULL,
+    NULL,
+    false,
+    NULL,
+    NULL,
+    false,
+    NULL,
+    NULL,
+    NULL,
+    v_source_artist.foh_console,
+    v_source_artist.foh_console_provided_by,
+    v_source_artist.foh_drive,
+    v_source_artist.foh_drive_position,
+    v_source_artist.foh_outboard,
+    v_source_artist.foh_tech,
+    v_source_artist.foh_waves_models,
+    v_source_artist.foh_waves_provided_by,
+    v_source_artist.mon_console,
+    v_source_artist.mon_console_provided_by,
+    v_source_artist.mon_position,
+    v_source_artist.mon_outboard,
+    v_source_artist.mon_tech,
+    v_source_artist.mon_waves_models,
+    v_source_artist.mon_waves_provided_by,
+    v_source_artist.monitors_from_foh,
+    v_source_artist.wireless_quantity,
+    v_source_artist.wireless_systems,
+    v_source_artist.wireless_provided_by,
+    v_source_artist.iem_systems,
+    v_source_artist.iem_provided_by,
+    v_source_artist.monitors_enabled,
+    v_source_artist.monitors_quantity,
+    v_source_artist.extras_sf,
+    v_source_artist.extras_df,
+    v_source_artist.extras_djbooth,
+    v_source_artist.extras_wired,
+    v_source_artist.mic_pack,
+    v_source_artist.rf_festival_mics,
+    v_source_artist.rf_festival_wireless,
+    v_source_artist.rf_festival_url,
+    v_source_artist.infra_cat6,
+    v_source_artist.infra_cat6_quantity,
+    v_source_artist.infra_hma,
+    v_source_artist.infra_hma_quantity,
+    v_source_artist.infra_coax,
+    v_source_artist.infra_coax_quantity,
+    v_source_artist.infra_opticalcon_duo,
+    v_source_artist.infra_opticalcon_duo_quantity,
+    v_source_artist.infra_analog,
+    v_source_artist.other_infrastructure,
+    v_source_artist.infrastructure_provided_by,
+    v_source_artist.notes,
+    v_source_artist.crew,
+    v_source_artist.timezone,
+    false,
+    false,
+    v_source_artist.date,
+    true,
+    false,
+    v_source_artist.mic_kit,
+    v_source_artist.wired_mics,
+    v_source_artist.form_language,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+  )
+  RETURNING id INTO v_imported_artist_id;
+
+  INSERT INTO public.festival_artist_files (
+    artist_id,
+    file_name,
+    file_path,
+    file_type,
+    file_size,
+    uploaded_by,
+    uploaded_at
+  )
+  SELECT
+    v_imported_artist_id,
+    file_name,
+    file_path,
+    file_type,
+    file_size,
+    uploaded_by,
+    uploaded_at
+  FROM public.festival_artist_files
+  WHERE artist_id = p_source_artist_id
+  ORDER BY uploaded_at DESC NULLS LAST, file_name ASC;
+
+  RETURN QUERY
+  SELECT v_imported_artist_id, v_file_count, p_target_date, p_target_stage;
+END;
+$$;
+
+COMMENT ON FUNCTION public.import_artist_rider_to_job(uuid, uuid, date, integer) IS
+  'Imports a rider-bearing source artist into a target job as an outdated technical copy with shared rider file references.';
+
+REVOKE ALL ON FUNCTION public.import_artist_rider_to_job(uuid, uuid, date, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.import_artist_rider_to_job(uuid, uuid, date, integer) TO authenticated;

--- a/supabase/migrations/20260706130000_rider_library_import.sql
+++ b/supabase/migrations/20260706130000_rider_library_import.sql
@@ -59,6 +59,7 @@ DECLARE
   v_source_artist public.festival_artists%ROWTYPE;
   v_imported_artist_id uuid;
   v_file_count integer;
+  v_file_path text;
 BEGIN
   v_role := public.get_current_user_role();
   IF v_role IS NULL OR v_role <> ALL (ARRAY['admin', 'management', 'logistics']) THEN
@@ -108,6 +109,18 @@ BEGIN
     RAISE EXCEPTION 'source_artist_has_no_riders'
       USING ERRCODE = 'P0002';
   END IF;
+
+  -- Serialize against delete_festival_artist_file_reference for every path this
+  -- import will reference, in a fixed order, so a concurrent delete can't drop
+  -- the shared storage object out from under this import (or vice versa).
+  FOR v_file_path IN
+    SELECT DISTINCT file_path
+    FROM public.festival_artist_files
+    WHERE artist_id = p_source_artist_id
+    ORDER BY file_path
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended(v_file_path, 0));
+  END LOOP;
 
   IF EXISTS (
     SELECT 1
@@ -342,6 +355,11 @@ BEGIN
     RAISE EXCEPTION 'file_not_found'
       USING ERRCODE = 'P0002';
   END IF;
+
+  -- Serialize against import_artist_rider_to_job for this path: hold the lock
+  -- across the delete-then-count so a concurrent import can't insert a fresh
+  -- reference in between and end up pointing at a storage object we just removed.
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_file.file_path, 0));
 
   DELETE FROM public.festival_artist_files
   WHERE id = v_file.id;

--- a/supabase/migrations/20260706130000_rider_library_import.sql
+++ b/supabase/migrations/20260706130000_rider_library_import.sql
@@ -10,6 +10,34 @@ CREATE INDEX IF NOT EXISTS idx_festival_artist_files_uploaded_at
 CREATE INDEX IF NOT EXISTS idx_festival_artist_files_file_path
   ON public.festival_artist_files (file_path);
 
+DROP POLICY IF EXISTS "p_storage_festival_artist_files_authorized_select" ON storage.objects;
+
+CREATE POLICY "p_storage_festival_artist_files_authorized_select"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'festival_artist_files'
+  AND public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM public.festival_artists fa
+      WHERE fa.id = CASE
+        WHEN split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          THEN split_part(storage.objects.name, '/', 1)::uuid
+        ELSE NULL
+      END
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.festival_artist_files faf
+      JOIN public.festival_artists fa ON fa.id = faf.artist_id
+      WHERE faf.file_path = storage.objects.name
+    )
+  )
+);
+
 CREATE OR REPLACE FUNCTION public.import_artist_rider_to_job(
   p_source_artist_id uuid,
   p_target_job_id uuid,

--- a/supabase/tests/database/festival_artist_permissions.sql
+++ b/supabase/tests/database/festival_artist_permissions.sql
@@ -130,6 +130,7 @@ SELECT ok(
       AND policyname = 'p_storage_festival_artist_files_authorized_select'
       AND cmd = 'SELECT'
       AND qual ILIKE '%festival_artist_files%'
+      AND qual ILIKE '%file_path%'
       AND qual ILIKE '%admin%'
       AND qual ILIKE '%management%'
       AND qual ILIKE '%logistics%'

--- a/supabase/tests/database/rider_library_import.sql
+++ b/supabase/tests/database/rider_library_import.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(15);
+SELECT plan(21);
 
 SELECT has_column('public', 'festival_artists', 'rider_outdated', 'festival artists track explicit outdated rider state');
 
@@ -52,6 +52,28 @@ SELECT ok(
 SELECT ok(
   has_function_privilege('authenticated', 'public.import_artist_rider_to_job(uuid, uuid, date, integer)', 'EXECUTE'),
   'authenticated callers can execute the rider library import RPC'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'delete_festival_artist_file_reference'
+      AND pg_get_function_identity_arguments(p.oid) = 'p_file_id uuid, p_artist_id uuid'
+  ),
+  'rider file reference delete RPC exists with the expected signature'
+);
+
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.delete_festival_artist_file_reference(uuid, uuid)', 'EXECUTE'),
+  'anon cannot execute the rider file reference delete RPC'
+);
+
+SELECT ok(
+  has_function_privilege('authenticated', 'public.delete_festival_artist_file_reference(uuid, uuid)', 'EXECUTE'),
+  'authenticated callers can execute the rider file reference delete RPC'
 );
 
 SELECT set_config('request.jwt.claim.role', 'service_role', false);
@@ -359,6 +381,15 @@ SELECT throws_ok(
   'house tech cannot import riders from the library'
 );
 
+SELECT throws_ok(
+  $$SELECT * FROM public.delete_festival_artist_file_reference(
+    '14000000-0000-0000-0000-000000000001'::uuid
+  )$$,
+  '42501',
+  'not_authorized',
+  'house tech cannot delete rider file references'
+);
+
 SELECT set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000001', false);
 
 SELECT is(
@@ -432,6 +463,44 @@ SELECT throws_ok(
   '23505',
   'duplicate_rider_import',
   'duplicate import is blocked when the target job already references a source file path'
+);
+
+SELECT is(
+  (
+    SELECT should_delete_storage
+    FROM public.delete_festival_artist_file_reference(
+      (
+        SELECT imported_file.id
+        FROM public.festival_artist_files imported_file
+        JOIN public.festival_artists imported_artist ON imported_artist.id = imported_file.artist_id
+        WHERE imported_artist.job_id = '12000000-0000-0000-0000-000000000002'::uuid
+          AND imported_artist.name = 'Source Rider Artist'
+          AND imported_file.file_path = 'shared/source-rider.pdf'
+        LIMIT 1
+      ),
+      (
+        SELECT imported_artist.id
+        FROM public.festival_artist_files imported_file
+        JOIN public.festival_artists imported_artist ON imported_artist.id = imported_file.artist_id
+        WHERE imported_artist.job_id = '12000000-0000-0000-0000-000000000002'::uuid
+          AND imported_artist.name = 'Source Rider Artist'
+          AND imported_file.file_path = 'shared/source-rider.pdf'
+        LIMIT 1
+      )
+    )
+  ),
+  false,
+  'deleting an imported rider metadata row preserves shared storage while the source still references it'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM public.festival_artist_files
+    WHERE id = '14000000-0000-0000-0000-000000000001'::uuid
+      AND file_path = 'shared/source-rider.pdf'
+  ),
+  'deleting a shared rider reference leaves the source rider metadata row intact'
 );
 
 SELECT throws_ok(

--- a/supabase/tests/database/rider_library_import.sql
+++ b/supabase/tests/database/rider_library_import.sql
@@ -1,0 +1,490 @@
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+SET search_path TO public, extensions;
+
+SELECT plan(15);
+
+SELECT has_column('public', 'festival_artists', 'rider_outdated', 'festival artists track explicit outdated rider state');
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'festival_artists'
+      AND column_name = 'rider_outdated'
+      AND is_nullable = 'NO'
+      AND column_default = 'false'
+  ),
+  'rider_outdated is not nullable and defaults to false'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'import_artist_rider_to_job'
+      AND pg_get_function_identity_arguments(p.oid) = 'p_source_artist_id uuid, p_target_job_id uuid, p_target_date date, p_target_stage integer'
+  ),
+  'rider library import RPC exists with the expected signature'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'import_artist_rider_to_job'
+      AND p.prosecdef
+      AND array_to_string(p.proconfig, ',') ILIKE '%search_path=pg_catalog, public%'
+  ),
+  'rider library import RPC is security definer with a pinned search_path'
+);
+
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.import_artist_rider_to_job(uuid, uuid, date, integer)', 'EXECUTE'),
+  'anon cannot execute the rider library import RPC'
+);
+
+SELECT ok(
+  has_function_privilege('authenticated', 'public.import_artist_rider_to_job(uuid, uuid, date, integer)', 'EXECUTE'),
+  'authenticated callers can execute the rider library import RPC'
+);
+
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+SELECT set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000001', false);
+
+DELETE FROM public.festival_artist_files
+WHERE artist_id IN (
+    '13000000-0000-0000-0000-000000000001'::uuid,
+    '13000000-0000-0000-0000-000000000002'::uuid,
+    '13000000-0000-0000-0000-000000000003'::uuid
+  )
+  OR file_path IN ('shared/source-rider.pdf', 'shared/second-rider.pdf')
+  OR artist_id IN (
+    SELECT id
+    FROM public.festival_artists
+    WHERE job_id = '12000000-0000-0000-0000-000000000002'::uuid
+  );
+
+DELETE FROM public.festival_artists
+WHERE id IN (
+    '13000000-0000-0000-0000-000000000001'::uuid,
+    '13000000-0000-0000-0000-000000000002'::uuid,
+    '13000000-0000-0000-0000-000000000003'::uuid
+  )
+  OR job_id IN (
+    '12000000-0000-0000-0000-000000000001'::uuid,
+    '12000000-0000-0000-0000-000000000002'::uuid
+  );
+
+DELETE FROM public.jobs
+WHERE id IN (
+  '12000000-0000-0000-0000-000000000001'::uuid,
+  '12000000-0000-0000-0000-000000000002'::uuid
+);
+
+DELETE FROM public.profiles
+WHERE id IN (
+  '11000000-0000-0000-0000-000000000001'::uuid,
+  '11000000-0000-0000-0000-000000000002'::uuid,
+  '11000000-0000-0000-0000-000000000003'::uuid
+);
+
+DELETE FROM auth.users
+WHERE id IN (
+  '11000000-0000-0000-0000-000000000001'::uuid,
+  '11000000-0000-0000-0000-000000000002'::uuid,
+  '11000000-0000-0000-0000-000000000003'::uuid
+);
+
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  aud,
+  role
+) VALUES
+  (
+    '11000000-0000-0000-0000-000000000001'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'rider-library-admin@test.local',
+    'test',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    'authenticated',
+    'authenticated'
+  ),
+  (
+    '11000000-0000-0000-0000-000000000002'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'rider-library-logistics@test.local',
+    'test',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    'authenticated',
+    'authenticated'
+  ),
+  (
+    '11000000-0000-0000-0000-000000000003'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'rider-library-house@test.local',
+    'test',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    'authenticated',
+    'authenticated'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.profiles (id, email, first_name, last_name, role, department)
+VALUES
+  ('11000000-0000-0000-0000-000000000001'::uuid, 'rider-library-admin@test.local', 'Rider', 'Admin', 'admin', 'sound'),
+  ('11000000-0000-0000-0000-000000000002'::uuid, 'rider-library-logistics@test.local', 'Rider', 'Logistics', 'logistics', 'logistics'),
+  ('11000000-0000-0000-0000-000000000003'::uuid, 'rider-library-house@test.local', 'Rider', 'House', 'house_tech', 'sound')
+ON CONFLICT (id) DO UPDATE
+SET email = excluded.email,
+    first_name = excluded.first_name,
+    last_name = excluded.last_name,
+    role = excluded.role,
+    department = excluded.department;
+
+INSERT INTO public.activity_catalog (code, label, default_visibility, severity, toast_enabled)
+VALUES ('job.created', 'Job created', 'management', 'info', false)
+ON CONFLICT (code) DO UPDATE
+SET label = excluded.label,
+    default_visibility = excluded.default_visibility,
+    severity = excluded.severity,
+    toast_enabled = excluded.toast_enabled;
+
+INSERT INTO public.jobs (id, title, start_time, end_time, job_type)
+VALUES
+  (
+    '12000000-0000-0000-0000-000000000001'::uuid,
+    'Rider Library Source',
+    '2026-07-01 08:00:00+02'::timestamptz,
+    '2026-07-02 02:00:00+02'::timestamptz,
+    'festival'
+  ),
+  (
+    '12000000-0000-0000-0000-000000000002'::uuid,
+    'Rider Library Target',
+    '2026-08-01 08:00:00+02'::timestamptz,
+    '2026-08-02 02:00:00+02'::timestamptz,
+    'festival'
+  )
+ON CONFLICT (id) DO UPDATE
+SET title = excluded.title,
+    start_time = excluded.start_time,
+    end_time = excluded.end_time,
+    job_type = excluded.job_type;
+
+INSERT INTO public.festival_artists (
+  id,
+  job_id,
+  name,
+  date,
+  stage,
+  show_start,
+  show_end,
+  soundcheck,
+  soundcheck_start,
+  soundcheck_end,
+  line_check,
+  line_check_start,
+  line_check_end,
+  load_in_time,
+  foh_console,
+  mon_console,
+  notes,
+  form_language,
+  rider_missing,
+  stage_plot_file_path,
+  stage_plot_file_name,
+  stage_plot_file_type,
+  stage_plot_uploaded_at
+) VALUES
+  (
+    '13000000-0000-0000-0000-000000000001'::uuid,
+    '12000000-0000-0000-0000-000000000001'::uuid,
+    'Source Rider Artist',
+    '2026-07-01',
+    2,
+    '22:00',
+    '23:00',
+    true,
+    '18:00',
+    '18:30',
+    true,
+    '17:30',
+    '17:45',
+    '16:00',
+    'SD7',
+    'PM5',
+    'source technical notes',
+    'en',
+    false,
+    '13000000-0000-0000-0000-000000000001/plot.pdf',
+    'plot.pdf',
+    'application/pdf',
+    '2026-07-01 10:00:00+02'::timestamptz
+  ),
+  (
+    '13000000-0000-0000-0000-000000000002'::uuid,
+    '12000000-0000-0000-0000-000000000001'::uuid,
+    'Second Source Rider Artist',
+    '2026-07-01',
+    1,
+    '20:00',
+    '21:00',
+    false,
+    NULL,
+    NULL,
+    false,
+    NULL,
+    NULL,
+    NULL,
+    'CL5',
+    'CL3',
+    'second notes',
+    'es',
+    false,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+  ),
+  (
+    '13000000-0000-0000-0000-000000000003'::uuid,
+    '12000000-0000-0000-0000-000000000001'::uuid,
+    'Source Without Rider',
+    '2026-07-01',
+    1,
+    NULL,
+    NULL,
+    false,
+    NULL,
+    NULL,
+    false,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    'es',
+    true,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+  )
+ON CONFLICT (id) DO UPDATE
+SET name = excluded.name,
+    job_id = excluded.job_id,
+    date = excluded.date,
+    stage = excluded.stage,
+    rider_missing = excluded.rider_missing;
+
+INSERT INTO public.festival_artist_files (
+  id,
+  artist_id,
+  file_name,
+  file_path,
+  file_type,
+  file_size,
+  uploaded_by,
+  uploaded_at
+) VALUES
+  (
+    '14000000-0000-0000-0000-000000000001'::uuid,
+    '13000000-0000-0000-0000-000000000001'::uuid,
+    'source-rider.pdf',
+    'shared/source-rider.pdf',
+    'application/pdf',
+    12345,
+    '11000000-0000-0000-0000-000000000001'::uuid,
+    '2026-07-01 12:00:00+02'::timestamptz
+  ),
+  (
+    '14000000-0000-0000-0000-000000000002'::uuid,
+    '13000000-0000-0000-0000-000000000002'::uuid,
+    'second-rider.pdf',
+    'shared/second-rider.pdf',
+    'application/pdf',
+    23456,
+    '11000000-0000-0000-0000-000000000001'::uuid,
+    '2026-07-01 13:00:00+02'::timestamptz
+  )
+ON CONFLICT (id) DO UPDATE
+SET artist_id = excluded.artist_id,
+    file_name = excluded.file_name,
+    file_path = excluded.file_path,
+    file_type = excluded.file_type,
+    file_size = excluded.file_size,
+    uploaded_by = excluded.uploaded_by,
+    uploaded_at = excluded.uploaded_at;
+
+SET ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+SELECT set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000003', false);
+
+SELECT throws_ok(
+  $$SELECT * FROM public.import_artist_rider_to_job(
+    '13000000-0000-0000-0000-000000000001'::uuid,
+    '12000000-0000-0000-0000-000000000002'::uuid,
+    '2026-08-01'::date,
+    2
+  )$$,
+  '42501',
+  'not_authorized',
+  'house tech cannot import riders from the library'
+);
+
+SELECT set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000001', false);
+
+SELECT is(
+  (
+    SELECT imported_file_count
+    FROM public.import_artist_rider_to_job(
+      '13000000-0000-0000-0000-000000000001'::uuid,
+      '12000000-0000-0000-0000-000000000002'::uuid,
+      '2026-08-01'::date,
+      2
+    )
+  ),
+  1,
+  'admin import returns the preserved rider file count'
+);
+
+RESET ROLE;
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM public.festival_artists
+    WHERE job_id = '12000000-0000-0000-0000-000000000002'::uuid
+      AND name = 'Source Rider Artist'
+      AND date = '2026-08-01'
+      AND stage = 2
+      AND rider_missing = false
+      AND rider_outdated = true
+      AND rider_outdated_dismissed = false
+      AND rider_copied_from_date = '2026-07-01'
+      AND show_start IS NULL
+      AND soundcheck_start IS NULL
+      AND line_check_start IS NULL
+      AND load_in_time IS NULL
+      AND stage_plot_file_path IS NULL
+      AND notes = 'source technical notes'
+      AND form_language = 'en'
+      AND foh_console = 'SD7'
+      AND mon_console = 'PM5'
+  ),
+  'imported artist maps technical fields, target scheduling, and outdated rider state'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM public.festival_artist_files imported_file
+    JOIN public.festival_artists imported_artist ON imported_artist.id = imported_file.artist_id
+    WHERE imported_artist.job_id = '12000000-0000-0000-0000-000000000002'::uuid
+      AND imported_artist.name = 'Source Rider Artist'
+      AND imported_file.file_name = 'source-rider.pdf'
+      AND imported_file.file_path = 'shared/source-rider.pdf'
+      AND imported_file.file_type = 'application/pdf'
+      AND imported_file.file_size = 12345
+      AND imported_file.uploaded_at = '2026-07-01 12:00:00+02'::timestamptz
+  ),
+  'imported rider metadata preserves the original storage reference and upload metadata'
+);
+
+SET ROLE authenticated;
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+SELECT set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000001', false);
+
+SELECT throws_ok(
+  $$SELECT * FROM public.import_artist_rider_to_job(
+    '13000000-0000-0000-0000-000000000001'::uuid,
+    '12000000-0000-0000-0000-000000000002'::uuid,
+    '2026-08-01'::date,
+    2
+  )$$,
+  '23505',
+  'duplicate_rider_import',
+  'duplicate import is blocked when the target job already references a source file path'
+);
+
+SELECT throws_ok(
+  $$SELECT * FROM public.import_artist_rider_to_job(
+    '13000000-0000-0000-0000-000000000003'::uuid,
+    '12000000-0000-0000-0000-000000000002'::uuid,
+    '2026-08-01'::date,
+    1
+  )$$,
+  'P0002',
+  'source_artist_has_no_riders',
+  'source artists without rider files cannot be imported'
+);
+
+SELECT set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000002', false);
+
+SELECT is(
+  (
+    SELECT imported_file_count
+    FROM public.import_artist_rider_to_job(
+      '13000000-0000-0000-0000-000000000002'::uuid,
+      '12000000-0000-0000-0000-000000000002'::uuid,
+      '2026-08-01'::date,
+      1
+    )
+  ),
+  1,
+  'logistics can import riders from the library'
+);
+
+RESET ROLE;
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.festival_artists
+    WHERE job_id = '12000000-0000-0000-0000-000000000002'::uuid
+      AND rider_outdated = true
+      AND rider_missing = false
+  ),
+  2,
+  'successful imports leave imported artists marked outdated but not missing'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artist_files'
+      AND indexname = 'idx_festival_artist_files_file_path'
+  ),
+  'rider file path index supports duplicate import checks'
+);
+
+SELECT * FROM finish();


### PR DESCRIPTION
## Summary
- Add a Rider Library in festival/job management and Planificación.
- Importing a library rider creates a technical-copy artist in the current job, references existing rider storage paths, and marks the rider as desactualizado.
- Add browse/search library modes, date/stage targeting, duplicate prevention, upload-date metadata, and shared-reference-safe rider deletion.

## Risk Assessment
- Medium: adds a Supabase migration/RPC and touches festival rider workflows.
- Main risks are import mapping, authorization, storage access for referenced riders, and shared rider file reference handling; these are covered by unit and pgtap database tests.

## Impact Checklist
- UI: Festival management nav, Planificación header, rider status badges/filters, Rider Library dialog.
- Data: festival_artists.rider_outdated, generated Supabase types, library fetch/import commands.
- Storage: imported riders reuse existing storage objects; select access follows active file metadata references, and deletes remove storage only when no metadata references remain.

## Migration Impact
- Adds festival_artists.rider_outdated boolean not null default false.
- Adds indexes for rider file upload sorting and duplicate file_path checks.
- Adds import_artist_rider_to_job and delete_festival_artist_file_reference RPCs.
- Updates festival rider storage select policy so referenced rider paths stay readable while any active file metadata row points to them.

## Rollback Plan
- Revert this PR to remove the UI/data-layer changes.
- If already deployed, apply a follow-up migration to drop the new RPCs, indexes, storage policy override, and rider_outdated column after confirming no dependent release remains live.

## Validation
- npm run lint
- npm run typecheck
- npm run governance:filesize
- npm run test:run
- npm run build
- npm run ci:db:migrations
- supabase db reset --local --no-seed
- supabase db lint --local --fail-on error --schema public,auth
- supabase test db supabase/tests/database/festival_artist_permissions.sql
- supabase test db supabase/tests/database/rider_library_import.sql
- supabase test db supabase/tests/database
- Browser check on http://localhost:8080/ confirmed Rider Library card plus Explorar/Buscar tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Riders library for browsing and importing rider files into a selected date and stage.
  * Added a Riders shortcut in festival scheduling and a new library card in the festival management navigation.
  * Added an “Outdated” rider status with updated labels and filtering.

* **Bug Fixes**
  * Rider uploads now refresh rider status more reliably after completion.
  * Deleting rider files now uses safer shared-file handling to avoid removing storage unexpectedly.
  * Missing rider reports now reflect the updated rider status more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->