### PR TITLE
Reduce hook dependency warnings

### DIFF
--- a/docs/CODEBASE_AUDIT_CURRENT_FINDINGS_2026-07-10.md
+++ b/docs/CODEBASE_AUDIT_CURRENT_FINDINGS_2026-07-10.md
@@ -38,7 +38,7 @@ historical schema states and must not be used as current schema inventories.
 | Check | Result on 2026-07-10 | Interpretation |
 | --- | --- | --- |
 | `npm run typecheck` | Pass | Useful, but the app compiles with `strict: false`. |
-| `npm run lint` | Pass with 1,883 warnings | 1,628 `no-explicit-any`, 91 hook dependency, 65 useless escape, 61 React-refresh, and 38 other warnings. |
+| `npm run lint` | Pass with 1,879 warnings | 1,628 `no-explicit-any`, 87 hook dependency, 65 useless escape, 61 React-refresh, and 38 other warnings. |
 | `npm run governance` | Pass | It prevents new debt but intentionally allowlists substantial existing debt. |
 | Source-boundary gate | 200 UI `dataLayerClient` matches | Down from baseline 213; still a large migration queue. |
 | File-size gate | 43 source files over 800 lines | Down from baseline 45. Generated Supabase types are excluded from remediation priority. |
@@ -223,7 +223,7 @@ or hosted-dashboard cron jobs.
 
 - **Severity:** High
 - **Status:** In progress on this branch
-- **Evidence:** 1,883 lint warnings are non-blocking; 91 are
+- **Evidence:** 1,879 lint warnings are non-blocking; 87 are
   `react-hooks/exhaustive-deps`; `react-hooks/rules-of-hooks` is configured as
   an error. The app uses `strict: false` and `strictNullChecks: false`.
 - **Action:** Check in warning counts by rule/file, fail new warnings, eliminate

--- a/src/components/disponibilidad/WeeklySummary.tsx
+++ b/src/components/disponibilidad/WeeklySummary.tsx
@@ -63,6 +63,7 @@ function FlexImage({
 
   useEffect(() => {
     let isMounted = true;
+    let objectUrl: string | null = null;
 
     const fetchImage = async () => {
       try {
@@ -88,8 +89,8 @@ function FlexImage({
 
         const blob = await response.blob();
         if (isMounted) {
-          const url = URL.createObjectURL(blob);
-          setImageSrc(url);
+          objectUrl = URL.createObjectURL(blob);
+          setImageSrc(objectUrl);
         }
       } catch {
         if (isMounted) {
@@ -102,8 +103,8 @@ function FlexImage({
 
     return () => {
       isMounted = false;
-      if (imageSrc) {
-        URL.revokeObjectURL(imageSrc);
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
       }
     };
   }, [imageId]);
@@ -138,7 +139,7 @@ export function WeeklySummary({ selectedDate, onDateChange }: WeeklySummaryProps
     if (newStart.getTime() !== currentWeekStart.getTime()) {
       setCurrentWeekStart(newStart);
     }
-  }, [selectedDate]);
+  }, [currentWeekStart, selectedDate]);
   const [isOpen, setIsOpen] = useState(() => safeGetJSON('weeklySummaryOpen', true));
 
   const departmentCategories = getCategoriesForDepartment(department);

--- a/src/components/equipment/EquipmentCreationManager.tsx
+++ b/src/components/equipment/EquipmentCreationManager.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useOptimizedAuth } from '@/hooks/useOptimizedAuth';
 import { dataLayerClient } from '@/services/dataLayerClient';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -32,7 +32,10 @@ function EditEquipmentDialog({ equipment, open, onOpenChange, onSave }: EditEqui
   const context = useOptionalDepartment();
   const department: Department | undefined = context?.department;
 
-  const categories = department ? getCategoriesForDepartment(department) : [...SOUND_CATEGORIES, ...LIGHTS_CATEGORIES];
+  const categories = useMemo(
+    () => department ? getCategoriesForDepartment(department) : [...SOUND_CATEGORIES, ...LIGHTS_CATEGORIES],
+    [department],
+  );
   const [name, setName] = useState(equipment?.name || '');
   const [category, setCategory] = useState<string>((equipment?.category as string) || categories[0]);
   const [manufacturer, setManufacturer] = useState(equipment?.manufacturer || '');
@@ -51,7 +54,7 @@ function EditEquipmentDialog({ equipment, open, onOpenChange, onSave }: EditEqui
       setImageId(equipment.image_id || '');
       setShowFlexSection(!!(equipment.resource_id || equipment.manufacturer || equipment.image_id));
     }
-  }, [equipment?.id]);
+  }, [categories, equipment]);
 
   const extractUuidFromUrl = (url: string): string | null => {
     const match = url.match(UUID_REGEX);

--- a/src/components/festival/ArtistFormLinksDialog.tsx
+++ b/src/components/festival/ArtistFormLinksDialog.tsx
@@ -126,7 +126,7 @@ export const ArtistFormLinksDialog = ({
     } finally {
       setIsLoading(false);
     }
-  }, [jobId, selectedDate, toast]);
+  }, [jobId, toast]);
 
   useEffect(() => {
     if (open) {


### PR DESCRIPTION
## Summary

- fix four hook-dependency findings across weekly summary, equipment creation, and artist form links
- make image URL cleanup deterministic and stabilize derived category dependencies
- update the current audit register to 1,879 warnings and 87 hook-dependency findings

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:critical`
- `npm run build`
- `npm run governance`

No migrations or Edge Function changes.