### PR TITLE
fix: send production WhatsApp messages sequentially

### DIFF
--- a/supabase/functions/_shared/whatsappSendPolicy.test.ts
+++ b/supabase/functions/_shared/whatsappSendPolicy.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWhatsappSendConcurrency } from "./whatsappSendPolicy";
+
+describe("resolveWhatsappSendConcurrency", () => {
+  it("defaults bulk sends to one sequential worker", () => {
+    expect(resolveWhatsappSendConcurrency(undefined)).toBe(1);
+  });
+
+  it("honors an explicit bounded override", () => {
+    expect(resolveWhatsappSendConcurrency("3")).toBe(3);
+    expect(resolveWhatsappSendConcurrency("20")).toBe(4);
+  });
+
+  it("uses the sequential default for invalid values", () => {
+    expect(resolveWhatsappSendConcurrency("not-a-number")).toBe(1);
+  });
+});

--- a/supabase/functions/_shared/whatsappSendPolicy.ts
+++ b/supabase/functions/_shared/whatsappSendPolicy.ts
@@ -1,0 +1,13 @@
+const DEFAULT_SEND_CONCURRENCY = 1;
+const MAX_SEND_CONCURRENCY = 4;
+
+/** Resolve the number of concurrent WAHA sends for a bulk job message. */
+export function resolveWhatsappSendConcurrency(rawValue: string | null | undefined): number {
+  const normalized = rawValue?.trim();
+  if (!normalized) return DEFAULT_SEND_CONCURRENCY;
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) return DEFAULT_SEND_CONCURRENCY;
+
+  return Math.max(1, Math.min(MAX_SEND_CONCURRENCY, Math.trunc(parsed)));
+}

--- a/supabase/functions/send-job-whatsapp-message/index.ts
+++ b/supabase/functions/send-job-whatsapp-message/index.ts
@@ -16,6 +16,7 @@ import {
   signJobHojaLink,
 } from "../_shared/hojaLinkToken.ts";
 import { checkAndRecordWhatsappQuota } from "../_shared/whatsappQuota.ts";
+import { resolveWhatsappSendConcurrency } from "../_shared/whatsappSendPolicy.ts";
 
 /** Request payload for sending a WhatsApp message to multiple assigned users. */
 type SendRequest = {
@@ -366,7 +367,7 @@ serve(createHttpHandler(async (req: Request) => {
     // Concurrency note: Deno JS is single-threaded, so mutating `queue`/`sentCount` is safe
     // as long as we only do it between `await` points (which we do in this loop).
     const queue = [...sendTargets];
-    const concurrency = Math.max(1, Math.min(4, Number(Deno.env.get("WAHA_SEND_CONCURRENCY") || 4)));
+    const concurrency = resolveWhatsappSendConcurrency(Deno.env.get("WAHA_SEND_CONCURRENCY"));
 
     let attachmentSentCount = 0;
     let attachmentLinkFallbackCount = 0;


### PR DESCRIPTION
## Summary

- default production job WhatsApp bulk sends to one sequential WAHA worker instead of four concurrent workers
- keep the existing bounded `WAHA_SEND_CONCURRENCY` override while falling back to one for missing or invalid values
- add focused regression coverage for the send-concurrency policy
- apply `WAHA_SEND_CONCURRENCY=1` to the linked production Supabase project as an immediate, reversible mitigation

## Root cause

Individually triggered WAHA messages are reported to work normally, while the production citación bulk action was dispatching up to four recipients concurrently. The burst shape is the isolated behavioral difference this fix addresses. The message copy is intentionally unchanged so the next controlled production batch can validate the concurrency hypothesis.

## User impact

Bulk citación sends now run sequentially and may take longer to finish. Recipient selection, message content, attachments, authorization, quota behavior, and failure reporting are unchanged.

## Test evidence

- Negative control: `npx vitest run supabase/functions/_shared/whatsappSendPolicy.test.ts` failed against the previous four-worker default (2 failed, 1 passed).
- Focused regression after the fix: 3 passed.
- `npm run lint`: passed with existing repository warnings only.
- `npm run typecheck`: passed.
- `npm run governance`: passed all gates.
- `npm run test:critical`: passed.
- `npm run test:run`: 247 files and 1,334 tests passed.
- `npm run build`: passed.
- `npm run budget:bundle`: passed.
- `./scripts/check-staged-secrets.sh`: passed.

No database migration is included.

## Production mitigation

The linked project `syldobdcdsgfgjtbuwxm` was updated with `WAHA_SEND_CONCURRENCY=1` on 2026-07-14. The deployed function already reads this value per invocation, so the mitigation does not depend on merging this PR.

## Rollback

- Immediate production setting: set `WAHA_SEND_CONCURRENCY=4` on the linked project.
- Code: revert this PR/commit and redeploy the previous function version.
- No database rollback is required.

## Post-change verification

Send one controlled multi-recipient citación batch and confirm that delivery remains successful and WhatsApp does not show the bulk/bot warning. This external behavior cannot be reproduced by the local test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added concurrency controls for bulk WhatsApp message sending.
  * Send concurrency defaults to sequential processing and is safely limited to a maximum of four simultaneous sends.
  * Invalid or unsupported concurrency values now fall back to the default.

* **Tests**
  * Added coverage for default, bounded, capped, and invalid concurrency settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->