### PR TITLE
Fix Rack Builder panel layout embeds

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -6744,6 +6744,13 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "rack_builder_panel_layout_ports_panel_layout_id_fkey"
+            columns: ["panel_layout_id"]
+            isOneToOne: false
+            referencedRelation: "rack_builder_panel_layouts"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "rack_builder_panel_layout_ports_row_fk"
             columns: ["panel_layout_id", "row_index"]
             isOneToOne: false

--- a/supabase/migrations/20260708093000_rack_builder_panel_layout_ports_direct_fk.sql
+++ b/supabase/migrations/20260708093000_rack_builder_panel_layout_ports_direct_fk.sql
@@ -1,0 +1,17 @@
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.rack_builder_panel_layout_ports'::regclass
+      and conname = 'rack_builder_panel_layout_ports_panel_layout_id_fkey'
+  ) then
+    alter table public.rack_builder_panel_layout_ports
+      add constraint rack_builder_panel_layout_ports_panel_layout_id_fkey
+      foreign key (panel_layout_id)
+      references public.rack_builder_panel_layouts(id)
+      on delete cascade;
+  end if;
+end $$;
+
+notify pgrst, 'reload schema';

--- a/supabase/tests/database/rack_builder_permissions.sql
+++ b/supabase/tests/database/rack_builder_permissions.sql
@@ -138,6 +138,7 @@ SELECT ok(
     WHERE conrelid = 'public.rack_builder_panel_layout_ports'::regclass
       AND conname = 'rack_builder_panel_layout_ports_panel_layout_id_fkey'
       AND confrelid = 'public.rack_builder_panel_layouts'::regclass
+      AND pg_get_constraintdef(oid) ILIKE '%ON DELETE CASCADE%'
   ),
   'panel layout ports expose a direct panel layout foreign key for PostgREST embeds'
 );

--- a/supabase/tests/database/rack_builder_permissions.sql
+++ b/supabase/tests/database/rack_builder_permissions.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(25);
+SELECT plan(26);
 
 SELECT has_table('public', 'rack_builder_racks', 'rack builder racks table exists');
 SELECT has_table('public', 'rack_builder_devices', 'rack builder devices table exists');
@@ -129,6 +129,17 @@ SELECT ok(
   NOT has_function_privilege('anon', 'public.rack_builder_rpc_replace_panel_layout_ports(uuid,jsonb)', 'EXECUTE')
   AND has_function_privilege('authenticated', 'public.rack_builder_rpc_replace_panel_layout_ports(uuid,jsonb)', 'EXECUTE'),
   'replace panel layout ports RPC is authenticated-only'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.rack_builder_panel_layout_ports'::regclass
+      AND conname = 'rack_builder_panel_layout_ports_panel_layout_id_fkey'
+      AND confrelid = 'public.rack_builder_panel_layouts'::regclass
+  ),
+  'panel layout ports expose a direct panel layout foreign key for PostgREST embeds'
 );
 
 SELECT ok(


### PR DESCRIPTION
## Summary
- Add the missing direct foreign key from `rack_builder_panel_layout_ports.panel_layout_id` to `rack_builder_panel_layouts.id`.
- Reload the PostgREST schema cache after the FK is added so nested `ports:` embeds resolve.
- Update Supabase type metadata and database tests for the relationship.

## Why
- Production currently returns `PGRST200` for `rack_builder_panel_layouts` -> `rack_builder_panel_layout_ports` embeds.
- The Rack Builder editor and print flows use that embed while loading layout items, so existing placements can occupy rack slots while rendering as an empty rack.

## Risk
- Low. This is an additive FK that matches the source Rack Builder schema. Existing ports already reference panel rows by `(panel_layout_id, row_index)`, and rows cascade from panel layouts.

## Impact Checklist
- [x] Rack Builder editor item loading
- [x] Rack Builder panel/project print loading
- [x] Supabase migration included
- [x] No frontend behavior rewrite
- [x] No dependency changes

## Rollback
- Drop constraint `rack_builder_panel_layout_ports_panel_layout_id_fkey` from `public.rack_builder_panel_layout_ports` and revert this PR.

## Migration Impact
- Requires applying `20260708093000_rack_builder_panel_layout_ports_direct_fk.sql` to production before/with merge.
- Includes `notify pgrst, 'reload schema'` so PostgREST refreshes the relationship cache.

## Validation
- Reproduced current production REST error with `PGRST200` on the nested `ports:` embed.
- `npm ci --legacy-peer-deps`
- `npm run ci:db:migrations`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npx supabase db reset --local --no-seed`
- `npx supabase db lint --local --fail-on error --schema public,auth` (warnings only)
- `npx supabase test db supabase/tests/database` after a clean reset
- `npm run test:run`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a missing direct relationship so port layouts can correctly link to their parent panel layouts.
  * Ensured the database constraint is applied safely and supports automatic cleanup when a parent layout is removed.

* **Tests**
  * Expanded database coverage to verify the new relationship is available for embedding and related queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->