### PR TITLE
Fix hook dependency warning debt

### DIFF
--- a/docs/CODEBASE_AUDIT_CURRENT_FINDINGS_2026-07-10.md
+++ b/docs/CODEBASE_AUDIT_CURRENT_FINDINGS_2026-07-10.md
@@ -38,7 +38,7 @@ historical schema states and must not be used as current schema inventories.
 | Check | Result on 2026-07-10 | Interpretation |
 | --- | --- | --- |
 | `npm run typecheck` | Pass | Useful, but the app compiles with `strict: false`. |
-| `npm run lint` | Pass with 1,901 warnings | 1,640 `no-explicit-any`, 96 hook dependency, 65 useless escape, 62 React-refresh, and 38 other warnings. |
+| `npm run lint` | Pass with 1,885 warnings | 1,628 `no-explicit-any`, 93 hook dependency, 65 useless escape, 61 React-refresh, and 38 other warnings. |
 | `npm run governance` | Pass | It prevents new debt but intentionally allowlists substantial existing debt. |
 | Source-boundary gate | 200 UI `dataLayerClient` matches | Down from baseline 213; still a large migration queue. |
 | File-size gate | 43 source files over 800 lines | Down from baseline 45. Generated Supabase types are excluded from remediation priority. |
@@ -223,7 +223,7 @@ or hosted-dashboard cron jobs.
 
 - **Severity:** High
 - **Status:** In progress on this branch
-- **Evidence:** 1,901 lint warnings are non-blocking; 96 are
+- **Evidence:** 1,885 lint warnings are non-blocking; 93 are
   `react-hooks/exhaustive-deps`, and `react-hooks/rules-of-hooks` remains a
   warning. The app uses `strict: false` and `strictNullChecks: false`.
 - **Action:** Check in warning counts by rule/file, fail new warnings, eliminate

--- a/docs/CODEBASE_AUDIT_CURRENT_FINDINGS_2026-07-10.md
+++ b/docs/CODEBASE_AUDIT_CURRENT_FINDINGS_2026-07-10.md
@@ -224,8 +224,8 @@ or hosted-dashboard cron jobs.
 - **Severity:** High
 - **Status:** In progress on this branch
 - **Evidence:** 1,885 lint warnings are non-blocking; 93 are
-  `react-hooks/exhaustive-deps`, and `react-hooks/rules-of-hooks` remains a
-  warning. The app uses `strict: false` and `strictNullChecks: false`.
+  `react-hooks/exhaustive-deps`; `react-hooks/rules-of-hooks` is configured as
+  an error. The app uses `strict: false` and `strictNullChecks: false`.
 - **Action:** Check in warning counts by rule/file, fail new warnings, eliminate
   hook warnings first, then ratchet `any` debt. Introduce strict subprojects in
   this order: unknown catches, null checks, indexed access, full strict.

--- a/src/components/disponibilidad/StockCreationManager.tsx
+++ b/src/components/disponibilidad/StockCreationManager.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { StockEntry, Equipment, getCategoriesForDepartment, allCategoryLabels, AllCategories, EquipmentCategory } from '@/types/equipment';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { StockEntry, Equipment, getCategoriesForDepartment, allCategoryLabels, AllCategories, EquipmentCategory, Department } from '@/types/equipment';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
@@ -71,14 +71,13 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
   const [showAdvFlexSection, setShowAdvFlexSection] = useState(false);
   const [isFetchingAdvFlex, setIsFetchingAdvFlex] = useState(false);
 
-  const categories = getCategoriesForDepartment(department as any);
-
+  const categories = useMemo(() => getCategoriesForDepartment(department as Department), [department]);
   // Initialize default category
   useEffect(() => {
     if (categories.length > 0 && !newCategory) {
       setNewCategory(categories[0]);
     }
-  }, [categories]);
+  }, [categories, newCategory]);
 
   // Flex integration helpers
   const extractUuidFromUrl = (url: string): string | null => {
@@ -220,35 +219,36 @@ export const StockCreationManager = ({ stock, onStockUpdate, department }: Stock
   });
 
   // Combine equipment with stock quantities
