### PR TITLE
fix: render weather icons in forecast PDFs

### DIFF
--- a/src/utils/hoja-de-ruta/pdf/sections/weather.ts
+++ b/src/utils/hoja-de-ruta/pdf/sections/weather.ts
@@ -1,5 +1,6 @@
 import { PDFDocument } from '../core/pdf-document';
 import { EventData, WeatherData } from '../core/pdf-types';
+import { createWeatherTableIconHooks } from '@/utils/pdf/weatherPdfIcons';
 
 export class WeatherSection {
   constructor(private pdfDoc: PDFDocument) {}
@@ -25,6 +26,11 @@ export class WeatherSection {
         weather.precipitationProbability ? `${weather.precipitationProbability}%` : '—'
       ];
     });
+    const weatherIconHooks = createWeatherTableIconHooks(this.pdfDoc.document, eventData.weather, {
+      iconInsetX: 1.2,
+      leftPadding: 8,
+      maxIconSize: 5,
+    });
 
     this.pdfDoc.addTable({
       startY: yPosition,
@@ -45,7 +51,8 @@ export class WeatherSection {
         fillColor: [250, 245, 245]
       },
       margin: { left: 20, right: 20 },
-      tableWidth: 'auto'
+      tableWidth: 'auto',
+      ...weatherIconHooks,
     });
 
     return this.pdfDoc.getLastAutoTableY() + 15;

--- a/src/utils/pdf/__tests__/weatherPdfIcons.test.ts
+++ b/src/utils/pdf/__tests__/weatherPdfIcons.test.ts
@@ -1,0 +1,86 @@
+import type { jsPDF } from 'jspdf';
+import type { CellHookData } from 'jspdf-autotable';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createWeatherTableIconHooks,
+  drawWeatherPdfIcon,
+  resolveWeatherPdfIconKind,
+} from '@/utils/pdf/weatherPdfIcons';
+
+const createPdfMock = () => ({
+  saveGraphicsState: vi.fn(),
+  restoreGraphicsState: vi.fn(),
+  setDrawColor: vi.fn(),
+  setFillColor: vi.fn(),
+  setLineWidth: vi.fn(),
+  setLineCap: vi.fn(),
+  circle: vi.fn(),
+  line: vi.fn(),
+  roundedRect: vi.fn(),
+  triangle: vi.fn(),
+  text: vi.fn(),
+});
+
+describe('weather PDF icons', () => {
+  it.each([
+    [0, 'sun'],
+    [2, 'partly-cloudy'],
+    [3, 'cloud'],
+    [45, 'fog'],
+    [51, 'drizzle'],
+    [65, 'rain'],
+    [73, 'snow'],
+    [95, 'storm'],
+  ] as const)('maps Open-Meteo code %s to %s', (weatherCode, expected) => {
+    expect(resolveWeatherPdfIconKind({ weatherCode })).toBe(expected);
+  });
+
+  it('falls back to the saved condition when legacy weather data has no code', () => {
+    expect(resolveWeatherPdfIconKind({ condition: 'Niebla con escarcha' })).toBe('fog');
+    expect(resolveWeatherPdfIconKind({ condition: 'Tormenta con granizo' })).toBe('storm');
+  });
+
+  it('draws vector paths without sending the emoji through jsPDF text rendering', () => {
+    const pdf = createPdfMock();
+
+    drawWeatherPdfIcon(pdf as unknown as jsPDF, { weatherCode: 95 }, 10, 20, 8);
+
+    expect(pdf.saveGraphicsState).toHaveBeenCalledOnce();
+    expect(pdf.line).toHaveBeenCalled();
+    expect(pdf.restoreGraphicsState).toHaveBeenCalledOnce();
+    expect(pdf.text).not.toHaveBeenCalled();
+  });
+
+  it('reserves room and draws the matching icon in an AutoTable condition cell', () => {
+    const pdf = createPdfMock();
+    const hooks = createWeatherTableIconHooks(
+      pdf as unknown as jsPDF,
+      [{ weatherCode: 0 }, { weatherCode: 61 }],
+    );
+    const hookData = {
+      section: 'body',
+      column: { index: 1 },
+      row: { index: 1 },
+      cell: {
+        x: 30,
+        y: 40,
+        width: 60,
+        height: 12,
+        styles: { cellPadding: 3 },
+      },
+    } as unknown as CellHookData;
+
+    hooks.didParseCell?.(hookData);
+    hooks.didDrawCell?.(hookData);
+
+    expect(hookData.cell.styles.cellPadding).toEqual({
+      top: 3,
+      right: 3,
+      bottom: 3,
+      left: 11,
+    });
+    expect(pdf.circle).toHaveBeenCalled();
+    expect(pdf.line).toHaveBeenCalled();
+  });
+});

