### PR TITLE
Fix Flex proxy calls for tour folder creation

### DIFF
--- a/src/hooks/tours/useTourCreationMutation.ts
+++ b/src/hooks/tours/useTourCreationMutation.ts
@@ -2,6 +2,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { Department } from "@/types/department";
 import { InvoicingCompany } from "@/types/job";
 import { useLocationManagement } from "@/hooks/useLocationManagement";
+import { createFlexFolder } from "@/utils/flex-folders/api";
 import { 
   FLEX_FOLDER_IDS, 
   DEPARTMENT_IDS, 
@@ -23,35 +24,6 @@ interface TourCreationData {
 export const useTourCreationMutation = () => {
   const { getOrCreateLocation } = useLocationManagement();
 
-  const createFlexFolder = async (payload: Record<string, any>) => {
-    console.log("Creating Flex folder with payload:", payload);
-    
-    try {
-      const { data, error } = await supabase.functions.invoke('secure-flex-api', {
-        body: {
-          endpoint: '/element',
-          method: 'POST',
-          payload
-        }
-      });
-
-      if (error) {
-        console.error("Secure Flex API error:", error);
-        throw new Error(error.message || "Failed to create folder in Flex");
-      }
-
-      if (!data.success) {
-        throw new Error(data.error || "Failed to create folder in Flex");
-      }
-
-      console.log("Created Flex folder:", data.data);
-      return data.data;
-    } catch (error) {
-      console.error("Error creating Flex folder:", error);
-      throw error;
-    }
-  };
-
   const createFlexFolders = async (tour: any, startDate: string, endDate: string) => {
     console.log("Creating Flex folders for tour:", tour.id);
     
@@ -62,7 +34,6 @@ export const useTourCreationMutation = () => {
 
       const mainFolderPayload = {
         definitionId: FLEX_FOLDER_IDS.mainFolder,
-        parentElementId: null as string | null,
         open: true,
         locked: false,
         name: tour.name,

--- a/src/utils/__tests__/tourFolders.test.ts
+++ b/src/utils/__tests__/tourFolders.test.ts
@@ -131,7 +131,7 @@ vi.mock("@/lib/supabase", () => {
   };
 });
 
-import { createTourRootFoldersManual } from "../tourFolders";
+import { createTourRootFoldersManual } from "@/utils/tourFolders";
 
 describe("createTourRootFoldersManual", () => {
   beforeEach(() => {

--- a/src/utils/__tests__/tourFolders.test.ts
+++ b/src/utils/__tests__/tourFolders.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface MockTourDate {
+  id: string;
+  date: string;
+  location_id: string | null;
+}
+
+interface MockTour {
+  id: string;
+  name: string;
+  start_date: string | null;
+  end_date: string | null;
+  tour_dates: MockTourDate[];
+}
+
+interface TourUpdate {
+  filters: Record<string, unknown>;
+  payload: unknown;
+}
+
+interface TestState {
+  flexFolderInserts: unknown[];
+  tourUpdates: TourUpdate[];
+  tour: MockTour | null;
+}
+
+interface FlexFolderMockResponse {
+  elementId: string;
+  elementNumber: string;
+}
+
+const { createFlexFolderMock, functionInvokeMock, state } = vi.hoisted(() => {
+  const state: TestState = {
+    flexFolderInserts: [],
+    tourUpdates: [],
+    tour: null,
+  };
+
+  return {
+    createFlexFolderMock:
+      vi.fn<(payload: Record<string, unknown>) => Promise<FlexFolderMockResponse>>(),
+    functionInvokeMock: vi.fn<() => Promise<unknown>>(),
+    state,
+  };
+});
+
+vi.mock("@/utils/flex-folders/api", () => ({
+  createFlexFolder: createFlexFolderMock,
+}));
+
+vi.mock("@/lib/supabase", () => {
+  type SupabaseResult<T> = Promise<{ data: T; error: unknown }>;
+
+  type QueryAction = "select" | "insert" | "update";
+
+  class MockQueryBuilder {
+    private table: string;
+    private action: QueryAction | null = null;
+    private payload: unknown = null;
+    private filters: Record<string, unknown> = {};
+
+    constructor(table: string) {
+      this.table = table;
+    }
+
+    select(_columns?: string) {
+      this.action = "select";
+      return this;
+    }
+
+    insert(payload: unknown) {
+      this.action = "insert";
+      this.payload = payload;
+      return this;
+    }
+
+    update(payload: unknown) {
+      this.action = "update";
+      this.payload = payload;
+      return this;
+    }
+
+    eq(column: string, value: unknown) {
+      this.filters[column] = value;
+      return this;
+    }
+
+    single() {
+      return this;
+    }
+
+    private async execute(): SupabaseResult<unknown> {
+      if (this.table === "tours" && this.action === "select") {
+        return { data: state.tour, error: state.tour ? null : { message: "not found" } };
+      }
+
+      if (this.table === "tours" && this.action === "update") {
+        state.tourUpdates.push({
+          filters: { ...this.filters },
+          payload: this.payload,
+        });
+        return { data: null, error: null };
+      }
+
+      if (this.table === "flex_folders" && this.action === "insert") {
+        state.flexFolderInserts.push(this.payload);
+        return { data: null, error: null };
+      }
+
+      return { data: null, error: null };
+    }
+
+    then<TResult1 = unknown, TResult2 = never>(
+      onfulfilled?:
+        | ((value: { data: unknown; error: unknown }) => TResult1 | PromiseLike<TResult1>)
+        | null,
+      onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+    ) {
+      return this.execute().then(onfulfilled, onrejected);
+    }
+  }
+
+  return {
+    supabase: {
+      from: (table: string) => new MockQueryBuilder(table),
+      functions: {
+        invoke: functionInvokeMock,
+      },
+    },
+  };
+});
+
+import { createTourRootFoldersManual } from "../tourFolders";
+
+describe("createTourRootFoldersManual", () => {
+  beforeEach(() => {
+    createFlexFolderMock.mockReset();
+    functionInvokeMock.mockReset();
+    state.flexFolderInserts = [];
+    state.tourUpdates = [];
+    state.tour = {
+      id: "tour-1",
+      name: "Kase-O",
+      start_date: null,
+      end_date: null,
+      tour_dates: [
+        { id: "date-2", date: "2026-08-05", location_id: null },
+        { id: "date-1", date: "2026-08-01", location_id: null },
+      ],
+    };
+
+    let counter = 0;
+    createFlexFolderMock.mockImplementation(async () => ({
+      elementId: `flex-${counter}`,
+      elementNumber: `F-${counter++}`,
+    }));
+  });
+
+  it("creates folders through the shared Flex API helper instead of invoking the proxy with a legacy payload", async () => {
+    const result = await createTourRootFoldersManual("tour-1");
+
+    expect(result.success).toBe(true);
+    expect(functionInvokeMock).not.toHaveBeenCalled();
+    expect(createFlexFolderMock).toHaveBeenCalled();
+
+    const [mainPayload] = createFlexFolderMock.mock.calls[0];
+    expect(mainPayload).toMatchObject({
+      name: "Kase-O",
+      documentNumber: "260801",
+      notes: "Manual folder creation from Web App",
+    });
+    expect(mainPayload).not.toHaveProperty("parentElementId");
+
+    expect(state.tourUpdates).toHaveLength(1);
+    expect(state.tourUpdates[0]).toMatchObject({
+      filters: { id: "tour-1" },
+      payload: {
+        flex_main_folder_id: "flex-0",
+        flex_main_folder_number: "F-0",
+        flex_folders_created: true,
+      },
+    });
+  });
+});

--- a/src/utils/tourFolders.ts
+++ b/src/utils/tourFolders.ts
@@ -6,6 +6,7 @@ import {
   RESPONSIBLE_PERSON_IDS, 
   DEPARTMENT_SUFFIXES 
 } from "@/utils/flex-folders/constants";
+import { createFlexFolder } from "@/utils/flex-folders/api";
 
 export interface TourFolderCreationResult {
   success: boolean;
@@ -98,37 +99,12 @@ export async function createTourRootFoldersManual(tourId: string): Promise<TourF
       endDate = dates[dates.length - 1];
     }
 
-    const createFlexFolder = async (payload: Record<string, any>) => {
-      console.log("Creating Flex folder with payload:", payload);
-      
-      const { data, error } = await supabase.functions.invoke('secure-flex-api', {
-        body: {
-          endpoint: '/element',
-          method: 'POST',
-          payload
-        }
-      });
-
-      if (error) {
-        console.error("Secure Flex API error:", error);
-        throw new Error(error.message || "Failed to create folder in Flex");
-      }
-
-      if (!data.success) {
-        throw new Error(data.error || "Failed to create folder in Flex");
-      }
-
-      console.log("Created Flex folder:", data.data);
-      return data.data;
-    };
-
     const formattedStartDate = new Date(startDate).toISOString().split('.')[0] + '.000Z';
     const formattedEndDate = new Date(endDate).toISOString().split('.')[0] + '.000Z';
     const documentNumber = new Date(startDate).toISOString().slice(2, 10).replace(/-/g, '');
 
     const mainFolderPayload = {
       definitionId: FLEX_FOLDER_IDS.mainFolder,
-      parentElementId: null as string | null,
       open: true,
       locked: false,
       name: tour.name,


### PR DESCRIPTION
## Summary
- Route tour root folder creation through the shared Flex API helper so POST bodies are serialized for secure-flex-api.
- Remove null parentElementId from root folder payloads to match existing root-folder creation paths.
- Add a regression test that guards the manual tour folder path against the legacy proxy payload shape.

## Validation
- npm run test:run
- npm run typecheck
- npm run lint
- npm run build

No Supabase migration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined tour folder creation to use a shared folder API helper, keeping the existing creation flow intact.
  * Minor adjustments to folder payload formatting.

* **Tests**
  * Added coverage for manual tour root folder creation, verifying the expected folder details and update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->