-  const equipmentWithStock: EquipmentWithStock[] = equipmentList.map(equipment => {
+  const equipmentWithStock = useMemo<EquipmentWithStock[]>(() => equipmentList.map(equipment => {
     const stockLevel = currentStockLevels.find(s => s.equipment_id === equipment.id);
     return {
       ...equipment,
-      quantity: stockLevel?.current_quantity || 0
+      quantity: stockLevel?.current_quantity || 0,
     };
-  });
+  }), [currentStockLevels, equipmentList]);
 
   // Filter by search
-  const filteredEquipment = equipmentWithStock.filter(item =>
-    item.name.toLowerCase().includes(searchQuery.toLowerCase())
+  const filteredEquipment = useMemo(
+    () => equipmentWithStock.filter(item => item.name.toLowerCase().includes(searchQuery.toLowerCase())),
+    [equipmentWithStock, searchQuery],
   );
 
   // Group by category
-  const groupedEquipment: GroupedEquipment = filteredEquipment.reduce((acc, item) => {
+  const groupedEquipment = useMemo<GroupedEquipment>(() => filteredEquipment.reduce((acc, item) => {
     const category = item.category || 'uncategorized';
     if (!acc[category]) {
       acc[category] = [];
     }
     acc[category].push(item);
     return acc;
-  }, {} as GroupedEquipment);
+  }, {} as GroupedEquipment), [filteredEquipment]);
 
   // Auto-expand categories with search matches
   useEffect(() => {
     if (searchQuery) {
       setExpandedCategories(new Set(Object.keys(groupedEquipment)));
     }
-  }, [searchQuery]);
+  }, [groupedEquipment, searchQuery]);
 
   const toggleCategory = (category: string) => {
     setExpandedCategories(prev => {

--- a/src/components/disponibilidad/StockCreationManager.tsx
+++ b/src/components/disponibilidad/StockCreationManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { StockEntry, Equipment, getCategoriesForDepartment, allCategoryLabels, AllCategories, EquipmentCategory, Department } from '@/types/equipment';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/components/festival/ArtistFileDialog.tsx
+++ b/src/components/festival/ArtistFileDialog.tsx
@@ -2,7 +2,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { FileText, Loader2, Trash2, Upload, Eye, X } from "lucide-react";
@@ -31,7 +31,7 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
   const [viewingFile, setViewingFile] = useState<any>(null);
   const [viewFileUrl, setViewFileUrl] = useState<string>("");
 
-  const fetchFiles = async () => {
+  const fetchFiles = useCallback(async () => {
     try {
       const { data, error } = await dataLayerClient.from("festival_artist_files")
         .select("*")
@@ -56,13 +56,13 @@ export const ArtistFileDialog = ({ open, onOpenChange, artistId }: ArtistFileDia
         variant: "destructive",
       });
     }
-  };
+  }, [artistId, toast]);
 
   useEffect(() => {
     if (open && artistId) {
       fetchFiles();
     }
-  }, [open, artistId]);
+  }, [open, artistId, fetchFiles]);
 
   const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFiles = Array.from(event.target.files ?? []);


### PR DESCRIPTION
## Summary

- memoize stock-derived categories and grouped results so hook dependencies are complete without repeat-effect loops
- memoize artist-file loading before using it in the dialog effect
- update the current audit register: lint warnings are now 1,885, including 93 hook-dependency warnings

## Why

The affected effects previously closed over recreated values or callback functions. Adding dependencies directly would either leave stale values or cause repeated effect execution; the derived values and loader are now stable.

## Validation

- `npm ci --legacy-peer-deps`
- `npm run lint`
- `npm run typecheck`
- `npm run test:critical`
- `npm run test:run`
- `npm run build`
- `npm run governance`
- `npm run budget:bundle`

No database migrations or Edge Function changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stock and equipment list updates so filtering, grouping, and category selection stay synchronized as data and searches change.
  - Improved file loading in artist dialogs when opening or switching between artists.

- **Performance**
  - Reduced unnecessary recalculation while managing stock and equipment lists, helping interactions feel more responsive.

- **Documentation**
  - Updated lint validation records and remediation evidence to reflect the latest warning counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->