### PR TITLE
Fix Rack Builder generated image rendering

### DIFF
--- a/src/features/rack-builder/hooks/__tests__/useDevices.test.ts
+++ b/src/features/rack-builder/hooks/__tests__/useDevices.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDeviceImageUrl } from '../useDevices'
+
+const mocks = vi.hoisted(() => {
+  const publicUrlForPath = vi.fn((path: string) => ({
+    data: {
+      publicUrl: `https://example.test/storage/${path}`,
+    },
+  }))
+  return {
+    publicUrlForPath,
+    fromBucket: vi.fn(() => ({
+      getPublicUrl: publicUrlForPath,
+    })),
+  }
+})
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    storage: {
+      from: mocks.fromBucket,
+    },
+  },
+}))
+
+describe('getDeviceImageUrl', () => {
+  it('preserves generated data URLs used by rack builder thumbnails', () => {
+    const dataUrl = 'data:image/svg+xml;utf8,%3Csvg%20/%3E'
+
+    expect(getDeviceImageUrl(dataUrl)).toBe(dataUrl)
+    expect(mocks.fromBucket).not.toHaveBeenCalled()
+  })
+
+  it('resolves storage paths through the rack builder device image bucket', () => {
+    expect(getDeviceImageUrl('front/device.jpg')).toBe('https://example.test/storage/front/device.jpg')
+    expect(mocks.fromBucket).toHaveBeenCalledWith('rack-builder-device-images')
+  })
+})

--- a/src/features/rack-builder/hooks/__tests__/useDevices.test.ts
+++ b/src/features/rack-builder/hooks/__tests__/useDevices.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { getDeviceImageUrl } from '../useDevices'
+import { getDeviceImageUrl } from '@/features/rack-builder/hooks/useDevices'
 
 const mocks = vi.hoisted(() => {
   const publicUrlForPath = vi.fn((path: string) => ({

--- a/src/features/rack-builder/hooks/useDevices.ts
+++ b/src/features/rack-builder/hooks/useDevices.ts
@@ -284,7 +284,7 @@ export function useDevices() {
 
 export function getDeviceImageUrl(path: string | null, bucket = 'rack-builder-device-images'): string | null {
   if (!path) return null
-  if (path.startsWith('data:')) return null
+  if (path.startsWith('data:')) return path
   if (path.startsWith('http://') || path.startsWith('https://')) return path
   if (path.startsWith('/')) {
     const base = import.meta.env.BASE_URL || '/'


### PR DESCRIPTION
## Summary
- Restore Rack Builder `data:` URL passthrough so generated SVG thumbnails render instead of being treated as missing images.
- Add a regression test for generated data URLs and rack-builder storage bucket URL resolution.
- Address CodeRabbit import-style feedback in the focused regression test.

## Risk
- Low. The code path only changes handling for image paths that already start with `data:` and leaves HTTP URLs plus Supabase storage paths unchanged.

## Impact Checklist
- [x] Frontend Rack Builder rendering fix
- [x] Focused unit test added
- [x] No dependency changes
- [x] No database schema or RLS changes
- [x] No Supabase Edge Function changes

## Rollback
- Revert this PR to restore the previous `data:` URL handling.
- No database rollback is required.

## Migration Impact
- None. This PR includes no Supabase migration and does not require a production `supabase db push`.

## Validation
- `npm run lint` (passes with existing warnings)
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- `npm run test:run -- src/features/rack-builder/hooks/__tests__/useDevices.test.ts`

## Notes
- Verified target Rack Builder layout items join device data correctly and sampled migrated device images return HTTP 200 from the public `rack-builder-device-images` bucket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device image loading so inline `data:` images now display correctly instead of disappearing.
  * Existing image sources still resolve as expected for web paths and stored image URLs.

* **Tests**
  * Added coverage for inline image handling and storage-based URL resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->