### PR TITLE
Fix Flex MOTOR serial unit retrieval

### DIFF
--- a/supabase/functions/fetch-flex-motor-units/index.ts
+++ b/supabase/functions/fetch-flex-motor-units/index.ts
@@ -10,6 +10,7 @@ import {
   requireEnvValues,
 } from "../_shared/http.ts";
 import {
+  buildMotorSerialUnitGridUrl,
   MOTOR_MODELS,
   normalizeMotorUnit,
   parseMotorGridPage,
@@ -28,11 +29,8 @@ import { allSettledWithConcurrency } from "./concurrency.ts";
 const FLEX_API_BASE_URL =
   Deno.env.get("FLEX_API_BASE_URL") ||
   "https://sectorpro.flexrentalsolutions.com/f5/api";
-const PAGE_SIZE = 250;
+const PAGE_SIZE = 25;
 const MAX_PAGES_PER_MODEL = 20;
-const ACTIVE_AND_OUT_FILTER = JSON.stringify([
-  { id: "includeOut", property: "includeOut", value: true },
-]);
 const MAX_EQUIPMENT_LISTS = 100;
 const FLEX_REQUEST_CONCURRENCY = 5;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -82,12 +80,12 @@ async function fetchUnitsForModel(
   const seenRawIds = new Set<string>();
 
   for (let pageIndex = 0; pageIndex < MAX_PAGES_PER_MODEL; pageIndex += 1) {
-    const url = new URL(`${FLEX_API_BASE_URL}/serial-unit/grid-node`);
-    url.searchParams.set("modelId", model.id);
-    url.searchParams.set("page", String(pageIndex + 1));
-    url.searchParams.set("start", String(pageIndex * PAGE_SIZE));
-    url.searchParams.set("size", String(PAGE_SIZE));
-    url.searchParams.set("filter", ACTIVE_AND_OUT_FILTER);
+    const url = buildMotorSerialUnitGridUrl({
+      apiBaseUrl: FLEX_API_BASE_URL,
+      modelId: model.id,
+      pageIndex,
+      pageSize: PAGE_SIZE,
+    });
 
     const response = await fetchWithRetry(url.toString(), {
       headers: flexHeaders(flexAuthToken),

--- a/supabase/functions/fetch-flex-motor-units/motorUnits.test.ts
+++ b/supabase/functions/fetch-flex-motor-units/motorUnits.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildMotorSerialUnitGridUrl,
   MOTOR_MODELS,
   normalizeMotorUnit,
   parseMotorGridPage,
@@ -32,14 +33,21 @@ describe("Flex motor unit normalization", () => {
   });
 
   it.each([
-    ["ooc", true],
-    ["presumedMissing", true],
     ["decommissioned", "true"],
     ["sold", true],
     ["deleted", true],
   ])("excludes unavailable units marked %s", (field, value) => {
     expect(normalizeMotorUnit({ id: "unit-1", serial: "SERIE-1", [field]: value }, MOTOR_MODELS[0]))
       .toBeNull();
+  });
+
+  it.each([
+    ["ooc", true],
+    ["outOfCommission", true],
+    ["presumedMissing", true],
+  ])("keeps repairable serial units included by the Flex grid's %s filter", (field, value) => {
+    expect(normalizeMotorUnit({ id: "unit-1", serial: "SERIE-1", [field]: value }, MOTOR_MODELS[0]))
+      .toEqual(expect.objectContaining({ id: "unit-1", serial: "SERIE-1" }));
   });
 
   it("requires both a Flex unit id and a serial number", () => {
@@ -50,6 +58,54 @@ describe("Flex motor unit normalization", () => {
   it("parses Flex pageable grid responses", () => {
     expect(parseMotorGridPage({ content: [{ id: "unit-1" }], totalElements: 3, last: false }))
       .toEqual({ rows: [{ id: "unit-1" }], totalElements: 3, last: false });
+  });
+
+  it("parses the ExtJS rows envelope returned by Flex serial-unit grids", () => {
+    expect(parseMotorGridPage({ rows: [{ id: "unit-1" }], total: "1" }))
+      .toEqual({ rows: [{ id: "unit-1" }], totalElements: 1, last: null });
+  });
+
+  it("normalizes serial-unit fields nested under the Flex grid data property", () => {
+    expect(normalizeMotorUnit({
+      id: "unit-1",
+      data: {
+        serialNumber: "J36717",
+        barcode: "04113-01",
+        currentLocation: { displayString: "Almacén" },
+      },
+    }, MOTOR_MODELS[2])).toEqual(expect.objectContaining({
+      id: "unit-1",
+      modelId: MOTOR_MODELS[2].id,
+      serial: "J36717",
+      barcode: "04113-01",
+      currentLocation: "Almacén",
+    }));
+  });
+
+  it("builds the Flex serial-unit grid request used by the inventory UI", () => {
+    const url = buildMotorSerialUnitGridUrl({
+      apiBaseUrl: "https://sectorpro.flexrentalsolutions.com/f5/api",
+      modelId: MOTOR_MODELS[3].id,
+      pageIndex: 1,
+      pageSize: 25,
+      cacheBuster: 123,
+    });
+
+    expect(url.pathname).toBe("/f5/api/serial-unit/grid-node");
+    expect(Object.fromEntries(url.searchParams)).toMatchObject({
+      _dc: "123",
+      modelId: MOTOR_MODELS[3].id,
+      page: "2",
+      start: "25",
+      size: "25",
+      sort: "createdDate,DESC",
+      dir: "",
+    });
+    expect(JSON.parse(url.searchParams.get("filter") || "[]")).toEqual([
+      { property: "includeOut", value: true },
+      { property: "includeOOC", value: true },
+      { property: "includePresumedMissing", value: true },
+    ]);
   });
 
   it("contains the nine supplied motor models without duplicate ids", () => {

--- a/supabase/functions/fetch-flex-motor-units/motorUnits.ts
+++ b/supabase/functions/fetch-flex-motor-units/motorUnits.ts
@@ -48,6 +48,11 @@ const textValue = (value: unknown): string | null => {
 const trueValue = (value: unknown): boolean =>
   value === true || (typeof value === "string" && value.toLowerCase() === "true");
 
+const recordValue = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+
 export function normalizeMotorUnit(
   value: unknown,
   model: MotorModelDefinition,
@@ -55,18 +60,23 @@ export function normalizeMotorUnit(
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
 
   const row = value as Record<string, unknown>;
-  const id = textValue(row.id) || textValue(row.unitId);
-  const serial = textValue(row.serial) || textValue(row.serialNumber);
+  const data = recordValue(row.data);
+  const field = (...keys: string[]): unknown => {
+    for (const key of keys) {
+      if (row[key] !== undefined && row[key] !== null) return row[key];
+      if (data?.[key] !== undefined && data[key] !== null) return data[key];
+    }
+    return null;
+  };
+  const id = textValue(field("id", "unitId"));
+  const serial = textValue(field("serial", "serialNumber"));
 
   if (!id || !serial) return null;
 
   const unavailable = [
-    row.ooc,
-    row.outOfCommission,
-    row.presumedMissing,
-    row.decommissioned,
-    row.sold,
-    row.deleted,
+    field("decommissioned"),
+    field("sold"),
+    field("deleted"),
   ].some(trueValue);
 
   if (unavailable) return null;
@@ -76,12 +86,12 @@ export function normalizeMotorUnit(
     modelId: model.id,
     modelName: model.name,
     serial,
-    barcode: textValue(row.barcode),
-    stencil: textValue(row.stencil),
-    modelNumber: textValue(row.modelNumber),
-    currentLocation: textValue(row.currentLocation),
-    shippedDate: textValue(row.shippedDate),
-    returnDate: textValue(row.returnDate),
+    barcode: textValue(field("barcode")),
+    stencil: textValue(field("stencil")),
+    modelNumber: textValue(field("modelNumber")),
+    currentLocation: textValue(field("currentLocation")),
+    shippedDate: textValue(field("shippedDate")),
+    returnDate: textValue(field("returnDate")),
   };
 }
 export type MotorGridPage = {
@@ -100,20 +110,56 @@ export function parseMotorGridPage(value: unknown): MotorGridPage {
   }
 
   const payload = value as Record<string, unknown>;
-  const rows = Array.isArray(payload.content)
-    ? payload.content
-    : Array.isArray(payload.items)
-      ? payload.items
-      : Array.isArray(payload.data)
-        ? payload.data
-        : [];
-  const totalCandidate = payload.totalElements ?? payload.total;
+  const rows = Array.isArray(payload.rows)
+    ? payload.rows
+    : Array.isArray(payload.content)
+      ? payload.content
+      : Array.isArray(payload.items)
+        ? payload.items
+        : Array.isArray(payload.data)
+          ? payload.data
+          : Array.isArray(payload.children)
+            ? payload.children
+            : [];
+  const totalCandidate = payload.totalElements
+    ?? payload.total
+    ?? payload.totalCount
+    ?? payload.count;
+  const numericTotal = typeof totalCandidate === "number"
+    ? totalCandidate
+    : typeof totalCandidate === "string" && totalCandidate.trim()
+      ? Number(totalCandidate)
+      : Number.NaN;
 
   return {
     rows,
-    totalElements: typeof totalCandidate === "number" && Number.isFinite(totalCandidate)
-      ? totalCandidate
+    totalElements: Number.isFinite(numericTotal)
+      ? numericTotal
       : null,
     last: typeof payload.last === "boolean" ? payload.last : null,
   };
+}
+
+export function buildMotorSerialUnitGridUrl(options: {
+  apiBaseUrl: string;
+  modelId: string;
+  pageIndex: number;
+  pageSize: number;
+  cacheBuster?: number;
+}): URL {
+  const { apiBaseUrl, modelId, pageIndex, pageSize } = options;
+  const url = new URL(`${apiBaseUrl}/serial-unit/grid-node`);
+  url.searchParams.set("_dc", String(options.cacheBuster ?? Date.now()));
+  url.searchParams.set("modelId", modelId);
+  url.searchParams.set("page", String(pageIndex + 1));
+  url.searchParams.set("start", String(pageIndex * pageSize));
+  url.searchParams.set("size", String(pageSize));
+  url.searchParams.set("sort", "createdDate,DESC");
+  url.searchParams.set("dir", "");
+  url.searchParams.set("filter", JSON.stringify([
+    { property: "includeOut", value: true },
+    { property: "includeOOC", value: true },
+    { property: "includePresumedMissing", value: true },
+  ]));
+  return url;
 }


### PR DESCRIPTION
## Summary
- [x] I described what changed and why.
- Affected route/feature: Job-card MOTOR certificate quick action and `fetch-flex-motor-units` Edge Function.
- Match Flex's serial-unit grid request contract, including pagination, sorting, and the `includeOut`, `includeOOC`, and `includePresumedMissing` filters.
- Parse Flex's ExtJS `rows` envelope and nested `data` fields so serial numbers populate manual and manifest selections.
- Keep repairable OOC/presumed-missing serial units selectable while excluding sold, deleted, or decommissioned units.
- Add regression coverage for the request URL, response envelope, nested fields, and status handling.

## Root Cause and User Impact
The Edge Function expected pageable `content`/`items` data and sent a different grid query, while this Flex endpoint returns an ExtJS `rows` envelope for the supplied request contract. The function therefore returned zero MOTOR units even though the configured model IDs were present.

Live verification against the deployed Edge Function changed the dialog from 0 selectable units to 152. Manifest selection also resolved 10 scanned MOTOR units on the tested job. Eight configured serialized model families are represented; Flex returned no serial-unit rows for model `39b21045-09f6-49ac-9c02-c24342caa70e`, so it cannot contribute an S/N option until Flex contains a serialized unit for that model.

## Risk Assessment
- [x] I assessed functional, data, and deployment risk.
- Risk level: medium
- Main risks: Flex response-shape drift or pagination behavior could affect inventory completeness. The request and observed response variants now have regression tests, and the existing page/model caps remain in place.
- [x] This does not touch database or money paths.

## Impact Checklist
- [x] Migration impact assessed: none.
- [x] Realtime/subscription impact assessed: none.
- [x] RLS/security impact assessed: no authorization or token-handling changes.
- [x] Performance impact assessed: requests use Flex's native page size of 25 with bounded concurrency and at most 20 pages per model.

## Test Evidence
- [x] I ran relevant tests and confirmed expected results.
- Commands executed:
  - `npm run lint`
  - `npm run lint:functions`
  - `npm run typecheck`
  - `npm run governance`
  - `npm run test:critical`
  - `npm run test:run`
  - `npm run build`
  - `npm run budget:bundle`
- Results:
  - All commands passed.
  - Full Vitest run: 260 files, 1,416 tests passed.
  - Edge Function tests include 13 MOTOR unit cases.
  - Live job-card browser check: 152/152 manual units loaded; 10 manifest-scanned units found.

## Deployment
The updated `fetch-flex-motor-units` Edge Function was deployed to the linked test project for live validation. No database migration or production database push is required. Merging `main` remains the application production deployment path; deploy the Edge Function revision through the normal Supabase release process if it is not handled by the production pipeline.

## Rollback Plan
- [x] I documented how to safely revert this change.
- [x] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert this commit and redeploy the previous `fetch-flex-motor-units` Edge Function revision, then verify the job-card quick action still enforces its existing access controls.

## Migration Impact
- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no.
- Edge Function source changes only; no schema, RLS, grants, or RPC changes.
