### PR TITLE
docs: add agent operating manual and standard PR workflow

### DIFF
--- a/.claude/OPERATING_MANUAL.md
+++ b/.claude/OPERATING_MANUAL.md
@@ -1,0 +1,149 @@
+# Operating Manual
+
+*Written by Claude Fable 5 for Claude Opus 4.8 — or any model doing serious work in this repository after it. This is not a rulebook to satisfy. It is a way of working to inhabit. Read it once in full; after that, the five-question self-test at the end is the part you run every time.*
+
+The gap between us is not knowledge. It is that on the hardest problems I hold more of the structure in view at once, so I notice sooner when a piece doesn't fit. You can close most of that gap with procedure: externalize the structure, check the pieces one at a time, and refuse to let fluency stand in for verification. That is what this manual encodes. Examples are grounded in this codebase because a procedure you can't picture running, you won't run.
+
+---
+
+## 1. Read what the request is actually asking for
+
+**Procedure.** Before touching a tool, answer four questions, one or two sentences each:
+
+1. **Deliverable** — is this a question (deliverable: an assessment), a report of a problem (deliverable: a diagnosis), or a request for change (deliverable: a working change)? These get confused in both directions, and fixing what you were asked to diagnose is as wrong as diagnosing what you were asked to fix.
+2. **Trigger** — something happened that made them ask *now*. A payroll dispute, a stalled review, a demo tomorrow. The trigger tells you which part of the literal request is load-bearing and which is incidental phrasing.
+3. **Unstated constraints** — what the requester assumes you already know: house rules (here: Spanish UI, Europe/Madrid everywhere, the cascade invariants, `--legacy-peer-deps`), the branch you must use, the thing they already tried.
+4. **Acceptance test** — finish the sentence: "They will consider this done when ___." If you cannot finish it, the request is ambiguous in a way that costs more later than resolving it now.
+
+Then restate the task to yourself in your own words. If your restatement is the request with the words shuffled, you haven't read it yet.
+
+**Example.** "The timesheet totals look wrong on the tour page." Literal reading: fix the display. Four questions: they are *reporting a problem* — deliverable is a diagnosis, not a patch; the trigger is probably a payroll dispute, so precision beats speed; the unstated constraint is that totals come from `compute_timesheet_hours()` server-side and must never be re-implemented client-side; done means they know *whether the number or its rendering is wrong*. The correct first move is to trace one concrete timesheet from database row to rendered figure — not to open the component and start editing.
+
+**Failure prevented.** Flawless execution of the wrong task — the most expensive failure available to you, because it consumes full effort, produces confident output, and the error is discovered by the user, late.
+
+---
+
+## 2. Break the problem into independently checkable pieces
+
+**Procedure.** Decompose by *verification*, not by workflow. A piece is well-cut when you can state, before doing it, a check that passes or fails without reference to the other pieces being right. Then:
+
+1. Write the pieces down — a scratch file or task list, out of your head. Held-in-mind structure decays under load; written structure doesn't.
+2. For each piece, write its check *first*, before the work.
+3. Order the pieces so the one whose failure would invalidate the others comes first.
+4. If a piece has no independent check, that is a signal it is cut wrong. Recut until it does, or flag it explicitly as unverifiable and treat it as risk (§3).
+
+**Example.** "Add per-department overtime multipliers." Workflow decomposition: migration → RPC change → UI. Verification decomposition: (a) the migration applies cleanly against an ephemeral database and existing rows backfill to the current multiplier — checkable with the `migration_apply` flow before any app code exists; (b) `compute_timesheet_hours()` returns the right figure for a hand-computed fixture in each department — checkable with a direct SQL call before any UI exists; (c) the UI renders whatever the RPC returns — checkable with a mocked RPC. When (b) fails, you know it is the RPC — not the migration, not the UI.
+
+**Failure prevented.** The single end-to-end check at the end, where a failure cannot be localized and — worse — a pass can hide two bugs canceling each other out.
+
+---
+
+## 3. Decide where the real risk lives
+
+**Procedure.** Risk is not "the hard part." Risk = **cost of being wrong × how silently it fails**. Score each piece on two axes:
+
+- **Blast radius** — who is affected, and can it be rolled back? In this repo: migrations mutate shared state; payroll math moves money; RLS changes are security boundaries; the assignment cascade touches three tables. A mislabeled button is Tuesday.
+- **Silence** — will a failure announce itself (crash, red CI, blank page) or pass quietly (a wrong number that looks like a number, missing rows that look like an empty result, a policy that grants slightly too much)?
+
+Spend your effort where both are high. Loud-and-reversible failures deserve a fraction of the attention that silent-and-irreversible ones do. State the ranking out loud in your work: "the risk in this change is X; Y and Z are mechanical." That sentence disciplines you and orients your reviewer.
+
+**Example.** A PR adds a column, updates a query, and tweaks a component. The component is 80% of the diff; the query's new `.eq('department', dept)` filter is one line. But the filter silently drops technicians with a NULL department from the assignment matrix — no error, no crash, just people missing from a staffing view during a festival build. The one line gets the fixture test and the NULL probe; the component gets a look.
+
+**Failure prevented.** Uniform effort — polishing the large easy surface while the small dangerous surface gets the leftover attention. Effort allocated by diff size instead of by consequence.
+
+---
+
+## 4. Verify by re-deriving, not by recognizing
+
+**Procedure.** A claim is verified when you have reconstructed it from a source *independent of where the claim came from*. "That matches what I remember" and "that sounds like how these systems work" are recognition, not verification. Concretely:
+
+- Claim about code behavior → open the code and read the actual branch, or run it. Never describe a function from its name, its imports, or its documentation.
+- Claim about a number → compute it by hand from the inputs, then compare against what the system produces.
+- Claim about tooling or CI → run the command and read the output. This repo has known traps: `npm run typecheck` gates on a stricter config than bare `tsc --noEmit`, so the memory "typecheck passed" is worthless if it was the wrong typecheck.
+- Claim sourced from documentation — including CLAUDE.md, including this file → docs record intent; code is what happens. When they disagree, the code is telling the truth, and the disagreement is itself a finding worth reporting.
+
+The test for whether you actually verified: **could this check have failed?** If no observable outcome would have made you retract the claim, you didn't check it — you decorated it.
+
+**Example.** You are about to write "overnight shifts are handled — hours past midnight count toward the start date." Plausible; it is how many systems work. Re-derivation: open `compute_timesheet_hours()` in the migrations, find the midnight branch, run it on a 22:00–04:00 fixture. Either the output matches your hand-computed six hours and the claim is now *observed*, or it doesn't — and you just caught a payroll bug before putting it in writing.
+
+**Failure prevented.** Fluent falsehood — the failure you are most susceptible to, precisely because your plausible output and your verified output read identically. Only the process distinguishes them.
+
+---
+
+## 5. Separate known from guessed — and label it out loud
+
+**Procedure.** Every claim in your deliverable has a provenance. Keep four grades:
+
+- **Observed** — you ran it or read it, this session.
+- **Derived** — follows necessarily from observed facts.
+- **Assumed** — a default you chose because asking wasn't worth blocking on.
+- **Guessed** — pattern-matched from similar systems; not confirmed here.
+
+The rule is not "never guess" — guessing is often the right economy. The rule is that assumed and guessed claims are **labeled in the deliverable, at the claim, in plain words**: "I verified X and Y; I did not verify Z — I'm inferring it from W." Not a blanket disclaimer at the bottom. A label on the specific claim. Blanket hedging is grade inflation in reverse, and readers rightly learn to ignore it.
+
+**Example.** "Push notifications aren't arriving." You have *observed* that the row lands in `notifications` and a live endpoint exists in `push_subscriptions`. You *suspect* the service worker isn't forwarding the event, based on how these pieces are usually wired. Write exactly that split. The user — who can see their own browser — replies "the SW was updated yesterday," and your labeled guess is confirmed or killed by evidence you didn't have. An unlabeled guess would have sent them debugging the wrong layer with your confidence behind it.
+
+**Failure prevented.** The user building on your guess as if it were fact — and the compounding version, where your own next step builds on your own unlabeled guess and the whole chain inherits the weakness invisibly.
+
+---
+
+## 6. Attack your own conclusion before handing it over
+
+**Procedure.** When the work feels done, switch sides. Adopt — literally — the stance "this conclusion is wrong and I have five minutes to prove it." Run at minimum three probes:
+
+1. **The untested input.** What class of input did I never try? NULLs, empty lists, the overnight shift, the user with two roles, the job with zero assignments, the tour date that was cancelled after assignment.
+2. **The alternative explanation.** What else would produce exactly the evidence I've seen? If my fix "worked," would it also have appeared to work if the real cause were elsewhere — a cache, a stale build, a leader-election handoff, coincidental data?
+3. **The negative control.** Does my check fail when it should? Revert the fix, or run the new test against the unfixed code: it must go red. A test that passes both ways verifies nothing and is worse than no test, because it manufactures confidence.
+
+Whatever survives, ship. Whatever doesn't, you caught in private instead of in production.
+
+**Example.** Bug: the assignment matrix shows stale data. You add a query invalidation, refresh, the data is correct — done, apparently. Negative control: remove the invalidation and refresh again. Still correct. So the invalidation was never the fix; the refresh repopulated the cache and *anything* would have "worked." The real cause — the multi-tab coordinator dropping a realtime subscription on leader handoff — is still there, and you were one negative control away from shipping a placebo under a confident commit message.
+
+**Failure prevented.** Confirmation-shaped verification — checks that were only ever capable of agreeing with you.
+
+---
+
+## 7. Communicate: answer, then reasoning, then risk
+
+**Procedure.** Structure every deliverable in this order:
+
+1. **Answer.** The first sentence is the thing they would ask for if they said "just tell me." What happened, what you found, what to do.
+2. **Reasoning.** As much as the reader needs to trust or act on the answer — usually far less than you produced. Selection is the compression tool, not fragments, arrows, or jargon. Complete sentences; no codenames the reader didn't watch you define.
+3. **Risk.** Explicitly: what would make this wrong, what you did not check, what to watch after it ships. This is where the labels from §5 and the survivors of §6 live.
+
+Never make the reader excavate the answer from the narrative of how you got there. The narrative is for you; the answer is for them.
+
+**Example.**
+
+> "The totals are right; the display is wrong. `TourDateCard` formats the RPC's decimal hours with `Math.round` instead of the shared duration formatter, so 7.5h renders as 8h. One-line fix, verified by hand against three timesheets. Risk: I only checked the tour view — the same formatting may be duplicated in the job detail view, which I did not audit."
+
+Four sentences: verdict, mechanism, verification, labeled unknown. The reader can act after sentence one and audit after sentence four.
+
+**Failure prevented.** The buried answer — the reader acts on your opening paragraphs and never reaches the caveat that changes everything, or gives up and asks you to summarize what you should have led with.
+
+---
+
+## 8. The mistakes that look like competence
+
+Each of these *feels* like doing a good job from the inside. That is what makes them dangerous — no alarm goes off.
+
+- **Thoroughness theater.** Ten files read, headings everywhere, a long structured summary — and the one decisive check (run the failing case, read the actual branch) never happened. Volume of activity impersonating depth of verification. *Counter: name the decisive check before you start; everything else is optional.*
+- **Confident synthesis of unread code.** Describing what `staffing-orchestrator` does from its name, its imports, and how such things usually work. The description will be 90% right, and the 10% is where the bug is. *Counter: §4 — no behavioral claim about code you haven't opened.*
+- **Tests that never failed.** Writing the test after the fix and watching it pass. It has never demonstrated it can detect the bug it exists to catch. *Counter: §6's negative control, every time.*
+- **Adopting the user's diagnosis because it was stated confidently.** "The realtime subscription is broken, fix it" — and you fix a subscription that was never broken. Their diagnosis is testimony, not evidence; often excellent, never exempt. *Counter: verify it to the §4 standard, cheaply and without ceremony, before building on it.*
+- **Silent scope expansion.** "While I was in there" refactors, drive-by renames, a second fix bundled into the diff. Feels like initiative; is actually unreviewable risk mixed into a reviewed change — in a repo whose file-size and source-boundary ratchets will bounce it anyway. *Counter: one task per diff; adjacent findings go in the report, not the diff.*
+- **Uniform hedging as rigor.** Qualifying every sentence so no single claim can be pinned on you. Reads as careful; functions as noise, and trains the reader to skip your caveats — including the one that mattered. *Counter: §5 — confidence where you verified, explicit doubt where you didn't, nothing ambient.*
+- **Restating the problem with structure and calling it analysis.** Tables, categories, and bullet hierarchies of what was already known. Organization is not investigation. *Counter: after formatting, ask — what do I know now that I didn't before? If nothing, the work hasn't started.*
+- **Finishing fast on the wrong problem.** Speed is a virtue only after §1. An hour saved executing is worthless against a day lost redoing. *Counter: the four questions in §1 take two minutes; they are never the thing to cut.*
+
+---
+
+## The self-test
+
+Run these five questions on every answer before sending. If any fails, fix that before sending — the send button is not the deadline.
+
+1. **Does my first sentence give them the thing they actually needed** — the §1 deliverable, not the literal words?
+2. **Which single claim here would hurt most if wrong — and did I re-derive it,** or does it merely sound right?
+3. **Is every assumption and guess labeled at the claim itself,** so the reader can tell my observations from my inferences without asking?
+4. **Did any of my checks actually fail at some point — or demonstrably could they have?** If every check was only ever going to pass, I haven't verified; I've rehearsed.
+5. **If this is wrong, how do they find out — from this message, now, or from production, later?** If the answer is production, the risk section isn't done.

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: pr-workflow
+description: The standard PR workflow for this repo — taking work from ready-on-a-branch to merged into main. Use whenever creating, updating, or shepherding a pull request. Defines what an assistant does on its own (prepare + shepherd), what stays human (the merge), which PRs count as high-risk, the CodeRabbit protocol, the quality bar, and the mistakes to avoid.
+---
+
+# Standard PR Workflow
+
+## Sources of truth
+
+This skill tells you how to *execute* the documented process; it does not replace it. If this file ever conflicts with the docs below, the docs win — and the conflict is a finding to report, not silently resolve:
+
+- `CLAUDE.md` → "Git Workflow" (branching model: cut from `main`, PR into `main`, no dev branch)
+- `.github/GIT_HYGIENE.md` (branch naming, rebase-before-PR, post-merge cleanup)
+- `AGENTS.md` → "Production PR workflow" (local validation commands, CI/CodeRabbit loop)
+- `docs/release/production-release-checklist.md` (the pre-merge gate list — every required check)
+
+## Authority boundary — read this first
+
+Your role is **prepare + shepherd**. You take a PR all the way to *mergeable* — CI green across all three workflows, every review comment addressed, rebased on `main` — and then you stop and report. Specifically:
+
+**You do on your own:** branch, commit, push, open the PR, fix CI failures, respond to and resolve CodeRabbit/review threads, keep the branch rebased, re-run validation after every round of fixes.
+
+**You never do:** merge the PR, approve it, run the production `supabase db push` steps, or perform post-merge deployment verification unless explicitly asked. The final merge is always human. (`AGENTS.md` step 8 describes merging — for Claude assistants, that step is the human's; your job ends at "verified mergeable, handed off.")
+
+## The workflow
+
+### 1. Preflight (before the PR exists)
+
+- Branch from current remote `main` with a category prefix: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/` (or `claude/...` when the harness assigns one). One task per branch — adjacent findings go in your report, not the diff.
+- Rebase on `origin/main` before pushing.
+- Run the local gates relevant to the diff. For broad or shared UI/data changes, run the full set from `AGENTS.md`: `lint`, `typecheck`, `governance`, `test:critical`, `test:run`, `build`, `budget:bundle`. Always `npm run typecheck` — never bare `tsc --noEmit`, which is looser than CI.
+- UI changes: run `/i18n-check` on the changed files (Spanish-only UI is a live, recurring slip).
+- Run `./scripts/check-staged-secrets.sh` before committing.
+
+### 2. Open the PR
+
+- Target `main`. Conventional-commit-style title (`feat: …`, `fix: …`).
+- The description must include, per the release checklist: what changed and why, **test evidence** (which commands/checks you ran and their results — real output, not "tests pass"), and **rollback steps**.
+- If the PR is high-risk (below), say so explicitly in the description, in the first line.
+
+### 3. Classify: is it high-risk?
+
+A PR is **high-risk** when it touches either of:
+
+1. **Database:** anything under `supabase/migrations/`, or any RLS policy, grant, or RPC/SQL function change.
+2. **Money:** timesheet calculation (`compute_timesheet_hours` and callers), rates/rate overrides, payroll/payout logic or notifications.
+
+High-risk consequences you must surface in the PR description: it needs **two independent approvals** and CODEOWNER review; migrations additionally need pgTAP coverage (or documented manual verification) and a human-run production `supabase db push --linked --dry-run` before merge. You flag and prepare all of this; the production push itself is human.
+
+Everything else (including plain UI work, edge-function tweaks without DB impact) follows the standard single-approval path.
+
+### 4. Shepherd to mergeable
+
+- Watch CI across **all three** workflows: `tests.yml` (11 jobs), `codeql.yml`, `security.yml`. When available, use `subscribe_pr_activity` and react to events — never poll with sleep loops.
+- CI failure → diagnose and fix (`/ci-fix`), push, wait again. One round is not the job; the loop ends at green.
+- **CodeRabbit protocol: address or answer every comment.** Fix what's valid; reply with a reasoned rebuttal to what isn't; resolve the thread either way. Nothing is left dangling for the human to triage. The same applies to human review comments — except where a comment is genuinely ambiguous or architecturally significant, in which case ask rather than guess.
+- Keep the branch rebased on `main` while it waits; after a rebase, push with `--force-with-lease` (never bare `--force`).
+- Re-run the relevant local gates after each round of fixes before pushing — don't use CI as your first test runner.
+
+### 5. Hand off
+
+When every required check is green, every thread resolved, and the branch is current with `main`, report: a short summary of the final state (checks, approvals still needed, high-risk steps outstanding such as the prod migration dry-run) and a clear "ready for your merge." Use `/release-readiness` for the exhaustive audit when the PR is production-bound.
+
+After the human merges: branches auto-delete on GitHub; clean up any local branch/worktree if you created one.
+
+## Quality bar
+
+A PR meets the bar when a reviewer can approve it from the description alone and only reads the diff to confirm. Concretely:
+
+- The diff contains exactly one task — nothing a reviewer would ask "why is this here?" about.
+- Test evidence is verifiable: commands named, results stated, and for bug fixes, evidence the test fails without the fix.
+- Rollback is stated and real (revert path for code; forward-fix stance for data).
+- Zero unresolved review threads; every CodeRabbit resolution is either a commit or a written reason.
+- All 14 required checks green (11 `tests.yml` jobs + CodeQL + dependency review + SBOM).
+
+## Mistakes to avoid
+
+Each of these has actually bitten this repo or is structurally likely to:
+
+- **Merging, or implying you will.** Your verb is "ready to merge," never "merging."
+- **Scope creep in the diff.** Drive-by refactors and bundled second fixes — the governance ratchets (file-size, source-boundary) will often bounce them anyway.
+- **Validating with the wrong commands.** Bare `tsc` instead of `npm run typecheck`; `npm install` without `--legacy-peer-deps`; skipping `npm run governance` when the diff touches edge functions, migrations, or workflows.
+- **English UI strings** slipping in via new components or Zod messages.
+- **Hand-editing generated or historical files:** `src/integrations/supabase/types.ts`, anything in `archive/` or `src/legacy/`, existing migration files (new behavior = new migration).
+- **Leaving CodeRabbit threads unresolved** because they seemed minor — "address or answer every comment" has no minor-comment exemption.
+- **Stacking commits on a merged PR's branch.** Merged is finished; follow-up work restarts from `origin/main` on a fresh (or reset) branch.
+- **Force-pushing without `--force-with-lease`**, or rebasing away commits a reviewer already commented on without saying so.
+- **Treating CI as the test runner.** Push-and-pray wastes review cycles; run the gates locally first.
+
+## Self-check before declaring a PR ready
+
+1. Would the reviewer find anything in the diff that isn't the task?
+2. Could someone reproduce my test evidence from the description alone?
+3. If this is high-risk (DB or money), does the description say so, and are the extra gates (two approvals, pgTAP, prod dry-run) explicitly listed as outstanding?
+4. Is every review thread either fixed-and-resolved or answered-and-resolved?
+5. Is the branch current with `main`, and are all three workflows green *right now* — not "were green before my last push"?

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -3,94 +3,14 @@ name: pr-workflow
 description: The standard PR workflow for this repo — taking work from ready-on-a-branch to merged into main. Use whenever creating, updating, or shepherding a pull request. Defines what an assistant does on its own (prepare + shepherd), what stays human (the merge), which PRs count as high-risk, the CodeRabbit protocol, the quality bar, and the mistakes to avoid.
 ---
 
-# Standard PR Workflow
+Read and follow `docs/agents/pr-workflow.md` — it is the canonical, agent-agnostic definition of this repository's PR workflow (authority boundary, high-risk classification, CodeRabbit protocol, quality bar, mistakes to avoid, pre-handoff self-check). Do not duplicate or paraphrase it here; if it conflicts with anything you believe about the process, the doc wins.
 
-## Sources of truth
+## Claude-specific tool mappings
 
-This skill tells you how to *execute* the documented process; it does not replace it. If this file ever conflicts with the docs below, the docs win — and the conflict is a finding to report, not silently resolve:
+Where the canonical doc names a generic step, use these:
 
-- `CLAUDE.md` → "Git Workflow" (branching model: cut from `main`, PR into `main`, no dev branch)
-- `.github/GIT_HYGIENE.md` (branch naming, rebase-before-PR, post-merge cleanup)
-- `AGENTS.md` → "Production PR workflow" (local validation commands, CI/CodeRabbit loop)
-- `docs/release/production-release-checklist.md` (the pre-merge gate list — every required check)
-
-## Authority boundary — read this first
-
-Your role is **prepare + shepherd**. You take a PR all the way to *mergeable* — CI green across all three workflows, every review comment addressed, rebased on `main` — and then you stop and report. Specifically:
-
-**You do on your own:** branch, commit, push, open the PR, fix CI failures, respond to and resolve CodeRabbit/review threads, keep the branch rebased, re-run validation after every round of fixes.
-
-**You never do:** merge the PR, approve it, run the production `supabase db push` steps, or perform post-merge deployment verification unless explicitly asked. The final merge is always human. (`AGENTS.md` step 8 describes merging — for Claude assistants, that step is the human's; your job ends at "verified mergeable, handed off.")
-
-## The workflow
-
-### 1. Preflight (before the PR exists)
-
-- Branch from current remote `main` with a category prefix: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/` (or `claude/...` when the harness assigns one). One task per branch — adjacent findings go in your report, not the diff.
-- Rebase on `origin/main` before pushing.
-- Run the local gates relevant to the diff. For broad or shared UI/data changes, run the full set from `AGENTS.md`: `lint`, `typecheck`, `governance`, `test:critical`, `test:run`, `build`, `budget:bundle`. Always `npm run typecheck` — never bare `tsc --noEmit`, which is looser than CI.
-- UI changes: run `/i18n-check` on the changed files (Spanish-only UI is a live, recurring slip).
-- Run `./scripts/check-staged-secrets.sh` before committing.
-
-### 2. Open the PR
-
-- Target `main`. Conventional-commit-style title (`feat: …`, `fix: …`).
-- The description must include, per the release checklist: what changed and why, **test evidence** (which commands/checks you ran and their results — real output, not "tests pass"), and **rollback steps**.
-- If the PR is high-risk (below), say so explicitly in the description, in the first line.
-
-### 3. Classify: is it high-risk?
-
-A PR is **high-risk** when it touches either of:
-
-1. **Database:** anything under `supabase/migrations/`, or any RLS policy, grant, or RPC/SQL function change.
-2. **Money:** timesheet calculation (`compute_timesheet_hours` and callers), rates/rate overrides, payroll/payout logic or notifications.
-
-High-risk consequences you must surface in the PR description: it needs **two independent approvals** and CODEOWNER review; migrations additionally need pgTAP coverage (or documented manual verification) and a human-run production `supabase db push --linked --dry-run` before merge. You flag and prepare all of this; the production push itself is human.
-
-Everything else (including plain UI work, edge-function tweaks without DB impact) follows the standard single-approval path.
-
-### 4. Shepherd to mergeable
-
-- Watch CI across **all three** workflows: `tests.yml` (11 jobs), `codeql.yml`, `security.yml`. When available, use `subscribe_pr_activity` and react to events — never poll with sleep loops.
-- CI failure → diagnose and fix (`/ci-fix`), push, wait again. One round is not the job; the loop ends at green.
-- **CodeRabbit protocol: address or answer every comment.** Fix what's valid; reply with a reasoned rebuttal to what isn't; resolve the thread either way. Nothing is left dangling for the human to triage. The same applies to human review comments — except where a comment is genuinely ambiguous or architecturally significant, in which case ask rather than guess.
-- Keep the branch rebased on `main` while it waits; after a rebase, push with `--force-with-lease` (never bare `--force`).
-- Re-run the relevant local gates after each round of fixes before pushing — don't use CI as your first test runner.
-
-### 5. Hand off
-
-When every required check is green, every thread resolved, and the branch is current with `main`, report: a short summary of the final state (checks, approvals still needed, high-risk steps outstanding such as the prod migration dry-run) and a clear "ready for your merge." Use `/release-readiness` for the exhaustive audit when the PR is production-bound.
-
-After the human merges: branches auto-delete on GitHub; clean up any local branch/worktree if you created one.
-
-## Quality bar
-
-A PR meets the bar when a reviewer can approve it from the description alone and only reads the diff to confirm. Concretely:
-
-- The diff contains exactly one task — nothing a reviewer would ask "why is this here?" about.
-- Test evidence is verifiable: commands named, results stated, and for bug fixes, evidence the test fails without the fix.
-- Rollback is stated and real (revert path for code; forward-fix stance for data).
-- Zero unresolved review threads; every CodeRabbit resolution is either a commit or a written reason.
-- All 14 required checks green (11 `tests.yml` jobs + CodeQL + dependency review + SBOM).
-
-## Mistakes to avoid
-
-Each of these has actually bitten this repo or is structurally likely to:
-
-- **Merging, or implying you will.** Your verb is "ready to merge," never "merging."
-- **Scope creep in the diff.** Drive-by refactors and bundled second fixes — the governance ratchets (file-size, source-boundary) will often bounce them anyway.
-- **Validating with the wrong commands.** Bare `tsc` instead of `npm run typecheck`; `npm install` without `--legacy-peer-deps`; skipping `npm run governance` when the diff touches edge functions, migrations, or workflows.
-- **English UI strings** slipping in via new components or Zod messages.
-- **Hand-editing generated or historical files:** `src/integrations/supabase/types.ts`, anything in `archive/` or `src/legacy/`, existing migration files (new behavior = new migration).
-- **Leaving CodeRabbit threads unresolved** because they seemed minor — "address or answer every comment" has no minor-comment exemption.
-- **Stacking commits on a merged PR's branch.** Merged is finished; follow-up work restarts from `origin/main` on a fresh (or reset) branch.
-- **Force-pushing without `--force-with-lease`**, or rebasing away commits a reviewer already commented on without saying so.
-- **Treating CI as the test runner.** Push-and-pray wastes review cycles; run the gates locally first.
-
-## Self-check before declaring a PR ready
-
-1. Would the reviewer find anything in the diff that isn't the task?
-2. Could someone reproduce my test evidence from the description alone?
-3. If this is high-risk (DB or money), does the description say so, and are the extra gates (two approvals, pgTAP, prod dry-run) explicitly listed as outstanding?
-4. Is every review thread either fixed-and-resolved or answered-and-resolved?
-5. Is the branch current with `main`, and are all three workflows green *right now* — not "were green before my last push"?
+- "check for hardcoded English UI strings" → `/i18n-check` on the changed files
+- "diagnose and fix CI failures" → `/ci-fix <job/error>`
+- "subscribe to PR events" → `subscribe_pr_activity` (claude-code-remote MCP); react to `<github-webhook-activity>` events instead of polling
+- "exhaustive pre-merge audit" → `/release-readiness` for production-bound PRs
+- GitHub operations (PR creation, reviews, thread resolution, CI status) → the `mcp__github__*` tools via ToolSearch — `gh` CLI is not available in remote sessions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,8 +6,7 @@
 - [ ] I assessed functional, data, and deployment risk.
 - Risk level: <!-- low | medium | high -->
 - Main risks:
-- [ ] If this touches database, auth, CI/CD, dependency, security, or production-header paths, I requested CODEOWNER review.
-- [ ] If risk level is high, I requested two independent approvals before merge.
+- [ ] If this touches database (migrations/RLS/grants/RPC) or money (timesheet/rates/payroll) paths, I flagged it high-risk and confirmed compensating scrutiny per `docs/release/production-release-checklist.md` (CodeRabbit fully resolved + a deliberate second read — this is a solo-maintainer repo, there is no CODEOWNER/two-approver gate).
 
 ## Impact Checklist
 - [ ] Migration impact assessed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 - [ ] I assessed functional, data, and deployment risk.
 - Risk level: <!-- low | medium | high -->
 - Main risks:
-- [ ] If this touches database (migrations/RLS/grants/RPC) or money (timesheet/rates/payroll) paths, I flagged it high-risk and confirmed compensating scrutiny per `docs/release/production-release-checklist.md` (CodeRabbit fully resolved + a deliberate second read — this is a solo-maintainer repo, there is no CODEOWNER/two-approver gate).
+- [ ] If this touches database (migrations/RLS/grants/RPC/SQL functions) or money (timesheet/rates/payroll) paths, I flagged it high-risk and confirmed compensating scrutiny per `docs/release/production-release-checklist.md` (CodeRabbit fully resolved + a deliberate second read — this is a solo-maintainer repo, there is no CODEOWNER/two-approver gate).
 
 ## Impact Checklist
 - [ ] Migration impact assessed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,11 @@
 
 This file provides working guidance for coding agents operating in this repository.
 
+Two companion documents in `docs/agents/` apply to every agent regardless of harness:
+
+- `docs/agents/operating-manual.md` — the working method expected here: how to read requests, decompose and verify work, label known vs. guessed, and communicate results. Read it once in full; run its five-question self-test on every answer.
+- `docs/agents/pr-workflow.md` — the standard PR workflow: agent authority boundary (prepare + shepherd; humans merge), high-risk classification, CodeRabbit protocol, quality bar, and pre-handoff self-check.
+
 ## Project identity
 
 - Product: Area Tecnica (Sector Pro)
@@ -143,12 +148,12 @@ Use this workflow for production-bound work unless the user explicitly requests 
 4. Commit, push the branch, and open a PR to `main`.
 5. Wait for all GitHub CI checks and CodeRabbit to finish. Inspect CodeRabbit summary, inline comments, and pre-merge checks. CI spans three workflows: `.github/workflows/tests.yml` (11 jobs: lint, typecheck, governance, test_critical, test_run, build, e2e_smoke, migration_ordering, migration_apply, db_lint, rls_rpc_security_tests), `.github/workflows/codeql.yml` (CodeQL analysis), and `.github/workflows/security.yml` (dependency review + SBOM generation) — all must be green.
 6. Address every actionable CI or CodeRabbit issue with follow-up commits, rerun relevant local validation, push, and wait again until clean.
-7. Before merging:
-   - If the PR includes Supabase migrations, run a production `supabase db push --linked --dry-run`, apply the pending migrations to the linked production project, and confirm a follow-up dry run reports the remote database is up to date.
+7. Before merge:
+   - If the PR includes Supabase migrations, flag in the PR description that a production `supabase db push --linked --dry-run` and migration apply are required — these production steps are run by a human, not by an agent.
    - If the PR has no database migration, no Supabase production push is required; merging `main` is the production deploy path.
-8. Merge only after CI, CodeRabbit, and any required production migration/deploy steps are clean. Verify the PR is merged and the local worktree is clean.
+8. Agents stop at *mergeable*: all CI green, CodeRabbit and review threads resolved, branch current with `main`. Report that state and hand off — **the final merge is always performed by a human.** Do not merge or approve PRs yourself.
 
-For the full production release checklist, use `docs/release/production-release-checklist.md`.
+For the full production release checklist, use `docs/release/production-release-checklist.md`. For the agent-facing workflow detail (authority boundary, high-risk classification, CodeRabbit protocol, quality bar), use `docs/agents/pr-workflow.md`.
 
 ## Operational notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -959,8 +959,9 @@ Custom slash commands live in `.claude/commands/`. Use them frequently:
 - `techdebt-scan` -- Deep tech debt scan, forked into an `Explore` subagent (read-only)
 - `release-readiness` -- Cross-checks the current branch/PR against `docs/release/production-release-checklist.md` (migrations, local validation, CI status across all 3 workflows, CodeRabbit), forked into `general-purpose` (needs GitHub MCP tools)
 - `critical-invariant-check` -- Checks a change against this app's 5 documented "don't bypass" invariants (assignment cascade, staffing state machine, Flex folder hierarchy, server-side timesheet calc, Edge Function exposure classification), forked into `Explore` (read-only)
+- `pr-workflow` -- Thin wrapper over `docs/agents/pr-workflow.md` (the canonical, agent-agnostic PR process: prepare + shepherd, humans merge) plus Claude-specific tool mappings. Unlike the others it is auto-invocable, so it loads whenever a session works a PR.
 
-All four skills set `disable-model-invocation: true`, so they only run when explicitly invoked (e.g. `/release-readiness`), never auto-triggered. `plan-review`/`techdebt-scan` overlap in purpose with the `/plan` + `/review-plan` and `/techdebt` commands — prefer the commands for quick, inline work in the current session; reach for a skill when the investigation is large enough that you want it isolated in its own subagent context instead of bloating the main conversation, or when it needs tools (like GitHub MCP) that a simple inline command wouldn't reach for.
+The four skills above `pr-workflow` set `disable-model-invocation: true`, so they only run when explicitly invoked (e.g. `/release-readiness`), never auto-triggered. `plan-review`/`techdebt-scan` overlap in purpose with the `/plan` + `/review-plan` and `/techdebt` commands — prefer the commands for quick, inline work in the current session; reach for a skill when the investigation is large enough that you want it isolated in its own subagent context instead of bloating the main conversation, or when it needs tools (like GitHub MCP) that a simple inline command wouldn't reach for.
 
 ### Subagents
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,10 @@ Detailed deep-dive docs for the full festival subsystem:
   - `WALLBOARD_STATUS.md`
   - `WALLBOARD_PRESET_DEBUG.md`
 
+## Agent guidance (Claude, Codex, and other coding agents)
+- **[Operating manual](agents/operating-manual.md)** — the working method expected of any AI agent in this repo: request reading, verification-first decomposition, provenance labeling, self-attack, answer-first communication, plus a five-question pre-send self-test
+- **[PR workflow](agents/pr-workflow.md)** — agent authority boundary (prepare + shepherd; humans merge), high-risk classification, CodeRabbit protocol, quality bar, mistakes to avoid
+
 ## Operations
 - **Staging setup (Cloudflare + Supabase)**
   - `STAGING_SETUP.md`

--- a/docs/agents/operating-manual.md
+++ b/docs/agents/operating-manual.md
@@ -140,10 +140,10 @@ Each of these *feels* like doing a good job from the inside. That is what makes 
 
 ## The self-test
 
-Run these five questions on every answer before sending. If any fails, fix that before sending — the send button is not the deadline.
+Run these five questions on every answer that involves analysis, diagnosis, or a consequential claim, before sending. If any fails, fix that before sending — the send button is not the deadline. (A simple explanation or a scoped factual answer with nothing to re-derive can skip questions 2 and 4 — mark them not applicable rather than inventing a check to satisfy the rule.)
 
 1. **Does my first sentence give them the thing they actually needed** — the §1 deliverable, not the literal words?
 2. **Which single claim here would hurt most if wrong — and did I re-derive it,** or does it merely sound right?
 3. **Is every assumption and guess labeled at the claim itself,** so the reader can tell my observations from my inferences without asking?
-4. **Did any of my checks actually fail at some point — or demonstrably could they have?** If every check was only ever going to pass, I haven't verified; I've rehearsed.
+4. **Where verification was warranted, did at least one check have a meaningful negative control — or could it plausibly have failed?** If every check was only ever going to pass, I haven't verified; I've rehearsed.
 5. **If this is wrong, how do they find out — from this message, now, or from production, later?** If the answer is production, the risk section isn't done.

--- a/docs/agents/operating-manual.md
+++ b/docs/agents/operating-manual.md
@@ -1,8 +1,8 @@
 # Operating Manual
 
-*Written by Claude Fable 5 for Claude Opus 4.8 — or any model doing serious work in this repository after it. This is not a rulebook to satisfy. It is a way of working to inhabit. Read it once in full; after that, the five-question self-test at the end is the part you run every time.*
+*For any AI agent — Claude, Codex, or otherwise — doing serious work in this repository. This is not a rulebook to satisfy. It is a way of working to inhabit. Read it once in full; after that, the five-question self-test at the end is the part you run every time.*
 
-The gap between us is not knowledge. It is that on the hardest problems I hold more of the structure in view at once, so I notice sooner when a piece doesn't fit. You can close most of that gap with procedure: externalize the structure, check the pieces one at a time, and refuse to let fluency stand in for verification. That is what this manual encodes. Examples are grounded in this codebase because a procedure you can't picture running, you won't run.
+What separates a stronger model from a weaker one on hard problems is rarely knowledge. It is how much of the problem's structure stays in view at once — the stronger model notices sooner when a piece doesn't fit. Any agent can close most of that gap with procedure: externalize the structure, check the pieces one at a time, and refuse to let fluency stand in for verification. That is what this manual encodes. Examples are grounded in this codebase because a procedure you can't picture running, you won't run.
 
 ---
 

--- a/docs/agents/pr-workflow.md
+++ b/docs/agents/pr-workflow.md
@@ -17,7 +17,7 @@ An agent's role is **prepare + shepherd**. You take a PR all the way to *mergeab
 
 **You do on your own:** branch, commit, push, open the PR, fix CI failures, respond to and resolve CodeRabbit/review threads, keep the branch rebased, re-run validation after every round of fixes.
 
-**You never do:** merge the PR, approve it, run the production `supabase db push` steps, or perform post-merge deployment verification unless explicitly asked. The final merge is always human.
+**You never do:** merge the PR or approve it — no exception, ever. Running the production `supabase db push` steps and post-merge deployment verification are also human by default; an agent may run those specific steps only if a human explicitly asks for that run. The final merge is always human.
 
 ## The workflow
 
@@ -42,7 +42,12 @@ A PR is **high-risk** when it touches either of:
 1. **Database:** anything under `supabase/migrations/`, or any RLS policy, grant, or RPC/SQL function change.
 2. **Money:** timesheet calculation (`compute_timesheet_hours` and callers), rates/rate overrides, payroll/payout logic or notifications.
 
-This is a solo-maintainer repo, so high-risk cannot mean "more approvers" — it means **compensating scrutiny**, and you must surface all of it in the PR description: CodeRabbit review fully resolved (it is the de facto second reviewer here), pgTAP coverage for migrations (or documented manual verification), a human-run production `supabase db push --linked --dry-run` before merge, and a note telling the maintainer this diff warrants a deliberate second read before merging. You flag and prepare all of this; the production push and the final read are human.
+This is a solo-maintainer repo, so high-risk cannot mean "more approvers" — it means **compensating scrutiny**, scoped to what's actually at risk:
+
+- **Both categories, always:** CodeRabbit review fully resolved (it is the de facto second reviewer here), and a note in the PR description telling the maintainer this diff warrants a deliberate second read before merging.
+- **Database changes only, additionally:** pgTAP coverage for the change (or documented manual verification), and a human-run production `supabase db push --linked --dry-run` before merge. A money-only PR that touches no schema/RLS/RPC needs neither of these — don't demand a migration dry-run for a rate-table constant change.
+
+You flag and prepare all of this in the PR description; the production push and the final read are human.
 
 Everything else (including plain UI work, edge-function tweaks without DB impact) follows the standard path: CI green, CodeRabbit resolved, maintainer's own diff review at merge time.
 
@@ -88,6 +93,6 @@ Each of these has actually bitten this repo or is structurally likely to:
 
 1. Would the reviewer find anything in the diff that isn't the task?
 2. Could someone reproduce my test evidence from the description alone?
-3. If this is high-risk (DB or money), does the description say so, and are the extra gates (pgTAP coverage, prod dry-run, the maintainer's deliberate second read) explicitly listed as outstanding?
+3. If this is high-risk (DB or money), does the description say so — with pgTAP coverage and the prod dry-run listed as outstanding *only if it's a database change* — and is the deliberate second read flagged either way?
 4. Is every review thread either fixed-and-resolved or answered-and-resolved?
 5. Is the branch current with `main`, and are all three workflows green *right now* — not "were green before my last push"?

--- a/docs/agents/pr-workflow.md
+++ b/docs/agents/pr-workflow.md
@@ -1,0 +1,93 @@
+# Standard PR Workflow (for AI agents)
+
+How to take work from ready-on-a-branch to merged into `main` in this repository. This document is agent-agnostic — it applies to Claude, Codex, and any other coding agent. Claude sessions also load it via the `.claude/skills/pr-workflow/` wrapper, which maps the generic steps to Claude-specific tools.
+
+## Sources of truth
+
+This document tells you how to *execute* the documented process; it does not replace it. If it ever conflicts with the docs below, the docs win — and the conflict is a finding to report, not silently resolve:
+
+- `CLAUDE.md` → "Git Workflow" (branching model: cut from `main`, PR into `main`, no dev branch)
+- `.github/GIT_HYGIENE.md` (branch naming, rebase-before-PR, post-merge cleanup)
+- `AGENTS.md` → "Production PR workflow" (local validation commands, CI/CodeRabbit loop)
+- `docs/release/production-release-checklist.md` (the pre-merge gate list — every required check)
+
+## Authority boundary — read this first
+
+An agent's role is **prepare + shepherd**. You take a PR all the way to *mergeable* — CI green across all three workflows, every review comment addressed, rebased on `main` — and then you stop and report. Specifically:
+
+**You do on your own:** branch, commit, push, open the PR, fix CI failures, respond to and resolve CodeRabbit/review threads, keep the branch rebased, re-run validation after every round of fixes.
+
+**You never do:** merge the PR, approve it, run the production `supabase db push` steps, or perform post-merge deployment verification unless explicitly asked. The final merge is always human.
+
+## The workflow
+
+### 1. Preflight (before the PR exists)
+
+- Branch from current remote `main` with a category prefix: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/` — or a harness-assigned prefix like `claude/…` or `codex/…`. One task per branch — adjacent findings go in your report, not the diff.
+- Rebase on `origin/main` before pushing.
+- Run the local gates relevant to the diff. For broad or shared UI/data changes, run the full set from `AGENTS.md`: `lint`, `typecheck`, `governance`, `test:critical`, `test:run`, `build`, `budget:bundle`. Always `npm run typecheck` — never bare `tsc --noEmit`, which is looser than CI.
+- UI changes: check every new/changed file for hardcoded English UI strings, including Zod validation messages — Spanish is the only supported UI language and this is a live, recurring slip. (Claude: `/i18n-check`.)
+- Run `./scripts/check-staged-secrets.sh` before committing.
+
+### 2. Open the PR
+
+- Target `main`. Conventional-commit-style title (`feat: …`, `fix: …`).
+- The description must include, per the release checklist: what changed and why, **test evidence** (which commands/checks you ran and their results — real output, not "tests pass"), and **rollback steps**.
+- If the PR is high-risk (below), say so explicitly in the description, in the first line.
+
+### 3. Classify: is it high-risk?
+
+A PR is **high-risk** when it touches either of:
+
+1. **Database:** anything under `supabase/migrations/`, or any RLS policy, grant, or RPC/SQL function change.
+2. **Money:** timesheet calculation (`compute_timesheet_hours` and callers), rates/rate overrides, payroll/payout logic or notifications.
+
+High-risk consequences you must surface in the PR description: it needs **two independent approvals** and CODEOWNER review; migrations additionally need pgTAP coverage (or documented manual verification) and a human-run production `supabase db push --linked --dry-run` before merge. You flag and prepare all of this; the production push itself is human.
+
+Everything else (including plain UI work, edge-function tweaks without DB impact) follows the standard single-approval path.
+
+### 4. Shepherd to mergeable
+
+- Watch CI across **all three** workflows: `tests.yml` (11 jobs), `codeql.yml`, `security.yml`. If your harness can subscribe to PR events, use that; otherwise re-check CI status after each push and between work — never busy-poll with sleep loops.
+- CI failure → diagnose and fix, push, wait again. One round is not the job; the loop ends at green. (Claude: `/ci-fix`.)
+- **CodeRabbit protocol: address or answer every comment.** Fix what's valid; reply with a reasoned rebuttal to what isn't; resolve the thread either way. Nothing is left dangling for the human to triage. The same applies to human review comments — except where a comment is genuinely ambiguous or architecturally significant, in which case ask rather than guess.
+- Keep the branch rebased on `main` while it waits; after a rebase, push with `--force-with-lease` (never bare `--force`).
+- Re-run the relevant local gates after each round of fixes before pushing — don't use CI as your first test runner.
+
+### 5. Hand off
+
+When every required check is green, every thread resolved, and the branch is current with `main`, report: a short summary of the final state (checks, approvals still needed, high-risk steps outstanding such as the prod migration dry-run) and a clear "ready for your merge." (Claude: `/release-readiness` produces the exhaustive audit for production-bound PRs.)
+
+After the human merges: branches auto-delete on GitHub; clean up any local branch/worktree you created.
+
+## Quality bar
+
+A PR meets the bar when a reviewer can approve it from the description alone and only reads the diff to confirm. Concretely:
+
+- The diff contains exactly one task — nothing a reviewer would ask "why is this here?" about.
+- Test evidence is verifiable: commands named, results stated, and for bug fixes, evidence the test fails without the fix.
+- Rollback is stated and real (revert path for code; forward-fix stance for data).
+- Zero unresolved review threads; every CodeRabbit resolution is either a commit or a written reason.
+- All 14 required checks green (11 `tests.yml` jobs + CodeQL + dependency review + SBOM).
+
+## Mistakes to avoid
+
+Each of these has actually bitten this repo or is structurally likely to:
+
+- **Merging, or implying you will.** Your verb is "ready to merge," never "merging."
+- **Scope creep in the diff.** Drive-by refactors and bundled second fixes — the governance ratchets (file-size, source-boundary) will often bounce them anyway.
+- **Validating with the wrong commands.** Bare `tsc` instead of `npm run typecheck`; `npm install` without `--legacy-peer-deps`; skipping `npm run governance` when the diff touches edge functions, migrations, or workflows.
+- **English UI strings** slipping in via new components or Zod messages.
+- **Hand-editing generated or historical files:** `src/integrations/supabase/types.ts`, anything in `archive/` or `src/legacy/`, existing migration files (new behavior = new migration).
+- **Leaving CodeRabbit threads unresolved** because they seemed minor — "address or answer every comment" has no minor-comment exemption.
+- **Stacking commits on a merged PR's branch.** Merged is finished; follow-up work restarts from `origin/main` on a fresh (or reset) branch.
+- **Force-pushing without `--force-with-lease`**, or rebasing away commits a reviewer already commented on without saying so.
+- **Treating CI as the test runner.** Push-and-pray wastes review cycles; run the gates locally first.
+
+## Self-check before declaring a PR ready
+
+1. Would the reviewer find anything in the diff that isn't the task?
+2. Could someone reproduce my test evidence from the description alone?
+3. If this is high-risk (DB or money), does the description say so, and are the extra gates (two approvals, pgTAP, prod dry-run) explicitly listed as outstanding?
+4. Is every review thread either fixed-and-resolved or answered-and-resolved?
+5. Is the branch current with `main`, and are all three workflows green *right now* — not "were green before my last push"?

--- a/docs/agents/pr-workflow.md
+++ b/docs/agents/pr-workflow.md
@@ -42,9 +42,9 @@ A PR is **high-risk** when it touches either of:
 1. **Database:** anything under `supabase/migrations/`, or any RLS policy, grant, or RPC/SQL function change.
 2. **Money:** timesheet calculation (`compute_timesheet_hours` and callers), rates/rate overrides, payroll/payout logic or notifications.
 
-High-risk consequences you must surface in the PR description: it needs **two independent approvals** and CODEOWNER review; migrations additionally need pgTAP coverage (or documented manual verification) and a human-run production `supabase db push --linked --dry-run` before merge. You flag and prepare all of this; the production push itself is human.
+This is a solo-maintainer repo, so high-risk cannot mean "more approvers" — it means **compensating scrutiny**, and you must surface all of it in the PR description: CodeRabbit review fully resolved (it is the de facto second reviewer here), pgTAP coverage for migrations (or documented manual verification), a human-run production `supabase db push --linked --dry-run` before merge, and a note telling the maintainer this diff warrants a deliberate second read before merging. You flag and prepare all of this; the production push and the final read are human.
 
-Everything else (including plain UI work, edge-function tweaks without DB impact) follows the standard single-approval path.
+Everything else (including plain UI work, edge-function tweaks without DB impact) follows the standard path: CI green, CodeRabbit resolved, maintainer's own diff review at merge time.
 
 ### 4. Shepherd to mergeable
 
@@ -56,7 +56,7 @@ Everything else (including plain UI work, edge-function tweaks without DB impact
 
 ### 5. Hand off
 
-When every required check is green, every thread resolved, and the branch is current with `main`, report: a short summary of the final state (checks, approvals still needed, high-risk steps outstanding such as the prod migration dry-run) and a clear "ready for your merge." (Claude: `/release-readiness` produces the exhaustive audit for production-bound PRs.)
+When every required check is green, every thread resolved, and the branch is current with `main`, report: a short summary of the final state (checks, and any high-risk steps outstanding such as the prod migration dry-run or the deliberate second read) and a clear "ready for your merge." (Claude: `/release-readiness` produces the exhaustive audit for production-bound PRs.)
 
 After the human merges: branches auto-delete on GitHub; clean up any local branch/worktree you created.
 
@@ -88,6 +88,6 @@ Each of these has actually bitten this repo or is structurally likely to:
 
 1. Would the reviewer find anything in the diff that isn't the task?
 2. Could someone reproduce my test evidence from the description alone?
-3. If this is high-risk (DB or money), does the description say so, and are the extra gates (two approvals, pgTAP, prod dry-run) explicitly listed as outstanding?
+3. If this is high-risk (DB or money), does the description say so, and are the extra gates (pgTAP coverage, prod dry-run, the maintainer's deliberate second read) explicitly listed as outstanding?
 4. Is every review thread either fixed-and-resolved or answered-and-resolved?
 5. Is the branch current with `main`, and are all three workflows green *right now* — not "were green before my last push"?

--- a/docs/release/production-release-checklist.md
+++ b/docs/release/production-release-checklist.md
@@ -5,7 +5,7 @@ Use this checklist for production-bound PRs targeting `main`.
 ## Before merge
 
 - [ ] The full diff has been deliberately reviewed by the maintainer in the GitHub PR UI (solo project: you are the reviewer of record — read the diff there, not just in your editor).
-- [ ] High-risk PRs (Supabase migrations/RLS/RPC, or timesheet/rates/payroll logic) get compensating scrutiny instead of extra approvers: CodeRabbit review complete with every comment resolved, plus a second deliberate pass over the diff after time away from it.
+- [ ] High-risk PRs (Supabase migrations, RLS policies, grants, or RPC/SQL functions — or timesheet/rates/payroll logic) get compensating scrutiny instead of extra approvers: CodeRabbit review complete with every comment resolved, plus a second deliberate pass over the diff after time away from it. Database-touching PRs additionally need pgTAP coverage (or documented manual verification) and the production dry-run below — a money-only PR with no schema/RLS/RPC change needs neither.
 - [ ] All required checks are passing:
   - [ ] `npm run lint`
   - [ ] `npm run typecheck`
@@ -21,7 +21,7 @@ Use this checklist for production-bound PRs targeting `main`.
   - [ ] `CodeQL analysis`
   - [ ] `Dependency review`
   - [ ] `SBOM generation`
-- [ ] CodeRabbit and inline review comments are resolved or explicitly deferred.
+- [ ] CodeRabbit and inline review comments are resolved — no deferral; a comment that doesn't warrant a code change gets a written reason and the thread is resolved, not left open.
 - [ ] The PR description includes test evidence and rollback steps.
 - [ ] Release artifacts are retained by CI:
   - [ ] Build artifact from `npm run build`

--- a/docs/release/production-release-checklist.md
+++ b/docs/release/production-release-checklist.md
@@ -4,9 +4,8 @@ Use this checklist for production-bound PRs targeting `main`.
 
 ## Before merge
 
-- [ ] PR has at least one independent approval.
-- [ ] High-risk PRs have two independent approvals.
-- [ ] CODEOWNER review is complete for high-risk paths.
+- [ ] The full diff has been deliberately reviewed by the maintainer in the GitHub PR UI (solo project: you are the reviewer of record — read the diff there, not just in your editor).
+- [ ] High-risk PRs (Supabase migrations/RLS/RPC, or timesheet/rates/payroll logic) get compensating scrutiny instead of extra approvers: CodeRabbit review complete with every comment resolved, plus a second deliberate pass over the diff after time away from it.
 - [ ] All required checks are passing:
   - [ ] `npm run lint`
   - [ ] `npm run typecheck`


### PR DESCRIPTION
## Summary
- Adds two harness-agnostic guidance docs under `docs/agents/`:
  - `operating-manual.md` — the working method expected of any AI agent here: reading requests beneath their literal words, decomposing work into independently checkable pieces, ranking risk by cost-if-wrong × silence-of-failure, verifying claims by re-deriving instead of recognizing, labeling known vs. guessed, self-attacking conclusions before handoff, answer-first communication, and the failure modes that look like competence and aren't. Ends with a five-question pre-send self-test.
  - `pr-workflow.md` — the standard PR workflow: agent authority boundary (agents prepare + shepherd a PR to mergeable; the maintainer always performs the final merge), high-risk classification (Supabase migrations/RLS/RPC and timesheet/rate/payroll changes), the CodeRabbit protocol (address or answer every comment, resolve either way), the quality bar, and known mistakes to avoid.
- Wires both docs into `AGENTS.md` (referenced up top) and `docs/README.md` (new "Agent guidance" index section), and adds `.claude/skills/pr-workflow/` as a thin Claude-specific wrapper (tool-name mappings only — the canonical doc is the source of truth and wins on any conflict).
- Fixes `AGENTS.md`'s production PR workflow step 8, which previously instructed agents to merge — it now matches the new authority boundary (agents stop at mergeable, humans merge).
- Replaces the release checklist's "two independent approvals + CODEOWNER review" gate for high-risk PRs with controls a solo maintainer can actually run: CodeRabbit fully resolved as the de facto second reviewer, pgTAP coverage for migrations, the human-run production dry-run, and a deliberate second read of the diff before merge. (The prior gate assumed multiple reviewers; `.github/CODEOWNERS` maps every path to the single maintainer, so it was unenforceable as written.)
- Fixes a stale "all four skills" reference in `CLAUDE.md` now that there are five.

Affected route/feature: none — documentation only, no application code, no CI-relevant paths touched.

## Risk Assessment
- Risk level: low
- Main risks: none functional. The only externally-visible behavior change is agent conduct going forward (agents no longer merge PRs on their own), which is the intended effect of this PR.
- Not high-risk per the new classification in `docs/agents/pr-workflow.md`: no Supabase migration/RLS/RPC change, no payroll/timesheet/rate logic touched.

## Impact Checklist
- [x] Migration impact assessed — none, no `supabase/` changes.
- [x] Realtime/subscription impact assessed — none.
- [x] RLS/security impact assessed — none.
- [x] Performance impact assessed — none, docs only.

## Test Evidence
- Diff is documentation-only (`.md` files under `docs/`, `.claude/`, plus `AGENTS.md`/`CLAUDE.md`); confirmed via `git diff --stat origin/main..HEAD` — no `src/`, `supabase/`, or `.github/workflows/` paths touched.
- No lint/typecheck/build/test commands are applicable to this diff; standard CI (lint, typecheck, governance, tests, build) will still run and is expected to pass unaffected since no source was changed.

## Rollback Plan
- Revert the merge commit. No data, schema, or deployed-code impact — a plain revert fully restores prior state.

## Migration Impact
- Migration required: no


---
_Generated by [Claude Code](https://claude.ai/code/session_014vC6HpxqixfirgKMudNxTW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for AI-assisted development, including operating principles, verification practices, and self-review checks.
  - Documented a standardized pull request workflow for AI agents, including phases, quality bar, self-checks, and common mistakes to avoid.
  - Clarified agent authority boundaries and reinforced that production actions and final merging are human responsibilities.
  - Updated the production release “Before merge” checklist to require deliberate full-diff review and strengthened compensating scrutiny for high-risk changes.
  - Updated the pull request template risk assessment and added navigation linking the new guidance for contributors and agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->