### PR TITLE
Fix tarifas tab date rendering crash

### DIFF
--- a/src/components/tours/TourRatesPanel.tsx
+++ b/src/components/tours/TourRatesPanel.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangle, Euro, Users, Calendar, AlertCircle, Send } from "lucide-react";
-import { format } from "date-fns";
+import { format, isValid } from "date-fns";
 import { useTourJobRateQuotes } from "@/hooks/useTourJobRateQuotes";
 import { useTourJobRateQuotesForManager } from "@/hooks/useTourJobRateQuotesForManager";
 import { useManagerJobQuotes } from "@/hooks/useManagerJobQuotes";
@@ -24,6 +24,14 @@ import { labelForJobExtraType } from "@/types/jobExtras";
 
 
 import { queryKeys } from "@/lib/react-query";
+
+const formatQuoteDate = (value: string | null | undefined): string => {
+  if (!value) return 'Fecha sin definir';
+
+  const date = new Date(value);
+  return isValid(date) ? format(date, 'MMM d, yyyy') : 'Fecha sin definir';
+};
+
 interface TourRatesPanelProps {
   jobId: string;
   jobType?: string | null;
@@ -375,7 +383,7 @@ export const TourRatesPanel: React.FC<TourRatesPanelProps> = ({
                           )}
                         </div>
                         <div className="text-sm text-muted-foreground">
-                          {format(new Date(quote.start_time), 'MMM d, yyyy')} • {quote.title}
+                          {formatQuoteDate(quote.start_time)} • {quote.title || 'Sin título'}
                         </div>
                       </div>
                       <div className="text-right flex flex-col items-end gap-2">

--- a/src/components/tours/TourRatesPanel.tsx
+++ b/src/components/tours/TourRatesPanel.tsx
@@ -5,6 +5,7 @@ import { Switch } from "@/components/ui/switch";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangle, Euro, Users, Calendar, AlertCircle, Send } from "lucide-react";
 import { format, isValid } from "date-fns";
+import { es } from "date-fns/locale";
 import { useTourJobRateQuotes } from "@/hooks/useTourJobRateQuotes";
 import { useTourJobRateQuotesForManager } from "@/hooks/useTourJobRateQuotesForManager";
 import { useManagerJobQuotes } from "@/hooks/useManagerJobQuotes";
@@ -29,7 +30,7 @@ const formatQuoteDate = (value: string | null | undefined): string => {
   if (!value) return 'Fecha sin definir';
 
   const date = new Date(value);
-  return isValid(date) ? format(date, 'MMM d, yyyy') : 'Fecha sin definir';
+  return isValid(date) ? format(date, 'MMM d, yyyy', { locale: es }) : 'Fecha sin definir';
 };
 
 interface TourRatesPanelProps {


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Prevents the Tarifas tab from crashing when a quote has a missing or invalid start date.
- Uses the Spanish date-fns locale for valid quote dates and Spanish fallbacks for incomplete quote data.
- Affected route/feature: tour rates / Tarifas tab (`src/components/tours/TourRatesPanel.tsx`).

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: low
- Main risks: valid quote dates could render differently because month names are now localized to Spanish; invalid or missing dates now show an explicit fallback.
- [x] No database, auth, CI/CD, dependency, security, or production-header path is changed, so CODEOWNER review is not required.
- [x] Risk is not high; two independent approvals are not required.

## Impact Checklist
- [x] Migration impact assessed: none.
- [x] Realtime/subscription impact assessed: none.
- [x] RLS/security impact assessed: none.
- [x] Performance impact assessed: negligible; validation is local to each rendered quote.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint:app`
  - `npm run typecheck`
  - `npm run test:critical`
  - `npm run build`
- Results: all completed successfully. No component-specific test file matched `TourRatesPanel.tsx`.

## Rollback Plan
- [x] I documented how to safely revert this change.
- [x] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert the PR merge commit and confirm the Tarifas tab returns to the previous rendering behavior.

## Migration Impact
- [x] I confirmed this PR does not change schema or functions.
- Migration required: no
- No Supabase production push is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quote date handling to display valid dates consistently in Spanish.
  * Added a clear fallback when a quote date is missing or invalid.
  * Added a fallback title for quotes without a title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->