--- a/src/utils/pdf/__tests__/weatherPdfIcons.test.ts
+++ b/src/utils/pdf/__tests__/weatherPdfIcons.test.ts
@@ -83,4 +83,25 @@ describe('weather PDF icons', () => {
     expect(pdf.circle).toHaveBeenCalled();
     expect(pdf.line).toHaveBeenCalled();
   });
+
+  it('uses zero defaults when AutoTable omits condition cell padding', () => {
+    const hooks = createWeatherTableIconHooks(
+      createPdfMock() as unknown as jsPDF,
+      [{ weatherCode: 0 }],
+    );
+    const hookData = {
+      section: 'body',
+      column: { index: 1 },
+      row: { index: 0 },
+      cell: { styles: { cellPadding: undefined } },
+    } as unknown as CellHookData;
+
+    expect(() => hooks.didParseCell?.(hookData)).not.toThrow();
+    expect(hookData.cell.styles.cellPadding).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 11,
+    });
+  });
 });

--- a/src/utils/pdf/weatherPdfGenerator.ts
+++ b/src/utils/pdf/weatherPdfGenerator.ts
@@ -1,6 +1,7 @@
 import { getWeatherForJob } from '@/utils/weather/weatherApi';
 import { WeatherData } from '@/types/hoja-de-ruta';
 import { loadPdfLibs } from '@/utils/pdf/lazyPdf';
+import { createWeatherTableIconHooks } from '@/utils/pdf/weatherPdfIcons';
 
 export interface WeatherPdfData {
   jobTitle: string;
@@ -170,6 +171,7 @@ export const generateWeatherPDF = async (data: WeatherPdfData): Promise<Blob> =>
       
       return [date, weather.condition, temp, precipitation];
     });
+    const weatherIconHooks = createWeatherTableIconHooks(pdf, weatherData);
     
     autoTable(pdf, {
       startY: yPosition,
@@ -197,6 +199,7 @@ export const generateWeatherPDF = async (data: WeatherPdfData): Promise<Blob> =>
       didDrawPage: () => {
         drawRunningHeader();
       },
+      ...weatherIconHooks,
     });
     
     yPosition = (pdf as any).lastAutoTable.finalY + 20;

--- a/src/utils/pdf/weatherPdfIcons.ts
+++ b/src/utils/pdf/weatherPdfIcons.ts
@@ -226,7 +226,11 @@ export const drawWeatherPdfIcon = (
   }
 };
 
