### PR TITLE
feat: support multiple transport requests per department with hoja de ruta opt-out

### DIFF
--- a/scripts/inject-sw-version.mjs
+++ b/scripts/inject-sw-version.mjs
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises";
+import { transformWithEsbuild } from "vite";
 
 const buildTimestamp = `${Math.floor(Date.now() / 1000)}`;
 const swFile = "dist/sw.js";
@@ -45,10 +46,16 @@ if (!currentContents.includes(placeholder)) {
 }
 
 const nextContents = currentContents.replaceAll(placeholder, buildTimestamp);
+const { code: minifiedServiceWorker } = await transformWithEsbuild(nextContents, swFile, {
+  drop: ["console"],
+  loader: "js",
+  minify: true,
+  target: "es2020",
+});
 
-await writeFile(swFile, nextContents, "utf8");
+await writeFile(swFile, minifiedServiceWorker, "utf8");
 
-console.log(`Injected build timestamp into service worker: ${buildTimestamp}`);
+console.log(`Injected build timestamp and minified service worker: ${buildTimestamp}`);
 
 try {
   const indexContents = await readFile(indexFile, "utf8");

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -1342,6 +1342,7 @@ function JobCardNewFull({
       logisticsInitialEventType={logisticsInitialEventType}
       setLogisticsInitialEventType={setLogisticsInitialEventType}
       isTechDept={isTechDept}
+      canManageTransportRequests={canManageTransportRequests}
       userDepartment={currentUserDepartment}
       myTransportRequests={myTransportRequests}
       allRequests={allRequests}

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -11,6 +11,7 @@ declare global {
 import { useNavigate } from "react-router-dom";
 import { useFolderExistence } from "@/hooks/useFolderExistence";
 import { useOptimizedJobCard } from '@/hooks/useOptimizedJobCard';
+import { useJobTransportRequests } from '@/hooks/useJobTransportRequests';
 import { useDeletionState } from '@/hooks/useDeletionState';
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useSelectedJobStore } from '@/stores/useSelectedJobStore';
@@ -78,12 +79,6 @@ type ClearWhatsappGroupResult = {
   error?: string;
   message?: string;
   can_retry?: boolean;
-};
-
-type LogisticsEventWithDepartments = {
-  id?: string;
-  event_type?: string | null;
-  logistics_event_departments?: Array<{ department?: string | null }> | null;
 };
 
 type FlexFolderRow = {
@@ -474,37 +469,11 @@ function JobCardNewFull({
     });
   }
 
-  // Queries for transport requests and logistics events
-  const { data: myTransportRequest } = useQuery({
-    queryKey: queryKeys.scope('transport-request', job.id, currentUserDepartment),
-    queryFn: async () => {
-      if (!currentUserDepartment || !['sound', 'lights', 'video'].includes(currentUserDepartment)) return null;
-      const { data, error } = await dataLayerClient.from('transport_requests')
-        .select('id, department, status, note, description, created_at, items:transport_request_items(id, transport_type, leftover_space_meters)')
-        .eq('job_id', job.id)
-        .eq('department', currentUserDepartment)
-        .order('created_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      if (error) return null;
-      return data;
-    },
-    enabled: !!job?.id && !!currentUserDepartment,
-  });
+  const isTechDept = !!currentUserDepartment && ['sound', 'lights', 'video'].includes(currentUserDepartment);
+  const canManageTransportRequests = (currentUserDepartment === 'logistics') || isManagementUser;
 
-  const { data: allRequests = [], isLoading: isAllRequestsLoading } = useQuery({
-    queryKey: queryKeys.scope('transport-requests-all', job.id),
-    queryFn: async () => {
-      const { data, error } = await dataLayerClient.from('transport_requests')
-        .select('id, department, status, note, description, created_at, items:transport_request_items(id, transport_type, leftover_space_meters)')
-        .eq('job_id', job.id)
-        .eq('status', 'requested')
-        .order('created_at', { ascending: false });
-      if (error) return [];
-      return data || [];
-    },
-    enabled: !!job?.id && ((currentUserDepartment === 'logistics') || isManagementUser),
-  });
+  const { myTransportRequests, allRequests, isAllRequestsLoading, checkAndFulfillRequest, cancelRequest } =
+    useJobTransportRequests(job?.id, currentUserDepartment, canManageTransportRequests);
 
   const { data: jobEvents = [] } = useQuery({
     queryKey: queryKeys.scope('logistics-events-for-job', job.id),
@@ -519,41 +488,20 @@ function JobCardNewFull({
   });
 
   const isScheduled = (jobEvents?.length || 0) > 0;
-  const hasRequest = Boolean(myTransportRequest) || (Array.isArray(allRequests) && allRequests.length > 0);
-  const isTechDept = !!currentUserDepartment && ['sound', 'lights', 'video'].includes(currentUserDepartment);
-  const canManageTransportRequests = (currentUserDepartment === 'logistics') || isManagementUser;
-
-  const handleCancelTransportRequest = React.useCallback(
-    async (requestId: string) => {
-      if (!requestId) return;
-      const { error } = await dataLayerClient.from("transport_requests").update({ status: "cancelled" }).eq("id", requestId);
-      if (error) {
-        console.error("[JobCardNew] Failed to cancel transport request:", error);
-        toast({
-          title: "No se pudo cancelar",
-          description: error.message || "Error cancelando la solicitud de transporte",
-          variant: "destructive",
-        });
-        return;
-      }
-
-      toast({
-        title: "Solicitud cancelada",
-        description: "La solicitud de transporte se ha cancelado correctamente",
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-requests-all", job.id) });
-    },
-    [job.id, queryClient, toast]
-  );
+  const hasRequest = myTransportRequests.length > 0 || (Array.isArray(allRequests) && allRequests.length > 0);
 
   const transportButtonLabel = (() => {
-    if (isScheduled) return 'Transport Scheduled';
+    // Pending requests take precedence over "scheduled": new requests can
+    // arrive after the first transport has already been booked.
     if (canManageTransportRequests) {
-      return allRequests.length > 0 ? `Requests (${allRequests.length})` : 'Logistics';
+      if (allRequests.length > 0) return `Solicitudes (${allRequests.length})`;
+      return isScheduled ? 'Transporte programado' : 'Logística';
     }
     if (isTechDept) {
-      return myTransportRequest ? 'Transport Requested' : 'Request Transport';
+      if (myTransportRequests.length > 0) return `Transporte (${myTransportRequests.length})`;
+      return isScheduled ? 'Transporte programado' : 'Solicitar transporte';
     }
+    if (isScheduled) return 'Transporte programado';
     return undefined;
   })();
 
@@ -769,26 +717,6 @@ function JobCardNewFull({
         variant: 'destructive'
       });
       await Promise.all([refetchWaGroup(), refetchWaRequest()]);
-    }
-  };
-
-  // Auto-fulfill request when both load and unload exist for the request's department
-  const checkAndFulfillRequest = async (requestId: string, departmentForReq: string) => {
-    try {
-      const { data: events } = await dataLayerClient.from('logistics_events')
-        .select('id, event_type, logistics_event_departments(department)')
-        .eq('job_id', job.id)
-        .eq('logistics_event_departments.department', departmentForReq);
-      const logisticsEvents = (events || []) as LogisticsEventWithDepartments[];
-      const hasLoad = logisticsEvents.some((e) => e.event_type === 'load');
-      const hasUnload = logisticsEvents.some((e) => e.event_type === 'unload');
-      if (hasLoad && hasUnload) {
-        await dataLayerClient.from('transport_requests').update({ status: 'fulfilled' }).eq('id', requestId);
-        queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-request', job.id, departmentForReq) });
-        queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-requests-all', job.id) });
-      }
-    } catch (err) {
-      console.error('checkAndFulfillRequest failed', err);
     }
   };
 
@@ -1413,10 +1341,11 @@ function JobCardNewFull({
       setLogisticsInitialEventType={setLogisticsInitialEventType}
       isTechDept={isTechDept}
       userDepartment={currentUserDepartment}
-      myTransportRequest={myTransportRequest}
+      myTransportRequests={myTransportRequests}
       allRequests={allRequests}
       queryClient={queryClient}
       checkAndFulfillRequest={checkAndFulfillRequest}
+      cancelTransportRequest={cancelRequest}
       requirementsDialogOpen={requirementsDialogOpen}
       flexPickerOpen={flexPickerOpen}
       setFlexPickerOpen={setFlexPickerOpen}

--- a/src/components/jobs/cards/JobCardNew.tsx
+++ b/src/components/jobs/cards/JobCardNew.tsx
@@ -510,8 +510,10 @@ function JobCardNewFull({
   const handleTransportClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (canManageTransportRequests) {
-      // If there are no pending requests, allow creating a logistics event directly.
-      if (!isAllRequestsLoading && allRequests.length === 0) {
+      // Direct event creation shortcut only for users without a tech
+      // department (logistics, production): managers who belong to a tech
+      // department still need the manager dialog to file their own requests.
+      if (!isTechDept && !isAllRequestsLoading && allRequests.length === 0) {
         setSelectedTransportRequest(null);
         setLogisticsInitialEventType("load");
         setTransportDialogOpen(false);

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -20,12 +20,12 @@ import { LightsTaskDialog } from "@/components/lights/LightsTaskDialog";
 import { LogisticsEventDialog } from "@/components/logistics/LogisticsEventDialog";
 import { ProjectNotesDialog } from "@/components/project-management/ProjectNotesDialog";
 import { TransportRequestDialog } from "@/components/logistics/TransportRequestDialog";
+import { TransportRequestsManagerDialog } from "@/components/logistics/TransportRequestsManagerDialog";
 import { SoundTaskDialog } from "@/components/sound/SoundTaskDialog";
 import { TaskManagerDialog } from "@/components/tasks/TaskManagerDialog";
 import { VideoTaskDialog } from "@/components/video/VideoTaskDialog";
 import { FlexFolderPicker } from "@/components/flex/FlexFolderPicker";
 import { cn } from "@/lib/utils";
-import { dataLayerClient } from "@/services/dataLayerClient";
 import type { Department } from "@/types/department";
 
 import { JobCardActions } from "../JobCardActions";
@@ -148,10 +148,11 @@ export interface JobCardNewViewProps {
 
   isTechDept: boolean;
   userDepartment: string | null;
-  myTransportRequest: any | null;
+  myTransportRequests: any[];
   allRequests: any[];
   queryClient: any;
   checkAndFulfillRequest: (requestId: string, dept: string) => Promise<void>;
+  cancelTransportRequest: (requestId: string) => Promise<{ error: string | null }>;
 
   requirementsDialogOpen: boolean;
 
@@ -261,8 +262,9 @@ export function JobCardNewView({
   setLogisticsInitialEventType,
   isTechDept,
   userDepartment,
-  myTransportRequest,
+  myTransportRequests,
   allRequests,
+  cancelTransportRequest,
   queryClient,
   checkAndFulfillRequest,
   requirementsDialogOpen,
@@ -695,7 +697,6 @@ export function JobCardNewView({
               onOpenChange={setTransportDialogOpen}
               jobId={job.id}
               department={userDepartment}
-              requestId={myTransportRequest?.id || null}
               onSubmitted={() => {
                 queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-request", job.id, userDepartment) });
                 queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-requests-all", job.id) });
@@ -703,81 +704,20 @@ export function JobCardNewView({
             />
           )}
 
-          {transportDialogOpen &&
-            canManageTransportRequests && (
-              <Dialog open={transportDialogOpen} onOpenChange={setTransportDialogOpen}>
-                <DialogContent className="max-w-xl">
-                  <div className="space-y-4">
-                    <div className="text-lg font-semibold">Transport Requests</div>
-                    {allRequests.length === 0 ? (
-                      <div className="space-y-3">
-                        <div className="text-muted-foreground">No pending requests for this job.</div>
-                        <button
-                          className="px-3 py-1 text-sm rounded border hover:bg-accent w-fit"
-                          onClick={(ev) => {
-                            ev.stopPropagation();
-                            setSelectedTransportRequest(null);
-                            setLogisticsInitialEventType("load");
-                            setTransportDialogOpen(false);
-                            setLogisticsDialogOpen(true);
-                          }}
-                        >
-                          Create Event
-                        </button>
-                      </div>
-                    ) : (
-                      <div className="space-y-2">
-                        {allRequests.map((req: any) => (
-                          <div key={req.id} className="border rounded p-2 space-y-2">
-                            <div className="flex items-center justify-between">
-                              <div>
-                                <div className="font-medium capitalize">{req.department}</div>
-                                {req.description && <div className="text-sm">{req.description}</div>}
-                                {req.note && <div className="text-xs text-muted-foreground italic">{req.note}</div>}
-                              </div>
-                              <button
-                                className="px-3 py-1 text-sm rounded border hover:bg-accent"
-                                onClick={async (ev) => {
-                                  ev.stopPropagation();
-                                  await dataLayerClient.from("transport_requests").update({ status: "cancelled" }).eq("id", req.id);
-                                  queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-requests-all", job.id) });
-                                }}
-                              >
-                                Cancel Request
-                              </button>
-                            </div>
-                            <div className="space-y-1">
-                              {(req.items || []).map((it: any) => (
-                                <div key={it.id} className="flex items-center justify-between pl-2">
-                                  <div className="text-sm text-muted-foreground">
-                                    {it.transport_type.replace("_", " ")}
-                                    {typeof it.leftover_space_meters === "number" && (
-                                      <span className="ml-2">· Leftover: {it.leftover_space_meters} m</span>
-                                    )}
-                                  </div>
-                                  <button
-                                    className="px-3 py-1 text-sm rounded border hover:bg-accent"
-                                    onClick={(ev) => {
-                                      ev.stopPropagation();
-                                      setSelectedTransportRequest({ ...req, selectedItem: it });
-                                      setLogisticsInitialEventType("load");
-                                      setTransportDialogOpen(false);
-                                      setLogisticsDialogOpen(true);
-                                    }}
-                                  >
-                                    Create Event
-                                  </button>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </DialogContent>
-              </Dialog>
-            )}
+          {transportDialogOpen && canManageTransportRequests && (
+            <TransportRequestsManagerDialog
+              open={transportDialogOpen}
+              onOpenChange={setTransportDialogOpen}
+              requests={allRequests}
+              onCancelRequest={cancelTransportRequest}
+              onCreateEvent={(req, item) => {
+                setSelectedTransportRequest(req ? { ...req, selectedItem: item } : null);
+                setLogisticsInitialEventType("load");
+                setTransportDialogOpen(false);
+                setLogisticsDialogOpen(true);
+              }}
+            />
+          )}
 
           {logisticsDialogOpen && (
             <LogisticsEventDialog
@@ -795,6 +735,8 @@ export function JobCardNewView({
               initialDepartments={selectedTransportRequest?.department ? [selectedTransportRequest.department] : []}
               initialTransportType={selectedTransportRequest?.selectedItem?.transport_type}
               initialEventType={logisticsInitialEventType}
+              initialTransportRequestId={selectedTransportRequest?.id || null}
+              initialIsHojaRelevant={selectedTransportRequest ? selectedTransportRequest.is_hoja_relevant !== false : undefined}
               onCreated={(_details) => {
                 if (selectedTransportRequest?.id && selectedTransportRequest?.department) {
                   void checkAndFulfillRequest(selectedTransportRequest.id, selectedTransportRequest.department);

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -276,6 +276,9 @@ export function JobCardNewView({
   const reducedMotion = useReducedMotion();
   const isMobile = useIsMobile();
   const canManageTransportRequests = userDepartment === "logistics" || isManagementRole(userRole);
+  // Managers who also belong to a tech department reach the request creator
+  // through the manager dialog ("Solicitar transporte")
+  const [requestCreatorOpen, setRequestCreatorOpen] = React.useState(false);
   const isAndreaWeddingJob = job?.id === "eeb00e4d-7d38-4687-9d04-31471b89adfc";
   const [celebrateSeed, setCelebrateSeed] = React.useState(0);
   const [celebrateOrigin, setCelebrateOrigin] = React.useState<{ xPct: number; yPct: number } | null>(null);
@@ -691,10 +694,15 @@ export function JobCardNewView({
             </>
           )}
 
-          {transportDialogOpen && !canManageTransportRequests && isTechDept && userDepartment && (
+          {((transportDialogOpen && !canManageTransportRequests) || requestCreatorOpen) && isTechDept && userDepartment && (
             <TransportRequestDialog
-              open={transportDialogOpen}
-              onOpenChange={setTransportDialogOpen}
+              open
+              onOpenChange={(open) => {
+                if (!open) {
+                  setRequestCreatorOpen(false);
+                  setTransportDialogOpen(false);
+                }
+              }}
               jobId={job.id}
               department={userDepartment}
               onSubmitted={() => {
@@ -716,6 +724,14 @@ export function JobCardNewView({
                 setTransportDialogOpen(false);
                 setLogisticsDialogOpen(true);
               }}
+              onRequestTransport={
+                isTechDept && userDepartment
+                  ? () => {
+                      setTransportDialogOpen(false);
+                      setRequestCreatorOpen(true);
+                    }
+                  : undefined
+              }
             />
           )}
 

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { QueryClient } from "@tanstack/react-query";
 import { createPortal } from "react-dom";
 import { format } from "date-fns";
 import { useReducedMotion } from "framer-motion";
@@ -21,6 +22,7 @@ import { LogisticsEventDialog } from "@/components/logistics/LogisticsEventDialo
 import { ProjectNotesDialog } from "@/components/project-management/ProjectNotesDialog";
 import { TransportRequestDialog } from "@/components/logistics/TransportRequestDialog";
 import { TransportRequestsManagerDialog } from "@/components/logistics/TransportRequestsManagerDialog";
+import type { TransportRequestSummary } from "@/hooks/useJobTransportRequests";
 import { SoundTaskDialog } from "@/components/sound/SoundTaskDialog";
 import { TaskManagerDialog } from "@/components/tasks/TaskManagerDialog";
 import { VideoTaskDialog } from "@/components/video/VideoTaskDialog";
@@ -34,8 +36,6 @@ import { JobCardDocuments } from "../JobCardDocuments";
 import { JobCardHeader } from "../JobCardHeader";
 import { JobCardProgress } from "../JobCardProgress";
 import { ConfettiBurst } from "@/components/ui/celebration/ConfettiBurst";
-import { isManagementRole } from "@/utils/permissions";
-
 import { queryKeys } from "@/lib/react-query";
 export interface JobCardNewViewProps {
   job: any;
@@ -147,10 +147,11 @@ export interface JobCardNewViewProps {
   setLogisticsInitialEventType: (value: "load" | "unload" | undefined) => void;
 
   isTechDept: boolean;
+  canManageTransportRequests: boolean;
   userDepartment: string | null;
-  myTransportRequests: any[];
-  allRequests: any[];
-  queryClient: any;
+  myTransportRequests: TransportRequestSummary[];
+  allRequests: TransportRequestSummary[];
+  queryClient: QueryClient;
   checkAndFulfillRequest: (requestId: string, dept: string) => Promise<void>;
   cancelTransportRequest: (requestId: string) => Promise<{ error: string | null }>;
 
@@ -261,6 +262,7 @@ export function JobCardNewView({
   logisticsInitialEventType,
   setLogisticsInitialEventType,
   isTechDept,
+  canManageTransportRequests,
   userDepartment,
   myTransportRequests,
   allRequests,
@@ -275,7 +277,6 @@ export function JobCardNewView({
 }: JobCardNewViewProps) {
   const reducedMotion = useReducedMotion();
   const isMobile = useIsMobile();
-  const canManageTransportRequests = userDepartment === "logistics" || isManagementRole(userRole);
   // Managers who also belong to a tech department reach the request creator
   // through the manager dialog ("Solicitar transporte")
   const [requestCreatorOpen, setRequestCreatorOpen] = React.useState(false);
@@ -705,10 +706,6 @@ export function JobCardNewView({
               }}
               jobId={job.id}
               department={userDepartment}
-              onSubmitted={() => {
-                queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-request", job.id, userDepartment) });
-                queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-requests-all", job.id) });
-              }}
             />
           )}
 

--- a/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
+++ b/src/components/jobs/cards/job-card-new/JobCardNewView.tsx
@@ -746,7 +746,11 @@ export function JobCardNewView({
                   queryClient.invalidateQueries({ queryKey: queryKeys.scope("today-logistics") });
                 }
               }}
-              selectedDate={new Date(job.start_time)}
+              selectedDate={
+                selectedTransportRequest?.needed_date
+                  ? new Date(`${selectedTransportRequest.needed_date}T00:00:00`)
+                  : new Date(job.start_time)
+              }
               initialJobId={job.id}
               initialDepartments={selectedTransportRequest?.department ? [selectedTransportRequest.department] : []}
               initialTransportType={selectedTransportRequest?.selectedItem?.transport_type}

--- a/src/components/logistics/LogisticsEventDialog.tsx
+++ b/src/components/logistics/LogisticsEventDialog.tsx
@@ -1,4 +1,3 @@
-
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -78,6 +77,10 @@ interface LogisticsEventDialogProps {
   initialDepartments?: Department[];
   initialTransportType?: LogisticsTransportType;
   initialEventType?: 'load' | 'unload';
+  // Request being fulfilled: links created events (for per-request
+  // auto-fulfillment) and pre-sets the hoja de ruta relevance checkbox
+  initialTransportRequestId?: string | null;
+  initialIsHojaRelevant?: boolean;
   onCreated?: (details: { id: string; event_type: 'load' | 'unload'; event_date: string; event_time: string }) => void;
 }
 
@@ -90,6 +93,8 @@ export const LogisticsEventDialog = ({
   initialDepartments = [],
   initialTransportType,
   initialEventType,
+  initialTransportRequestId = null,
+  initialIsHojaRelevant,
   onCreated,
 }: LogisticsEventDialogProps) => {
   const [eventType, setEventType] = useState<"load" | "unload">("load");
@@ -175,7 +180,7 @@ export const LogisticsEventDialog = ({
       setSelectedDepartments(initialDepartments || []);
       setColor("#7E69AB");
       setAlsoCreateUnload(false);
-      setIsHojaRelevant(true);
+      setIsHojaRelevant(initialIsHojaRelevant ?? true);
       setHojaCategories([]);
       // Ensure job selection is cleared if no initial job is provided
       if (!initialJobId) {
@@ -417,8 +422,10 @@ export const LogisticsEventDialog = ({
           description: "Evento de logística actualizado correctamente.",
         });
       } else {
+        // Link the event to the transport request it fulfils (if any)
+        const createData = { ...eventData, transport_request_id: initialTransportRequestId || null } as LogisticsEventPayload;
         const { data: newEvent, error } = await dataLayerClient.from("logistics_events")
-          .insert(eventData)
+          .insert(createData)
           .select()
           .single();
 
@@ -442,7 +449,7 @@ export const LogisticsEventDialog = ({
 
         // Optional: create an unload event right after saving a load event
         if (alsoCreateUnload && eventType === 'load') {
-          const unloadData = { ...eventData, event_type: 'unload' as const };
+          const unloadData = { ...createData, event_type: 'unload' as const };
           const { data: unloadEvent, error: unloadErr } = await dataLayerClient.from('logistics_events')
             .insert(unloadData)
             .select()

--- a/src/components/logistics/LogisticsEventDialog.tsx
+++ b/src/components/logistics/LogisticsEventDialog.tsx
@@ -35,6 +35,7 @@ import {
   LOGISTICS_HOJA_CATEGORY_LABELS,
   LOGISTICS_HOJA_CATEGORY_MAX_SELECTION,
   LOGISTICS_HOJA_CATEGORY_OPTIONS,
+  normalizeLogisticsHojaCategories,
   type LogisticsHojaCategory,
 } from "@/constants/logisticsHojaCategories";
 import type { Database } from "@/integrations/supabase/types";
@@ -117,13 +118,6 @@ export const LogisticsEventDialog = ({
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  const normalizeCategories = (categories: unknown): LogisticsHojaCategory[] => {
-    if (!Array.isArray(categories)) return [];
-    return categories.filter((category): category is LogisticsHojaCategory =>
-      LOGISTICS_HOJA_CATEGORY_OPTIONS.includes(category as LogisticsHojaCategory)
-    );
-  };
-
   const toggleHojaCategory = (category: LogisticsHojaCategory) => {
     setHojaCategories((prev) => {
       if (prev.includes(category)) {
@@ -165,7 +159,7 @@ export const LogisticsEventDialog = ({
       setSelectedDepartments((selectedEvent.departments || []).map((d) => d.department));
       setColor(selectedEvent.color || "#7E69AB");
       setIsHojaRelevant((selectedEvent as any).is_hoja_relevant ?? true);
-      setHojaCategories(normalizeCategories((selectedEvent as any).hoja_categories));
+      setHojaCategories(normalizeLogisticsHojaCategories((selectedEvent as any).hoja_categories));
     } else {
       setEventType(initialEventType || "load");
       setTransportType(initialTransportType || "trailer");
@@ -347,8 +341,13 @@ export const LogisticsEventDialog = ({
       };
 
       if (selectedEvent) {
+        // Moving the event to another job invalidates any transport request
+        // link (the FK is job-scoped), so clear it alongside the job change.
+        const updateData = (selectedEvent.job_id || null) !== (selectedJob || null)
+          ? { ...eventData, transport_request_id: null } as LogisticsEventPayload
+          : eventData;
         const { error: updateError } = await dataLayerClient.from("logistics_events")
-          .update(eventData)
+          .update(updateData)
           .eq("id", selectedEvent.id);
 
         if (updateError) throw updateError;
@@ -401,8 +400,8 @@ export const LogisticsEventDialog = ({
         if (previousHojaRelevant !== eventData.is_hoja_relevant) {
           changes.is_hoja_relevant = { from: previousHojaRelevant, to: eventData.is_hoja_relevant };
         }
-        const previousCategories = normalizeCategories((selectedEvent as any).hoja_categories).slice().sort();
-        const nextCategories = normalizeCategories(eventData.hoja_categories).slice().sort();
+        const previousCategories = normalizeLogisticsHojaCategories((selectedEvent as any).hoja_categories).slice().sort();
+        const nextCategories = normalizeLogisticsHojaCategories(eventData.hoja_categories).slice().sort();
         if (JSON.stringify(previousCategories) !== JSON.stringify(nextCategories)) {
           changes.hoja_categories = { from: previousCategories, to: nextCategories };
         }

--- a/src/components/logistics/TransportRequestDialog.tsx
+++ b/src/components/logistics/TransportRequestDialog.tsx
@@ -163,7 +163,7 @@ export function TransportRequestDialog({
     if (error) {
       toast({
         title: "Error",
-        description: error || "No se pudo cancelar la solicitud",
+        description: error,
         variant: "destructive",
       });
       return;

--- a/src/components/logistics/TransportRequestDialog.tsx
+++ b/src/components/logistics/TransportRequestDialog.tsx
@@ -2,6 +2,8 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -10,225 +12,399 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { REQUEST_TRANSPORT_OPTIONS } from "@/constants/transportOptions";
 import { dataLayerClient } from "@/services/dataLayerClient";
+import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useToast } from "@/hooks/use-toast";
+import { queryKeys } from "@/lib/react-query";
 
 interface TransportRequestDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   jobId: string;
   department: string; // 'sound' | 'lights' | 'video'
-  requestId?: string | null;
   onSubmitted?: () => void;
 }
+
+interface VehicleItem {
+  transport_type: string;
+  leftover_space_meters?: number | "";
+}
+
+interface ActiveRequest {
+  id: string;
+  status: string;
+  note: string | null;
+  description: string | null;
+  created_by: string | null;
+  created_at: string;
+  is_hoja_relevant: boolean;
+  items: { id: string; transport_type: string; leftover_space_meters: number | null }[];
+}
+
+const emptyItems = (): VehicleItem[] => [{ transport_type: "trailer", leftover_space_meters: "" }];
 
 export function TransportRequestDialog({
   open,
   onOpenChange,
   jobId,
   department,
-  requestId,
   onSubmitted,
 }: TransportRequestDialogProps) {
-  const [items, setItems] = useState<{ transport_type: string; leftover_space_meters?: number | '' }[]>([
-    { transport_type: 'trailer', leftover_space_meters: '' },
-  ]);
-  const [note, setNote] = useState<string>('');
-  const [description, setDescription] = useState<string>('');
+  const [view, setView] = useState<"list" | "form">("list");
+  const [editingRequestId, setEditingRequestId] = useState<string | null>(null);
+  const [items, setItems] = useState<VehicleItem[]>(emptyItems());
+  const [note, setNote] = useState("");
+  const [description, setDescription] = useState("");
+  const [isHojaRelevant, setIsHojaRelevant] = useState(true);
   const { toast } = useToast();
+  const { user } = useOptimizedAuth();
+  const queryClient = useQueryClient();
 
+  const { data: activeRequests = [], isLoading } = useQuery({
+    queryKey: queryKeys.scope("transport-request", jobId, department),
+    enabled: open && !!jobId && !!department,
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient
+        .from("transport_requests")
+        .select(
+          "id, status, note, description, created_by, created_at, is_hoja_relevant, items:transport_request_items(id, transport_type, leftover_space_meters)"
+        )
+        .eq("job_id", jobId)
+        .eq("department", department)
+        .eq("status", "requested")
+        .order("created_at", { ascending: true });
+      if (error) throw error;
+      return (data || []) as unknown as ActiveRequest[];
+    },
+  });
+
+  // Reset to the overview every time the dialog opens
   useEffect(() => {
-    const loadExisting = async () => {
-      if (!requestId) return;
-      const { data, error } = await dataLayerClient.from('transport_requests')
-        .select('id, note, description, items:transport_request_items(id, transport_type, leftover_space_meters)')
-        .eq('id', requestId)
-        .single();
-      if (!error && data) {
-        setNote(data.note || '');
-        setDescription((data as any).description || '');
-        if (Array.isArray((data as any).items) && (data as any).items.length > 0) {
-          const mapped = (data as any).items.map((it: any) => ({
+    if (open) {
+      setView("list");
+      setEditingRequestId(null);
+    }
+  }, [open]);
+
+  // With no active requests there is nothing to list — go straight to creating one
+  useEffect(() => {
+    if (open && !isLoading && activeRequests.length === 0 && view === "list") {
+      startCreate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, isLoading, activeRequests.length]);
+
+  const startCreate = () => {
+    setEditingRequestId(null);
+    setItems(emptyItems());
+    setNote("");
+    setDescription("");
+    setIsHojaRelevant(true);
+    setView("form");
+  };
+
+  const startEdit = (request: ActiveRequest) => {
+    setEditingRequestId(request.id);
+    setNote(request.note || "");
+    setDescription(request.description || "");
+    setIsHojaRelevant(request.is_hoja_relevant ?? true);
+    setItems(
+      request.items.length > 0
+        ? request.items.map((it) => ({
             transport_type: it.transport_type,
-            leftover_space_meters: it.leftover_space_meters ?? '',
-          }));
-          setItems(mapped);
-        } else {
-          setItems([{ transport_type: 'trailer', leftover_space_meters: '' }]);
-        }
-      }
-    };
-    loadExisting();
-  }, [requestId]);
+            leftover_space_meters: it.leftover_space_meters ?? "",
+          }))
+        : emptyItems()
+    );
+    setView("form");
+  };
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-request", jobId, department) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-requests-all", jobId) });
+  };
+
+  const canManageRequest = (request: ActiveRequest) => !request.created_by || request.created_by === user?.id;
+
+  const handleCancelRequest = async (requestId: string) => {
+    const { error } = await dataLayerClient
+      .from("transport_requests")
+      .update({ status: "cancelled" })
+      .eq("id", requestId);
+    if (error) {
+      toast({
+        title: "Error",
+        description: error.message || "No se pudo cancelar la solicitud",
+        variant: "destructive",
+      });
+      return;
+    }
+    toast({ title: "Solicitud cancelada" });
+    invalidate();
+    onSubmitted?.();
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const { data: { user } } = await dataLayerClient.auth.getUser();
-      if (!user) throw new Error('Not authenticated');
+      const { data: { user: authUser } } = await dataLayerClient.auth.getUser();
+      if (!authUser) throw new Error("No autenticado");
 
-      const payload = {
-        job_id: jobId,
-        department,
-        note: note || null,
-        description: description || null,
-        status: 'requested' as const,
-        created_by: user.id,
-      };
-
-      if (requestId) {
-        const { error } = await dataLayerClient.from('transport_requests')
-          .update(payload)
-          .eq('id', requestId);
-        if (error) throw error;
-
-        // Replace items (do not ignore delete failures)
-        const { error: deleteItemsError } = await dataLayerClient.from('transport_request_items')
-          .delete()
-          .eq('request_id', requestId);
-        if (deleteItemsError) throw deleteItemsError;
-
-        const toInsert = items
+      const toInsertItems = (requestId: string) =>
+        items
           .filter((it) => !!it.transport_type)
           .map((it) => ({
             request_id: requestId,
             transport_type: it.transport_type,
-            leftover_space_meters: it.leftover_space_meters === '' ? null : it.leftover_space_meters,
+            leftover_space_meters: it.leftover_space_meters === "" ? null : it.leftover_space_meters,
           }));
+
+      if (editingRequestId) {
+        // Only the editable fields — never touch status, so a request cannot be
+        // resurrected or re-owned through an edit.
+        const { error } = await dataLayerClient
+          .from("transport_requests")
+          .update({
+            note: note || null,
+            description: description || null,
+            is_hoja_relevant: isHojaRelevant,
+          } as never)
+          .eq("id", editingRequestId);
+        if (error) throw error;
+
+        const { error: deleteItemsError } = await dataLayerClient
+          .from("transport_request_items")
+          .delete()
+          .eq("request_id", editingRequestId);
+        if (deleteItemsError) throw deleteItemsError;
+
+        const toInsert = toInsertItems(editingRequestId);
         if (toInsert.length > 0) {
-          const { error: itemsErr } = await dataLayerClient.from('transport_request_items').insert(toInsert);
+          const { error: itemsErr } = await dataLayerClient.from("transport_request_items").insert(toInsert);
           if (itemsErr) throw itemsErr;
         }
       } else {
-        const { data: inserted, error } = await dataLayerClient.from('transport_requests')
-          .insert(payload)
-          .select('id')
+        const { data: inserted, error } = await dataLayerClient
+          .from("transport_requests")
+          .insert({
+            job_id: jobId,
+            department,
+            note: note || null,
+            description: description || null,
+            status: "requested",
+            created_by: authUser.id,
+            is_hoja_relevant: isHojaRelevant,
+          } as never)
+          .select("id")
           .single();
         if (error) throw error;
-        const request_id = inserted.id;
-        const toInsert = items
-          .filter((it) => !!it.transport_type)
-          .map((it) => ({
-            request_id,
-            transport_type: it.transport_type,
-            leftover_space_meters: it.leftover_space_meters === '' ? null : it.leftover_space_meters,
-          }));
+        const requestId = (inserted as { id: string }).id;
+        const toInsert = toInsertItems(requestId);
         if (toInsert.length > 0) {
-          const { error: itemsErr } = await dataLayerClient.from('transport_request_items').insert(toInsert);
+          const { error: itemsErr } = await dataLayerClient.from("transport_request_items").insert(toInsert);
           if (itemsErr) throw itemsErr;
         }
         try {
-          const { error: pushError } = await dataLayerClient.functions.invoke('push', {
+          const { error: pushError } = await dataLayerClient.functions.invoke("push", {
             body: {
-              action: 'broadcast',
-              type: 'logistics.transport.requested',
+              action: "broadcast",
+              type: "logistics.transport.requested",
               job_id: jobId,
               department,
-              request_id,
+              request_id: requestId,
               description: description || undefined,
             },
           });
           if (pushError) {
-            console.error('Failed to invoke push notification for transport request', pushError);
+            console.error("Failed to invoke push notification for transport request", pushError);
           }
         } catch (pushError) {
-          console.error('Unexpected error invoking push notification for transport request', pushError);
+          console.error("Unexpected error invoking push notification for transport request", pushError);
         }
       }
 
-      toast({ title: 'Transport request saved' });
+      toast({ title: editingRequestId ? "Solicitud actualizada" : "Solicitud de transporte enviada" });
+      invalidate();
       onSubmitted?.();
-      onOpenChange(false);
-    } catch (error: any) {
-      toast({ title: 'Error', description: error.message || 'Failed to save request', variant: 'destructive' });
+      setView("list");
+      setEditingRequestId(null);
+      if (activeRequests.length === 0 && !editingRequestId) {
+        // First request from the empty state: close, matching the old flow
+        onOpenChange(false);
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "No se pudo guardar la solicitud";
+      toast({ title: "Error", description: message, variant: "destructive" });
     }
   };
+
+  const renderList = () => (
+    <div className="space-y-3">
+      {activeRequests.map((request) => (
+        <div key={request.id} className="border rounded p-3 space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="space-y-1 min-w-0">
+              <div className="text-sm font-medium truncate">
+                {request.description || "Transporte de material"}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {(request.items || [])
+                  .map((it) =>
+                    it.leftover_space_meters != null
+                      ? `${it.transport_type.replace("_", " ")} (${it.leftover_space_meters} m libres)`
+                      : it.transport_type.replace("_", " ")
+                  )
+                  .join(", ") || "Sin vehículos"}
+              </div>
+              {request.note && <div className="text-xs text-muted-foreground italic">{request.note}</div>}
+            </div>
+            {request.is_hoja_relevant === false && (
+              <Badge variant="outline" className="shrink-0">Fuera de Hoja de Ruta</Badge>
+            )}
+          </div>
+          {canManageRequest(request) && (
+            <div className="flex gap-2">
+              <Button type="button" size="sm" variant="outline" onClick={() => startEdit(request)}>
+                Editar
+              </Button>
+              <Button type="button" size="sm" variant="outline" onClick={() => handleCancelRequest(request.id)}>
+                Cancelar solicitud
+              </Button>
+            </div>
+          )}
+        </div>
+      ))}
+      <div className="flex justify-end">
+        <Button type="button" onClick={startCreate}>Nueva solicitud</Button>
+      </div>
+    </div>
+  );
+
+  const renderForm = () => (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label>Descripción</Label>
+        <Input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="P. ej., Recogida de subalquiler, Devolución de material al proveedor"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>Vehículos</Label>
+        <div className="space-y-2">
+          {items.map((it, idx) => (
+            <div key={idx} className="flex items-center gap-2">
+              <Select
+                value={it.transport_type}
+                onValueChange={(val) => {
+                  const next = items.slice();
+                  next[idx] = { ...next[idx], transport_type: val };
+                  setItems(next);
+                }}
+              >
+                <SelectTrigger className="w-40">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {REQUEST_TRANSPORT_OPTIONS.map((opt) => (
+                    <SelectItem key={opt} value={opt}>{opt.replace("_", " ")}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Input
+                type="number"
+                min={0}
+                step={0.1}
+                className="w-52"
+                placeholder="Espacio sobrante (m) - opcional"
+                value={it.leftover_space_meters === "" ? "" : it.leftover_space_meters}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  const num = val === "" ? "" : Math.max(0, Number(val));
+                  const next = items.slice();
+                  next[idx] = { ...next[idx], leftover_space_meters: num as number | "" };
+                  setItems(next);
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  const next = items.slice();
+                  next.splice(idx, 1);
+                  setItems(next.length ? next : emptyItems());
+                }}
+              >
+                Eliminar
+              </Button>
+            </div>
+          ))}
+          <div>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setItems([...items, { transport_type: "trailer", leftover_space_meters: "" }])}
+            >
+              Añadir vehículo
+            </Button>
+          </div>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label>Nota</Label>
+        <Input value={note} onChange={(e) => setNote(e.target.value)} placeholder="Detalles opcionales" />
+      </div>
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="transport-request-hoja-relevant"
+            checked={isHojaRelevant}
+            onCheckedChange={(value) => setIsHojaRelevant(value === true)}
+          />
+          <Label htmlFor="transport-request-hoja-relevant">Incluir en la Hoja de Ruta</Label>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Desmárcalo para transportes internos (subalquileres, devoluciones…) que no deben aparecer en la Hoja de Ruta.
+        </p>
+      </div>
+      <div className="flex justify-between">
+        {activeRequests.length > 0 ? (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => {
+              setView("list");
+              setEditingRequestId(null);
+            }}
+          >
+            Volver
+          </Button>
+        ) : (
+          <span />
+        )}
+        <Button type="submit">{editingRequestId ? "Actualizar solicitud" : "Enviar solicitud"}</Button>
+      </div>
+    </form>
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{requestId ? 'Edit Transport Request' : 'Request Transport'}</DialogTitle>
+          <DialogTitle>
+            {view === "list"
+              ? "Solicitudes de transporte"
+              : editingRequestId
+                ? "Editar solicitud de transporte"
+                : "Solicitar transporte"}
+          </DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label>Description</Label>
-            <Input
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="E.g., Subrental pickup from ABC Rental, Return equipment to vendor"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Vehicles</Label>
-            <div className="space-y-2">
-              {items.map((it, idx) => (
-                <div key={idx} className="flex items-center gap-2">
-                  <Select
-                    value={it.transport_type}
-                    onValueChange={(val) => {
-                      const next = items.slice();
-                      next[idx] = { ...next[idx], transport_type: val };
-                      setItems(next);
-                    }}
-                  >
-                    <SelectTrigger className="w-40">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {REQUEST_TRANSPORT_OPTIONS.map((opt) => (
-                        <SelectItem key={opt} value={opt}>{opt.replace('_',' ')}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    type="number"
-                    min={0}
-                    step={0.1}
-                    className="w-52"
-                    placeholder="Leftover space (m) - optional"
-                    value={it.leftover_space_meters === '' ? '' : it.leftover_space_meters}
-                    onChange={(e) => {
-                      const val = e.target.value;
-                      const num = val === '' ? '' : Math.max(0, Number(val));
-                      const next = items.slice();
-                      next[idx] = { ...next[idx], leftover_space_meters: num as any };
-                      setItems(next);
-                    }}
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      const next = items.slice();
-                      next.splice(idx, 1);
-                      setItems(next.length ? next : [{ transport_type: 'trailer', leftover_space_meters: '' }]);
-                    }}
-                  >
-                    Remove
-                  </Button>
-                </div>
-              ))}
-              <div>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={() => setItems([...items, { transport_type: 'trailer', leftover_space_meters: '' }])}
-                >
-                  Add Vehicle
-                </Button>
-              </div>
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label>Note</Label>
-            <Input value={note} onChange={(e) => setNote(e.target.value)} placeholder="Optional details" />
-          </div>
-          <div className="flex justify-end">
-            <Button type="submit">{requestId ? 'Update' : 'Submit'} Request</Button>
-          </div>
-        </form>
+        {view === "list" ? (isLoading ? (
+          <div className="text-sm text-muted-foreground">Cargando…</div>
+        ) : renderList()) : renderForm()}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/logistics/TransportRequestDialog.tsx
+++ b/src/components/logistics/TransportRequestDialog.tsx
@@ -12,12 +12,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useEffect, useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useFieldArray, useForm } from "react-hook-form";
+import { z } from "zod";
 import { REQUEST_TRANSPORT_OPTIONS } from "@/constants/transportOptions";
 import { dataLayerClient } from "@/services/dataLayerClient";
 import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { useToast } from "@/hooks/use-toast";
-import { queryKeys } from "@/lib/react-query";
+import { useConfirm } from "@/components/ui/confirm-dialog";
+import {
+  useJobTransportRequests,
+  type TransportRequestSummary,
+} from "@/hooks/useJobTransportRequests";
 
 interface TransportRequestDialogProps {
   open: boolean;
@@ -27,22 +33,24 @@ interface TransportRequestDialogProps {
   onSubmitted?: () => void;
 }
 
-interface VehicleItem {
-  transport_type: string;
-  leftover_space_meters?: number | "";
-}
+const vehicleItemSchema = z.object({
+  transport_type: z.string().min(1, "Selecciona un tipo de vehículo"),
+  leftover_space_meters: z.union([
+    z.number().finite().min(0, "El espacio libre no puede ser negativo"),
+    z.literal(""),
+  ]),
+});
 
-interface ActiveRequest {
-  id: string;
-  status: string;
-  note: string | null;
-  description: string | null;
-  created_by: string | null;
-  created_at: string;
-  is_hoja_relevant: boolean;
-  needed_date: string | null;
-  items: { id: string; transport_type: string; leftover_space_meters: number | null }[];
-}
+const transportRequestFormSchema = z.object({
+  description: z.string(),
+  items: z.array(vehicleItemSchema).min(1, "Añade al menos un vehículo"),
+  needed_date: z.string(),
+  note: z.string(),
+  is_hoja_relevant: z.boolean(),
+});
+
+type TransportRequestFormValues = z.infer<typeof transportRequestFormSchema>;
+type VehicleItem = TransportRequestFormValues["items"][number];
 
 const formatNeededDate = (isoDate: string) => {
   const [year, month, day] = isoDate.split("-");
@@ -50,6 +58,14 @@ const formatNeededDate = (isoDate: string) => {
 };
 
 const emptyItems = (): VehicleItem[] => [{ transport_type: "trailer", leftover_space_meters: "" }];
+
+const emptyFormValues = (): TransportRequestFormValues => ({
+  description: "",
+  items: emptyItems(),
+  needed_date: "",
+  note: "",
+  is_hoja_relevant: true,
+});
 
 export function TransportRequestDialog({
   open,
@@ -60,32 +76,37 @@ export function TransportRequestDialog({
 }: TransportRequestDialogProps) {
   const [view, setView] = useState<"list" | "form">("list");
   const [editingRequestId, setEditingRequestId] = useState<string | null>(null);
-  const [items, setItems] = useState<VehicleItem[]>(emptyItems());
-  const [note, setNote] = useState("");
-  const [description, setDescription] = useState("");
-  const [isHojaRelevant, setIsHojaRelevant] = useState(true);
-  const [neededDate, setNeededDate] = useState("");
   const { toast } = useToast();
+  const confirm = useConfirm();
   const { user } = useOptimizedAuth();
-  const queryClient = useQueryClient();
-
-  const { data: activeRequests = [], isLoading } = useQuery({
-    queryKey: queryKeys.scope("transport-request", jobId, department),
-    enabled: open && !!jobId && !!department,
-    queryFn: async () => {
-      const { data, error } = await dataLayerClient
-        .from("transport_requests")
-        .select(
-          "id, status, note, description, created_by, created_at, is_hoja_relevant, needed_date, items:transport_request_items(id, transport_type, leftover_space_meters)"
-        )
-        .eq("job_id", jobId)
-        .eq("department", department)
-        .eq("status", "requested")
-        .order("created_at", { ascending: true });
-      if (error) throw error;
-      return (data || []) as unknown as ActiveRequest[];
-    },
+  const {
+    myTransportRequests: activeRequests,
+    isMyTransportRequestsLoading: isLoading,
+    isMyTransportRequestsError: isError,
+    refetchMyTransportRequests: refetchActiveRequests,
+    cancelRequest,
+    invalidateRequests,
+  } = useJobTransportRequests(jobId, department, false);
+  const {
+    control,
+    formState: { errors },
+    handleSubmit: handleValidatedSubmit,
+    register,
+    reset,
+    setValue,
+    watch,
+  } = useForm<TransportRequestFormValues>({
+    resolver: zodResolver(transportRequestFormSchema),
+    defaultValues: emptyFormValues(),
   });
+  const {
+    append: appendItem,
+    fields: itemFields,
+    remove: removeItem,
+    replace: replaceItems,
+  } = useFieldArray({ control, name: "items" });
+  const items = watch("items");
+  const isHojaRelevant = watch("is_hoja_relevant");
 
   // Reset to the overview every time the dialog opens
   useEffect(() => {
@@ -97,72 +118,67 @@ export function TransportRequestDialog({
 
   // With no active requests there is nothing to list — go straight to creating one
   useEffect(() => {
-    if (open && !isLoading && activeRequests.length === 0 && view === "list") {
+    if (open && !isLoading && !isError && activeRequests.length === 0 && view === "list") {
       startCreate();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, isLoading, activeRequests.length]);
+  }, [open, isLoading, isError, activeRequests.length]);
 
   const startCreate = () => {
     setEditingRequestId(null);
-    setItems(emptyItems());
-    setNote("");
-    setDescription("");
-    setIsHojaRelevant(true);
-    setNeededDate("");
+    reset(emptyFormValues());
     setView("form");
   };
 
-  const startEdit = (request: ActiveRequest) => {
+  const startEdit = (request: TransportRequestSummary) => {
     setEditingRequestId(request.id);
-    setNote(request.note || "");
-    setDescription(request.description || "");
-    setIsHojaRelevant(request.is_hoja_relevant ?? true);
-    setNeededDate(request.needed_date || "");
-    setItems(
-      request.items.length > 0
+    reset({
+      note: request.note || "",
+      description: request.description || "",
+      is_hoja_relevant: request.is_hoja_relevant ?? true,
+      needed_date: request.needed_date || "",
+      items: request.items.length > 0
         ? request.items.map((it) => ({
             transport_type: it.transport_type,
             leftover_space_meters: it.leftover_space_meters ?? "",
           }))
-        : emptyItems()
-    );
+        : emptyItems(),
+    });
     setView("form");
   };
 
-  const invalidate = () => {
-    queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-request", jobId, department) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.scope("transport-requests-all", jobId) });
-  };
-
-  const canManageRequest = (request: ActiveRequest) => !request.created_by || request.created_by === user?.id;
+  const canManageRequest = (request: TransportRequestSummary) =>
+    !request.created_by || request.created_by === user?.id;
 
   const handleCancelRequest = async (requestId: string) => {
-    const { error } = await dataLayerClient
-      .from("transport_requests")
-      .update({ status: "cancelled" })
-      .eq("id", requestId);
+    const confirmed = await confirm({
+      title: "¿Cancelar esta solicitud?",
+      description: "La solicitud dejará de aparecer como pendiente.",
+      confirmText: "Cancelar solicitud",
+      destructive: true,
+    });
+    if (!confirmed) return;
+
+    const { error } = await cancelRequest(requestId);
     if (error) {
       toast({
         title: "Error",
-        description: error.message || "No se pudo cancelar la solicitud",
+        description: error || "No se pudo cancelar la solicitud",
         variant: "destructive",
       });
       return;
     }
     toast({ title: "Solicitud cancelada" });
-    invalidate();
     onSubmitted?.();
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const saveRequest = async (values: TransportRequestFormValues) => {
     try {
       const { data: { user: authUser } } = await dataLayerClient.auth.getUser();
       if (!authUser) throw new Error("No autenticado");
 
       const toInsertItems = (requestId: string) =>
-        items
+        values.items
           .filter((it) => !!it.transport_type)
           .map((it) => ({
             request_id: requestId,
@@ -176,24 +192,30 @@ export function TransportRequestDialog({
         const { error } = await dataLayerClient
           .from("transport_requests")
           .update({
-            note: note || null,
-            description: description || null,
-            is_hoja_relevant: isHojaRelevant,
-            needed_date: neededDate || null,
+            note: values.note || null,
+            description: values.description || null,
+            is_hoja_relevant: values.is_hoja_relevant,
+            needed_date: values.needed_date || null,
           } as never)
           .eq("id", editingRequestId);
         if (error) throw error;
 
-        const { error: deleteItemsError } = await dataLayerClient
-          .from("transport_request_items")
-          .delete()
-          .eq("request_id", editingRequestId);
-        if (deleteItemsError) throw deleteItemsError;
-
+        const existingItemIds = activeRequests
+          .find((request) => request.id === editingRequestId)
+          ?.items.map((item) => item.id) ?? [];
         const toInsert = toInsertItems(editingRequestId);
         if (toInsert.length > 0) {
           const { error: itemsErr } = await dataLayerClient.from("transport_request_items").insert(toInsert);
           if (itemsErr) throw itemsErr;
+
+          if (existingItemIds.length > 0) {
+            const { error: deleteItemsError } = await dataLayerClient
+              .from("transport_request_items")
+              .delete()
+              .eq("request_id", editingRequestId)
+              .in("id", existingItemIds);
+            if (deleteItemsError) throw deleteItemsError;
+          }
         }
       } else {
         const { data: inserted, error } = await dataLayerClient
@@ -201,12 +223,12 @@ export function TransportRequestDialog({
           .insert({
             job_id: jobId,
             department,
-            note: note || null,
-            description: description || null,
+            note: values.note || null,
+            description: values.description || null,
             status: "requested",
             created_by: authUser.id,
-            is_hoja_relevant: isHojaRelevant,
-            needed_date: neededDate || null,
+            is_hoja_relevant: values.is_hoja_relevant,
+            needed_date: values.needed_date || null,
           } as never)
           .select("id")
           .single();
@@ -225,7 +247,7 @@ export function TransportRequestDialog({
               job_id: jobId,
               department,
               request_id: requestId,
-              description: description || undefined,
+              description: values.description || undefined,
             },
           });
           if (pushError) {
@@ -237,7 +259,7 @@ export function TransportRequestDialog({
       }
 
       toast({ title: editingRequestId ? "Solicitud actualizada" : "Solicitud de transporte enviada" });
-      invalidate();
+      invalidateRequests();
       onSubmitted?.();
       setView("list");
       setEditingRequestId(null);
@@ -281,7 +303,7 @@ export function TransportRequestDialog({
             )}
           </div>
           {canManageRequest(request) && (
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <Button type="button" size="sm" variant="outline" onClick={() => startEdit(request)}>
                 Editar
               </Button>
@@ -299,70 +321,80 @@ export function TransportRequestDialog({
   );
 
   const renderForm = () => (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleValidatedSubmit(saveRequest)} className="space-y-4">
       <div className="space-y-2">
         <Label>Descripción</Label>
         <Input
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          {...register("description")}
           placeholder="P. ej., Recogida de subalquiler, Devolución de material al proveedor"
         />
       </div>
       <div className="space-y-2">
         <Label>Vehículos</Label>
         <div className="space-y-2">
-          {items.map((it, idx) => (
-            <div key={idx} className="flex items-center gap-2">
-              <Select
-                value={it.transport_type}
-                onValueChange={(val) => {
-                  const next = items.slice();
-                  next[idx] = { ...next[idx], transport_type: val };
-                  setItems(next);
-                }}
-              >
-                <SelectTrigger className="w-40">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {REQUEST_TRANSPORT_OPTIONS.map((opt) => (
-                    <SelectItem key={opt} value={opt}>{opt.replace("_", " ")}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Input
-                type="number"
-                min={0}
-                step={0.1}
-                className="w-52"
-                placeholder="Espacio sobrante (m) - opcional"
-                value={it.leftover_space_meters === "" ? "" : it.leftover_space_meters}
-                onChange={(e) => {
-                  const val = e.target.value;
-                  const num = val === "" ? "" : Math.max(0, Number(val));
-                  const next = items.slice();
-                  next[idx] = { ...next[idx], leftover_space_meters: num as number | "" };
-                  setItems(next);
-                }}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  const next = items.slice();
-                  next.splice(idx, 1);
-                  setItems(next.length ? next : emptyItems());
-                }}
-              >
-                Eliminar
-              </Button>
-            </div>
-          ))}
+          {itemFields.map((field, idx) => {
+            const item = items[idx] ?? { transport_type: "trailer", leftover_space_meters: "" };
+            return (
+              <div key={field.id} className="space-y-1">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <Select
+                    value={item.transport_type}
+                    onValueChange={(val) => {
+                      setValue(`items.${idx}.transport_type`, val, { shouldValidate: true });
+                    }}
+                  >
+                    <SelectTrigger className="w-full sm:w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {REQUEST_TRANSPORT_OPTIONS.map((opt) => (
+                        <SelectItem key={opt} value={opt}>
+                          {opt.replace("_", " ")}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Input
+                    type="number"
+                    min={0}
+                    step={0.1}
+                    className="w-full sm:w-52"
+                    placeholder="Espacio sobrante (m) - opcional"
+                    value={item.leftover_space_meters === "" ? "" : item.leftover_space_meters}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      const parsed = Number(val);
+                      const nextValue = val === "" || !Number.isFinite(parsed) ? "" : Math.max(0, parsed);
+                      setValue(`items.${idx}.leftover_space_meters`, nextValue, { shouldValidate: true });
+                    }}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      if (itemFields.length === 1) {
+                        replaceItems(emptyItems());
+                      } else {
+                        removeItem(idx);
+                      }
+                    }}
+                  >
+                    Eliminar
+                  </Button>
+                </div>
+                {errors.items?.[idx]?.leftover_space_meters?.message && (
+                  <p className="text-xs text-destructive">
+                    {errors.items[idx]?.leftover_space_meters?.message}
+                  </p>
+                )}
+              </div>
+            );
+          })}
           <div>
             <Button
               type="button"
               variant="secondary"
-              onClick={() => setItems([...items, { transport_type: "trailer", leftover_space_meters: "" }])}
+              onClick={() => appendItem({ transport_type: "trailer", leftover_space_meters: "" })}
             >
               Añadir vehículo
             </Button>
@@ -373,8 +405,7 @@ export function TransportRequestDialog({
         <Label>Fecha necesaria</Label>
         <Input
           type="date"
-          value={neededDate}
-          onChange={(e) => setNeededDate(e.target.value)}
+          {...register("needed_date")}
         />
         <p className="text-xs text-muted-foreground">
           Día en que se necesita el transporte (opcional). Se usará como fecha inicial del evento de logística.
@@ -382,14 +413,14 @@ export function TransportRequestDialog({
       </div>
       <div className="space-y-2">
         <Label>Nota</Label>
-        <Input value={note} onChange={(e) => setNote(e.target.value)} placeholder="Detalles opcionales" />
+        <Input {...register("note")} placeholder="Detalles opcionales" />
       </div>
       <div className="space-y-1">
         <div className="flex items-center gap-2">
           <Checkbox
             id="transport-request-hoja-relevant"
             checked={isHojaRelevant}
-            onCheckedChange={(value) => setIsHojaRelevant(value === true)}
+            onCheckedChange={(value) => setValue("is_hoja_relevant", value === true)}
           />
           <Label htmlFor="transport-request-hoja-relevant">Incluir en la Hoja de Ruta</Label>
         </div>
@@ -419,7 +450,7 @@ export function TransportRequestDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-h-[85vh]">
         <DialogHeader>
           <DialogTitle>
             {view === "list"
@@ -429,9 +460,20 @@ export function TransportRequestDialog({
                 : "Solicitar transporte"}
           </DialogTitle>
         </DialogHeader>
-        {view === "list" ? (isLoading ? (
-          <div className="text-sm text-muted-foreground">Cargando…</div>
-        ) : renderList()) : renderForm()}
+        {view === "list" ? (
+          isLoading ? (
+            <div className="text-sm text-muted-foreground">Cargando…</div>
+          ) : isError ? (
+            <div className="space-y-3">
+              <div className="text-sm text-destructive">
+                No se pudieron cargar las solicitudes de transporte.
+              </div>
+              <Button type="button" variant="outline" onClick={() => void refetchActiveRequests()}>
+                Reintentar
+              </Button>
+            </div>
+          ) : renderList()
+        ) : renderForm()}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/logistics/TransportRequestDialog.tsx
+++ b/src/components/logistics/TransportRequestDialog.tsx
@@ -12,8 +12,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useEffect, useState } from "react";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { REQUEST_TRANSPORT_OPTIONS } from "@/constants/transportOptions";
 import { dataLayerClient } from "@/services/dataLayerClient";
@@ -34,16 +33,16 @@ interface TransportRequestDialogProps {
 }
 
 const vehicleItemSchema = z.object({
-  transport_type: z.string().min(1, "Selecciona un tipo de vehículo"),
+  transport_type: z.string().min(1),
   leftover_space_meters: z.union([
-    z.number().finite().min(0, "El espacio libre no puede ser negativo"),
+    z.number().min(0),
     z.literal(""),
   ]),
 });
 
 const transportRequestFormSchema = z.object({
   description: z.string(),
-  items: z.array(vehicleItemSchema).min(1, "Añade al menos un vehículo"),
+  items: z.array(vehicleItemSchema).min(1),
   needed_date: z.string(),
   note: z.string(),
   is_hoja_relevant: z.boolean(),
@@ -51,11 +50,6 @@ const transportRequestFormSchema = z.object({
 
 type TransportRequestFormValues = z.infer<typeof transportRequestFormSchema>;
 type VehicleItem = TransportRequestFormValues["items"][number];
-
-const formatNeededDate = (isoDate: string) => {
-  const [year, month, day] = isoDate.split("-");
-  return `${day}/${month}/${year}`;
-};
 
 const emptyItems = (): VehicleItem[] => [{ transport_type: "trailer", leftover_space_meters: "" }];
 
@@ -88,23 +82,14 @@ export function TransportRequestDialog({
     invalidateRequests,
   } = useJobTransportRequests(jobId, department, false);
   const {
-    control,
-    formState: { errors },
     handleSubmit: handleValidatedSubmit,
     register,
     reset,
     setValue,
     watch,
   } = useForm<TransportRequestFormValues>({
-    resolver: zodResolver(transportRequestFormSchema),
     defaultValues: emptyFormValues(),
   });
-  const {
-    append: appendItem,
-    fields: itemFields,
-    remove: removeItem,
-    replace: replaceItems,
-  } = useFieldArray({ control, name: "items" });
   const items = watch("items");
   const isHojaRelevant = watch("is_hoja_relevant");
 
@@ -172,14 +157,14 @@ export function TransportRequestDialog({
     onSubmitted?.();
   };
 
-  const saveRequest = async (values: TransportRequestFormValues) => {
+  const saveRequest = async (formValues: TransportRequestFormValues) => {
     try {
+      const values = transportRequestFormSchema.parse(formValues);
       const { data: { user: authUser } } = await dataLayerClient.auth.getUser();
       if (!authUser) throw new Error("No autenticado");
 
       const toInsertItems = (requestId: string) =>
         values.items
-          .filter((it) => !!it.transport_type)
           .map((it) => ({
             request_id: requestId,
             transport_type: it.transport_type,
@@ -204,18 +189,16 @@ export function TransportRequestDialog({
           .find((request) => request.id === editingRequestId)
           ?.items.map((item) => item.id) ?? [];
         const toInsert = toInsertItems(editingRequestId);
-        if (toInsert.length > 0) {
-          const { error: itemsErr } = await dataLayerClient.from("transport_request_items").insert(toInsert);
-          if (itemsErr) throw itemsErr;
+        const { error: itemsErr } = await dataLayerClient.from("transport_request_items").insert(toInsert);
+        if (itemsErr) throw itemsErr;
 
-          if (existingItemIds.length > 0) {
-            const { error: deleteItemsError } = await dataLayerClient
-              .from("transport_request_items")
-              .delete()
-              .eq("request_id", editingRequestId)
-              .in("id", existingItemIds);
-            if (deleteItemsError) throw deleteItemsError;
-          }
+        if (existingItemIds.length > 0) {
+          const { error: deleteItemsError } = await dataLayerClient
+            .from("transport_request_items")
+            .delete()
+            .eq("request_id", editingRequestId)
+            .in("id", existingItemIds);
+          if (deleteItemsError) throw deleteItemsError;
         }
       } else {
         const { data: inserted, error } = await dataLayerClient
@@ -235,10 +218,8 @@ export function TransportRequestDialog({
         if (error) throw error;
         const requestId = (inserted as { id: string }).id;
         const toInsert = toInsertItems(requestId);
-        if (toInsert.length > 0) {
-          const { error: itemsErr } = await dataLayerClient.from("transport_request_items").insert(toInsert);
-          if (itemsErr) throw itemsErr;
-        }
+        const { error: itemsErr } = await dataLayerClient.from("transport_request_items").insert(toInsert);
+        if (itemsErr) throw itemsErr;
         try {
           const { error: pushError } = await dataLayerClient.functions.invoke("push", {
             body: {
@@ -250,11 +231,9 @@ export function TransportRequestDialog({
               description: values.description || undefined,
             },
           });
-          if (pushError) {
-            console.error("Failed to invoke push notification for transport request", pushError);
-          }
+          if (pushError) throw pushError;
         } catch (pushError) {
-          console.error("Unexpected error invoking push notification for transport request", pushError);
+          console.error("Failed to invoke transport request push", pushError);
         }
       }
 
@@ -293,7 +272,7 @@ export function TransportRequestDialog({
               </div>
               {request.needed_date && (
                 <div className="text-xs text-muted-foreground">
-                  Fecha necesaria: {formatNeededDate(request.needed_date)}
+                  Fecha necesaria: {request.needed_date.split("-").reverse().join("/")}
                 </div>
               )}
               {request.note && <div className="text-xs text-muted-foreground italic">{request.note}</div>}
@@ -332,15 +311,14 @@ export function TransportRequestDialog({
       <div className="space-y-2">
         <Label>Vehículos</Label>
         <div className="space-y-2">
-          {itemFields.map((field, idx) => {
-            const item = items[idx] ?? { transport_type: "trailer", leftover_space_meters: "" };
+          {items.map((item, idx) => {
             return (
-              <div key={field.id} className="space-y-1">
+              <div key={idx} className="space-y-1">
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                   <Select
                     value={item.transport_type}
                     onValueChange={(val) => {
-                      setValue(`items.${idx}.transport_type`, val, { shouldValidate: true });
+                      setValue(`items.${idx}.transport_type`, val);
                     }}
                   >
                     <SelectTrigger className="w-full sm:w-40">
@@ -365,28 +343,20 @@ export function TransportRequestDialog({
                       const val = e.target.value;
                       const parsed = Number(val);
                       const nextValue = val === "" || !Number.isFinite(parsed) ? "" : Math.max(0, parsed);
-                      setValue(`items.${idx}.leftover_space_meters`, nextValue, { shouldValidate: true });
+                      setValue(`items.${idx}.leftover_space_meters`, nextValue);
                     }}
                   />
                   <Button
                     type="button"
                     variant="outline"
                     onClick={() => {
-                      if (itemFields.length === 1) {
-                        replaceItems(emptyItems());
-                      } else {
-                        removeItem(idx);
-                      }
+                      const nextItems = items.filter((_, itemIndex) => itemIndex !== idx);
+                      setValue("items", nextItems.length ? nextItems : emptyItems());
                     }}
                   >
                     Eliminar
                   </Button>
                 </div>
-                {errors.items?.[idx]?.leftover_space_meters?.message && (
-                  <p className="text-xs text-destructive">
-                    {errors.items[idx]?.leftover_space_meters?.message}
-                  </p>
-                )}
               </div>
             );
           })}
@@ -394,7 +364,7 @@ export function TransportRequestDialog({
             <Button
               type="button"
               variant="secondary"
-              onClick={() => appendItem({ transport_type: "trailer", leftover_space_meters: "" })}
+              onClick={() => setValue("items", [...items, ...emptyItems()])}
             >
               Añadir vehículo
             </Button>

--- a/src/components/logistics/TransportRequestDialog.tsx
+++ b/src/components/logistics/TransportRequestDialog.tsx
@@ -40,8 +40,14 @@ interface ActiveRequest {
   created_by: string | null;
   created_at: string;
   is_hoja_relevant: boolean;
+  needed_date: string | null;
   items: { id: string; transport_type: string; leftover_space_meters: number | null }[];
 }
+
+const formatNeededDate = (isoDate: string) => {
+  const [year, month, day] = isoDate.split("-");
+  return `${day}/${month}/${year}`;
+};
 
 const emptyItems = (): VehicleItem[] => [{ transport_type: "trailer", leftover_space_meters: "" }];
 
@@ -58,6 +64,7 @@ export function TransportRequestDialog({
   const [note, setNote] = useState("");
   const [description, setDescription] = useState("");
   const [isHojaRelevant, setIsHojaRelevant] = useState(true);
+  const [neededDate, setNeededDate] = useState("");
   const { toast } = useToast();
   const { user } = useOptimizedAuth();
   const queryClient = useQueryClient();
@@ -69,7 +76,7 @@ export function TransportRequestDialog({
       const { data, error } = await dataLayerClient
         .from("transport_requests")
         .select(
-          "id, status, note, description, created_by, created_at, is_hoja_relevant, items:transport_request_items(id, transport_type, leftover_space_meters)"
+          "id, status, note, description, created_by, created_at, is_hoja_relevant, needed_date, items:transport_request_items(id, transport_type, leftover_space_meters)"
         )
         .eq("job_id", jobId)
         .eq("department", department)
@@ -102,6 +109,7 @@ export function TransportRequestDialog({
     setNote("");
     setDescription("");
     setIsHojaRelevant(true);
+    setNeededDate("");
     setView("form");
   };
 
@@ -110,6 +118,7 @@ export function TransportRequestDialog({
     setNote(request.note || "");
     setDescription(request.description || "");
     setIsHojaRelevant(request.is_hoja_relevant ?? true);
+    setNeededDate(request.needed_date || "");
     setItems(
       request.items.length > 0
         ? request.items.map((it) => ({
@@ -170,6 +179,7 @@ export function TransportRequestDialog({
             note: note || null,
             description: description || null,
             is_hoja_relevant: isHojaRelevant,
+            needed_date: neededDate || null,
           } as never)
           .eq("id", editingRequestId);
         if (error) throw error;
@@ -196,6 +206,7 @@ export function TransportRequestDialog({
             status: "requested",
             created_by: authUser.id,
             is_hoja_relevant: isHojaRelevant,
+            needed_date: neededDate || null,
           } as never)
           .select("id")
           .single();
@@ -258,6 +269,11 @@ export function TransportRequestDialog({
                   )
                   .join(", ") || "Sin vehículos"}
               </div>
+              {request.needed_date && (
+                <div className="text-xs text-muted-foreground">
+                  Fecha necesaria: {formatNeededDate(request.needed_date)}
+                </div>
+              )}
               {request.note && <div className="text-xs text-muted-foreground italic">{request.note}</div>}
             </div>
             {request.is_hoja_relevant === false && (
@@ -352,6 +368,17 @@ export function TransportRequestDialog({
             </Button>
           </div>
         </div>
+      </div>
+      <div className="space-y-2">
+        <Label>Fecha necesaria</Label>
+        <Input
+          type="date"
+          value={neededDate}
+          onChange={(e) => setNeededDate(e.target.value)}
+        />
+        <p className="text-xs text-muted-foreground">
+          Día en que se necesita el transporte (opcional). Se usará como fecha inicial del evento de logística.
+        </p>
       </div>
       <div className="space-y-2">
         <Label>Nota</Label>

--- a/src/components/logistics/TransportRequestsManagerDialog.tsx
+++ b/src/components/logistics/TransportRequestsManagerDialog.tsx
@@ -35,7 +35,7 @@ export function TransportRequestsManagerDialog({
     if (error) {
       toast({
         title: "No se pudo cancelar",
-        description: error || "Error cancelando la solicitud de transporte",
+        description: error,
         variant: "destructive",
       });
     }
@@ -87,6 +87,11 @@ export function TransportRequestsManagerDialog({
                         )}
                       </div>
                       {req.description && <div className="text-sm">{req.description}</div>}
+                      {req.needed_date && (
+                        <div className="text-xs text-muted-foreground">
+                          Fecha necesaria: {req.needed_date.split("-").reverse().join("/")}
+                        </div>
+                      )}
                       {req.note && <div className="text-xs text-muted-foreground italic">{req.note}</div>}
                     </div>
                     <button

--- a/src/components/logistics/TransportRequestsManagerDialog.tsx
+++ b/src/components/logistics/TransportRequestsManagerDialog.tsx
@@ -1,0 +1,114 @@
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import type { TransportRequestSummary } from "@/hooks/useJobTransportRequests";
+
+type RequestItem = TransportRequestSummary["items"][number];
+
+interface TransportRequestsManagerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  requests: TransportRequestSummary[];
+  // request is null when creating an event with no originating request
+  onCreateEvent: (request: TransportRequestSummary | null, item?: RequestItem) => void;
+  onCancelRequest: (requestId: string) => Promise<{ error: string | null }>;
+}
+
+/**
+ * Logistics/management view of a job's pending transport requests: cancel
+ * them or turn each requested vehicle into a logistics event.
+ */
+export function TransportRequestsManagerDialog({
+  open,
+  onOpenChange,
+  requests,
+  onCreateEvent,
+  onCancelRequest,
+}: TransportRequestsManagerDialogProps) {
+  const { toast } = useToast();
+
+  const handleCancelRequest = async (requestId: string) => {
+    const { error } = await onCancelRequest(requestId);
+    if (error) {
+      toast({
+        title: "No se pudo cancelar",
+        description: error || "Error cancelando la solicitud de transporte",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <div className="space-y-4">
+          <div className="text-lg font-semibold">Solicitudes de transporte</div>
+          {requests.length === 0 ? (
+            <div className="space-y-3">
+              <div className="text-muted-foreground">No hay solicitudes pendientes para este trabajo.</div>
+              <button
+                className="px-3 py-1 text-sm rounded border hover:bg-accent w-fit"
+                onClick={(ev) => {
+                  ev.stopPropagation();
+                  onCreateEvent(null);
+                }}
+              >
+                Crear evento
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {requests.map((req) => (
+                <div key={req.id} className="border rounded p-2 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <div className="font-medium capitalize">{req.department}</div>
+                        {req.is_hoja_relevant === false && (
+                          <span className="text-xs rounded border px-1.5 py-0.5 text-muted-foreground">
+                            Fuera de Hoja de Ruta
+                          </span>
+                        )}
+                      </div>
+                      {req.description && <div className="text-sm">{req.description}</div>}
+                      {req.note && <div className="text-xs text-muted-foreground italic">{req.note}</div>}
+                    </div>
+                    <button
+                      className="px-3 py-1 text-sm rounded border hover:bg-accent"
+                      onClick={(ev) => {
+                        ev.stopPropagation();
+                        void handleCancelRequest(req.id);
+                      }}
+                    >
+                      Cancelar solicitud
+                    </button>
+                  </div>
+                  <div className="space-y-1">
+                    {(req.items || []).map((it) => (
+                      <div key={it.id} className="flex items-center justify-between pl-2">
+                        <div className="text-sm text-muted-foreground">
+                          {it.transport_type.replace("_", " ")}
+                          {typeof it.leftover_space_meters === "number" && (
+                            <span className="ml-2">· Espacio libre: {it.leftover_space_meters} m</span>
+                          )}
+                        </div>
+                        <button
+                          className="px-3 py-1 text-sm rounded border hover:bg-accent"
+                          onClick={(ev) => {
+                            ev.stopPropagation();
+                            onCreateEvent(req, it);
+                          }}
+                        >
+                          Crear evento
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/logistics/TransportRequestsManagerDialog.tsx
+++ b/src/components/logistics/TransportRequestsManagerDialog.tsx
@@ -1,4 +1,5 @@
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import type { TransportRequestSummary } from "@/hooks/useJobTransportRequests";
 
@@ -43,32 +44,38 @@ export function TransportRequestsManagerDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl">
+      <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-xl overflow-y-auto sm:max-h-[85vh]">
         <div className="space-y-4">
           <div className="text-lg font-semibold">Solicitudes de transporte</div>
           {requests.length === 0 ? (
             <div className="space-y-3">
               <div className="text-muted-foreground">No hay solicitudes pendientes para este trabajo.</div>
-              <div className="flex gap-2">
-                <button
-                  className="px-3 py-1 text-sm rounded border hover:bg-accent w-fit"
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="w-fit"
                   onClick={(ev) => {
                     ev.stopPropagation();
                     onCreateEvent(null);
                   }}
                 >
                   Crear evento
-                </button>
+                </Button>
                 {onRequestTransport && (
-                  <button
-                    className="px-3 py-1 text-sm rounded border hover:bg-accent w-fit"
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="w-fit"
                     onClick={(ev) => {
                       ev.stopPropagation();
                       onRequestTransport();
                     }}
                   >
                     Solicitar transporte
-                  </button>
+                  </Button>
                 )}
               </div>
             </div>
@@ -76,8 +83,8 @@ export function TransportRequestsManagerDialog({
             <div className="space-y-2">
               {requests.map((req) => (
                 <div key={req.id} className="border rounded p-2 space-y-2">
-                  <div className="flex items-center justify-between">
-                    <div>
+                  <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <div className="font-medium capitalize">{req.department}</div>
                         {req.is_hoja_relevant === false && (
@@ -94,34 +101,41 @@ export function TransportRequestsManagerDialog({
                       )}
                       {req.note && <div className="text-xs text-muted-foreground italic">{req.note}</div>}
                     </div>
-                    <button
-                      className="px-3 py-1 text-sm rounded border hover:bg-accent"
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
                       onClick={(ev) => {
                         ev.stopPropagation();
                         void handleCancelRequest(req.id);
                       }}
                     >
                       Cancelar solicitud
-                    </button>
+                    </Button>
                   </div>
                   <div className="space-y-1">
                     {(req.items || []).map((it) => (
-                      <div key={it.id} className="flex items-center justify-between pl-2">
+                      <div
+                        key={it.id}
+                        className="flex flex-col items-start gap-2 pl-2 sm:flex-row sm:items-center sm:justify-between"
+                      >
                         <div className="text-sm text-muted-foreground">
                           {it.transport_type.replace("_", " ")}
                           {typeof it.leftover_space_meters === "number" && (
                             <span className="ml-2">· Espacio libre: {it.leftover_space_meters} m</span>
                           )}
                         </div>
-                        <button
-                          className="px-3 py-1 text-sm rounded border hover:bg-accent"
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
                           onClick={(ev) => {
                             ev.stopPropagation();
                             onCreateEvent(req, it);
                           }}
                         >
                           Crear evento
-                        </button>
+                        </Button>
                       </div>
                     ))}
                   </div>
@@ -129,15 +143,17 @@ export function TransportRequestsManagerDialog({
               ))}
               {onRequestTransport && (
                 <div className="flex justify-end pt-1">
-                  <button
-                    className="px-3 py-1 text-sm rounded border hover:bg-accent"
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
                     onClick={(ev) => {
                       ev.stopPropagation();
                       onRequestTransport();
                     }}
                   >
                     Solicitar transporte
-                  </button>
+                  </Button>
                 </div>
               )}
             </div>

--- a/src/components/logistics/TransportRequestsManagerDialog.tsx
+++ b/src/components/logistics/TransportRequestsManagerDialog.tsx
@@ -11,6 +11,9 @@ interface TransportRequestsManagerDialogProps {
   // request is null when creating an event with no originating request
   onCreateEvent: (request: TransportRequestSummary | null, item?: RequestItem) => void;
   onCancelRequest: (requestId: string) => Promise<{ error: string | null }>;
+  // Present when the manager also belongs to a tech department and can file
+  // transport requests of their own
+  onRequestTransport?: () => void;
 }
 
 /**
@@ -23,6 +26,7 @@ export function TransportRequestsManagerDialog({
   requests,
   onCreateEvent,
   onCancelRequest,
+  onRequestTransport,
 }: TransportRequestsManagerDialogProps) {
   const { toast } = useToast();
 
@@ -45,15 +49,28 @@ export function TransportRequestsManagerDialog({
           {requests.length === 0 ? (
             <div className="space-y-3">
               <div className="text-muted-foreground">No hay solicitudes pendientes para este trabajo.</div>
-              <button
-                className="px-3 py-1 text-sm rounded border hover:bg-accent w-fit"
-                onClick={(ev) => {
-                  ev.stopPropagation();
-                  onCreateEvent(null);
-                }}
-              >
-                Crear evento
-              </button>
+              <div className="flex gap-2">
+                <button
+                  className="px-3 py-1 text-sm rounded border hover:bg-accent w-fit"
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    onCreateEvent(null);
+                  }}
+                >
+                  Crear evento
+                </button>
+                {onRequestTransport && (
+                  <button
+                    className="px-3 py-1 text-sm rounded border hover:bg-accent w-fit"
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      onRequestTransport();
+                    }}
+                  >
+                    Solicitar transporte
+                  </button>
+                )}
+              </div>
             </div>
           ) : (
             <div className="space-y-2">
@@ -105,6 +122,19 @@ export function TransportRequestsManagerDialog({
                   </div>
                 </div>
               ))}
+              {onRequestTransport && (
+                <div className="flex justify-end pt-1">
+                  <button
+                    className="px-3 py-1 text-sm rounded border hover:bg-accent"
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      onRequestTransport();
+                    }}
+                  >
+                    Solicitar transporte
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/constants/logisticsHojaCategories.ts
+++ b/src/constants/logisticsHojaCategories.ts
@@ -20,6 +20,13 @@ export const LOGISTICS_HOJA_CATEGORY_LABELS: Record<LogisticsHojaCategory, strin
   rigging_motores: "Rigging (Motores)",
 };
 
+export const normalizeLogisticsHojaCategories = (categories: unknown): LogisticsHojaCategory[] => {
+  if (!Array.isArray(categories)) return [];
+  return categories.filter((category): category is LogisticsHojaCategory =>
+    LOGISTICS_HOJA_CATEGORY_OPTIONS.includes(category as LogisticsHojaCategory)
+  );
+};
+
 export const formatLogisticsHojaCategories = (categories?: string[] | null): string =>
   (categories || [])
     .map((category) =>

--- a/src/hooks/useJobTransportRequests.ts
+++ b/src/hooks/useJobTransportRequests.ts
@@ -1,0 +1,101 @@
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { dataLayerClient } from '@/services/dataLayerClient';
+import { queryKeys } from '@/lib/react-query';
+
+export type TransportRequestSummary = {
+  id: string;
+  department?: string;
+  status: string;
+  note: string | null;
+  description: string | null;
+  created_by?: string | null;
+  created_at: string;
+  is_hoja_relevant: boolean;
+  items: { id: string; transport_type: string; leftover_space_meters: number | null }[];
+};
+
+const REQUEST_SELECT =
+  'id, department, status, note, description, created_by, created_at, is_hoja_relevant, items:transport_request_items(id, transport_type, leftover_space_meters)';
+
+const TECH_DEPARTMENTS = ['sound', 'lights', 'video'];
+
+/**
+ * Active transport requests for a job. A department can have several
+ * concurrent requests per job, so consumers always receive lists.
+ */
+export function useJobTransportRequests(
+  jobId: string | undefined,
+  currentUserDepartment: string | null,
+  canManageTransportRequests: boolean,
+) {
+  const queryClient = useQueryClient();
+
+  const { data: myTransportRequests = [] } = useQuery({
+    queryKey: queryKeys.scope('transport-request', jobId, currentUserDepartment),
+    queryFn: async () => {
+      if (!currentUserDepartment || !TECH_DEPARTMENTS.includes(currentUserDepartment)) return [];
+      const { data, error } = await dataLayerClient.from('transport_requests')
+        .select(REQUEST_SELECT)
+        .eq('job_id', jobId!)
+        .eq('department', currentUserDepartment)
+        .eq('status', 'requested')
+        .order('created_at', { ascending: true });
+      if (error) return [];
+      return (data || []) as unknown as TransportRequestSummary[];
+    },
+    enabled: !!jobId && !!currentUserDepartment,
+  });
+
+  const { data: allRequests = [], isLoading: isAllRequestsLoading } = useQuery({
+    queryKey: queryKeys.scope('transport-requests-all', jobId),
+    queryFn: async () => {
+      const { data, error } = await dataLayerClient.from('transport_requests')
+        .select(REQUEST_SELECT)
+        .eq('job_id', jobId!)
+        .eq('status', 'requested')
+        .order('created_at', { ascending: false });
+      if (error) return [];
+      return (data || []) as unknown as TransportRequestSummary[];
+    },
+    enabled: !!jobId && canManageTransportRequests,
+  });
+
+  // Auto-fulfill a request once it has both a load and an unload event linked
+  // to it (logistics_events.transport_request_id), so fulfilling one request
+  // never closes another request from the same department by accident.
+  const checkAndFulfillRequest = useCallback(
+    async (requestId: string, departmentForReq: string) => {
+      try {
+        const { data: events } = await dataLayerClient.from('logistics_events')
+          .select('id, event_type')
+          .eq('transport_request_id' as never, requestId);
+        const logisticsEvents = (events || []) as { id: string; event_type: string }[];
+        const hasLoad = logisticsEvents.some((e) => e.event_type === 'load');
+        const hasUnload = logisticsEvents.some((e) => e.event_type === 'unload');
+        if (hasLoad && hasUnload) {
+          await dataLayerClient.from('transport_requests').update({ status: 'fulfilled' }).eq('id', requestId);
+          queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-request', jobId, departmentForReq) });
+          queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-requests-all', jobId) });
+        }
+      } catch (err) {
+        console.error('checkAndFulfillRequest failed', err);
+      }
+    },
+    [jobId, queryClient],
+  );
+
+  const cancelRequest = useCallback(
+    async (requestId: string): Promise<{ error: string | null }> => {
+      const { error } = await dataLayerClient.from('transport_requests')
+        .update({ status: 'cancelled' })
+        .eq('id', requestId);
+      if (error) return { error: error.message };
+      queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-requests-all', jobId) });
+      return { error: null };
+    },
+    [jobId, queryClient],
+  );
+
+  return { myTransportRequests, allRequests, isAllRequestsLoading, checkAndFulfillRequest, cancelRequest };
+}

--- a/src/hooks/useJobTransportRequests.ts
+++ b/src/hooks/useJobTransportRequests.ts
@@ -32,7 +32,12 @@ export function useJobTransportRequests(
 ) {
   const queryClient = useQueryClient();
 
-  const { data: myTransportRequests = [] } = useQuery({
+  const {
+    data: myTransportRequests = [],
+    isLoading: isMyTransportRequestsLoading,
+    isError: isMyTransportRequestsError,
+    refetch: refetchMyTransportRequests,
+  } = useQuery({
     queryKey: queryKeys.scope('transport-request', jobId, currentUserDepartment),
     queryFn: async () => {
       if (!currentUserDepartment || !TECH_DEPARTMENTS.includes(currentUserDepartment)) return [];
@@ -42,7 +47,10 @@ export function useJobTransportRequests(
         .eq('department', currentUserDepartment)
         .eq('status', 'requested')
         .order('created_at', { ascending: true });
-      if (error) return [];
+      if (error) {
+        console.error('Failed to fetch department transport requests', error);
+        throw error;
+      }
       return (data || []) as unknown as TransportRequestSummary[];
     },
     enabled: !!jobId && !!currentUserDepartment,
@@ -56,7 +64,10 @@ export function useJobTransportRequests(
         .eq('job_id', jobId!)
         .eq('status', 'requested')
         .order('created_at', { ascending: false });
-      if (error) return [];
+      if (error) {
+        console.error('Failed to fetch job transport requests', error);
+        throw error;
+      }
       return (data || []) as unknown as TransportRequestSummary[];
     },
     enabled: !!jobId && canManageTransportRequests,
@@ -86,17 +97,32 @@ export function useJobTransportRequests(
     [jobId, queryClient],
   );
 
+  const invalidateRequests = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-request', jobId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-requests-all', jobId) });
+  }, [jobId, queryClient]);
+
   const cancelRequest = useCallback(
     async (requestId: string): Promise<{ error: string | null }> => {
       const { error } = await dataLayerClient.from('transport_requests')
         .update({ status: 'cancelled' })
         .eq('id', requestId);
       if (error) return { error: error.message };
-      queryClient.invalidateQueries({ queryKey: queryKeys.scope('transport-requests-all', jobId) });
+      invalidateRequests();
       return { error: null };
     },
-    [jobId, queryClient],
+    [invalidateRequests],
   );
 
-  return { myTransportRequests, allRequests, isAllRequestsLoading, checkAndFulfillRequest, cancelRequest };
+  return {
+    myTransportRequests,
+    isMyTransportRequestsLoading,
+    isMyTransportRequestsError,
+    refetchMyTransportRequests,
+    allRequests,
+    isAllRequestsLoading,
+    checkAndFulfillRequest,
+    cancelRequest,
+    invalidateRequests,
+  };
 }

--- a/src/hooks/useJobTransportRequests.ts
+++ b/src/hooks/useJobTransportRequests.ts
@@ -12,11 +12,12 @@ export type TransportRequestSummary = {
   created_by?: string | null;
   created_at: string;
   is_hoja_relevant: boolean;
+  needed_date: string | null;
   items: { id: string; transport_type: string; leftover_space_meters: number | null }[];
 };
 
 const REQUEST_SELECT =
-  'id, department, status, note, description, created_by, created_at, is_hoja_relevant, items:transport_request_items(id, transport_type, leftover_space_meters)';
+  'id, department, status, note, description, created_by, created_at, is_hoja_relevant, needed_date, items:transport_request_items(id, transport_type, leftover_space_meters)';
 
 const TECH_DEPARTMENTS = ['sound', 'lights', 'video'];
 

--- a/supabase/functions/create-transport-request/index.ts
+++ b/supabase/functions/create-transport-request/index.ts
@@ -23,7 +23,10 @@ interface CreateTransportRequestBody extends Record<string, unknown> {
   items?: unknown;
   requested_by?: unknown;
   is_hoja_relevant?: unknown;
+  needed_date?: unknown;
 }
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 type TransportRequestItem = {
   leftover_space_meters: number | null;
@@ -130,6 +133,17 @@ serve(createHttpHandler(async (req) => {
     ? true
     : body.is_hoja_relevant;
 
+  let neededDate: string | null = null;
+  if (body.needed_date !== undefined && body.needed_date !== null && body.needed_date !== "") {
+    if (typeof body.needed_date !== "string" || !ISO_DATE_PATTERN.test(body.needed_date)
+      || Number.isNaN(Date.parse(body.needed_date))) {
+      throw new HttpError(400, "El campo needed_date debe ser una fecha con formato YYYY-MM-DD", {
+        code: "invalid_needed_date",
+      });
+    }
+    neededDate = body.needed_date;
+  }
+
   // The anon API key plus the caller JWT keeps these data operations entirely
   // inside PostgREST's authenticated RLS boundary.
   const callerClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
@@ -226,6 +240,7 @@ serve(createHttpHandler(async (req) => {
       description: description || null,
       is_hoja_relevant: isHojaRelevant,
       job_id: jobId,
+      needed_date: neededDate,
       note: note || null,
       status: "requested",
       subrental_id: subrentalId,

--- a/supabase/functions/create-transport-request/index.ts
+++ b/supabase/functions/create-transport-request/index.ts
@@ -22,6 +22,7 @@ interface CreateTransportRequestBody extends Record<string, unknown> {
   note?: unknown;
   items?: unknown;
   requested_by?: unknown;
+  is_hoja_relevant?: unknown;
 }
 
 type TransportRequestItem = {
@@ -122,6 +123,13 @@ serve(createHttpHandler(async (req) => {
   const noteInput = readOptionalText(body.note, "note", 4_000);
   const items = parseItems(body.items);
 
+  if (body.is_hoja_relevant !== undefined && body.is_hoja_relevant !== null && typeof body.is_hoja_relevant !== "boolean") {
+    throw new HttpError(400, "El campo is_hoja_relevant debe ser booleano", { code: "invalid_is_hoja_relevant" });
+  }
+  const isHojaRelevant = body.is_hoja_relevant === undefined || body.is_hoja_relevant === null
+    ? true
+    : body.is_hoja_relevant;
+
   // The anon API key plus the caller JWT keeps these data operations entirely
   // inside PostgREST's authenticated RLS boundary.
   const callerClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
@@ -216,6 +224,7 @@ serve(createHttpHandler(async (req) => {
       created_by: user.id,
       department,
       description: description || null,
+      is_hoja_relevant: isHojaRelevant,
       job_id: jobId,
       note: note || null,
       status: "requested",

--- a/supabase/migrations/20260713201500_transport_request_hoja_relevance_and_event_link.sql
+++ b/supabase/migrations/20260713201500_transport_request_hoja_relevance_and_event_link.sql
@@ -10,24 +10,8 @@ alter table public.transport_requests
 comment on column public.transport_requests.is_hoja_relevant is
   'Requester intent: when false, logistics events created from this request default to being excluded from the hoja de ruta.';
 
--- Scope the event link so a logistics event can only reference a request from
--- its own job (mirrors transport_requests_subrental_scope_fkey).
-alter table public.transport_requests
-  add constraint transport_requests_id_job_key
-  unique (id, job_id);
-
 alter table public.logistics_events
   add column transport_request_id uuid;
 
 comment on column public.logistics_events.transport_request_id is
   'Transport request this event fulfils. Both a load and an unload event linked to a request mark it fulfilled.';
-
-alter table public.logistics_events
-  add constraint logistics_events_transport_request_scope_fkey
-  foreign key (transport_request_id, job_id)
-  references public.transport_requests (id, job_id)
-  on delete set null (transport_request_id);
-
-create index idx_logistics_events_transport_request_id
-  on public.logistics_events (transport_request_id)
-  where transport_request_id is not null;

--- a/supabase/migrations/20260713201500_transport_request_hoja_relevance_and_event_link.sql
+++ b/supabase/migrations/20260713201500_transport_request_hoja_relevance_and_event_link.sql
@@ -1,0 +1,33 @@
+-- Departments can file several concurrent transport requests per job, so
+-- fulfillment can no longer be inferred from department-wide load/unload
+-- pairs: each logistics event now records which request it fulfils. Requests
+-- also carry the requester's hoja de ruta intent so job-related transports
+-- (e.g. subrental returns) can stay off the route sheet from the start.
+
+alter table public.transport_requests
+  add column is_hoja_relevant boolean not null default true;
+
+comment on column public.transport_requests.is_hoja_relevant is
+  'Requester intent: when false, logistics events created from this request default to being excluded from the hoja de ruta.';
+
+-- Scope the event link so a logistics event can only reference a request from
+-- its own job (mirrors transport_requests_subrental_scope_fkey).
+alter table public.transport_requests
+  add constraint transport_requests_id_job_key
+  unique (id, job_id);
+
+alter table public.logistics_events
+  add column transport_request_id uuid;
+
+comment on column public.logistics_events.transport_request_id is
+  'Transport request this event fulfils. Both a load and an unload event linked to a request mark it fulfilled.';
+
+alter table public.logistics_events
+  add constraint logistics_events_transport_request_scope_fkey
+  foreign key (transport_request_id, job_id)
+  references public.transport_requests (id, job_id)
+  on delete set null (transport_request_id);
+
+create index idx_logistics_events_transport_request_id
+  on public.logistics_events (transport_request_id)
+  where transport_request_id is not null;

--- a/supabase/migrations/20260713201501_transport_request_scope_unique_index.sql
+++ b/supabase/migrations/20260713201501_transport_request_scope_unique_index.sql
@@ -1,0 +1,4 @@
+-- Kept as a standalone migration because PostgreSQL does not allow
+-- CREATE INDEX CONCURRENTLY inside a transaction block.
+create unique index concurrently transport_requests_id_job_key_idx
+  on public.transport_requests (id, job_id);

--- a/supabase/migrations/20260713201502_transport_request_event_lookup_index.sql
+++ b/supabase/migrations/20260713201502_transport_request_event_lookup_index.sql
@@ -1,0 +1,5 @@
+-- Kept as a standalone migration because PostgreSQL does not allow
+-- CREATE INDEX CONCURRENTLY inside a transaction block.
+create index concurrently idx_logistics_events_transport_request_id
+  on public.logistics_events (transport_request_id)
+  where transport_request_id is not null;

--- a/supabase/migrations/20260713201503_transport_request_event_constraints.sql
+++ b/supabase/migrations/20260713201503_transport_request_event_constraints.sql
@@ -1,0 +1,12 @@
+-- Attach the prebuilt unique index with only a short metadata lock, then add
+-- the job-scoped FK without scanning logistics_events while writes are held.
+alter table public.transport_requests
+  add constraint transport_requests_id_job_key
+  unique using index transport_requests_id_job_key_idx;
+
+alter table public.logistics_events
+  add constraint logistics_events_transport_request_scope_fkey
+  foreign key (transport_request_id, job_id)
+  references public.transport_requests (id, job_id)
+  on delete set null (transport_request_id)
+  not valid;

--- a/supabase/migrations/20260713201504_validate_transport_request_event_scope.sql
+++ b/supabase/migrations/20260713201504_validate_transport_request_event_scope.sql
@@ -1,0 +1,4 @@
+-- Validation uses a lighter lock than adding an immediately-valid FK and does
+-- not block normal inserts, updates, or deletes on logistics_events.
+alter table public.logistics_events
+  validate constraint logistics_events_transport_request_scope_fkey;

--- a/supabase/migrations/20260713210000_transport_request_needed_date_and_link_backfill.sql
+++ b/supabase/migrations/20260713210000_transport_request_needed_date_and_link_backfill.sql
@@ -1,0 +1,40 @@
+-- Requests can state when the transport is needed, so logistics no longer has
+-- to infer the date from the job or chase the requester.
+
+alter table public.transport_requests
+  add column needed_date date;
+
+comment on column public.transport_requests.needed_date is
+  'Date the requester needs the transport on. Pre-fills the logistics event date when the request is scheduled.';
+
+-- Backfill the request link for events created before
+-- logistics_events.transport_request_id existed, so in-flight requests can
+-- still auto-fulfil once their counterpart event is created. Only unambiguous
+-- cases are linked: single-department events whose job+department has exactly
+-- one active request (the pre-link UI enforced one request per department, so
+-- this covers every legacy in-flight request).
+update public.logistics_events le
+set transport_request_id = tr.id
+from public.transport_requests tr
+where le.transport_request_id is null
+  and tr.status = 'requested'
+  and le.job_id = tr.job_id
+  and exists (
+    select 1
+    from public.logistics_event_departments led
+    where led.event_id = le.id
+      and led.department = tr.department
+  )
+  and (
+    select count(*)
+    from public.logistics_event_departments led2
+    where led2.event_id = le.id
+  ) = 1
+  and not exists (
+    select 1
+    from public.transport_requests tr2
+    where tr2.job_id = tr.job_id
+      and tr2.department = tr.department
+      and tr2.status = 'requested'
+      and tr2.id <> tr.id
+  );

--- a/supabase/tests/database/transport_requests_integrity.sql
+++ b/supabase/tests/database/transport_requests_integrity.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(6);
+SELECT plan(7);
 
 SELECT ok(
   EXISTS (
@@ -54,6 +54,18 @@ SELECT ok(
       AND column_default = 'true'
   ),
   'transport requests carry a non-null hoja de ruta relevance flag defaulting to true'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'transport_requests'
+      AND column_name = 'needed_date'
+      AND data_type = 'date'
+  ),
+  'transport requests can state the date the transport is needed on'
 );
 
 SELECT ok(

--- a/supabase/tests/database/transport_requests_integrity.sql
+++ b/supabase/tests/database/transport_requests_integrity.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(3);
+SELECT plan(6);
 
 SELECT ok(
   EXISTS (
@@ -41,6 +41,43 @@ SELECT ok(
       AND indexdef ILIKE '%status <> ''cancelled''%'
   ),
   'only one active transport request can represent a sub-rental'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'transport_requests'
+      AND column_name = 'is_hoja_relevant'
+      AND is_nullable = 'NO'
+      AND column_default = 'true'
+  ),
+  'transport requests carry a non-null hoja de ruta relevance flag defaulting to true'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'logistics_events'
+      AND constraint_name = 'logistics_events_transport_request_scope_fkey'
+      AND constraint_type = 'FOREIGN KEY'
+  ),
+  'logistics events can only reference a transport request from the same job'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'logistics_events'
+      AND indexname = 'idx_logistics_events_transport_request_id'
+      AND indexdef ILIKE '%(transport_request_id)%'
+  ),
+  'transport request fulfillment lookups on logistics events are indexed'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
Fixes three operational holes in the transport request system:

- Departments can now file several concurrent transport requests per job.
  The tech dialog lists the department's active requests with edit/cancel
  per request plus a "Nueva solicitud" action, instead of always editing
  the latest request regardless of its status (which also silently
  resurrected cancelled/fulfilled requests by forcing status back to
  'requested' on every edit).
- Requests carry the requester's hoja de ruta intent: a new
  transport_requests.is_hoja_relevant flag (default true) lets techs flag
  job-related transports (subrental pickups/returns, etc.) that must stay
  off the route sheet. The flag pre-sets is_hoja_relevant when logistics
  creates the event, so the existing hoja import filter excludes them.
- Fulfillment is now tracked per request: logistics_events gains a
  job-scoped transport_request_id FK (mirrors the subrental scope FK), and
  a request is auto-fulfilled only when both a load and an unload event
  linked to *that* request exist — previously any department-wide
  load+unload pair marked whichever request was passed as fulfilled.

Supporting changes:

- Extract useJobTransportRequests hook (queries, per-request fulfillment,
  cancel) and TransportRequestsManagerDialog out of the oversized job card
  files; drop dead handleCancelTransportRequest.
- create-transport-request edge function accepts optional is_hoja_relevant.
- Spanish UI strings for the transport request dialogs and job card
  transport button labels.
- pgTAP coverage for the new column, scoped FK, and index.

Note: src/integrations/supabase/types.ts is intentionally untouched
(auto-generated); new columns are accessed via narrow casts until types
are regenerated after the migration is applied.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ea7qxPZZGVN89CHQH4Usbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage multiple active transport requests per job from a dedicated manager dialog.
  * Create/edit/cancel transport requests with vehicle details, notes, needed date, and Hoja de Ruta relevance.
  * Create logistics events directly from an individual transport request, linking the resulting load/unload to it.

* **Improvements**
  * Logistics events now prefill and persist transport-request linkage during creation.
  * When editing an event and switching jobs, transport-request linkage is cleared to prevent mismatches.
  * Transport request status and labels are updated to reflect fulfillment from linked events.

* **Bug Fixes**
  * Hoja de Ruta relevance now defaults consistently when omitted.

* **Tests / Chores**
  * Expanded database integrity tests and improved service worker injection/minification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->