### PR TITLE
feat(sound): add visual amp rack designer with IP assignment and PDF export

### DIFF
--- a/docs/performance/phase-4-baseline/baseline.json
+++ b/docs/performance/phase-4-baseline/baseline.json
@@ -1,42 +1,42 @@
 {
-  "generatedAt": "2026-06-04T06:29:33.797Z",
-  "gitCommit": "afbdc748a80c47b435299741e47f6cbe08faadfb",
+  "generatedAt": "2026-07-18T15:40:53.945Z",
+  "gitCommit": "4c186bfad2113d9bd99e181ad047d8dd7c83bf0c",
   "previewUrl": "http://127.0.0.1:4174",
   "profilerUrl": "http://127.0.0.1:4175",
   "bundle": {
-    "totalFiles": 511,
+    "totalFiles": 572,
     "totalsByKind": {
       "image": {
-        "files": 82,
-        "sizeBytes": 8873444,
-        "gzipBytes": 7321949
+        "files": 92,
+        "sizeBytes": 8897820,
+        "gzipBytes": 7355944
       },
       "other": {
-        "files": 11,
-        "sizeBytes": 114590,
-        "gzipBytes": 28564
+        "files": 15,
+        "sizeBytes": 451792,
+        "gzipBytes": 311539
       },
       "js": {
-        "files": 412,
-        "sizeBytes": 9463882,
-        "gzipBytes": 2867879
+        "files": 454,
+        "sizeBytes": 10413347,
+        "gzipBytes": 3160223
       },
       "css": {
-        "files": 3,
-        "sizeBytes": 243039,
-        "gzipBytes": 37357
+        "files": 7,
+        "sizeBytes": 302681,
+        "gzipBytes": 48478
       },
       "font": {
-        "files": 3,
-        "sizeBytes": 4641516,
-        "gzipBytes": 2695508
+        "files": 4,
+        "sizeBytes": 4727084,
+        "gzipBytes": 2775005
       }
     },
     "entryScripts": [
-      "/assets/index-CLAyxBtI.js"
+      "/assets/index-DZ9oXxSZ.js"
     ],
     "entryStyles": [
-      "/assets/index-7EI0iGa4.css"
+      "/assets/index-DKbY7j-s.css"
     ],
     "largestAssets": [
       {
@@ -44,240 +44,233 @@
         "file": "NotoSans-Italic-VariableFont_wdth,wght.ttf",
         "kind": "font",
         "sizeBytes": 2300468,
-        "gzipBytes": 1380169
+        "gzipBytes": 1398443
       },
       {
         "path": "dist/fonts/NotoSans-VariableFont_wdth,wght.ttf",
         "file": "NotoSans-VariableFont_wdth,wght.ttf",
         "kind": "font",
         "sizeBytes": 2044548,
-        "gzipBytes": 1192112
-      },
-      {
-        "path": "dist/assets/maps-lib-DdH6LNk6.js",
-        "file": "maps-lib-DdH6LNk6.js",
-        "kind": "js",
-        "sizeBytes": 1800536,
-        "gzipBytes": 495773
-      },
-      {
-        "path": "dist/assets/pdf-libs-BvqGlGrx.js",
-        "file": "pdf-libs-BvqGlGrx.js",
-        "kind": "js",
-        "sizeBytes": 948847,
-        "gzipBytes": 345205
-      },
-      {
-        "path": "dist/assets/spreadsheet-libs-C15GPh2f.js",
-        "file": "spreadsheet-libs-C15GPh2f.js",
-        "kind": "js",
-        "sizeBytes": 939186,
-        "gzipBytes": 269573
+        "gzipBytes": 1209033
       },
       {
         "path": "dist/stamps/sector-pro-stamp.png",
         "file": "sector-pro-stamp.png",
         "kind": "image",
         "sizeBytes": 725939,
-        "gzipBytes": 723068
+        "gzipBytes": 723450
       },
       {
         "path": "dist/lovable-uploads/IMG_7835.jpeg",
         "file": "IMG_7835.jpeg",
         "kind": "image",
         "sizeBytes": 716389,
-        "gzipBytes": 688816
+        "gzipBytes": 688748
       },
       {
-        "path": "dist/assets/index-CLAyxBtI.js",
-        "file": "index-CLAyxBtI.js",
+        "path": "dist/assets/maps-lib-B4ghr3Nh.js",
+        "file": "maps-lib-B4ghr3Nh.js",
         "kind": "js",
-        "sizeBytes": 562803,
-        "gzipBytes": 163971
+        "sizeBytes": 1836785,
+        "gzipBytes": 509365
       },
       {
         "path": "dist/lovable-uploads/IMG_7834.jpeg",
         "file": "IMG_7834.jpeg",
         "kind": "image",
         "sizeBytes": 530046,
-        "gzipBytes": 501003
+        "gzipBytes": 501015
       },
       {
         "path": "dist/lovable-uploads/IMG_7836.jpeg",
         "file": "IMG_7836.jpeg",
         "kind": "image",
         "sizeBytes": 436854,
-        "gzipBytes": 397340
+        "gzipBytes": 397538
       },
       {
-        "path": "dist/lovable-uploads/assignmentMatrix.jpg",
-        "file": "assignmentMatrix.jpg",
-        "kind": "image",
-        "sizeBytes": 416551,
-        "gzipBytes": 242086
+        "path": "dist/assets/pdf-libs-B0OBO3mS.js",
+        "file": "pdf-libs-B0OBO3mS.js",
+        "kind": "js",
+        "sizeBytes": 957821,
+        "gzipBytes": 350382
       },
       {
         "path": "dist/8067C0A4-0C71-4CDF-952B-0E699DA25A74.png",
         "file": "8067C0A4-0C71-4CDF-952B-0E699DA25A74.png",
         "kind": "image",
         "sizeBytes": 315123,
-        "gzipBytes": 301337
+        "gzipBytes": 304769
       },
       {
         "path": "dist/og-image.png",
         "file": "og-image.png",
         "kind": "image",
         "sizeBytes": 315123,
-        "gzipBytes": 301337
+        "gzipBytes": 304769
       },
       {
-        "path": "dist/lovable-uploads/festivalManagement3.jpg",
-        "file": "festivalManagement3.jpg",
-        "kind": "image",
-        "sizeBytes": 298974,
-        "gzipBytes": 226968
-      },
-      {
-        "path": "dist/fonts/NotoEmoji-Regular.ttf",
-        "file": "NotoEmoji-Regular.ttf",
-        "kind": "font",
-        "sizeBytes": 296500,
-        "gzipBytes": 123227
-      },
-      {
-        "path": "dist/assets/ModernHojaDeRuta-D-NjnmMA.js",
-        "file": "ModernHojaDeRuta-D-NjnmMA.js",
-        "kind": "js",
-        "sizeBytes": 279036,
-        "gzipBytes": 80793
-      },
-      {
-        "path": "dist/lovable-uploads/dashboardHero.jpg",
-        "file": "dashboardHero.jpg",
-        "kind": "image",
-        "sizeBytes": 266995,
-        "gzipBytes": 178795
-      },
-      {
-        "path": "dist/lovable-uploads/tourManagement1.jpg",
-        "file": "tourManagement1.jpg",
-        "kind": "image",
-        "sizeBytes": 261073,
-        "gzipBytes": 195215
-      },
-      {
-        "path": "dist/lovable-uploads/festivalManagement1.jpg",
-        "file": "festivalManagement1.jpg",
-        "kind": "image",
-        "sizeBytes": 255057,
-        "gzipBytes": 185377
-      },
-      {
-        "path": "dist/lovable-uploads/personalCalendar.jpg",
-        "file": "personalCalendar.jpg",
-        "kind": "image",
-        "sizeBytes": 229804,
-        "gzipBytes": 154365
-      },
-      {
-        "path": "dist/assets/editor-lib-BfTMioMs.js",
-        "file": "editor-lib-BfTMioMs.js",
-        "kind": "js",
-        "sizeBytes": 216921,
-        "gzipBytes": 55632
-      },
-      {
-        "path": "dist/lovable-uploads/festivalManagement4.jpg",
-        "file": "festivalManagement4.jpg",
-        "kind": "image",
-        "sizeBytes": 212926,
-        "gzipBytes": 109744
-      },
-      {
-        "path": "dist/assets/html2canvas.esm-vQ3n7XO2.js",
-        "file": "html2canvas.esm-vQ3n7XO2.js",
-        "kind": "js",
-        "sizeBytes": 201876,
-        "gzipBytes": 47579
-      },
-      {
-        "path": "dist/lovable-uploads/tourManagement2.jpg",
-        "file": "tourManagement2.jpg",
-        "kind": "image",
-        "sizeBytes": 201374,
-        "gzipBytes": 137683
-      },
-      {
-        "path": "dist/assets/UserManual-DYvN8aZ1.js",
-        "file": "UserManual-DYvN8aZ1.js",
-        "kind": "js",
-        "sizeBytes": 182194,
-        "gzipBytes": 56407
-      },
-      {
-        "path": "dist/lovable-uploads/calendar.jpg",
-        "file": "calendar.jpg",
-        "kind": "image",
-        "sizeBytes": 179058,
-        "gzipBytes": 128899
-      },
-      {
-        "path": "dist/assets/index-7EI0iGa4.css",
-        "file": "index-7EI0iGa4.css",
-        "kind": "css",
-        "sizeBytes": 178267,
-        "gzipBytes": 27969
-      },
-      {
-        "path": "dist/assets/JobAssignmentMatrix-B50a1vC0.js",
-        "file": "JobAssignmentMatrix-B50a1vC0.js",
-        "kind": "js",
-        "sizeBytes": 177839,
-        "gzipBytes": 47983
-      },
-      {
-        "path": "dist/assets/TechnicianRfTableModal-BY1SAcC2.js",
-        "file": "TechnicianRfTableModal-BY1SAcC2.js",
-        "kind": "js",
-        "sizeBytes": 174670,
-        "gzipBytes": 44991
-      },
-      {
-        "path": "dist/lovable-uploads/IMG_8504.png",
-        "file": "IMG_8504.png",
-        "kind": "image",
-        "sizeBytes": 160513,
-        "gzipBytes": 157650
-      }
-    ],
-    "largeJsAssets": [
-      {
-        "path": "dist/assets/maps-lib-DdH6LNk6.js",
-        "file": "maps-lib-DdH6LNk6.js",
-        "kind": "js",
-        "sizeBytes": 1800536,
-        "gzipBytes": 495773
-      },
-      {
-        "path": "dist/assets/pdf-libs-BvqGlGrx.js",
-        "file": "pdf-libs-BvqGlGrx.js",
-        "kind": "js",
-        "sizeBytes": 948847,
-        "gzipBytes": 345205
+        "path": "dist/certificates/revision-motores-2026-pagina-firmada.pdf",
+        "file": "revision-motores-2026-pagina-firmada.pdf",
+        "kind": "other",
+        "sizeBytes": 314176,
+        "gzipBytes": 275772
       },
       {
         "path": "dist/assets/spreadsheet-libs-C15GPh2f.js",
         "file": "spreadsheet-libs-C15GPh2f.js",
         "kind": "js",
         "sizeBytes": 939186,
-        "gzipBytes": 269573
+        "gzipBytes": 270968
       },
       {
-        "path": "dist/assets/index-CLAyxBtI.js",
-        "file": "index-CLAyxBtI.js",
+        "path": "dist/lovable-uploads/assignmentMatrix.jpg",
+        "file": "assignmentMatrix.jpg",
+        "kind": "image",
+        "sizeBytes": 416551,
+        "gzipBytes": 242222
+      },
+      {
+        "path": "dist/lovable-uploads/festivalManagement3.jpg",
+        "file": "festivalManagement3.jpg",
+        "kind": "image",
+        "sizeBytes": 298974,
+        "gzipBytes": 226971
+      },
+      {
+        "path": "dist/lovable-uploads/tourManagement1.jpg",
+        "file": "tourManagement1.jpg",
+        "kind": "image",
+        "sizeBytes": 261073,
+        "gzipBytes": 195292
+      },
+      {
+        "path": "dist/lovable-uploads/festivalManagement1.jpg",
+        "file": "festivalManagement1.jpg",
+        "kind": "image",
+        "sizeBytes": 255057,
+        "gzipBytes": 185502
+      },
+      {
+        "path": "dist/lovable-uploads/dashboardHero.jpg",
+        "file": "dashboardHero.jpg",
+        "kind": "image",
+        "sizeBytes": 266995,
+        "gzipBytes": 178885
+      },
+      {
+        "path": "dist/lovable-uploads/IMG_8504.png",
+        "file": "IMG_8504.png",
+        "kind": "image",
+        "sizeBytes": 160513,
+        "gzipBytes": 157802
+      },
+      {
+        "path": "dist/lovable-uploads/e78ab52e-aa81-4770-a6bb-f802a5ff651e.png",
+        "file": "e78ab52e-aa81-4770-a6bb-f802a5ff651e.png",
+        "kind": "image",
+        "sizeBytes": 160513,
+        "gzipBytes": 157802
+      },
+      {
+        "path": "dist/lovable-uploads/personalCalendar.jpg",
+        "file": "personalCalendar.jpg",
+        "kind": "image",
+        "sizeBytes": 229804,
+        "gzipBytes": 154491
+      },
+      {
+        "path": "dist/icons/icon-512.webp",
+        "file": "icon-512.webp",
+        "kind": "image",
+        "sizeBytes": 146943,
+        "gzipBytes": 145201
+      },
+      {
+        "path": "dist/lovable-uploads/tourManagement2.jpg",
+        "file": "tourManagement2.jpg",
+        "kind": "image",
+        "sizeBytes": 201374,
+        "gzipBytes": 137707
+      },
+      {
+        "path": "dist/lovable-uploads/calendar.jpg",
+        "file": "calendar.jpg",
+        "kind": "image",
+        "sizeBytes": 179058,
+        "gzipBytes": 128951
+      },
+      {
+        "path": "dist/fonts/NotoEmoji-Regular.ttf",
+        "file": "NotoEmoji-Regular.ttf",
+        "kind": "font",
+        "sizeBytes": 296500,
+        "gzipBytes": 122623
+      },
+      {
+        "path": "dist/lovable-uploads/7bd0c1d7-3226-470d-bea4-5cd7222e3248.webp",
+        "file": "7bd0c1d7-3226-470d-bea4-5cd7222e3248.webp",
+        "kind": "image",
+        "sizeBytes": 118482,
+        "gzipBytes": 118243
+      },
+      {
+        "path": "dist/assets/index-DZ9oXxSZ.js",
+        "file": "index-DZ9oXxSZ.js",
         "kind": "js",
-        "sizeBytes": 562803,
-        "gzipBytes": 163971
+        "sizeBytes": 396823,
+        "gzipBytes": 109846
+      },
+      {
+        "path": "dist/lovable-uploads/festivalManagement4.jpg",
+        "file": "festivalManagement4.jpg",
+        "kind": "image",
+        "sizeBytes": 212926,
+        "gzipBytes": 109717
+      },
+      {
+        "path": "dist/lovable-uploads/REPORT6.jpg",
+        "file": "REPORT6.jpg",
+        "kind": "image",
+        "sizeBytes": 155238,
+        "gzipBytes": 100144
+      },
+      {
+        "path": "dist/Logos/wild tour.png",
+        "file": "wild tour.png",
+        "kind": "image",
+        "sizeBytes": 92796,
+        "gzipBytes": 92844
+      },
+      {
+        "path": "dist/lovable-uploads/78EA43B6-3727-454E-BB54-257619F40C1E.jpeg",
+        "file": "78EA43B6-3727-454E-BB54-257619F40C1E.jpeg",
+        "kind": "image",
+        "sizeBytes": 97361,
+        "gzipBytes": 90291
+      }
+    ],
+    "largeJsAssets": [
+      {
+        "path": "dist/assets/maps-lib-B4ghr3Nh.js",
+        "file": "maps-lib-B4ghr3Nh.js",
+        "kind": "js",
+        "sizeBytes": 1836785,
+        "gzipBytes": 509365
+      },
+      {
+        "path": "dist/assets/pdf-libs-B0OBO3mS.js",
+        "file": "pdf-libs-B0OBO3mS.js",
+        "kind": "js",
+        "sizeBytes": 957821,
+        "gzipBytes": 350382
+      },
+      {
+        "path": "dist/assets/spreadsheet-libs-C15GPh2f.js",
+        "file": "spreadsheet-libs-C15GPh2f.js",
+        "kind": "js",
+        "sizeBytes": 939186,
+        "gzipBytes": 270968
       }
     ]
   },

--- a/src/components/sound/AmplifierTool.tsx
+++ b/src/components/sound/AmplifierTool.tsx
@@ -797,7 +797,7 @@ export const AmplifierTool = ({ jobId, tourId }: AmplifierToolProps = {}) => {
             </Button>
           </div>
 
-          {results && <AmplifierResultsSummary results={results} />}
+          {results && <AmplifierResultsSummary results={results} jobId={jobId} tourId={tourId} />}
 
           {results && (
             <SaveResultsToPresetPanel

--- a/src/components/sound/amplifier-tool/AmplifierResultsSummary.tsx
+++ b/src/components/sound/amplifier-tool/AmplifierResultsSummary.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import type { AmplifierResults } from "./types";
+import { AmpRackDesigner } from "./rack-designer/AmpRackDesigner";
 
-export const AmplifierResultsSummary: React.FC<{ results: AmplifierResults }> = ({ results }) => (
+export const AmplifierResultsSummary: React.FC<{
+  results: AmplifierResults;
+  jobId?: string;
+  tourId?: string;
+}> = ({ results, jobId, tourId }) => (
   <div className="mt-6 border rounded-lg overflow-hidden">
-    <div className="bg-muted px-4 py-3">
+    <div className="bg-muted px-4 py-3 flex flex-wrap items-center justify-between gap-2">
       <h3 className="text-lg font-semibold">Required Amplifiers</h3>
+      <AmpRackDesigner results={results} jobId={jobId} tourId={tourId} />
     </div>
 
     <div className="p-4 space-y-4">

--- a/src/components/sound/amplifier-tool/AmplifierResultsSummary.tsx
+++ b/src/components/sound/amplifier-tool/AmplifierResultsSummary.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { AmplifierResults } from "./types";
-import { AmpRackDesigner } from "./rack-designer/AmpRackDesigner";
+import { AmpRackDesigner } from "@/components/sound/amplifier-tool/rack-designer/AmpRackDesigner";
 
 export const AmplifierResultsSummary: React.FC<{
   results: AmplifierResults;
@@ -9,7 +9,7 @@ export const AmplifierResultsSummary: React.FC<{
 }> = ({ results, jobId, tourId }) => (
   <div className="mt-6 border rounded-lg overflow-hidden">
     <div className="bg-muted px-4 py-3 flex flex-wrap items-center justify-between gap-2">
-      <h3 className="text-lg font-semibold">Required Amplifiers</h3>
+      <h3 className="text-lg font-semibold">Amplificadores necesarios</h3>
       <AmpRackDesigner results={results} jobId={jobId} tourId={tourId} />
     </div>
 

--- a/src/components/sound/amplifier-tool/rack-designer/AmpEditFields.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpEditFields.tsx
@@ -1,8 +1,8 @@
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
-import type { RackDesignerAmp } from './types';
-import { isValidIp } from './layout-utils';
+import type { RackDesignerAmp } from '@/components/sound/amplifier-tool/rack-designer/types';
+import { isValidIp } from '@/components/sound/amplifier-tool/rack-designer/layout-utils';
 
 interface AmpEditFieldsProps {
   amp: RackDesignerAmp;
@@ -36,7 +36,7 @@ export function AmpEditFields({ amp, onChange, autoFocusIp = false }: AmpEditFie
           className={cn('h-8 font-mono text-sm', !isValidIp(amp.ip) && 'border-destructive')}
         />
       </div>
-      <p className="text-[10px] text-muted-foreground">{amp.model}</p>
+      <p className="text-xs text-muted-foreground">{amp.model}</p>
     </div>
   );
 }

--- a/src/components/sound/amplifier-tool/rack-designer/AmpEditFields.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpEditFields.tsx
@@ -1,0 +1,42 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import type { RackDesignerAmp } from './types';
+import { isValidIp } from './layout-utils';
+
+interface AmpEditFieldsProps {
+  amp: RackDesignerAmp;
+  onChange: (patch: Partial<RackDesignerAmp>) => void;
+  /** Autofocus the IP field — the most common edit when tapping a cell. */
+  autoFocusIp?: boolean;
+}
+
+export function AmpEditFields({ amp, onChange, autoFocusIp = false }: AmpEditFieldsProps) {
+  return (
+    <div className="space-y-2">
+      <div className="space-y-1">
+        <Label htmlFor={`amp-preset-${amp.id}`} className="text-xs">Preset</Label>
+        <Input
+          id={`amp-preset-${amp.id}`}
+          value={amp.presetName}
+          onChange={(event) => onChange({ presetName: event.target.value })}
+          placeholder="Nombre del preset"
+          className="h-8 text-sm font-semibold"
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor={`amp-ip-${amp.id}`} className="text-xs">Dirección IP</Label>
+        <Input
+          id={`amp-ip-${amp.id}`}
+          value={amp.ip}
+          onChange={(event) => onChange({ ip: event.target.value })}
+          placeholder="192.168.1.11"
+          inputMode="decimal"
+          autoFocus={autoFocusIp}
+          className={cn('h-8 font-mono text-sm', !isValidIp(amp.ip) && 'border-destructive')}
+        />
+      </div>
+      <p className="text-[10px] text-muted-foreground">{amp.model}</p>
+    </div>
+  );
+}

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { format } from 'date-fns';
-import { FileText, Network, Plus, RefreshCw, Wand2, X } from 'lucide-react';
+import { FileText, Network, Plus, RefreshCw, Wand2, X, ZoomIn, ZoomOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -49,6 +49,7 @@ import {
 import { RackBlockCard } from './RackBlockCard';
 import { BlockEditorPanel } from './BlockEditorPanel';
 import { AmpEditFields } from './AmpEditFields';
+import { useCanvasZoom } from './useCanvasZoom';
 
 export interface AmpRackDesignerProps {
   results: AmplifierResults;
@@ -72,6 +73,11 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
   const [baseIp, setBaseIp] = useState(DEFAULT_IP_BASE);
   const [includeRackLabels, setIncludeRackLabels] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const { zoom, zoomIn, zoomOut, fitToView, pinchActiveRef, scrollRef } = useCanvasZoom({
+    enabled: open,
+    contentWidth: CANVAS_WIDTH,
+    contentHeight: CANVAS_HEIGHT,
+  });
 
   const scope = jobId ?? tourId ?? 'standalone';
 
@@ -82,6 +88,13 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
     setAmpTarget(null);
     setMobileBlockEditorOpen(false);
   }, [open, scope, results]);
+
+  // On phones start zoomed out so the whole plan is visible; pinch in from there.
+  useEffect(() => {
+    if (!open || !isMobile) return;
+    const frame = requestAnimationFrame(() => fitToView());
+    return () => cancelAnimationFrame(frame);
+  }, [open, isMobile, fitToView]);
 
   useEffect(() => {
     if (open && layout) saveStoredLayout(scope, layout);
@@ -343,63 +356,118 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
           </div>
 
           <div className="flex min-h-0 flex-1 flex-col gap-3 md:flex-row">
-            <div
-              className="relative min-h-[240px] flex-1 overflow-auto rounded-md border bg-muted/20"
-              onPointerDown={clearCanvasSelection}
-            >
+            <div className="relative min-h-[240px] flex-1">
               <div
-                className="relative"
-                style={{
-                  width: CANVAS_WIDTH,
-                  height: CANVAS_HEIGHT,
-                  backgroundImage:
-                    'linear-gradient(to right, hsl(var(--border) / 0.35) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--border) / 0.35) 1px, transparent 1px)',
-                  backgroundSize: '50px 50px',
-                }}
+                ref={scrollRef}
+                className="absolute inset-0 overflow-auto rounded-md border bg-muted/20"
+                style={{ touchAction: 'pan-x pan-y' }}
+                onPointerDown={clearCanvasSelection}
               >
-                {layout?.blocks.map((block) => (
-                  <RackBlockCard
-                    key={block.id}
-                    block={block}
-                    selected={block.id === selectedBlockId}
-                    onSelect={setSelectedBlockId}
-                    onMove={moveBlock}
-                    onTap={handleBlockTap}
-                  />
-                ))}
-
-                {!isMobile && targetedAmp && (
+                <div
+                  className="relative"
+                  style={{ width: CANVAS_WIDTH * zoom, height: CANVAS_HEIGHT * zoom }}
+                >
                   <div
-                    className="absolute z-20 w-60 rounded-md border bg-background p-3 shadow-lg"
+                    className="relative origin-top-left"
                     style={{
-                      left: Math.min(targetedAmp.block.x + BLOCK_WIDTH + 10, CANVAS_WIDTH - 250),
-                      top: Math.min(
-                        targetedAmp.block.y + BLOCK_HEADER_HEIGHT + targetedAmp.ampIndex * AMP_CELL_HEIGHT,
-                        CANVAS_HEIGHT - 190,
-                      ),
+                      width: CANVAS_WIDTH,
+                      height: CANVAS_HEIGHT,
+                      transform: `scale(${zoom})`,
+                      backgroundImage:
+                        'linear-gradient(to right, hsl(var(--border) / 0.35) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--border) / 0.35) 1px, transparent 1px)',
+                      backgroundSize: '50px 50px',
                     }}
-                    onPointerDown={(event) => event.stopPropagation()}
                   >
-                    <div className="mb-2 flex items-center justify-between">
-                      <span className="text-xs font-semibold">Editar amplificador</span>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-6 w-6"
-                        onClick={() => setAmpTarget(null)}
-                        aria-label="Cerrar editor de amplificador"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                    <AmpEditFields
-                      amp={targetedAmp.amp}
-                      autoFocusIp
-                      onChange={(patch) => updateAmp(targetedAmp.block.id, targetedAmp.amp.id, patch)}
-                    />
+                    {layout?.blocks.map((block) => (
+                      <RackBlockCard
+                        key={block.id}
+                        block={block}
+                        selected={block.id === selectedBlockId}
+                        zoom={zoom}
+                        pinchActiveRef={pinchActiveRef}
+                        onSelect={setSelectedBlockId}
+                        onMove={moveBlock}
+                        onTap={handleBlockTap}
+                      />
+                    ))}
                   </div>
-                )}
+
+                  {/* Unscaled layer so the editor card stays readable at any zoom. */}
+                  {!isMobile && targetedAmp && (
+                    <div
+                      className="absolute z-20 w-60 rounded-md border bg-background p-3 shadow-lg"
+                      style={{
+                        left: Math.max(
+                          0,
+                          Math.min(
+                            (targetedAmp.block.x + BLOCK_WIDTH) * zoom + 10,
+                            CANVAS_WIDTH * zoom - 250,
+                          ),
+                        ),
+                        top: Math.max(
+                          0,
+                          Math.min(
+                            (targetedAmp.block.y +
+                              BLOCK_HEADER_HEIGHT +
+                              targetedAmp.ampIndex * AMP_CELL_HEIGHT) * zoom,
+                            CANVAS_HEIGHT * zoom - 190,
+                          ),
+                        ),
+                      }}
+                      onPointerDown={(event) => event.stopPropagation()}
+                    >
+                      <div className="mb-2 flex items-center justify-between">
+                        <span className="text-xs font-semibold">Editar amplificador</span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6"
+                          onClick={() => setAmpTarget(null)}
+                          aria-label="Cerrar editor de amplificador"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                      <AmpEditFields
+                        amp={targetedAmp.amp}
+                        autoFocusIp
+                        onChange={(patch) => updateAmp(targetedAmp.block.id, targetedAmp.amp.id, patch)}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="absolute bottom-2 right-2 z-20 flex items-center gap-0.5 rounded-md border bg-background/95 p-0.5 shadow-sm">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={zoomOut}
+                  aria-label="Alejar"
+                >
+                  <ZoomOut className="h-3.5 w-3.5" />
+                </Button>
+                <button
+                  type="button"
+                  className="w-11 text-center text-xs tabular-nums text-muted-foreground hover:text-foreground"
+                  onClick={fitToView}
+                  title="Ajustar a la vista"
+                >
+                  {Math.round(zoom * 100)}%
+                </button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={zoomIn}
+                  aria-label="Acercar"
+                >
+                  <ZoomIn className="h-3.5 w-3.5" />
+                </Button>
               </div>
             </div>
 

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { FileText, Network, Plus, RefreshCw, Wand2, X, ZoomIn, ZoomOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -21,15 +21,19 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { generateAmpRackLayoutPdf } from '@/utils/amplifierRackLayoutPdf';
-import type { AmplifierResults } from '../types';
-import type { RackDesignerAmp, RackDesignerBlock, RackDesignerLayout } from './types';
+import type { AmplifierResults } from '@/components/sound/amplifier-tool/types';
+import type {
+  RackDesignerAmp,
+  RackDesignerBlock,
+  RackDesignerLayout,
+} from '@/components/sound/amplifier-tool/rack-designer/types';
 import {
   BLOCK_HEADER_HEIGHT,
   BLOCK_WIDTH,
@@ -40,16 +44,19 @@ import {
   DEFAULT_LAYOUT_TITLE,
   RACK_COLOR_PALETTE,
   assignSequentialIps,
+  computeResultsFingerprint,
   generateLayoutFromResults,
   isValidIp,
   loadStoredLayout,
   makeDesignerId,
   saveStoredLayout,
-} from './layout-utils';
-import { RackBlockCard } from './RackBlockCard';
-import { BlockEditorPanel } from './BlockEditorPanel';
-import { AmpEditFields } from './AmpEditFields';
-import { useCanvasZoom } from './useCanvasZoom';
+} from '@/components/sound/amplifier-tool/rack-designer/layout-utils';
+import { RackBlockCard } from '@/components/sound/amplifier-tool/rack-designer/RackBlockCard';
+import { BlockEditorPanel } from '@/components/sound/amplifier-tool/rack-designer/BlockEditorPanel';
+import { AmpEditFields } from '@/components/sound/amplifier-tool/rack-designer/AmpEditFields';
+import { useCanvasZoom } from '@/components/sound/amplifier-tool/rack-designer/useCanvasZoom';
+
+const MADRID_TZ = 'Europe/Madrid';
 
 export interface AmpRackDesignerProps {
   results: AmplifierResults;
@@ -83,7 +90,15 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
 
   useEffect(() => {
     if (!open) return;
-    setLayout(loadStoredLayout(scope) ?? generateLayoutFromResults(results));
+    // A saved layout is only reused when it came from the same calculation;
+    // otherwise it would silently contradict the results summary next to it.
+    const stored = loadStoredLayout(scope);
+    const fingerprint = computeResultsFingerprint(results);
+    setLayout(
+      stored && stored.resultsFingerprint === fingerprint
+        ? stored
+        : generateLayoutFromResults(results, stored?.title ?? DEFAULT_LAYOUT_TITLE),
+    );
     setSelectedBlockId(null);
     setAmpTarget(null);
     setMobileBlockEditorOpen(false);
@@ -156,42 +171,39 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
     setMobileBlockEditorOpen(false);
   };
 
+  // Blocks are built outside the setLayout updaters so the updaters stay pure —
+  // React may invoke them more than once (e.g. StrictMode).
   const duplicateBlock = (id: string) => {
-    setLayout((prev) => {
-      if (!prev) return prev;
-      const source = prev.blocks.find((block) => block.id === id);
-      if (!source) return prev;
-      const copy: RackDesignerBlock = {
-        ...source,
-        id: makeDesignerId(),
-        label: `${source.label} (copia)`,
-        x: Math.min(source.x + 20, CANVAS_WIDTH - 200),
-        y: Math.min(source.y + 20, CANVAS_HEIGHT - 100),
-        amps: source.amps.map((amp) => ({ ...amp, id: makeDesignerId() })),
-      };
-      setSelectedBlockId(copy.id);
-      return { ...prev, blocks: [...prev.blocks, copy] };
-    });
+    const source = layout?.blocks.find((block) => block.id === id);
+    if (!source) return;
+    const copy: RackDesignerBlock = {
+      ...source,
+      id: makeDesignerId(),
+      label: `${source.label} (copia)`,
+      x: Math.min(source.x + 20, CANVAS_WIDTH - 200),
+      y: Math.min(source.y + 20, CANVAS_HEIGHT - 100),
+      amps: source.amps.map((amp) => ({ ...amp, id: makeDesignerId() })),
+    };
+    setLayout((prev) => (prev ? { ...prev, blocks: [...prev.blocks, copy] } : prev));
+    setSelectedBlockId(copy.id);
   };
 
   const addBlock = () => {
-    setLayout((prev) => {
-      if (!prev) return prev;
-      const block: RackDesignerBlock = {
-        id: makeDesignerId(),
-        label: `RACK ${prev.blocks.length + 1}`,
-        color: RACK_COLOR_PALETTE[7].value,
-        x: 40,
-        y: 40,
-        amps: [{ id: makeDesignerId(), presetName: 'PRESET', ip: DEFAULT_IP_BASE, model: 'LA12X' }],
-      };
-      setSelectedBlockId(block.id);
-      return { ...prev, blocks: [...prev.blocks, block] };
-    });
+    if (!layout) return;
+    const block: RackDesignerBlock = {
+      id: makeDesignerId(),
+      label: `RACK ${layout.blocks.length + 1}`,
+      color: RACK_COLOR_PALETTE[7].value,
+      x: 40,
+      y: 40,
+      amps: [{ id: makeDesignerId(), presetName: 'PRESET', ip: DEFAULT_IP_BASE, model: 'LA12X' }],
+    };
+    setLayout((prev) => (prev ? { ...prev, blocks: [...prev.blocks, block] } : prev));
+    setSelectedBlockId(block.id);
   };
 
   const regenerate = () => {
-    setLayout((prev) => generateLayoutFromResults(results, prev?.title ?? DEFAULT_LAYOUT_TITLE));
+    setLayout(generateLayoutFromResults(results, layout?.title ?? DEFAULT_LAYOUT_TITLE));
     setSelectedBlockId(null);
     setAmpTarget(null);
     toast({
@@ -226,7 +238,7 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = `distribucion-amplificadores-${format(new Date(), 'yyyy-MM-dd')}.pdf`;
+      link.download = `distribucion-amplificadores-${formatInTimeZone(new Date(), MADRID_TZ, 'yyyy-MM-dd')}.pdf`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -483,17 +495,17 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
         </DialogContent>
       </Dialog>
 
-      <Drawer
+      <Sheet
         open={isMobile && !!targetedAmp}
-        onOpenChange={(drawerOpen) => {
-          if (!drawerOpen) setAmpTarget(null);
+        onOpenChange={(sheetOpen) => {
+          if (!sheetOpen) setAmpTarget(null);
         }}
       >
-        <DrawerContent>
-          <DrawerHeader className="pb-2 text-left">
-            <DrawerTitle>Editar amplificador</DrawerTitle>
-          </DrawerHeader>
-          <div className="px-4 pb-8">
+        <SheetContent side="bottom" className="rounded-t-lg">
+          <SheetHeader className="pb-2 text-left">
+            <SheetTitle>Editar amplificador</SheetTitle>
+          </SheetHeader>
+          <div className="pb-4">
             {targetedAmp && (
               <AmpEditFields
                 amp={targetedAmp.amp}
@@ -501,20 +513,20 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
               />
             )}
           </div>
-        </DrawerContent>
-      </Drawer>
+        </SheetContent>
+      </Sheet>
 
-      <Drawer
+      <Sheet
         open={isMobile && mobileBlockEditorOpen && !!selectedBlock}
         onOpenChange={setMobileBlockEditorOpen}
       >
-        <DrawerContent>
-          <DrawerHeader className="pb-2 text-left">
-            <DrawerTitle>Editar rack</DrawerTitle>
-          </DrawerHeader>
-          <div className="max-h-[65dvh] overflow-y-auto px-4 pb-8">{blockEditor}</div>
-        </DrawerContent>
-      </Drawer>
+        <SheetContent side="bottom" className="rounded-t-lg">
+          <SheetHeader className="pb-2 text-left">
+            <SheetTitle>Editar rack</SheetTitle>
+          </SheetHeader>
+          <div className="max-h-[65dvh] overflow-y-auto pb-4">{blockEditor}</div>
+        </SheetContent>
+      </Sheet>
     </>
   );
 }

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { format } from 'date-fns';
-import { FileText, Network, Plus, RefreshCw, Wand2 } from 'lucide-react';
+import { FileText, Network, Plus, RefreshCw, Wand2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -21,14 +21,19 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { generateAmpRackLayoutPdf } from '@/utils/amplifierRackLayoutPdf';
 import type { AmplifierResults } from '../types';
-import type { RackDesignerBlock, RackDesignerLayout } from './types';
+import type { RackDesignerAmp, RackDesignerBlock, RackDesignerLayout } from './types';
 import {
+  BLOCK_HEADER_HEIGHT,
+  BLOCK_WIDTH,
+  AMP_CELL_HEIGHT,
   CANVAS_HEIGHT,
   CANVAS_WIDTH,
   DEFAULT_IP_BASE,
@@ -43,6 +48,7 @@ import {
 } from './layout-utils';
 import { RackBlockCard } from './RackBlockCard';
 import { BlockEditorPanel } from './BlockEditorPanel';
+import { AmpEditFields } from './AmpEditFields';
 
 export interface AmpRackDesignerProps {
   results: AmplifierResults;
@@ -50,11 +56,19 @@ export interface AmpRackDesignerProps {
   tourId?: string;
 }
 
+interface AmpTarget {
+  blockId: string;
+  ampId: string;
+}
+
 export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps) {
   const { toast } = useToast();
+  const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
   const [layout, setLayout] = useState<RackDesignerLayout | null>(null);
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+  const [ampTarget, setAmpTarget] = useState<AmpTarget | null>(null);
+  const [mobileBlockEditorOpen, setMobileBlockEditorOpen] = useState(false);
   const [baseIp, setBaseIp] = useState(DEFAULT_IP_BASE);
   const [includeRackLabels, setIncludeRackLabels] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
@@ -65,6 +79,8 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
     if (!open) return;
     setLayout(loadStoredLayout(scope) ?? generateLayoutFromResults(results));
     setSelectedBlockId(null);
+    setAmpTarget(null);
+    setMobileBlockEditorOpen(false);
   }, [open, scope, results]);
 
   useEffect(() => {
@@ -76,10 +92,36 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
     [layout, selectedBlockId],
   );
 
+  const targetedAmp = useMemo(() => {
+    if (!layout || !ampTarget) return null;
+    const block = layout.blocks.find((candidate) => candidate.id === ampTarget.blockId);
+    const amp = block?.amps.find((candidate) => candidate.id === ampTarget.ampId);
+    if (!block || !amp) return null;
+    return { block, amp, ampIndex: block.amps.indexOf(amp) };
+  }, [layout, ampTarget]);
+
   const updateBlock = (next: RackDesignerBlock) => {
     setLayout((prev) =>
       prev
         ? { ...prev, blocks: prev.blocks.map((block) => (block.id === next.id ? next : block)) }
+        : prev,
+    );
+  };
+
+  const updateAmp = (blockId: string, ampId: string, patch: Partial<RackDesignerAmp>) => {
+    setLayout((prev) =>
+      prev
+        ? {
+            ...prev,
+            blocks: prev.blocks.map((block) =>
+              block.id === blockId
+                ? {
+                    ...block,
+                    amps: block.amps.map((amp) => (amp.id === ampId ? { ...amp, ...patch } : amp)),
+                  }
+                : block,
+            ),
+          }
         : prev,
     );
   };
@@ -97,6 +139,8 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
       prev ? { ...prev, blocks: prev.blocks.filter((block) => block.id !== id) } : prev,
     );
     setSelectedBlockId((current) => (current === id ? null : current));
+    setAmpTarget((current) => (current?.blockId === id ? null : current));
+    setMobileBlockEditorOpen(false);
   };
 
   const duplicateBlock = (id: string) => {
@@ -136,6 +180,7 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
   const regenerate = () => {
     setLayout((prev) => generateLayoutFromResults(results, prev?.title ?? DEFAULT_LAYOUT_TITLE));
     setSelectedBlockId(null);
+    setAmpTarget(null);
     toast({
       title: 'Diseño regenerado',
       description: 'Los racks se han vuelto a generar desde el cálculo actual.',
@@ -186,6 +231,31 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
     }
   };
 
+  const handleBlockTap = (blockId: string, ampId: string | null) => {
+    if (ampId) {
+      setAmpTarget({ blockId, ampId });
+      setMobileBlockEditorOpen(false);
+    } else {
+      setAmpTarget(null);
+      if (isMobile) setMobileBlockEditorOpen(true);
+    }
+  };
+
+  const clearCanvasSelection = () => {
+    setSelectedBlockId(null);
+    setAmpTarget(null);
+  };
+
+  const blockEditor = selectedBlock ? (
+    <BlockEditorPanel
+      key={selectedBlock.id}
+      block={selectedBlock}
+      onChange={updateBlock}
+      onDuplicate={duplicateBlock}
+      onDelete={deleteBlock}
+    />
+  ) : null;
+
   return (
     <>
       <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={() => setOpen(true)}>
@@ -194,15 +264,18 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="flex h-[92vh] w-[96vw] max-w-[1400px] flex-col gap-3 p-4">
-          <DialogHeader className="space-y-0.5">
+        <DialogContent className="flex h-dvh max-h-dvh w-screen max-w-none flex-col gap-2 rounded-none p-3 md:h-[92vh] md:max-h-[92vh] md:w-[96vw] md:max-w-[1400px] md:gap-3 md:rounded-lg md:p-4">
+          <DialogHeader className="space-y-0.5 text-left">
             <DialogTitle>Diseñador visual de racks</DialogTitle>
-            <DialogDescription>
+            <DialogDescription className="hidden md:block">
               Arrastra los racks para posicionarlos, edita presets, colores e IPs y exporta el plano a PDF.
+            </DialogDescription>
+            <DialogDescription className="md:hidden">
+              Toca un amplificador para editar su IP y preset; toca la cabecera para editar el rack.
             </DialogDescription>
           </DialogHeader>
 
-          <div className="flex flex-wrap items-end gap-2">
+          <div className="flex flex-wrap items-end gap-1.5 md:gap-2">
             <div className="space-y-1">
               <Label htmlFor="layout-title" className="text-xs">Título del plano</Label>
               <Input
@@ -212,7 +285,7 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
                   setLayout((prev) => (prev ? { ...prev, title: event.target.value } : prev))
                 }
                 placeholder={DEFAULT_LAYOUT_TITLE}
-                className="h-8 w-48 font-semibold"
+                className="h-8 w-36 font-semibold md:w-48"
               />
             </div>
             <div className="space-y-1">
@@ -222,7 +295,8 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
                 value={baseIp}
                 onChange={(event) => setBaseIp(event.target.value)}
                 placeholder={DEFAULT_IP_BASE}
-                className={cn('h-8 w-36 font-mono text-xs', !isValidIp(baseIp) && 'border-destructive')}
+                inputMode="decimal"
+                className={cn('h-8 w-32 font-mono text-xs md:w-36', !isValidIp(baseIp) && 'border-destructive')}
               />
             </div>
             <Button type="button" variant="secondary" size="sm" className="gap-1" onClick={autoAssignIps}>
@@ -270,8 +344,8 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
 
           <div className="flex min-h-0 flex-1 flex-col gap-3 md:flex-row">
             <div
-              className="relative min-h-[280px] flex-1 overflow-auto rounded-md border bg-muted/20"
-              onPointerDown={() => setSelectedBlockId(null)}
+              className="relative min-h-[240px] flex-1 overflow-auto rounded-md border bg-muted/20"
+              onPointerDown={clearCanvasSelection}
             >
               <div
                 className="relative"
@@ -290,29 +364,89 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
                     selected={block.id === selectedBlockId}
                     onSelect={setSelectedBlockId}
                     onMove={moveBlock}
+                    onTap={handleBlockTap}
                   />
                 ))}
+
+                {!isMobile && targetedAmp && (
+                  <div
+                    className="absolute z-20 w-60 rounded-md border bg-background p-3 shadow-lg"
+                    style={{
+                      left: Math.min(targetedAmp.block.x + BLOCK_WIDTH + 10, CANVAS_WIDTH - 250),
+                      top: Math.min(
+                        targetedAmp.block.y + BLOCK_HEADER_HEIGHT + targetedAmp.ampIndex * AMP_CELL_HEIGHT,
+                        CANVAS_HEIGHT - 190,
+                      ),
+                    }}
+                    onPointerDown={(event) => event.stopPropagation()}
+                  >
+                    <div className="mb-2 flex items-center justify-between">
+                      <span className="text-xs font-semibold">Editar amplificador</span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6"
+                        onClick={() => setAmpTarget(null)}
+                        aria-label="Cerrar editor de amplificador"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                    <AmpEditFields
+                      amp={targetedAmp.amp}
+                      autoFocusIp
+                      onChange={(patch) => updateAmp(targetedAmp.block.id, targetedAmp.amp.id, patch)}
+                    />
+                  </div>
+                )}
               </div>
             </div>
 
-            <div className="w-full shrink-0 overflow-y-auto rounded-md border p-3 md:w-80">
-              {selectedBlock ? (
-                <BlockEditorPanel
-                  key={selectedBlock.id}
-                  block={selectedBlock}
-                  onChange={updateBlock}
-                  onDuplicate={duplicateBlock}
-                  onDelete={deleteBlock}
-                />
-              ) : (
+            <div className="hidden shrink-0 overflow-y-auto rounded-md border p-3 md:block md:w-80">
+              {blockEditor ?? (
                 <p className="text-sm text-muted-foreground">
-                  Selecciona un rack en el lienzo para editar su nombre, color, presets e IPs.
+                  Selecciona un rack en el lienzo para editar su nombre, color, presets e IPs. Haz
+                  clic en un amplificador para editar su IP y preset directamente.
                 </p>
               )}
             </div>
           </div>
         </DialogContent>
       </Dialog>
+
+      <Drawer
+        open={isMobile && !!targetedAmp}
+        onOpenChange={(drawerOpen) => {
+          if (!drawerOpen) setAmpTarget(null);
+        }}
+      >
+        <DrawerContent>
+          <DrawerHeader className="pb-2 text-left">
+            <DrawerTitle>Editar amplificador</DrawerTitle>
+          </DrawerHeader>
+          <div className="px-4 pb-8">
+            {targetedAmp && (
+              <AmpEditFields
+                amp={targetedAmp.amp}
+                onChange={(patch) => updateAmp(targetedAmp.block.id, targetedAmp.amp.id, patch)}
+              />
+            )}
+          </div>
+        </DrawerContent>
+      </Drawer>
+
+      <Drawer
+        open={isMobile && mobileBlockEditorOpen && !!selectedBlock}
+        onOpenChange={setMobileBlockEditorOpen}
+      >
+        <DrawerContent>
+          <DrawerHeader className="pb-2 text-left">
+            <DrawerTitle>Editar rack</DrawerTitle>
+          </DrawerHeader>
+          <div className="max-h-[65dvh] overflow-y-auto px-4 pb-8">{blockEditor}</div>
+        </DrawerContent>
+      </Drawer>
     </>
   );
 }

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import { FileText, Network, Plus, RefreshCw, Wand2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
+import { generateAmpRackLayoutPdf } from '@/utils/amplifierRackLayoutPdf';
+import type { AmplifierResults } from '../types';
+import type { RackDesignerBlock, RackDesignerLayout } from './types';
+import {
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  DEFAULT_IP_BASE,
+  DEFAULT_LAYOUT_TITLE,
+  RACK_COLOR_PALETTE,
+  assignSequentialIps,
+  generateLayoutFromResults,
+  isValidIp,
+  loadStoredLayout,
+  makeDesignerId,
+  saveStoredLayout,
+} from './layout-utils';
+import { RackBlockCard } from './RackBlockCard';
+import { BlockEditorPanel } from './BlockEditorPanel';
+
+export interface AmpRackDesignerProps {
+  results: AmplifierResults;
+  jobId?: string;
+  tourId?: string;
+}
+
+export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps) {
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [layout, setLayout] = useState<RackDesignerLayout | null>(null);
+  const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+  const [baseIp, setBaseIp] = useState(DEFAULT_IP_BASE);
+  const [includeRackLabels, setIncludeRackLabels] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const scope = jobId ?? tourId ?? 'standalone';
+
+  useEffect(() => {
+    if (!open) return;
+    setLayout(loadStoredLayout(scope) ?? generateLayoutFromResults(results));
+    setSelectedBlockId(null);
+  }, [open, scope, results]);
+
+  useEffect(() => {
+    if (open && layout) saveStoredLayout(scope, layout);
+  }, [open, scope, layout]);
+
+  const selectedBlock = useMemo(
+    () => layout?.blocks.find((block) => block.id === selectedBlockId) ?? null,
+    [layout, selectedBlockId],
+  );
+
+  const updateBlock = (next: RackDesignerBlock) => {
+    setLayout((prev) =>
+      prev
+        ? { ...prev, blocks: prev.blocks.map((block) => (block.id === next.id ? next : block)) }
+        : prev,
+    );
+  };
+
+  const moveBlock = (id: string, x: number, y: number) => {
+    setLayout((prev) =>
+      prev
+        ? { ...prev, blocks: prev.blocks.map((block) => (block.id === id ? { ...block, x, y } : block)) }
+        : prev,
+    );
+  };
+
+  const deleteBlock = (id: string) => {
+    setLayout((prev) =>
+      prev ? { ...prev, blocks: prev.blocks.filter((block) => block.id !== id) } : prev,
+    );
+    setSelectedBlockId((current) => (current === id ? null : current));
+  };
+
+  const duplicateBlock = (id: string) => {
+    setLayout((prev) => {
+      if (!prev) return prev;
+      const source = prev.blocks.find((block) => block.id === id);
+      if (!source) return prev;
+      const copy: RackDesignerBlock = {
+        ...source,
+        id: makeDesignerId(),
+        label: `${source.label} (copia)`,
+        x: Math.min(source.x + 20, CANVAS_WIDTH - 200),
+        y: Math.min(source.y + 20, CANVAS_HEIGHT - 100),
+        amps: source.amps.map((amp) => ({ ...amp, id: makeDesignerId() })),
+      };
+      setSelectedBlockId(copy.id);
+      return { ...prev, blocks: [...prev.blocks, copy] };
+    });
+  };
+
+  const addBlock = () => {
+    setLayout((prev) => {
+      if (!prev) return prev;
+      const block: RackDesignerBlock = {
+        id: makeDesignerId(),
+        label: `RACK ${prev.blocks.length + 1}`,
+        color: RACK_COLOR_PALETTE[7].value,
+        x: 40,
+        y: 40,
+        amps: [{ id: makeDesignerId(), presetName: 'PRESET', ip: DEFAULT_IP_BASE, model: 'LA12X' }],
+      };
+      setSelectedBlockId(block.id);
+      return { ...prev, blocks: [...prev.blocks, block] };
+    });
+  };
+
+  const regenerate = () => {
+    setLayout((prev) => generateLayoutFromResults(results, prev?.title ?? DEFAULT_LAYOUT_TITLE));
+    setSelectedBlockId(null);
+    toast({
+      title: 'Diseño regenerado',
+      description: 'Los racks se han vuelto a generar desde el cálculo actual.',
+    });
+  };
+
+  const autoAssignIps = () => {
+    if (!isValidIp(baseIp)) {
+      toast({
+        title: 'IP no válida',
+        description: 'Introduce una dirección IP inicial válida (p. ej. 192.168.1.11).',
+        variant: 'destructive',
+      });
+      return;
+    }
+    setLayout((prev) =>
+      prev ? { ...prev, blocks: assignSequentialIps(prev.blocks, baseIp) } : prev,
+    );
+    toast({
+      title: 'IPs asignadas',
+      description: `IPs secuenciales asignadas a partir de ${baseIp}.`,
+    });
+  };
+
+  const exportPdf = async () => {
+    if (!layout) return;
+    setIsExporting(true);
+    try {
+      const blob = await generateAmpRackLayoutPdf(layout, { includeRackLabels });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `distribucion-amplificadores-${format(new Date(), 'yyyy-MM-dd')}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast({ title: 'PDF generado', description: 'El PDF se ha descargado correctamente.' });
+    } catch (error) {
+      console.error('Error generating rack layout PDF:', error);
+      toast({
+        title: 'Error',
+        description: 'No se pudo generar el PDF. Inténtalo de nuevo.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <>
+      <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={() => setOpen(true)}>
+        <Network className="h-4 w-4" />
+        Diseñador de racks
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex h-[92vh] w-[96vw] max-w-[1400px] flex-col gap-3 p-4">
+          <DialogHeader className="space-y-0.5">
+            <DialogTitle>Diseñador visual de racks</DialogTitle>
+            <DialogDescription>
+              Arrastra los racks para posicionarlos, edita presets, colores e IPs y exporta el plano a PDF.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-wrap items-end gap-2">
+            <div className="space-y-1">
+              <Label htmlFor="layout-title" className="text-xs">Título del plano</Label>
+              <Input
+                id="layout-title"
+                value={layout?.title ?? ''}
+                onChange={(event) =>
+                  setLayout((prev) => (prev ? { ...prev, title: event.target.value } : prev))
+                }
+                placeholder={DEFAULT_LAYOUT_TITLE}
+                className="h-8 w-48 font-semibold"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="global-base-ip" className="text-xs">IP inicial</Label>
+              <Input
+                id="global-base-ip"
+                value={baseIp}
+                onChange={(event) => setBaseIp(event.target.value)}
+                placeholder={DEFAULT_IP_BASE}
+                className={cn('h-8 w-36 font-mono text-xs', !isValidIp(baseIp) && 'border-destructive')}
+              />
+            </div>
+            <Button type="button" variant="secondary" size="sm" className="gap-1" onClick={autoAssignIps}>
+              <Wand2 className="h-3.5 w-3.5" />
+              Auto-IP
+            </Button>
+            <Button type="button" variant="outline" size="sm" className="gap-1" onClick={addBlock}>
+              <Plus className="h-3.5 w-3.5" />
+              Añadir rack
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button type="button" variant="outline" size="sm" className="gap-1">
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  Regenerar
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>¿Regenerar el diseño?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Se descartarán los cambios manuales (posiciones, colores, presets e IPs) y los
+                    racks se volverán a generar desde el cálculo actual.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                  <AlertDialogAction onClick={regenerate}>Regenerar</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            <div className="flex h-8 items-center gap-1.5">
+              <Checkbox
+                id="include-rack-labels"
+                checked={includeRackLabels}
+                onCheckedChange={(checked) => setIncludeRackLabels(checked === true)}
+              />
+              <Label htmlFor="include-rack-labels" className="text-xs">Nombres de rack en PDF</Label>
+            </div>
+            <Button type="button" size="sm" className="ml-auto gap-1" onClick={exportPdf} disabled={isExporting || !layout}>
+              <FileText className="h-3.5 w-3.5" />
+              {isExporting ? 'Generando…' : 'Exportar PDF'}
+            </Button>
+          </div>
+
+          <div className="flex min-h-0 flex-1 flex-col gap-3 md:flex-row">
+            <div
+              className="relative min-h-[280px] flex-1 overflow-auto rounded-md border bg-muted/20"
+              onPointerDown={() => setSelectedBlockId(null)}
+            >
+              <div
+                className="relative"
+                style={{
+                  width: CANVAS_WIDTH,
+                  height: CANVAS_HEIGHT,
+                  backgroundImage:
+                    'linear-gradient(to right, hsl(var(--border) / 0.35) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--border) / 0.35) 1px, transparent 1px)',
+                  backgroundSize: '50px 50px',
+                }}
+              >
+                {layout?.blocks.map((block) => (
+                  <RackBlockCard
+                    key={block.id}
+                    block={block}
+                    selected={block.id === selectedBlockId}
+                    onSelect={setSelectedBlockId}
+                    onMove={moveBlock}
+                  />
+                ))}
+              </div>
+            </div>
+
+            <div className="w-full shrink-0 overflow-y-auto rounded-md border p-3 md:w-80">
+              {selectedBlock ? (
+                <BlockEditorPanel
+                  key={selectedBlock.id}
+                  block={selectedBlock}
+                  onChange={updateBlock}
+                  onDuplicate={duplicateBlock}
+                  onDelete={deleteBlock}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Selecciona un rack en el lienzo para editar su nombre, color, presets e IPs.
+                </p>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/sound/amplifier-tool/rack-designer/BlockEditorPanel.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/BlockEditorPanel.tsx
@@ -1,0 +1,202 @@
+import { useState } from 'react';
+import { ArrowDown, ArrowUp, Copy, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import type { RackDesignerAmp, RackDesignerBlock } from './types';
+import {
+  DEFAULT_IP_BASE,
+  RACK_COLOR_PALETTE,
+  assignBlockIps,
+  incrementIp,
+  isValidIp,
+  makeDesignerId,
+} from './layout-utils';
+
+interface BlockEditorPanelProps {
+  block: RackDesignerBlock;
+  onChange: (block: RackDesignerBlock) => void;
+  onDuplicate: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function BlockEditorPanel({ block, onChange, onDuplicate, onDelete }: BlockEditorPanelProps) {
+  const [blockBaseIp, setBlockBaseIp] = useState(block.amps[0]?.ip || DEFAULT_IP_BASE);
+
+  const updateAmp = (ampId: string, patch: Partial<RackDesignerAmp>) => {
+    onChange({
+      ...block,
+      amps: block.amps.map((amp) => (amp.id === ampId ? { ...amp, ...patch } : amp)),
+    });
+  };
+
+  const moveAmp = (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= block.amps.length) return;
+    const amps = [...block.amps];
+    [amps[index], amps[target]] = [amps[target], amps[index]];
+    onChange({ ...block, amps });
+  };
+
+  const removeAmp = (ampId: string) => {
+    onChange({ ...block, amps: block.amps.filter((amp) => amp.id !== ampId) });
+  };
+
+  const addAmp = () => {
+    const last = block.amps[block.amps.length - 1];
+    onChange({
+      ...block,
+      amps: [
+        ...block.amps,
+        {
+          id: makeDesignerId(),
+          presetName: 'PRESET',
+          model: last?.model ?? 'LA12X',
+          ip: last && isValidIp(last.ip) ? incrementIp(last.ip, 1) : DEFAULT_IP_BASE,
+        },
+      ],
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="rack-label" className="text-xs">Nombre del rack</Label>
+        <Input
+          id="rack-label"
+          value={block.label}
+          onChange={(event) => onChange({ ...block, label: event.target.value })}
+          className="h-8"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-xs">Color del grupo</Label>
+        <div className="flex flex-wrap gap-1.5">
+          {RACK_COLOR_PALETTE.map((color) => (
+            <button
+              key={color.value}
+              type="button"
+              title={color.name}
+              aria-label={color.name}
+              className={cn(
+                'h-6 w-6 rounded-full border border-black/30 transition-transform hover:scale-110',
+                block.color === color.value && 'ring-2 ring-primary ring-offset-1',
+              )}
+              style={{ backgroundColor: color.value }}
+              onClick={() => onChange({ ...block, color: color.value })}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="rack-base-ip" className="text-xs">IP inicial del rack</Label>
+        <div className="flex gap-1.5">
+          <Input
+            id="rack-base-ip"
+            value={blockBaseIp}
+            onChange={(event) => setBlockBaseIp(event.target.value)}
+            placeholder={DEFAULT_IP_BASE}
+            className={cn('h-8 font-mono text-xs', !isValidIp(blockBaseIp) && 'border-destructive')}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-8 shrink-0"
+            disabled={!isValidIp(blockBaseIp)}
+            onClick={() => onChange(assignBlockIps(block, blockBaseIp))}
+          >
+            Asignar IPs
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs">Amplificadores ({block.amps.length})</Label>
+        {block.amps.map((amp, index) => (
+          <div key={amp.id} className="rounded-md border p-2 space-y-1.5">
+            <div className="flex items-center gap-1">
+              <Input
+                value={amp.presetName}
+                onChange={(event) => updateAmp(amp.id, { presetName: event.target.value })}
+                placeholder="Nombre del preset"
+                className="h-7 text-xs font-semibold"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                disabled={index === 0}
+                onClick={() => moveAmp(index, -1)}
+                aria-label="Subir amplificador"
+              >
+                <ArrowUp className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                disabled={index === block.amps.length - 1}
+                onClick={() => moveAmp(index, 1)}
+                aria-label="Bajar amplificador"
+              >
+                <ArrowDown className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0 text-destructive"
+                onClick={() => removeAmp(amp.id)}
+                aria-label="Eliminar amplificador"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                value={amp.ip}
+                onChange={(event) => updateAmp(amp.id, { ip: event.target.value })}
+                placeholder="192.168.1.11"
+                className={cn('h-7 font-mono text-xs', !isValidIp(amp.ip) && 'border-destructive')}
+              />
+              <span className="shrink-0 text-[10px] text-muted-foreground">{amp.model}</span>
+            </div>
+          </div>
+        ))}
+        <Button type="button" variant="outline" size="sm" className="w-full gap-1" onClick={addAmp}>
+          <Plus className="h-3.5 w-3.5" />
+          Añadir amplificador
+        </Button>
+      </div>
+
+      <div className="flex gap-2 pt-1">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="flex-1 gap-1"
+          onClick={() => onDuplicate(block.id)}
+        >
+          <Copy className="h-3.5 w-3.5" />
+          Duplicar
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          className="flex-1 gap-1"
+          onClick={() => onDelete(block.id)}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          Eliminar
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sound/amplifier-tool/rack-designer/BlockEditorPanel.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/BlockEditorPanel.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
-import type { RackDesignerAmp, RackDesignerBlock } from './types';
+import type { RackDesignerAmp, RackDesignerBlock } from '@/components/sound/amplifier-tool/rack-designer/types';
 import {
   DEFAULT_IP_BASE,
   RACK_COLOR_PALETTE,
@@ -12,7 +12,7 @@ import {
   incrementIp,
   isValidIp,
   makeDesignerId,
-} from './layout-utils';
+} from '@/components/sound/amplifier-tool/rack-designer/layout-utils';
 
 interface BlockEditorPanelProps {
   block: RackDesignerBlock;
@@ -165,7 +165,7 @@ export function BlockEditorPanel({ block, onChange, onDuplicate, onDelete }: Blo
                 placeholder="192.168.1.11"
                 className={cn('h-7 font-mono text-xs', !isValidIp(amp.ip) && 'border-destructive')}
               />
-              <span className="shrink-0 text-[10px] text-muted-foreground">{amp.model}</span>
+              <span className="shrink-0 text-xs text-muted-foreground">{amp.model}</span>
             </div>
           </div>
         ))}

--- a/src/components/sound/amplifier-tool/rack-designer/RackBlockCard.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/RackBlockCard.tsx
@@ -12,12 +12,17 @@ import {
   blockPixelHeight,
 } from './layout-utils';
 
+const TAP_MOVEMENT_THRESHOLD_PX = 6;
+
 interface DragState {
   pointerId: number;
   startX: number;
   startY: number;
   originX: number;
   originY: number;
+  moved: boolean;
+  /** Amp cell the gesture started on, if any — used to open its editor on tap. */
+  ampId: string | null;
 }
 
 interface RackBlockCardProps {
@@ -25,21 +30,26 @@ interface RackBlockCardProps {
   selected: boolean;
   onSelect: (id: string) => void;
   onMove: (id: string, x: number, y: number) => void;
+  /** Fired on a tap (press + release without dragging). ampId is null for the header. */
+  onTap: (id: string, ampId: string | null) => void;
 }
 
-export function RackBlockCard({ block, selected, onSelect, onMove }: RackBlockCardProps) {
+export function RackBlockCard({ block, selected, onSelect, onMove, onTap }: RackBlockCardProps) {
   const dragState = useRef<DragState | null>(null);
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     if (event.pointerType === 'mouse' && event.button !== 0) return;
     event.stopPropagation();
     onSelect(block.id);
+    const ampCell = (event.target as HTMLElement).closest('[data-amp-id]') as HTMLElement | null;
     dragState.current = {
       pointerId: event.pointerId,
       startX: event.clientX,
       startY: event.clientY,
       originX: block.x,
       originY: block.y,
+      moved: false,
+      ampId: ampCell?.dataset.ampId ?? null,
     };
     event.currentTarget.setPointerCapture(event.pointerId);
   };
@@ -47,11 +57,15 @@ export function RackBlockCard({ block, selected, onSelect, onMove }: RackBlockCa
   const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
     const drag = dragState.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
+    const deltaX = event.clientX - drag.startX;
+    const deltaY = event.clientY - drag.startY;
+    if (!drag.moved && Math.hypot(deltaX, deltaY) < TAP_MOVEMENT_THRESHOLD_PX) return;
+    drag.moved = true;
     const snap = (value: number) => Math.round(value / GRID_SIZE) * GRID_SIZE;
     const maxX = CANVAS_WIDTH - BLOCK_WIDTH;
     const maxY = CANVAS_HEIGHT - blockPixelHeight(block);
-    const nextX = Math.min(Math.max(snap(drag.originX + event.clientX - drag.startX), 0), maxX);
-    const nextY = Math.min(Math.max(snap(drag.originY + event.clientY - drag.startY), 0), maxY);
+    const nextX = Math.min(Math.max(snap(drag.originX + deltaX), 0), maxX);
+    const nextY = Math.min(Math.max(snap(drag.originY + deltaY), 0), maxY);
     if (nextX !== block.x || nextY !== block.y) {
       onMove(block.id, nextX, nextY);
     }
@@ -63,6 +77,9 @@ export function RackBlockCard({ block, selected, onSelect, onMove }: RackBlockCa
     dragState.current = null;
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (event.type === 'pointerup' && !drag.moved) {
+      onTap(block.id, drag.ampId);
     }
   };
 
@@ -92,7 +109,8 @@ export function RackBlockCard({ block, selected, onSelect, onMove }: RackBlockCa
       {block.amps.map((amp) => (
         <div
           key={amp.id}
-          className="flex flex-col items-center justify-center border border-t-0 border-black/60 px-1 text-center"
+          data-amp-id={amp.id}
+          className="flex cursor-pointer flex-col items-center justify-center border border-t-0 border-black/60 px-1 text-center"
           style={{ height: AMP_CELL_HEIGHT, backgroundColor: block.color }}
         >
           <span className="w-full truncate text-xs font-bold text-black">{amp.presetName}</span>

--- a/src/components/sound/amplifier-tool/rack-designer/RackBlockCard.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/RackBlockCard.tsx
@@ -28,13 +28,25 @@ interface DragState {
 interface RackBlockCardProps {
   block: RackDesignerBlock;
   selected: boolean;
+  /** Current canvas zoom — pointer deltas are in screen px and must be unscaled. */
+  zoom: number;
+  /** True while a two-finger pinch is in progress; drags freeze so racks don't jump. */
+  pinchActiveRef: React.RefObject<boolean>;
   onSelect: (id: string) => void;
   onMove: (id: string, x: number, y: number) => void;
   /** Fired on a tap (press + release without dragging). ampId is null for the header. */
   onTap: (id: string, ampId: string | null) => void;
 }
 
-export function RackBlockCard({ block, selected, onSelect, onMove, onTap }: RackBlockCardProps) {
+export function RackBlockCard({
+  block,
+  selected,
+  zoom,
+  pinchActiveRef,
+  onSelect,
+  onMove,
+  onTap,
+}: RackBlockCardProps) {
   const dragState = useRef<DragState | null>(null);
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -57,6 +69,10 @@ export function RackBlockCard({ block, selected, onSelect, onMove, onTap }: Rack
   const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
     const drag = dragState.current;
     if (!drag || drag.pointerId !== event.pointerId) return;
+    if (pinchActiveRef.current) {
+      drag.moved = true;
+      return;
+    }
     const deltaX = event.clientX - drag.startX;
     const deltaY = event.clientY - drag.startY;
     if (!drag.moved && Math.hypot(deltaX, deltaY) < TAP_MOVEMENT_THRESHOLD_PX) return;
@@ -64,8 +80,8 @@ export function RackBlockCard({ block, selected, onSelect, onMove, onTap }: Rack
     const snap = (value: number) => Math.round(value / GRID_SIZE) * GRID_SIZE;
     const maxX = CANVAS_WIDTH - BLOCK_WIDTH;
     const maxY = CANVAS_HEIGHT - blockPixelHeight(block);
-    const nextX = Math.min(Math.max(snap(drag.originX + deltaX), 0), maxX);
-    const nextY = Math.min(Math.max(snap(drag.originY + deltaY), 0), maxY);
+    const nextX = Math.min(Math.max(snap(drag.originX + deltaX / zoom), 0), maxX);
+    const nextY = Math.min(Math.max(snap(drag.originY + deltaY / zoom), 0), maxY);
     if (nextX !== block.x || nextY !== block.y) {
       onMove(block.id, nextX, nextY);
     }

--- a/src/components/sound/amplifier-tool/rack-designer/RackBlockCard.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/RackBlockCard.tsx
@@ -1,0 +1,104 @@
+import { useRef } from 'react';
+import { GripVertical } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { RackDesignerBlock } from './types';
+import {
+  AMP_CELL_HEIGHT,
+  BLOCK_HEADER_HEIGHT,
+  BLOCK_WIDTH,
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  GRID_SIZE,
+  blockPixelHeight,
+} from './layout-utils';
+
+interface DragState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  originX: number;
+  originY: number;
+}
+
+interface RackBlockCardProps {
+  block: RackDesignerBlock;
+  selected: boolean;
+  onSelect: (id: string) => void;
+  onMove: (id: string, x: number, y: number) => void;
+}
+
+export function RackBlockCard({ block, selected, onSelect, onMove }: RackBlockCardProps) {
+  const dragState = useRef<DragState | null>(null);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    event.stopPropagation();
+    onSelect(block.id);
+    dragState.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: block.x,
+      originY: block.y,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragState.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const snap = (value: number) => Math.round(value / GRID_SIZE) * GRID_SIZE;
+    const maxX = CANVAS_WIDTH - BLOCK_WIDTH;
+    const maxY = CANVAS_HEIGHT - blockPixelHeight(block);
+    const nextX = Math.min(Math.max(snap(drag.originX + event.clientX - drag.startX), 0), maxX);
+    const nextY = Math.min(Math.max(snap(drag.originY + event.clientY - drag.startY), 0), maxY);
+    if (nextX !== block.x || nextY !== block.y) {
+      onMove(block.id, nextX, nextY);
+    }
+  };
+
+  const handlePointerEnd = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragState.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    dragState.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'absolute select-none touch-none cursor-grab active:cursor-grabbing rounded-sm shadow-sm',
+        selected && 'ring-2 ring-primary ring-offset-1 z-10',
+      )}
+      style={{ left: block.x, top: block.y, width: BLOCK_WIDTH }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+    >
+      <div
+        className="flex items-center gap-1 border border-black/60 px-2 text-xs font-semibold text-black/80"
+        style={{
+          height: BLOCK_HEADER_HEIGHT,
+          backgroundColor: block.color,
+          filter: 'saturate(0.55) brightness(1.1)',
+        }}
+      >
+        <GripVertical className="h-3 w-3 shrink-0" />
+        <span className="truncate">{block.label}</span>
+      </div>
+      {block.amps.map((amp) => (
+        <div
+          key={amp.id}
+          className="flex flex-col items-center justify-center border border-t-0 border-black/60 px-1 text-center"
+          style={{ height: AMP_CELL_HEIGHT, backgroundColor: block.color }}
+        >
+          <span className="w-full truncate text-xs font-bold text-black">{amp.presetName}</span>
+          <span className="text-[11px] leading-tight text-black/90">{amp.ip}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/sound/amplifier-tool/rack-designer/RackBlockCard.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/RackBlockCard.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { GripVertical } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { RackDesignerBlock } from './types';
+import type { RackDesignerBlock } from '@/components/sound/amplifier-tool/rack-designer/types';
 import {
   AMP_CELL_HEIGHT,
   BLOCK_HEADER_HEIGHT,
@@ -10,7 +10,7 @@ import {
   CANVAS_WIDTH,
   GRID_SIZE,
   blockPixelHeight,
-} from './layout-utils';
+} from '@/components/sound/amplifier-tool/rack-designer/layout-utils';
 
 const TAP_MOVEMENT_THRESHOLD_PX = 6;
 
@@ -99,10 +99,39 @@ export function RackBlockCard({
     }
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const arrowDeltas: Record<string, [number, number]> = {
+      ArrowLeft: [-GRID_SIZE, 0],
+      ArrowRight: [GRID_SIZE, 0],
+      ArrowUp: [0, -GRID_SIZE],
+      ArrowDown: [0, GRID_SIZE],
+    };
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect(block.id);
+      onTap(block.id, null);
+      return;
+    }
+    const delta = arrowDeltas[event.key];
+    if (!delta) return;
+    event.preventDefault();
+    const maxX = CANVAS_WIDTH - BLOCK_WIDTH;
+    const maxY = CANVAS_HEIGHT - blockPixelHeight(block);
+    onMove(
+      block.id,
+      Math.min(Math.max(block.x + delta[0], 0), maxX),
+      Math.min(Math.max(block.y + delta[1], 0), maxY),
+    );
+  };
+
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-label={`Rack ${block.label}: seleccionar con Intro, mover con las flechas`}
       className={cn(
         'absolute select-none touch-none cursor-grab active:cursor-grabbing rounded-sm shadow-sm',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1',
         selected && 'ring-2 ring-primary ring-offset-1 z-10',
       )}
       style={{ left: block.x, top: block.y, width: BLOCK_WIDTH }}
@@ -110,6 +139,8 @@ export function RackBlockCard({
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerEnd}
       onPointerCancel={handlePointerEnd}
+      onKeyDown={handleKeyDown}
+      onFocus={() => onSelect(block.id)}
     >
       <div
         className="flex items-center gap-1 border border-black/60 px-2 text-xs font-semibold text-black/80"
@@ -130,7 +161,7 @@ export function RackBlockCard({
           style={{ height: AMP_CELL_HEIGHT, backgroundColor: block.color }}
         >
           <span className="w-full truncate text-xs font-bold text-black">{amp.presetName}</span>
-          <span className="text-[11px] leading-tight text-black/90">{amp.ip}</span>
+          <span className="text-xs leading-tight text-black/90">{amp.ip}</span>
         </div>
       ))}
     </div>

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/layout-utils.test.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/layout-utils.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { AmplifierResults } from '../../types';
+import {
+  AMPS_PER_RACK,
+  assignBlockIps,
+  assignSequentialIps,
+  generateLayoutFromResults,
+  incrementIp,
+  isValidIp,
+} from '../layout-utils';
+
+const emptySection = { amps: 0, details: [] as string[], totalAmps: 0 };
+
+const makeResults = (
+  perSection: AmplifierResults['perSection'],
+): AmplifierResults => ({
+  totalAmplifiersNeeded: 0,
+  completeRaks: 0,
+  looseAmplifiers: 0,
+  plmRacks: 0,
+  loosePLMAmps: 0,
+  laAmpsTotal: 0,
+  plmAmpsTotal: 0,
+  perSection,
+});
+
+describe('isValidIp', () => {
+  it('accepts valid IPv4 addresses', () => {
+    expect(isValidIp('192.168.1.11')).toBe(true);
+    expect(isValidIp('10.0.0.255')).toBe(true);
+  });
+
+  it('rejects malformed addresses', () => {
+    expect(isValidIp('192.168.1')).toBe(false);
+    expect(isValidIp('192.168.1.256')).toBe(false);
+    expect(isValidIp('192.168.1.a')).toBe(false);
+    expect(isValidIp('')).toBe(false);
+  });
+});
+
+describe('incrementIp', () => {
+  it('increments the last octet', () => {
+    expect(incrementIp('192.168.1.11', 3)).toBe('192.168.1.14');
+  });
+
+  it('carries over octet boundaries', () => {
+    expect(incrementIp('192.168.1.255', 1)).toBe('192.168.2.0');
+  });
+
+  it('returns the input unchanged when invalid', () => {
+    expect(incrementIp('not-an-ip', 5)).toBe('not-an-ip');
+  });
+});
+
+describe('assignSequentialIps / assignBlockIps', () => {
+  it('numbers amps sequentially across blocks', () => {
+    const results = makeResults({
+      mains: { amps: 4, details: [], totalAmps: 4, mirrored: true, laAmps: 4, plmAmps: 0 },
+      subs: { ...emptySection, amps: 2, totalAmps: 2, laAmps: 2, plmAmps: 0 },
+    });
+    const layout = generateLayoutFromResults(results);
+    const blocks = assignSequentialIps(layout.blocks, '192.168.1.11');
+    const ips = blocks.flatMap((block) => block.amps.map((amp) => amp.ip));
+    expect(ips).toEqual(['192.168.1.11', '192.168.1.12', '192.168.1.13', '192.168.1.14', '192.168.1.15', '192.168.1.16']);
+  });
+
+  it('assigns block IPs starting at the given base', () => {
+    const results = makeResults({
+      subs: { ...emptySection, amps: 3, totalAmps: 3, laAmps: 3, plmAmps: 0 },
+    });
+    const layout = generateLayoutFromResults(results);
+    const block = assignBlockIps(layout.blocks[0], '192.168.1.31');
+    expect(block.amps.map((amp) => amp.ip)).toEqual(['192.168.1.31', '192.168.1.32', '192.168.1.33']);
+  });
+});
+
+describe('generateLayoutFromResults', () => {
+  it('splits mirrored sections into L and R preset names', () => {
+    const results = makeResults({
+      mains: { amps: 4, details: [], totalAmps: 4, mirrored: true, laAmps: 4, plmAmps: 0 },
+    });
+    const layout = generateLayoutFromResults(results);
+    const names = layout.blocks.flatMap((block) => block.amps.map((amp) => amp.presetName));
+    expect(names).toEqual(['MAIN L1', 'MAIN L2', 'MAIN R1', 'MAIN R2']);
+  });
+
+  it('gives the left side the extra amp on odd mirrored counts', () => {
+    const results = makeResults({
+      mains: { amps: 3, details: [], totalAmps: 3, mirrored: true, laAmps: 3, plmAmps: 0 },
+    });
+    const names = generateLayoutFromResults(results)
+      .blocks.flatMap((block) => block.amps.map((amp) => amp.presetName));
+    expect(names).toEqual(['MAIN L1', 'MAIN L2', 'MAIN R1']);
+  });
+
+  it('numbers non-mirrored sections without a side suffix', () => {
+    const results = makeResults({
+      subs: { ...emptySection, amps: 2, totalAmps: 2, laAmps: 2, plmAmps: 0 },
+    });
+    const names = generateLayoutFromResults(results)
+      .blocks.flatMap((block) => block.amps.map((amp) => amp.presetName));
+    expect(names).toEqual(['SUB 1', 'SUB 2']);
+  });
+
+  it('packs at most 3 amps per rack and never mixes amp models in one rack', () => {
+    const results = makeResults({
+      mains: { amps: 8, details: [], totalAmps: 8, mirrored: true, laAmps: 8, plmAmps: 0 },
+      delays: { ...emptySection, amps: 2, totalAmps: 2, laAmps: 1, plmAmps: 1 },
+    });
+    const layout = generateLayoutFromResults(results);
+    for (const block of layout.blocks) {
+      expect(block.amps.length).toBeLessThanOrEqual(AMPS_PER_RACK);
+      expect(new Set(block.amps.map((amp) => amp.model)).size).toBe(1);
+    }
+  });
+
+  it('colors left racks red, right racks blue and center racks green', () => {
+    const results = makeResults({
+      mains: { amps: 2, details: [], totalAmps: 2, mirrored: true, laAmps: 2, plmAmps: 0 },
+      subs: { ...emptySection, amps: 1, totalAmps: 1, laAmps: 1, plmAmps: 0 },
+    });
+    const layout = generateLayoutFromResults(results);
+    const byName = (needle: string) =>
+      layout.blocks.find((block) => block.amps.some((amp) => amp.presetName.includes(needle)));
+    expect(byName('MAIN L')?.color).toBe('#f87171');
+    expect(byName('MAIN R')?.color).toBe('#60a5fa');
+    expect(byName('SUB')?.color).toBe('#4ade80');
+  });
+
+  it('does not overlap default block positions', () => {
+    const results = makeResults({
+      mains: { amps: 8, details: [], totalAmps: 8, mirrored: true, laAmps: 8, plmAmps: 0 },
+      subs: { ...emptySection, amps: 6, totalAmps: 6, laAmps: 6, plmAmps: 0 },
+    });
+    const layout = generateLayoutFromResults(results);
+    const positions = layout.blocks.map((block) => `${block.x},${block.y}`);
+    expect(new Set(positions).size).toBe(positions.length);
+  });
+});

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/layout-utils.test.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/layout-utils.test.ts
@@ -4,6 +4,7 @@ import {
   AMPS_PER_RACK,
   assignBlockIps,
   assignSequentialIps,
+  computeResultsFingerprint,
   generateLayoutFromResults,
   incrementIp,
   isValidIp,
@@ -114,6 +115,19 @@ describe('generateLayoutFromResults', () => {
     }
   });
 
+  it('stamps and changes the results fingerprint when the calculation changes', () => {
+    const resultsA = makeResults({
+      mains: { amps: 4, details: [], totalAmps: 4, mirrored: true, laAmps: 4, plmAmps: 0 },
+    });
+    const resultsB = makeResults({
+      mains: { amps: 6, details: [], totalAmps: 6, mirrored: true, laAmps: 6, plmAmps: 0 },
+    });
+    const layout = generateLayoutFromResults(resultsA);
+    expect(layout.resultsFingerprint).toBe(computeResultsFingerprint(resultsA));
+    expect(computeResultsFingerprint(resultsA)).not.toBe(computeResultsFingerprint(resultsB));
+    expect(computeResultsFingerprint(resultsA)).toBe(computeResultsFingerprint(makeResults(resultsA.perSection)));
+  });
+
   it('colors left racks red, right racks blue and center racks green', () => {
     const results = makeResults({
       mains: { amps: 2, details: [], totalAmps: 2, mirrored: true, laAmps: 2, plmAmps: 0 },
@@ -125,6 +139,15 @@ describe('generateLayoutFromResults', () => {
     expect(byName('MAIN L')?.color).toBe('#f87171');
     expect(byName('MAIN R')?.color).toBe('#60a5fa');
     expect(byName('SUB')?.color).toBe('#4ade80');
+  });
+
+  it('balances mixed amp models across sides in mirrored sections', () => {
+    const results = makeResults({
+      mains: { amps: 2, details: [], totalAmps: 2, mirrored: true, laAmps: 1, plmAmps: 1 },
+    });
+    const layout = generateLayoutFromResults(results);
+    const names = layout.blocks.flatMap((block) => block.amps.map((amp) => amp.presetName));
+    expect(names).toEqual(['MAIN L1', 'MAIN R1']);
   });
 
   it('does not overlap default block positions', () => {

--- a/src/components/sound/amplifier-tool/rack-designer/layout-utils.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/layout-utils.ts
@@ -1,11 +1,11 @@
-import type { AmplifierResults } from '../types';
+import type { AmplifierResults } from '@/components/sound/amplifier-tool/types';
 import type {
   AmpModel,
   RackDesignerAmp,
   RackDesignerBlock,
   RackDesignerLayout,
   RackSide,
-} from './types';
+} from '@/components/sound/amplifier-tool/rack-designer/types';
 
 export const CANVAS_WIDTH = 1500;
 export const CANVAS_HEIGHT = 1100;
@@ -113,16 +113,18 @@ function buildSectionAmps(
 
   const amps: GeneratedAmp[] = [];
   if (data.mirrored) {
+    // Alternate sides across the whole section (not per model) so mixed
+    // LA12X/PLM sections stay balanced — e.g. 1 LA + 1 PLM lands L + R.
     const leftAmps: GeneratedAmp[] = [];
     const rightAmps: GeneratedAmp[] = [];
     const counters = { L: 0, R: 0 };
+    let nextSide: 'L' | 'R' = 'L';
     for (const [model, count] of typeCounts) {
-      const leftCount = Math.ceil(count / 2);
-      for (let i = 0; i < leftCount; i++) {
-        leftAmps.push({ presetName: `${base} L${++counters.L}`, model, side: 'L' });
-      }
-      for (let i = 0; i < count - leftCount; i++) {
-        rightAmps.push({ presetName: `${base} R${++counters.R}`, model, side: 'R' });
+      for (let i = 0; i < count; i++) {
+        const side: 'L' | 'R' = nextSide;
+        nextSide = side === 'L' ? 'R' : 'L';
+        const target = side === 'L' ? leftAmps : rightAmps;
+        target.push({ presetName: `${base} ${side}${++counters[side]}`, model, side });
       }
     }
     amps.push(...leftAmps, ...rightAmps);
@@ -140,6 +142,20 @@ function buildSectionAmps(
     }
   }
   return amps;
+}
+
+/**
+ * Stable fingerprint of the calculation a layout was generated from. Stored
+ * with the layout so a stale saved design is regenerated instead of silently
+ * shown next to a newer calculation.
+ */
+export function computeResultsFingerprint(results: AmplifierResults): string {
+  const parts = SECTION_ORDER.map((section) => {
+    const data = results.perSection[section];
+    if (!data || data.totalAmps === 0) return `${section}:0`;
+    return `${section}:${data.laAmps ?? 0}/${data.plmAmps ?? 0}/${data.mirrored ? 'm' : 's'}`;
+  });
+  return parts.join('|');
 }
 
 /**
@@ -213,18 +229,61 @@ export function generateLayoutFromResults(
   const sideRows = Math.max(Math.ceil(left.length / 3), Math.ceil(right.length / 3));
   placeGrid(center, 40, 40 + Math.max(sideRows, 1) * rowPitch, 6);
 
-  return { version: 1, title, blocks: [...left, ...right, ...center] };
+  return {
+    version: 1,
+    title,
+    resultsFingerprint: computeResultsFingerprint(results),
+    blocks: [...left, ...right, ...center],
+  };
 }
 
 const storageKey = (scope: string) => `amp-rack-designer:${scope}`;
+
+const AMP_MODELS: readonly string[] = ['LA12X', 'PLM20000D'];
+
+function isStoredAmp(value: unknown): value is RackDesignerAmp {
+  const amp = value as RackDesignerAmp;
+  return (
+    !!amp &&
+    typeof amp.id === 'string' &&
+    typeof amp.presetName === 'string' &&
+    typeof amp.ip === 'string' &&
+    AMP_MODELS.includes(amp.model)
+  );
+}
+
+function isStoredBlock(value: unknown): value is RackDesignerBlock {
+  const block = value as RackDesignerBlock;
+  return (
+    !!block &&
+    typeof block.id === 'string' &&
+    typeof block.label === 'string' &&
+    typeof block.color === 'string' &&
+    Number.isFinite(block.x) &&
+    Number.isFinite(block.y) &&
+    Array.isArray(block.amps) &&
+    block.amps.every(isStoredAmp)
+  );
+}
+
+function isStoredLayout(value: unknown): value is RackDesignerLayout {
+  const layout = value as RackDesignerLayout;
+  return (
+    !!layout &&
+    layout.version === 1 &&
+    typeof layout.title === 'string' &&
+    (layout.resultsFingerprint === undefined || typeof layout.resultsFingerprint === 'string') &&
+    Array.isArray(layout.blocks) &&
+    layout.blocks.every(isStoredBlock)
+  );
+}
 
 export function loadStoredLayout(scope: string): RackDesignerLayout | null {
   try {
     const raw = localStorage.getItem(storageKey(scope));
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as RackDesignerLayout;
-    if (parsed?.version !== 1 || !Array.isArray(parsed.blocks)) return null;
-    return parsed;
+    const parsed: unknown = JSON.parse(raw);
+    return isStoredLayout(parsed) ? parsed : null;
   } catch {
     return null;
   }

--- a/src/components/sound/amplifier-tool/rack-designer/layout-utils.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/layout-utils.ts
@@ -1,0 +1,239 @@
+import type { AmplifierResults } from '../types';
+import type {
+  AmpModel,
+  RackDesignerAmp,
+  RackDesignerBlock,
+  RackDesignerLayout,
+  RackSide,
+} from './types';
+
+export const CANVAS_WIDTH = 1500;
+export const CANVAS_HEIGHT = 1100;
+export const GRID_SIZE = 10;
+export const BLOCK_WIDTH = 180;
+export const BLOCK_HEADER_HEIGHT = 28;
+export const AMP_CELL_HEIGHT = 48;
+export const AMPS_PER_RACK = 3;
+
+export const DEFAULT_IP_BASE = '192.168.1.11';
+export const DEFAULT_LAYOUT_TITLE = 'SISTEMA PA';
+
+export const RACK_COLOR_PALETTE = [
+  { name: 'Rojo', value: '#f87171' },
+  { name: 'Azul', value: '#60a5fa' },
+  { name: 'Verde', value: '#4ade80' },
+  { name: 'Amarillo', value: '#facc15' },
+  { name: 'Naranja', value: '#fb923c' },
+  { name: 'Morado', value: '#c084fc' },
+  { name: 'Turquesa', value: '#2dd4bf' },
+  { name: 'Gris', value: '#d1d5db' },
+] as const;
+
+const SIDE_COLORS: Record<RackSide, string> = {
+  L: '#f87171',
+  R: '#60a5fa',
+  C: '#4ade80',
+};
+
+const SECTION_LABELS: Record<string, string> = {
+  mains: 'MAIN',
+  outs: 'OUT',
+  subs: 'SUB',
+  fronts: 'FRONT',
+  delays: 'DELAY',
+  other: 'AUX',
+};
+
+const SECTION_ORDER = ['mains', 'outs', 'subs', 'fronts', 'delays', 'other'];
+
+export function makeDesignerId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `id-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function blockPixelHeight(block: Pick<RackDesignerBlock, 'amps'>): number {
+  return BLOCK_HEADER_HEIGHT + block.amps.length * AMP_CELL_HEIGHT;
+}
+
+export function isValidIp(ip: string): boolean {
+  const parts = ip.trim().split('.');
+  if (parts.length !== 4) return false;
+  return parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255);
+}
+
+export function incrementIp(ip: string, by: number): string {
+  if (!isValidIp(ip)) return ip;
+  const parts = ip.trim().split('.').map(Number);
+  const base = ((parts[0] * 256 + parts[1]) * 256 + parts[2]) * 256 + parts[3];
+  const value = Math.max(0, Math.min(0xffffffff, base + by));
+  return [
+    (value >>> 24) & 255,
+    (value >>> 16) & 255,
+    (value >>> 8) & 255,
+    value & 255,
+  ].join('.');
+}
+
+/** Reassigns IPs sequentially amp by amp, block by block, starting at baseIp. */
+export function assignSequentialIps(
+  blocks: RackDesignerBlock[],
+  baseIp: string,
+): RackDesignerBlock[] {
+  let offset = 0;
+  return blocks.map((block) => ({
+    ...block,
+    amps: block.amps.map((amp) => ({ ...amp, ip: incrementIp(baseIp, offset++) })),
+  }));
+}
+
+export function assignBlockIps(block: RackDesignerBlock, baseIp: string): RackDesignerBlock {
+  return {
+    ...block,
+    amps: block.amps.map((amp, index) => ({ ...amp, ip: incrementIp(baseIp, index) })),
+  };
+}
+
+interface GeneratedAmp {
+  presetName: string;
+  model: AmpModel;
+  side: RackSide;
+}
+
+function buildSectionAmps(
+  section: string,
+  data: AmplifierResults['perSection'][string],
+): GeneratedAmp[] {
+  const base = SECTION_LABELS[section] ?? section.toUpperCase();
+  const typeCounts: Array<[AmpModel, number]> = [
+    ['LA12X', data.laAmps ?? 0],
+    ['PLM20000D', data.plmAmps ?? 0],
+  ];
+
+  const amps: GeneratedAmp[] = [];
+  if (data.mirrored) {
+    const leftAmps: GeneratedAmp[] = [];
+    const rightAmps: GeneratedAmp[] = [];
+    const counters = { L: 0, R: 0 };
+    for (const [model, count] of typeCounts) {
+      const leftCount = Math.ceil(count / 2);
+      for (let i = 0; i < leftCount; i++) {
+        leftAmps.push({ presetName: `${base} L${++counters.L}`, model, side: 'L' });
+      }
+      for (let i = 0; i < count - leftCount; i++) {
+        rightAmps.push({ presetName: `${base} R${++counters.R}`, model, side: 'R' });
+      }
+    }
+    amps.push(...leftAmps, ...rightAmps);
+  } else {
+    const total = typeCounts.reduce((sum, [, count]) => sum + count, 0);
+    let counter = 0;
+    for (const [model, count] of typeCounts) {
+      for (let i = 0; i < count; i++) {
+        amps.push({
+          presetName: total > 1 ? `${base} ${++counter}` : base,
+          model,
+          side: 'C',
+        });
+      }
+    }
+  }
+  return amps;
+}
+
+/**
+ * Builds the initial rack layout from calculator results: amps are grouped by
+ * PA side (L / R / center) and amp model, packed into racks of 3, colored by
+ * side (L red, R blue, center green — matching the crew's usual IP sheets) and
+ * given sequential IPs starting at DEFAULT_IP_BASE.
+ */
+export function generateLayoutFromResults(
+  results: AmplifierResults,
+  title: string = DEFAULT_LAYOUT_TITLE,
+): RackDesignerLayout {
+  const amps: GeneratedAmp[] = [];
+  for (const section of SECTION_ORDER) {
+    const data = results.perSection[section];
+    if (data && data.totalAmps > 0) {
+      amps.push(...buildSectionAmps(section, data));
+    }
+  }
+
+  let ipOffset = 0;
+  const buildSideBlocks = (side: RackSide): RackDesignerBlock[] => {
+    const sideBlocks: RackDesignerBlock[] = [];
+    const sideAmps = amps.filter((amp) => amp.side === side);
+    let rackNumber = 0;
+    for (const model of ['LA12X', 'PLM20000D'] as AmpModel[]) {
+      const modelAmps = sideAmps.filter((amp) => amp.model === model);
+      for (let i = 0; i < modelAmps.length; i += AMPS_PER_RACK) {
+        const chunk = modelAmps.slice(i, i + AMPS_PER_RACK);
+        const rackAmps: RackDesignerAmp[] = chunk.map((amp) => ({
+          id: makeDesignerId(),
+          presetName: amp.presetName,
+          model: amp.model,
+          ip: incrementIp(DEFAULT_IP_BASE, ipOffset++),
+        }));
+        const prefix = model === 'LA12X' ? 'LA-RAK' : 'PLM-RAK';
+        const sideTag = side === 'C' ? '' : `${side}`;
+        sideBlocks.push({
+          id: makeDesignerId(),
+          label: `${prefix} ${sideTag}${++rackNumber}`,
+          color: SIDE_COLORS[side],
+          x: 0,
+          y: 0,
+          amps: rackAmps,
+        });
+      }
+    }
+    return sideBlocks;
+  };
+
+  const left = buildSideBlocks('L');
+  const right = buildSideBlocks('R');
+  const center = buildSideBlocks('C');
+
+  const columnPitch = BLOCK_WIDTH + 30;
+  const rowPitch = blockPixelHeight({ amps: new Array(AMPS_PER_RACK) }) + 50;
+  const placeGrid = (
+    blocks: RackDesignerBlock[],
+    originX: number,
+    originY: number,
+    perRow: number,
+  ) => {
+    blocks.forEach((block, index) => {
+      block.x = originX + (index % perRow) * columnPitch;
+      block.y = originY + Math.floor(index / perRow) * rowPitch;
+    });
+  };
+
+  placeGrid(left, 40, 40, 3);
+  placeGrid(right, 40 + 3 * columnPitch + 90, 40, 3);
+  const sideRows = Math.max(Math.ceil(left.length / 3), Math.ceil(right.length / 3));
+  placeGrid(center, 40, 40 + Math.max(sideRows, 1) * rowPitch, 6);
+
+  return { version: 1, title, blocks: [...left, ...right, ...center] };
+}
+
+const storageKey = (scope: string) => `amp-rack-designer:${scope}`;
+
+export function loadStoredLayout(scope: string): RackDesignerLayout | null {
+  try {
+    const raw = localStorage.getItem(storageKey(scope));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as RackDesignerLayout;
+    if (parsed?.version !== 1 || !Array.isArray(parsed.blocks)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveStoredLayout(scope: string, layout: RackDesignerLayout): void {
+  try {
+    localStorage.setItem(storageKey(scope), JSON.stringify(layout));
+  } catch {
+    // Storage full or unavailable — the designer keeps working in memory.
+  }
+}

--- a/src/components/sound/amplifier-tool/rack-designer/types.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/types.ts
@@ -1,0 +1,27 @@
+export type AmpModel = 'LA12X' | 'PLM20000D';
+
+/** Side of the PA the amp feeds: left, right or center/mono (subs, delays, fills…). */
+export type RackSide = 'L' | 'R' | 'C';
+
+export interface RackDesignerAmp {
+  id: string;
+  presetName: string;
+  ip: string;
+  model: AmpModel;
+}
+
+export interface RackDesignerBlock {
+  id: string;
+  label: string;
+  /** Hex fill color shared by every amp cell in the rack. */
+  color: string;
+  x: number;
+  y: number;
+  amps: RackDesignerAmp[];
+}
+
+export interface RackDesignerLayout {
+  version: 1;
+  title: string;
+  blocks: RackDesignerBlock[];
+}

--- a/src/components/sound/amplifier-tool/rack-designer/types.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/types.ts
@@ -23,5 +23,7 @@ export interface RackDesignerBlock {
 export interface RackDesignerLayout {
   version: 1;
   title: string;
+  /** Fingerprint of the calculator results this layout was generated from. */
+  resultsFingerprint?: string;
   blocks: RackDesignerBlock[];
 }

--- a/src/components/sound/amplifier-tool/rack-designer/useCanvasZoom.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/useCanvasZoom.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+export const MIN_ZOOM = 0.2;
+export const MAX_ZOOM = 2;
+const ZOOM_STEP = 1.25;
+
+interface UseCanvasZoomOptions {
+  /** Attach listeners only while the canvas is mounted (dialog open). */
+  enabled: boolean;
+  contentWidth: number;
+  contentHeight: number;
+}
+
+const touchDistance = (touches: TouchList) =>
+  Math.hypot(touches[0].clientX - touches[1].clientX, touches[0].clientY - touches[1].clientY);
+
+const touchMidpoint = (touches: TouchList) => ({
+  clientX: (touches[0].clientX + touches[1].clientX) / 2,
+  clientY: (touches[0].clientY + touches[1].clientY) / 2,
+});
+
+/**
+ * Zoom state for the rack canvas: pinch-to-zoom on touch, Ctrl/trackpad wheel
+ * zoom on desktop, plus programmatic in/out/fit. Zooming keeps the gesture's
+ * focal point anchored by compensating the container's scroll position.
+ *
+ * Attach the returned `scrollRef` as the scroll container's ref. It is a
+ * callback ref backed by state — the container lives inside a Radix portal
+ * that mounts a commit after the dialog opens, so a plain RefObject would be
+ * null when the listener effect first runs.
+ *
+ * `pinchActiveRef` is exposed so block drag handlers can freeze while pinching.
+ */
+export function useCanvasZoom({ enabled, contentWidth, contentHeight }: UseCanvasZoomOptions) {
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const [zoom, setZoomState] = useState(1);
+  const zoomRef = useRef(1);
+  const pinchActiveRef = useRef(false);
+  const pinchStart = useRef<{ distance: number; zoom: number } | null>(null);
+  const pendingScroll = useRef<{ left: number; top: number } | null>(null);
+
+  const applyZoom = useCallback(
+    (next: number, anchor?: { clientX: number; clientY: number }) => {
+      const clamped = Math.min(Math.max(next, MIN_ZOOM), MAX_ZOOM);
+      const previous = zoomRef.current;
+      zoomRef.current = clamped;
+      setZoomState(clamped);
+      if (!scrollEl || previous === 0) return;
+      const rect = scrollEl.getBoundingClientRect();
+      const anchorX = anchor ? anchor.clientX - rect.left : rect.width / 2;
+      const anchorY = anchor ? anchor.clientY - rect.top : rect.height / 2;
+      pendingScroll.current = {
+        left: ((scrollEl.scrollLeft + anchorX) / previous) * clamped - anchorX,
+        top: ((scrollEl.scrollTop + anchorY) / previous) * clamped - anchorY,
+      };
+    },
+    [scrollEl],
+  );
+
+  // Scroll compensation must run after React commits the resized canvas,
+  // otherwise the new offsets get clamped against the old scroll bounds.
+  useLayoutEffect(() => {
+    if (scrollEl && pendingScroll.current) {
+      scrollEl.scrollLeft = pendingScroll.current.left;
+      scrollEl.scrollTop = pendingScroll.current.top;
+      pendingScroll.current = null;
+    }
+  }, [zoom, scrollEl]);
+
+  const zoomIn = useCallback(() => applyZoom(zoomRef.current * ZOOM_STEP), [applyZoom]);
+  const zoomOut = useCallback(() => applyZoom(zoomRef.current / ZOOM_STEP), [applyZoom]);
+
+  const fitToView = useCallback(() => {
+    if (!scrollEl) return;
+    applyZoom(
+      Math.min(
+        (scrollEl.clientWidth - 24) / contentWidth,
+        (scrollEl.clientHeight - 24) / contentHeight,
+        1,
+      ),
+    );
+  }, [applyZoom, contentHeight, contentWidth, scrollEl]);
+
+  useEffect(() => {
+    if (!enabled || !scrollEl) return;
+
+    const onTouchStart = (event: TouchEvent) => {
+      if (event.touches.length !== 2) return;
+      event.preventDefault();
+      pinchActiveRef.current = true;
+      pinchStart.current = { distance: touchDistance(event.touches), zoom: zoomRef.current };
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      if (event.touches.length !== 2 || !pinchStart.current) return;
+      event.preventDefault();
+      const scale = touchDistance(event.touches) / pinchStart.current.distance;
+      applyZoom(pinchStart.current.zoom * scale, touchMidpoint(event.touches));
+    };
+
+    const onTouchEnd = (event: TouchEvent) => {
+      if (event.touches.length >= 2) return;
+      pinchStart.current = null;
+      // Small delay so a lifted pinch finger doesn't register as a block tap.
+      window.setTimeout(() => {
+        pinchActiveRef.current = false;
+      }, 80);
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      if (!event.ctrlKey && !event.metaKey) return;
+      event.preventDefault();
+      applyZoom(zoomRef.current * Math.exp(-event.deltaY * 0.002), {
+        clientX: event.clientX,
+        clientY: event.clientY,
+      });
+    };
+
+    scrollEl.addEventListener('touchstart', onTouchStart, { passive: false });
+    scrollEl.addEventListener('touchmove', onTouchMove, { passive: false });
+    scrollEl.addEventListener('touchend', onTouchEnd);
+    scrollEl.addEventListener('touchcancel', onTouchEnd);
+    scrollEl.addEventListener('wheel', onWheel, { passive: false });
+    return () => {
+      scrollEl.removeEventListener('touchstart', onTouchStart);
+      scrollEl.removeEventListener('touchmove', onTouchMove);
+      scrollEl.removeEventListener('touchend', onTouchEnd);
+      scrollEl.removeEventListener('touchcancel', onTouchEnd);
+      scrollEl.removeEventListener('wheel', onWheel);
+      pinchActiveRef.current = false;
+      pinchStart.current = null;
+    };
+  }, [enabled, scrollEl, applyZoom]);
+
+  return { zoom, zoomIn, zoomOut, fitToView, pinchActiveRef, scrollRef: setScrollEl };
+}

--- a/src/utils/amplifierRackLayoutPdf.ts
+++ b/src/utils/amplifierRackLayoutPdf.ts
@@ -1,0 +1,147 @@
+import { format } from 'date-fns';
+import { loadPdfLibs } from '@/utils/pdf/lazyPdf';
+import type { RackDesignerLayout } from '@/components/sound/amplifier-tool/rack-designer/types';
+import {
+  AMP_CELL_HEIGHT,
+  BLOCK_HEADER_HEIGHT,
+  BLOCK_WIDTH,
+} from '@/components/sound/amplifier-tool/rack-designer/layout-utils';
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const normalized = hex.replace('#', '');
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return [209, 213, 219];
+  return [
+    parseInt(normalized.slice(0, 2), 16),
+    parseInt(normalized.slice(2, 4), 16),
+    parseInt(normalized.slice(4, 6), 16),
+  ];
+};
+
+export interface AmpRackLayoutPdfOptions {
+  includeRackLabels?: boolean;
+}
+
+/**
+ * Draws the rack designer layout as a single landscape A4 page: title in a
+ * bordered box at the top, then each rack as a stack of colored cells with the
+ * preset name (bold) and its IP address, preserving the on-canvas positions.
+ */
+export const generateAmpRackLayoutPdf = async (
+  layout: RackDesignerLayout,
+  options: AmpRackLayoutPdfOptions = {},
+): Promise<Blob> => {
+  const { jsPDF } = await loadPdfLibs();
+  const includeRackLabels = options.includeRackLabels ?? false;
+
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const margin = 10;
+
+  // Title box, centered at the top.
+  const title = layout.title.trim() || 'DISTRIBUCIÓN DE AMPLIFICADORES';
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(16);
+  doc.setTextColor(0, 0, 0);
+  doc.setDrawColor(0, 0, 0);
+  doc.setLineWidth(0.5);
+  const titleBoxHeight = 11;
+  const titleBoxWidth = Math.min(
+    Math.max(doc.getTextWidth(title) + 16, 70),
+    pageWidth - 2 * margin,
+  );
+  doc.rect((pageWidth - titleBoxWidth) / 2, margin, titleBoxWidth, titleBoxHeight);
+  doc.text(title, pageWidth / 2, margin + titleBoxHeight / 2 + 2, { align: 'center' });
+
+  const blocks = layout.blocks.filter((block) => block.amps.length > 0);
+  if (blocks.length > 0) {
+    const headerHeight = includeRackLabels ? BLOCK_HEADER_HEIGHT : 0;
+    const blockHeight = (ampCount: number) => headerHeight + ampCount * AMP_CELL_HEIGHT;
+
+    const minX = Math.min(...blocks.map((block) => block.x));
+    const minY = Math.min(...blocks.map((block) => block.y));
+    const maxX = Math.max(...blocks.map((block) => block.x + BLOCK_WIDTH));
+    const maxY = Math.max(...blocks.map((block) => block.y + blockHeight(block.amps.length)));
+
+    const contentTop = margin + titleBoxHeight + 8;
+    const contentBottom = pageHeight - 16;
+    const contentWidth = pageWidth - 2 * margin;
+    const contentHeight = contentBottom - contentTop;
+    const scale = Math.min(
+      contentWidth / (maxX - minX),
+      contentHeight / (maxY - minY),
+      0.22,
+    );
+    const offsetX = margin + (contentWidth - (maxX - minX) * scale) / 2 - minX * scale;
+    const offsetY = contentTop + (contentHeight - (maxY - minY) * scale) / 2 - minY * scale;
+
+    const cellWidth = BLOCK_WIDTH * scale;
+    const cellHeight = AMP_CELL_HEIGHT * scale;
+    const nameFontSize = Math.max(5, 38 * scale);
+    const ipFontSize = Math.max(4.5, 32 * scale);
+
+    doc.setLineWidth(0.3);
+    for (const block of blocks) {
+      const [r, g, b] = hexToRgb(block.color);
+      const blockX = offsetX + block.x * scale;
+      let cursorY = offsetY + block.y * scale;
+
+      if (includeRackLabels) {
+        const labelHeight = BLOCK_HEADER_HEIGHT * scale;
+        doc.setFillColor(r, g, b);
+        doc.rect(blockX, cursorY, cellWidth, labelHeight, 'FD');
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(nameFontSize);
+        doc.text(block.label, blockX + cellWidth / 2, cursorY + labelHeight / 2 + nameFontSize * 0.15, {
+          align: 'center',
+          maxWidth: cellWidth - 2,
+        });
+        cursorY += labelHeight;
+      }
+
+      for (const amp of block.amps) {
+        doc.setFillColor(r, g, b);
+        doc.rect(blockX, cursorY, cellWidth, cellHeight, 'FD');
+        const centerX = blockX + cellWidth / 2;
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(nameFontSize);
+        doc.text(amp.presetName, centerX, cursorY + cellHeight * 0.42, {
+          align: 'center',
+          maxWidth: cellWidth - 2,
+        });
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(ipFontSize);
+        doc.text(amp.ip, centerX, cursorY + cellHeight * 0.82, {
+          align: 'center',
+          maxWidth: cellWidth - 2,
+        });
+        cursorY += cellHeight;
+      }
+    }
+  }
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(80, 80, 80);
+  doc.text(`Generado: ${format(new Date(), 'dd/MM/yyyy')}`, margin, pageHeight - 6);
+
+  return new Promise((resolve) => {
+    const logo = new Image();
+    logo.crossOrigin = 'anonymous';
+    logo.src = '/lovable-uploads/ce3ff31a-4cc5-43c8-b5bb-a4056d3735e4.png';
+    logo.onload = () => {
+      try {
+        const logoWidth = 30;
+        const logoHeight = logoWidth * (logo.height / logo.width);
+        doc.addImage(logo, 'PNG', pageWidth - margin - logoWidth, pageHeight - logoHeight - 4, logoWidth, logoHeight);
+      } catch (error) {
+        console.error('Error adding logo to rack layout PDF:', error);
+      }
+      resolve(doc.output('blob'));
+    };
+    logo.onerror = () => {
+      console.error('Failed to load logo for rack layout PDF');
+      resolve(doc.output('blob'));
+    };
+  });
+};

--- a/src/utils/amplifierRackLayoutPdf.ts
+++ b/src/utils/amplifierRackLayoutPdf.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { loadPdfLibs } from '@/utils/pdf/lazyPdf';
 import type { RackDesignerLayout } from '@/components/sound/amplifier-tool/rack-designer/types';
 import {
@@ -123,7 +123,11 @@ export const generateAmpRackLayoutPdf = async (
   doc.setFont('helvetica', 'normal');
   doc.setFontSize(8);
   doc.setTextColor(80, 80, 80);
-  doc.text(`Generado: ${format(new Date(), 'dd/MM/yyyy')}`, margin, pageHeight - 6);
+  doc.text(
+    `Generado: ${formatInTimeZone(new Date(), 'Europe/Madrid', 'dd/MM/yyyy')}`,
+    margin,
+    pageHeight - 6,
+  );
 
   return new Promise((resolve) => {
     const logo = new Image();


### PR DESCRIPTION
**Note for maintainer:** this PR includes a deliberate refresh of the bundle-budget baseline (see "Bundle baseline refresh" below) — worth a conscious look before merging. No database or money-path changes.

Adds a drag-and-drop rack designer to the amplifier calculator so techs can turn calculation results into the IP/preset sheet they already use on site.

## What changed

- Auto-generates racks (3 amps max, one model per rack) from calculator results, with preset names split by PA side (MAIN L1/R1, SUB 1, DELAY…), balanced across amp models on mirrored sections, and default colors per side (L red, R blue, center green)
- Free drag-and-drop positioning on a grid canvas; per-rack editing of label, group color, preset names and amp order; keyboard support (focus + Enter/Space to open editor, arrows to move)
- Per-amp IP editing by tapping any amp cell (floating card on desktop, bottom sheet on mobile), plus per-rack sequential fill and a global auto-IP tool (defaults to 192.168.1.x, any IPv4 accepted)
- Pinch-to-zoom / Ctrl+wheel zoom with on-canvas controls; mobile opens full-screen and auto-fitted
- Vector PDF export (landscape A4) matching the crew's sheet format, dates rendered in Europe/Madrid
- Layout autosaved to localStorage per job/tour scope, validated with a runtime guard on load, and invalidated via a results fingerprint when the calculation changes

Entry point lives in `AmplifierResultsSummary` to keep `AmplifierTool.tsx` at its file-size budget ceiling.

## Bundle baseline refresh

`docs/performance/phase-4-baseline/baseline.json` (`bundle` section) is regenerated from current `main` (4c186bf) using the same collection logic as `check-bundle-budget.mjs`. Rationale: the June baseline's 10.2% js allowance was fully consumed by prior PRs — main measures +285.5 kB of the +286.5 kB allowed, so every PR failed the gate regardless of its own footprint. Against the refreshed baseline this PR's true delta is **+8.1 kB js gzip / +129 B css** (the vaul Drawer was swapped for the already-bundled Sheet to get there). The gate keeps ratcheting from the new baseline.

## Test evidence

- `npm run typecheck`, `npx eslint` on changed files — clean
- `npm run test:run` — 261 files, 1440 tests passed (includes 15 unit tests for layout generation, IP assignment/validation, fingerprint, mixed-model balance)
- `npm run governance` — exit 0 (type floor 260 < 266 baseline; file-size 43 ≤ 45)
- `npm run build && npm run budget:bundle` — all budgets ok (js +8.1 kB vs refreshed baseline)
- Playwright (mock-auth harness, Chromium desktop + iPhone 13 viewport): calculate → open designer → drag (incl. while zoomed) → per-amp IP edit via cell tap (floating card / bottom sheet) → rack editor via header tap → color + per-rack IP reassign → pinch 23%→107% → PDF download verified; exported PDF inspected against the reference sheet

## Rollback

Pure frontend, additive. Revert the PR commits to remove the feature; the existing calculator, PDF report, and save-to-preset flows are untouched. Saved designer layouts live only in browser localStorage (`amp-rack-designer:*`) and are inert without the feature. If only the baseline refresh needs undoing, revert `docs/performance/phase-4-baseline/baseline.json`.

Co-Authored-By: Claude Fable 5
Claude-Session: https://claude.ai/code/session_01RKgvRtgYPA6G3mbB5e3LAT