### PR TITLE
Add sound documentation duplication

### DIFF
--- a/src/components/jobs/cards/JobCardActions.tsx
+++ b/src/components/jobs/cards/JobCardActions.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 import { FlexSelectorDialogHost } from "@/components/jobs/cards/job-card-actions/FlexSelectorDialogHost";
+import { DuplicateSoundDocumentationDialog } from "@/components/jobs/cards/job-card-actions/DuplicateSoundDocumentationDialog";
 import { JobCardActionButtons } from "@/components/jobs/cards/job-card-actions/JobCardActionButtons";
 import { ProductionWhatsappDialog } from "@/components/jobs/cards/job-card-actions/ProductionWhatsappDialog";
 import { WarehouseWhatsappDialog } from "@/components/jobs/cards/job-card-actions/WarehouseWhatsappDialog";
@@ -66,6 +67,7 @@ export const JobCardActions: React.FC<JobCardActionsProps> = ({
   const allowedJobType = ["single", "festival", "ciclo", "tourdate"].includes(job?.job_type);
   const canViewCalculators = isProjectManagementPage && isManagementUser;
   const tourId: string | undefined = job?.tour_id || job?.tour?.id || undefined;
+  const [duplicateSoundDocsOpen, setDuplicateSoundDocsOpen] = React.useState(false);
 
   const productionWhatsapp = useProductionWhatsapp({
     job,
@@ -163,6 +165,10 @@ export const JobCardActions: React.FC<JobCardActionsProps> = ({
     navigate(`/festival-management/${job.id}?${params.toString()}`);
   }, [job.id, navigate]);
 
+  const openDuplicateSoundDocsDialog = React.useCallback(() => {
+    setDuplicateSoundDocsOpen(true);
+  }, []);
+
   return (
     <>
       <JobCardActionButtons
@@ -216,6 +222,7 @@ export const JobCardActions: React.FC<JobCardActionsProps> = ({
         isTechnicianUser={isTechnicianUser}
         navigateToCalculator={navigateToCalculator}
         navigateToMemoria={navigateToMemoria}
+        openDuplicateSoundDocsDialog={openDuplicateSoundDocsDialog}
         openProductionWhatsappDialog={productionWhatsapp.openProductionWhatsappDialog}
         openWarehouseWhatsappDialog={warehouseWhatsapp.openWarehouseWhatsappDialog}
         technicalPower={technicalPower}
@@ -227,6 +234,11 @@ export const JobCardActions: React.FC<JobCardActionsProps> = ({
         department={department}
         flexOpening={flexOpening}
         job={job}
+      />
+      <DuplicateSoundDocumentationDialog
+        job={job}
+        open={duplicateSoundDocsOpen}
+        onOpenChange={setDuplicateSoundDocsOpen}
       />
     </>
   );

--- a/src/components/jobs/cards/job-card-actions/DuplicateSoundDocumentationDialog.tsx
+++ b/src/components/jobs/cards/job-card-actions/DuplicateSoundDocumentationDialog.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { CheckSquare, Copy, Loader2, Search } from "lucide-react";
 import { format } from "date-fns";
+import { toZonedTime } from "date-fns-tz";
 
-import type { JobCardJob } from "@/components/jobs/cards/job-card-actions/types";
+import { MADRID_TIME_ZONE, type JobCardJob } from "@/components/jobs/cards/job-card-actions/types";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -40,28 +41,28 @@ const COPY_SCOPE_OPTIONS: Array<{
 }> = [
   {
     scope: "soundDocuments",
-    label: "Sound docs",
-    description: "Uploaded sound department files",
+    label: "Documentos de sonido",
+    description: "Archivos subidos del departamento de sonido",
   },
   {
     scope: "power",
-    label: "Power / Consumos",
-    description: "Editable tables and latest generated report",
+    label: "Consumos",
+    description: "Tablas editables y último informe generado",
   },
   {
     scope: "soundvision",
     label: "SoundVision",
-    description: "Venue template and latest generated SV report",
+    description: "Plantilla de venue y último informe SV generado",
   },
   {
     scope: "material",
     label: "Lista de material",
-    description: "Latest Flex material-list PDF",
+    description: "Último PDF de lista de material Flex",
   },
   {
     scope: "memoria",
     label: "Memoria",
-    description: "Stage records for regenerating Memoria Técnica",
+    description: "Registros para regenerar Memoria Técnica",
   },
 ];
 
@@ -69,7 +70,7 @@ const formatJobDate = (value: string | null) => {
   if (!value) return "";
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return "";
-  return format(parsed, "dd MMM yyyy");
+  return format(toZonedTime(parsed, MADRID_TIME_ZONE), "dd MMM yyyy");
 };
 
 const normalizeSearch = (value: string) =>

--- a/src/components/jobs/cards/job-card-actions/DuplicateSoundDocumentationDialog.tsx
+++ b/src/components/jobs/cards/job-card-actions/DuplicateSoundDocumentationDialog.tsx
@@ -19,19 +19,13 @@ import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/hooks/use-toast";
 import { queryKeys } from "@/lib/react-query";
-import { dataLayerClient } from "@/services/dataLayerClient";
 import {
   duplicateSoundDocumentation,
+  fetchSoundDocumentationSourceJobs,
   SOUND_DOCUMENTATION_COPY_SCOPES,
+  type SoundDocumentationSourceJob,
   type SoundDocumentationCopyScope,
 } from "@/utils/duplicateSoundDocumentation";
-
-type SourceJob = {
-  id: string;
-  title: string;
-  start_time: string | null;
-  end_time: string | null;
-};
 
 type DuplicateSoundDocumentationDialogProps = {
   job: JobCardJob;
@@ -120,21 +114,10 @@ export const DuplicateSoundDocumentationDialog = ({
     }
   }, [open]);
 
-  const { data: sourceJobs = [], isLoading } = useQuery<SourceJob[]>({
+  const { data: sourceJobs = [], isLoading } = useQuery<SoundDocumentationSourceJob[]>({
     queryKey: queryKeys.scope("sound-documentation-copy-source-jobs", job.id),
     enabled: open && Boolean(job.id),
-    queryFn: async () => {
-      const { data, error } = await dataLayerClient
-        .from("jobs")
-        .select("id, title, start_time, end_time")
-        .neq("id", job.id)
-        .in("job_type", ["single", "festival", "ciclo", "tourdate"])
-        .order("start_time", { ascending: false })
-        .limit(250);
-
-      if (error) throw error;
-      return (data || []) as SourceJob[];
-    },
+    queryFn: () => fetchSoundDocumentationSourceJobs(job.id),
   });
 
   const filteredJobs = React.useMemo(() => {

--- a/src/components/jobs/cards/job-card-actions/DuplicateSoundDocumentationDialog.tsx
+++ b/src/components/jobs/cards/job-card-actions/DuplicateSoundDocumentationDialog.tsx
@@ -1,0 +1,292 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { CheckSquare, Copy, Loader2, Search } from "lucide-react";
+import { format } from "date-fns";
+
+import type { JobCardJob } from "@/components/jobs/cards/job-card-actions/types";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useToast } from "@/hooks/use-toast";
+import { queryKeys } from "@/lib/react-query";
+import { dataLayerClient } from "@/services/dataLayerClient";
+import {
+  duplicateSoundDocumentation,
+  SOUND_DOCUMENTATION_COPY_SCOPES,
+  type SoundDocumentationCopyScope,
+} from "@/utils/duplicateSoundDocumentation";
+
+type SourceJob = {
+  id: string;
+  title: string;
+  start_time: string | null;
+  end_time: string | null;
+};
+
+type DuplicateSoundDocumentationDialogProps = {
+  job: JobCardJob;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+};
+
+const COPY_SCOPE_OPTIONS: Array<{
+  description: string;
+  label: string;
+  scope: SoundDocumentationCopyScope;
+}> = [
+  {
+    scope: "soundDocuments",
+    label: "Sound docs",
+    description: "Uploaded sound department files",
+  },
+  {
+    scope: "power",
+    label: "Power / Consumos",
+    description: "Editable tables and latest generated report",
+  },
+  {
+    scope: "soundvision",
+    label: "SoundVision",
+    description: "Venue template and latest generated SV report",
+  },
+  {
+    scope: "material",
+    label: "Lista de material",
+    description: "Latest Flex material-list PDF",
+  },
+  {
+    scope: "memoria",
+    label: "Memoria",
+    description: "Stage records for regenerating Memoria Técnica",
+  },
+];
+
+const formatJobDate = (value: string | null) => {
+  if (!value) return "";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return format(parsed, "dd MMM yyyy");
+};
+
+const normalizeSearch = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+
+const buildResultDescription = (result: Awaited<ReturnType<typeof duplicateSoundDocumentation>>) => {
+  const parts = [
+    result.copiedDocuments ? `${result.copiedDocuments} documentos` : null,
+    result.copiedPowerTables ? `${result.copiedPowerTables} tablas de consumos` : null,
+    result.copiedMemoriaRows ? `${result.copiedMemoriaRows} registros de memoria` : null,
+  ].filter(Boolean);
+
+  const base = parts.length > 0 ? parts.join(", ") : "No se encontraron documentos para copiar";
+  return result.skippedDocuments > 0
+    ? `${base}. ${result.skippedDocuments} documentos no se pudieron copiar.`
+    : `${base}.`;
+};
+
+export const DuplicateSoundDocumentationDialog = ({
+  job,
+  onOpenChange,
+  open,
+}: DuplicateSoundDocumentationDialogProps) => {
+  const { toast } = useToast();
+  const [query, setQuery] = React.useState("");
+  const [selectedSourceJobId, setSelectedSourceJobId] = React.useState("");
+  const [selectedScopes, setSelectedScopes] = React.useState<SoundDocumentationCopyScope[]>([
+    ...SOUND_DOCUMENTATION_COPY_SCOPES,
+  ]);
+  const [isCopying, setIsCopying] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setSelectedSourceJobId("");
+      setSelectedScopes([...SOUND_DOCUMENTATION_COPY_SCOPES]);
+      setIsCopying(false);
+    }
+  }, [open]);
+
+  const { data: sourceJobs = [], isLoading } = useQuery<SourceJob[]>({
+    queryKey: queryKeys.scope("sound-documentation-copy-source-jobs", job.id),
+    enabled: open && Boolean(job.id),
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient
+        .from("jobs")
+        .select("id, title, start_time, end_time")
+        .neq("id", job.id)
+        .in("job_type", ["single", "festival", "ciclo", "tourdate"])
+        .order("start_time", { ascending: false })
+        .limit(250);
+
+      if (error) throw error;
+      return (data || []) as SourceJob[];
+    },
+  });
+
+  const filteredJobs = React.useMemo(() => {
+    const normalizedQuery = normalizeSearch(query);
+    if (!normalizedQuery) return sourceJobs;
+
+    return sourceJobs.filter((sourceJob) => {
+      const haystack = normalizeSearch(`${sourceJob.title} ${formatJobDate(sourceJob.start_time)}`);
+      return haystack.includes(normalizedQuery);
+    });
+  }, [query, sourceJobs]);
+
+  const selectedSourceJob = sourceJobs.find((sourceJob) => sourceJob.id === selectedSourceJobId);
+  const canCopy = Boolean(selectedSourceJobId && selectedScopes.length > 0 && !isCopying);
+
+  const toggleScope = (scope: SoundDocumentationCopyScope, checked: boolean) => {
+    setSelectedScopes((current) =>
+      checked
+        ? Array.from(new Set([...current, scope]))
+        : current.filter((selectedScope) => selectedScope !== scope)
+    );
+  };
+
+  const handleCopy = async () => {
+    if (!selectedSourceJob) return;
+
+    setIsCopying(true);
+    try {
+      const result = await duplicateSoundDocumentation({
+        sourceJobId: selectedSourceJob.id,
+        sourceJobTitle: selectedSourceJob.title,
+        targetJobDate: job.start_time || job.date || null,
+        targetJobId: job.id,
+        targetJobTitle: job.title || job.name || job.job_name,
+        scopes: selectedScopes,
+      });
+
+      toast({
+        title: "Documentación copiada",
+        description: buildResultDescription(result),
+      });
+      onOpenChange(false);
+    } catch (error) {
+      console.error("Error duplicating sound documentation:", error);
+      toast({
+        title: "No se pudo copiar",
+        description: error instanceof Error ? error.message : "Error al duplicar la documentación de sonido.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsCopying(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Duplicar documentación de sonido</DialogTitle>
+          <DialogDescription>
+            Copia documentación técnica desde otro trabajo a {job.title || job.name || "este trabajo"}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div className="space-y-2">
+            <Label htmlFor="sound-doc-source-search">Trabajo origen</Label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="sound-doc-source-search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Buscar trabajo"
+                className="pl-9"
+              />
+            </div>
+            <ScrollArea className="h-56 rounded-md border">
+              <div className="divide-y">
+                {isLoading ? (
+                  <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Cargando trabajos
+                  </div>
+                ) : filteredJobs.length > 0 ? (
+                  filteredJobs.map((sourceJob) => {
+                    const selected = sourceJob.id === selectedSourceJobId;
+                    return (
+                      <button
+                        key={sourceJob.id}
+                        type="button"
+                        onClick={() => setSelectedSourceJobId(sourceJob.id)}
+                        className={[
+                          "flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors",
+                          selected ? "bg-primary/10 text-primary" : "hover:bg-muted",
+                        ].join(" ")}
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate font-medium">{sourceJob.title}</span>
+                          <span className="block text-xs text-muted-foreground">
+                            {formatJobDate(sourceJob.start_time)}
+                          </span>
+                        </span>
+                        {selected && <CheckSquare className="h-4 w-4 shrink-0" />}
+                      </button>
+                    );
+                  })
+                ) : (
+                  <div className="flex h-24 items-center justify-center px-4 text-center text-sm text-muted-foreground">
+                    No hay trabajos que coincidan.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+
+          <div className="space-y-3">
+            <Label>Categorías</Label>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {COPY_SCOPE_OPTIONS.map((option) => {
+                const checked = selectedScopes.includes(option.scope);
+                return (
+                  <label
+                    key={option.scope}
+                    className="flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors hover:bg-muted/50"
+                  >
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={(value) => toggleScope(option.scope, value === true)}
+                      className="mt-0.5"
+                    />
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium">{option.label}</span>
+                      <span className="block text-xs text-muted-foreground">{option.description}</span>
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isCopying}>
+            Cancelar
+          </Button>
+          <Button onClick={handleCopy} disabled={!canCopy} className="gap-2">
+            {isCopying ? <Loader2 className="h-4 w-4 animate-spin" /> : <Copy className="h-4 w-4" />}
+            Copiar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
+++ b/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import {
   Clock,
+  Copy,
   Edit,
   ExternalLink,
   FileStack,
@@ -61,6 +62,7 @@ type JobCardActionButtonsProps = JobCardActionsProps & {
   isTechnicianUser: boolean;
   navigateToCalculator: (e: React.MouseEvent, type: "pesos" | "consumos") => void;
   navigateToMemoria: (e: React.MouseEvent) => void;
+  openDuplicateSoundDocsDialog: () => void;
   openProductionWhatsappDialog: () => void;
   openWarehouseWhatsappDialog: () => void;
   technicalPower: TechnicalPowerPackState;
@@ -143,6 +145,7 @@ export const JobCardActionButtons = ({
   job,
   navigateToCalculator,
   navigateToMemoria,
+  openDuplicateSoundDocsDialog,
   onAddFlexFolders,
   onAssignmentDialogOpen,
   onCreateFlexFolders,
@@ -171,6 +174,12 @@ export const JobCardActionButtons = ({
   whatsappRequest,
 }: JobCardActionButtonsProps) => {
   const isProductionDepartment = department === "production";
+  const canDuplicateSoundDocs =
+    department === "sound" &&
+    isProjectManagementPage &&
+    isManagementUser &&
+    allowedJobType &&
+    job.job_type !== "dryhire";
   const flexReportDepartment = department === "sound" || department === "lights" ? department : null;
   const normalizedJobType = String(job.job_type || "").toLowerCase();
   const canOpenTimesheets = !["dryhire", "dry_hire"].includes(normalizedJobType) && (
@@ -391,6 +400,18 @@ export const JobCardActionButtons = ({
           <FileStack className="h-4 w-4" />
           <span className="hidden sm:inline">Memoria</span>
         </Button>
+        {canDuplicateSoundDocs && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            title="Duplicar documentación de sonido"
+            onClick={openDuplicateSoundDocsDialog}
+          >
+            <Copy className="h-4 w-4" />
+            <span className="hidden sm:inline">Duplicar docs</span>
+          </Button>
+        )}
       </>
     )}
     {flexReportDepartment && isProjectManagementPage && isManagementUser && (

--- a/src/utils/__tests__/duplicateSoundDocumentation.test.ts
+++ b/src/utils/__tests__/duplicateSoundDocumentation.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it, vi } from "vitest";
+import { PDFDocument } from "pdf-lib";
+
+import {
+  buildCopiedSoundDocumentPath,
+  duplicateSoundDocumentation,
+  renameCopiedSoundDocumentFile,
+  selectSoundDocumentsForCopy,
+} from "@/utils/duplicateSoundDocumentation";
+
+type TableName = "job_documents" | "power_requirement_tables" | "memoria_tecnica_documents";
+
+type FakeTables = Record<TableName, Array<Record<string, unknown>>>;
+
+const createPdfBlob = async () => {
+  const pdf = await PDFDocument.create();
+  pdf.addPage([595, 842]);
+  const bytes = await pdf.save();
+  const arrayBuffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(arrayBuffer).set(bytes);
+  return new Blob([arrayBuffer], { type: "application/pdf" });
+};
+
+const createFakeClient = (tables: FakeTables, storageEntries: Record<string, Blob>) => {
+  const uploads: Array<{ bucket: string; path: string; blob: Blob; options: unknown }> = [];
+
+  const applyFilters = (
+    rows: Array<Record<string, unknown>>,
+    filters: Array<{ column: string; value: unknown }>
+  ) =>
+    rows.filter((row) => filters.every((filter) => row[filter.column] === filter.value));
+
+  const client = {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } }),
+    },
+    from: vi.fn((table: TableName) => {
+      const filters: Array<{ column: string; value: unknown }> = [];
+      let mode: "select" | "delete" | "insert" = "select";
+      let insertPayload: unknown;
+      let orderColumn: string | null = null;
+      let ascending = true;
+
+      const builder = {
+        delete: vi.fn(() => {
+          mode = "delete";
+          return builder;
+        }),
+        eq: vi.fn((column: string, value: unknown) => {
+          filters.push({ column, value });
+          return builder;
+        }),
+        insert: vi.fn((payload: unknown) => {
+          mode = "insert";
+          insertPayload = payload;
+          return builder;
+        }),
+        is: vi.fn((column: string, value: unknown) => {
+          filters.push({ column, value });
+          return builder;
+        }),
+        order: vi.fn((column: string, options?: { ascending?: boolean }) => {
+          orderColumn = column;
+          ascending = options?.ascending !== false;
+          return builder;
+        }),
+        select: vi.fn(() => {
+          mode = "select";
+          return builder;
+        }),
+        then: (resolve: (value: { data: unknown; error: null }) => void) => {
+          if (mode === "insert") {
+            const payloadRows = Array.isArray(insertPayload) ? insertPayload : [insertPayload];
+            tables[table].push(...(payloadRows as Array<Record<string, unknown>>));
+            return Promise.resolve({ data: payloadRows, error: null }).then(resolve);
+          }
+
+          if (mode === "delete") {
+            const toDelete = new Set(applyFilters(tables[table], filters));
+            tables[table] = tables[table].filter((row) => !toDelete.has(row));
+            return Promise.resolve({ data: null, error: null }).then(resolve);
+          }
+
+          let rows = applyFilters(tables[table], filters);
+          if (orderColumn) {
+            rows = [...rows].sort((a, b) => {
+              const av = String(a[orderColumn!] ?? "");
+              const bv = String(b[orderColumn!] ?? "");
+              return ascending ? av.localeCompare(bv) : bv.localeCompare(av);
+            });
+          }
+          return Promise.resolve({ data: rows, error: null }).then(resolve);
+        },
+      };
+
+      return builder;
+    }),
+    storage: {
+      from: vi.fn((bucket: string) => ({
+        download: vi.fn(async (path: string) => ({
+          data: storageEntries[`${bucket}:${path}`] || null,
+          error: storageEntries[`${bucket}:${path}`] ? null : { message: "not found" },
+        })),
+        upload: vi.fn(async (path: string, blob: Blob, options: unknown) => {
+          uploads.push({ bucket, path, blob, options });
+          storageEntries[`${bucket}:${path}`] = blob;
+          return { data: {}, error: null };
+        }),
+      })),
+    },
+  };
+
+  return { client, uploads };
+};
+
+describe("duplicate sound documentation helpers", () => {
+  it("renames copied files and preserves the source stage scope in the target path", () => {
+    expect(
+      renameCopiedSoundDocumentFile({
+        sourceFileName: "SoundVision_Report_Source_Show.pdf",
+        sourceJobTitle: "Source Show",
+        targetJobTitle: "Target Show",
+      })
+    ).toBe("SoundVision_Report_Target_Show.pdf");
+
+    expect(
+      buildCopiedSoundDocumentPath({
+        idFactory: () => "copy-id",
+        sourceFilePath: "calculators/consumos/source-job/stage-2-main/source.pdf",
+        sourceJobId: "source-job",
+        targetFileName: "Sound Power Report - Target Show.pdf",
+        targetJobId: "target-job",
+      })
+    ).toBe("calculators/consumos/target-job/stage-2-main/copy-id-Sound_Power_Report_-_Target_Show.pdf");
+  });
+
+  it("selects generic sound docs and only the latest generated sound docs per category scope", () => {
+    const docs = [
+      {
+        id: "task-doc",
+        file_name: "Task.pdf",
+        file_path: "sound/source-job/task-1/Task.pdf",
+        uploaded_at: "2026-01-05T00:00:00Z",
+      },
+      {
+        id: "generic-doc",
+        file_name: "Patch.pdf",
+        file_path: "sound/source-job/Patch.pdf",
+        uploaded_at: "2026-01-05T00:00:00Z",
+      },
+      {
+        id: "old-power",
+        file_name: "Sound Power Report - Source.pdf",
+        file_path: "calculators/consumos/source-job/report-old.pdf",
+        uploaded_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "new-power",
+        file_name: "Sound Power Report - Source.pdf",
+        file_path: "calculators/consumos/source-job/report-new.pdf",
+        uploaded_at: "2026-01-02T00:00:00Z",
+      },
+      {
+        id: "video-power",
+        file_name: "Video Power Report - Source.pdf",
+        file_path: "calculators/consumos/source-job/video.pdf",
+        uploaded_at: "2026-01-03T00:00:00Z",
+      },
+      {
+        id: "material",
+        file_name: "Lista de material - sound.pdf",
+        file_path: "calculators/lista-material/sound/source-job/lista.pdf",
+        uploaded_at: "2026-01-04T00:00:00Z",
+      },
+      {
+        id: "template",
+        file_name: "Venue.xmls",
+        file_path: "soundvision-files/venues/venue.xmls",
+        uploaded_at: "2026-01-04T00:00:00Z",
+        template_type: "soundvision",
+      },
+    ].map((doc) => ({
+      ...doc,
+      file_size: 1,
+      file_type: "application/pdf",
+      original_type: "pdf",
+      read_only: false,
+      template_type: doc.template_type ?? null,
+      uploaded_by: null as string | null,
+      visible_to_tech: true,
+    }));
+
+    const selected = selectSoundDocumentsForCopy(docs, "source-job", [
+      "soundDocuments",
+      "power",
+      "material",
+      "soundvision",
+    ]);
+
+    expect(selected.map((item) => item.doc.id).sort()).toEqual([
+      "generic-doc",
+      "material",
+      "new-power",
+      "template",
+    ]);
+  });
+});
+
+describe("duplicateSoundDocumentation", () => {
+  it("copies documents and replaces target sound power/memoria rows from the source job", async () => {
+    const blob = await createPdfBlob();
+    const sourcePdfSize = blob.size;
+    const tables: FakeTables = {
+      job_documents: [
+        {
+          id: "generic",
+          job_id: "source-job",
+          file_name: "Patch Source Show.pdf",
+          file_path: "sound/source-job/Patch Source Show.pdf",
+          file_size: 3,
+          file_type: "application/pdf",
+          original_type: "pdf",
+          read_only: false,
+          template_type: null,
+          uploaded_at: "2026-01-01T00:00:00Z",
+          uploaded_by: "source-user",
+          visible_to_tech: true,
+        },
+        {
+          id: "power",
+          job_id: "source-job",
+          file_name: "Sound Power Report - Source Show.pdf",
+          file_path: "calculators/consumos/source-job/power.pdf",
+          file_size: 3,
+          file_type: "application/pdf",
+          original_type: "pdf",
+          read_only: false,
+          template_type: null,
+          uploaded_at: "2026-01-02T00:00:00Z",
+          uploaded_by: "source-user",
+          visible_to_tech: true,
+        },
+        {
+          id: "template",
+          job_id: "source-job",
+          file_name: "Venue.xmls",
+          file_path: "soundvision-files/venues/venue.xmls",
+          file_size: 3,
+          file_type: "application/octet-stream",
+          original_type: null,
+          read_only: true,
+          template_type: "soundvision",
+          uploaded_at: "2026-01-03T00:00:00Z",
+          uploaded_by: "source-user",
+          visible_to_tech: true,
+        },
+      ],
+      power_requirement_tables: [
+        {
+          id: "source-power-row",
+          job_id: "source-job",
+          department: "sound",
+          table_name: "FOH",
+          total_watts: 1200,
+          current_per_phase: 5,
+          pdu_type: "32A",
+          custom_pdu_type: null,
+          position: "foh",
+          custom_position: null,
+          includes_hoist: false,
+          table_data: { rows: [], generationTimestamp: "old" },
+          stage_number: null,
+          stage_name: null,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "target-power-row",
+          job_id: "target-job",
+          department: "sound",
+          table_name: "Old",
+          total_watts: 1,
+          current_per_phase: 1,
+          pdu_type: "16A",
+          custom_pdu_type: null,
+          position: null,
+          custom_position: null,
+          includes_hoist: false,
+          table_data: {},
+          stage_number: null,
+          stage_name: null,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      memoria_tecnica_documents: [
+        {
+          id: "source-memoria",
+          job_id: "source-job",
+          project_name: "Source Show",
+          stage_number: null,
+          stage_name: null,
+          final_document_url: "https://old.example/final.pdf",
+          material_list_url: "https://old.example/material.pdf",
+          soundvision_report_url: "https://old.example/sv.pdf",
+          power_report_url: "https://old.example/power.pdf",
+          weight_report_url: null,
+          rigging_plot_url: null,
+        },
+        {
+          id: "target-memoria",
+          job_id: "target-job",
+          project_name: "Old Target",
+          final_document_url: "https://old.example/target.pdf",
+        },
+      ],
+    };
+    const storageEntries = {
+      "job_documents:sound/source-job/Patch Source Show.pdf": blob,
+      "job-documents:calculators/consumos/source-job/power.pdf": blob,
+    };
+    const { client, uploads } = createFakeClient(tables, storageEntries);
+    const ids = ["copy-a", "copy-b"];
+
+    const result = await duplicateSoundDocumentation({
+      client: client as never,
+      idFactory: () => ids.shift() || "fallback",
+      sourceJobId: "source-job",
+      sourceJobTitle: "Source Show",
+      targetJobDate: "2026-02-14T20:00:00Z",
+      targetJobId: "target-job",
+      targetJobTitle: "Target Show",
+    });
+
+    expect(result).toMatchObject({
+      copiedDocuments: 3,
+      copiedMemoriaRows: 1,
+      copiedPowerTables: 1,
+      skippedDocuments: 0,
+    });
+
+    expect(uploads.map((upload) => `${upload.bucket}:${upload.path}`).sort()).toEqual([
+      "job-documents:calculators/consumos/target-job/copy-a-Sound_Power_Report_-_Target_Show.pdf",
+      "job_documents:sound/target-job/copy-b-Patch_Target_Show.pdf",
+    ]);
+    const powerUpload = uploads.find((upload) => upload.path.includes("calculators/consumos/target-job"));
+    expect(powerUpload?.blob.size).toBeGreaterThan(sourcePdfSize);
+    await expect(PDFDocument.load(await powerUpload!.blob.arrayBuffer())).resolves.toBeTruthy();
+
+    const targetDocs = tables.job_documents.filter((row) => row.job_id === "target-job");
+    expect(targetDocs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file_name: "Patch Target Show.pdf",
+          file_path: "sound/target-job/copy-b-Patch_Target_Show.pdf",
+          uploaded_by: "user-1",
+        }),
+        expect.objectContaining({
+          file_name: "Sound Power Report - Target Show.pdf",
+          file_path: "calculators/consumos/target-job/copy-a-Sound_Power_Report_-_Target_Show.pdf",
+          uploaded_by: "user-1",
+        }),
+        expect.objectContaining({
+          file_name: "Venue.xmls",
+          file_path: "soundvision-files/venues/venue.xmls",
+          read_only: true,
+          template_type: "soundvision",
+        }),
+      ])
+    );
+
+    expect(tables.power_requirement_tables.filter((row) => row.job_id === "target-job")).toEqual([
+      expect.objectContaining({
+        department: "sound",
+        job_id: "target-job",
+        table_name: "FOH",
+        total_watts: 1200,
+      }),
+    ]);
+
+    expect(tables.memoria_tecnica_documents.filter((row) => row.job_id === "target-job")).toEqual([
+      expect.objectContaining({
+        project_name: "Target Show",
+        final_document_url: null,
+        material_list_url: null,
+        soundvision_report_url: null,
+        power_report_url: null,
+      }),
+    ]);
+  });
+});

--- a/src/utils/__tests__/duplicateSoundDocumentation.test.ts
+++ b/src/utils/__tests__/duplicateSoundDocumentation.test.ts
@@ -132,6 +132,17 @@ describe("duplicate sound documentation helpers", () => {
         targetJobId: "target-job",
       })
     ).toBe("calculators/consumos/target-job/stage-2-main/copy-id-Sound_Power_Report_-_Target_Show.pdf");
+
+    expect(
+      buildCopiedSoundDocumentPath({
+        idFactory: () => "copy-id",
+        jobScopedStorage: true,
+        sourceFilePath: "calculators/consumos/source-job/stage-2-main/source.pdf",
+        sourceJobId: "source-job",
+        targetFileName: "Sound Power Report - Target Show.pdf",
+        targetJobId: "target-job",
+      })
+    ).toBe("target-job/calculators/consumos/stage-2-main/copy-id-Sound_Power_Report_-_Target_Show.pdf");
   });
 
   it("selects generic sound docs and only the latest generated sound docs per category scope", () => {
@@ -159,6 +170,12 @@ describe("duplicate sound documentation helpers", () => {
         file_name: "Sound Power Report - Source.pdf",
         file_path: "calculators/consumos/source-job/report-new.pdf",
         uploaded_at: "2026-01-02T00:00:00Z",
+      },
+      {
+        id: "job-scoped-power",
+        file_name: "Sound Power Report - Source.pdf",
+        file_path: "source-job/calculators/consumos/report-copy.pdf",
+        uploaded_at: "2026-01-06T00:00:00Z",
       },
       {
         id: "video-power",
@@ -199,8 +216,8 @@ describe("duplicate sound documentation helpers", () => {
 
     expect(selected.map((item) => item.doc.id).sort()).toEqual([
       "generic-doc",
+      "job-scoped-power",
       "material",
-      "new-power",
       "template",
     ]);
   });
@@ -338,10 +355,10 @@ describe("duplicateSoundDocumentation", () => {
     });
 
     expect(uploads.map((upload) => `${upload.bucket}:${upload.path}`).sort()).toEqual([
-      "job-documents:calculators/consumos/target-job/copy-a-Sound_Power_Report_-_Target_Show.pdf",
+      "job-documents:target-job/calculators/consumos/copy-a-Sound_Power_Report_-_Target_Show.pdf",
       "job_documents:sound/target-job/copy-b-Patch_Target_Show.pdf",
     ]);
-    const powerUpload = uploads.find((upload) => upload.path.includes("calculators/consumos/target-job"));
+    const powerUpload = uploads.find((upload) => upload.path.includes("target-job/calculators/consumos"));
     expect(powerUpload?.blob.size).toBeGreaterThan(sourcePdfSize);
     await expect(PDFDocument.load(await powerUpload!.blob.arrayBuffer())).resolves.toBeTruthy();
 
@@ -355,7 +372,7 @@ describe("duplicateSoundDocumentation", () => {
         }),
         expect.objectContaining({
           file_name: "Sound Power Report - Target Show.pdf",
-          file_path: "calculators/consumos/target-job/copy-a-Sound_Power_Report_-_Target_Show.pdf",
+          file_path: "target-job/calculators/consumos/copy-a-Sound_Power_Report_-_Target_Show.pdf",
           uploaded_by: "user-1",
         }),
         expect.objectContaining({

--- a/src/utils/__tests__/powerReportReadiness.test.ts
+++ b/src/utils/__tests__/powerReportReadiness.test.ts
@@ -30,6 +30,14 @@ describe('powerReportReadiness', () => {
         uploaded_at: '2026-04-07T10:02:00.000Z',
       })
     ).toBe('video');
+
+    expect(
+      getTechnicalPowerDepartmentFromDocument({
+        file_name: 'Sound_Power_Report_-_Copied_Show.pdf',
+        file_path: 'job-1/calculators/consumos/Sound_Power_Report_-_Copied_Show.pdf',
+        uploaded_at: '2026-04-07T10:03:00.000Z',
+      })
+    ).toBe('sound');
   });
 
   it('keeps only the newest upload per department', () => {

--- a/src/utils/duplicateSoundDocumentation.ts
+++ b/src/utils/duplicateSoundDocumentation.ts
@@ -1,0 +1,835 @@
+import { dataLayerClient } from "@/services/dataLayerClient";
+import { resolveJobDocLocation } from "@/utils/jobDocuments";
+import { getTechnicalPowerDepartmentFromDocument } from "@/utils/powerReportReadiness";
+import type { Color, PDFFont, PDFPage } from "pdf-lib";
+
+export const SOUND_DOCUMENTATION_COPY_SCOPES = [
+  "soundDocuments",
+  "power",
+  "soundvision",
+  "material",
+  "memoria",
+] as const;
+
+export type SoundDocumentationCopyScope = (typeof SOUND_DOCUMENTATION_COPY_SCOPES)[number];
+
+export type SoundDocumentationCopyResult = {
+  copiedDocuments: number;
+  copiedMemoriaRows: number;
+  copiedPowerTables: number;
+  skippedDocuments: number;
+  documentsByScope: Partial<Record<SoundDocumentationCopyScope, number>>;
+};
+
+type SupabaseLikeError = {
+  message?: string;
+  code?: string;
+};
+
+type SupabaseLikeResult<T> = {
+  data: T | null;
+  error: SupabaseLikeError | null;
+};
+
+type SupabaseLikeQuery<T> = PromiseLike<SupabaseLikeResult<T>> & {
+  delete: () => SupabaseLikeQuery<T>;
+  eq: (column: string, value: unknown) => SupabaseLikeQuery<T>;
+  insert: (payload: unknown) => SupabaseLikeQuery<T>;
+  is: (column: string, value: unknown) => SupabaseLikeQuery<T>;
+  order: (column: string, options?: { ascending?: boolean }) => SupabaseLikeQuery<T>;
+  select: (columns?: string) => SupabaseLikeQuery<T>;
+};
+
+type SupabaseLikeStorageBucket = {
+  download: (path: string) => Promise<SupabaseLikeResult<Blob>>;
+  upload: (
+    path: string,
+    file: Blob,
+    options?: { cacheControl?: string; contentType?: string; upsert?: boolean }
+  ) => Promise<SupabaseLikeResult<unknown>>;
+};
+
+type SupabaseLikeClient = {
+  auth?: {
+    getUser: () => Promise<{ data?: { user?: { id?: string | null } | null } | null }>;
+  };
+  from: <T = unknown>(table: string) => SupabaseLikeQuery<T>;
+  storage: {
+    from: (bucket: string) => SupabaseLikeStorageBucket;
+  };
+};
+
+type JobDocumentRow = {
+  file_name: string;
+  file_path: string;
+  file_size: number | null;
+  file_type: string | null;
+  has_preview?: boolean | null;
+  id: string;
+  original_type: string | null;
+  preview_generated_at?: string | null;
+  preview_url?: string | null;
+  read_only: boolean | null;
+  template_type: string | null;
+  uploaded_at: string | null;
+  uploaded_by: string | null;
+  visible_to_tech: boolean | null;
+};
+
+type PowerRequirementRow = {
+  created_at: string | null;
+  current_per_phase: number;
+  custom_pdu_type: string | null;
+  custom_position: string | null;
+  department: string | null;
+  id: string;
+  includes_hoist: boolean | null;
+  job_id: string | null;
+  pdu_type: string;
+  position: string | null;
+  stage_name: string | null;
+  stage_number: number | null;
+  table_data: unknown;
+  table_name: string;
+  total_watts: number;
+};
+
+type MemoriaTecnicaRow = Record<string, unknown> & {
+  id?: string;
+  job_id?: string | null;
+  project_name?: string;
+};
+
+type ClassifiedDocument = {
+  doc: JobDocumentRow;
+  groupKey: string;
+  scope: SoundDocumentationCopyScope;
+};
+
+export type DuplicateSoundDocumentationOptions = {
+  client?: SupabaseLikeClient;
+  idFactory?: () => string;
+  scopes?: SoundDocumentationCopyScope[];
+  sourceJobId: string;
+  sourceJobTitle?: string | null;
+  targetJobDate?: string | null;
+  targetJobId: string;
+  targetJobTitle?: string | null;
+};
+
+const JOB_DOCUMENT_SELECT = [
+  "id",
+  "job_id",
+  "file_name",
+  "file_path",
+  "file_size",
+  "file_type",
+  "uploaded_at",
+  "uploaded_by",
+  "original_type",
+  "visible_to_tech",
+  "read_only",
+  "template_type",
+  "has_preview",
+  "preview_url",
+  "preview_generated_at",
+].join(", ");
+
+const generatedDocumentPrefixes = {
+  material: "calculators/lista-material/sound",
+  power: "calculators/consumos",
+  soundvision: "calculators/sv-report",
+} as const;
+
+const emptyResult = (): SoundDocumentationCopyResult => ({
+  copiedDocuments: 0,
+  copiedMemoriaRows: 0,
+  copiedPowerTables: 0,
+  skippedDocuments: 0,
+  documentsByScope: {},
+});
+
+const normalizePath = (path: string) => path.replace(/^\/+/, "");
+
+const sanitizeFileName = (fileName: string) =>
+  fileName
+    .replace(/[^a-zA-Z0-9._-]/g, "_")
+    .replace(/_{2,}/g, "_")
+    .replace(/^_|_$/g, "") || "document.pdf";
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const slugLikeTitle = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/_{2,}/g, "_")
+    .replace(/^_|_$/g, "");
+
+const createDocumentVersionSegment = (idFactory?: () => string) =>
+  idFactory?.() ?? globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const isPdfDocument = (doc: Pick<JobDocumentRow, "file_name" | "file_type">) =>
+  doc.file_type?.toLowerCase().includes("pdf") || doc.file_name.toLowerCase().endsWith(".pdf");
+
+const formatDateForCopiedPdf = (
+  dateValue: string | null | undefined,
+  formatStyle: "short" | "long" = "short"
+) => {
+  if (!dateValue) return "";
+  const parsed = new Date(dateValue);
+  if (Number.isNaN(parsed.getTime())) return "";
+
+  return formatStyle === "long"
+    ? new Intl.DateTimeFormat("en-US", {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+      }).format(parsed)
+    : new Intl.DateTimeFormat("en-GB").format(parsed);
+};
+
+const drawCenteredPdfText = (
+  page: Pick<PDFPage, "drawText" | "getWidth">,
+  text: string,
+  y: number,
+  options: {
+    color: Color;
+    font: PDFFont;
+    maxWidth?: number;
+    minSize?: number;
+    size: number;
+  }
+) => {
+  const pageWidth = page.getWidth();
+  const maxWidth = options.maxWidth ?? pageWidth - 72;
+  let size = options.size;
+
+  while (size > (options.minSize ?? 8) && options.font.widthOfTextAtSize(text, size) > maxWidth) {
+    size -= 1;
+  }
+
+  const textWidth = options.font.widthOfTextAtSize(text, size);
+  page.drawText(text, {
+    color: options.color,
+    font: options.font,
+    size,
+    x: Math.max(18, (pageWidth - textWidth) / 2),
+    y,
+  });
+};
+
+const getGeneratedPdfHeader = ({
+  scope,
+  targetJobDate,
+  targetJobTitle,
+}: {
+  scope: SoundDocumentationCopyScope;
+  targetJobDate?: string | null;
+  targetJobTitle?: string | null;
+}) => {
+  const title = targetJobTitle?.trim() || "Trabajo";
+
+  switch (scope) {
+    case "power":
+      return {
+        background: "corporate" as const,
+        lines: [
+          { text: "Informe de Distribución de Potencia", size: 20, weight: "bold" as const },
+          { text: title, size: 14, weight: "regular" as const },
+          { text: `Fecha del Trabajo: ${formatDateForCopiedPdf(targetJobDate) || "Sin fecha"}`, size: 11, weight: "regular" as const },
+        ],
+      };
+    case "soundvision":
+      return {
+        background: "corporate" as const,
+        lines: [
+          { text: "SOUNDVISION REPORT", size: 20, weight: "bold" as const },
+          { text: title, size: 13, weight: "regular" as const },
+          { text: formatDateForCopiedPdf(targetJobDate, "long") || "No date", size: 11, weight: "regular" as const },
+        ],
+      };
+    case "material":
+      return {
+        background: "white" as const,
+        lines: [
+          { text: "Listado de Material", size: 16, weight: "bold" as const },
+          { text: title, size: 12, weight: "regular" as const },
+          { text: formatDateForCopiedPdf(targetJobDate) ? `Fecha del Trabajo: ${formatDateForCopiedPdf(targetJobDate)}` : "", size: 10, weight: "regular" as const },
+        ].filter((line) => line.text),
+      };
+    default:
+      return null;
+  }
+};
+
+const rewriteGeneratedPdfHeader = async ({
+  blob,
+  scope,
+  targetJobDate,
+  targetJobTitle,
+}: {
+  blob: Blob;
+  scope: SoundDocumentationCopyScope;
+  targetJobDate?: string | null;
+  targetJobTitle?: string | null;
+}) => {
+  const header = getGeneratedPdfHeader({ scope, targetJobDate, targetJobTitle });
+  if (!header) return blob;
+
+  const { PDFDocument, StandardFonts, rgb } = await import("pdf-lib");
+  const pdf = await PDFDocument.load(await blob.arrayBuffer());
+  const boldFont = await pdf.embedFont(StandardFonts.HelveticaBold);
+  const regularFont = await pdf.embedFont(StandardFonts.Helvetica);
+  const corporate = rgb(125 / 255, 1 / 255, 1 / 255);
+  const white = rgb(1, 1, 1);
+  const dark = rgb(0.12, 0.12, 0.12);
+  const topBandHeight = header.background === "corporate" ? 114 : 76;
+
+  pdf.getPages().forEach((page) => {
+    const pageHeight = page.getHeight();
+    const pageWidth = page.getWidth();
+    const bandY = pageHeight - topBandHeight;
+
+    page.drawRectangle({
+      x: 0,
+      y: bandY,
+      width: pageWidth,
+      height: topBandHeight,
+      color: header.background === "corporate" ? corporate : white,
+    });
+
+    const textColor = header.background === "corporate" ? white : corporate;
+    const secondaryTextColor = header.background === "corporate" ? white : dark;
+    const yPositions =
+      header.background === "corporate"
+        ? [pageHeight - 55, pageHeight - 82, pageHeight - 104]
+        : [pageHeight - 24, pageHeight - 45, pageHeight - 62];
+
+    header.lines.forEach((line, index) => {
+      drawCenteredPdfText(page, line.text, yPositions[index] ?? yPositions[yPositions.length - 1], {
+        color: index === 0 ? textColor : secondaryTextColor,
+        font: line.weight === "bold" ? boldFont : regularFont,
+        maxWidth: pageWidth - 72,
+        minSize: 7,
+        size: line.size,
+      });
+    });
+  });
+
+  const bytes = await pdf.save();
+  const arrayBuffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(arrayBuffer).set(bytes);
+  return new Blob([arrayBuffer], { type: "application/pdf" });
+};
+
+const maybeRewriteCopiedPdf = async ({
+  blob,
+  doc,
+  scope,
+  targetJobDate,
+  targetJobTitle,
+}: {
+  blob: Blob;
+  doc: JobDocumentRow;
+  scope: SoundDocumentationCopyScope;
+  targetJobDate?: string | null;
+  targetJobTitle?: string | null;
+}) => {
+  if (!isPdfDocument(doc) || !["power", "soundvision", "material"].includes(scope)) {
+    return blob;
+  }
+
+  try {
+    return await rewriteGeneratedPdfHeader({
+      blob,
+      scope,
+      targetJobDate,
+      targetJobTitle,
+    });
+  } catch (error) {
+    console.warn("[duplicateSoundDocumentation] PDF header rewrite failed; copying original PDF", {
+      error,
+      filePath: doc.file_path,
+    });
+    return blob;
+  }
+};
+
+export const renameCopiedSoundDocumentFile = ({
+  sourceFileName,
+  sourceJobTitle,
+  targetJobTitle,
+}: {
+  sourceFileName: string;
+  sourceJobTitle?: string | null;
+  targetJobTitle?: string | null;
+}) => {
+  const sourceTitle = sourceJobTitle?.trim();
+  const targetTitle = targetJobTitle?.trim();
+  if (!sourceTitle || !targetTitle || sourceTitle === targetTitle) {
+    return sourceFileName;
+  }
+
+  const variants = [
+    { source: sourceTitle, target: targetTitle },
+    { source: sourceTitle.replace(/\s+/g, "_"), target: targetTitle.replace(/\s+/g, "_") },
+    { source: slugLikeTitle(sourceTitle), target: slugLikeTitle(targetTitle) },
+  ].filter((variant) => variant.source && variant.target);
+
+  let nextFileName = sourceFileName;
+  for (const variant of variants) {
+    nextFileName = nextFileName.replace(new RegExp(escapeRegExp(variant.source), "gi"), variant.target);
+  }
+
+  return nextFileName;
+};
+
+export const buildCopiedSoundDocumentPath = ({
+  idFactory,
+  sourceFilePath,
+  sourceJobId,
+  targetFileName,
+  targetJobId,
+}: {
+  idFactory?: () => string;
+  sourceFilePath: string;
+  sourceJobId: string;
+  targetFileName: string;
+  targetJobId: string;
+}) => {
+  const normalized = normalizePath(sourceFilePath);
+  const sourceSegment = `/${sourceJobId}/`;
+  const sourceIndex = normalized.indexOf(sourceSegment);
+
+  if (sourceIndex < 0) {
+    throw new Error(`Document path does not include source job id: ${sourceFilePath}`);
+  }
+
+  const beforeJob = normalized.slice(0, sourceIndex + 1);
+  const afterJob = normalized.slice(sourceIndex + sourceSegment.length);
+  const afterSegments = afterJob.split("/").filter(Boolean);
+  const scopeSegments = afterSegments.slice(0, -1);
+  const destinationFolder = [beforeJob.replace(/\/$/, ""), targetJobId, ...scopeSegments]
+    .filter(Boolean)
+    .join("/");
+  const version = createDocumentVersionSegment(idFactory);
+
+  return `${destinationFolder}/${version}-${sanitizeFileName(targetFileName)}`;
+};
+
+const incrementScope = (
+  counts: SoundDocumentationCopyResult["documentsByScope"],
+  scope: SoundDocumentationCopyScope
+) => {
+  counts[scope] = (counts[scope] ?? 0) + 1;
+};
+
+const parseGeneratedScope = (filePath: string, sourceJobId: string, prefix: string) => {
+  const fullPrefix = `${prefix}/${sourceJobId}/`;
+  if (!filePath.startsWith(fullPrefix)) return null;
+
+  const rest = filePath.slice(fullPrefix.length);
+  const segments = rest.split("/").filter(Boolean);
+  return segments.length > 1 ? segments[0] : "unscoped";
+};
+
+const classifySoundDocument = (
+  doc: JobDocumentRow,
+  sourceJobId: string,
+  wantedScopes: Set<SoundDocumentationCopyScope>
+): ClassifiedDocument | null => {
+  const filePath = normalizePath(doc.file_path);
+
+  if (
+    wantedScopes.has("soundvision") &&
+    doc.template_type === "soundvision" &&
+    filePath.startsWith("soundvision-files/")
+  ) {
+    return { doc, groupKey: "soundvision-template", scope: "soundvision" };
+  }
+
+  if (wantedScopes.has("soundDocuments") && filePath.startsWith(`sound/${sourceJobId}/`)) {
+    const afterJob = filePath.slice(`sound/${sourceJobId}/`.length);
+    if (!afterJob.startsWith("task-")) {
+      return { doc, groupKey: `sound-document:${doc.id}`, scope: "soundDocuments" };
+    }
+  }
+
+  if (wantedScopes.has("material")) {
+    const materialScope = parseGeneratedScope(filePath, sourceJobId, generatedDocumentPrefixes.material);
+    if (materialScope) {
+      return { doc, groupKey: `material:${materialScope}`, scope: "material" };
+    }
+  }
+
+  if (wantedScopes.has("soundvision")) {
+    const soundvisionScope = parseGeneratedScope(filePath, sourceJobId, generatedDocumentPrefixes.soundvision);
+    if (soundvisionScope) {
+      return { doc, groupKey: `soundvision-report:${soundvisionScope}`, scope: "soundvision" };
+    }
+  }
+
+  if (wantedScopes.has("power")) {
+    const powerScope = parseGeneratedScope(filePath, sourceJobId, generatedDocumentPrefixes.power);
+    if (powerScope && getTechnicalPowerDepartmentFromDocument(doc) === "sound") {
+      return { doc, groupKey: `power:${powerScope}`, scope: "power" };
+    }
+  }
+
+  return null;
+};
+
+export const selectSoundDocumentsForCopy = (
+  docs: JobDocumentRow[],
+  sourceJobId: string,
+  scopes: SoundDocumentationCopyScope[]
+) => {
+  const wantedScopes = new Set(scopes);
+  const latestByGroup = new Map<string, ClassifiedDocument>();
+
+  docs.forEach((doc) => {
+    const classified = classifySoundDocument(doc, sourceJobId, wantedScopes);
+    if (!classified) return;
+
+    if (classified.scope === "soundDocuments") {
+      latestByGroup.set(classified.groupKey, classified);
+      return;
+    }
+
+    const existing = latestByGroup.get(classified.groupKey);
+    const existingTime = Date.parse(existing?.doc.uploaded_at || "") || 0;
+    const nextTime = Date.parse(classified.doc.uploaded_at || "") || 0;
+    if (!existing || nextTime >= existingTime) {
+      latestByGroup.set(classified.groupKey, classified);
+    }
+  });
+
+  return [...latestByGroup.values()];
+};
+
+const getCurrentUserId = async (client: SupabaseLikeClient) => {
+  const response = await client.auth?.getUser();
+  return response?.data?.user?.id ?? null;
+};
+
+const insertCopiedTemplateDocument = async ({
+  client,
+  doc,
+  targetJobId,
+  uploadedBy,
+}: {
+  client: SupabaseLikeClient;
+  doc: JobDocumentRow;
+  targetJobId: string;
+  uploadedBy: string | null;
+}) => {
+  const { error } = await client.from("job_documents").insert({
+    job_id: targetJobId,
+    file_name: doc.file_name,
+    file_path: doc.file_path,
+    file_size: doc.file_size,
+    file_type: doc.file_type,
+    uploaded_by: uploadedBy,
+    original_type: doc.original_type,
+    visible_to_tech: doc.visible_to_tech ?? true,
+    read_only: true,
+    template_type: "soundvision",
+    has_preview: false,
+    preview_url: null,
+    preview_generated_at: null,
+  });
+  if (error) throw error;
+};
+
+const copyJobDocumentFile = async ({
+  client,
+  doc,
+  idFactory,
+  scope,
+  sourceJobId,
+  sourceJobTitle,
+  targetJobDate,
+  targetJobId,
+  targetJobTitle,
+  uploadedBy,
+}: {
+  client: SupabaseLikeClient;
+  doc: JobDocumentRow;
+  idFactory?: () => string;
+  scope: SoundDocumentationCopyScope;
+  sourceJobId: string;
+  sourceJobTitle?: string | null;
+  targetJobDate?: string | null;
+  targetJobId: string;
+  targetJobTitle?: string | null;
+  uploadedBy: string | null;
+}) => {
+  const sourceLocation = resolveJobDocLocation(doc.file_path);
+  const { data: blob, error: downloadError } = await client.storage
+    .from(sourceLocation.bucket)
+    .download(sourceLocation.path);
+
+  if (downloadError) throw downloadError;
+  if (!blob) throw new Error(`No file data returned for ${doc.file_name}`);
+
+  const targetFileName = renameCopiedSoundDocumentFile({
+    sourceFileName: doc.file_name,
+    sourceJobTitle,
+    targetJobTitle,
+  });
+  const targetPath = buildCopiedSoundDocumentPath({
+    idFactory,
+    sourceFilePath: doc.file_path,
+    sourceJobId,
+    targetFileName,
+    targetJobId,
+  });
+  const targetLocation = resolveJobDocLocation(targetPath);
+  const uploadBlob = await maybeRewriteCopiedPdf({
+    blob,
+    doc,
+    scope,
+    targetJobDate,
+    targetJobTitle,
+  });
+
+  const { error: uploadError } = await client.storage
+    .from(targetLocation.bucket)
+    .upload(targetLocation.path, uploadBlob, {
+      cacheControl: "0",
+      contentType: doc.file_type || "application/octet-stream",
+      upsert: false,
+    });
+  if (uploadError) throw uploadError;
+
+  const { error: insertError } = await client.from("job_documents").insert({
+    job_id: targetJobId,
+    file_name: targetFileName,
+    file_path: targetPath,
+    file_size: uploadBlob.size,
+    file_type: doc.file_type,
+    uploaded_by: uploadedBy,
+    original_type: doc.original_type,
+    visible_to_tech: doc.visible_to_tech ?? true,
+    read_only: doc.read_only ?? false,
+    template_type: doc.template_type,
+    has_preview: false,
+    preview_url: null,
+    preview_generated_at: null,
+  });
+  if (insertError) throw insertError;
+};
+
+const copyPowerRequirementRows = async ({
+  client,
+  sourceJobId,
+  targetJobId,
+}: {
+  client: SupabaseLikeClient;
+  sourceJobId: string;
+  targetJobId: string;
+}) => {
+  const { data, error } = await client
+    .from<PowerRequirementRow[]>("power_requirement_tables")
+    .select("*")
+    .eq("job_id", sourceJobId)
+    .eq("department", "sound")
+    .order("created_at", { ascending: true });
+  if (error) throw error;
+
+  const rows = data || [];
+  if (rows.length === 0) return 0;
+
+  const { error: deleteError } = await client
+    .from("power_requirement_tables")
+    .delete()
+    .eq("job_id", targetJobId)
+    .eq("department", "sound");
+  if (deleteError) throw deleteError;
+
+  const now = new Date().toISOString();
+  const payload = rows.map((row) => {
+    const tableData =
+      row.table_data && typeof row.table_data === "object" && !Array.isArray(row.table_data)
+        ? { ...row.table_data, generationTimestamp: now }
+        : row.table_data;
+
+    return {
+      current_per_phase: row.current_per_phase,
+      custom_pdu_type: row.custom_pdu_type,
+      custom_position: row.custom_position,
+      department: "sound",
+      includes_hoist: row.includes_hoist,
+      job_id: targetJobId,
+      pdu_type: row.pdu_type,
+      position: row.position,
+      stage_name: row.stage_name,
+      stage_number: row.stage_number,
+      table_data: tableData,
+      table_name: row.table_name,
+      total_watts: row.total_watts,
+      created_at: now,
+    };
+  });
+
+  const { error: insertError } = await client.from("power_requirement_tables").insert(payload);
+  if (insertError) throw insertError;
+  return payload.length;
+};
+
+const copyMemoriaRows = async ({
+  client,
+  sourceJobId,
+  targetJobId,
+  targetJobTitle,
+}: {
+  client: SupabaseLikeClient;
+  sourceJobId: string;
+  targetJobId: string;
+  targetJobTitle?: string | null;
+}) => {
+  const { data, error } = await client
+    .from<MemoriaTecnicaRow[]>("memoria_tecnica_documents")
+    .select("*")
+    .eq("job_id", sourceJobId);
+  if (error) throw error;
+
+  const rows = data || [];
+  if (rows.length === 0) return 0;
+
+  const { error: deleteError } = await client
+    .from("memoria_tecnica_documents")
+    .delete()
+    .eq("job_id", targetJobId);
+  if (deleteError) throw deleteError;
+
+  const payload = rows.map((row) => {
+    const clearedUrl: string | null = null;
+    const {
+      id,
+      job_id,
+      created_at,
+      updated_at,
+      cover_page_url,
+      final_document_url,
+      material_list_url,
+      power_report_url,
+      rigging_plot_url,
+      soundvision_report_url,
+      weight_report_url,
+      ...rest
+    } = row;
+
+    return {
+      ...rest,
+      job_id: targetJobId,
+      project_name: targetJobTitle?.trim() || row.project_name || "Trabajo",
+      cover_page_url: clearedUrl,
+      final_document_url: clearedUrl,
+      material_list_url: clearedUrl,
+      power_report_url: clearedUrl,
+      rigging_plot_url: clearedUrl,
+      soundvision_report_url: clearedUrl,
+      weight_report_url: clearedUrl,
+    };
+  });
+
+  const { error: insertError } = await client.from("memoria_tecnica_documents").insert(payload);
+  if (insertError) throw insertError;
+  return payload.length;
+};
+
+export const duplicateSoundDocumentation = async ({
+  client = dataLayerClient as unknown as SupabaseLikeClient,
+  idFactory,
+  scopes = [...SOUND_DOCUMENTATION_COPY_SCOPES],
+  sourceJobId,
+  sourceJobTitle,
+  targetJobDate,
+  targetJobId,
+  targetJobTitle,
+}: DuplicateSoundDocumentationOptions): Promise<SoundDocumentationCopyResult> => {
+  if (!sourceJobId || !targetJobId) {
+    throw new Error("Source and target jobs are required");
+  }
+
+  if (sourceJobId === targetJobId) {
+    throw new Error("Choose a different source job");
+  }
+
+  const result = emptyResult();
+  const wantedScopes = new Set(scopes);
+  const uploadedBy = await getCurrentUserId(client);
+
+  if (wantedScopes.has("power")) {
+    result.copiedPowerTables = await copyPowerRequirementRows({ client, sourceJobId, targetJobId });
+  }
+
+  if (wantedScopes.has("memoria")) {
+    result.copiedMemoriaRows = await copyMemoriaRows({
+      client,
+      sourceJobId,
+      targetJobId,
+      targetJobTitle,
+    });
+  }
+
+  const documentScopes = scopes.filter((scope) => scope !== "memoria");
+  if (documentScopes.length === 0) return result;
+
+  const { data: docs, error } = await client
+    .from<JobDocumentRow[]>("job_documents")
+    .select(JOB_DOCUMENT_SELECT)
+    .eq("job_id", sourceJobId)
+    .order("uploaded_at", { ascending: false });
+  if (error) throw error;
+
+  const selectedDocuments = selectSoundDocumentsForCopy(docs || [], sourceJobId, documentScopes);
+  const hasTemplate = selectedDocuments.some(
+    ({ doc }) => doc.template_type === "soundvision" && normalizePath(doc.file_path).startsWith("soundvision-files/")
+  );
+
+  if (hasTemplate) {
+    const { error: deleteTemplateError } = await client
+      .from("job_documents")
+      .delete()
+      .eq("job_id", targetJobId)
+      .eq("template_type", "soundvision");
+    if (deleteTemplateError) throw deleteTemplateError;
+  }
+
+  for (const { doc, scope } of selectedDocuments) {
+    try {
+      if (doc.template_type === "soundvision" && normalizePath(doc.file_path).startsWith("soundvision-files/")) {
+        await insertCopiedTemplateDocument({ client, doc, targetJobId, uploadedBy });
+      } else {
+        await copyJobDocumentFile({
+          client,
+          doc,
+          idFactory,
+          scope,
+          sourceJobId,
+          sourceJobTitle,
+          targetJobDate,
+          targetJobId,
+          targetJobTitle,
+          uploadedBy,
+        });
+      }
+      result.copiedDocuments += 1;
+      incrementScope(result.documentsByScope, scope);
+    } catch (error) {
+      result.skippedDocuments += 1;
+      console.error("[duplicateSoundDocumentation] Failed to copy document", {
+        error,
+        filePath: doc.file_path,
+        sourceJobId,
+        targetJobId,
+      });
+    }
+  }
+
+  return result;
+};

--- a/src/utils/duplicateSoundDocumentation.ts
+++ b/src/utils/duplicateSoundDocumentation.ts
@@ -1,7 +1,7 @@
 import { dataLayerClient } from "@/services/dataLayerClient";
+import { maybeRewriteCopiedGeneratedPdf } from "@/utils/duplicateSoundDocumentationPdf";
 import { resolveJobDocLocation } from "@/utils/jobDocuments";
 import { getTechnicalPowerDepartmentFromDocument } from "@/utils/powerReportReadiness";
-import type { Color, PDFFont, PDFPage } from "pdf-lib";
 
 export const SOUND_DOCUMENTATION_COPY_SCOPES = [
   "soundDocuments",
@@ -19,6 +19,13 @@ export type SoundDocumentationCopyResult = {
   copiedPowerTables: number;
   skippedDocuments: number;
   documentsByScope: Partial<Record<SoundDocumentationCopyScope, number>>;
+};
+
+export type SoundDocumentationSourceJob = {
+  end_time: string | null;
+  id: string;
+  start_time: string | null;
+  title: string;
 };
 
 type SupabaseLikeError = {
@@ -141,6 +148,21 @@ const generatedDocumentPrefixes = {
   soundvision: "calculators/sv-report",
 } as const;
 
+export const fetchSoundDocumentationSourceJobs = async (
+  targetJobId: string
+): Promise<SoundDocumentationSourceJob[]> => {
+  const { data, error } = await dataLayerClient
+    .from("jobs")
+    .select("id, title, start_time, end_time")
+    .neq("id", targetJobId)
+    .in("job_type", ["single", "festival", "ciclo", "tourdate"])
+    .order("start_time", { ascending: false })
+    .limit(250);
+
+  if (error) throw error;
+  return (data || []) as SoundDocumentationSourceJob[];
+};
+
 const emptyResult = (): SoundDocumentationCopyResult => ({
   copiedDocuments: 0,
   copiedMemoriaRows: 0,
@@ -169,193 +191,6 @@ const slugLikeTitle = (value: string) =>
 
 const createDocumentVersionSegment = (idFactory?: () => string) =>
   idFactory?.() ?? globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-
-const isPdfDocument = (doc: Pick<JobDocumentRow, "file_name" | "file_type">) =>
-  doc.file_type?.toLowerCase().includes("pdf") || doc.file_name.toLowerCase().endsWith(".pdf");
-
-const formatDateForCopiedPdf = (
-  dateValue: string | null | undefined,
-  formatStyle: "short" | "long" = "short"
-) => {
-  if (!dateValue) return "";
-  const parsed = new Date(dateValue);
-  if (Number.isNaN(parsed.getTime())) return "";
-
-  return formatStyle === "long"
-    ? new Intl.DateTimeFormat("en-US", {
-        day: "2-digit",
-        month: "long",
-        year: "numeric",
-      }).format(parsed)
-    : new Intl.DateTimeFormat("en-GB").format(parsed);
-};
-
-const drawCenteredPdfText = (
-  page: Pick<PDFPage, "drawText" | "getWidth">,
-  text: string,
-  y: number,
-  options: {
-    color: Color;
-    font: PDFFont;
-    maxWidth?: number;
-    minSize?: number;
-    size: number;
-  }
-) => {
-  const pageWidth = page.getWidth();
-  const maxWidth = options.maxWidth ?? pageWidth - 72;
-  let size = options.size;
-
-  while (size > (options.minSize ?? 8) && options.font.widthOfTextAtSize(text, size) > maxWidth) {
-    size -= 1;
-  }
-
-  const textWidth = options.font.widthOfTextAtSize(text, size);
-  page.drawText(text, {
-    color: options.color,
-    font: options.font,
-    size,
-    x: Math.max(18, (pageWidth - textWidth) / 2),
-    y,
-  });
-};
-
-const getGeneratedPdfHeader = ({
-  scope,
-  targetJobDate,
-  targetJobTitle,
-}: {
-  scope: SoundDocumentationCopyScope;
-  targetJobDate?: string | null;
-  targetJobTitle?: string | null;
-}) => {
-  const title = targetJobTitle?.trim() || "Trabajo";
-
-  switch (scope) {
-    case "power":
-      return {
-        background: "corporate" as const,
-        lines: [
-          { text: "Informe de Distribución de Potencia", size: 20, weight: "bold" as const },
-          { text: title, size: 14, weight: "regular" as const },
-          { text: `Fecha del Trabajo: ${formatDateForCopiedPdf(targetJobDate) || "Sin fecha"}`, size: 11, weight: "regular" as const },
-        ],
-      };
-    case "soundvision":
-      return {
-        background: "corporate" as const,
-        lines: [
-          { text: "SOUNDVISION REPORT", size: 20, weight: "bold" as const },
-          { text: title, size: 13, weight: "regular" as const },
-          { text: formatDateForCopiedPdf(targetJobDate, "long") || "No date", size: 11, weight: "regular" as const },
-        ],
-      };
-    case "material":
-      return {
-        background: "white" as const,
-        lines: [
-          { text: "Listado de Material", size: 16, weight: "bold" as const },
-          { text: title, size: 12, weight: "regular" as const },
-          { text: formatDateForCopiedPdf(targetJobDate) ? `Fecha del Trabajo: ${formatDateForCopiedPdf(targetJobDate)}` : "", size: 10, weight: "regular" as const },
-        ].filter((line) => line.text),
-      };
-    default:
-      return null;
-  }
-};
-
-const rewriteGeneratedPdfHeader = async ({
-  blob,
-  scope,
-  targetJobDate,
-  targetJobTitle,
-}: {
-  blob: Blob;
-  scope: SoundDocumentationCopyScope;
-  targetJobDate?: string | null;
-  targetJobTitle?: string | null;
-}) => {
-  const header = getGeneratedPdfHeader({ scope, targetJobDate, targetJobTitle });
-  if (!header) return blob;
-
-  const { PDFDocument, StandardFonts, rgb } = await import("pdf-lib");
-  const pdf = await PDFDocument.load(await blob.arrayBuffer());
-  const boldFont = await pdf.embedFont(StandardFonts.HelveticaBold);
-  const regularFont = await pdf.embedFont(StandardFonts.Helvetica);
-  const corporate = rgb(125 / 255, 1 / 255, 1 / 255);
-  const white = rgb(1, 1, 1);
-  const dark = rgb(0.12, 0.12, 0.12);
-  const topBandHeight = header.background === "corporate" ? 114 : 76;
-
-  pdf.getPages().forEach((page) => {
-    const pageHeight = page.getHeight();
-    const pageWidth = page.getWidth();
-    const bandY = pageHeight - topBandHeight;
-
-    page.drawRectangle({
-      x: 0,
-      y: bandY,
-      width: pageWidth,
-      height: topBandHeight,
-      color: header.background === "corporate" ? corporate : white,
-    });
-
-    const textColor = header.background === "corporate" ? white : corporate;
-    const secondaryTextColor = header.background === "corporate" ? white : dark;
-    const yPositions =
-      header.background === "corporate"
-        ? [pageHeight - 55, pageHeight - 82, pageHeight - 104]
-        : [pageHeight - 24, pageHeight - 45, pageHeight - 62];
-
-    header.lines.forEach((line, index) => {
-      drawCenteredPdfText(page, line.text, yPositions[index] ?? yPositions[yPositions.length - 1], {
-        color: index === 0 ? textColor : secondaryTextColor,
-        font: line.weight === "bold" ? boldFont : regularFont,
-        maxWidth: pageWidth - 72,
-        minSize: 7,
-        size: line.size,
-      });
-    });
-  });
-
-  const bytes = await pdf.save();
-  const arrayBuffer = new ArrayBuffer(bytes.byteLength);
-  new Uint8Array(arrayBuffer).set(bytes);
-  return new Blob([arrayBuffer], { type: "application/pdf" });
-};
-
-const maybeRewriteCopiedPdf = async ({
-  blob,
-  doc,
-  scope,
-  targetJobDate,
-  targetJobTitle,
-}: {
-  blob: Blob;
-  doc: JobDocumentRow;
-  scope: SoundDocumentationCopyScope;
-  targetJobDate?: string | null;
-  targetJobTitle?: string | null;
-}) => {
-  if (!isPdfDocument(doc) || !["power", "soundvision", "material"].includes(scope)) {
-    return blob;
-  }
-
-  try {
-    return await rewriteGeneratedPdfHeader({
-      blob,
-      scope,
-      targetJobDate,
-      targetJobTitle,
-    });
-  } catch (error) {
-    console.warn("[duplicateSoundDocumentation] PDF header rewrite failed; copying original PDF", {
-      error,
-      filePath: doc.file_path,
-    });
-    return blob;
-  }
-};
 
 export const renameCopiedSoundDocumentFile = ({
   sourceFileName,
@@ -587,7 +422,7 @@ const copyJobDocumentFile = async ({
     targetJobId,
   });
   const targetLocation = resolveJobDocLocation(targetPath);
-  const uploadBlob = await maybeRewriteCopiedPdf({
+  const uploadBlob = await maybeRewriteCopiedGeneratedPdf({
     blob,
     doc,
     scope,

--- a/src/utils/duplicateSoundDocumentation.ts
+++ b/src/utils/duplicateSoundDocumentation.ts
@@ -223,32 +223,34 @@ export const renameCopiedSoundDocumentFile = ({
 
 export const buildCopiedSoundDocumentPath = ({
   idFactory,
+  jobScopedStorage = false,
   sourceFilePath,
   sourceJobId,
   targetFileName,
   targetJobId,
 }: {
   idFactory?: () => string;
+  jobScopedStorage?: boolean;
   sourceFilePath: string;
   sourceJobId: string;
   targetFileName: string;
   targetJobId: string;
 }) => {
   const normalized = normalizePath(sourceFilePath);
-  const sourceSegment = `/${sourceJobId}/`;
-  const sourceIndex = normalized.indexOf(sourceSegment);
+  const segments = normalized.split("/").filter(Boolean);
+  const sourceIndex = segments.indexOf(sourceJobId);
 
   if (sourceIndex < 0) {
     throw new Error(`Document path does not include source job id: ${sourceFilePath}`);
   }
 
-  const beforeJob = normalized.slice(0, sourceIndex + 1);
-  const afterJob = normalized.slice(sourceIndex + sourceSegment.length);
-  const afterSegments = afterJob.split("/").filter(Boolean);
+  const beforeJobSegments = segments.slice(0, sourceIndex);
+  const afterSegments = segments.slice(sourceIndex + 1);
   const scopeSegments = afterSegments.slice(0, -1);
-  const destinationFolder = [beforeJob.replace(/\/$/, ""), targetJobId, ...scopeSegments]
-    .filter(Boolean)
-    .join("/");
+  const destinationSegments = jobScopedStorage
+    ? [targetJobId, ...beforeJobSegments, ...scopeSegments]
+    : [...beforeJobSegments, targetJobId, ...scopeSegments];
+  const destinationFolder = destinationSegments.filter(Boolean).join("/");
   const version = createDocumentVersionSegment(idFactory);
 
   return `${destinationFolder}/${version}-${sanitizeFileName(targetFileName)}`;
@@ -262,10 +264,16 @@ const incrementScope = (
 };
 
 const parseGeneratedScope = (filePath: string, sourceJobId: string, prefix: string) => {
-  const fullPrefix = `${prefix}/${sourceJobId}/`;
-  if (!filePath.startsWith(fullPrefix)) return null;
+  const legacyPrefix = `${prefix}/${sourceJobId}/`;
+  const jobScopedPrefix = `${sourceJobId}/${prefix}/`;
+  const matchedPrefix = filePath.startsWith(legacyPrefix)
+    ? legacyPrefix
+    : filePath.startsWith(jobScopedPrefix)
+      ? jobScopedPrefix
+      : null;
+  if (!matchedPrefix) return null;
 
-  const rest = filePath.slice(fullPrefix.length);
+  const rest = filePath.slice(matchedPrefix.length);
   const segments = rest.split("/").filter(Boolean);
   return segments.length > 1 ? segments[0] : "unscoped";
 };
@@ -416,6 +424,7 @@ const copyJobDocumentFile = async ({
   });
   const targetPath = buildCopiedSoundDocumentPath({
     idFactory,
+    jobScopedStorage: ["power", "soundvision", "material"].includes(scope),
     sourceFilePath: doc.file_path,
     sourceJobId,
     targetFileName,

--- a/src/utils/duplicateSoundDocumentationPdf.ts
+++ b/src/utils/duplicateSoundDocumentationPdf.ts
@@ -1,0 +1,210 @@
+import type { Color, PDFFont, PDFPage } from "pdf-lib";
+
+import type { SoundDocumentationCopyScope } from "@/utils/duplicateSoundDocumentation";
+
+type GeneratedPdfDocument = {
+  file_name: string;
+  file_path: string;
+  file_type: string | null;
+};
+
+const isPdfDocument = (doc: Pick<GeneratedPdfDocument, "file_name" | "file_type">) =>
+  doc.file_type?.toLowerCase().includes("pdf") || doc.file_name.toLowerCase().endsWith(".pdf");
+
+const formatDateForCopiedPdf = (
+  dateValue: string | null | undefined,
+  formatStyle: "short" | "long" = "short"
+) => {
+  if (!dateValue) return "";
+  const parsed = new Date(dateValue);
+  if (Number.isNaN(parsed.getTime())) return "";
+
+  return formatStyle === "long"
+    ? new Intl.DateTimeFormat("en-US", {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+      }).format(parsed)
+    : new Intl.DateTimeFormat("en-GB").format(parsed);
+};
+
+const drawCenteredPdfText = (
+  page: Pick<PDFPage, "drawText" | "getWidth">,
+  text: string,
+  y: number,
+  options: {
+    color: Color;
+    font: PDFFont;
+    maxWidth?: number;
+    minSize?: number;
+    size: number;
+  }
+) => {
+  const pageWidth = page.getWidth();
+  const maxWidth = options.maxWidth ?? pageWidth - 72;
+  let size = options.size;
+
+  while (size > (options.minSize ?? 8) && options.font.widthOfTextAtSize(text, size) > maxWidth) {
+    size -= 1;
+  }
+
+  const textWidth = options.font.widthOfTextAtSize(text, size);
+  page.drawText(text, {
+    color: options.color,
+    font: options.font,
+    size,
+    x: Math.max(18, (pageWidth - textWidth) / 2),
+    y,
+  });
+};
+
+const getGeneratedPdfHeader = ({
+  scope,
+  targetJobDate,
+  targetJobTitle,
+}: {
+  scope: SoundDocumentationCopyScope;
+  targetJobDate?: string | null;
+  targetJobTitle?: string | null;
+}) => {
+  const title = targetJobTitle?.trim() || "Trabajo";
+
+  switch (scope) {
+    case "power":
+      return {
+        background: "corporate" as const,
+        lines: [
+          { text: "Informe de Distribución de Potencia", size: 20, weight: "bold" as const },
+          { text: title, size: 14, weight: "regular" as const },
+          {
+            text: `Fecha del Trabajo: ${formatDateForCopiedPdf(targetJobDate) || "Sin fecha"}`,
+            size: 11,
+            weight: "regular" as const,
+          },
+        ],
+      };
+    case "soundvision":
+      return {
+        background: "corporate" as const,
+        lines: [
+          { text: "SOUNDVISION REPORT", size: 20, weight: "bold" as const },
+          { text: title, size: 13, weight: "regular" as const },
+          {
+            text: formatDateForCopiedPdf(targetJobDate, "long") || "No date",
+            size: 11,
+            weight: "regular" as const,
+          },
+        ],
+      };
+    case "material":
+      return {
+        background: "white" as const,
+        lines: [
+          { text: "Listado de Material", size: 16, weight: "bold" as const },
+          { text: title, size: 12, weight: "regular" as const },
+          {
+            text: formatDateForCopiedPdf(targetJobDate)
+              ? `Fecha del Trabajo: ${formatDateForCopiedPdf(targetJobDate)}`
+              : "",
+            size: 10,
+            weight: "regular" as const,
+          },
+        ].filter((line) => line.text),
+      };
+    default:
+      return null;
+  }
+};
+
+const rewriteGeneratedPdfHeader = async ({
+  blob,
+  scope,
+  targetJobDate,
+  targetJobTitle,
+}: {
+  blob: Blob;
+  scope: SoundDocumentationCopyScope;
+  targetJobDate?: string | null;
+  targetJobTitle?: string | null;
+}) => {
+  const header = getGeneratedPdfHeader({ scope, targetJobDate, targetJobTitle });
+  if (!header) return blob;
+
+  const { PDFDocument, StandardFonts, rgb } = await import("pdf-lib");
+  const pdf = await PDFDocument.load(await blob.arrayBuffer());
+  const boldFont = await pdf.embedFont(StandardFonts.HelveticaBold);
+  const regularFont = await pdf.embedFont(StandardFonts.Helvetica);
+  const corporate = rgb(125 / 255, 1 / 255, 1 / 255);
+  const white = rgb(1, 1, 1);
+  const dark = rgb(0.12, 0.12, 0.12);
+  const topBandHeight = header.background === "corporate" ? 114 : 76;
+
+  pdf.getPages().forEach((page) => {
+    const pageHeight = page.getHeight();
+    const pageWidth = page.getWidth();
+    const bandY = pageHeight - topBandHeight;
+
+    page.drawRectangle({
+      x: 0,
+      y: bandY,
+      width: pageWidth,
+      height: topBandHeight,
+      color: header.background === "corporate" ? corporate : white,
+    });
+
+    const textColor = header.background === "corporate" ? white : corporate;
+    const secondaryTextColor = header.background === "corporate" ? white : dark;
+    const yPositions =
+      header.background === "corporate"
+        ? [pageHeight - 55, pageHeight - 82, pageHeight - 104]
+        : [pageHeight - 24, pageHeight - 45, pageHeight - 62];
+
+    header.lines.forEach((line, index) => {
+      drawCenteredPdfText(page, line.text, yPositions[index] ?? yPositions[yPositions.length - 1], {
+        color: index === 0 ? textColor : secondaryTextColor,
+        font: line.weight === "bold" ? boldFont : regularFont,
+        maxWidth: pageWidth - 72,
+        minSize: 7,
+        size: line.size,
+      });
+    });
+  });
+
+  const bytes = await pdf.save();
+  const arrayBuffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(arrayBuffer).set(bytes);
+  return new Blob([arrayBuffer], { type: "application/pdf" });
+};
+
+export const maybeRewriteCopiedGeneratedPdf = async ({
+  blob,
+  doc,
+  scope,
+  targetJobDate,
+  targetJobTitle,
+}: {
+  blob: Blob;
+  doc: GeneratedPdfDocument;
+  scope: SoundDocumentationCopyScope;
+  targetJobDate?: string | null;
+  targetJobTitle?: string | null;
+}) => {
+  if (!isPdfDocument(doc) || !["power", "soundvision", "material"].includes(scope)) {
+    return blob;
+  }
+
+  try {
+    return await rewriteGeneratedPdfHeader({
+      blob,
+      scope,
+      targetJobDate,
+      targetJobTitle,
+    });
+  } catch (error) {
+    console.warn("[duplicateSoundDocumentation] PDF header rewrite failed; copying original PDF", {
+      error,
+      filePath: doc.file_path,
+    });
+    return blob;
+  }
+};

--- a/src/utils/jobDocuments/__tests__/stageAwareLookup.test.ts
+++ b/src/utils/jobDocuments/__tests__/stageAwareLookup.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseStageScopeSegment } from "@/utils/jobDocuments/stageAwareLookup";
+
+describe("stage-aware job document lookup helpers", () => {
+  it("parses stage scopes from legacy and job-scoped generated document paths", () => {
+    expect(
+      parseStageScopeSegment(
+        "calculators/consumos/job-1/stage-2-main/copy-id-report.pdf",
+        "job-1",
+        "calculators/consumos"
+      )
+    ).toBe("stage-2-main");
+
+    expect(
+      parseStageScopeSegment(
+        "job-1/calculators/consumos/stage-2-main/copy-id-report.pdf",
+        "job-1",
+        "calculators/consumos"
+      )
+    ).toBe("stage-2-main");
+
+    expect(
+      parseStageScopeSegment(
+        "job-1/calculators/consumos/copy-id-report.pdf",
+        "job-1",
+        "calculators/consumos"
+      )
+    ).toBeNull();
+  });
+});

--- a/src/utils/jobDocuments/stageAwareLookup.ts
+++ b/src/utils/jobDocuments/stageAwareLookup.ts
@@ -14,18 +14,25 @@ export interface StageAwareJobDocument {
 export type StageAwareJobDocumentFilter = (document: StageAwareJobDocument) => boolean;
 
 /**
- * uploadJobPdfWithCleanup writes to `${category}/${jobId}[/${scope}]/${uuid}-${name}`.
- * Given a full file_path known to start with `${category}/${jobId}/`, return the
- * scope segment (e.g. "stage-2-mainstage") if present, or null for an unscoped upload.
+ * Generated PDFs may use the legacy `${category}/${jobId}/...` layout or the
+ * RLS-compatible `${jobId}/${category}/...` layout. Return the scope segment
+ * (e.g. "stage-2-mainstage") if present, or null for an unscoped upload.
  */
 export const parseStageScopeSegment = (
   filePath: string,
   jobId: string,
   category: string
 ): string | null => {
-  const prefix = `${category}/${jobId}/`;
-  if (!filePath.startsWith(prefix)) return null;
-  const rest = filePath.slice(prefix.length);
+  const legacyPrefix = `${category}/${jobId}/`;
+  const jobScopedPrefix = `${jobId}/${category}/`;
+  const matchedPrefix = filePath.startsWith(legacyPrefix)
+    ? legacyPrefix
+    : filePath.startsWith(jobScopedPrefix)
+      ? jobScopedPrefix
+      : null;
+  if (!matchedPrefix) return null;
+
+  const rest = filePath.slice(matchedPrefix.length);
   const segments = rest.split("/");
   // The last segment is always the `${uuid}-${name}` file itself; anything before
   // it is the stage-scope folder written by getTechnicalStageStorageScope().
@@ -46,7 +53,7 @@ export const findLatestJobDocumentForStage = async (
     .from("job_documents")
     .select("id, file_name, file_path, uploaded_at")
     .eq("job_id", jobId)
-    .like("file_path", `${category}/${jobId}/%`)
+    .or(`file_path.like.${category}/${jobId}/%,file_path.like.${jobId}/${category}/%`)
     .order("uploaded_at", { ascending: false });
 
   if (error) throw error;

--- a/src/utils/powerReportReadiness.ts
+++ b/src/utils/powerReportReadiness.ts
@@ -14,6 +14,11 @@ const normalizeValue = (value: string | null | undefined) =>
     .toLowerCase()
     .replace(/\\/g, '/');
 
+const stripJobScopedStoragePrefix = (path: string) => {
+  const segments = path.split('/').filter(Boolean);
+  return segments[1] === 'calculators' ? segments.slice(1).join('/') : path;
+};
+
 const parseUploadedAtTimestamp = (value: string | null) => {
   if (!value) return 0;
   const parsed = Date.parse(value);
@@ -23,7 +28,7 @@ const parseUploadedAtTimestamp = (value: string | null) => {
 export const getTechnicalPowerDepartmentFromDocument = (
   document: PowerReportDocument
 ): TechnicalPowerDepartment | null => {
-  const normalizedPath = normalizeValue(document.file_path);
+  const normalizedPath = stripJobScopedStoragePrefix(normalizeValue(document.file_path));
   const normalizedName = normalizeValue(document.file_name).replace(/[\s-]+/g, '_');
 
   if (normalizedPath.startsWith(LIGHTS_REPORT_PREFIX)) {


### PR DESCRIPTION
## Summary

Adds a sound-documentation duplication flow for project-management sound jobs so users can copy technical documentation from a similar previous job instead of rebuilding it manually.

## What Changed

- Adds a `Duplicar docs` action for eligible sound jobs.
- Adds a dialog to choose a source job and select which documentation groups to copy.
- Copies uploaded sound docs, latest generated power reports, SoundVision reports/templates, latest Flex material-list reports, sound power requirement tables, and Memoria Técnica rows.
- Rewrites the visible header on copied generated PDFs for power, SoundVision, and material-list documents so the target job name/date are shown instead of the source job values.
- Stores copied generated reports under job-scoped `job-documents` object paths so uploads satisfy current storage policies.
- Keeps arbitrary uploaded sound PDFs as normal file copies because their body text cannot be safely rewritten generically.

## Risk Assessment

Medium. This touches document copy/storage paths and generated-report discovery. Risk is contained to the new sound documentation duplication action and supporting generated-report lookup helpers. Existing generated report paths remain supported.

## Impact Checklist

- Sound PM users can duplicate documentation from another eligible job.
- Generated copied reports are stored under authorized job-scoped paths.
- Memoria auto-fill and power report readiness recognize both legacy generated paths and new job-scoped copied paths.
- No Supabase schema or RLS migration is included.

## Rollback Plan

Revert the PR. It adds a new action and supporting utilities without altering existing persisted rows. Already-copied documents would remain as normal `job_documents` rows/storage objects and can be deleted through existing document management flows if needed.

## Migration Impact

No database migration. No production Supabase push is required. The change uses existing `job_documents`, `power_requirement_tables`, `memoria_tecnica_documents`, and storage buckets.

## Validation

- `npm run test:run -- src/utils/__tests__/duplicateSoundDocumentation.test.ts src/utils/__tests__/powerReportReadiness.test.ts src/utils/jobDocuments/__tests__/stageAwareLookup.test.ts`
- `npm run test:run -- src/components/jobs/cards/__tests__/JobCardActions.test.tsx src/utils/__tests__/duplicateSoundDocumentation.test.ts`
- `npm run typecheck`
- `npm run governance`
- `npm run lint`
- `npm run build`
- `npm run test:critical`
- `npm run test:run`
- `npm run budget:bundle`
- `git diff --check`
