### PR TITLE
feat(sound): add standalone NM/SV rack designer

### DIFF
--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -301,6 +301,7 @@ export function AmpRackDesigner({
   };
 
   const importSession = async (file: File) => {
+    if (isImporting) return;
     if (!isLaSessionFileName(file.name)) {
       toast({
         title: 'Archivo no compatible',

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -1,6 +1,17 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type DragEvent } from 'react';
 import { formatInTimeZone } from 'date-fns-tz';
-import { FileText, Network, Plus, RefreshCw, Upload, Wand2, X, ZoomIn, ZoomOut } from 'lucide-react';
+import {
+  FileText,
+  Network,
+  Plus,
+  RefreshCw,
+  Upload,
+  UploadCloud,
+  Wand2,
+  X,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -45,6 +56,7 @@ import {
   RACK_COLOR_PALETTE,
   assignSequentialIps,
   computeResultsFingerprint,
+  createEmptyRackDesignerLayout,
   generateLayoutFromResults,
   isValidIp,
   loadStoredLayout,
@@ -55,7 +67,11 @@ import { RackBlockCard } from '@/components/sound/amplifier-tool/rack-designer/R
 import { BlockEditorPanel } from '@/components/sound/amplifier-tool/rack-designer/BlockEditorPanel';
 import { AmpEditFields } from '@/components/sound/amplifier-tool/rack-designer/AmpEditFields';
 import { useCanvasZoom } from '@/components/sound/amplifier-tool/rack-designer/useCanvasZoom';
-import { nwmMapToLayout, type NwmMap } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import {
+  isLaSessionFileName,
+  nwmMapToLayout,
+  type NwmMap,
+} from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 import { supabase } from '@/integrations/supabase/client';
 
 const MADRID_TZ = 'Europe/Madrid';
@@ -75,9 +91,14 @@ function fileToBase64(file: File): Promise<string> {
 }
 
 export interface AmpRackDesignerProps {
-  results: AmplifierResults;
+  results?: AmplifierResults;
   jobId?: string;
   tourId?: string;
+  standalone?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  hideTrigger?: boolean;
+  storageScope?: string;
 }
 
 interface AmpTarget {
@@ -85,10 +106,19 @@ interface AmpTarget {
   ampId: string;
 }
 
-export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps) {
+export function AmpRackDesigner({
+  results,
+  jobId,
+  tourId,
+  standalone = false,
+  open: controlledOpen,
+  onOpenChange,
+  hideTrigger = false,
+  storageScope,
+}: AmpRackDesignerProps) {
   const { toast } = useToast();
   const isMobile = useIsMobile();
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
   const [layout, setLayout] = useState<RackDesignerLayout | null>(null);
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
   const [ampTarget, setAmpTarget] = useState<AmpTarget | null>(null);
@@ -97,20 +127,35 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
   const [includeRackLabels, setIncludeRackLabels] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
+  const [isDraggingFile, setIsDraggingFile] = useState(false);
   const nwmInputRef = useRef<HTMLInputElement>(null);
+  const dragDepthRef = useRef(0);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = (nextOpen: boolean) => {
+    if (controlledOpen === undefined) setInternalOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
   const { zoom, zoomIn, zoomOut, fitToView, pinchActiveRef, scrollRef } = useCanvasZoom({
     enabled: open,
     contentWidth: CANVAS_WIDTH,
     contentHeight: CANVAS_HEIGHT,
   });
 
-  const scope = jobId ?? tourId ?? 'standalone';
+  const scope =
+    storageScope ?? (standalone ? 'sound-session-rack-designer' : jobId ?? tourId ?? 'standalone');
 
   useEffect(() => {
     if (!open) return;
-    // A saved layout is only reused when it came from the same calculation;
-    // otherwise it would silently contradict the results summary next to it.
     const stored = loadStoredLayout(scope);
+    if (!results) {
+      setLayout(stored ?? createEmptyRackDesignerLayout());
+      setSelectedBlockId(null);
+      setAmpTarget(null);
+      setMobileBlockEditorOpen(false);
+      return;
+    }
+    // A calculator layout is only reused when it came from the same calculation;
+    // otherwise it would silently contradict the results summary next to it.
     const fingerprint = computeResultsFingerprint(results);
     setLayout(
       stored && stored.resultsFingerprint === fingerprint
@@ -121,6 +166,12 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
     setAmpTarget(null);
     setMobileBlockEditorOpen(false);
   }, [open, scope, results]);
+
+  useEffect(() => {
+    if (open) return;
+    dragDepthRef.current = 0;
+    setIsDraggingFile(false);
+  }, [open]);
 
   // On phones start zoomed out so the whole plan is visible; pinch in from there.
   useEffect(() => {
@@ -221,6 +272,7 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
   };
 
   const regenerate = () => {
+    if (!results) return;
     setLayout(generateLayoutFromResults(results, layout?.title ?? DEFAULT_LAYOUT_TITLE));
     setSelectedBlockId(null);
     setAmpTarget(null);
@@ -248,7 +300,15 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
     });
   };
 
-  const importNwm = async (file: File) => {
+  const importSession = async (file: File) => {
+    if (!isLaSessionFileName(file.name)) {
+      toast({
+        title: 'Archivo no compatible',
+        description: 'Selecciona una sesión de Network Manager (.nwm) o Soundvision (.xmlp).',
+        variant: 'destructive',
+      });
+      return;
+    }
     setIsImporting(true);
     try {
       const base64 = await fileToBase64(file);
@@ -260,7 +320,7 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
       if (!map || !map.units?.length) {
         throw new Error('La sesión no contiene amplificadores.');
       }
-      setLayout(nwmMapToLayout(map, computeResultsFingerprint(results)));
+      setLayout(nwmMapToLayout(map, results ? computeResultsFingerprint(results) : undefined));
       setSelectedBlockId(null);
       setAmpTarget(null);
       toast({
@@ -269,11 +329,37 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
       });
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'No se pudo importar el archivo de NM.';
+        error instanceof Error ? error.message : 'No se pudo importar el archivo de NM/SV.';
       toast({ title: 'Error al importar', description: message, variant: 'destructive' });
     } finally {
       setIsImporting(false);
     }
+  };
+
+  const handleDragEnter = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (!event.dataTransfer.types.includes('Files')) return;
+    dragDepthRef.current += 1;
+    setIsDraggingFile(true);
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setIsDraggingFile(false);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    dragDepthRef.current = 0;
+    setIsDraggingFile(false);
+    const file = event.dataTransfer.files[0];
+    if (file) void importSession(file);
   };
 
   const exportPdf = async () => {
@@ -329,20 +415,28 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
 
   return (
     <>
-      <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={() => setOpen(true)}>
-        <Network className="h-4 w-4" />
-        Diseñador de racks
-      </Button>
+      {!hideTrigger && (
+        <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={() => setOpen(true)}>
+          <Network className="h-4 w-4" />
+          Diseñador de racks
+        </Button>
+      )}
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="flex h-dvh max-h-dvh w-screen max-w-none flex-col gap-2 rounded-none p-3 md:h-[92vh] md:max-h-[92vh] md:w-[96vw] md:max-w-[1400px] md:gap-3 md:rounded-lg md:p-4">
           <DialogHeader className="space-y-0.5 text-left">
-            <DialogTitle>Diseñador visual de racks</DialogTitle>
+            <DialogTitle>
+              {standalone ? 'Diseñador NM/SV de racks' : 'Diseñador visual de racks'}
+            </DialogTitle>
             <DialogDescription className="hidden md:block">
-              Arrastra los racks para posicionarlos, edita presets, colores e IPs y exporta el plano a PDF.
+              {standalone
+                ? 'Suelta una sesión .nwm o .xmlp, ajusta los racks y exporta el plano a PDF.'
+                : 'Arrastra los racks para posicionarlos, edita presets, colores e IPs y exporta el plano a PDF.'}
             </DialogDescription>
             <DialogDescription className="md:hidden">
-              Toca un amplificador para editar su IP y preset; toca la cabecera para editar el rack.
+              {standalone
+                ? 'Importa una sesión NM/SV, edita los racks y exporta el plano a PDF.'
+                : 'Toca un amplificador para editar su IP y preset; toca la cabecera para editar el rack.'}
             </DialogDescription>
           </DialogHeader>
 
@@ -386,7 +480,7 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
               onChange={(event) => {
                 const file = event.target.files?.[0];
                 event.target.value = '';
-                if (file) void importNwm(file);
+                if (file) void importSession(file);
               }}
             />
             <Button
@@ -401,27 +495,29 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
               <Upload className="h-3.5 w-3.5" />
               {isImporting ? 'Importando…' : 'Importar NM/SV'}
             </Button>
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button type="button" variant="outline" size="sm" className="gap-1">
-                  <RefreshCw className="h-3.5 w-3.5" />
-                  Regenerar
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>¿Regenerar el diseño?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Se descartarán los cambios manuales (posiciones, colores, presets e IPs) y los
-                    racks se volverán a generar desde el cálculo actual.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                  <AlertDialogAction onClick={regenerate}>Regenerar</AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+            {results && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button type="button" variant="outline" size="sm" className="gap-1">
+                    <RefreshCw className="h-3.5 w-3.5" />
+                    Regenerar
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>¿Regenerar el diseño?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Se descartarán los cambios manuales (posiciones, colores, presets e IPs) y los
+                      racks se volverán a generar desde el cálculo actual.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                    <AlertDialogAction onClick={regenerate}>Regenerar</AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
             <div className="flex h-8 items-center gap-1.5">
               <Checkbox
                 id="include-rack-labels"
@@ -430,14 +526,29 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
               />
               <Label htmlFor="include-rack-labels" className="text-xs">Nombres de rack en PDF</Label>
             </div>
-            <Button type="button" size="sm" className="ml-auto gap-1" onClick={exportPdf} disabled={isExporting || !layout}>
+            <Button
+              type="button"
+              size="sm"
+              className="ml-auto gap-1"
+              onClick={exportPdf}
+              disabled={isExporting || !layout?.blocks.length}
+            >
               <FileText className="h-3.5 w-3.5" />
               {isExporting ? 'Generando…' : 'Exportar PDF'}
             </Button>
           </div>
 
           <div className="flex min-h-0 flex-1 flex-col gap-3 md:flex-row">
-            <div className="relative min-h-[240px] flex-1">
+            <div
+              className={cn(
+                'relative min-h-[240px] flex-1 rounded-md transition-shadow',
+                isDraggingFile && 'ring-2 ring-primary ring-offset-2',
+              )}
+              onDragEnter={handleDragEnter}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+            >
               <div
                 ref={scrollRef}
                 className="absolute inset-0 overflow-auto rounded-md border bg-muted/20"
@@ -519,6 +630,32 @@ export function AmpRackDesigner({ results, jobId, tourId }: AmpRackDesignerProps
                   )}
                 </div>
               </div>
+
+              {standalone && !layout?.blocks.length && (
+                <button
+                  type="button"
+                  className={cn(
+                    'absolute inset-4 z-10 flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed bg-background/90 px-6 text-center transition-colors',
+                    isDraggingFile
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-muted-foreground/30 hover:border-primary/60 hover:bg-muted/60',
+                  )}
+                  onClick={() => nwmInputRef.current?.click()}
+                  onPointerDown={(event) => event.stopPropagation()}
+                >
+                  <UploadCloud className="h-10 w-10" />
+                  <span className="font-semibold">Suelta aquí una sesión NM o Soundvision</span>
+                  <span className="text-sm text-muted-foreground">
+                    o pulsa para seleccionar un archivo .nwm o .xmlp
+                  </span>
+                </button>
+              )}
+
+              {isDraggingFile && !!layout?.blocks.length && (
+                <div className="pointer-events-none absolute inset-4 z-30 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-background/90 text-center text-sm font-semibold text-primary shadow-lg">
+                  Suelta el archivo para reemplazar el diseño actual
+                </div>
+              )}
 
               <div className="absolute bottom-2 right-2 z-20 flex items-center gap-0.5 rounded-md border bg-background/95 p-0.5 shadow-sm">
                 <Button

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
@@ -28,6 +28,27 @@ const calculatorResults: AmplifierResults = {
   },
 };
 
+const parsedSessionResponse = {
+  data: {
+    map: {
+      sessionName: 'GIRA 2026',
+      units: [
+        {
+          octet: 11,
+          ip: '192.168.1.11',
+          presetName: 'K2 110',
+          familyName: 'K2',
+          model: 'LA12X',
+          x: 0,
+          y: 0,
+        },
+      ],
+      groups: [{ name: 'K2 L', role: 'source', members: [11] }],
+    },
+  },
+  error: null as null,
+};
+
 describe('AmpRackDesigner — modo independiente', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -70,26 +91,7 @@ describe('AmpRackDesigner — modo independiente', () => {
   });
 
   it('imports a dropped Soundvision file through the shared session parser', async () => {
-    mockSupabase.functions.invoke.mockResolvedValueOnce({
-      data: {
-        map: {
-          sessionName: 'GIRA 2026',
-          units: [
-            {
-              octet: 11,
-              ip: '192.168.1.11',
-              presetName: 'K2 110',
-              familyName: 'K2',
-              model: 'LA12X',
-              x: 0,
-              y: 0,
-            },
-          ],
-          groups: [{ name: 'K2 L', role: 'source', members: [11] }],
-        },
-      },
-      error: null,
-    });
+    mockSupabase.functions.invoke.mockResolvedValueOnce(parsedSessionResponse);
     render(
       <AmpRackDesigner
         standalone
@@ -116,6 +118,42 @@ describe('AmpRackDesigner — modo independiente', () => {
     });
     expect(await screen.findByText('K2 L')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Exportar PDF' })).toBeEnabled();
+  });
+
+  it('ignores a second dropped session while an import is already in progress', async () => {
+    let resolveImport!: (value: typeof parsedSessionResponse) => void;
+    const pendingImport = new Promise<typeof parsedSessionResponse>((resolve) => {
+      resolveImport = resolve;
+    });
+    mockSupabase.functions.invoke.mockImplementationOnce(() => pendingImport);
+    render(
+      <AmpRackDesigner
+        standalone
+        hideTrigger
+        open
+        onOpenChange={vi.fn()}
+        storageScope="standalone-reentrant-test"
+      />,
+    );
+
+    const dropPrompt = await screen.findByText('Suelta aquí una sesión NM o Soundvision');
+    const dropTarget = dropPrompt.closest('button')?.parentElement;
+    expect(dropTarget).not.toBeNull();
+    const firstFile = new File(['first-session'], 'first.xmlp');
+    const secondFile = new File(['second-session'], 'second.nwm');
+    fireEvent.drop(dropTarget!, {
+      dataTransfer: { types: ['Files'], files: [firstFile] },
+    });
+    await waitFor(() => expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Importando…' })).toBeDisabled();
+
+    fireEvent.drop(dropTarget!, {
+      dataTransfer: { types: ['Files'], files: [secondFile] },
+    });
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(1);
+
+    resolveImport(parsedSessionResponse);
+    expect(await screen.findByText('K2 L')).toBeInTheDocument();
   });
 });
 

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AmplifierResults } from '@/components/sound/amplifier-tool/types';
+import { mockSupabase } from '@/test/mockSupabase';
+import { AmpRackDesigner } from '../AmpRackDesigner';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+const calculatorResults: AmplifierResults = {
+  totalAmplifiersNeeded: 1,
+  completeRaks: 0,
+  looseAmplifiers: 1,
+  plmRacks: 0,
+  loosePLMAmps: 0,
+  laAmpsTotal: 1,
+  plmAmpsTotal: 0,
+  perSection: {
+    mains: {
+      amps: 1,
+      details: [],
+      totalAmps: 1,
+      mirrored: false,
+      laAmps: 1,
+      plmAmps: 0,
+    },
+  },
+};
+
+describe('AmpRackDesigner — modo independiente', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('opens an empty import canvas without calculator-only regeneration controls', async () => {
+    render(
+      <AmpRackDesigner
+        standalone
+        hideTrigger
+        open
+        onOpenChange={vi.fn()}
+        storageScope="standalone-test"
+      />,
+    );
+
+    expect(await screen.findByText('Suelta aquí una sesión NM o Soundvision')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Regenerar' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Exportar PDF' })).toBeDisabled();
+  });
+
+  it('allows starting a design manually and persists it in the standalone scope', async () => {
+    render(
+      <AmpRackDesigner
+        standalone
+        hideTrigger
+        open
+        onOpenChange={vi.fn()}
+        storageScope="standalone-manual-test"
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Añadir rack' }));
+
+    expect(screen.queryByText('Suelta aquí una sesión NM o Soundvision')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Exportar PDF' })).toBeEnabled();
+    await waitFor(() => {
+      expect(localStorage.getItem('amp-rack-designer:standalone-manual-test')).toContain('RACK 1');
+    });
+  });
+
+  it('imports a dropped Soundvision file through the shared session parser', async () => {
+    mockSupabase.functions.invoke.mockResolvedValueOnce({
+      data: {
+        map: {
+          sessionName: 'GIRA 2026',
+          units: [
+            {
+              octet: 11,
+              ip: '192.168.1.11',
+              presetName: 'K2 110',
+              familyName: 'K2',
+              model: 'LA12X',
+              x: 0,
+              y: 0,
+            },
+          ],
+          groups: [{ name: 'K2 L', role: 'source', members: [11] }],
+        },
+      },
+      error: null,
+    });
+    render(
+      <AmpRackDesigner
+        standalone
+        hideTrigger
+        open
+        onOpenChange={vi.fn()}
+        storageScope="standalone-drop-test"
+      />,
+    );
+
+    const dropPrompt = await screen.findByText('Suelta aquí una sesión NM o Soundvision');
+    const dropTarget = dropPrompt.closest('button')?.parentElement;
+    expect(dropTarget).not.toBeNull();
+    const file = new File(['soundvision-session'], 'gira.xmlp', {
+      type: 'application/octet-stream',
+    });
+    fireEvent.dragEnter(dropTarget!, { dataTransfer: { types: ['Files'], files: [file] } });
+    fireEvent.drop(dropTarget!, { dataTransfer: { types: ['Files'], files: [file] } });
+
+    await waitFor(() => {
+      expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('parse-la-session', {
+        body: { file: 'c291bmR2aXNpb24tc2Vzc2lvbg==' },
+      });
+    });
+    expect(await screen.findByText('K2 L')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Exportar PDF' })).toBeEnabled();
+  });
+});
+
+describe('AmpRackDesigner — modo calculadora', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('still generates from calculator results and keeps the regeneration action', async () => {
+    render(
+      <AmpRackDesigner
+        results={calculatorResults}
+        hideTrigger
+        open
+        onOpenChange={vi.fn()}
+        storageScope="calculator-test"
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Regenerar' })).toBeInTheDocument();
+    expect(screen.queryByText('Suelta aquí una sesión NM o Soundvision')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Exportar PDF' })).toBeEnabled();
+  });
+});

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/layout-utils.test.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/layout-utils.test.ts
@@ -5,10 +5,21 @@ import {
   assignBlockIps,
   assignSequentialIps,
   computeResultsFingerprint,
+  createEmptyRackDesignerLayout,
   generateLayoutFromResults,
   incrementIp,
   isValidIp,
 } from '../layout-utils';
+
+describe('createEmptyRackDesignerLayout', () => {
+  it('creates a standalone canvas without a calculator fingerprint', () => {
+    expect(createEmptyRackDesignerLayout()).toEqual({
+      version: 1,
+      title: 'SISTEMA PA',
+      blocks: [],
+    });
+  });
+});
 
 const emptySection = { amps: 0, details: [] as string[], totalAmps: 0 };
 

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/nwm-import.test.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/nwm-import.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { nwmMapToLayout, type NwmMap } from '../nwm-import';
+import { isLaSessionFileName, nwmMapToLayout, type NwmMap } from '../nwm-import';
+
+describe('isLaSessionFileName', () => {
+  it('accepts NM and Soundvision session files case-insensitively', () => {
+    expect(isLaSessionFileName('show.nwm')).toBe(true);
+    expect(isLaSessionFileName('SHOW.XMLP')).toBe(true);
+  });
+
+  it('rejects unrelated files and misleading partial extensions', () => {
+    expect(isLaSessionFileName('show.xml')).toBe(false);
+    expect(isLaSessionFileName('show.nwm.pdf')).toBe(false);
+    expect(isLaSessionFileName('nwm')).toBe(false);
+  });
+});
 
 // Mirrors the real NM structure: overlapping logical groups (a unit can appear
 // in several), top-level sections (MAINS/SUBS…), and LEFT/RIGHT side groups.

--- a/src/components/sound/amplifier-tool/rack-designer/layout-utils.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/layout-utils.ts
@@ -18,6 +18,16 @@ export const AMPS_PER_RACK = 3;
 export const DEFAULT_IP_BASE = '192.168.1.11';
 export const DEFAULT_LAYOUT_TITLE = 'SISTEMA PA';
 
+export function createEmptyRackDesignerLayout(
+  title: string = DEFAULT_LAYOUT_TITLE,
+): RackDesignerLayout {
+  return {
+    version: 1,
+    title,
+    blocks: [],
+  };
+}
+
 export const RACK_COLOR_PALETTE = [
   { name: 'Rojo', value: '#f87171' },
   { name: 'Azul', value: '#60a5fa' },

--- a/src/components/sound/amplifier-tool/rack-designer/nwm-import.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/nwm-import.ts
@@ -33,6 +33,10 @@ export interface NwmMap {
 
 const SIDE_COLORS = { L: '#f87171', R: '#60a5fa', C: '#4ade80' } as const;
 
+export function isLaSessionFileName(fileName: string): boolean {
+  return /\.(nwm|xmlp)$/i.test(fileName.trim());
+}
+
 // Top-level sections in the order they should appear, and the group name NM uses
 // for each. A unit is assigned to the first section whose group contains it.
 const SECTION_ORDER: Array<{ key: string; group: string }> = [

--- a/src/pages/Sound.tsx
+++ b/src/pages/Sound.tsx
@@ -10,7 +10,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { LightsHeader } from "@/components/lights/LightsHeader";
 import { TodaySchedule } from "@/components/dashboard/TodaySchedule";
 import { CalendarSection } from "@/components/dashboard/CalendarSection";
-import { Calculator, PieChart, FileText, Zap, FileStack, AlertTriangle, Plus, Database, Lock, Music, Box, Layout, Binary, Server } from 'lucide-react';
+import { Calculator, PieChart, FileText, Zap, FileStack, AlertTriangle, Plus, Database, Lock, Music, Box, Layout, Binary, Network, Server } from 'lucide-react';
 import type { JobType } from "@/types/job";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -18,6 +18,7 @@ import { Separator } from "@/components/ui/separator";
 import { ReportGenerator } from "../components/sound/ReportGenerator";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { AmplifierTool } from "@/components/sound/AmplifierTool";
+import { AmpRackDesigner } from "@/components/sound/amplifier-tool/rack-designer/AmpRackDesigner";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { MemoriaTecnica } from "@/components/sound/MemoriaTecnica";
 import { IncidentReport } from "@/components/sound/tools";
@@ -53,6 +54,7 @@ const Sound = () => {
   const [date, setDate] = useState<Date | undefined>(new Date());
   const [showReportGenerator, setShowReportGenerator] = useState(false);
   const [showAmplifierTool, setShowAmplifierTool] = useState(false);
+  const [showSessionRackDesigner, setShowSessionRackDesigner] = useState(false);
   const [showMemoriaTecnica, setShowMemoriaTecnica] = useState(false);
   const [showIncidentReport, setShowIncidentReport] = useState(false);
   const [showAccessRequestDialog, setShowAccessRequestDialog] = useState(false);
@@ -141,6 +143,7 @@ const Sound = () => {
     { label: "Consumos", to: "/consumos-tool", icon: Calculator, color: "text-purple-500" },
     { label: "Informe SV", onClick: () => setShowReportGenerator(true), icon: FileText, color: "text-blue-500" },
     { label: "Amplificador", onClick: () => setShowAmplifierTool(true), icon: Zap, color: "text-orange-500" },
+    { label: "Diseño NM/SV", onClick: () => setShowSessionRackDesigner(true), icon: Network, color: "text-emerald-500" },
     { label: "Memoria", onClick: () => setShowMemoriaTecnica(true), icon: FileStack, color: "text-cyan-500" },
     { label: "Incidencia", onClick: () => setShowIncidentReport(true), icon: AlertTriangle, color: "text-red-500" },
     { label: "Plano de escenario", to: "/stage-plot", icon: Layout, color: "text-green-500" },
@@ -366,6 +369,16 @@ const Sound = () => {
                   variant="outline"
                   size="lg"
                   className="h-auto py-2 sm:py-3"
+                  onClick={() => setShowSessionRackDesigner(true)}
+                >
+                  <Network className="h-4 w-4 sm:h-5 sm:w-5 mr-2" />
+                  Diseñador NM/SV
+                </Button>
+
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="h-auto py-2 sm:py-3"
                   onClick={() => setShowMemoriaTecnica(true)}
                 >
                   <FileStack className="h-4 w-4 sm:h-5 sm:w-5 mr-2" />
@@ -534,6 +547,13 @@ const Sound = () => {
           <AmplifierTool />
         </DialogContent>
       </Dialog>
+
+      <AmpRackDesigner
+        standalone
+        hideTrigger
+        open={showSessionRackDesigner}
+        onOpenChange={setShowSessionRackDesigner}
+      />
 
       <Dialog open={showMemoriaTecnica} onOpenChange={setShowMemoriaTecnica}>
         <DialogContent className="w-[95vw] max-w-4xl overflow-y-auto">


### PR DESCRIPTION
## Summary

Follow-up to #863: the imported L-Acoustics session map can now be used as its own Sound tool, without running the amplifier calculator first.

- adds a new **Diseño NM/SV** entry to the mobile Sound tools and **Diseñador NM/SV** to the desktop toolbar, while keeping the existing `/sound` route
- reuses the existing editable rack canvas and PDF exporter in a controlled standalone mode
- accepts click-to-import or drag-and-drop for `.nwm` and `.xmlp`
- restores the standalone tool from its own local storage scope, or starts with an empty canvas that can also be built manually
- keeps calculator mode fingerprint regeneration and storage behavior unchanged
- validates supported session file extensions before calling `parse-la-session`

## Verification

- `npm run lint` — passed (0 errors; existing baseline warnings only)
- `npm run typecheck` — passed
- `npm run governance` — passed
- `npm run test:critical` — passed, including coverage gate
- `npm run test:run` — passed
- `npm run build` — passed
- `npm run budget:bundle` — passed (+10.5 kB total JS gzip, within budget)
- focused rack-designer suite — 37 tests passed, including standalone empty/manual modes, independent persistence, dropped `.xmlp` import through `parse-la-session`, and calculator-mode regression coverage
- staged secret scan — passed; no cryptographic material or dotenv files are included

The authenticated `/sound` shell could not be rendered from this local checkout because its required Supabase environment URL is intentionally absent; the component UI was rendered and exercised in jsdom, and the deployment preview is the remaining integrated visual check.

## Risk

Low-risk UI-only follow-up. No database migration, Edge Function change, deployment secret, or server-side crypto change is included.

## Rollback

Revert commit `bb9760db`. This removes the new Sound-page entry point and standalone mode while leaving the calculator-integrated rack designer and #863 import pipeline intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Diseño NM/SV” tool for creating amplifier rack designs.
  * Import Network Manager and Soundvision session files by selecting or dragging and dropping them.
  * Added standalone mode with dedicated upload guidance and independent layout persistence.
  * Added controlled dialog behavior and optional trigger visibility.
  * Added export availability indicators and support for regenerating designs when calculator results are available.

* **Bug Fixes**
  * Improved validation for supported session file extensions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->