-const normalizePadding = (padding: MarginPaddingInput): { top: number; right: number; bottom: number; left: number } => {
+const normalizePadding = (padding?: MarginPaddingInput | null): { top: number; right: number; bottom: number; left: number } => {
+  if (padding == null) {
+    return { top: 0, right: 0, bottom: 0, left: 0 };
+  }
+
   if (typeof padding === 'number') {
     return { top: padding, right: padding, bottom: padding, left: padding };
   }

--- a/src/utils/pdf/weatherPdfIcons.ts
+++ b/src/utils/pdf/weatherPdfIcons.ts
@@ -1,0 +1,295 @@
+import type { jsPDF } from 'jspdf';
+import type { MarginPaddingInput, UserOptions } from 'jspdf-autotable';
+
+export type WeatherPdfIconKind =
+  | 'sun'
+  | 'partly-cloudy'
+  | 'cloud'
+  | 'fog'
+  | 'drizzle'
+  | 'rain'
+  | 'snow'
+  | 'storm';
+
+export interface WeatherPdfIconData {
+  weatherCode?: number | null;
+  condition?: string | null;
+  icon?: string | null;
+}
+
+type WeatherTableIconHooks = Pick<UserOptions, 'didParseCell' | 'didDrawCell'>;
+
+interface WeatherTableIconOptions {
+  conditionColumnIndex?: number;
+  iconInsetX?: number;
+  leftPadding?: number;
+  maxIconSize?: number;
+}
+
+const normalizeWeatherLabel = (value?: string | null): string =>
+  (value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+export const resolveWeatherPdfIconKind = ({
+  weatherCode,
+  condition,
+  icon,
+}: WeatherPdfIconData): WeatherPdfIconKind => {
+  if (typeof weatherCode === 'number' && Number.isFinite(weatherCode)) {
+    if (weatherCode === 0) return 'sun';
+    if (weatherCode === 1 || weatherCode === 2) return 'partly-cloudy';
+    if (weatherCode === 3) return 'cloud';
+    if (weatherCode === 45 || weatherCode === 48) return 'fog';
+    if (weatherCode >= 51 && weatherCode <= 57) return 'drizzle';
+    if ((weatherCode >= 61 && weatherCode <= 67) || (weatherCode >= 80 && weatherCode <= 82)) return 'rain';
+    if ((weatherCode >= 71 && weatherCode <= 77) || (weatherCode >= 85 && weatherCode <= 86)) return 'snow';
+    if (weatherCode >= 95) return 'storm';
+  }
+
+  const label = normalizeWeatherLabel(`${condition ?? ''} ${icon ?? ''}`);
+  if (/tormenta|granizo|⛈/.test(label)) return 'storm';
+  if (/nieve|nevada|❄|🌨/.test(label)) return 'snow';
+  if (/niebla|bruma|🌫/.test(label)) return 'fog';
+  if (/llovizna|🌦/.test(label)) return 'drizzle';
+  if (/lluvia|chubasco|🌧/.test(label)) return 'rain';
+  if (/parcial|mayormente despejado|intervalos|⛅|🌤/.test(label)) return 'partly-cloudy';
+  if (/nublado|cubierto|☁/.test(label)) return 'cloud';
+  if (/despejado|soleado|☀/.test(label)) return 'sun';
+  return 'partly-cloudy';
+};
+
+const drawSun = (doc: jsPDF, x: number, y: number, size: number): void => {
+  const centerX = x + size * 0.5;
+  const centerY = y + size * 0.5;
+  const radius = size * 0.19;
+
+  doc.setDrawColor(184, 120, 0);
+  doc.setFillColor(250, 204, 21);
+  doc.setLineWidth(Math.max(0.2, size * 0.035));
+  doc.circle(centerX, centerY, radius, 'FD');
+
+  for (let index = 0; index < 8; index += 1) {
+    const angle = (Math.PI * index) / 4;
+    const innerRadius = size * 0.31;
+    const outerRadius = size * 0.44;
+    doc.line(
+      centerX + Math.cos(angle) * innerRadius,
+      centerY + Math.sin(angle) * innerRadius,
+      centerX + Math.cos(angle) * outerRadius,
+      centerY + Math.sin(angle) * outerRadius,
+    );
+  }
+};
+
+const drawCloud = (doc: jsPDF, x: number, y: number, size: number): void => {
+  const cloudFill: [number, number, number] = [226, 232, 240];
+  doc.setFillColor(...cloudFill);
+  doc.setDrawColor(...cloudFill);
+  doc.setLineWidth(Math.max(0.18, size * 0.025));
+  doc.circle(x + size * 0.37, y + size * 0.54, size * 0.2, 'FD');
+  doc.circle(x + size * 0.56, y + size * 0.43, size * 0.25, 'FD');
+  doc.circle(x + size * 0.75, y + size * 0.56, size * 0.16, 'FD');
+  doc.roundedRect(
+    x + size * 0.22,
+    y + size * 0.52,
+    size * 0.63,
+    size * 0.25,
+    size * 0.06,
+    size * 0.06,
+    'FD',
+  );
+  doc.setDrawColor(71, 85, 105);
+  doc.line(x + size * 0.24, y + size * 0.77, x + size * 0.82, y + size * 0.77);
+};
+
+const drawPartlyCloudy = (doc: jsPDF, x: number, y: number, size: number): void => {
+  drawSun(doc, x, y, size * 0.68);
+  drawCloud(doc, x + size * 0.12, y + size * 0.12, size * 0.88);
+};
+
+const drawFog = (doc: jsPDF, x: number, y: number, size: number): void => {
+  drawCloud(doc, x + size * 0.06, y, size * 0.83);
+  doc.setDrawColor(100, 116, 139);
+  doc.setLineWidth(Math.max(0.22, size * 0.035));
+  doc.setLineCap('round');
+  doc.line(x + size * 0.12, y + size * 0.76, x + size * 0.82, y + size * 0.76);
+  doc.line(x + size * 0.22, y + size * 0.88, x + size * 0.9, y + size * 0.88);
+  doc.line(x + size * 0.1, y + size, x + size * 0.68, y + size);
+};
+
+const drawDrizzle = (doc: jsPDF, x: number, y: number, size: number): void => {
+  drawCloud(doc, x + size * 0.05, y, size * 0.86);
+  doc.setDrawColor(14, 116, 144);
+  doc.setFillColor(56, 189, 248);
+  for (const offset of [0.3, 0.52, 0.74]) {
+    doc.circle(x + size * offset, y + size * 0.9, Math.max(0.18, size * 0.035), 'FD');
+  }
+};
+
+const drawRain = (doc: jsPDF, x: number, y: number, size: number): void => {
+  drawCloud(doc, x + size * 0.05, y, size * 0.86);
+  doc.setDrawColor(2, 132, 199);
+  doc.setLineWidth(Math.max(0.25, size * 0.045));
+  doc.setLineCap('round');
+  for (const offset of [0.3, 0.52, 0.74]) {
+    doc.line(
+      x + size * offset,
+      y + size * 0.81,
+      x + size * (offset - 0.06),
+      y + size,
+    );
+  }
+};
+
+const drawSnowflake = (doc: jsPDF, centerX: number, centerY: number, radius: number): void => {
+  for (let index = 0; index < 3; index += 1) {
+    const angle = (Math.PI * index) / 3;
+    const dx = Math.cos(angle) * radius;
+    const dy = Math.sin(angle) * radius;
+    doc.line(centerX - dx, centerY - dy, centerX + dx, centerY + dy);
+  }
+};
+
+const drawSnow = (doc: jsPDF, x: number, y: number, size: number): void => {
+  drawCloud(doc, x + size * 0.05, y, size * 0.86);
+  doc.setDrawColor(14, 116, 144);
+  doc.setLineWidth(Math.max(0.16, size * 0.025));
+  drawSnowflake(doc, x + size * 0.34, y + size * 0.9, size * 0.08);
+  drawSnowflake(doc, x + size * 0.68, y + size * 0.9, size * 0.08);
+};
+
+const drawStorm = (doc: jsPDF, x: number, y: number, size: number): void => {
+  drawCloud(doc, x + size * 0.05, y, size * 0.86);
+  doc.setDrawColor(180, 83, 9);
+  doc.setFillColor(250, 204, 21);
+  doc.setLineWidth(Math.max(0.18, size * 0.025));
+  doc.triangle(
+    x + size * 0.47,
+    y + size * 0.72,
+    x + size * 0.65,
+    y + size * 0.72,
+    x + size * 0.53,
+    y + size * 0.9,
+    'FD',
+  );
+  doc.triangle(
+    x + size * 0.53,
+    y + size * 0.85,
+    x + size * 0.65,
+    y + size * 0.85,
+    x + size * 0.43,
+    y + size,
+    'FD',
+  );
+};
+
+export const drawWeatherPdfIcon = (
+  doc: jsPDF,
+  weather: WeatherPdfIconData,
+  x: number,
+  y: number,
+  size: number,
+): void => {
+  doc.saveGraphicsState();
+  try {
+    switch (resolveWeatherPdfIconKind(weather)) {
+      case 'sun':
+        drawSun(doc, x, y, size);
+        break;
+      case 'cloud':
+        drawCloud(doc, x, y, size);
+        break;
+      case 'fog':
+        drawFog(doc, x, y, size);
+        break;
+      case 'drizzle':
+        drawDrizzle(doc, x, y, size);
+        break;
+      case 'rain':
+        drawRain(doc, x, y, size);
+        break;
+      case 'snow':
+        drawSnow(doc, x, y, size);
+        break;
+      case 'storm':
+        drawStorm(doc, x, y, size);
+        break;
+      case 'partly-cloudy':
+      default:
+        drawPartlyCloudy(doc, x, y, size);
+        break;
+    }
+  } finally {
+    doc.restoreGraphicsState();
+  }
+};
+
+const normalizePadding = (padding: MarginPaddingInput): { top: number; right: number; bottom: number; left: number } => {
+  if (typeof padding === 'number') {
+    return { top: padding, right: padding, bottom: padding, left: padding };
+  }
+
+  if (Array.isArray(padding)) {
+    if (padding.length === 2) {
+      return { top: padding[0], right: padding[1], bottom: padding[0], left: padding[1] };
+    }
+    if (padding.length === 3) {
+      return { top: padding[0], right: padding[1], bottom: padding[2], left: padding[1] };
+    }
+    return {
+      top: padding[0] ?? 0,
+      right: padding[1] ?? padding[0] ?? 0,
+      bottom: padding[2] ?? padding[0] ?? 0,
+      left: padding[3] ?? padding[1] ?? padding[0] ?? 0,
+    };
+  }
+
+  return {
+    top: padding.top ?? padding.vertical ?? 0,
+    right: padding.right ?? padding.horizontal ?? 0,
+    bottom: padding.bottom ?? padding.vertical ?? 0,
+    left: padding.left ?? padding.horizontal ?? 0,
+  };
+};
+
+export const createWeatherTableIconHooks = (
+  doc: jsPDF,
+  weatherRows: readonly WeatherPdfIconData[],
+  options: WeatherTableIconOptions = {},
+): WeatherTableIconHooks => {
+  const conditionColumnIndex = options.conditionColumnIndex ?? 1;
+  const iconInsetX = options.iconInsetX ?? 2;
+  const leftPadding = options.leftPadding ?? 11;
+  const maxIconSize = options.maxIconSize ?? 7.2;
+
+  return {
+    didParseCell: (data) => {
+      if (data.section !== 'body' || data.column.index !== conditionColumnIndex || !weatherRows[data.row.index]) return;
+
+      const padding = normalizePadding(data.cell.styles.cellPadding);
+      data.cell.styles.cellPadding = {
+        ...padding,
+        left: Math.max(padding.left, leftPadding),
+      };
+    },
+    didDrawCell: (data) => {
+      if (data.section !== 'body' || data.column.index !== conditionColumnIndex) return;
+
+      const weather = weatherRows[data.row.index];
+      if (!weather) return;
+
+      const size = Math.min(maxIconSize, data.cell.height - 2.4);
+      if (size < 3) return;
+
+      drawWeatherPdfIcon(
+        doc,
+        weather,
+        data.cell.x + iconInsetX,
+        data.cell.y + (data.cell.height - size) / 2,
+        size,
+      );
+    },
+  };
+};

--- a/src/utils/tour-scheduling-pdf-enhanced.ts
+++ b/src/utils/tour-scheduling-pdf-enhanced.ts
@@ -4,6 +4,7 @@ import { es } from 'date-fns/locale';
 import { fetchTourLogo } from '@/utils/pdf/logoUtils';
 import { supabase } from '@/integrations/supabase/client';
 import { getWeatherForJob } from '@/utils/weather/weatherApi';
+import { createWeatherTableIconHooks } from '@/utils/pdf/weatherPdfIcons';
 import type { AutoTableFn } from '@/utils/pdf/lazyPdf';
 import {
   createPdfExportDocument,
@@ -598,10 +599,11 @@ export const generateEnhancedEventDaySheet = async (
 
         const weatherTableData = weatherData.map((w) => [
           format(new Date(w.date), 'EEE d MMM', { locale: es }),
-          w.icon + ' ' + w.condition,
+          w.condition,
           `${w.maxTemp}°C / ${w.minTemp}°C`,
           `${w.precipitationProbability}%`,
         ]);
+        const weatherIconHooks = createWeatherTableIconHooks(pdf, weatherData);
 
         autoTable(pdf, {
           head: [['Fecha', 'Condición', 'Temperatura', 'Lluvia']],
@@ -619,6 +621,7 @@ export const generateEnhancedEventDaySheet = async (
             fontStyle: 'bold',
           },
           margin: { left: 10, right: 10 },
+          ...weatherIconHooks,
         });
 
         currentY = getLastAutoTableY(pdf, currentY) + 10;

--- a/src/utils/tour-scheduling-pdf.ts
+++ b/src/utils/tour-scheduling-pdf.ts
@@ -4,6 +4,7 @@ import { es } from 'date-fns/locale';
 import { fetchTourLogo } from '@/utils/pdf/logoUtils';
 import { supabase } from '@/integrations/supabase/client';
 import { getWeatherForJob } from '@/utils/weather/weatherApi';
+import { createWeatherTableIconHooks } from '@/utils/pdf/weatherPdfIcons';
 import {
   createPdfExportDocument,
   drawCorporatePdfHeader,
@@ -259,10 +260,11 @@ export const generateTourDaySheet = async (
 
           const weatherTableData = weatherData.map(w => [
             format(new Date(w.date), "EEE d MMM", { locale: es }),
-            w.icon + ' ' + w.condition,
+            w.condition,
             `${w.maxTemp}°C / ${w.minTemp}°C`,
             `${w.precipitationProbability}%`,
           ]);
+          const weatherIconHooks = createWeatherTableIconHooks(pdf, weatherData);
 
           autoTable(pdf, {
             head: [['Fecha', 'Condición', 'Temperatura', 'Lluvia']],
@@ -286,6 +288,7 @@ export const generateTourDaySheet = async (
               3: { cellWidth: 30, halign: 'center' },
             },
             margin: { left: 10, right: 10 },
+            ...weatherIconHooks,
           });
 
           currentY = getLastAutoTableY(pdf, currentY) + 10;

--- a/src/utils/weather/__tests__/weatherApi.test.ts
+++ b/src/utils/weather/__tests__/weatherApi.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getWeatherForJob, parseEventDates } from "@/utils/weather/weatherApi";
+import { formatWeatherForPdf, getWeatherForJob, parseEventDates } from "@/utils/weather/weatherApi";
 
 const dateKey = (date: Date) => {
   const year = date.getFullYear();
@@ -92,5 +92,23 @@ describe("getWeatherForJob", () => {
 
     expect(result).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatWeatherForPdf", () => {
+  it("keeps emoji out of PDF text rows so vector hooks can render the icon", () => {
+    const rows = formatWeatherForPdf([
+      {
+        date: "2026-06-03",
+        condition: "Despejado",
+        weatherCode: 0,
+        maxTemp: 28,
+        minTemp: 17,
+        precipitationProbability: 0,
+        icon: "☀️",
+      },
+    ]);
+
+    expect(rows[1][1]).toBe("Despejado");
   });
 });

--- a/src/utils/weather/weatherApi.ts
+++ b/src/utils/weather/weatherApi.ts
@@ -401,7 +401,7 @@ export const formatWeatherForPdf = (weather: WeatherData[]): Array<[string, stri
     
     return [
       formattedDate,
-      `${day.icon} ${day.condition}`,
+      day.condition,
       `${day.maxTemp}°C / ${day.minTemp}°C`,
       `${day.precipitationProbability}%`
     ] as [string, string, string, string];


### PR DESCRIPTION
## Summary

- draw weather icons as native PDF vectors for the festival forecast, Hoja de Ruta, standard tour day sheet, and enhanced tour day sheet
- cover clear, partly cloudy, cloudy, fog, drizzle, rain, snow, and storm conditions
- fall back to saved Spanish condition text for legacy Hoja de Ruta rows without an Open-Meteo code
- keep emoji out of jsPDF text so PDF output no longer depends on emoji-capable fonts
- safely normalize sparse AutoTable cell padding before reserving icon space

## Root cause

The tour exporters concatenated weather emoji into text rendered with jsPDF's built-in Helvetica font, which does not reliably encode emoji. The festival and Hoja de Ruta exporters did not carry the icon into their tables at all. The shared renderer bypasses font handling and writes small vector paths directly into each AutoTable condition cell.

## Risk and impact

Standard risk, limited to client-side PDF rendering. Weather symbols are embedded, sharp, offline-safe, and printable across every forecast PDF path. No schema, RLS, RPC, dependency, authorization, or money-path changes are included.

## Validation

- focused weather/PDF suite: 19 tests passed
- `npm run lint`: passed with no errors; existing repository warning baseline only
- `npm run typecheck`: passed, including after the CodeRabbit follow-up
- `npm run governance`: all governance gates passed
- `npm run test:critical`: passed
- `npm run test:run`: passed
- `npm run build`: passed; 5,796 modules transformed
- `npm run budget:bundle`: all bundle budgets passed
- rendered actual festival and Hoja de Ruta PDFs with Poppler at 180 DPI and visually verified alignment, legibility, and all eight icon families
- negative control: the icon test failed against the unfixed tree because the vector renderer did not exist; it now asserts vector drawing and verifies jsPDF text is not used for icons
- staged-secret scan passed

## Rollback

Revert commits `df9519d9` and `d52c7a18`, then redeploy the previous `main` build. No data rollback or Supabase action is required.
