### PR TITLE
Stabilize dashboard date dependencies

### DIFF
--- a/docs/CODEBASE_AUDIT_CURRENT_FINDINGS_2026-07-10.md
+++ b/docs/CODEBASE_AUDIT_CURRENT_FINDINGS_2026-07-10.md
@@ -38,7 +38,7 @@ historical schema states and must not be used as current schema inventories.
 | Check | Result on 2026-07-10 | Interpretation |
 | --- | --- | --- |
 | `npm run typecheck` | Pass | Useful, but the app compiles with `strict: false`. |
-| `npm run lint` | Pass with 1,885 warnings | 1,628 `no-explicit-any`, 93 hook dependency, 65 useless escape, 61 React-refresh, and 38 other warnings. |
+| `npm run lint` | Pass with 1,883 warnings | 1,628 `no-explicit-any`, 91 hook dependency, 65 useless escape, 61 React-refresh, and 38 other warnings. |
 | `npm run governance` | Pass | It prevents new debt but intentionally allowlists substantial existing debt. |
 | Source-boundary gate | 200 UI `dataLayerClient` matches | Down from baseline 213; still a large migration queue. |
 | File-size gate | 43 source files over 800 lines | Down from baseline 45. Generated Supabase types are excluded from remediation priority. |
@@ -223,7 +223,7 @@ or hosted-dashboard cron jobs.
 
 - **Severity:** High
 - **Status:** In progress on this branch
-- **Evidence:** 1,885 lint warnings are non-blocking; 93 are
+- **Evidence:** 1,883 lint warnings are non-blocking; 91 are
   `react-hooks/exhaustive-deps`; `react-hooks/rules-of-hooks` is configured as
   an error. The app uses `strict: false` and `strictNullChecks: false`.
 - **Action:** Check in warning counts by rule/file, fail new warnings, eliminate

--- a/src/components/dashboard/CalendarSection.tsx
+++ b/src/components/dashboard/CalendarSection.tsx
@@ -71,8 +71,7 @@ export const CalendarSection: React.FC<CalendarSectionProps> = ({
   const isPrintableJobType = (value: string | undefined): value is PrintableJobType =>
     Boolean(value && value in printSettings.jobTypes);
 
-  const currentMonth = date || new Date();
-  const currentMonthKey = `${currentMonth.getFullYear()}-${currentMonth.getMonth()}`;
+  const currentMonth = useMemo(() => date ?? new Date(), [date]);
 
   const allDays = useMemo(() => {
     const firstDayOfMonth = startOfMonth(currentMonth);
@@ -95,7 +94,7 @@ export const CalendarSection: React.FC<CalendarSectionProps> = ({
     });
 
     return [...prefixDays, ...daysInMonth, ...suffixDays];
-  }, [currentMonthKey]);
+  }, [currentMonth]);
   const distinctJobTypes = jobs ? Array.from(new Set(jobs.map((job) => job.job_type).filter(Boolean))) : [];
   const distinctJobStatuses = jobs ? Array.from(new Set(jobs.map((job) => job.status).filter(Boolean))) : [];
 

--- a/src/components/dashboard/DashboardMobileHub.tsx
+++ b/src/components/dashboard/DashboardMobileHub.tsx
@@ -70,7 +70,7 @@ export const DashboardMobileHub: React.FC<DashboardMobileHubProps> = ({
   onEmailClick,
 }) => {
   const isMobile = useIsMobile();
-  const selectedDate = date ?? new Date();
+  const selectedDate = useMemo(() => date ?? new Date(), [date]);
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [selectedJobTypes, setSelectedJobTypes] = useState<string[]>([]);
   const [selectedJobStatuses, setSelectedJobStatuses] = useState<string[]>([]);


### PR DESCRIPTION
## Summary

- stabilize dashboard fallback dates with `useMemo`
- remove two `react-hooks/exhaustive-deps` warnings without changing displayed-date behavior
- update the current audit register to 1,883 warnings, including 91 hook-dependency warnings

## Why

Fallback `new Date()` expressions were recreated on each render, making memo dependencies unstable. Memoizing those values gives dependent calculations a stable input.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:critical`
- `npm run test:run`
- `npm run build`
- `npm run governance`

No database migrations or Edge Function changes are included.