### PR TITLE
Fix tour power summaries to stay synced with package defaults

### DIFF
--- a/src/utils/__tests__/powerSummaryData.test.ts
+++ b/src/utils/__tests__/powerSummaryData.test.ts
@@ -753,13 +753,26 @@ describe('powerSummaryData', () => {
     expect(summary.totalSystemWatts).toBe(4300);
   });
 
-  it('uses only the resolved package default set for tourdate summaries', async () => {
+  it('uses resolved package defaults instead of stale job snapshots for tourdate summaries', async () => {
     const supabase = createMockSupabase({
+      power_requirement_tables: [
+        {
+          id: 'stale-sound-job-table',
+          job_id: 'job-tour',
+          department: 'sound',
+          table_name: 'Stale Job FoH',
+          total_watts: 4000,
+          current_per_phase: 16,
+          pdu_type: '63A',
+          custom_pdu_type: null,
+          includes_hoist: false,
+        },
+      ],
       tour_dates: [
         {
           id: 'tour-date-1',
           tour_id: 'tour-1',
-          sound_package_size: 'xl',
+          sound_package_size: 'l',
           is_tour_pack_only: false,
           sound_default_set_id: null,
           lights_default_set_id: null,
@@ -770,10 +783,10 @@ describe('powerSummaryData', () => {
       tour_power_defaults: [],
       tour_default_sets: [
         {
-          id: 'set-sound-xl',
+          id: 'set-sound-l',
           tour_id: 'tour-1',
           department: 'sound',
-          package_size: 'xl',
+          package_size: 'l',
         },
         {
           id: 'set-sound-s',
@@ -784,9 +797,9 @@ describe('powerSummaryData', () => {
       ],
       tour_default_tables: [
         {
-          id: 'default-sound-xl',
-          set_id: 'set-sound-xl',
-          table_name: 'XL FoH',
+          id: 'default-sound-l',
+          set_id: 'set-sound-l',
+          table_name: 'L FoH',
           table_type: 'power',
           total_value: 3000,
           metadata: { current_per_phase: 12, pdu_type: '63A', pf: 0.95 },
@@ -816,7 +829,8 @@ describe('powerSummaryData', () => {
       supabase,
     });
 
-    expect(summary.departments.sound.rows.map((row) => row.name)).toEqual(['XL FoH']);
+    expect(summary.departments.sound.rows.map((row) => row.name)).toEqual(['L FoH']);
+    expect(summary.departments.sound.rows[0].source).toBe('tour-default');
     expect(summary.departments.sound.totalWatts).toBe(3000);
   });
 

--- a/src/utils/powerSummaryData.ts
+++ b/src/utils/powerSummaryData.ts
@@ -517,15 +517,22 @@ const loadTourdatePowerData = async ({
         ];
       }
 
-      const jobSpecificSummary = jobSpecificDepartments[department];
-      if (jobSpecificSummary.rows.length > 0) {
-        return [department, jobSpecificSummary];
-      }
-
       const hasPackageIntent =
         tourDate && isPackageDepartment(department)
           ? Boolean(getDepartmentPackageSize(tourDate, department))
           : false;
+      const hasResolvedPackageDefaults =
+        hasPackageIntent && departmentDefaultTables.length > 0;
+      const jobSpecificSummary = jobSpecificDepartments[department];
+
+      // Package-bound tour dates must keep following their resolved defaults.
+      // Intentional date-specific changes are stored as overrides and returned
+      // above; legacy job snapshots are only a fallback when no package default
+      // can currently be resolved.
+      if (jobSpecificSummary.rows.length > 0 && !hasResolvedPackageDefaults) {
+        return [department, jobSpecificSummary];
+      }
+
       const canUseLegacyDefaults =
         departmentDefaultTables.length === 0 &&
         !hasPackageIntent &&


### PR DESCRIPTION
## Summary

- [x] I described what changed and why.
- Affected route/feature: Job-card `Resumen Potencia` generation for package-bound tour dates.
- Resolved L/M/S/XL package defaults now remain authoritative after edits.
- Explicit date-level overrides still have highest priority; saved job tables remain a fallback when no usable package default exists.
- Root cause: the older `power_requirement_tables` snapshot path was evaluated before the newer package-default path.

## Risk Assessment

- [x] I assessed functional, data, and deployment risk.
- Risk level: low
- Main risks: A package-bound tour date that previously displayed a stale job snapshot will now display its current resolved package default. Intentional per-date differences must use the existing `tour_date_power_overrides` path. Regression coverage confirms the precedence, and unresolved/missing package defaults still fall back safely.
- [x] This does not touch database migrations/RLS/grants/RPC/SQL functions or money paths, so the high-risk compensating-scrutiny requirement is not applicable.

## Impact Checklist

- [x] Migration impact assessed: no schema or data migration.
- [x] Realtime/subscription impact assessed: no realtime changes.
- [x] RLS/security impact assessed: no authorization or query-scope changes.
- [x] Performance impact assessed: no additional queries; only in-memory source precedence changes.

## Test Evidence

- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint` — passed with existing warning baseline only
  - `npm run typecheck` — passed
  - `npm run governance` — passed, including `ci:db:migrations`
  - `npm run test:critical` — passed
  - `npm run test:run` — passed
  - `npm run build` — passed
  - `npm run budget:bundle` — passed
  - `npm run test:run -- src/utils/__tests__/powerSummaryData.test.ts` — 20/20 passed
- CI results:
  - Lint, typecheck, governance, critical/full tests, build, desktop/mobile E2E smoke, migration apply/order, DB lint, RLS/RPC tests, CodeQL, dependency review, SBOM, Cloudflare preview — all passed.
  - CodeRabbit — no actionable code comments.

## Rollback Plan

- [x] I documented how to safely revert this change.
- [x] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert commit `1ef7463a` on `main` and redeploy. No database rollback or data restoration is required. Verify that the previous job-snapshot precedence is restored in a tour-date `Resumen Potencia` PDF.

## Migration Impact

- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no
- No database migration, Edge Function deployment, or Supabase production push is required.