### PR TITLE
Fix Rack Builder equipment placement validation

### DIFF
--- a/supabase/migrations/20260707213000_harden_rack_builder_layout_item_validation.sql
+++ b/supabase/migrations/20260707213000_harden_rack_builder_layout_item_validation.sql
@@ -1,0 +1,139 @@
+-- Rack Builder placement validation reads related racks, layouts, devices,
+-- panel layouts, and existing layout items while an insert/update is in flight.
+-- In Area Tecnica those tables are protected by RLS, unlike the standalone
+-- source project. Keep the same backend-authoritative placement semantics, but
+-- execute the trigger with owner privileges after first checking the caller
+-- still has Rack Builder access.
+
+alter function public.rack_builder_layout_item_traits(uuid, uuid)
+  set search_path = public, pg_temp;
+
+alter function public.rack_builder_layout_item_slot(
+  public.rack_builder_rack_width,
+  integer,
+  integer,
+  boolean,
+  boolean
+) set search_path = public, pg_temp;
+
+alter function public.rack_builder_u_ranges_overlap(integer, integer, integer, integer)
+  set search_path = public, pg_temp;
+
+alter function public.rack_builder_slots_conflict(integer, integer, integer, integer)
+  set search_path = public, pg_temp;
+
+create or replace function public.rack_builder_validate_layout_item_semantics()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_rack record;
+  v_new_traits record;
+  v_new_slot record;
+  v_other record;
+  v_other_traits record;
+  v_other_slot record;
+begin
+  if auth.uid() is not null
+    and coalesce(auth.role(), '') <> 'service_role'
+    and not (
+      public.current_user_department() = any (array['sound', 'admin', 'management'])
+      or public.is_admin_or_management()
+    )
+  then
+    raise exception 'RB_AUTH: rack builder placement requires sound, admin, or management access'
+      using errcode = '42501';
+  end if;
+
+  select r.id, r.rack_units, r.depth_mm, r.width
+  into v_rack
+  from rack_builder_layouts l
+  join rack_builder_racks r on r.id = l.rack_id
+  where l.id = new.layout_id;
+
+  if not found then
+    raise exception 'RB_BOUNDS: layout % has no rack', new.layout_id;
+  end if;
+
+  select *
+  into v_new_traits
+  from rack_builder_layout_item_traits(new.device_id, new.panel_layout_id);
+
+  if new.start_u < 1 or new.start_u + v_new_traits.height_ru - 1 > v_rack.rack_units then
+    raise exception
+      'RB_BOUNDS: item % at U% with %U exceeds rack bounds 1..%U',
+      coalesce(new.id::text, '<new>'),
+      new.start_u,
+      v_new_traits.height_ru,
+      v_rack.rack_units;
+  end if;
+
+  select *
+  into v_new_slot
+  from rack_builder_layout_item_slot(
+    v_rack.width,
+    new.preferred_lane,
+    new.preferred_sub_lane,
+    v_new_traits.is_half_rack,
+    new.force_full_width
+  );
+
+  for v_other in
+    select *
+    from rack_builder_layout_items
+    where layout_id = new.layout_id
+      and id <> coalesce(new.id, '00000000-0000-0000-0000-000000000000'::uuid)
+  loop
+    select *
+    into v_other_traits
+    from rack_builder_layout_item_traits(v_other.device_id, v_other.panel_layout_id);
+
+    if not rack_builder_u_ranges_overlap(new.start_u, v_new_traits.height_ru, v_other.start_u, v_other_traits.height_ru) then
+      continue;
+    end if;
+
+    select *
+    into v_other_slot
+    from rack_builder_layout_item_slot(
+      v_rack.width,
+      v_other.preferred_lane,
+      v_other.preferred_sub_lane,
+      v_other_traits.is_half_rack,
+      v_other.force_full_width
+    );
+
+    if not rack_builder_slots_conflict(
+      v_new_slot.outer_lane,
+      v_new_slot.inner_lane,
+      v_other_slot.outer_lane,
+      v_other_slot.inner_lane
+    ) then
+      continue;
+    end if;
+
+    if v_other.facing = new.facing then
+      raise exception
+        'RB_SLOT: item % overlaps item % on facing %',
+        coalesce(new.id::text, '<new>'),
+        v_other.id,
+        new.facing;
+    end if;
+
+    if v_new_traits.depth_mm + v_other_traits.depth_mm > v_rack.depth_mm then
+      raise exception
+        'RB_DEPTH: item % (%mm) collides with item % (%mm) in rack depth %mm',
+        coalesce(new.id::text, '<new>'),
+        v_new_traits.depth_mm,
+        v_other.id,
+        v_other_traits.depth_mm,
+        v_rack.depth_mm;
+    end if;
+  end loop;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.rack_builder_validate_layout_item_semantics() from public, anon;

--- a/supabase/tests/database/rack_builder_permissions.sql
+++ b/supabase/tests/database/rack_builder_permissions.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(23);
+SELECT plan(25);
 
 SELECT has_table('public', 'rack_builder_racks', 'rack builder racks table exists');
 SELECT has_table('public', 'rack_builder_devices', 'rack builder devices table exists');
