### PR TITLE
Fix rider file access and governance gates

### DIFF
--- a/scripts/ci/check-github-action-pins.mjs
+++ b/scripts/ci/check-github-action-pins.mjs
@@ -2,8 +2,9 @@
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = new URL("../..", import.meta.url).pathname;
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const workflowsRoot = join(repoRoot, ".github", "workflows");
 const fullShaPattern = /^[a-f0-9]{40}$/i;
 const problems = [];

--- a/scripts/ci/check-supabase-migrations.mjs
+++ b/scripts/ci/check-supabase-migrations.mjs
@@ -2,8 +2,9 @@
 
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = new URL("../..", import.meta.url).pathname;
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const migrationsRoot = join(repoRoot, "supabase", "migrations");
 const files = readdirSync(migrationsRoot)
   .filter((file) => file.endsWith(".sql"))

--- a/scripts/governance/check-dependency-audit.mjs
+++ b/scripts/governance/check-dependency-audit.mjs
@@ -24,11 +24,17 @@ function toPosix(path) {
 }
 
 function runAudit() {
+  const isWindows = process.platform === "win32";
   const result = spawnSync("npm", ["audit", "--json"], {
     cwd: repoRoot,
     encoding: "utf8",
     maxBuffer: 20 * 1024 * 1024,
+    shell: isWindows,
   });
+
+  if (result.error) {
+    throw new Error(`Failed to run npm audit: ${result.error.message}`);
+  }
 
   const output = result.stdout || result.stderr;
 

--- a/supabase/functions/delete-public-artist-rider/index.ts
+++ b/supabase/functions/delete-public-artist-rider/index.ts
@@ -168,12 +168,21 @@ serve(createHttpHandler(async (req) => {
     }
 
     if (deleteResult.should_delete_storage && deleteResult.file_path) {
-      const { error: storageError } = await supabaseAdmin.storage
+      const { count: remainingReferences, error: referenceCountError } = await supabaseAdmin
         .from("festival_artist_files")
-        .remove([deleteResult.file_path]);
+        .select("id", { count: "exact", head: true })
+        .eq("file_path", deleteResult.file_path);
 
-      if (storageError) {
-        console.error("[delete-public-artist-rider] storage remove error", storageError);
+      if (referenceCountError) {
+        console.error("[delete-public-artist-rider] storage reference count error", referenceCountError);
+      } else if ((remainingReferences ?? 0) === 0) {
+        const { error: storageError } = await supabaseAdmin.storage
+          .from("festival_artist_files")
+          .remove([deleteResult.file_path]);
+
+        if (storageError) {
+          console.error("[delete-public-artist-rider] storage remove error", storageError);
+        }
       }
     }
 

--- a/supabase/functions/upload-public-artist-rider/index.ts
+++ b/supabase/functions/upload-public-artist-rider/index.ts
@@ -4,6 +4,7 @@ import {
   createHttpHandler,
   HttpError,
   jsonResponse,
+  readBoundedJsonObject,
   requireEnvValues,
 } from "../_shared/http.ts";
 import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
@@ -11,6 +12,7 @@ import { checkEdgeRateLimit, rateLimitHeaders } from "../_shared/rateLimit.ts";
 const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
 const MAX_FILES_PER_REQUEST = 10;
 const MAX_MULTIPART_BODY_BYTES = MAX_FILES_PER_REQUEST * MAX_FILE_SIZE_BYTES + 1024 * 1024;
+const MAX_JSON_BODY_BYTES = 64 * 1024;
 const INGRESS_RATE_LIMIT_WINDOW_SECONDS = 60;
 const INGRESS_RATE_LIMIT_MAX_REQUESTS = 30;
 const TOKEN_RATE_LIMIT_WINDOW_SECONDS = 60 * 60;
@@ -390,6 +392,7 @@ async function insertUploadedRiderFiles(
   files: Array<{ file_name: string; file_path: string; file_type: string | null; file_size: number }>,
 ) {
   const insertedFiles: Array<Record<string, unknown>> = [];
+  const uploadedPaths: string[] = [];
 
   try {
     for (const file of files) {
@@ -425,6 +428,23 @@ async function insertUploadedRiderFiles(
         throw new Error("uploaded_file_type_mismatch");
       }
 
+      const { data: existingReferences, error: existingReferenceError } = await supabaseAdmin
+        .from("festival_artist_files")
+        .select("id")
+        .eq("file_path", file.file_path)
+        .limit(1);
+
+      if (existingReferenceError) {
+        console.error("[upload-public-artist-rider] file metadata lookup error", existingReferenceError);
+        throw new Error("metadata_lookup_failed");
+      }
+
+      if ((existingReferences ?? []).length > 0) {
+        throw new Error("duplicate_file_path");
+      }
+
+      uploadedPaths.push(file.file_path);
+
       const { data: insertedFile, error: insertError } = await supabaseAdmin
         .from("festival_artist_files")
         .insert({
@@ -447,6 +467,16 @@ async function insertUploadedRiderFiles(
 
     await clearArtistRiderFreshness(supabaseAdmin, context.formRow.artist_id);
   } catch (error) {
+    if (uploadedPaths.length > 0) {
+      const { error: cleanupError } = await supabaseAdmin.storage
+        .from("festival_artist_files")
+        .remove(uploadedPaths);
+
+      if (cleanupError) {
+        console.error("[upload-public-artist-rider] signed upload cleanup error", cleanupError);
+      }
+    }
+
     if (insertedFiles.length > 0) {
       const insertedIds = insertedFiles
         .map((file) => String(file.id ?? ""))
@@ -500,8 +530,22 @@ serve(createHttpHandler(async (req) => {
     if (contentType.includes("application/json")) {
       let body: Record<string, unknown>;
       try {
-        body = await req.json() as Record<string, unknown>;
-      } catch {
+        body = await readBoundedJsonObject<Record<string, unknown>>(req, {
+          maxBytes: MAX_JSON_BODY_BYTES,
+        });
+      } catch (error) {
+        if (error instanceof HttpError && error.status === 413) {
+          return jsonResponse({ ok: false, error: "payload_too_large" }, { status: 413 });
+        }
+
+        if (error instanceof HttpError && error.status === 400) {
+          return jsonResponse({ ok: false, error: "invalid_json" }, { status: 400 });
+        }
+
+        throw error;
+      }
+
+      if (!body) {
         return jsonResponse({ ok: false, error: "invalid_json" }, { status: 400 });
       }
 
@@ -599,7 +643,8 @@ serve(createHttpHandler(async (req) => {
             errorCode === "invalid_file_path" ||
             errorCode === "uploaded_file_missing" ||
             errorCode === "uploaded_file_size_mismatch" ||
-            errorCode === "uploaded_file_type_mismatch"
+            errorCode === "uploaded_file_type_mismatch" ||
+            errorCode === "duplicate_file_path"
               ? 400
               : getFileValidationStatus(errorCode);
           return jsonResponse({ ok: false, error: errorCode }, { status });

--- a/supabase/migrations/20260708120000_fix_rider_file_access_policies.sql
+++ b/supabase/migrations/20260708120000_fix_rider_file_access_policies.sql
@@ -1,0 +1,236 @@
+-- Align rider file metadata and storage access with the festival role contract:
+-- house_tech can manage rider files end to end, while assigned technicians can
+-- only read metadata and download/view storage objects for their assigned jobs.
+
+DROP POLICY IF EXISTS "p_festival_artist_files_public_select_1fa3b3" ON public.festival_artist_files;
+DROP POLICY IF EXISTS "p_festival_artist_files_public_insert_279f74" ON public.festival_artist_files;
+DROP POLICY IF EXISTS "p_festival_artist_files_public_update_29eab2" ON public.festival_artist_files;
+DROP POLICY IF EXISTS "p_festival_artist_files_public_delete_d213bb" ON public.festival_artist_files;
+
+CREATE POLICY "p_festival_artist_files_public_select_1fa3b3"
+ON public.festival_artist_files
+FOR SELECT
+TO authenticated
+USING (
+  public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  OR (
+    public.get_current_user_role() = 'technician'::text
+    AND EXISTS (
+      SELECT 1
+      FROM public.festival_artists fa
+      JOIN public.job_assignments ja ON ja.job_id = fa.job_id
+      WHERE fa.id = festival_artist_files.artist_id
+        AND ja.technician_id = auth.uid()
+    )
+  )
+  OR public.is_admin_or_management()
+);
+
+CREATE POLICY "p_festival_artist_files_public_insert_279f74"
+ON public.festival_artist_files
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+);
+
+CREATE POLICY "p_festival_artist_files_public_update_29eab2"
+ON public.festival_artist_files
+FOR UPDATE
+TO authenticated
+USING (
+  public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+)
+WITH CHECK (
+  public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+);
+
+CREATE POLICY "p_festival_artist_files_public_delete_d213bb"
+ON public.festival_artist_files
+FOR DELETE
+TO authenticated
+USING (
+  public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+);
+
+DROP POLICY IF EXISTS "p_storage_festival_artist_files_authorized_select" ON storage.objects;
+DROP POLICY IF EXISTS "p_storage_festival_artist_files_authorized_insert" ON storage.objects;
+DROP POLICY IF EXISTS "p_storage_festival_artist_files_authorized_update" ON storage.objects;
+DROP POLICY IF EXISTS "p_storage_festival_artist_files_authorized_delete" ON storage.objects;
+
+CREATE POLICY "p_storage_festival_artist_files_authorized_select"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'festival_artist_files'
+  AND (
+    (
+      public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM public.festival_artists fa
+          WHERE fa.id = CASE
+            WHEN split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              THEN split_part(storage.objects.name, '/', 1)::uuid
+            ELSE NULL
+          END
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM public.festival_artist_files faf
+          WHERE faf.file_path = storage.objects.name
+        )
+      )
+    )
+    OR (
+      public.get_current_user_role() = 'technician'::text
+      AND EXISTS (
+        SELECT 1
+        FROM public.festival_artist_files faf
+        JOIN public.festival_artists fa ON fa.id = faf.artist_id
+        JOIN public.job_assignments ja ON ja.job_id = fa.job_id
+        WHERE faf.file_path = storage.objects.name
+          AND ja.technician_id = auth.uid()
+      )
+    )
+  )
+);
+
+CREATE POLICY "p_storage_festival_artist_files_authorized_insert"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'festival_artist_files'
+  AND public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  AND EXISTS (
+    SELECT 1
+    FROM public.festival_artists fa
+    WHERE fa.id = CASE
+      WHEN split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        THEN split_part(storage.objects.name, '/', 1)::uuid
+      ELSE NULL
+    END
+  )
+);
+
+CREATE POLICY "p_storage_festival_artist_files_authorized_update"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'festival_artist_files'
+  AND public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  AND EXISTS (
+    SELECT 1
+    FROM public.festival_artists fa
+    WHERE fa.id = CASE
+      WHEN split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        THEN split_part(storage.objects.name, '/', 1)::uuid
+      ELSE NULL
+    END
+  )
+)
+WITH CHECK (
+  bucket_id = 'festival_artist_files'
+  AND public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  AND EXISTS (
+    SELECT 1
+    FROM public.festival_artists fa
+    WHERE fa.id = CASE
+      WHEN split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        THEN split_part(storage.objects.name, '/', 1)::uuid
+      ELSE NULL
+    END
+  )
+);
+
+CREATE POLICY "p_storage_festival_artist_files_authorized_delete"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'festival_artist_files'
+  AND public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM public.festival_artists fa
+      WHERE fa.id = CASE
+        WHEN split_part(storage.objects.name, '/', 1) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+          THEN split_part(storage.objects.name, '/', 1)::uuid
+        ELSE NULL
+      END
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.festival_artist_files faf
+      WHERE faf.file_path = storage.objects.name
+    )
+  )
+);
+
+CREATE OR REPLACE FUNCTION public.delete_festival_artist_file_reference(
+  p_file_id uuid,
+  p_artist_id uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  deleted_file_id uuid,
+  file_path text,
+  should_delete_storage boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_role text;
+  v_file public.festival_artist_files%ROWTYPE;
+  v_remaining_references integer;
+BEGIN
+  v_role := public.get_current_user_role();
+  IF auth.role() <> 'service_role'
+    AND (v_role IS NULL OR v_role <> ALL (ARRAY['admin', 'management', 'logistics', 'house_tech'])) THEN
+    RAISE EXCEPTION 'not_authorized'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_file_id IS NULL THEN
+    RAISE EXCEPTION 'missing_required_argument'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT *
+  INTO v_file
+  FROM public.festival_artist_files
+  WHERE id = p_file_id
+    AND (p_artist_id IS NULL OR artist_id = p_artist_id)
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'file_not_found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_file.file_path, 0));
+
+  DELETE FROM public.festival_artist_files
+  WHERE id = v_file.id;
+
+  SELECT count(*)::integer
+  INTO v_remaining_references
+  FROM public.festival_artist_files remaining_file
+  WHERE remaining_file.file_path = v_file.file_path;
+
+  RETURN QUERY
+  SELECT v_file.id, v_file.file_path, v_remaining_references = 0;
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_festival_artist_file_reference(uuid, uuid) IS
+  'Deletes one rider file metadata reference and reports whether the shared storage object has no remaining references.';
+
+REVOKE ALL ON FUNCTION public.delete_festival_artist_file_reference(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.delete_festival_artist_file_reference(uuid, uuid) TO authenticated, service_role;

--- a/supabase/migrations/20260708120000_fix_rider_file_access_policies.sql
+++ b/supabase/migrations/20260708120000_fix_rider_file_access_policies.sql
@@ -154,6 +154,11 @@ TO authenticated
 USING (
   bucket_id = 'festival_artist_files'
   AND public.get_current_user_role() = ANY (ARRAY['admin'::text, 'management'::text, 'logistics'::text, 'house_tech'::text])
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.festival_artist_files faf
+    WHERE faf.file_path = storage.objects.name
+  )
   AND (
     EXISTS (
       SELECT 1
@@ -163,11 +168,6 @@ USING (
           THEN split_part(storage.objects.name, '/', 1)::uuid
         ELSE NULL
       END
-    )
-    OR EXISTS (
-      SELECT 1
-      FROM public.festival_artist_files faf
-      WHERE faf.file_path = storage.objects.name
     )
   )
 );

--- a/supabase/tests/database/festival_artist_permissions.sql
+++ b/supabase/tests/database/festival_artist_permissions.sql
@@ -262,7 +262,7 @@ SELECT ok(
       AND qual ILIKE '%logistics%'
       AND qual ILIKE '%house_tech%'
       AND qual ILIKE '%festival_artists%'
-      AND qual ILIKE '%NOT EXISTS%'
+      AND qual ILIKE '%NOT%EXISTS%'
       AND qual NOT ILIKE '%''technician''%'
   ),
   'house techs may delete festival artist file storage objects while technicians cannot'

--- a/supabase/tests/database/festival_artist_permissions.sql
+++ b/supabase/tests/database/festival_artist_permissions.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(17);
+SELECT plan(21);
 
 SELECT is(
   (
@@ -95,11 +95,13 @@ SELECT ok(
       AND qual ILIKE '%admin%'
       AND qual ILIKE '%management%'
       AND qual ILIKE '%logistics%'
+      AND qual ILIKE '%house_tech%'
       AND qual ILIKE '%job_assignments%'
       AND qual ILIKE '%auth.uid%'
+      AND qual ILIKE '%''technician''%'
       AND qual NOT ILIKE '%OR true%'
   ),
-  'festival artist file metadata reads are scoped to elevated roles or assigned jobs'
+  'festival artist file metadata reads are scoped to elevated roles or assigned technicians'
 );
 
 SELECT ok(
@@ -112,6 +114,48 @@ SELECT ok(
       AND with_check ILIKE '%house_tech%'
   ),
   'house techs may insert festival artist file metadata'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artist_files'
+      AND cmd = 'UPDATE'
+      AND qual ILIKE '%house_tech%'
+      AND with_check ILIKE '%house_tech%'
+      AND qual NOT ILIKE '%''technician''%'
+      AND with_check NOT ILIKE '%''technician''%'
+  ),
+  'house techs may update festival artist file metadata while technicians cannot'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'festival_artist_files'
+      AND cmd = 'DELETE'
+      AND qual ILIKE '%house_tech%'
+      AND qual NOT ILIKE '%''technician''%'
+  ),
+  'house techs may delete festival artist file metadata while technicians cannot'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'delete_festival_artist_file_reference'
+      AND pg_get_function_identity_arguments(p.oid) = 'p_file_id uuid, p_artist_id uuid'
+      AND pg_get_functiondef(p.oid) ILIKE '%house_tech%'
+      AND pg_get_functiondef(p.oid) NOT ILIKE '%''technician''%'
+  ),
+  'rider file delete RPC allows house techs but not technicians'
 );
 
 SELECT ok(
@@ -153,9 +197,12 @@ SELECT ok(
       AND qual ILIKE '%management%'
       AND qual ILIKE '%logistics%'
       AND qual ILIKE '%house_tech%'
+      AND qual ILIKE '%job_assignments%'
+      AND qual ILIKE '%auth.uid%'
+      AND qual ILIKE '%''technician''%'
       AND qual ILIKE '%festival_artists%'
   ),
-  'house techs may view festival artist file storage objects'
+  'house techs and assigned technicians may view festival artist file storage objects'
 );
 
 SELECT ok(
@@ -172,8 +219,9 @@ SELECT ok(
       AND with_check ILIKE '%logistics%'
       AND with_check ILIKE '%house_tech%'
       AND with_check ILIKE '%festival_artists%'
+      AND with_check NOT ILIKE '%''technician''%'
   ),
-  'house techs may upload festival artist file storage objects'
+  'house techs may upload festival artist file storage objects while technicians cannot'
 );
 
 SELECT ok(
@@ -194,8 +242,29 @@ SELECT ok(
       AND with_check ILIKE '%management%'
       AND with_check ILIKE '%logistics%'
       AND with_check ILIKE '%house_tech%'
+      AND qual NOT ILIKE '%''technician''%'
+      AND with_check NOT ILIKE '%''technician''%'
   ),
-  'house techs may upsert festival artist file storage objects'
+  'house techs may upsert festival artist file storage objects while technicians cannot'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'p_storage_festival_artist_files_authorized_delete'
+      AND cmd = 'DELETE'
+      AND qual ILIKE '%festival_artist_files%'
+      AND qual ILIKE '%admin%'
+      AND qual ILIKE '%management%'
+      AND qual ILIKE '%logistics%'
+      AND qual ILIKE '%house_tech%'
+      AND qual ILIKE '%festival_artists%'
+      AND qual NOT ILIKE '%''technician''%'
+  ),
+  'house techs may delete festival artist file storage objects while technicians cannot'
 );
 
 SELECT ok(

--- a/supabase/tests/database/festival_artist_permissions.sql
+++ b/supabase/tests/database/festival_artist_permissions.sql
@@ -262,6 +262,7 @@ SELECT ok(
       AND qual ILIKE '%logistics%'
       AND qual ILIKE '%house_tech%'
       AND qual ILIKE '%festival_artists%'
+      AND qual ILIKE '%NOT EXISTS%'
       AND qual NOT ILIKE '%''technician''%'
   ),
   'house techs may delete festival artist file storage objects while technicians cannot'

--- a/supabase/tests/database/rider_library_import.sql
+++ b/supabase/tests/database/rider_library_import.sql
@@ -99,6 +99,7 @@ WHERE artist_id IN (
     '13000000-0000-0000-0000-000000000003'::uuid
   )
   OR file_path IN ('shared/source-rider.pdf', 'shared/second-rider.pdf')
+  OR file_path IN ('shared/house-delete-rider.pdf')
   OR artist_id IN (
     SELECT id
     FROM public.festival_artists
@@ -368,6 +369,16 @@ INSERT INTO public.festival_artist_files (
     23456,
     '11000000-0000-0000-0000-000000000001'::uuid,
     '2026-07-01 13:00:00+02'::timestamptz
+  ),
+  (
+    '14000000-0000-0000-0000-000000000003'::uuid,
+    '13000000-0000-0000-0000-000000000003'::uuid,
+    'house-delete-rider.pdf',
+    'shared/house-delete-rider.pdf',
+    'application/pdf',
+    34567,
+    '11000000-0000-0000-0000-000000000001'::uuid,
+    '2026-07-01 14:00:00+02'::timestamptz
   )
 ON CONFLICT (id) DO UPDATE
 SET artist_id = excluded.artist_id,
@@ -394,13 +405,15 @@ SELECT throws_ok(
   'house tech cannot import riders from the library'
 );
 
-SELECT throws_ok(
-  $$SELECT * FROM public.delete_festival_artist_file_reference(
-    '14000000-0000-0000-0000-000000000001'::uuid
-  )$$,
-  '42501',
-  'not_authorized',
-  'house tech cannot delete rider file references'
+SELECT is(
+  (
+    SELECT should_delete_storage
+    FROM public.delete_festival_artist_file_reference(
+      '14000000-0000-0000-0000-000000000003'::uuid
+    )
+  ),
+  true,
+  'house tech can delete rider file references'
 );
 
 SELECT set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000001', false);


### PR DESCRIPTION
## Summary

- Align rider file metadata/storage policies so house techs can upload, edit, read, download, and delete rider files while assigned technicians can only read/download.
- Add database policy coverage for the house-tech and technician rider-file contract.
- Harden public rider signed-upload completion with bounded JSON parsing, duplicate-path checks, and storage cleanup on metadata/freshness failures.
- Fix Windows-local governance gates for GitHub Action pin checks, migration ordering, and dependency audit execution.

## Affected Route / Feature

- Festival artist rider file management.
- Public artist rider upload/delete token flows.
- Supabase RLS/storage policies and database authorization tests.
- Local governance scripts used by Windows contributors.

## Root Cause

Recent rider-library policy changes reintroduced metadata/storage access drift: assigned technicians could see rider metadata without matching storage access, while house techs could upload but lost reliable metadata read/mutation coverage. Separately, Node governance scripts used URL pathnames directly on Windows, producing malformed paths, and the dependency audit wrapper did not invoke npm reliably on Windows.

## Risk Assessment

- Medium: this changes RLS/storage authorization for rider files and includes a production Supabase migration.
- Mitigation: migration apply, db lint, and pgtap RLS/RPC tests run in CI; local governance/typecheck/lint/test/build/budget checks were also run.
- Residual risk: production migration must be applied before relying on the new policy behavior in production.

## Impact Checklist

- [x] House techs can manage rider files end to end.
- [x] Assigned technicians remain read/download only for assigned jobs.
- [x] Public upload JSON bodies are bounded.
- [x] Rider storage deletion revalidates that no metadata references remain.
- [x] Windows governance scripts no longer build malformed paths.

## Rollback Plan

- Revert this PR to restore the previous application code and migration history state.
- If the migration has already been applied, follow with an explicit rollback migration that recreates the prior rider metadata/storage policies and RPC body.
- No data-destructive schema changes are introduced; the migration is policy/RPC only.

## Migration Impact

This PR includes Supabase migration `20260708120000_fix_rider_file_access_policies.sql`.

Before merge, run the production migration sequence from the release checklist:

1. `supabase db push --linked --dry-run`
2. apply pending migrations to the linked production project
3. run a follow-up dry run and confirm production is up to date

## Validation

- `npm run governance`
- `npm run typecheck`
- `npm run lint` (existing warnings only)
- `npm run lint:functions` (existing warnings only)
- `npm run test:run`
- `npm run build`
- `npm run budget:bundle`