### PR TITLE
Add lights Rack Builder access

### DIFF
--- a/src/features/rack-builder/components/editor/DesktopEditorView.tsx
+++ b/src/features/rack-builder/components/editor/DesktopEditorView.tsx
@@ -13,7 +13,7 @@ import {
   MAX_ZOOM_PERCENT,
   type RackViewMode,
 } from '../../lib/layoutEditorHelpers'
-import { getRackBuilderProjectsPath } from '../../lib/department'
+import { getRackBuilderProjectsPath } from '@/features/rack-builder/lib/department'
 import type {
   ConnectorDefinition,
   Device,

--- a/src/features/rack-builder/components/editor/DesktopEditorView.tsx
+++ b/src/features/rack-builder/components/editor/DesktopEditorView.tsx
@@ -13,6 +13,7 @@ import {
   MAX_ZOOM_PERCENT,
   type RackViewMode,
 } from '../../lib/layoutEditorHelpers'
+import { getRackBuilderProjectsPath } from '../../lib/department'
 import type {
   ConnectorDefinition,
   Device,
@@ -187,7 +188,7 @@ export default function DesktopEditorView({
           <div className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 px-6 py-3 shrink-0">
             <div className="flex items-center justify-between gap-4">
               <div className="flex items-center gap-4 min-w-0">
-                <Button variant="secondary" onClick={() => navigate('/rack-builder/projects')}>
+                <Button variant="secondary" onClick={() => navigate(getRackBuilderProjectsPath(project.department))}>
                   &larr; Back
                 </Button>
                 <div className="min-w-0">

--- a/src/features/rack-builder/components/editor/MobileEditorView.tsx
+++ b/src/features/rack-builder/components/editor/MobileEditorView.tsx
@@ -11,6 +11,7 @@ import {
   VIEW_MODE_OPTIONS,
   type RackViewMode,
 } from '../../lib/layoutEditorHelpers'
+import { getRackBuilderProjectsPath } from '../../lib/department'
 import type {
   Device,
   DeviceCategory,
@@ -200,7 +201,7 @@ export default function MobileEditorView({
   return (
     <div className="flex flex-col h-screen bg-white dark:bg-slate-950 text-gray-900 dark:text-slate-100 overflow-hidden">
       <header className="flex items-center justify-between px-4 h-14 bg-gray-50 dark:bg-slate-900 border-b border-gray-200 dark:border-slate-800 shrink-0 z-30" style={{ paddingTop: 'env(safe-area-inset-top)', height: 'calc(3.5rem + env(safe-area-inset-top))' }}>
-        <button onClick={() => navigate('/rack-builder/projects')} className="text-gray-600 dark:text-slate-300 text-sm font-semibold">
+        <button onClick={() => navigate(getRackBuilderProjectsPath(project.department))} className="text-gray-600 dark:text-slate-300 text-sm font-semibold">
           &larr; Back
         </button>
         <div className="flex flex-col items-center min-w-0 px-2">

--- a/src/features/rack-builder/components/editor/MobileEditorView.tsx
+++ b/src/features/rack-builder/components/editor/MobileEditorView.tsx
@@ -11,7 +11,7 @@ import {
   VIEW_MODE_OPTIONS,
   type RackViewMode,
 } from '../../lib/layoutEditorHelpers'
-import { getRackBuilderProjectsPath } from '../../lib/department'
+import { getRackBuilderProjectsPath } from '@/features/rack-builder/lib/department'
 import type {
   Device,
   DeviceCategory,

--- a/src/features/rack-builder/hooks/useActiveRackBuilderDepartment.ts
+++ b/src/features/rack-builder/hooks/useActiveRackBuilderDepartment.ts
@@ -1,0 +1,15 @@
+import { useSearchParams } from 'react-router-dom'
+import { useOptimizedAuth } from '@/hooks/useOptimizedAuth'
+import { normalizeRackBuilderDepartment } from '../lib/department'
+import type { RackBuilderDepartment } from '../types'
+
+export function useActiveRackBuilderDepartment(): RackBuilderDepartment {
+  const [searchParams] = useSearchParams()
+  const { userDepartment } = useOptimizedAuth()
+
+  return (
+    normalizeRackBuilderDepartment(searchParams.get('department'))
+    ?? normalizeRackBuilderDepartment(userDepartment)
+    ?? 'sound'
+  )
+}

--- a/src/features/rack-builder/hooks/useProjects.ts
+++ b/src/features/rack-builder/hooks/useProjects.ts
@@ -1,12 +1,13 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '@/integrations/supabase/client'
+import type { RackBuilderDepartment } from '../lib/department'
 import type { DrawingState, Project, ProjectSummary } from '../types'
 
 interface ProjectWithLayoutsRow extends Project {
   layouts?: Array<{ id: string }>
 }
 
-export function useProjects() {
+export function useProjects(activeDepartment: RackBuilderDepartment = 'sound') {
   const [projects, setProjects] = useState<ProjectSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -16,6 +17,7 @@ export function useProjects() {
     const { data, error: err } = await supabase
       .from('rack_builder_projects')
       .select('*, layouts:rack_builder_layouts(id)')
+      .eq('department', activeDepartment)
       .order('created_at', { ascending: false })
 
     if (err) {
@@ -26,6 +28,7 @@ export function useProjects() {
         id: row.id,
         name: row.name,
         owner: row.owner ?? null,
+        department: row.department,
         drawing_state: row.drawing_state,
         revision_number: row.revision_number,
         created_at: row.created_at,
@@ -36,7 +39,7 @@ export function useProjects() {
       setError(null)
     }
     setLoading(false)
-  }, [])
+  }, [activeDepartment])
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -61,6 +64,7 @@ export function useProjects() {
       .insert({
         name: payload.project_name,
         owner: payload.project_owner ?? null,
+        department: activeDepartment,
         drawing_state: payload.drawing_state,
       })
       .select()

--- a/src/features/rack-builder/hooks/useProjects.ts
+++ b/src/features/rack-builder/hooks/useProjects.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '@/integrations/supabase/client'
-import type { RackBuilderDepartment } from '../lib/department'
-import type { DrawingState, Project, ProjectSummary } from '../types'
+import type { DrawingState, Project, ProjectSummary, RackBuilderDepartment } from '../types'
 
 interface ProjectWithLayoutsRow extends Project {
   layouts?: Array<{ id: string }>

--- a/src/features/rack-builder/lib/department.ts
+++ b/src/features/rack-builder/lib/department.ts
@@ -1,0 +1,18 @@
+export const RACK_BUILDER_DEPARTMENTS = ['sound', 'lights'] as const
+
+export type RackBuilderDepartment = (typeof RACK_BUILDER_DEPARTMENTS)[number]
+
+export const normalizeRackBuilderDepartment = (
+  value: string | null | undefined,
+): RackBuilderDepartment | null => {
+  const normalized = value?.trim().toLowerCase()
+  return normalized === 'sound' || normalized === 'lights' ? normalized : null
+}
+
+export const getRackBuilderProjectsPath = (department: string | null | undefined) => {
+  const normalized = normalizeRackBuilderDepartment(department)
+  return normalized ? `/rack-builder/projects?department=${normalized}` : '/rack-builder/projects'
+}
+
+export const formatRackBuilderDepartment = (department: RackBuilderDepartment) =>
+  department === 'lights' ? 'Lights' : 'Sound'

--- a/src/features/rack-builder/lib/department.ts
+++ b/src/features/rack-builder/lib/department.ts
@@ -1,12 +1,13 @@
-export const RACK_BUILDER_DEPARTMENTS = ['sound', 'lights'] as const
-
-export type RackBuilderDepartment = (typeof RACK_BUILDER_DEPARTMENTS)[number]
+import { RACK_BUILDER_DEPARTMENTS, type RackBuilderDepartment } from '../types'
 
 export const normalizeRackBuilderDepartment = (
   value: string | null | undefined,
 ): RackBuilderDepartment | null => {
   const normalized = value?.trim().toLowerCase()
-  return normalized === 'sound' || normalized === 'lights' ? normalized : null
+  if (!normalized) return null
+  return RACK_BUILDER_DEPARTMENTS.includes(normalized as RackBuilderDepartment)
+    ? normalized as RackBuilderDepartment
+    : null
 }
 
 export const getRackBuilderProjectsPath = (department: string | null | undefined) => {
@@ -15,4 +16,4 @@ export const getRackBuilderProjectsPath = (department: string | null | undefined
 }
 
 export const formatRackBuilderDepartment = (department: RackBuilderDepartment) =>
-  department === 'lights' ? 'Lights' : 'Sound'
+  department === 'lights' ? 'Luces' : 'Sonido'

--- a/src/features/rack-builder/types.ts
+++ b/src/features/rack-builder/types.ts
@@ -1,6 +1,7 @@
 export type RackWidth = 'single' | 'dual'
 export type DeviceFacing = 'front' | 'rear'
 export type DrawingState = 'preliminary' | 'rev' | 'as_built'
+export type RackBuilderDepartment = 'sound' | 'lights'
 export type ConnectorMounting = 'front' | 'rear' | 'both'
 export type ConnectorCategory = 'audio' | 'data' | 'power' | 'multipin' | 'other'
 
@@ -104,6 +105,7 @@ export interface Project {
   id: string
   name: string
   owner: string | null
+  department: RackBuilderDepartment
   drawing_state: DrawingState
   revision_number: number
   created_at: string

--- a/src/features/rack-builder/types.ts
+++ b/src/features/rack-builder/types.ts
@@ -1,7 +1,8 @@
 export type RackWidth = 'single' | 'dual'
 export type DeviceFacing = 'front' | 'rear'
 export type DrawingState = 'preliminary' | 'rev' | 'as_built'
-export type RackBuilderDepartment = 'sound' | 'lights'
+export const RACK_BUILDER_DEPARTMENTS = ['sound', 'lights'] as const
+export type RackBuilderDepartment = (typeof RACK_BUILDER_DEPARTMENTS)[number]
 export type ConnectorMounting = 'front' | 'rear' | 'both'
 export type ConnectorCategory = 'audio' | 'data' | 'power' | 'multipin' | 'other'
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -6856,6 +6856,7 @@ export type Database = {
       rack_builder_projects: {
         Row: {
           created_at: string
+          department: string
           drawing_state: Database["public"]["Enums"]["rack_builder_drawing_state"]
           id: string
           name: string
@@ -6865,6 +6866,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          department?: string
           drawing_state?: Database["public"]["Enums"]["rack_builder_drawing_state"]
           id?: string
           name: string
@@ -6874,6 +6876,7 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          department?: string
           drawing_state?: Database["public"]["Enums"]["rack_builder_drawing_state"]
           id?: string
           name?: string

--- a/src/pages/Lights.tsx
+++ b/src/pages/Lights.tsx
@@ -11,7 +11,7 @@ import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useQueryClient } from "@tanstack/react-query";
 import { LightsHeader } from "@/components/lights/LightsHeader";
-import { Scale, Zap, Calendar, FileText, Plus, Calculator, Lightbulb } from "lucide-react";
+import { Scale, Zap, Calendar, FileText, Plus, Calculator, Lightbulb, Server } from "lucide-react";
 import type { JobType } from "@/types/job";
 import { Button } from "@/components/ui/button";
 import { CalendarSection } from "@/components/dashboard/CalendarSection";
@@ -43,6 +43,7 @@ const Lights = () => {
       { label: "Pesos", to: "/lights-pesos-tool", icon: Scale },
       { label: "Consumos", to: "/lights-consumos-tool", icon: Calculator },
       { label: "Memoria técnica", to: "/lights-memoria-tecnica", icon: FileText },
+      { label: "Rack Builder", to: "/rack-builder?department=lights", icon: Server },
     ],
     [],
   );
@@ -176,6 +177,7 @@ const Lights = () => {
   const goToPesosTool = useCallback(() => navigate("/lights-pesos-tool"), [navigate]);
   const goToConsumosTool = useCallback(() => navigate("/lights-consumos-tool"), [navigate]);
   const goToMemoriaTecnica = useCallback(() => navigate("/lights-memoria-tecnica"), [navigate]);
+  const goToRackBuilder = useCallback(() => navigate("/rack-builder?department=lights"), [navigate]);
 
   return (
     <div className="min-h-screen bg-background text-foreground p-4 md:p-8">
@@ -238,6 +240,14 @@ const Lights = () => {
                 >
                   <FileText className="h-4 w-4" />
                   Memoria Técnica
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={goToRackBuilder}
+                  className="flex items-center gap-2"
+                >
+                  <Server className="h-4 w-4" />
+                  Rack Builder
                 </Button>
               </div>
             </div>

--- a/src/pages/Lights.tsx
+++ b/src/pages/Lights.tsx
@@ -43,7 +43,7 @@ const Lights = () => {
       { label: "Pesos", to: "/lights-pesos-tool", icon: Scale },
       { label: "Consumos", to: "/lights-consumos-tool", icon: Calculator },
       { label: "Memoria técnica", to: "/lights-memoria-tecnica", icon: FileText },
-      { label: "Rack Builder", to: "/rack-builder?department=lights", icon: Server },
+      { label: "Constructor de racks", to: "/rack-builder?department=lights", icon: Server },
     ],
     [],
   );
@@ -247,7 +247,7 @@ const Lights = () => {
                   className="flex items-center gap-2"
                 >
                   <Server className="h-4 w-4" />
-                  Rack Builder
+                  Constructor de racks
                 </Button>
               </div>
             </div>

--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -145,7 +145,7 @@ const Sound = () => {
     { label: "Incident", onClick: () => setShowIncidentReport(true), icon: AlertTriangle, color: "text-red-500" },
     { label: "Plano Escenario", to: "/stage-plot", icon: Layout, color: "text-green-500" },
     { label: "SysCalc", to: "/syscalc", icon: Binary, color: "text-teal-500" },
-    { label: "Rack Builder", to: "/rack-builder", icon: Server, color: "text-amber-500" },
+    { label: "Rack Builder", to: "/rack-builder?department=sound", icon: Server, color: "text-amber-500" },
     {
       label: hasSoundVisionAccess ? "SoundVision" : "Request Access",
       to: hasSoundVisionAccess ? "/soundvision-files" : undefined,
@@ -405,7 +405,7 @@ const Sound = () => {
                   variant="outline"
                   size="lg"
                   className="h-auto py-2 sm:py-3"
-                  onClick={() => navigate('/rack-builder')}
+                  onClick={() => navigate('/rack-builder?department=sound')}
                 >
                   <Server className="h-4 w-4 sm:h-5 sm:w-5 mr-2" />
                   Rack Builder

--- a/src/pages/rack-builder/PanelLayoutsOverviewPage.tsx
+++ b/src/pages/rack-builder/PanelLayoutsOverviewPage.tsx
@@ -1,13 +1,21 @@
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useProjects } from '@/features/rack-builder/hooks/useProjects'
 import { usePanelLayoutCounts } from '@/features/rack-builder/hooks/usePanelLayoutCounts'
+import { useOptimizedAuth } from '@/hooks/useOptimizedAuth'
+import { getRackBuilderProjectsPath, normalizeRackBuilderDepartment } from '@/features/rack-builder/lib/department'
 import PageHeader from '@/features/rack-builder/components/layout/PageHeader'
 import Button from '@/features/rack-builder/components/ui/Button'
 
 export default function PanelLayoutsOverviewPage() {
-  const { projects, loading: projectsLoading } = useProjects()
-  const { counts, loading: countsLoading } = usePanelLayoutCounts()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const { userDepartment } = useOptimizedAuth()
+  const activeDepartment =
+    normalizeRackBuilderDepartment(searchParams.get('department'))
+    ?? normalizeRackBuilderDepartment(userDepartment)
+    ?? 'sound'
+  const { projects, loading: projectsLoading } = useProjects(activeDepartment)
+  const { counts, loading: countsLoading } = usePanelLayoutCounts()
 
   const loading = projectsLoading || countsLoading
 
@@ -22,7 +30,7 @@ export default function PanelLayoutsOverviewPage() {
         <p className="text-gray-500 text-sm">
           No projects yet. Create a project first to start designing panel layouts.
         </p>
-        <Button className="mt-3" onClick={() => navigate('/rack-builder/projects')}>
+        <Button className="mt-3" onClick={() => navigate(getRackBuilderProjectsPath(activeDepartment))}>
           Go to Projects
         </Button>
       </div>

--- a/src/pages/rack-builder/PanelLayoutsOverviewPage.tsx
+++ b/src/pages/rack-builder/PanelLayoutsOverviewPage.tsx
@@ -1,19 +1,14 @@
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+import { useActiveRackBuilderDepartment } from '@/features/rack-builder/hooks/useActiveRackBuilderDepartment'
 import { useProjects } from '@/features/rack-builder/hooks/useProjects'
 import { usePanelLayoutCounts } from '@/features/rack-builder/hooks/usePanelLayoutCounts'
-import { useOptimizedAuth } from '@/hooks/useOptimizedAuth'
-import { getRackBuilderProjectsPath, normalizeRackBuilderDepartment } from '@/features/rack-builder/lib/department'
+import { getRackBuilderProjectsPath } from '@/features/rack-builder/lib/department'
 import PageHeader from '@/features/rack-builder/components/layout/PageHeader'
 import Button from '@/features/rack-builder/components/ui/Button'
 
 export default function PanelLayoutsOverviewPage() {
   const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
-  const { userDepartment } = useOptimizedAuth()
-  const activeDepartment =
-    normalizeRackBuilderDepartment(searchParams.get('department'))
-    ?? normalizeRackBuilderDepartment(userDepartment)
-    ?? 'sound'
+  const activeDepartment = useActiveRackBuilderDepartment()
   const { projects, loading: projectsLoading } = useProjects(activeDepartment)
   const { counts, loading: countsLoading } = usePanelLayoutCounts()
 

--- a/src/pages/rack-builder/ProjectManagerPage.tsx
+++ b/src/pages/rack-builder/ProjectManagerPage.tsx
@@ -1,8 +1,13 @@
 import { type FormEvent, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useProjects } from '@/features/rack-builder/hooks/useProjects'
 import { useRacks } from '@/features/rack-builder/hooks/useRacks'
+import { useOptimizedAuth } from '@/hooks/useOptimizedAuth'
 import { DRAWING_STATE_OPTIONS, formatDrawingState, formatRevisionLabel } from '@/features/rack-builder/lib/drawingState'
+import {
+  formatRackBuilderDepartment,
+  normalizeRackBuilderDepartment,
+} from '@/features/rack-builder/lib/department'
 import type { DrawingState, ProjectSummary } from '@/features/rack-builder/types'
 import PageHeader from '@/features/rack-builder/components/layout/PageHeader'
 import Button from '@/features/rack-builder/components/ui/Button'
@@ -12,9 +17,15 @@ import Input from '@/features/rack-builder/components/ui/Input'
 import Select from '@/features/rack-builder/components/ui/Select'
 
 export default function ProjectManagerPage() {
-  const { projects, loading: projectsLoading, createProjectWithInitialLayout, updateProject, deleteProject } = useProjects()
-  const { racks, loading: racksLoading } = useRacks()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const { userDepartment } = useOptimizedAuth()
+  const activeDepartment =
+    normalizeRackBuilderDepartment(searchParams.get('department'))
+    ?? normalizeRackBuilderDepartment(userDepartment)
+    ?? 'sound'
+  const { projects, loading: projectsLoading, createProjectWithInitialLayout, updateProject, deleteProject } = useProjects(activeDepartment)
+  const { racks, loading: racksLoading } = useRacks()
 
   const [formOpen, setFormOpen] = useState(false)
   const [editingProject, setEditingProject] = useState<ProjectSummary | undefined>()
@@ -98,7 +109,7 @@ export default function ProjectManagerPage() {
   return (
     <div>
       <PageHeader
-        title="Project Manager"
+        title={`Project Manager - ${formatRackBuilderDepartment(activeDepartment)}`}
         action={
           <Button onClick={openCreateModal} disabled={racks.length === 0}>
             New Project

--- a/src/pages/rack-builder/ProjectManagerPage.tsx
+++ b/src/pages/rack-builder/ProjectManagerPage.tsx
@@ -1,13 +1,10 @@
 import { type FormEvent, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
+import { useActiveRackBuilderDepartment } from '@/features/rack-builder/hooks/useActiveRackBuilderDepartment'
 import { useProjects } from '@/features/rack-builder/hooks/useProjects'
 import { useRacks } from '@/features/rack-builder/hooks/useRacks'
-import { useOptimizedAuth } from '@/hooks/useOptimizedAuth'
 import { DRAWING_STATE_OPTIONS, formatDrawingState, formatRevisionLabel } from '@/features/rack-builder/lib/drawingState'
-import {
-  formatRackBuilderDepartment,
-  normalizeRackBuilderDepartment,
-} from '@/features/rack-builder/lib/department'
+import { formatRackBuilderDepartment } from '@/features/rack-builder/lib/department'
 import type { DrawingState, ProjectSummary } from '@/features/rack-builder/types'
 import PageHeader from '@/features/rack-builder/components/layout/PageHeader'
 import Button from '@/features/rack-builder/components/ui/Button'
@@ -18,12 +15,7 @@ import Select from '@/features/rack-builder/components/ui/Select'
 
 export default function ProjectManagerPage() {
   const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
-  const { userDepartment } = useOptimizedAuth()
-  const activeDepartment =
-    normalizeRackBuilderDepartment(searchParams.get('department'))
-    ?? normalizeRackBuilderDepartment(userDepartment)
-    ?? 'sound'
+  const activeDepartment = useActiveRackBuilderDepartment()
   const { projects, loading: projectsLoading, createProjectWithInitialLayout, updateProject, deleteProject } = useProjects(activeDepartment)
   const { racks, loading: racksLoading } = useRacks()
 
@@ -109,7 +101,7 @@ export default function ProjectManagerPage() {
   return (
     <div>
       <PageHeader
-        title={`Project Manager - ${formatRackBuilderDepartment(activeDepartment)}`}
+        title={`Gestor de proyectos - ${formatRackBuilderDepartment(activeDepartment)}`}
         action={
           <Button onClick={openCreateModal} disabled={racks.length === 0}>
             New Project

--- a/src/routes/app-route-manifest.tsx
+++ b/src/routes/app-route-manifest.tsx
@@ -60,6 +60,7 @@ const passThroughAccess: RouteAccessPolicy = {
 };
 
 const SOUND_DEPARTMENT = "sound";
+const RACK_BUILDER_DEPARTMENTS = new Set(["sound", "lights", "admin", "management"]);
 const SOUND_TOOL_ROLES = ["admin", "management", "house_tech"] as const;
 const SOUND_TOOL_ROLES_WITH_TECH = [...SOUND_TOOL_ROLES, "technician"] as const;
 const PERSONAL_ALLOWED_ROLES = ["admin", "management", "logistics", "house_tech"] as const;
@@ -86,10 +87,9 @@ const FestivalsDepartmentGuard = ({ children }: { children: React.ReactNode }) =
   return <>{children}</>;
 };
 
-// Mirrors the rack_builder_* RLS boundary exactly (current_user_department()
-// = ANY (ARRAY['sound','admin','management']) OR is_admin_or_management()),
-// so a house_tech in another department can't land on a page that RLS then
-// renders empty/broken for them - see PR #824 review discussion.
+// Mirrors the rack_builder_* RLS boundary: sound/lights departments plus
+// management/admin. A house_tech in another department should not land on
+// pages that RLS then renders empty/broken for them.
 const RackBuilderDepartmentGuard = ({ children }: { children: React.ReactNode }) => {
   const { userRole, userDepartment, isLoading } = useOptimizedAuth();
 
@@ -98,9 +98,9 @@ const RackBuilderDepartmentGuard = ({ children }: { children: React.ReactNode })
   }
 
   const isManagement = isManagementRole(userRole);
-  const isSoundMember = userDepartment?.toLowerCase() === SOUND_DEPARTMENT;
+  const isRackBuilderDepartmentMember = RACK_BUILDER_DEPARTMENTS.has(userDepartment?.toLowerCase() ?? "");
 
-  if (!isManagement && !isSoundMember) {
+  if (!isManagement && !isRackBuilderDepartmentMember) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/supabase/migrations/20260709103000_scope_rack_builder_projects_by_department.sql
+++ b/supabase/migrations/20260709103000_scope_rack_builder_projects_by_department.sql
@@ -1,0 +1,376 @@
+-- Rack Builder: make the shared tool available to lights while keeping
+-- project-owned data isolated by department. Catalog tables remain shared.
+
+alter table public.rack_builder_projects
+  add column if not exists department text;
+
+update public.rack_builder_projects
+set department = 'sound'
+where department is null;
+
+alter table public.rack_builder_projects
+  alter column department set default 'sound',
+  alter column department set not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.rack_builder_projects'::regclass
+      and conname = 'rack_builder_projects_department_check'
+  ) then
+    alter table public.rack_builder_projects
+      add constraint rack_builder_projects_department_check
+      check (department = any (array['sound'::text, 'lights'::text]));
+  end if;
+end
+$$;
+
+create index if not exists rack_builder_projects_department_created_at_idx
+  on public.rack_builder_projects (department, created_at desc);
+
+create or replace function public.rack_builder_can_use_tool()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select coalesce(auth.role(), '') = 'service_role'
+    or public.is_admin_or_management()
+    or lower(coalesce(public.current_user_department(), '')) = any (
+      array['sound', 'lights', 'admin', 'management']
+    );
+$$;
+
+create or replace function public.rack_builder_can_access_department(p_department text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select coalesce(auth.role(), '') = 'service_role'
+    or public.is_admin_or_management()
+    or lower(coalesce(public.current_user_department(), '')) = any (array['admin', 'management'])
+    or (
+      lower(coalesce(p_department, '')) = any (array['sound', 'lights'])
+      and lower(coalesce(public.current_user_department(), '')) = lower(coalesce(p_department, ''))
+    );
+$$;
+
+create or replace function public.rack_builder_can_access_project(p_project_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.rack_builder_projects p
+    where p.id = p_project_id
+      and public.rack_builder_can_access_department(p.department)
+  );
+$$;
+
+create or replace function public.rack_builder_can_access_layout(p_layout_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.rack_builder_layouts l
+    where l.id = p_layout_id
+      and public.rack_builder_can_access_project(l.project_id)
+  );
+$$;
+
+create or replace function public.rack_builder_can_access_panel_layout(p_panel_layout_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.rack_builder_panel_layouts p
+    where p.id = p_panel_layout_id
+      and public.rack_builder_can_access_project(p.project_id)
+  );
+$$;
+
+revoke all on function public.rack_builder_can_use_tool() from public, anon;
+revoke all on function public.rack_builder_can_access_department(text) from public, anon;
+revoke all on function public.rack_builder_can_access_project(uuid) from public, anon;
+revoke all on function public.rack_builder_can_access_layout(uuid) from public, anon;
+revoke all on function public.rack_builder_can_access_panel_layout(uuid) from public, anon;
+
+grant execute on function public.rack_builder_can_use_tool() to authenticated, service_role;
+grant execute on function public.rack_builder_can_access_department(text) to authenticated, service_role;
+grant execute on function public.rack_builder_can_access_project(uuid) to authenticated, service_role;
+grant execute on function public.rack_builder_can_access_layout(uuid) to authenticated, service_role;
+grant execute on function public.rack_builder_can_access_panel_layout(uuid) to authenticated, service_role;
+
+drop policy if exists rack_builder_racks_all on public.rack_builder_racks;
+drop policy if exists rack_builder_device_categories_all on public.rack_builder_device_categories;
+drop policy if exists rack_builder_devices_all on public.rack_builder_devices;
+drop policy if exists rack_builder_projects_all on public.rack_builder_projects;
+drop policy if exists rack_builder_layouts_all on public.rack_builder_layouts;
+drop policy if exists rack_builder_connectors_all on public.rack_builder_connectors;
+drop policy if exists rack_builder_panel_layouts_all on public.rack_builder_panel_layouts;
+drop policy if exists rack_builder_panel_layout_rows_all on public.rack_builder_panel_layout_rows;
+drop policy if exists rack_builder_panel_layout_ports_all on public.rack_builder_panel_layout_ports;
+drop policy if exists rack_builder_layout_items_all on public.rack_builder_layout_items;
+
+create policy rack_builder_racks_all on public.rack_builder_racks
+  for all
+  using (public.rack_builder_can_use_tool())
+  with check (public.rack_builder_can_use_tool());
+
+create policy rack_builder_device_categories_all on public.rack_builder_device_categories
+  for all
+  using (public.rack_builder_can_use_tool())
+  with check (public.rack_builder_can_use_tool());
+
+create policy rack_builder_devices_all on public.rack_builder_devices
+  for all
+  using (public.rack_builder_can_use_tool())
+  with check (public.rack_builder_can_use_tool());
+
+create policy rack_builder_projects_all on public.rack_builder_projects
+  for all
+  using (public.rack_builder_can_access_department(department))
+  with check (public.rack_builder_can_access_department(department));
+
+create policy rack_builder_layouts_all on public.rack_builder_layouts
+  for all
+  using (public.rack_builder_can_access_project(project_id))
+  with check (public.rack_builder_can_access_project(project_id));
+
+create policy rack_builder_connectors_all on public.rack_builder_connectors
+  for all
+  using (public.rack_builder_can_use_tool())
+  with check (public.rack_builder_can_use_tool());
+
+create policy rack_builder_panel_layouts_all on public.rack_builder_panel_layouts
+  for all
+  using (public.rack_builder_can_access_project(project_id))
+  with check (public.rack_builder_can_access_project(project_id));
+
+create policy rack_builder_panel_layout_rows_all on public.rack_builder_panel_layout_rows
+  for all
+  using (public.rack_builder_can_access_panel_layout(panel_layout_id))
+  with check (public.rack_builder_can_access_panel_layout(panel_layout_id));
+
+create policy rack_builder_panel_layout_ports_all on public.rack_builder_panel_layout_ports
+  for all
+  using (public.rack_builder_can_access_panel_layout(panel_layout_id))
+  with check (public.rack_builder_can_access_panel_layout(panel_layout_id));
+
+create policy rack_builder_layout_items_all on public.rack_builder_layout_items
+  for all
+  using (
+    public.rack_builder_can_access_layout(layout_id)
+    and (
+      panel_layout_id is null
+      or public.rack_builder_can_access_panel_layout(panel_layout_id)
+    )
+  )
+  with check (
+    public.rack_builder_can_access_layout(layout_id)
+    and (
+      panel_layout_id is null
+      or public.rack_builder_can_access_panel_layout(panel_layout_id)
+    )
+  );
+
+drop policy if exists rack_builder_device_images_select on storage.objects;
+drop policy if exists rack_builder_device_images_insert on storage.objects;
+drop policy if exists rack_builder_device_images_update on storage.objects;
+drop policy if exists rack_builder_device_images_delete on storage.objects;
+drop policy if exists rack_builder_connector_images_select on storage.objects;
+drop policy if exists rack_builder_connector_images_insert on storage.objects;
+drop policy if exists rack_builder_connector_images_update on storage.objects;
+drop policy if exists rack_builder_connector_images_delete on storage.objects;
+
+create policy rack_builder_device_images_select on storage.objects
+  for select to authenticated
+  using (
+    bucket_id = 'rack-builder-device-images'
+    and public.rack_builder_can_use_tool()
+  );
+
+create policy rack_builder_device_images_insert on storage.objects
+  for insert to authenticated
+  with check (
+    bucket_id = 'rack-builder-device-images'
+    and public.rack_builder_can_use_tool()
+  );
+
+create policy rack_builder_device_images_update on storage.objects
+  for update to authenticated
+  using (
+    bucket_id = 'rack-builder-device-images'
+    and public.rack_builder_can_use_tool()
+  );
+
+create policy rack_builder_device_images_delete on storage.objects
+  for delete to authenticated
+  using (
+    bucket_id = 'rack-builder-device-images'
+    and public.rack_builder_can_use_tool()
+  );
+
+create policy rack_builder_connector_images_select on storage.objects
+  for select to authenticated
+  using (
+    bucket_id = 'rack-builder-connector-images'
+    and public.rack_builder_can_use_tool()
+  );
+
+create policy rack_builder_connector_images_insert on storage.objects
+  for insert to authenticated
+  with check (
+    bucket_id = 'rack-builder-connector-images'
+    and public.rack_builder_can_use_tool()
+  );
+
+create policy rack_builder_connector_images_update on storage.objects
+  for update to authenticated
+  using (
+    bucket_id = 'rack-builder-connector-images'
+    and public.rack_builder_can_use_tool()
+  );
+
+create policy rack_builder_connector_images_delete on storage.objects
+  for delete to authenticated
+  using (
+    bucket_id = 'rack-builder-connector-images'
+    and public.rack_builder_can_use_tool()
+  );
+
+create or replace function public.rack_builder_validate_layout_item_semantics()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_rack record;
+  v_new_traits record;
+  v_new_slot record;
+  v_other record;
+  v_other_traits record;
+  v_other_slot record;
+begin
+  if auth.uid() is not null
+    and coalesce(auth.role(), '') <> 'service_role'
+    and (
+      not public.rack_builder_can_use_tool()
+      or not public.rack_builder_can_access_layout(new.layout_id)
+      or (
+        new.panel_layout_id is not null
+        and not public.rack_builder_can_access_panel_layout(new.panel_layout_id)
+      )
+    )
+  then
+    raise exception 'RB_AUTH: rack builder placement requires access to this project'
+      using errcode = '42501';
+  end if;
+
+  select r.id, r.rack_units, r.depth_mm, r.width
+  into v_rack
+  from rack_builder_layouts l
+  join rack_builder_racks r on r.id = l.rack_id
+  where l.id = new.layout_id;
+
+  if not found then
+    raise exception 'RB_BOUNDS: layout % has no rack', new.layout_id;
+  end if;
+
+  select *
+  into v_new_traits
+  from rack_builder_layout_item_traits(new.device_id, new.panel_layout_id);
+
+  if new.start_u < 1 or new.start_u + v_new_traits.height_ru - 1 > v_rack.rack_units then
+    raise exception
+      'RB_BOUNDS: item % at U% with %U exceeds rack bounds 1..%U',
+      coalesce(new.id::text, '<new>'),
+      new.start_u,
+      v_new_traits.height_ru,
+      v_rack.rack_units;
+  end if;
+
+  select *
+  into v_new_slot
+  from rack_builder_layout_item_slot(
+    v_rack.width,
+    new.preferred_lane,
+    new.preferred_sub_lane,
+    v_new_traits.is_half_rack,
+    new.force_full_width
+  );
+
+  for v_other in
+    select *
+    from rack_builder_layout_items
+    where layout_id = new.layout_id
+      and id <> coalesce(new.id, '00000000-0000-0000-0000-000000000000'::uuid)
+  loop
+    select *
+    into v_other_traits
+    from rack_builder_layout_item_traits(v_other.device_id, v_other.panel_layout_id);
+
+    if not rack_builder_u_ranges_overlap(new.start_u, v_new_traits.height_ru, v_other.start_u, v_other_traits.height_ru) then
+      continue;
+    end if;
+
+    select *
+    into v_other_slot
+    from rack_builder_layout_item_slot(
+      v_rack.width,
+      v_other.preferred_lane,
+      v_other.preferred_sub_lane,
+      v_other_traits.is_half_rack,
+      v_other.force_full_width
+    );
+
+    if not rack_builder_slots_conflict(
+      v_new_slot.outer_lane,
+      v_new_slot.inner_lane,
+      v_other_slot.outer_lane,
+      v_other_slot.inner_lane
+    ) then
+      continue;
+    end if;
+
+    if v_other.facing = new.facing then
+      raise exception
+        'RB_SLOT: item % overlaps item % on facing %',
+        coalesce(new.id::text, '<new>'),
+        v_other.id,
+        new.facing;
+    end if;
+
+    if v_new_traits.depth_mm + v_other_traits.depth_mm > v_rack.depth_mm then
+      raise exception
+        'RB_DEPTH: item % (%mm) collides with item % (%mm) in rack depth %mm',
+        coalesce(new.id::text, '<new>'),
+        v_new_traits.depth_mm,
+        v_other.id,
+        v_other_traits.depth_mm,
+        v_rack.depth_mm;
+    end if;
+  end loop;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.rack_builder_validate_layout_item_semantics() from public, anon;

--- a/supabase/tests/database/rack_builder_permissions.sql
+++ b/supabase/tests/database/rack_builder_permissions.sql
@@ -2,12 +2,13 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(26);
+SELECT plan(31);
 
 SELECT has_table('public', 'rack_builder_racks', 'rack builder racks table exists');
 SELECT has_table('public', 'rack_builder_devices', 'rack builder devices table exists');
 SELECT has_table('public', 'rack_builder_projects', 'rack builder projects table exists');
 SELECT has_table('public', 'rack_builder_layout_items', 'rack builder layout items table exists');
+SELECT has_column('public', 'rack_builder_projects', 'department', 'rack builder projects track department ownership');
 
 SELECT ok(
   (
@@ -38,13 +39,21 @@ SELECT ok(
     WHERE schemaname = 'public'
       AND tablename LIKE 'rack_builder_%'
       AND cmd = 'ALL'
-      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%current_user_department%'
-      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%sound%'
-      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%admin%'
-      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%management%'
-      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%is_admin_or_management%'
+      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%rack_builder_can_%'
   ) = 10,
-  'every rack_builder table policy is gated to sound/admin/management'
+  'every rack_builder table policy delegates to shared rack builder access helpers'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.rack_builder_projects'::regclass
+      AND conname = 'rack_builder_projects_department_check'
+      AND pg_get_constraintdef(oid) ILIKE '%sound%'
+      AND pg_get_constraintdef(oid) ILIKE '%lights%'
+  ),
+  'rack builder project departments are constrained to sound or lights'
 );
 
 SELECT ok(
@@ -217,6 +226,18 @@ INSERT INTO auth.users (
   '{}'::jsonb,
   'authenticated',
   'authenticated'
+), (
+  '82400000-0000-0000-0000-000000000002'::uuid,
+  '00000000-0000-0000-0000-000000000000'::uuid,
+  'rack-builder-lights@test.local',
+  'test',
+  now(),
+  now(),
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{}'::jsonb,
+  'authenticated',
+  'authenticated'
 )
 ON CONFLICT (id) DO NOTHING;
 
@@ -228,6 +249,13 @@ VALUES (
   'Builder',
   'house_tech',
   'sound'
+), (
+  '82400000-0000-0000-0000-000000000002'::uuid,
+  'rack-builder-lights@test.local',
+  'Rack',
+  'Builder Lights',
+  'house_tech',
+  'lights'
 )
 ON CONFLICT (id) DO UPDATE
 SET email = excluded.email,
@@ -273,10 +301,13 @@ SET name = excluded.name,
     depth_mm = excluded.depth_mm,
     width = excluded.width;
 
-INSERT INTO public.rack_builder_projects (id, name)
-VALUES ('82410000-0000-0000-0000-000000000004'::uuid, 'Placement Test Project')
+INSERT INTO public.rack_builder_projects (id, name, department)
+VALUES
+  ('82410000-0000-0000-0000-000000000004'::uuid, 'Placement Test Project', 'sound'),
+  ('82410000-0000-0000-0000-000000000006'::uuid, 'Placement Lights Project', 'lights')
 ON CONFLICT (id) DO UPDATE
-SET name = excluded.name;
+SET name = excluded.name,
+    department = excluded.department;
 
 INSERT INTO public.rack_builder_layouts (id, project_id, rack_id, name)
 VALUES (
@@ -284,6 +315,11 @@ VALUES (
   '82410000-0000-0000-0000-000000000004'::uuid,
   '82410000-0000-0000-0000-000000000003'::uuid,
   'Placement Test Layout'
+), (
+  '82410000-0000-0000-0000-000000000007'::uuid,
+  '82410000-0000-0000-0000-000000000006'::uuid,
+  '82410000-0000-0000-0000-000000000003'::uuid,
+  'Placement Lights Layout'
 )
 ON CONFLICT (id) DO UPDATE
 SET project_id = excluded.project_id,
@@ -312,19 +348,80 @@ SELECT lives_ok(
   'authenticated sound users can insert valid equipment placements'
 );
 
+SELECT is(
+  ARRAY(
+    SELECT id
+    FROM public.rack_builder_projects
+    WHERE id IN (
+      '82410000-0000-0000-0000-000000000004'::uuid,
+      '82410000-0000-0000-0000-000000000006'::uuid
+    )
+    ORDER BY id
+  ),
+  ARRAY['82410000-0000-0000-0000-000000000004'::uuid],
+  'sound rack builder users only see sound projects'
+);
+
+RESET ROLE;
+
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+SELECT set_config('request.jwt.claim.sub', '82400000-0000-0000-0000-000000000002', false);
+
+SET ROLE authenticated;
+
+SELECT is(
+  ARRAY(
+    SELECT id
+    FROM public.rack_builder_projects
+    WHERE id IN (
+      '82410000-0000-0000-0000-000000000004'::uuid,
+      '82410000-0000-0000-0000-000000000006'::uuid
+    )
+    ORDER BY id
+  ),
+  ARRAY['82410000-0000-0000-0000-000000000006'::uuid],
+  'lights rack builder users only see lights projects'
+);
+
+SELECT lives_ok(
+  $$
+    INSERT INTO public.rack_builder_layout_items (
+      layout_id,
+      device_id,
+      start_u,
+      facing
+    ) VALUES (
+      '82410000-0000-0000-0000-000000000007'::uuid,
+      '82410000-0000-0000-0000-000000000002'::uuid,
+      1,
+      'front'
+    )
+  $$,
+  'authenticated lights users can insert valid equipment placements'
+);
+
 RESET ROLE;
 
 SELECT set_config('request.jwt.claim.role', 'service_role', false);
 SELECT set_config('request.jwt.claim.sub', '', false);
 
 DELETE FROM public.rack_builder_layout_items
-WHERE layout_id = '82410000-0000-0000-0000-000000000005'::uuid;
+WHERE layout_id IN (
+  '82410000-0000-0000-0000-000000000005'::uuid,
+  '82410000-0000-0000-0000-000000000007'::uuid
+);
 
 DELETE FROM public.rack_builder_layouts
-WHERE id = '82410000-0000-0000-0000-000000000005'::uuid;
+WHERE id IN (
+  '82410000-0000-0000-0000-000000000005'::uuid,
+  '82410000-0000-0000-0000-000000000007'::uuid
+);
 
 DELETE FROM public.rack_builder_projects
-WHERE id = '82410000-0000-0000-0000-000000000004'::uuid;
+WHERE id IN (
+  '82410000-0000-0000-0000-000000000004'::uuid,
+  '82410000-0000-0000-0000-000000000006'::uuid
+);
 
 DELETE FROM public.rack_builder_racks
 WHERE id = '82410000-0000-0000-0000-000000000003'::uuid;
@@ -336,10 +433,16 @@ DELETE FROM public.rack_builder_device_categories
 WHERE id = '82410000-0000-0000-0000-000000000001'::uuid;
 
 DELETE FROM public.profiles
-WHERE id = '82400000-0000-0000-0000-000000000001'::uuid;
+WHERE id IN (
+  '82400000-0000-0000-0000-000000000001'::uuid,
+  '82400000-0000-0000-0000-000000000002'::uuid
+);
 
 DELETE FROM auth.users
-WHERE id = '82400000-0000-0000-0000-000000000001'::uuid;
+WHERE id IN (
+  '82400000-0000-0000-0000-000000000001'::uuid,
+  '82400000-0000-0000-0000-000000000002'::uuid
+);
 
 SELECT ok(
   EXISTS (
@@ -368,11 +471,9 @@ SELECT ok(
     WHERE schemaname = 'storage'
       AND tablename = 'objects'
       AND policyname LIKE 'rack_builder_%_images_%'
-      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%current_user_department%'
-      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%sound%'
-      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%is_admin_or_management%'
+      AND (COALESCE(qual, '') || COALESCE(with_check, '')) ILIKE '%rack_builder_can_use_tool%'
   ) = 8,
-  'rack builder storage object policies gate both buckets and all mutations'
+  'rack builder storage object policies gate both buckets and all mutations to rack builder users'
 );
 
 SELECT ok(

--- a/supabase/tests/database/rack_builder_permissions.sql
+++ b/supabase/tests/database/rack_builder_permissions.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(31);
+SELECT plan(32);
 
 SELECT has_table('public', 'rack_builder_racks', 'rack builder racks table exists');
 SELECT has_table('public', 'rack_builder_devices', 'rack builder devices table exists');
@@ -360,6 +360,25 @@ SELECT is(
   ),
   ARRAY['82410000-0000-0000-0000-000000000004'::uuid],
   'sound rack builder users only see sound projects'
+);
+
+SELECT throws_ok(
+  $$
+    INSERT INTO public.rack_builder_layout_items (
+      layout_id,
+      device_id,
+      start_u,
+      facing
+    ) VALUES (
+      '82410000-0000-0000-0000-000000000007'::uuid,
+      '82410000-0000-0000-0000-000000000002'::uuid,
+      3,
+      'front'
+    )
+  $$,
+  '42501',
+  NULL,
+  'sound rack builder users cannot place equipment in lights projects'
 );
 
 RESET ROLE;


### PR DESCRIPTION
## Summary
- Adds Rack Builder as a Lights department tool while preserving Sound links with an explicit sound department context.
- Adds department-scoped Rack Builder projects so Sound and Lights project trees stay separate.
- Keeps racks, devices, connectors, and image buckets shared through Rack Builder tool access, while layouts, panel layouts, rows, ports, and layout items inherit project department access.

## Risk Assessment
- Primary risk is Rack Builder RLS behavior, especially cross-department project access and writes.
- Existing Rack Builder projects are backfilled to `sound`, so existing Sound workflows keep their project data.
- Lights users get their own isolated project set; shared catalog assets remain common by design.

## Impact Checklist
- Lights department users can open Rack Builder from the Lights tools page.
- Sound and Lights project lists are filtered by active department and enforced by RLS.
- Admin/management retain cross-department Rack Builder access.
- No dependency or build pipeline changes.

## Rollback Plan
- Revert this PR to remove the Lights UI entry and client-side department routing.
- If the migration has already been applied, restore the previous Rack Builder RLS policies or run a follow-up migration that drops the department-scoped helpers/policies and removes `rack_builder_projects.department` after data review.
- Existing project rows are preserved by the migration; rollback should not delete Rack Builder data.

## Migration Impact
- Adds `rack_builder_projects.department text not null default 'sound'` with a `sound`/`lights` check constraint and department index.
- Backfills existing Rack Builder projects as `sound`.
- Replaces Rack Builder table/storage policies with helper-backed department-aware policies.
- Updates Rack Builder layout-item validation to reject cross-department placement attempts.

## Validation
- `npm run typecheck`
- `npm run test:run -- src/features/rack-builder/hooks/__tests__/useDevices.test.ts`
- `npm run test:run -- src/routes/__tests__/app-route-manifest.test.ts`
- `npm run test:run -- src/features/rack-builder/hooks/__tests__/useDevices.test.ts src/routes/__tests__/app-route-manifest.test.ts`
- `npm run lint` (existing warnings only, 0 errors)
- `npm run ci:db:migrations`
- `supabase db reset --local --no-seed`
- `supabase test db supabase/tests/database/rack_builder_permissions.sql`
- `supabase db lint --local --fail-on error --schema public,auth` (existing warning-level items only)
- `npm run test:run`
- `npm run build`
- `npm run budget:bundle`