@@ -165,6 +165,169 @@ SELECT ok(
   ),
   'rack layout item geometry validation trigger is installed'
 );
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'rack_builder_validate_layout_item_semantics'
+      AND p.prosecdef
+      AND p.proconfig @> ARRAY['search_path=public, pg_temp']
+  ),
+  'rack layout item validation trigger function runs as a pinned security definer'
+);
+
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  aud,
+  role
+) VALUES (
+  '82400000-0000-0000-0000-000000000001'::uuid,
+  '00000000-0000-0000-0000-000000000000'::uuid,
+  'rack-builder-placement@test.local',
+  'test',
+  now(),
+  now(),
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{}'::jsonb,
+  'authenticated',
+  'authenticated'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.profiles (id, email, first_name, last_name, role, department)
+VALUES (
+  '82400000-0000-0000-0000-000000000001'::uuid,
+  'rack-builder-placement@test.local',
+  'Rack',
+  'Builder',
+  'house_tech',
+  'sound'
+)
+ON CONFLICT (id) DO UPDATE
+SET email = excluded.email,
+    first_name = excluded.first_name,
+    last_name = excluded.last_name,
+    role = excluded.role,
+    department = excluded.department;
+
+INSERT INTO public.rack_builder_device_categories (id, name)
+VALUES ('82410000-0000-0000-0000-000000000001'::uuid, 'Placement Test Category')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.rack_builder_devices (
+  id,
+  brand,
+  model,
+  rack_units,
+  depth_mm,
+  category_id,
+  is_half_rack
+) VALUES (
+  '82410000-0000-0000-0000-000000000002'::uuid,
+  'Placement',
+  'Validator',
+  2,
+  200,
+  '82410000-0000-0000-0000-000000000001'::uuid,
+  false
+)
+ON CONFLICT (id) DO UPDATE
+SET brand = excluded.brand,
+    model = excluded.model,
+    rack_units = excluded.rack_units,
+    depth_mm = excluded.depth_mm,
+    category_id = excluded.category_id,
+    is_half_rack = excluded.is_half_rack;
+
+INSERT INTO public.rack_builder_racks (id, name, rack_units, depth_mm, width)
+VALUES ('82410000-0000-0000-0000-000000000003'::uuid, 'Placement Test Rack', 8, 600, 'single')
+ON CONFLICT (id) DO UPDATE
+SET name = excluded.name,
+    rack_units = excluded.rack_units,
+    depth_mm = excluded.depth_mm,
+    width = excluded.width;
+
+INSERT INTO public.rack_builder_projects (id, name)
+VALUES ('82410000-0000-0000-0000-000000000004'::uuid, 'Placement Test Project')
+ON CONFLICT (id) DO UPDATE
+SET name = excluded.name;
+
+INSERT INTO public.rack_builder_layouts (id, project_id, rack_id, name)
+VALUES (
+  '82410000-0000-0000-0000-000000000005'::uuid,
+  '82410000-0000-0000-0000-000000000004'::uuid,
+  '82410000-0000-0000-0000-000000000003'::uuid,
+  'Placement Test Layout'
+)
+ON CONFLICT (id) DO UPDATE
+SET project_id = excluded.project_id,
+    rack_id = excluded.rack_id,
+    name = excluded.name;
+
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+SELECT set_config('request.jwt.claim.sub', '82400000-0000-0000-0000-000000000001', false);
+
+SET ROLE authenticated;
+
+SELECT lives_ok(
+  $$
+    INSERT INTO public.rack_builder_layout_items (
+      layout_id,
+      device_id,
+      start_u,
+      facing
+    ) VALUES (
+      '82410000-0000-0000-0000-000000000005'::uuid,
+      '82410000-0000-0000-0000-000000000002'::uuid,
+      1,
+      'front'
+    )
+  $$,
+  'authenticated sound users can insert valid equipment placements'
+);
+
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+SELECT set_config('request.jwt.claim.sub', '', false);
+
+DELETE FROM public.rack_builder_layout_items
+WHERE layout_id = '82410000-0000-0000-0000-000000000005'::uuid;
+
+DELETE FROM public.rack_builder_layouts
+WHERE id = '82410000-0000-0000-0000-000000000005'::uuid;
+
+DELETE FROM public.rack_builder_projects
+WHERE id = '82410000-0000-0000-0000-000000000004'::uuid;
+
+DELETE FROM public.rack_builder_racks
+WHERE id = '82410000-0000-0000-0000-000000000003'::uuid;
+
+DELETE FROM public.rack_builder_devices
+WHERE id = '82410000-0000-0000-0000-000000000002'::uuid;
+
+DELETE FROM public.rack_builder_device_categories
+WHERE id = '82410000-0000-0000-0000-000000000001'::uuid;
+
+DELETE FROM public.profiles
+WHERE id = '82400000-0000-0000-0000-000000000001'::uuid;
+
+DELETE FROM auth.users
+WHERE id = '82400000-0000-0000-0000-000000000001'::uuid;
 
 SELECT ok(
   EXISTS (


### PR DESCRIPTION
## Summary
- run Rack Builder layout-item semantic validation as a pinned security-definer trigger after checking caller Rack Builder access
- pin helper function search paths used by placement validation
- add a pgTAP regression test that switches to the authenticated role and inserts a valid equipment placement

## Validation
- supabase db reset --local --no-seed
- supabase test db supabase/tests/database/rack_builder_permissions.sql
- npm run ci:db:migrations
- supabase db lint --local --fail-on error --schema public,auth
- supabase test db supabase/tests/database
- git diff --check
- npm run lint
- npm run typecheck
- npm run build
- npm run test:run

## Release note
This PR includes a Supabase migration. Before merge, run production dry-run/apply/dry-run for the linked project per the production checklist.