### PR TITLE
Enable timesheet reviews for hourly tour dates

### DIFF
--- a/src/components/technician/AssignmentCard.tsx
+++ b/src/components/technician/AssignmentCard.tsx
@@ -95,7 +95,7 @@ export const AssignmentCard = ({ assignment, techName = '' }: AssignmentCardProp
     jobData.has_prep_day_timesheet === true ||
     hasPrepDayDateType(jobData.job_date_types);
   const showTimesheetButton = !['dryhire', 'dry_hire'].includes(normalizedJobType) && (
-    normalizedJobType !== 'tourdate' || hasPrepDayTimesheets
+    normalizedJobType !== 'tourdate' || hasPrepDayTimesheets || jobData.has_hourly_timesheet === true
   );
 
   const jobTimezone = jobData.timezone || 'Europe/Madrid';

--- a/src/components/technician/TechJobCard.tsx
+++ b/src/components/technician/TechJobCard.tsx
@@ -68,7 +68,8 @@ export const TechJobCard = ({ job, theme, isDark, onAction, isCrewChief, techNam
     const hasPrepDayTimesheets =
         jobData?.has_prep_day_timesheet === true ||
         hasPrepDayDateType(jobData?.job_date_types);
-    const showTimesheetButton = !isDryhire && (!isTourdate || hasPrepDayTimesheets);
+    const hasEligibleTimesheets = hasPrepDayTimesheets || jobData?.has_hourly_timesheet === true;
+    const showTimesheetButton = !isDryhire && (!isTourdate || hasEligibleTimesheets);
     const showIncidentReport = !isDryhire;
     const artistCountFromJob = Number(jobData?.artist_count || 0);
     const shouldFetchArtistCountFallback = jobData?.artist_count == null && Boolean(jobData?.id);

--- a/src/components/technician/__tests__/TechJobCard.hourly-tourdate.test.tsx
+++ b/src/components/technician/__tests__/TechJobCard.hourly-tourdate.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TechJobCard } from '@/components/technician/TechJobCard';
+import type { Theme } from '@/components/technician/types';
+import { renderWithProviders } from '@/test/renderWithProviders';
+
+vi.mock('@/hooks/useExpensePermissions', () => ({
+  useExpensePermissions: () => ({ data: [] as unknown[] }),
+  isPermissionActive: () => false,
+}));
+
+vi.mock('@/hooks/useJobExpenses', () => ({
+  useJobExpenses: () => ({ data: [] as unknown[] }),
+}));
+
+vi.mock('@/components/incident-reports/TechnicianIncidentReportDialog', () => ({
+  TechnicianIncidentReportDialog: (): null => null,
+}));
+
+const theme: Theme = {
+  bg: 'bg-background',
+  nav: 'bg-background',
+  card: 'bg-card',
+  textMain: 'text-foreground',
+  textMuted: 'text-muted-foreground',
+  accent: 'bg-primary',
+  input: 'bg-background',
+  modalOverlay: 'bg-black/50',
+  divider: 'border-border',
+  danger: 'text-destructive',
+  success: 'text-green-600',
+  warning: 'text-amber-600',
+  cluster: 'bg-muted',
+};
+
+const createTourDateAssignment = (hasHourlyTimesheet: boolean) => ({
+  id: 'assignment-1',
+  job_id: 'tourdate-1',
+  technician_id: 'tech-1',
+  role: 'Técnico',
+  jobs: {
+    id: 'tourdate-1',
+    title: 'Fecha de gira',
+    start_time: '2026-07-10T08:00:00Z',
+    end_time: '2026-07-10T20:00:00Z',
+    job_type: 'tourdate',
+    artist_count: 0,
+    has_hourly_timesheet: hasHourlyTimesheet,
+    job_date_types: [] as Array<{ date?: string | null; type?: string | null }>,
+  },
+});
+
+describe('TechJobCard hourly tour-date timesheets', () => {
+  it('shows the hours action for a tour date with an hourly timesheet', () => {
+    const onAction = vi.fn();
+    const assignment = createTourDateAssignment(true);
+
+    renderWithProviders(
+      <TechJobCard
+        job={assignment}
+        theme={theme}
+        isDark={false}
+        onAction={onAction}
+        isCrewChief={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /horas/i }));
+    expect(onAction).toHaveBeenCalledWith('timesheet', assignment.jobs);
+  });
+
+  it('keeps the hours action hidden for a tour date without prep or hourly timesheets', () => {
+    renderWithProviders(
+      <TechJobCard
+        job={createTourDateAssignment(false)}
+        theme={theme}
+        isDark={false}
+        onAction={vi.fn()}
+        isCrewChief={false}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /horas/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/technician/types.ts
+++ b/src/components/technician/types.ts
@@ -28,6 +28,7 @@ export interface TechnicianJobData {
   created_at?: string;
   artist_count?: number;
   has_prep_day_timesheet?: boolean;
+  has_hourly_timesheet?: boolean;
   job_date_types?: Array<{ date?: string | null; type?: string | null }> | null;
   preventive_resource_technician_id?: string | null;
   location?: { name: string } | null;

--- a/src/components/timesheet/TimesheetSidebar.tsx
+++ b/src/components/timesheet/TimesheetSidebar.tsx
@@ -8,6 +8,10 @@ import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { format, isAfter, isBefore, addDays } from "date-fns";
 import { es } from "date-fns/locale";
 import { useNavigate } from "react-router-dom";
+import { useQuery } from '@tanstack/react-query';
+import { fetchHourlyTourDateRateModes } from '@/services/hourlyTourDateTimesheets';
+import { queryKeys } from '@/lib/react-query';
+import { hasPrepDayDateType } from '@/utils/timesheetPrepDays';
 
 interface TimesheetSidebarProps {
   isOpen: boolean;
@@ -18,17 +22,30 @@ const JOBS_PER_PAGE = 5;
 
 export const TimesheetSidebar = ({ isOpen, onClose }: TimesheetSidebarProps) => {
   const { data: allJobs = [], isLoading } = useOptimizedJobs();
-  const { userRole, user } = useOptimizedAuth();
+  const { user } = useOptimizedAuth();
   const navigate = useNavigate();
+  const { data: hourlyRateModes = [] } = useQuery({
+    queryKey: queryKeys.scope('hourly-tourdate-rate-modes', user?.id ?? 'anonymous'),
+    queryFn: () => fetchHourlyTourDateRateModes(),
+    enabled: Boolean(user?.id),
+    staleTime: 30_000,
+  });
+  const hourlyTourDateJobIds = useMemo(
+    () => new Set(hourlyRateModes.map((row) => row.job_id)),
+    [hourlyRateModes],
+  );
 
   // Filter jobs and exclude dry hire and tourdate jobs and jobs with only off/travel date types
   const relevantJobs = useMemo(() => {
     return allJobs
       .filter(job => {
-        // Filter out dry hire and tourdate jobs since they don't have timesheets
+        // Tour dates only use timesheets for prep days or explicit hourly overrides.
         const isDryHire = job.job_type === 'dry_hire' || job.job_type === 'dryhire';
         const isTourDate = job.job_type === 'tourdate';
-        if (isDryHire || isTourDate) return false;
+        if (isDryHire) return false;
+        if (isTourDate) {
+          return hasPrepDayDateType(job.job_date_types) || hourlyTourDateJobIds.has(job.id);
+        }
 
         // Check if job has any work date types (not just "off" or "travel")
         if (job.job_date_types && job.job_date_types.length > 0) {
@@ -43,7 +60,7 @@ export const TimesheetSidebar = ({ isOpen, onClose }: TimesheetSidebarProps) => 
         return true;
       })
       .sort((a, b) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime()); // Most recent first
-  }, [allJobs]);
+  }, [allJobs, hourlyTourDateJobIds]);
 
   // Find the current page based on today's date
   const getCurrentPageIndex = useMemo(() => {

--- a/src/features/rates/components/RatesApprovalsTable.tsx
+++ b/src/features/rates/components/RatesApprovalsTable.tsx
@@ -46,6 +46,7 @@ export function RatesApprovalsTable({ onManageTour }: RatesApprovalsTableProps) 
     if (normalized === 'festival') return 'Festival';
     if (normalized === 'single') return 'Trabajo';
     if (normalized === 'tour') return 'Gira';
+    if (normalized === 'tourdate') return 'Fecha de gira';
     if (!jobType) return 'Trabajo';
     return jobType;
   }, []);

--- a/src/hooks/useTechnicianRateModeDates.ts
+++ b/src/hooks/useTechnicianRateModeDates.ts
@@ -84,15 +84,22 @@ async function ensureTimesheetForDate(
 ): Promise<string[]> {
   const { data: existing, error: existingError } = await supabase
     .from('timesheets')
-    .select('id')
+    .select('id, is_active')
     .eq('job_id', jobId)
     .eq('technician_id', technicianId)
-    .eq('date', date)
-    .eq('is_active', true);
+    .eq('date', date);
 
   if (existingError) throw existingError;
 
   if (existing && existing.length > 0) {
+    const inactiveIds = existing.filter((row) => !row.is_active).map((row) => row.id);
+    if (inactiveIds.length > 0) {
+      const { error: reactivateError } = await supabase
+        .from('timesheets')
+        .update({ is_active: true, source: 'hourly_rate_override' })
+        .in('id', inactiveIds);
+      if (reactivateError) throw reactivateError;
+    }
     return existing.map((row) => row.id);
   }
 
@@ -103,6 +110,7 @@ async function ensureTimesheetForDate(
       technician_id: technicianId,
       date,
       created_by: (await supabase.auth.getUser()).data.user?.id,
+      source: 'hourly_rate_override',
     })
     .select('id')
     .single();

--- a/src/hooks/useTimesheets.ts
+++ b/src/hooks/useTimesheets.ts
@@ -6,6 +6,10 @@ import { toast } from "sonner";
 import { RATES_QUERY_KEYS } from "@/constants/ratesQueryKeys";
 import { isManagementRole } from "@/utils/permissions";
 import { getTimesheetAutoCreateDatesForAssignment, isPrepDayBreakdown } from "@/utils/timesheetPrepDays";
+import {
+  filterEligibleTourDateTimesheets,
+  fetchHourlyTourDateRateModes,
+} from "@/services/hourlyTourDateTimesheets";
 
 
 import { queryKeys } from "@/lib/react-query";
@@ -51,23 +55,22 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
           .map((row) => row.date as string),
       );
       const isTourDateJob = String(jobMeta?.job_type || "").toLowerCase() === "tourdate";
+      const hourlyRateModes = isTourDateJob
+        ? await fetchHourlyTourDateRateModes({ jobIds: [jobId] })
+        : [];
 
-      let timesheetQuery = supabase
+      if (isTourDateJob && prepDayDates.size === 0 && hourlyRateModes.length === 0) {
+        setTimesheets([]);
+        return;
+      }
+
+      const timesheetQuery = supabase
         .from("timesheets")
         .select("*")
         .eq("job_id", jobId)
         .eq("is_active", true)
         .order("date", { ascending: true })
         .order("created_at", { ascending: true });
-
-      if (isTourDateJob) {
-        if (prepDayDates.size === 0) {
-          setTimesheets([]);
-          return;
-        }
-
-        timesheetQuery = timesheetQuery.in("date", Array.from(prepDayDates));
-      }
 
       const { data: timesheetRows, error } = await timesheetQuery;
 
@@ -78,7 +81,9 @@ export const useTimesheets = (jobId: string, opts?: { userRole?: string | null }
         return;
       }
 
-      const data = timesheetRows || [];
+      const data = isTourDateJob
+        ? filterEligibleTourDateTimesheets(timesheetRows || [], prepDayDates, hourlyRateModes)
+        : (timesheetRows || []);
 
       if (!data || data.length === 0) {
         setTimesheets([]);

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -216,7 +216,6 @@ const TechnicianDashboard = () => {
                 file_name,
                 file_path,
                 visible_to_tech,
-                visible_to_tech,
                 uploaded_at,
                 read_only,
                 template_type

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -17,6 +17,10 @@ import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { getCategoryFromAssignment } from '@/utils/roleCategory';
 import { hasPrepDayDateTypeForDate, isPrepDayBreakdown } from '@/utils/timesheetPrepDays';
 import { persistExplicitThemePreference } from '@/lib/theme';
+import {
+  fetchHourlyTourDateRateModes,
+  type HourlyTourDateRateMode,
+} from '@/services/hourlyTourDateTimesheets';
 
 import { DashboardScreen } from '@/components/technician/DashboardScreen';
 import { JobsView } from '@/components/technician/JobsView';
@@ -48,6 +52,7 @@ interface TechnicianJobData {
   created_at?: string;
   artist_count?: number;
   has_prep_day_timesheet?: boolean;
+  has_hourly_timesheet?: boolean;
   job_date_types?: Array<{ date?: string | null; type?: string | null }> | null;
   preventive_resource_technician_id?: string | null;
   location?: { name: string } | null;
@@ -184,45 +189,53 @@ const TechnicianDashboard = () => {
       );
       const jobIds = Array.from(new Set(assignmentsData.map((assignment) => assignment.job_id)));
 
-      // Step 2: Fetch timesheets (with jobs) for those assignments
-      const { data: timesheetData, error } = await dataLayerClient.from('timesheets')
-        .select(`
-          job_id,
-          technician_id,
-          date,
-          amount_breakdown,
-          jobs!inner (
-            id,
-            title,
-            description,
-            start_time,
-            end_time,
-            timezone,
-            location_id,
-            job_type,
-            color,
-            status,
-            preventive_resource_technician_id,
-            location:locations(name),
-            job_date_types(date, type),
-            job_documents(
+      // Step 2: Fetch timesheets and exact hourly tour-date eligibility together.
+      const [timesheetResult, hourlyRateModes] = await Promise.all([
+        dataLayerClient.from('timesheets')
+          .select(`
+            job_id,
+            technician_id,
+            date,
+            amount_breakdown,
+            jobs!inner (
               id,
-              file_name,
-              file_path,
-              visible_to_tech,
-              visible_to_tech,
-              uploaded_at,
-              read_only,
-              template_type
+              title,
+              description,
+              start_time,
+              end_time,
+              timezone,
+              location_id,
+              job_type,
+              color,
+              status,
+              preventive_resource_technician_id,
+              location:locations(name),
+              job_date_types(date, type),
+              job_documents(
+                id,
+                file_name,
+                file_path,
+                visible_to_tech,
+                visible_to_tech,
+                uploaded_at,
+                read_only,
+                template_type
+              )
             )
-          )
-        `)
-        .eq('technician_id', user.id)
-        .eq('is_active', true)
-        .in('job_id', jobIds)
-        .gte('jobs.start_time', startDate.toISOString())
-        .lte('jobs.start_time', endDate.toISOString())
-        .order('start_time', { referencedTable: 'jobs' });
+          `)
+          .eq('technician_id', user.id)
+          .eq('is_active', true)
+          .in('job_id', jobIds)
+          .gte('jobs.start_time', startDate.toISOString())
+          .lte('jobs.start_time', endDate.toISOString())
+          .order('start_time', { referencedTable: 'jobs' }),
+        fetchHourlyTourDateRateModes({ jobIds, technicianId: user.id }).catch((hourlyRateModeError) => {
+          console.warn('Could not load hourly tour-date eligibility:', hourlyRateModeError);
+          return [] as HourlyTourDateRateMode[];
+        }),
+      ]);
+      const { data: timesheetData, error } = timesheetResult;
+      const hourlyTourDateJobIds = new Set(hourlyRateModes.map((row) => row.job_id));
 
       if (error) {
         console.error('Error fetching assignments:', error);
@@ -306,6 +319,7 @@ const TechnicianDashboard = () => {
               location,
               artist_count: artistCountByJob.get(row.job_id) || 0,
               has_prep_day_timesheet: prepTimesheetByJobId.get(row.job_id) === true,
+              has_hourly_timesheet: hourlyTourDateJobIds.has(row.job_id),
             } as unknown as TechnicianJobData
           };
         })

--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -14,6 +14,10 @@ import { getCategoryFromAssignment } from '@/utils/roleCategory';
 import { labelForCode } from '@/utils/roles';
 import { hasPrepDayDateTypeForDate, isPrepDayBreakdown } from '@/utils/timesheetPrepDays';
 import { persistExplicitThemePreference } from '@/lib/theme';
+import {
+  fetchHourlyTourDateRateModes,
+  type HourlyTourDateRateMode,
+} from '@/services/hourlyTourDateTimesheets';
 
 import {
   LayoutDashboard, Calendar as CalendarIcon, User, Menu,
@@ -76,6 +80,7 @@ interface TechnicianJobData extends JobWithLocationAndDocs {
   status?: string;
   artist_count?: number;
   has_prep_day_timesheet?: boolean;
+  has_hourly_timesheet?: boolean;
   job_date_types?: Array<{ date?: string | null; type?: string | null }> | null;
   location?: JobWithLocationAndDocs['location'];
   job_documents?: JobWithLocationAndDocs['job_documents'];
@@ -207,45 +212,53 @@ export default function TechnicianSuperApp() {
       // Get unique job IDs from assignments
       const jobIds = assignmentsData.map(a => a.job_id);
 
-      // Then fetch timesheets and jobs for those job IDs
-      const { data: timesheetData, error } = await dataLayerClient.from('timesheets')
-        .select(`
-          job_id,
-          technician_id,
-          date,
-          amount_breakdown,
-          jobs!inner (
-            id,
-            title,
-            description,
-            start_time,
-            end_time,
-            created_at,
-            timezone,
-            location_id,
-            job_type,
-            color,
-            status,
-            preventive_resource_technician_id,
-            location:locations(name),
-            job_date_types(date, type),
-            job_documents(
+      // Fetch timesheets and exact hourly tour-date eligibility together.
+      const [timesheetResult, hourlyRateModes] = await Promise.all([
+        dataLayerClient.from('timesheets')
+          .select(`
+            job_id,
+            technician_id,
+            date,
+            amount_breakdown,
+            jobs!inner (
               id,
-              file_name,
-              file_path,
-              visible_to_tech,
-              uploaded_at,
-              read_only,
-              template_type
+              title,
+              description,
+              start_time,
+              end_time,
+              created_at,
+              timezone,
+              location_id,
+              job_type,
+              color,
+              status,
+              preventive_resource_technician_id,
+              location:locations(name),
+              job_date_types(date, type),
+              job_documents(
+                id,
+                file_name,
+                file_path,
+                visible_to_tech,
+                uploaded_at,
+                read_only,
+                template_type
+              )
             )
-          )
-        `)
-        .eq('technician_id', user.id)
-        .eq('is_active', true)
-        .in('job_id', jobIds)
-        .gte('jobs.start_time', startDate.toISOString())
-        .lte('jobs.start_time', endDate.toISOString())
-        .order('start_time', { referencedTable: 'jobs' });
+          `)
+          .eq('technician_id', user.id)
+          .eq('is_active', true)
+          .in('job_id', jobIds)
+          .gte('jobs.start_time', startDate.toISOString())
+          .lte('jobs.start_time', endDate.toISOString())
+          .order('start_time', { referencedTable: 'jobs' }),
+        fetchHourlyTourDateRateModes({ jobIds, technicianId: user.id }).catch((hourlyRateModeError) => {
+          console.warn('Could not load hourly tour-date eligibility:', hourlyRateModeError);
+          return [] as HourlyTourDateRateMode[];
+        }),
+      ]);
+      const { data: timesheetData, error } = timesheetResult;
+      const hourlyTourDateJobIds = new Set(hourlyRateModes.map((row) => row.job_id));
 
       if (error) {
         console.error('Error fetching assignments:', error);
@@ -335,6 +348,7 @@ export default function TechnicianSuperApp() {
               job_type: job.job_type || 'single',
               artist_count: artistCountByJob.get(row.job_id) || 0,
               has_prep_day_timesheet: prepTimesheetByJobId.get(row.job_id) === true,
+              has_hourly_timesheet: hourlyTourDateJobIds.has(row.job_id),
             }
           };
         }) as TechnicianAssignment[];

--- a/src/pages/Timesheets.tsx
+++ b/src/pages/Timesheets.tsx
@@ -15,6 +15,9 @@ import { useSearchParams } from "react-router-dom";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { isManagementRole } from '@/utils/permissions';
 import { hasPrepDayDateType } from '@/utils/timesheetPrepDays';
+import { useQuery } from '@tanstack/react-query';
+import { fetchHourlyTourDateRateModes } from '@/services/hourlyTourDateTimesheets';
+import { queryKeys } from '@/lib/react-query';
 
 export default function Timesheets() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -27,6 +30,16 @@ export default function Timesheets() {
 
   const canManage = isManagementRole(userRole);
   const canDownloadPDF = canManage;
+  const { data: hourlyRateModes = [], isLoading: hourlyRateModesLoading } = useQuery({
+    queryKey: queryKeys.scope('hourly-tourdate-rate-modes', user?.id ?? 'anonymous'),
+    queryFn: () => fetchHourlyTourDateRateModes(),
+    enabled: Boolean(user?.id),
+    staleTime: 30_000,
+  });
+  const hourlyTourDateJobIds = useMemo(
+    () => new Set(hourlyRateModes.map((row) => row.job_id)),
+    [hourlyRateModes],
+  );
 
   // Initialize department filter with user's department if available
   const [filterDepartment, setFilterDepartment] = useState<string>("all");
@@ -54,7 +67,9 @@ export default function Timesheets() {
         const isDryHire = type === 'dryhire' || type === 'dry_hire';
         const isTourDate = type === 'tourdate';
         if (isDryHire) return false;
-        if (isTourDate) return hasPrepDayDateType(job.job_date_types);
+        if (isTourDate) {
+          return hasPrepDayDateType(job.job_date_types) || hourlyTourDateJobIds.has(job.id);
+        }
         if (Array.isArray(job.job_date_types) && job.job_date_types.length > 0) {
           return job.job_date_types.some(
             (dt: { type?: string } | null | undefined) => dt?.type !== 'off' && dt?.type !== 'travel'
@@ -64,14 +79,19 @@ export default function Timesheets() {
       })
       .sort((a, b) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime());
     return filtered;
-  }, [jobs]);
+  }, [hourlyTourDateJobIds, jobs]);
 
   const selectedJob = jobs.find(job => job.id === selectedJobId);
   const selectedJobType = String(selectedJob?.job_type || '').toLowerCase();
   const timesheetsDisabled = selectedJob && (
     selectedJobType === 'dryhire' ||
     selectedJobType === 'dry_hire' ||
-    (selectedJobType === 'tourdate' && !hasPrepDayDateType(selectedJob.job_date_types))
+    (
+      selectedJobType === 'tourdate' &&
+      !hourlyRateModesLoading &&
+      !hasPrepDayDateType(selectedJob.job_date_types) &&
+      !hourlyTourDateJobIds.has(selectedJob.id)
+    )
   );
 
 

--- a/src/pages/__tests__/TechnicianSuperApp.test.tsx
+++ b/src/pages/__tests__/TechnicianSuperApp.test.tsx
@@ -51,6 +51,10 @@ vi.mock("@/services/dataLayerClient", () => ({
   dataLayerClient: mockSupabase,
 }));
 
+vi.mock("@/services/hourlyTourDateTimesheets", () => ({
+  fetchHourlyTourDateRateModes: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("@/components/technician/DashboardScreen", () => ({
   DashboardScreen: ({ assignments }: { assignments: any[] }) => (
     <div data-testid="dashboard-screen">Dashboard assignments: {assignments.length}</div>

--- a/src/pages/__tests__/Timesheets.hourly-tourdate.test.tsx
+++ b/src/pages/__tests__/Timesheets.hourly-tourdate.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Timesheets from '@/pages/Timesheets';
+import { fetchHourlyTourDateRateModes } from '@/services/hourlyTourDateTimesheets';
+import { renderWithProviders } from '@/test/renderWithProviders';
+
+vi.mock('@/hooks/useOptimizedJobs', () => ({
+  useOptimizedJobs: () => ({
+    data: [
+      {
+        id: 'tourdate-1',
+        title: 'Fecha de gira con tarifa por horas',
+        start_time: '2026-07-10T08:00:00Z',
+        end_time: '2026-07-10T20:00:00Z',
+        job_type: 'tourdate',
+        status: 'Confirmado',
+        job_date_types: [] as Array<{ type?: string | null; date?: string | null }>,
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useOptimizedAuth', () => ({
+  useOptimizedAuth: () => ({
+    user: { id: 'manager-1', department: 'sound' },
+    userRole: 'management',
+  }),
+}));
+
+vi.mock('@/hooks/useTimesheets', () => ({
+  useTimesheets: () => ({ timesheets: [] as unknown[] }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/services/hourlyTourDateTimesheets', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/hourlyTourDateTimesheets')>();
+  return {
+    ...actual,
+    fetchHourlyTourDateRateModes: vi.fn(),
+  };
+});
+
+vi.mock('@/components/timesheet/TimesheetView', () => ({
+  TimesheetView: ({ jobId }: { jobId: string }) => (
+    <div data-testid="timesheet-view">Timesheets for {jobId}</div>
+  ),
+}));
+
+vi.mock('@/components/timesheet/TimesheetReminderSettings', () => ({
+  TimesheetReminderSettings: (): null => null,
+}));
+
+describe('Timesheets hourly tour-date access', () => {
+  beforeEach(() => {
+    vi.mocked(fetchHourlyTourDateRateModes).mockReset();
+  });
+
+  it('enables the manager interface when the tour date has an hourly override', async () => {
+    vi.mocked(fetchHourlyTourDateRateModes).mockResolvedValue([
+      { job_id: 'tourdate-1', technician_id: 'tech-1', date: '2026-07-10' },
+    ]);
+
+    renderWithProviders(<Timesheets />, { route: '/timesheets?jobId=tourdate-1' });
+
+    expect(await screen.findByTestId('timesheet-view')).toHaveTextContent('tourdate-1');
+    expect(screen.queryByText('Partes deshabilitados')).not.toBeInTheDocument();
+  });
+
+  it('keeps ordinary non-prep tour dates disabled', async () => {
+    vi.mocked(fetchHourlyTourDateRateModes).mockResolvedValue([]);
+
+    renderWithProviders(<Timesheets />, { route: '/timesheets?jobId=tourdate-1' });
+
+    expect(await screen.findByText('Partes deshabilitados')).toBeInTheDocument();
+    expect(screen.queryByTestId('timesheet-view')).not.toBeInTheDocument();
+  });
+});

--- a/src/services/hourlyTourDateTimesheets.test.ts
+++ b/src/services/hourlyTourDateTimesheets.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterEligibleTourDateTimesheets } from '@/services/hourlyTourDateTimesheets';
+
+const timesheets = [
+  { id: 'hourly-match', technician_id: 'tech-1', date: '2026-07-10' },
+  { id: 'same-date-other-tech', technician_id: 'tech-2', date: '2026-07-10' },
+  { id: 'prep-day', technician_id: 'tech-2', date: '2026-07-09' },
+  { id: 'ordinary-tourdate', technician_id: 'tech-1', date: '2026-07-11' },
+];
+
+describe('filterEligibleTourDateTimesheets', () => {
+  it('keeps prep-day rows and exact technician/date hourly matches only', () => {
+    const result = filterEligibleTourDateTimesheets(
+      timesheets,
+      new Set(['2026-07-09']),
+      [{ job_id: 'job-1', technician_id: 'tech-1', date: '2026-07-10' }],
+    );
+
+    expect(result.map((row) => row.id)).toEqual(['hourly-match', 'prep-day']);
+  });
+
+  it('does not expose ordinary tour-date timesheets without an eligible mode', () => {
+    expect(filterEligibleTourDateTimesheets(timesheets, new Set(), [])).toEqual([]);
+  });
+});

--- a/src/services/hourlyTourDateTimesheets.ts
+++ b/src/services/hourlyTourDateTimesheets.ts
@@ -1,0 +1,59 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export interface HourlyTourDateRateMode {
+  job_id: string;
+  technician_id: string;
+  date: string;
+}
+
+interface FetchHourlyTourDateRateModesOptions {
+  jobIds?: string[];
+  technicianId?: string;
+}
+
+interface HourlyTourDateRpcClient {
+  rpc: (
+    functionName: 'get_hourly_rate_mode_dates_for_timesheets',
+    args: { _job_ids: string[] | null },
+  ) => PromiseLike<{ data: HourlyTourDateRateMode[] | null; error: unknown }>;
+}
+
+export const hourlyTourDateTimesheetKey = (technicianId: string, date: string): string =>
+  `${technicianId}:${date}`;
+
+export function filterEligibleTourDateTimesheets<
+  T extends { technician_id: string; date: string },
+>(
+  timesheets: T[],
+  prepDayDates: ReadonlySet<string>,
+  hourlyRateModes: HourlyTourDateRateMode[],
+): T[] {
+  const hourlyTimesheetKeys = new Set(
+    hourlyRateModes.map((row) => hourlyTourDateTimesheetKey(row.technician_id, row.date)),
+  );
+
+  return timesheets.filter((row) => (
+    prepDayDates.has(row.date) ||
+    hourlyTimesheetKeys.has(hourlyTourDateTimesheetKey(row.technician_id, row.date))
+  ));
+}
+
+export async function fetchHourlyTourDateRateModes(
+  options: FetchHourlyTourDateRateModesOptions = {},
+): Promise<HourlyTourDateRateMode[]> {
+  const { jobIds, technicianId } = options;
+
+  if (jobIds && jobIds.length === 0) return [];
+
+  // The generated Supabase types lag behind this RPC's migration.
+  const rpcClient = supabase as unknown as HourlyTourDateRpcClient;
+  const { data, error } = await rpcClient.rpc('get_hourly_rate_mode_dates_for_timesheets', {
+    _job_ids: jobIds ?? null,
+  });
+  if (error) throw error;
+
+  const rows = data || [];
+  return technicianId
+    ? rows.filter((row) => row.technician_id === technicianId)
+    : rows;
+}

--- a/src/services/ratesService.ts
+++ b/src/services/ratesService.ts
@@ -242,10 +242,12 @@ export async function fetchRatesApprovals(): Promise<RatesApprovalRow[]> {
     }
   }
 
-  // 2) Fetch jobs that follow the timesheet approval flow
-  //    Include standalone jobs and also tour-linked jobs that are not tour dates (e.g. 'single', 'festival').
-  //    Always exclude dry hire and tour dates from this list.
-  const { data: jobsList, error: jobsError2 } = await supabase
+  // 2) Fetch jobs that follow the timesheet approval flow.
+  //    Include standalone jobs and tour-linked jobs that are not tour dates (e.g. 'single', 'festival').
+  //    Tour dates normally roll up into the tour approval row, but an explicit per-tech/date
+  //    hourly override requires a real timesheet, so those tour-date jobs need their own
+  //    review row with the timesheet approval interface.
+  const { data: nonTourDateJobs, error: jobsError2 } = await supabase
     .from('jobs')
     .select('id, title, start_time, end_time, job_type, status, rates_approved, tour_id')
     .neq('job_type', 'tourdate')
@@ -255,9 +257,39 @@ export async function fetchRatesApprovals(): Promise<RatesApprovalRow[]> {
 
   if (jobsError2) throw jobsError2;
 
+  let hourlyTourDateJobs: NonNullable<typeof nonTourDateJobs> = [];
+
+  if (jobReviewIds.size > 0) {
+    const { data: hourlyOverrides, error: hourlyOverridesError } = await supabase
+      .from('job_technician_rate_mode_dates')
+      .select('job_id')
+      // rate_mode exists in the live schema but generated Supabase types lag behind the migration.
+      .filter('rate_mode' as never, 'eq', 'hourly')
+      .in('job_id', Array.from(jobReviewIds));
+
+    if (hourlyOverridesError) throw hourlyOverridesError;
+
+    const hourlyTourDateJobIds = Array.from(
+      new Set((hourlyOverrides || []).map((row) => row.job_id).filter(Boolean) as string[]),
+    );
+
+    if (hourlyTourDateJobIds.length > 0) {
+      const { data: tourDateJobs, error: tourDateJobsError } = await supabase
+        .from('jobs')
+        .select('id, title, start_time, end_time, job_type, status, rates_approved, tour_id')
+        .in('id', hourlyTourDateJobIds)
+        .eq('job_type', 'tourdate')
+        .in('status', ['Confirmado', 'Completado'])
+        .order('start_time', { ascending: true });
+
+      if (tourDateJobsError) throw tourDateJobsError;
+      hourlyTourDateJobs = tourDateJobs || [];
+    }
+  }
+
   // Keep jobs even if they belong to a tour, as long as they are not 'tourdate'.
   // This ensures tour-linked 'single' jobs appear in the approvals table as individual jobs.
-  const jobsNeedingTimesheetApproval = (jobsList || []).filter(
+  const jobsNeedingTimesheetApproval = [...(nonTourDateJobs || []), ...hourlyTourDateJobs].filter(
     (j) => (j.job_type ?? '').toLowerCase() !== 'tour'
   );
   const jobIds = jobsNeedingTimesheetApproval.map((j) => j.id);

--- a/src/services/ratesService.ts
+++ b/src/services/ratesService.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { RateExtraRow } from '@/hooks/useRateExtrasCatalog';
 import { TourBaseRateRow } from '@/hooks/useTourBaseRates';
 import { RATES_QUERY_KEYS } from '@/constants/ratesQueryKeys';
+import { fetchHourlyTourDateRateModes } from '@/services/hourlyTourDateTimesheets';
 
 type Nullable<T> = T | null | undefined;
 
@@ -260,17 +261,12 @@ export async function fetchRatesApprovals(): Promise<RatesApprovalRow[]> {
   let hourlyTourDateJobs: NonNullable<typeof nonTourDateJobs> = [];
 
   if (jobReviewIds.size > 0) {
-    const { data: hourlyOverrides, error: hourlyOverridesError } = await supabase
-      .from('job_technician_rate_mode_dates')
-      .select('job_id')
-      // rate_mode exists in the live schema but generated Supabase types lag behind the migration.
-      .filter('rate_mode' as never, 'eq', 'hourly')
-      .in('job_id', Array.from(jobReviewIds));
-
-    if (hourlyOverridesError) throw hourlyOverridesError;
+    const hourlyOverrides = await fetchHourlyTourDateRateModes({
+      jobIds: Array.from(jobReviewIds),
+    });
 
     const hourlyTourDateJobIds = Array.from(
-      new Set((hourlyOverrides || []).map((row) => row.job_id).filter(Boolean) as string[]),
+      new Set(hourlyOverrides.map((row) => row.job_id).filter(Boolean)),
     );
 
     if (hourlyTourDateJobIds.length > 0) {

--- a/supabase/migrations/20260710210000_enable_hourly_tourdate_timesheet_flow.sql
+++ b/supabase/migrations/20260710210000_enable_hourly_tourdate_timesheet_flow.sql
@@ -1,0 +1,121 @@
+-- Hourly technician/date overrides are the exception to the normal tour-date
+-- rule: they require a real timesheet that technicians can fill and management
+-- can review. Keep the source table admin-only and expose only the identifiers
+-- needed by the timesheet UI.
+
+CREATE OR REPLACE FUNCTION public.get_hourly_rate_mode_dates_for_timesheets(
+  _job_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  job_id uuid,
+  technician_id uuid,
+  date date
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+  SELECT
+    override_row.job_id,
+    override_row.technician_id,
+    override_row.date
+  FROM public.job_technician_rate_mode_dates AS override_row
+  WHERE override_row.rate_mode = 'hourly'
+    AND (_job_ids IS NULL OR override_row.job_id = ANY(_job_ids))
+    AND (
+      public.is_admin_or_management()
+      OR override_row.technician_id = (SELECT auth.uid())
+    );
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_hourly_rate_mode_dates_for_timesheets(uuid[]) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_hourly_rate_mode_dates_for_timesheets(uuid[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_hourly_rate_mode_dates_for_timesheets(uuid[]) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.ensure_hourly_rate_mode_timesheet()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+BEGIN
+  IF NEW.rate_mode = 'hourly' THEN
+    INSERT INTO public.timesheets (
+      job_id,
+      technician_id,
+      date,
+      created_by,
+      source,
+      is_active
+    ) VALUES (
+      NEW.job_id,
+      NEW.technician_id,
+      NEW.date,
+      COALESCE(NEW.updated_by, NEW.created_by),
+      'hourly_rate_override',
+      true
+    )
+    ON CONFLICT (job_id, technician_id, date)
+    DO UPDATE
+      SET is_active = true,
+          source = CASE
+            WHEN public.timesheets.source IS NULL OR public.timesheets.source = 'matrix'
+              THEN 'hourly_rate_override'
+            ELSE public.timesheets.source
+          END,
+          updated_at = now()
+      WHERE public.timesheets.is_active IS DISTINCT FROM true
+         OR public.timesheets.source IS NULL
+         OR public.timesheets.source = 'matrix';
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.ensure_hourly_rate_mode_timesheet() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.ensure_hourly_rate_mode_timesheet() FROM anon, authenticated;
+
+DROP TRIGGER IF EXISTS trg_ensure_hourly_rate_mode_timesheet
+  ON public.job_technician_rate_mode_dates;
+CREATE TRIGGER trg_ensure_hourly_rate_mode_timesheet
+  AFTER INSERT OR UPDATE OF rate_mode
+  ON public.job_technician_rate_mode_dates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.ensure_hourly_rate_mode_timesheet();
+
+-- Repair any hourly overrides created before this invariant existed, including
+-- reactivating a soft-deleted timesheet that occupies the unique key.
+INSERT INTO public.timesheets (
+  job_id,
+  technician_id,
+  date,
+  created_by,
+  source,
+  is_active
+)
+SELECT
+  override_row.job_id,
+  override_row.technician_id,
+  override_row.date,
+  COALESCE(override_row.updated_by, override_row.created_by),
+  'hourly_rate_override',
+  true
+FROM public.job_technician_rate_mode_dates AS override_row
+WHERE override_row.rate_mode = 'hourly'
+ON CONFLICT (job_id, technician_id, date)
+DO UPDATE
+  SET is_active = true,
+      source = CASE
+        WHEN public.timesheets.source IS NULL OR public.timesheets.source = 'matrix'
+          THEN 'hourly_rate_override'
+        ELSE public.timesheets.source
+      END,
+      updated_at = now()
+  WHERE public.timesheets.is_active IS DISTINCT FROM true
+     OR public.timesheets.source IS NULL
+     OR public.timesheets.source = 'matrix';
+
+COMMENT ON FUNCTION public.ensure_hourly_rate_mode_timesheet() IS
+  'Maintains the invariant that every hourly technician/date rate override has an active timesheet.';

--- a/supabase/tests/database/hourly_tourdate_timesheet_flow.sql
+++ b/supabase/tests/database/hourly_tourdate_timesheet_flow.sql
@@ -1,0 +1,331 @@
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+SET search_path TO public, extensions;
+
+SELECT plan(19);
+
+SELECT ok(
+  to_regprocedure('public.get_hourly_rate_mode_dates_for_timesheets(uuid[])') IS NOT NULL,
+  'scoped hourly timesheet eligibility function exists'
+);
+
+SELECT ok(
+  COALESCE((
+    SELECT prosecdef
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.get_hourly_rate_mode_dates_for_timesheets(uuid[])')
+  ), false),
+  'hourly eligibility function is security definer'
+);
+
+SELECT ok(
+  COALESCE((
+    SELECT provolatile = 's'
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.get_hourly_rate_mode_dates_for_timesheets(uuid[])')
+  ), false),
+  'hourly eligibility function is stable'
+);
+
+SELECT ok(
+  COALESCE((
+    SELECT proconfig @> ARRAY['search_path=public, pg_temp']::text[]
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.get_hourly_rate_mode_dates_for_timesheets(uuid[])')
+  ), false),
+  'hourly eligibility function pins its search path'
+);
+
+SELECT ok(
+  has_function_privilege(
+    'authenticated',
+    'public.get_hourly_rate_mode_dates_for_timesheets(uuid[])',
+    'EXECUTE'
+  ),
+  'authenticated callers can request scoped hourly eligibility rows'
+);
+
+SELECT ok(
+  NOT has_function_privilege(
+    'anon',
+    'public.get_hourly_rate_mode_dates_for_timesheets(uuid[])',
+    'EXECUTE'
+  ),
+  'anonymous callers cannot request hourly eligibility rows'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'job_technician_rate_mode_dates'
+      AND policyname IN (
+        'job_technician_rate_mode_dates_select_management',
+        'job_technician_rate_mode_dates_select_own'
+      )
+  ),
+  'source rate-mode table remains admin-only instead of exposing full rows'
+);
+
+SELECT ok(
+  COALESCE((
+    SELECT prosecdef
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.ensure_hourly_rate_mode_timesheet()')
+  ), false),
+  'hourly timesheet invariant trigger function is security definer'
+);
+
+SELECT ok(
+  COALESCE((
+    SELECT proconfig @> ARRAY['search_path=public, pg_temp']::text[]
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.ensure_hourly_rate_mode_timesheet()')
+  ), false),
+  'hourly timesheet invariant trigger function pins its search path'
+);
+
+SELECT ok(
+  NOT has_function_privilege(
+    'authenticated',
+    'public.ensure_hourly_rate_mode_timesheet()',
+    'EXECUTE'
+  ),
+  'authenticated callers cannot invoke the trigger function directly'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.job_technician_rate_mode_dates'::regclass
+      AND tgname = 'trg_ensure_hourly_rate_mode_timesheet'
+      AND NOT tgisinternal
+  ),
+  'hourly rate-mode writes are guarded by the timesheet invariant trigger'
+);
+
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+
+INSERT INTO auth.users (
+  id, instance_id, email, encrypted_password, email_confirmed_at, created_at,
+  updated_at, raw_app_meta_data, raw_user_meta_data, aud, role
+) VALUES
+  (
+    'b8100000-0000-0000-0000-000000000001'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'hourly-manager@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'b8100000-0000-0000-0000-000000000002'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'hourly-tech@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'b8100000-0000-0000-0000-000000000003'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'fixed-tech@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'b8100000-0000-0000-0000-000000000004'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'unrelated-tech@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.profiles (id, email, first_name, last_name, role, department)
+VALUES
+  ('b8100000-0000-0000-0000-000000000001'::uuid, 'hourly-manager@test.local', 'Hourly', 'Manager', 'management', 'sound'),
+  ('b8100000-0000-0000-0000-000000000002'::uuid, 'hourly-tech@test.local', 'Hourly', 'Tech', 'technician', 'sound'),
+  ('b8100000-0000-0000-0000-000000000003'::uuid, 'fixed-tech@test.local', 'Fixed', 'Tech', 'technician', 'lights'),
+  ('b8100000-0000-0000-0000-000000000004'::uuid, 'unrelated-tech@test.local', 'Unrelated', 'Tech', 'technician', 'video')
+ON CONFLICT (id) DO UPDATE
+SET email = excluded.email,
+    first_name = excluded.first_name,
+    last_name = excluded.last_name,
+    role = excluded.role,
+    department = excluded.department;
+
+INSERT INTO public.activity_catalog (code, label, default_visibility, severity, toast_enabled)
+VALUES
+  ('job.created', 'Job created', 'management', 'info', false),
+  ('assignment.created', 'Assignment created', 'management', 'info', false),
+  ('assignment.removed', 'Assignment removed', 'management', 'info', false)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO public.jobs (id, title, start_time, end_time, job_type, status)
+VALUES (
+  'b8200000-0000-0000-0000-000000000001'::uuid,
+  'Hourly Tour Date RLS Test',
+  '2026-07-10 08:00:00+02'::timestamptz,
+  '2026-07-11 02:00:00+02'::timestamptz,
+  'tourdate',
+  'Confirmado'
+)
+ON CONFLICT (id) DO UPDATE
+SET title = excluded.title,
+    start_time = excluded.start_time,
+    end_time = excluded.end_time,
+    job_type = excluded.job_type,
+    status = excluded.status;
+
+INSERT INTO public.job_technician_rate_mode_dates (
+  job_id, technician_id, date, use_rehearsal_rate, rate_mode, fixed_amount_eur
+) VALUES
+  (
+    'b8200000-0000-0000-0000-000000000001'::uuid,
+    'b8100000-0000-0000-0000-000000000002'::uuid,
+    '2026-07-10', false, 'hourly', NULL
+  ),
+  (
+    'b8200000-0000-0000-0000-000000000001'::uuid,
+    'b8100000-0000-0000-0000-000000000003'::uuid,
+    '2026-07-10', false, 'fixed', 250
+  )
+ON CONFLICT (job_id, technician_id, date) DO UPDATE
+SET rate_mode = excluded.rate_mode,
+    fixed_amount_eur = excluded.fixed_amount_eur,
+    use_rehearsal_rate = excluded.use_rehearsal_rate;
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.timesheets
+    WHERE job_id = 'b8200000-0000-0000-0000-000000000001'::uuid
+      AND technician_id = 'b8100000-0000-0000-0000-000000000002'::uuid
+      AND date = '2026-07-10'
+      AND is_active
+  ),
+  1,
+  'an hourly override creates its required active timesheet'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.timesheets
+    WHERE job_id = 'b8200000-0000-0000-0000-000000000001'::uuid
+      AND technician_id = 'b8100000-0000-0000-0000-000000000003'::uuid
+      AND date = '2026-07-10'
+  ),
+  0,
+  'a fixed override does not create a timesheet'
+);
+
+UPDATE public.timesheets
+SET is_active = false
+WHERE job_id = 'b8200000-0000-0000-0000-000000000001'::uuid
+  AND technician_id = 'b8100000-0000-0000-0000-000000000002'::uuid
+  AND date = '2026-07-10';
+
+UPDATE public.job_technician_rate_mode_dates
+SET rate_mode = 'hourly'
+WHERE job_id = 'b8200000-0000-0000-0000-000000000001'::uuid
+  AND technician_id = 'b8100000-0000-0000-0000-000000000002'::uuid
+  AND date = '2026-07-10';
+
+SELECT is(
+  (
+    SELECT is_active
+    FROM public.timesheets
+    WHERE job_id = 'b8200000-0000-0000-0000-000000000001'::uuid
+      AND technician_id = 'b8100000-0000-0000-0000-000000000002'::uuid
+      AND date = '2026-07-10'
+  ),
+  true,
+  'writing an hourly override reactivates an existing soft-deleted timesheet'
+);
+
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+SELECT set_config('request.jwt.claim.sub', 'b8100000-0000-0000-0000-000000000001', false);
+SET ROLE authenticated;
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.get_hourly_rate_mode_dates_for_timesheets(
+      ARRAY['b8200000-0000-0000-0000-000000000001'::uuid]
+    )
+  ),
+  1,
+  'management can read hourly identifiers needed for approvals'
+);
+
+SELECT is_empty(
+  $$
+    SELECT technician_id
+    FROM public.job_technician_rate_mode_dates
+    WHERE job_id = 'b8200000-0000-0000-0000-000000000001'::uuid
+  $$,
+  'management eligibility does not expose the admin-only source table'
+);
+
+RESET ROLE;
+SELECT set_config('request.jwt.claim.sub', 'b8100000-0000-0000-0000-000000000002', false);
+SET ROLE authenticated;
+
+SELECT is(
+  ARRAY(
+    SELECT technician_id
+    FROM public.get_hourly_rate_mode_dates_for_timesheets(
+      ARRAY['b8200000-0000-0000-0000-000000000001'::uuid]
+    )
+  ),
+  ARRAY['b8100000-0000-0000-0000-000000000002'::uuid],
+  'a technician receives only their own hourly eligibility row'
+);
+
+SELECT is_empty(
+  $$
+    SELECT technician_id
+    FROM public.job_technician_rate_mode_dates
+    WHERE job_id = 'b8200000-0000-0000-0000-000000000001'::uuid
+  $$,
+  'technician eligibility does not expose the admin-only source table'
+);
+
+RESET ROLE;
+SELECT set_config('request.jwt.claim.sub', 'b8100000-0000-0000-0000-000000000004', false);
+SET ROLE authenticated;
+
+SELECT is_empty(
+  $$
+    SELECT technician_id
+    FROM public.get_hourly_rate_mode_dates_for_timesheets(
+      ARRAY['b8200000-0000-0000-0000-000000000001'::uuid]
+    )
+  $$,
+  'an unrelated technician receives no hourly eligibility rows'
+);
+
+RESET ROLE;
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+SELECT set_config('request.jwt.claim.sub', '', false);
+
+DELETE FROM public.jobs
+WHERE id = 'b8200000-0000-0000-0000-000000000001'::uuid;
+DELETE FROM public.profiles
+WHERE id IN (
+  'b8100000-0000-0000-0000-000000000001'::uuid,
+  'b8100000-0000-0000-0000-000000000002'::uuid,
+  'b8100000-0000-0000-0000-000000000003'::uuid,
+  'b8100000-0000-0000-0000-000000000004'::uuid
+);
+DELETE FROM auth.users
+WHERE id IN (
+  'b8100000-0000-0000-0000-000000000001'::uuid,
+  'b8100000-0000-0000-0000-000000000002'::uuid,
+  'b8100000-0000-0000-0000-000000000003'::uuid,
+  'b8100000-0000-0000-0000-000000000004'::uuid
+);
+
+SELECT * FROM finish();


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Surfaces confirmed/completed tour-date jobs as individual approval rows when a technician/date override uses `rate_mode = 'hourly'`.
- Enables the manager timesheet interface for those rows while keeping ordinary non-prep tour dates disabled.
- Exposes the technician `Horas` action only for their own hourly/prep tour-date timesheets and filters rows by exact technician/date eligibility.
- Adds a scoped security-definer RPC that returns only hourly eligibility identifiers; the admin-only override table remains protected.
- Adds a trigger and backfill so every hourly override has an active timesheet, including reactivating soft-deleted rows.
- Affected features: rates approvals, management timesheets, technician dashboard/super-app, and technician/date rate modes.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: medium
- Main risks: incorrectly widening tour-date timesheet visibility or failing to create the required draft. The implementation uses exact technician/date matching, preserves the normal tour-date exclusion, and enforces the hourly-timesheet invariant in the database.
- [x] Database/RLS-sensitive behavior has dedicated pgTAP authorization coverage.
- [x] Risk is not high; two independent approvals are not required.

## Impact Checklist
- [x] Migration impact assessed: one additive RPC, one trigger function/trigger, and an idempotent backfill.
- [x] Realtime/subscription impact assessed: no subscription topology changes; existing rates invalidation remains.
- [x] RLS/security impact assessed: the source override table remains admin-only; authenticated callers can execute a scoped RPC that returns only allowed hourly identifiers.
- [x] Performance impact assessed: one bounded eligibility RPC is added to the relevant rates/timesheet flows; job/date filters and 30-second query caching limit repeated reads.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint`
  - `npm run typecheck`
  - `npm run governance`
  - `npm run test:critical`
  - `npm run test:run`
  - `npm run build`
  - `npm run budget:bundle`
  - `npx vitest run src/services/hourlyTourDateTimesheets.test.ts src/components/technician/__tests__/TechJobCard.hourly-tourdate.test.tsx src/pages/__tests__/Timesheets.hourly-tourdate.test.tsx`
- Results: all passed. Lint reports only existing repository warnings.
- Local DB execution was unavailable because Docker Desktop was not running; CI must pass migration apply, DB lint, and the new 19-assertion pgTAP authorization test before merge.

## Rollback Plan
- [x] I documented how to safely revert this change.
- [x] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert the application commit and add a forward migration that drops `trg_ensure_hourly_rate_mode_timesheet`, `ensure_hourly_rate_mode_timesheet()`, and `get_hourly_rate_mode_dates_for_timesheets(uuid[])`. Backfilled timesheets are preserved to avoid deleting technician-entered hours.

## Migration Impact
- [x] I confirmed this PR changes database functions/trigger behavior.
- Migration required: yes
- Migration: `20260710210000_enable_hourly_tourdate_timesheet_flow.sql`.
- Before merge, run `npx supabase db push --linked --dry-run`, apply the pending migration to the linked production project, and confirm a follow-up dry run reports the database is up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tour-date jobs with hourly rate overrides now support timesheet access and approval workflows.
  * Timesheets are automatically created or reactivated for eligible hourly tour-date entries.
  * Eligible tour-date timesheets appear in technician and manager views.

* **Bug Fixes**
  * Improved timesheet filtering and availability handling for hourly tour-date jobs.
  * Added the “Fecha de gira” label for tour-date jobs.

* **Tests**
  * Added coverage for hourly tour-date access, filtering, approval, and reactivation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->