### PR TITLE
fix: restore payout email send path

### DIFF
--- a/supabase/functions/send-job-payout-email/__tests__/sourceRegression.test.ts
+++ b/supabase/functions/send-job-payout-email/__tests__/sourceRegression.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const functionSource = readFileSync(resolve(__dirname, "../index.ts"), "utf8");
+
+describe("send-job-payout-email source regressions", () => {
+  it("does not reintroduce removed job client fields", () => {
+    expect(functionSource).not.toContain("client_name");
+    expect(functionSource).not.toContain("client_phone");
+  });
+
+  it("declares the debug flag used by the send path", () => {
+    expect(functionSource).toContain(
+      'const DEBUG = Deno.env.get("DEBUG_PAYOUT_EMAILS") === "true";',
+    );
+  });
+});

--- a/supabase/functions/send-job-payout-email/index.ts
+++ b/supabase/functions/send-job-payout-email/index.ts
@@ -246,6 +246,8 @@ serve(createHttpHandler(async (req) => {
   const body = await readBoundedJsonObject<JobPayoutRequestBody>(req, {
     maxBytes: MAX_PAYOUT_EMAIL_BODY_BYTES,
   });
+  const DEBUG = Deno.env.get("DEBUG_PAYOUT_EMAILS") === "true";
+
     // Avoid dumping base64 PDFs / PII into logs.
     console.log('[send-job-payout-email] Incoming payload', JSON.stringify(redactSensitiveValues({
       correlationId,


### PR DESCRIPTION
## What changed
- Restored the `DEBUG_PAYOUT_EMAILS` flag required by the payout email send path.
- Added a regression test that rejects the retired `client_name` and `client_phone` fields and verifies the debug flag remains declared.

## Root cause
A July 11 audit cleanup removed the debug-flag declaration but left three `DEBUG` checks in the handler. Every payout email request therefore failed before reaching Brevo. The reported client-field failure was a plausible historical cause, but is not present in the current source.

## Validation
- `npm run test:run -- supabase/functions/send-job-payout-email/__tests__`
- `npm run lint:functions` (0 errors; existing repository warnings only)
- `npm run typecheck`
- `npm run build`
- Reviewed all Edge Functions changed in the July 11 releases; no other blocking runtime defects found.

## Deployment
Deployed `send-job-payout-email` to production project `syldobdcdsgfgjtbuwxm`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Debug logging for payout emails is now controlled by the `DEBUG_PAYOUT_EMAILS` configuration setting.
  * Removed obsolete client details from payout email processing.

* **Tests**
  * Added regression coverage to verify debug configuration and prevent reintroduction of removed client fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->