### PR TITLE
feat(sound): generate flysheets and grant NM/SV tool access

### DIFF
--- a/scripts/governance/edge-function-exposure.json
+++ b/scripts/governance/edge-function-exposure.json
@@ -73,7 +73,7 @@
       "verifyJwt": true,
       "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; validates the caller JWT, requires admin/management, and validates created Flex element records before service-role persistence."
     },
-    "parse-la-session": { "class": "privileged-role", "verifyJwt": true, "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; validates the caller JWT and requires admin/management/house_tech via requireAuthenticatedRole before decrypting an uploaded L-Acoustics session (.nwm via NWM_AES_KEY/IV, .xmlp via SV_AES_KEY/IV). Decryption keys are deployment secrets (each format returns 503 when its secret is unset); the file and decrypted XML are processed transiently and never persisted." },
+    "parse-la-session": { "class": "privileged-role", "verifyJwt": true, "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; validates the caller JWT and allows admin/management, sound house techs, or explicitly entitled sound technicians before decrypting an uploaded L-Acoustics session (.nwm via NWM_AES_KEY/IV, .xmlp via SV_AES_KEY/IV). Technician entitlement is stored on profiles and granted by a protected responsable-assignment trigger or admin/management. Decryption keys are deployment secrets (each format returns 503 when its secret is unset); the file and decrypted XML are processed transiently and never persisted." },
     "place-photos": { "class": "authenticated-user", "verifyJwt": true },
     "place-restaurants": { "class": "authenticated-user", "verifyJwt": true },
     "push": { "class": "authenticated-user", "verifyJwt": true },

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -100,6 +100,7 @@ export interface AmpRackDesignerProps {
   onOpenChange?: (open: boolean) => void;
   hideTrigger?: boolean;
   storageScope?: string;
+  createdBy?: string;
 }
 
 interface AmpTarget {
@@ -116,6 +117,7 @@ export function AmpRackDesigner({
   onOpenChange,
   hideTrigger = false,
   storageScope,
+  createdBy,
 }: AmpRackDesignerProps) {
   const { toast } = useToast();
   const isMobile = useIsMobile();
@@ -501,7 +503,10 @@ export function AmpRackDesigner({
               <Upload className="h-3.5 w-3.5" />
               {isImporting ? 'Importando…' : 'Importar NM/SV'}
             </Button>
-            <SoundvisionFlysheetButton parseSessionFile={parseLaSessionFile} />
+            <SoundvisionFlysheetButton
+              parseSessionFile={parseLaSessionFile}
+              createdBy={createdBy}
+            />
             {results && (
               <AlertDialog>
                 <AlertDialogTrigger asChild>

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -64,6 +64,7 @@ import {
   saveStoredLayout,
 } from '@/components/sound/amplifier-tool/rack-designer/layout-utils';
 import { RackBlockCard } from '@/components/sound/amplifier-tool/rack-designer/RackBlockCard';
+import { SoundvisionFlysheetButton } from '@/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton';
 import { BlockEditorPanel } from '@/components/sound/amplifier-tool/rack-designer/BlockEditorPanel';
 import { AmpEditFields } from '@/components/sound/amplifier-tool/rack-designer/AmpEditFields';
 import { useCanvasZoom } from '@/components/sound/amplifier-tool/rack-designer/useCanvasZoom';
@@ -300,6 +301,17 @@ export function AmpRackDesigner({
     });
   };
 
+  const parseLaSessionFile = async (file: File): Promise<NwmMap> => {
+    const base64 = await fileToBase64(file);
+    const { data, error } = await supabase.functions.invoke('parse-la-session', {
+      body: { file: base64, fileName: file.name },
+    });
+    if (error) throw error;
+    const map = (data as { map?: NwmMap } | null)?.map;
+    if (!map) throw new Error('No se pudo interpretar el archivo de L-Acoustics.');
+    return map;
+  };
+
   const importSession = async (file: File) => {
     if (isImporting) return;
     if (!isLaSessionFileName(file.name)) {
@@ -312,15 +324,8 @@ export function AmpRackDesigner({
     }
     setIsImporting(true);
     try {
-      const base64 = await fileToBase64(file);
-      const { data, error } = await supabase.functions.invoke('parse-la-session', {
-        body: { file: base64 },
-      });
-      if (error) throw error;
-      const map = (data as { map?: NwmMap } | null)?.map;
-      if (!map || !map.units?.length) {
-        throw new Error('La sesión no contiene amplificadores.');
-      }
+      const map = await parseLaSessionFile(file);
+      if (!map.units?.length) throw new Error('La sesión no contiene amplificadores.');
       setLayout(nwmMapToLayout(map, results ? computeResultsFingerprint(results) : undefined));
       setSelectedBlockId(null);
       setAmpTarget(null);
@@ -496,6 +501,7 @@ export function AmpRackDesigner({
               <Upload className="h-3.5 w-3.5" />
               {isImporting ? 'Importando…' : 'Importar NM/SV'}
             </Button>
+            <SoundvisionFlysheetButton parseSessionFile={parseLaSessionFile} />
             {results && (
               <AlertDialog>
                 <AlertDialogTrigger asChild>

--- a/src/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton.tsx
@@ -1,0 +1,97 @@
+import { useRef, useState } from 'react';
+import { formatInTimeZone } from 'date-fns-tz';
+import { FileDown } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import type { NwmMap } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import { generateSoundvisionFlysheetPdf } from '@/utils/soundvisionFlysheetPdf';
+
+const MADRID_TZ = 'Europe/Madrid';
+
+interface SoundvisionFlysheetButtonProps {
+  parseSessionFile: (file: File) => Promise<NwmMap>;
+}
+
+export function SoundvisionFlysheetButton({
+  parseSessionFile,
+}: SoundvisionFlysheetButtonProps) {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { toast } = useToast();
+
+  const generateFlysheet = async (file: File) => {
+    if (isGenerating) return;
+    if (!file.name.toLowerCase().endsWith('.xmlp')) {
+      toast({
+        title: 'Archivo no compatible',
+        description: 'El flysheet se genera a partir de un proyecto Soundvision (.xmlp).',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsGenerating(true);
+    try {
+      const map = await parseSessionFile(file);
+      if (!map.flysheet?.arrays.length) {
+        throw new Error('El proyecto no contiene arrays compatibles con el flysheet.');
+      }
+      const blob = await generateSoundvisionFlysheetPdf(map.flysheet, {
+        sourceFileName: file.name,
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      const projectSlug = (map.flysheet.projectName || file.name.replace(/\.xmlp$/i, ''))
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-zA-Z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+        .toLowerCase() || 'soundvision';
+      link.href = url;
+      link.download = `flysheet-${projectSlug}-${formatInTimeZone(new Date(), MADRID_TZ, 'yyyy-MM-dd')}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast({
+        title: 'Flysheet generado',
+        description: `${map.flysheet.arrays.length} arrays incluidos en el PDF en español.`,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'No se pudo generar el flysheet.';
+      toast({ title: 'Error al generar el flysheet', description: message, variant: 'destructive' });
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".xmlp"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          event.target.value = '';
+          if (file) void generateFlysheet(file);
+        }}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="gap-1"
+        disabled={isGenerating}
+        onClick={() => inputRef.current?.click()}
+        title="Generar un flysheet en español desde un proyecto Soundvision (.xmlp)"
+      >
+        <FileDown className="h-3.5 w-3.5" />
+        {isGenerating ? 'Generando flysheet…' : 'Generar flysheet'}
+      </Button>
+    </>
+  );
+}

--- a/src/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton.tsx
@@ -5,20 +5,45 @@ import { FileDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import type { NwmMap } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import { supabase } from '@/integrations/supabase/client';
 import { generateSoundvisionFlysheetPdf } from '@/utils/soundvisionFlysheetPdf';
+import { formatUserName } from '@/utils/userName';
 
 const MADRID_TZ = 'Europe/Madrid';
 
 interface SoundvisionFlysheetButtonProps {
   parseSessionFile: (file: File) => Promise<NwmMap>;
+  createdBy?: string;
 }
 
 export function SoundvisionFlysheetButton({
   parseSessionFile,
+  createdBy,
 }: SoundvisionFlysheetButtonProps) {
   const [isGenerating, setIsGenerating] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
+
+  const resolvePredictionCreator = async (): Promise<string> => {
+    if (createdBy?.trim()) return createdBy.trim();
+
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return 'No identificado';
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('first_name, nickname, last_name')
+        .eq('id', user.id)
+        .maybeSingle();
+      return formatUserName(profile?.first_name, profile?.nickname, profile?.last_name)
+        || user.email
+        || 'No identificado';
+    } catch (error) {
+      console.warn('No se pudo resolver el autor del flysheet:', error);
+      return 'No identificado';
+    }
+  };
 
   const generateFlysheet = async (file: File) => {
     if (isGenerating) return;
@@ -37,8 +62,10 @@ export function SoundvisionFlysheetButton({
       if (!map.flysheet?.arrays.length) {
         throw new Error('El proyecto no contiene arrays compatibles con el flysheet.');
       }
+      const predictionCreator = await resolvePredictionCreator();
       const blob = await generateSoundvisionFlysheetPdf(map.flysheet, {
         sourceFileName: file.name,
+        createdBy: predictionCreator,
       });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
@@ -66,6 +66,7 @@ describe('AmpRackDesigner — modo independiente', () => {
     );
 
     expect(await screen.findByText('Suelta aquí una sesión NM o Soundvision')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Generar flysheet' })).toBeEnabled();
     expect(screen.queryByRole('button', { name: 'Regenerar' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Exportar PDF' })).toBeDisabled();
   });
@@ -113,7 +114,7 @@ describe('AmpRackDesigner — modo independiente', () => {
 
     await waitFor(() => {
       expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('parse-la-session', {
-        body: { file: 'c291bmR2aXNpb24tc2Vzc2lvbg==' },
+        body: { file: 'c291bmR2aXNpb24tc2Vzc2lvbg==', fileName: 'gira.xmlp' },
       });
     });
     expect(await screen.findByText('K2 L')).toBeInTheDocument();

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/SoundvisionFlysheetButton.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/SoundvisionFlysheetButton.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SoundvisionFlysheet } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import { mockSupabase, resetMockSupabase } from '@/test/mockSupabase';
+
+const { generateFlysheetPdfMock, toastMock } = vi.hoisted(() => ({
+  generateFlysheetPdfMock: vi.fn(),
+  toastMock: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock('@/utils/soundvisionFlysheetPdf', () => ({
+  generateSoundvisionFlysheetPdf: (...args: unknown[]) => generateFlysheetPdfMock(...args),
+}));
+
+import { SoundvisionFlysheetButton } from '../SoundvisionFlysheetButton';
+
+describe('SoundvisionFlysheetButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    generateFlysheetPdfMock.mockResolvedValue(new Blob(['pdf'], { type: 'application/pdf' }));
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:flysheet'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+  });
+
+  it('writes the triggering user into the flysheet metadata', async () => {
+    const flysheet: SoundvisionFlysheet = {
+      projectName: 'Gira 2026',
+      arrays: [{
+        groupName: 'PA',
+        arrayName: 'MAIN L',
+        deployment: 'flown' as const,
+        azimuthDegrees: 0,
+        topSiteDegrees: 0,
+        bottomSiteDegrees: -12,
+        topHeightMeters: 10,
+        bottomHeightMeters: 4,
+        riggingFrame: 'K2-BUMP',
+        flyingBarSetting: '1x K2-BAR · Orificio A',
+        pickupConfiguration: 'F: 5 / R: 21',
+        totalMassKg: 1000,
+        frontLoadKg: null,
+        rearLoadKg: null,
+        enclosures: [],
+        warnings: [],
+      }],
+    };
+    const parseSessionFile = vi.fn().mockResolvedValue({
+      sessionName: 'Gira 2026',
+      units: [],
+      groups: [],
+      flysheet,
+    });
+    const { container } = render(
+      <SoundvisionFlysheetButton
+        parseSessionFile={parseSessionFile}
+        createdBy="Pat Jones"
+      />,
+    );
+    const input = container.querySelector('input[type="file"]');
+    const file = new File(['encrypted'], 'gira.xmlp', { type: 'application/octet-stream' });
+
+    fireEvent.change(input!, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(generateFlysheetPdfMock).toHaveBeenCalledWith(
+        flysheet,
+        expect.objectContaining({
+          sourceFileName: 'gira.xmlp',
+          createdBy: 'Pat Jones',
+        }),
+      );
+    });
+    expect(mockSupabase.auth.getUser).not.toHaveBeenCalled();
+    expect(await screen.findByRole('button', { name: 'Generar flysheet' })).toBeEnabled();
+  });
+});

--- a/src/components/sound/amplifier-tool/rack-designer/nwm-import.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/nwm-import.ts
@@ -25,10 +25,39 @@ export interface NwmGroup {
   role: string;
   members: number[];
 }
+export interface SoundvisionFlysheetEnclosure {
+  model: string;
+  splayAngleDegrees: number | null;
+  siteAngleDegrees: number | null;
+  trimHeightMeters: number | null;
+}
+export interface SoundvisionFlysheetArray {
+  groupName: string;
+  arrayName: string;
+  deployment: 'flown' | 'stacked' | 'unknown';
+  azimuthDegrees: number | null;
+  topSiteDegrees: number | null;
+  bottomSiteDegrees: number | null;
+  topHeightMeters: number | null;
+  bottomHeightMeters: number | null;
+  riggingFrame: string;
+  flyingBarSetting: string;
+  pickupConfiguration: string;
+  totalMassKg: number | null;
+  frontLoadKg: number | null;
+  rearLoadKg: number | null;
+  enclosures: SoundvisionFlysheetEnclosure[];
+  warnings: string[];
+}
+export interface SoundvisionFlysheet {
+  projectName: string;
+  arrays: SoundvisionFlysheetArray[];
+}
 export interface NwmMap {
   sessionName: string;
   units: NwmUnit[];
   groups: NwmGroup[];
+  flysheet?: SoundvisionFlysheet;
 }
 
 const SIDE_COLORS = { L: '#f87171', R: '#60a5fa', C: '#4ade80' } as const;

--- a/src/components/technician/DashboardScreen.tsx
+++ b/src/components/technician/DashboardScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { format, startOfWeek, endOfWeek } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { Map as MapIcon, Calendar as CalendarIcon, MessageSquare, Euro, Loader2, Briefcase, Binary, Network } from 'lucide-react';
+import { Map as MapIcon, MessageSquare, Euro, Loader2, Briefcase, Binary, Network } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { useMyTours } from '@/hooks/useMyTours';

--- a/src/components/technician/DashboardScreen.tsx
+++ b/src/components/technician/DashboardScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { format, startOfWeek, endOfWeek } from 'date-fns';
 import { es } from 'date-fns/locale';
-import { Map as MapIcon, Calendar as CalendarIcon, MessageSquare, Euro, Loader2, Briefcase, Binary } from 'lucide-react';
+import { Map as MapIcon, Calendar as CalendarIcon, MessageSquare, Euro, Loader2, Briefcase, Binary, Network } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { useMyTours } from '@/hooks/useMyTours';
@@ -37,10 +37,29 @@ interface DashboardScreenProps {
     onOpenRates: () => void;
     onOpenMessages: () => void;
     onOpenSysCalc?: () => void;
+    onOpenSoundVisionTools: () => void;
     hasSoundVisionAccess: boolean;
+    hasSoundVisionToolAccess: boolean;
 }
 
-export const DashboardScreen = ({ theme, isDark, user, userProfile, assignments, isLoading, onOpenAction, onOpenSV, onOpenObliqueStrategy, onOpenTour, onOpenRates, onOpenMessages, onOpenSysCalc, hasSoundVisionAccess }: DashboardScreenProps) => {
+export const DashboardScreen = ({
+    theme,
+    isDark,
+    user,
+    userProfile,
+    assignments,
+    isLoading,
+    onOpenAction,
+    onOpenSV,
+    onOpenObliqueStrategy,
+    onOpenTour,
+    onOpenRates,
+    onOpenMessages,
+    onOpenSysCalc,
+    onOpenSoundVisionTools,
+    hasSoundVisionAccess,
+    hasSoundVisionToolAccess,
+}: DashboardScreenProps) => {
     const { activeTours } = useMyTours();
 
     const userInitials = userProfile?.first_name && userProfile?.last_name
@@ -146,6 +165,16 @@ export const DashboardScreen = ({ theme, isDark, user, userProfile, assignments,
                         >
                             <MapIcon size={20} className="text-blue-500 group-hover:scale-110 transition-transform" />
                             <span className={`text-xs font-bold ${theme.textMain}`}>SoundVision<br />Database</span>
+                        </button>
+                    )}
+                    {hasSoundVisionToolAccess && (
+                        <button
+                            type="button"
+                            onClick={onOpenSoundVisionTools}
+                            className={`flex-shrink-0 w-28 h-24 p-3 rounded-xl border ${theme.card} flex flex-col justify-between hover:border-red-500 transition-colors text-left group`}
+                        >
+                            <Network size={20} className="text-red-500 group-hover:scale-110 transition-transform" />
+                            <span className={`text-xs font-bold ${theme.textMain}`}>Diseñador<br />NM/SV</span>
                         </button>
                     )}
                     <button

--- a/src/components/technician/__tests__/DashboardScreen.test.tsx
+++ b/src/components/technician/__tests__/DashboardScreen.test.tsx
@@ -110,7 +110,9 @@ describe("DashboardScreen", () => {
         onOpenRates={vi.fn()}
         onOpenMessages={vi.fn()}
         onOpenSysCalc={vi.fn()}
+        onOpenSoundVisionTools={vi.fn()}
         hasSoundVisionAccess
+        hasSoundVisionToolAccess
       />,
     );
 
@@ -121,6 +123,7 @@ describe("DashboardScreen", () => {
     expect(screen.getByTestId("tech-job-card")).toHaveTextContent("Hoy");
     expect(screen.getByTestId("tech-job-card")).toHaveTextContent("crew-chief:true");
     expect(screen.getByRole("button", { name: /open madrid run/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /diseñador\s*nm\/sv/i })).toBeInTheDocument();
   });
 
   it("gates optional tools and routes tour navigation through the card callback", async () => {
@@ -128,6 +131,7 @@ describe("DashboardScreen", () => {
     const onOpenTour = vi.fn();
     const onOpenSysCalc = vi.fn();
     const onOpenSV = vi.fn();
+    const onOpenSoundVisionTools = vi.fn();
 
     useMyToursMock.mockReturnValue({
       activeTours: [createTour({ id: "tour-77", name: "Mini Tour" })],
@@ -148,17 +152,21 @@ describe("DashboardScreen", () => {
         onOpenRates={vi.fn()}
         onOpenMessages={vi.fn()}
         onOpenSysCalc={onOpenSysCalc}
+        onOpenSoundVisionTools={onOpenSoundVisionTools}
         hasSoundVisionAccess={false}
+        hasSoundVisionToolAccess={false}
       />,
     );
 
     expect(screen.queryByText(/soundvision/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/syscalc/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/diseñador/i)).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /open mini tour/i }));
 
     expect(onOpenTour).toHaveBeenCalledWith("tour-77");
     expect(onOpenSV).not.toHaveBeenCalled();
     expect(onOpenSysCalc).not.toHaveBeenCalled();
+    expect(onOpenSoundVisionTools).not.toHaveBeenCalled();
   });
 });

--- a/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
+++ b/src/components/tours/__tests__/TourDateManagementDialog.test.tsx
@@ -182,7 +182,7 @@ describe("TourDateManagementDialog", () => {
       { job_id: "job-1", date: "2026-04-11", type: "rehearsal" },
       { job_id: "job-1", date: "2026-04-12", type: "rehearsal" },
     ]);
-  });
+  }, 10_000);
 
   it("stores S package intent when creating a date with the Tour Pack shortcut and no default sets", async () => {
     const user = userEvent.setup();

--- a/src/components/users/EditUserDialog.tsx
+++ b/src/components/users/EditUserDialog.tsx
@@ -30,6 +30,7 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
   const [assignableAsTech, setAssignableAsTech] = useState<boolean>(!!user?.assignable_as_tech);
   const [warehouseDutyExempt, setWarehouseDutyExempt] = useState<boolean>(!!user?.warehouse_duty_exempt);
   const [soundvisionAccessEnabled, setSoundvisionAccessEnabled] = useState<boolean>(!!user?.soundvision_access_enabled);
+  const [soundvisionToolAccessEnabled, setSoundvisionToolAccessEnabled] = useState<boolean>(!!user?.soundvision_tool_access_enabled);
   const [isAutonomo, setIsAutonomo] = useState<boolean>(user?.autonomo !== false);
   const [selectedRole, setSelectedRole] = useState<string>(user?.role || "technician");
   const { userRole } = useOptimizedAuth();
@@ -48,6 +49,7 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
     setWarehouseDutyExempt(!!user?.warehouse_duty_exempt);
     const forceSoundvisionForHouseTech = user?.department === 'sound' && user?.role === 'house_tech';
     setSoundvisionAccessEnabled(forceSoundvisionForHouseTech ? true : !!user?.soundvision_access_enabled);
+    setSoundvisionToolAccessEnabled(forceSoundvisionForHouseTech ? true : !!user?.soundvision_tool_access_enabled);
     setSelectedRole(user?.role || "technician");
     setFlexResourceId(user?.flex_resource_id || "");
     setFlexUrl("");
@@ -88,6 +90,9 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
       console.error("Cannot update user: No valid ID");
       return;
     }
+    const nextDepartment = formData.get('department') as Department;
+    const nextRole = formData.get('role') as string;
+    const nextIsSoundHouseTech = nextDepartment === 'sound' && nextRole === 'house_tech';
 
     const updatedData: Partial<Profile> = {
       id: user.id,
@@ -95,17 +100,21 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
       nickname: formData.get('nickname') as string,
       last_name: formData.get('lastName') as string,
       phone: formData.get('phone') as string,
-      department: formData.get('department') as Department,
+      department: nextDepartment,
       dni: formData.get('dni') as string,
       residencia: residencia,
       home_latitude: homeLatitude,
       home_longitude: homeLongitude,
       bg_color: bgColor || null,
-      role: formData.get('role') as string,
+      role: nextRole,
       assignable_as_tech: assignableAsTech,
       warehouse_duty_exempt: warehouseDutyExempt,
       flex_resource_id: (formData.get('flex_resource_id') as string || flexResourceId || '').trim() || null,
       soundvision_access_enabled: forceSoundvisionAccess ? true : soundvisionAccessEnabled,
+      soundvision_tool_access_enabled:
+        nextDepartment === 'sound'
+          ? nextIsSoundHouseTech || soundvisionToolAccessEnabled
+          : false,
       autonomo: isAutonomo,
     };
 
@@ -190,20 +199,38 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
               </div>
             </div>
             {isManagementUser && (isSoundTechnician || isSoundHouseTech) && (
-              <div className="space-y-2">
-                <Label htmlFor="soundvisionAccess">SoundVision Access</Label>
-                <div className="flex items-center gap-3">
-                  <Checkbox
-                    id="soundvisionAccess"
-                    checked={forceSoundvisionAccess ? true : soundvisionAccessEnabled}
-                    onCheckedChange={(v) => !forceSoundvisionAccess && setSoundvisionAccessEnabled(!!v)}
-                    disabled={forceSoundvisionAccess}
-                  />
-                  <span className="text-sm text-muted-foreground">
-                    {forceSoundvisionAccess
-                      ? 'House techs always retain SoundVision access.'
-                      : 'Allow this sound technician to access SoundVision files and tools.'}
-                  </span>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="soundvisionAccess">SoundVision Access</Label>
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      id="soundvisionAccess"
+                      checked={forceSoundvisionAccess ? true : soundvisionAccessEnabled}
+                      onCheckedChange={(v) => !forceSoundvisionAccess && setSoundvisionAccessEnabled(!!v)}
+                      disabled={forceSoundvisionAccess}
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      {forceSoundvisionAccess
+                        ? 'House techs always retain SoundVision access.'
+                        : 'Allow this sound technician to access the SoundVision file library.'}
+                    </span>
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="soundvisionToolAccess">NM/SV Designer Access</Label>
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      id="soundvisionToolAccess"
+                      checked={forceSoundvisionAccess ? true : soundvisionToolAccessEnabled}
+                      onCheckedChange={(v) => !forceSoundvisionAccess && setSoundvisionToolAccessEnabled(!!v)}
+                      disabled={forceSoundvisionAccess}
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      {forceSoundvisionAccess
+                        ? 'Sound house techs always retain access to amplifier maps and flysheets.'
+                        : 'Allow this sound technician to create NM/SV amplifier maps and Spanish flysheets.'}
+                    </span>
+                  </div>
                 </div>
               </div>
             )}

--- a/src/components/users/UsersList.tsx
+++ b/src/components/users/UsersList.tsx
@@ -87,7 +87,7 @@ export const UsersList = ({
       
       try {
         let query = dataLayerClient.from('profiles')
-          .select('id, first_name, nickname, last_name, email, role, phone, department, dni, residencia, assignable_as_tech, warehouse_duty_exempt, flex_resource_id, soundvision_access_enabled, autonomo', { count: 'exact' });
+          .select('id, first_name, nickname, last_name, email, role, phone, department, dni, residencia, assignable_as_tech, warehouse_duty_exempt, flex_resource_id, soundvision_access_enabled, soundvision_tool_access_enabled, autonomo', { count: 'exact' });
 
         // Apply filters
         if (roleFilter) {

--- a/src/components/users/__tests__/EditUserDialog.test.tsx
+++ b/src/components/users/__tests__/EditUserDialog.test.tsx
@@ -118,6 +118,9 @@ describe("EditUserDialog", () => {
     const soundVisionCheckbox = screen.getByRole("checkbox", { name: /soundvision access/i });
     expect(soundVisionCheckbox).toBeChecked();
     expect(soundVisionCheckbox).toBeDisabled();
+    const designerCheckbox = screen.getByRole("checkbox", { name: /nm\/sv designer access/i });
+    expect(designerCheckbox).toBeChecked();
+    expect(designerCheckbox).toBeDisabled();
 
     expect(screen.getByText("Profile picture: none")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /simulate upload/i }));
@@ -144,6 +147,7 @@ describe("EditUserDialog", () => {
           assignable_as_tech: true,
           warehouse_duty_exempt: true,
           soundvision_access_enabled: true,
+          soundvision_tool_access_enabled: true,
           residencia: "Valencia",
           home_latitude: 39.4699,
           home_longitude: -0.3763,
@@ -167,9 +171,13 @@ describe("EditUserDialog", () => {
 
     const soundVisionCheckbox = screen.getByRole("checkbox", { name: /soundvision access/i });
     expect(soundVisionCheckbox).not.toBeChecked();
+    const designerCheckbox = screen.getByRole("checkbox", { name: /nm\/sv designer access/i });
+    expect(designerCheckbox).not.toBeChecked();
 
     await user.click(soundVisionCheckbox);
     expect(soundVisionCheckbox).toBeChecked();
+    await user.click(designerCheckbox);
+    expect(designerCheckbox).toBeChecked();
 
     const flexUrlInput = screen.getByLabelText(/flex contact url/i);
     const flexIdInput = screen.getByLabelText(/flex resource id/i);
@@ -195,11 +203,25 @@ describe("EditUserDialog", () => {
         expect.objectContaining({
           id: "tech-1",
           soundvision_access_enabled: true,
+          soundvision_tool_access_enabled: true,
           flex_resource_id: extractedFromRaw,
         }),
       );
     });
   }, 15000);
+
+  it("does not offer NM/SV tool access to technicians outside the sound department", () => {
+    renderDialog(
+      createUserProfile({
+        id: "lights-tech-1",
+        role: "technician",
+        department: "lights",
+        soundvision_tool_access_enabled: false,
+      }),
+    );
+
+    expect(screen.queryByRole("checkbox", { name: /nm\/sv designer access/i })).not.toBeInTheDocument();
+  });
 
   it("sends onboarding emails and surfaces both success and failure toasts", async () => {
     const user = userEvent.setup();

--- a/src/components/users/types.ts
+++ b/src/components/users/types.ts
@@ -18,6 +18,7 @@ export type Profile = {
   warehouse_duty_exempt?: boolean | null;
   flex_resource_id?: string | null;
   soundvision_access_enabled?: boolean | null;
+  soundvision_tool_access_enabled?: boolean | null;
   autonomo?: boolean | null;
   bg_color?: string | null;
 };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -6110,6 +6110,7 @@ export type Database = {
           selected_job_statuses: string[] | null
           selected_job_types: string[] | null
           soundvision_access_enabled: boolean | null
+          soundvision_tool_access_enabled: boolean
           time_span: string | null
           timezone: string | null
           tours_expanded: boolean | null
@@ -6147,6 +6148,7 @@ export type Database = {
           selected_job_statuses?: string[] | null
           selected_job_types?: string[] | null
           soundvision_access_enabled?: boolean | null
+          soundvision_tool_access_enabled?: boolean
           time_span?: string | null
           timezone?: string | null
           tours_expanded?: boolean | null
@@ -6184,6 +6186,7 @@ export type Database = {
           selected_job_statuses?: string[] | null
           selected_job_types?: string[] | null
           soundvision_access_enabled?: boolean | null
+          soundvision_tool_access_enabled?: boolean
           time_span?: string | null
           timezone?: string | null
           tours_expanded?: boolean | null

--- a/src/pages/TechnicianDashboard.tsx
+++ b/src/pages/TechnicianDashboard.tsx
@@ -36,6 +36,7 @@ import { TechnicianTourRates } from '@/components/dashboard/TechnicianTourRates'
 import { TechnicianArtistReadOnlyModal } from '@/components/technician/TechnicianArtistReadOnlyModal';
 import { TechnicianRfTableModal } from '@/components/technician/TechnicianRfTableModal';
 import { FestivalPushFeedButton } from '@/components/festival/FestivalPushFeedButton';
+import { AmpRackDesigner } from '@/components/sound/amplifier-tool/rack-designer/AmpRackDesigner';
 
 // Type definitions
 interface TechnicianJobData {
@@ -146,7 +147,7 @@ const TechnicianDashboard = () => {
     async () => {
       if (!user?.id) return null;
       const { data, error } = await dataLayerClient.from('profiles')
-        .select('first_name, last_name, nickname, phone, residencia, dni, bg_color, profile_picture_url, role, department')
+        .select('first_name, last_name, nickname, phone, residencia, dni, bg_color, profile_picture_url, role, department, soundvision_tool_access_enabled')
         .eq('id', user.id)
         .single();
       if (error) throw error;
@@ -343,6 +344,8 @@ const TechnicianDashboard = () => {
   const userName = userProfile?.first_name && userProfile?.last_name
     ? `${userProfile.first_name} ${userProfile.last_name}`
     : user?.email || 'Técnico';
+  const hasSoundVisionToolAccess = userProfile?.department === 'sound'
+    && (userProfile.role === 'house_tech' || userProfile.soundvision_tool_access_enabled === true);
 
   return (
     <div className={`min-h-screen flex flex-col ${t.bg} transition-colors duration-300 font-sans`}>
@@ -363,7 +366,9 @@ const TechnicianDashboard = () => {
             onOpenRates={() => setShowRatesModal(true)}
             onOpenMessages={() => setShowMessagesModal(true)}
             onOpenSysCalc={() => navigate('/syscalc')}
+            onOpenSoundVisionTools={() => setActiveModal('soundvision-tools')}
             hasSoundVisionAccess={hasSoundVisionAccess}
+            hasSoundVisionToolAccess={hasSoundVisionToolAccess}
           />
         )}
         {tab === 'jobs' && (
@@ -430,6 +435,16 @@ const TechnicianDashboard = () => {
       )}
       {activeModal === 'soundvision' && hasSoundVisionAccess && (
         <SoundVisionModal theme={t} isDark={isDark} onClose={() => setActiveModal(null)} />
+      )}
+      {activeModal === 'soundvision-tools' && hasSoundVisionToolAccess && (
+        <AmpRackDesigner
+          standalone
+          hideTrigger
+          open
+          onOpenChange={(isOpen) => !isOpen && setActiveModal(null)}
+          storageScope={`technician-soundvision-tools:${user?.id ?? 'unknown'}`}
+          createdBy={userName}
+        />
       )}
       {showObliqueStrategy && (
         <ObliqueStrategyModal theme={t} isDark={isDark} onClose={() => setShowObliqueStrategy(false)} />

--- a/src/pages/TechnicianSuperApp.tsx
+++ b/src/pages/TechnicianSuperApp.tsx
@@ -62,6 +62,7 @@ import { AboutModal } from '@/components/technician/AboutModal';
 import { TechnicianArtistReadOnlyModal } from '@/components/technician/TechnicianArtistReadOnlyModal';
 import { TechnicianRfTableModal } from '@/components/technician/TechnicianRfTableModal';
 import { FestivalPushFeedButton } from '@/components/festival/FestivalPushFeedButton';
+import { AmpRackDesigner } from '@/components/sound/amplifier-tool/rack-designer/AmpRackDesigner';
 import type { JobWithLocationAndDocs } from '@/types/job';
 
 
@@ -175,7 +176,7 @@ export default function TechnicianSuperApp() {
     queryFn: async () => {
       if (!user?.id) return null;
       const { data, error } = await dataLayerClient.from('profiles')
-        .select('first_name, last_name, nickname, phone, residencia, dni, bg_color, profile_picture_url, role, department, calendar_ics_token')
+        .select('first_name, last_name, nickname, phone, residencia, dni, bg_color, profile_picture_url, role, department, calendar_ics_token, soundvision_tool_access_enabled')
         .eq('id', user.id)
         .single();
       if (error) throw error;
@@ -517,6 +518,8 @@ export default function TechnicianSuperApp() {
   const userName = userProfile?.first_name && userProfile?.last_name
     ? `${userProfile.first_name} ${userProfile.last_name}`
     : user?.email || 'Técnico';
+  const hasSoundVisionToolAccess = userProfile?.department === 'sound'
+    && (userProfile.role === 'house_tech' || userProfile.soundvision_tool_access_enabled === true);
 
   return (
     <div className={`min-h-screen flex flex-col ${t.bg} transition-colors duration-300 font-sans`}>
@@ -538,7 +541,9 @@ export default function TechnicianSuperApp() {
             onOpenRates={() => setShowRatesModal(true)}
             onOpenMessages={() => setShowMessagesModal(true)}
             onOpenSysCalc={() => navigate('/syscalc')}
+            onOpenSoundVisionTools={() => setActiveModal('soundvision-tools')}
             hasSoundVisionAccess={hasSoundVisionAccess}
+            hasSoundVisionToolAccess={hasSoundVisionToolAccess}
           />
         )}
         {tab === 'jobs' && (
@@ -627,6 +632,16 @@ export default function TechnicianSuperApp() {
       )}
       {activeModal === 'soundvision' && hasSoundVisionAccess && (
         <SoundVisionModal theme={t} isDark={isDark} onClose={() => setActiveModal(null)} />
+      )}
+      {activeModal === 'soundvision-tools' && hasSoundVisionToolAccess && (
+        <AmpRackDesigner
+          standalone
+          hideTrigger
+          open
+          onOpenChange={(isOpen) => !isOpen && setActiveModal(null)}
+          storageScope={`technician-soundvision-tools:${user?.id ?? 'unknown'}`}
+          createdBy={userName}
+        />
       )}
       {showObliqueStrategy && (
         <ObliqueStrategyModal theme={t} isDark={isDark} onClose={() => setShowObliqueStrategy(false)} />

--- a/src/pages/__tests__/TechnicianSuperApp.test.tsx
+++ b/src/pages/__tests__/TechnicianSuperApp.test.tsx
@@ -15,12 +15,14 @@ const {
   setThemeMock,
   useMyToursMock,
   useTableSubscriptionMock,
+  dashboardScreenMock,
 } = vi.hoisted(() => ({
   useOptimizedAuthMock: vi.fn(),
   useThemeMock: vi.fn(),
   setThemeMock: vi.fn(),
   useMyToursMock: vi.fn(),
   useTableSubscriptionMock: vi.fn(),
+  dashboardScreenMock: vi.fn(),
 }));
 
 vi.mock("@/hooks/useOptimizedAuth", () => ({
@@ -56,9 +58,10 @@ vi.mock("@/services/hourlyTourDateTimesheets", () => ({
 }));
 
 vi.mock("@/components/technician/DashboardScreen", () => ({
-  DashboardScreen: ({ assignments }: { assignments: any[] }) => (
-    <div data-testid="dashboard-screen">Dashboard assignments: {assignments.length}</div>
-  ),
+  DashboardScreen: (props: { assignments: any[]; hasSoundVisionToolAccess: boolean }) => {
+    dashboardScreenMock(props);
+    return <div data-testid="dashboard-screen">Dashboard assignments: {props.assignments.length}</div>;
+  },
 }));
 
 vi.mock("@/components/technician/JobsView", () => ({
@@ -179,9 +182,14 @@ describe("TechnicianSuperApp", () => {
     useTableSubscriptionMock.mockReturnValue({ isSubscribed: true, isStale: false });
   });
 
-  const configureSupabase = () => {
+  const configureSupabase = (profileOverrides: Record<string, unknown> = {}) => {
     const profileBuilder = createMockQueryBuilder({
-      data: createTechnicianProfile({ id: "technician-user", role: "technician", department: "sound" }),
+      data: createTechnicianProfile({
+        id: "technician-user",
+        role: "technician",
+        department: "sound",
+        ...profileOverrides,
+      }),
       error: null,
     });
     const assignmentBuilder = createMockQueryBuilder({
@@ -260,6 +268,30 @@ describe("TechnicianSuperApp", () => {
 
     expect(await screen.findByText("Dashboard assignments: 2")).toBeInTheDocument();
     expect(assignmentBuilder.eq).toHaveBeenCalledWith("status", "confirmed");
+  });
+
+  it("passes the permanent NM/SV entitlement to the technician dashboard", async () => {
+    configureSupabase({ soundvision_tool_access_enabled: true });
+
+    renderWithProviders(<TechnicianSuperApp />, { route: "/tech-app" });
+
+    await waitFor(() => {
+      expect(dashboardScreenMock).toHaveBeenCalledWith(
+        expect.objectContaining({ hasSoundVisionToolAccess: true }),
+      );
+    });
+  });
+
+  it("does not expose the NM/SV designer outside the sound department", async () => {
+    configureSupabase({ department: "lights", soundvision_tool_access_enabled: true });
+
+    renderWithProviders(<TechnicianSuperApp />, { route: "/tech-app" });
+
+    await waitFor(() => {
+      expect(dashboardScreenMock).toHaveBeenCalledWith(
+        expect.objectContaining({ hasSoundVisionToolAccess: false }),
+      );
+    });
   });
 
   it("opens the about modal from the URL parameter and clears the search param", async () => {

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -154,6 +154,7 @@ export const createTechnicianProfile = (overrides: Record<string, unknown> = {})
   department: "sound",
   assignable_as_tech: false,
   soundvision_access_enabled: false,
+  soundvision_tool_access_enabled: false,
   tours_expanded: true,
   ...overrides,
 });
@@ -169,6 +170,7 @@ export const createUserProfile = (overrides: Record<string, unknown> = {}) => ({
   assignable_as_tech: false,
   warehouse_duty_exempt: false,
   soundvision_access_enabled: false,
+  soundvision_tool_access_enabled: false,
   autonomo: true,
   ...overrides,
 });

--- a/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
+++ b/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
@@ -46,6 +46,7 @@ describe('generateSoundvisionFlysheetPdf', () => {
     const blob = await generateSoundvisionFlysheetPdf(makeFlysheet(6), {
       sourceFileName: 'prueba.xmlp',
       generatedAt: new Date('2026-07-19T12:00:00Z'),
+      brandLogoDataUrl: null,
     });
     const pdf = await PDFDocument.load(await blob.arrayBuffer());
 
@@ -71,6 +72,7 @@ describe('generateSoundvisionFlysheetPdf', () => {
     const blob = await generateSoundvisionFlysheetPdf(flysheet, {
       sourceFileName: 'array-largo.xmlp',
       generatedAt: new Date('2026-07-19T10:00:00Z'),
+      brandLogoDataUrl: null,
     });
     const pdf = await PDFDocument.load(await blob.arrayBuffer());
 

--- a/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
+++ b/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
@@ -1,0 +1,110 @@
+import { PDFDocument } from 'pdf-lib';
+import { describe, expect, it } from 'vitest';
+import type {
+  SoundvisionFlysheet,
+  SoundvisionFlysheetArray,
+  SoundvisionFlysheetEnclosure,
+} from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import {
+  generateSoundvisionFlysheetPdf,
+  soundvisionWarningSeverity,
+  translateSoundvisionWarning,
+} from '@/utils/soundvisionFlysheetPdf';
+
+const makeFlysheet = (arrayCount: number): SoundvisionFlysheet => ({
+  projectName: 'Prueba de gira',
+  arrays: Array.from({ length: arrayCount }, (_, arrayIndex): SoundvisionFlysheetArray => ({
+    groupName: 'PA principal',
+    arrayName: `MAIN ${arrayIndex + 1}`,
+    deployment: 'flown',
+    azimuthDegrees: arrayIndex * 10,
+    topSiteDegrees: -2.5,
+    bottomSiteDegrees: -20,
+    topHeightMeters: 10,
+    bottomHeightMeters: 4.2,
+    riggingFrame: 'K2-BUMP',
+    flyingBarSetting: 'Orificio A',
+    pickupConfiguration: 'F: 5 / R: 21',
+    totalMassKg: 1180.6,
+    frontLoadKg: null,
+    rearLoadKg: null,
+    enclosures: Array.from(
+      { length: 12 },
+      (_, enclosureIndex): SoundvisionFlysheetEnclosure => ({
+      model: 'K2',
+      splayAngleDegrees: enclosureIndex < 2 ? 5 : 0.25,
+      siteAngleDegrees: -2.5 - enclosureIndex,
+      trimHeightMeters: 10 - enclosureIndex * 0.45,
+      }),
+    ),
+    warnings: arrayIndex === 0 ? ['Tipping hazard'] : [],
+  })),
+});
+
+describe('generateSoundvisionFlysheetPdf', () => {
+  it('creates one A3 landscape page per five arrays', async () => {
+    const blob = await generateSoundvisionFlysheetPdf(makeFlysheet(6), {
+      sourceFileName: 'prueba.xmlp',
+      generatedAt: new Date('2026-07-19T12:00:00Z'),
+    });
+    const pdf = await PDFDocument.load(await blob.arrayBuffer());
+
+    expect(blob.type).toBe('application/pdf');
+    expect(pdf.getPageCount()).toBe(2);
+    const firstPage = pdf.getPage(0).getSize();
+    expect(firstPage.width).toBeGreaterThan(firstPage.height);
+    expect(firstPage.width).toBeGreaterThan(1_000);
+  });
+
+  it('continues long enclosure lists without overflowing the page', async () => {
+    const flysheet = makeFlysheet(1);
+    flysheet.arrays[0].enclosures = Array.from(
+      { length: 31 },
+      (_, index): SoundvisionFlysheetEnclosure => ({
+        model: `K2 ${index + 1}`,
+        splayAngleDegrees: 0.25,
+        siteAngleDegrees: null,
+        trimHeightMeters: null,
+      }),
+    );
+
+    const blob = await generateSoundvisionFlysheetPdf(flysheet, {
+      sourceFileName: 'array-largo.xmlp',
+      generatedAt: new Date('2026-07-19T10:00:00Z'),
+    });
+    const pdf = await PDFDocument.load(await blob.arrayBuffer());
+
+    expect(pdf.getPageCount()).toBe(2);
+  });
+
+  it('refuses to generate an empty deployment sheet', async () => {
+    await expect(
+      generateSoundvisionFlysheetPdf({ projectName: 'Vacío', arrays: [] }, {
+        sourceFileName: 'vacio.xmlp',
+      }),
+    ).rejects.toThrow('no contiene arrays compatibles');
+  });
+});
+
+describe('translateSoundvisionWarning', () => {
+  it('translates common Soundvision mechanical warnings into Spanish', () => {
+    expect(translateSoundvisionWarning('Tipping hazard')).toBe('Riesgo de vuelco.');
+    expect(translateSoundvisionWarning('Maximum limit is 9 KARA II.')).toBe(
+      'El límite máximo es 9 KARA II.',
+    );
+  });
+
+  it('preserves unknown messages instead of inventing a translation', () => {
+    expect(translateSoundvisionWarning('Custom engineering note')).toBe(
+      'Custom engineering note',
+    );
+  });
+
+  it('assigns Spanish safety headings matching the known warning severity', () => {
+    expect(
+      soundvisionWarningSeverity('Safety factor is below minimum recommended by applicable standards.'),
+    ).toBe('danger');
+    expect(soundvisionWarningSeverity('Tipping hazard')).toBe('warning');
+    expect(soundvisionWarningSeverity('Site angle is impossible.')).toBe('caution');
+  });
+});

--- a/src/utils/soundvisionFlysheetPdf.ts
+++ b/src/utils/soundvisionFlysheetPdf.ts
@@ -4,11 +4,16 @@ import type {
   SoundvisionFlysheet,
   SoundvisionFlysheetArray,
 } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import {
+  loadCompanyLogoDataUrl,
+  safeAddPdfImage,
+  SECTOR_PRO_RED,
+} from '@/utils/pdf/exportHelpers';
 import { loadJsPDF } from '@/utils/pdf/lazyPdf';
 import { MADRID_TIMEZONE } from '@/utils/timezoneUtils';
 
 const MAX_ARRAYS_PER_PAGE = 5;
-const MAX_ENCLOSURES_PER_PAGE = 30;
+const MAX_ENCLOSURES_PER_PAGE = 21;
 const MARGIN = 8;
 const LABEL_COLUMN_WIDTH = 37;
 const SUMMARY_ROW_HEIGHT = 5.5;
@@ -21,11 +26,13 @@ const LIGHT_GRAY: PdfColor = [238, 238, 238];
 const MEDIUM_GRAY: PdfColor = [210, 210, 210];
 const YELLOW: PdfColor = [255, 235, 0];
 const RED: PdfColor = [222, 30, 30];
-const SECTOR_RED: PdfColor = [125, 1, 1];
 
 export interface SoundvisionFlysheetPdfOptions {
   sourceFileName: string;
   generatedAt?: Date;
+  createdBy?: string;
+  /** Optional override used by non-browser renderers; the app loads the Sector Pro asset by default. */
+  brandLogoDataUrl?: string | null;
 }
 
 const formatNumber = (value: number | null, suffix: string, digits = 1): string =>
@@ -284,63 +291,97 @@ function drawHeader(
   pdf: jsPDF,
   flysheet: SoundvisionFlysheet,
   sourceFileName: string,
+  createdBy: string,
   pageNumber: number,
   pageCount: number,
 ): number {
   const pageWidth = pdf.internal.pageSize.getWidth();
-  const titleWidth = pageWidth * 0.43;
-  drawCell(pdf, 'Proyecto', MARGIN, MARGIN, 30, 8, { bold: true, fontSize: 8 });
-  drawCell(pdf, flysheet.projectName || 'SIN NOMBRE', MARGIN + 30, MARGIN, titleWidth - 30, 8, {
-    bold: true,
-    fontSize: 9,
-  });
-  drawCell(pdf, 'FLYSHEET', MARGIN, MARGIN + 8, titleWidth, 13, {
-    bold: true,
-    fill: SECTOR_RED,
-    fontSize: 18,
-    textColor: [255, 255, 255],
-  });
+  const contentWidth = pageWidth - MARGIN * 2;
+  pdf.setFillColor(...SECTOR_PRO_RED);
+  pdf.rect(0, 0, pageWidth, 30, 'F');
+  pdf.setFont('helvetica', 'bold');
+  pdf.setFontSize(20);
+  pdf.setTextColor(255, 255, 255);
+  pdf.text('FLYSHEET SOUNDVISION', pageWidth / 2, 20, { align: 'center' });
 
-  const metaX = MARGIN + titleWidth + 12;
-  const metaWidth = pageWidth - MARGIN - metaX;
-  drawCell(pdf, 'Archivo XMLP', metaX, MARGIN, 36, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
-  drawCell(pdf, sourceFileName, metaX + 36, MARGIN, metaWidth - 36, 7, { fontSize: 7.5 });
-  drawCell(pdf, 'Página', metaX, MARGIN + 7, 36, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
-  drawCell(pdf, `${pageNumber} / ${pageCount}`, metaX + 36, MARGIN + 7, metaWidth - 36, 7, { fontSize: 7.5 });
-  drawCell(pdf, 'Validación', metaX, MARGIN + 14, 36, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
-  drawCell(pdf, 'Cargas, seguridad y flying bar: comprobar en Soundvision', metaX + 36, MARGIN + 14, metaWidth - 36, 7, {
+  const metaY = 36;
+  const columnGap = 6;
+  const columnWidth = (contentWidth - columnGap) / 2;
+  const leftValueX = MARGIN + 34;
+  const rightX = MARGIN + columnWidth + columnGap;
+  const rightValueX = rightX + 34;
+  drawCell(pdf, 'Proyecto', MARGIN, metaY, 34, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
+  drawCell(pdf, flysheet.projectName || 'SIN NOMBRE', leftValueX, metaY, columnWidth - 34, 7, { bold: true, fontSize: 7.5 });
+  drawCell(pdf, 'Archivo XMLP', rightX, metaY, 34, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
+  drawCell(pdf, sourceFileName, rightValueX, metaY, columnWidth - 34, 7, { fontSize: 7.5 });
+  drawCell(pdf, 'Predicción creada por', MARGIN, metaY + 7, 34, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7 });
+  drawCell(pdf, createdBy, leftValueX, metaY + 7, columnWidth - 34, 7, { bold: true, fontSize: 7.5 });
+  drawCell(pdf, 'Página', rightX, metaY + 7, 34, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
+  drawCell(pdf, `${pageNumber} / ${pageCount}`, rightValueX, metaY + 7, columnWidth - 34, 7, { fontSize: 7.5 });
+  drawCell(pdf, 'Validación', MARGIN, metaY + 14, 34, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
+  drawCell(pdf, 'Cargas, seguridad y flying bar: comprobar en Soundvision', leftValueX, metaY + 14, contentWidth - 34, 7, {
     bold: true,
     fill: YELLOW,
     fontSize: 7.2,
   });
-  return MARGIN + 26;
+  return metaY + 25;
 }
 
-function drawFooter(pdf: jsPDF, generatedAt: Date): void {
+function drawFooter(
+  pdf: jsPDF,
+  generatedAt: Date,
+  brandLogoDataUrl: string | null,
+  pageNumber: number,
+  pageCount: number,
+): void {
   const pageWidth = pdf.internal.pageSize.getWidth();
   const pageHeight = pdf.internal.pageSize.getHeight();
-  pdf.setDrawColor(...SECTOR_RED);
-  pdf.setLineWidth(0.8);
-  pdf.line(MARGIN, pageHeight - 9, pageWidth - MARGIN, pageHeight - 9);
   pdf.setFont('helvetica', 'normal');
   pdf.setFontSize(7);
   pdf.setTextColor(80, 80, 80);
   pdf.text(
-    `Generado el ${formatInTimeZone(generatedAt, MADRID_TIMEZONE, 'dd/MM/yyyy HH:mm')} · Confirme cargas, seguridad y ajuste del flying bar en Soundvision.`,
+    `Generado: ${formatInTimeZone(generatedAt, MADRID_TIMEZONE, 'dd/MM/yyyy HH:mm')}`,
     MARGIN,
-    pageHeight - 5,
+    pageHeight - 10,
+  );
+
+  pdf.setTextColor(...BLACK);
+  pdf.setFontSize(8);
+  pdf.text(`Página ${pageNumber} de ${pageCount}`, pageWidth / 2, pageHeight - 10, {
+    align: 'center',
+  });
+
+  const logoWidth = 40;
+  const logoHeight = logoWidth / 7.94;
+  safeAddPdfImage(
+    pdf,
+    brandLogoDataUrl,
+    'PNG',
+    pageWidth - 50,
+    pageHeight - 25,
+    logoWidth,
+    logoHeight,
+    'No se pudo añadir el logotipo de Sector Pro al flysheet:',
   );
 }
 
 /** Generates an A3 landscape Spanish deployment flysheet from normalized XMLP data. */
 export async function generateSoundvisionFlysheetPdf(
   flysheet: SoundvisionFlysheet,
-  { sourceFileName, generatedAt = new Date() }: SoundvisionFlysheetPdfOptions,
+  {
+    sourceFileName,
+    generatedAt = new Date(),
+    createdBy = 'No identificado',
+    brandLogoDataUrl,
+  }: SoundvisionFlysheetPdfOptions,
 ): Promise<Blob> {
   if (flysheet.arrays.length === 0) {
     throw new Error('El proyecto no contiene arrays compatibles con el flysheet.');
   }
 
+  const sectorProLogo = brandLogoDataUrl === undefined
+    ? await loadCompanyLogoDataUrl()
+    : brandLogoDataUrl;
   const jsPDF = await loadJsPDF();
   const pdf = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a3' });
   const pages: Array<{
@@ -380,14 +421,15 @@ export async function generateSoundvisionFlysheetPdf(
       pdf,
       flysheet,
       sourceFileName,
+      createdBy.trim() || 'No identificado',
       pageIndex + 1,
       pages.length,
     );
     const cabinetsStartY = drawSummaryRows(pdf, arrays, MARGIN, tableStartY, arrayWidth) + 2;
     const warningsStartY =
       drawCabinetRows(pdf, arrays, MARGIN, cabinetsStartY, arrayWidth, enclosureOffset) + 4;
-    drawWarnings(pdf, arrays, MARGIN, warningsStartY, arrayWidth, pageHeight - 14, continues);
-    drawFooter(pdf, generatedAt);
+    drawWarnings(pdf, arrays, MARGIN, warningsStartY, arrayWidth, pageHeight - 27, continues);
+    drawFooter(pdf, generatedAt, sectorProLogo, pageIndex + 1, pages.length);
   });
 
   return pdf.output('blob') as Blob;

--- a/src/utils/soundvisionFlysheetPdf.ts
+++ b/src/utils/soundvisionFlysheetPdf.ts
@@ -1,0 +1,394 @@
+import type jsPDF from 'jspdf';
+import { formatInTimeZone } from 'date-fns-tz';
+import type {
+  SoundvisionFlysheet,
+  SoundvisionFlysheetArray,
+} from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import { loadJsPDF } from '@/utils/pdf/lazyPdf';
+import { MADRID_TIMEZONE } from '@/utils/timezoneUtils';
+
+const MAX_ARRAYS_PER_PAGE = 5;
+const MAX_ENCLOSURES_PER_PAGE = 30;
+const MARGIN = 8;
+const LABEL_COLUMN_WIDTH = 37;
+const SUMMARY_ROW_HEIGHT = 5.5;
+const CABINET_ROW_HEIGHT = 4.5;
+
+type PdfColor = [number, number, number];
+
+const BLACK: PdfColor = [0, 0, 0];
+const LIGHT_GRAY: PdfColor = [238, 238, 238];
+const MEDIUM_GRAY: PdfColor = [210, 210, 210];
+const YELLOW: PdfColor = [255, 235, 0];
+const RED: PdfColor = [222, 30, 30];
+const SECTOR_RED: PdfColor = [125, 1, 1];
+
+export interface SoundvisionFlysheetPdfOptions {
+  sourceFileName: string;
+  generatedAt?: Date;
+}
+
+const formatNumber = (value: number | null, suffix: string, digits = 1): string =>
+  value === null ? '-' : `${value.toFixed(digits)}${suffix}`;
+
+const formatCompactNumber = (value: number | null, suffix: string): string =>
+  value === null ? '-' : `${value.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
+
+const deploymentLabel = (deployment: SoundvisionFlysheetArray['deployment']): string => {
+  if (deployment === 'flown') return 'VOLADO';
+  if (deployment === 'stacked') return 'APILADO';
+  return 'SIN DEFINIR';
+};
+
+export const translateSoundvisionWarning = (warning: string): string => {
+  const normalized = warning.trim();
+  const exact: Record<string, string> = {
+    'L-Acoustics does not allow this configuration.':
+      'L-Acoustics no permite esta configuración.',
+    'Safety factor is below minimum recommended by applicable standards.':
+      'El factor de seguridad está por debajo del mínimo recomendado por la normativa aplicable.',
+    'Change the site angle, rigging option, or number of enclosures.':
+      'Cambie el ángulo de inclinación, la opción de rigging o el número de recintos.',
+    'Site angle is impossible.': 'El ángulo de inclinación no es posible.',
+    'Tipping hazard': 'Riesgo de vuelco.',
+    'L-Acoustics recommends securing the array to the ground.':
+      'L-Acoustics recomienda asegurar el array al suelo.',
+  };
+  if (exact[normalized]) return exact[normalized];
+
+  const maximum = normalized.match(/^Maximum limit is (.+)\.$/i);
+  if (maximum) return `El límite máximo es ${maximum[1]}.`;
+  return normalized;
+};
+
+type WarningSeverity = 'danger' | 'warning' | 'caution';
+
+export const soundvisionWarningSeverity = (warning: string): WarningSeverity => {
+  const normalized = warning.trim().toLowerCase();
+  if (
+    normalized.includes('does not allow') ||
+    normalized.includes('safety factor') ||
+    normalized.includes('no permite') ||
+    normalized.includes('factor de seguridad')
+  ) {
+    return 'danger';
+  }
+  if (
+    normalized.includes('site angle is impossible') ||
+    normalized.includes('recommends securing') ||
+    normalized.includes('ángulo de inclinación no es posible') ||
+    normalized.includes('recomienda asegurar')
+  ) {
+    return 'caution';
+  }
+  return 'warning';
+};
+
+function drawCell(
+  pdf: jsPDF,
+  text: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  options: {
+    fill?: PdfColor;
+    bold?: boolean;
+    fontSize?: number;
+    align?: 'left' | 'center' | 'right';
+    textColor?: PdfColor;
+  } = {},
+): void {
+  if (options.fill) {
+    pdf.setFillColor(...options.fill);
+    pdf.rect(x, y, width, height, 'FD');
+  } else {
+    pdf.rect(x, y, width, height);
+  }
+  pdf.setTextColor(...(options.textColor ?? BLACK));
+  pdf.setFont('helvetica', options.bold ? 'bold' : 'normal');
+  pdf.setFontSize(options.fontSize ?? 8);
+  const align = options.align ?? 'center';
+  const textX = align === 'left' ? x + 1.5 : align === 'right' ? x + width - 1.5 : x + width / 2;
+  const lines = pdf.splitTextToSize(text || '-', Math.max(1, width - 3));
+  const lineHeight = (options.fontSize ?? 8) * 0.36;
+  const blockHeight = lines.length * lineHeight;
+  const textY = y + Math.max(lineHeight, (height - blockHeight) / 2 + lineHeight * 0.82);
+  pdf.text(lines, textX, textY, { align, maxWidth: width - 3 });
+}
+
+function drawSummaryRows(
+  pdf: jsPDF,
+  arrays: SoundvisionFlysheetArray[],
+  startX: number,
+  startY: number,
+  arrayWidth: number,
+): number {
+  const rows: Array<{
+    label: string;
+    value: (array: SoundvisionFlysheetArray) => string;
+    fill?: PdfColor;
+  }> = [
+    { label: 'Grupo', value: (array) => array.groupName },
+    { label: 'Array', value: (array) => array.arrayName },
+    { label: 'Configuración', value: (array) => deploymentLabel(array.deployment) },
+    { label: 'Masa total', value: (array) => formatNumber(array.totalMassKg, ' kg') },
+    { label: 'Carga frontal', value: (array) => formatNumber(array.frontLoadKg, ' kg') },
+    { label: 'Carga trasera', value: (array) => formatNumber(array.rearLoadKg, ' kg') },
+    { label: 'Altura superior', value: (array) => formatNumber(array.topHeightMeters, ' m', 2) },
+    { label: 'Altura inferior', value: (array) => formatNumber(array.bottomHeightMeters, ' m', 2), fill: YELLOW },
+    { label: 'Ángulo superior', value: (array) => formatNumber(array.topSiteDegrees, '°'), fill: YELLOW },
+    { label: 'Ángulo inferior', value: (array) => formatNumber(array.bottomSiteDegrees, '°') },
+    { label: 'Azimut', value: (array) => formatNumber(array.azimuthDegrees, '°') },
+    { label: 'Rigging', value: (array) => array.riggingFrame || '-' },
+    {
+      label: 'Ajuste flying bar',
+      value: (array) =>
+        array.deployment === 'flown'
+          ? array.flyingBarSetting || 'NO DISPONIBLE - VERIFICAR'
+          : 'NO APLICA',
+      fill: YELLOW,
+    },
+    { label: 'Puntos (F/R/PB)', value: (array) => array.pickupConfiguration || '-' },
+  ];
+
+  let y = startY;
+  for (const row of rows) {
+    drawCell(pdf, row.label, startX, y, LABEL_COLUMN_WIDTH, SUMMARY_ROW_HEIGHT, {
+      bold: true,
+      fill: row.fill ?? LIGHT_GRAY,
+      fontSize: 7.5,
+    });
+    arrays.forEach((array, index) => {
+      drawCell(
+        pdf,
+        row.value(array),
+        startX + LABEL_COLUMN_WIDTH + index * arrayWidth,
+        y,
+        arrayWidth,
+        SUMMARY_ROW_HEIGHT,
+        { fill: row.fill, fontSize: 7.3 },
+      );
+    });
+    y += SUMMARY_ROW_HEIGHT;
+  }
+  return y;
+}
+
+function drawCabinetRows(
+  pdf: jsPDF,
+  arrays: SoundvisionFlysheetArray[],
+  startX: number,
+  startY: number,
+  arrayWidth: number,
+  enclosureOffset: number,
+): number {
+  const rowCount = Math.max(...arrays.map((array) => array.enclosures.length));
+  let y = startY;
+  drawCell(pdf, 'N.º', startX, y, LABEL_COLUMN_WIDTH, CABINET_ROW_HEIGHT, {
+    bold: true,
+    fill: MEDIUM_GRAY,
+    fontSize: 7.5,
+  });
+  arrays.forEach((array, index) => {
+    drawCell(
+      pdf,
+      `${array.arrayName} · Recinto / Ángulo`,
+      startX + LABEL_COLUMN_WIDTH + index * arrayWidth,
+      y,
+      arrayWidth,
+      CABINET_ROW_HEIGHT,
+      { bold: true, fill: MEDIUM_GRAY, fontSize: 7 },
+    );
+  });
+  y += CABINET_ROW_HEIGHT;
+
+  for (let row = 0; row < rowCount; row += 1) {
+    drawCell(pdf, String(enclosureOffset + row + 1), startX, y, LABEL_COLUMN_WIDTH, CABINET_ROW_HEIGHT, {
+      fontSize: 7.5,
+    });
+    arrays.forEach((array, index) => {
+      const enclosure = array.enclosures[row];
+      const value = enclosure
+        ? `${enclosure.model}  |  ${formatCompactNumber(enclosure.splayAngleDegrees, '°')}`
+        : '';
+      drawCell(
+        pdf,
+        value,
+        startX + LABEL_COLUMN_WIDTH + index * arrayWidth,
+        y,
+        arrayWidth,
+        CABINET_ROW_HEIGHT,
+        { fontSize: 7.2 },
+      );
+    });
+    y += CABINET_ROW_HEIGHT;
+  }
+  return y;
+}
+
+function drawWarnings(
+  pdf: jsPDF,
+  arrays: SoundvisionFlysheetArray[],
+  startX: number,
+  startY: number,
+  arrayWidth: number,
+  maxY: number,
+  continues: boolean,
+): void {
+  arrays.forEach((array, index) => {
+    const x = startX + LABEL_COLUMN_WIDTH + index * arrayWidth;
+    const messages = array.warnings.map(translateSoundvisionWarning);
+    const flyingBarReminder =
+      array.deployment === 'flown'
+        ? `Confirme en Soundvision el modelo, la posición y el orificio del flying bar (${array.flyingBarSetting || 'ajuste no disponible en el XMLP'}) antes del izado.`
+        : '';
+    const severities = array.warnings.map(soundvisionWarningSeverity);
+    const severity: WarningSeverity = severities.includes('danger')
+      ? 'danger'
+      : severities.includes('warning')
+        ? 'warning'
+        : 'caution';
+    const title = continues
+      ? 'LISTADO CONTINÚA'
+      : messages.length > 0
+        ? severity === 'danger'
+          ? 'PELIGRO'
+          : severity === 'warning'
+            ? 'ADVERTENCIA'
+            : 'PRECAUCIÓN'
+        : 'VERIFICACIÓN PENDIENTE';
+    const body = continues
+      ? 'Los recintos restantes aparecen en la página siguiente.'
+      : messages.length > 0
+        ? [...messages, flyingBarReminder].filter(Boolean).join('\n')
+        : [
+            'El XMLP no contiene resultados de carga o seguridad. Verifique la configuración en Soundvision antes del montaje.',
+            flyingBarReminder,
+          ].filter(Boolean).join('\n');
+    const titleColor = !continues && messages.length > 0 && severity === 'danger' ? RED : YELLOW;
+    const availableHeight = Math.max(20, maxY - startY);
+    const titleHeight = 6;
+    drawCell(pdf, title, x, startY, arrayWidth, titleHeight, {
+      bold: true,
+      fill: titleColor,
+      fontSize: 7.5,
+    });
+    drawCell(pdf, body, x, startY + titleHeight, arrayWidth, availableHeight - titleHeight, {
+      fontSize: 6.7,
+    });
+  });
+}
+
+function drawHeader(
+  pdf: jsPDF,
+  flysheet: SoundvisionFlysheet,
+  sourceFileName: string,
+  pageNumber: number,
+  pageCount: number,
+): number {
+  const pageWidth = pdf.internal.pageSize.getWidth();
+  const titleWidth = pageWidth * 0.43;
+  drawCell(pdf, 'Proyecto', MARGIN, MARGIN, 30, 8, { bold: true, fontSize: 8 });
+  drawCell(pdf, flysheet.projectName || 'SIN NOMBRE', MARGIN + 30, MARGIN, titleWidth - 30, 8, {
+    bold: true,
+    fontSize: 9,
+  });
+  drawCell(pdf, 'FLYSHEET', MARGIN, MARGIN + 8, titleWidth, 13, {
+    bold: true,
+    fill: SECTOR_RED,
+    fontSize: 18,
+    textColor: [255, 255, 255],
+  });
+
+  const metaX = MARGIN + titleWidth + 12;
+  const metaWidth = pageWidth - MARGIN - metaX;
+  drawCell(pdf, 'Archivo XMLP', metaX, MARGIN, 36, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
+  drawCell(pdf, sourceFileName, metaX + 36, MARGIN, metaWidth - 36, 7, { fontSize: 7.5 });
+  drawCell(pdf, 'Página', metaX, MARGIN + 7, 36, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
+  drawCell(pdf, `${pageNumber} / ${pageCount}`, metaX + 36, MARGIN + 7, metaWidth - 36, 7, { fontSize: 7.5 });
+  drawCell(pdf, 'Validación', metaX, MARGIN + 14, 36, 7, { bold: true, fill: LIGHT_GRAY, fontSize: 7.5 });
+  drawCell(pdf, 'Cargas, seguridad y flying bar: comprobar en Soundvision', metaX + 36, MARGIN + 14, metaWidth - 36, 7, {
+    bold: true,
+    fill: YELLOW,
+    fontSize: 7.2,
+  });
+  return MARGIN + 26;
+}
+
+function drawFooter(pdf: jsPDF, generatedAt: Date): void {
+  const pageWidth = pdf.internal.pageSize.getWidth();
+  const pageHeight = pdf.internal.pageSize.getHeight();
+  pdf.setDrawColor(...SECTOR_RED);
+  pdf.setLineWidth(0.8);
+  pdf.line(MARGIN, pageHeight - 9, pageWidth - MARGIN, pageHeight - 9);
+  pdf.setFont('helvetica', 'normal');
+  pdf.setFontSize(7);
+  pdf.setTextColor(80, 80, 80);
+  pdf.text(
+    `Generado el ${formatInTimeZone(generatedAt, MADRID_TIMEZONE, 'dd/MM/yyyy HH:mm')} · Confirme cargas, seguridad y ajuste del flying bar en Soundvision.`,
+    MARGIN,
+    pageHeight - 5,
+  );
+}
+
+/** Generates an A3 landscape Spanish deployment flysheet from normalized XMLP data. */
+export async function generateSoundvisionFlysheetPdf(
+  flysheet: SoundvisionFlysheet,
+  { sourceFileName, generatedAt = new Date() }: SoundvisionFlysheetPdfOptions,
+): Promise<Blob> {
+  if (flysheet.arrays.length === 0) {
+    throw new Error('El proyecto no contiene arrays compatibles con el flysheet.');
+  }
+
+  const jsPDF = await loadJsPDF();
+  const pdf = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a3' });
+  const pages: Array<{
+    arrays: SoundvisionFlysheetArray[];
+    enclosureOffset: number;
+    continues: boolean;
+  }> = [];
+  for (let arrayOffset = 0; arrayOffset < flysheet.arrays.length; arrayOffset += MAX_ARRAYS_PER_PAGE) {
+    const arrayGroup = flysheet.arrays.slice(arrayOffset, arrayOffset + MAX_ARRAYS_PER_PAGE);
+    const enclosureCount = Math.max(...arrayGroup.map((array) => array.enclosures.length));
+    const verticalPageCount = Math.max(1, Math.ceil(enclosureCount / MAX_ENCLOSURES_PER_PAGE));
+    for (let verticalPage = 0; verticalPage < verticalPageCount; verticalPage += 1) {
+      const enclosureOffset = verticalPage * MAX_ENCLOSURES_PER_PAGE;
+      pages.push({
+        arrays: arrayGroup.map((array) => ({
+          ...array,
+          enclosures: array.enclosures.slice(
+            enclosureOffset,
+            enclosureOffset + MAX_ENCLOSURES_PER_PAGE,
+          ),
+        })),
+        enclosureOffset,
+        continues: verticalPage < verticalPageCount - 1,
+      });
+    }
+  }
+
+  pages.forEach(({ arrays, enclosureOffset, continues }, pageIndex) => {
+    if (pageIndex > 0) pdf.addPage('a3', 'landscape');
+    pdf.setDrawColor(...BLACK);
+    pdf.setLineWidth(0.35);
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const pageHeight = pdf.internal.pageSize.getHeight();
+    const contentWidth = pageWidth - MARGIN * 2;
+    const arrayWidth = (contentWidth - LABEL_COLUMN_WIDTH) / arrays.length;
+    const tableStartY = drawHeader(
+      pdf,
+      flysheet,
+      sourceFileName,
+      pageIndex + 1,
+      pages.length,
+    );
+    const cabinetsStartY = drawSummaryRows(pdf, arrays, MARGIN, tableStartY, arrayWidth) + 2;
+    const warningsStartY =
+      drawCabinetRows(pdf, arrays, MARGIN, cabinetsStartY, arrayWidth, enclosureOffset) + 4;
+    drawWarnings(pdf, arrays, MARGIN, warningsStartY, arrayWidth, pageHeight - 14, continues);
+    drawFooter(pdf, generatedAt);
+  });
+
+  return pdf.output('blob') as Blob;
+}

--- a/supabase/functions/parse-la-session/access.test.ts
+++ b/supabase/functions/parse-la-session/access.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { canUseLaSessionTools } from './access.ts';
+
+describe('canUseLaSessionTools', () => {
+  it('allows admin and management to retain access to the NM/SV parser', () => {
+    expect(canUseLaSessionTools('admin', null, false)).toBe(true);
+    expect(canUseLaSessionTools('management', 'lights', false)).toBe(true);
+  });
+
+  it('allows Sound house techs without an explicit grant', () => {
+    expect(canUseLaSessionTools('house_tech', 'sound', false)).toBe(true);
+    expect(canUseLaSessionTools('house_tech', 'lights', true)).toBe(false);
+  });
+
+  it('allows only explicitly entitled Sound technicians', () => {
+    expect(canUseLaSessionTools('technician', 'sound', true)).toBe(true);
+    expect(canUseLaSessionTools('technician', 'sound', false)).toBe(false);
+    expect(canUseLaSessionTools('technician', 'lights', true)).toBe(false);
+  });
+});

--- a/supabase/functions/parse-la-session/access.ts
+++ b/supabase/functions/parse-la-session/access.ts
@@ -1,0 +1,15 @@
+const PRIVILEGED_ROLES = new Set(['admin', 'management']);
+
+export function canUseLaSessionTools(
+  role: string,
+  department: string | null | undefined,
+  hasExplicitToolAccess: boolean,
+): boolean {
+  const normalizedRole = role.trim().toLowerCase();
+  if (PRIVILEGED_ROLES.has(normalizedRole)) return true;
+
+  const isSoundDepartment = department?.trim().toLowerCase() === 'sound';
+  if (!isSoundDepartment) return false;
+  if (normalizedRole === 'house_tech') return true;
+  return normalizedRole === 'technician' && hasExplicitToolAccess;
+}

--- a/supabase/functions/parse-la-session/index.ts
+++ b/supabase/functions/parse-la-session/index.ts
@@ -27,6 +27,8 @@ const SQLITE_MAGIC = "SQLite format 3";
 interface ParseSessionBody extends Record<string, unknown> {
   /** base64-encoded raw .nwm / .xmlp file bytes. */
   file?: unknown;
+  /** Original client filename, used only as a display-name fallback. */
+  fileName?: unknown;
 }
 
 function hexToBytes(hex: string, expectedLen: number, name: string): Uint8Array {
@@ -121,6 +123,9 @@ serve(
       if (typeof body.file !== "string" || body.file.length === 0) {
         throw new HttpError(400, "Missing base64 'file' field", { code: "missing_file" });
       }
+      const fileName = typeof body.fileName === "string"
+        ? body.fileName.slice(0, 200).replace(/^.*[\\/]/, "")
+        : "";
 
       let fileBytes: Uint8Array;
       try {
@@ -166,7 +171,7 @@ serve(
           if (!xml.includes("<project") && !xml.includes("amplification")) {
             throw new HttpError(422, "El archivo no parece un proyecto de Soundvision válido", { code: "xmlp_not_recognized" });
           }
-          map = parseXmlpXml(xml);
+          map = parseXmlpXml(xml, fileName);
         }
       } catch (error) {
         if (error instanceof HttpError) throw error;
@@ -177,8 +182,10 @@ serve(
         });
       }
 
-      if (map.units.length === 0) {
-        throw new HttpError(422, "La sesión no contiene amplificadores", { code: "session_no_units" });
+      if (map.units.length === 0 && !map.flysheet?.arrays.length) {
+        throw new HttpError(422, "La sesión no contiene amplificadores ni arrays compatibles", {
+          code: "session_no_units_or_arrays",
+        });
       }
 
       // Transient: we return the parsed map and never persist the file or XML.

--- a/supabase/functions/parse-la-session/index.ts
+++ b/supabase/functions/parse-la-session/index.ts
@@ -12,10 +12,12 @@ import {
 } from "../_shared/http.ts";
 import { extractNwmBlob } from "./sqlite.ts";
 import { parseNwmXml, parseXmlpXml, type NwmMap } from "./parse.ts";
+import { canUseLaSessionTools } from "./access.ts";
 
-// Roles allowed to import sessions. House techs run the amp systems, so they are
-// included alongside admin/management.
-const ALLOWED_ROLES = new Set(["admin", "management", "house_tech"]);
+// Technician access is additionally checked against the permanent per-profile
+// entitlement below; keeping the function privileged-role classified prevents
+// the XMLP/NWM decryption service from becoming a general authenticated API.
+const ALLOWED_ROLES = new Set(["admin", "management", "house_tech", "technician"]);
 
 // Generous ceiling: real sessions are tens–hundreds of KB; base64 adds ~33%.
 // Cap the decrypted XML too so a crafted file can't exhaust memory.
@@ -113,11 +115,35 @@ serve(
       );
 
       const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
-      await requireAuthenticatedRole(supabase, req, {
+      const caller = await requireAuthenticatedRole(supabase, req, {
         allowedRoles: ALLOWED_ROLES,
         logContext: "parse-la-session",
-        forbiddenMessage: "Solo admin, management o house_tech pueden importar sesiones.",
+        forbiddenMessage: "No tiene acceso al diseñador NM/SV.",
       });
+
+      const { data: callerProfile, error: callerProfileError } = await supabase
+        .from("profiles")
+        .select("department, soundvision_tool_access_enabled")
+        .eq("id", caller.userId)
+        .maybeSingle();
+
+      if (callerProfileError) {
+        console.error("[parse-la-session] Tool entitlement lookup failed:", callerProfileError.message);
+        throw new HttpError(500, "Authorization lookup failed", {
+          code: "authorization_lookup_failed",
+          exposeDetails: false,
+        });
+      }
+
+      if (!canUseLaSessionTools(
+        caller.role,
+        callerProfile?.department,
+        Boolean(callerProfile?.soundvision_tool_access_enabled),
+      )) {
+        throw new HttpError(403, "No tiene acceso al diseñador NM/SV.", {
+          code: "soundvision_tool_access_required",
+        });
+      }
 
       const body = await readBoundedJsonObject<ParseSessionBody>(req, { maxBytes: MAX_BODY_BYTES });
       if (typeof body.file !== "string" || body.file.length === 0) {

--- a/supabase/functions/parse-la-session/parse.test.ts
+++ b/supabase/functions/parse-la-session/parse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseNwmXml } from "./parse.ts";
+import { parseNwmXml, parseSoundvisionFlysheet, parseXmlpXml } from "./parse.ts";
 
 describe("parseNwmXml", () => {
   it("decodes XML entities once without double-unescaping literal entity text", () => {
@@ -25,5 +25,152 @@ describe("parseNwmXml", () => {
       "LA12X",
       "LA4X",
     ]);
+  });
+});
+
+const soundvisionProject = `<project name="Gira &amp; Festival.xmlp">
+  <physical_configuration name="PA principal">
+    <cluster name="MAIN L">
+      <deployment_orientation>flown</deployment_orientation>
+      <azimuth>12.5</azimuth>
+      <top_height>11.2</top_height>
+      <bottom_height>4.35</bottom_height>
+      <top_site>-2.5</top_site>
+      <bottom_site>-24.5</bottom_site>
+      <total_mass>1180.6</total_mass>
+      <front_load>640.2</front_load>
+      <rear_load>540.4</rear_load>
+      <rigging_element type="K2-BUMP">
+        <bar_hole>A</bar_hole>
+        <motor_configuration><front>5</front><rear>21</rear></motor_configuration>
+      </rigging_element>
+      <elements>
+        <element type="K2"><site>-2.5</site><z>11.2</z></element>
+        <element type="K2"><site>-7.5</site><z>9.8</z></element>
+        <element type="K2"><site>-17.5</site><z>7.1</z></element>
+        <element type="K2"><site>-24.5</site><z>4.35</z></element>
+      </elements>
+      <connection_sets><connection_set><inter_angles>
+        <angle>5</angle><angle>10</angle><angle>0.25</angle>
+      </inter_angles></connection_set></connection_sets>
+      <mechanical_warning>Factor de seguridad por debajo del mínimo.</mechanical_warning>
+    </cluster>
+    <Cluster name="SUB L" deployment="stacked_cardioid" azimuth="0">
+      <rigging_element><type>KS28-OUTRIG</type></rigging_element>
+      <elements>
+        <enclosure model="KS28" splay="0" />
+        <enclosure model="KS28" splay="0" />
+      </elements>
+    </Cluster>
+  </physical_configuration>
+</project>`;
+
+describe("parseSoundvisionFlysheet", () => {
+  it("extracts Spanish-flysheet deployment data without calculating missing mechanics", () => {
+    const flysheet = parseSoundvisionFlysheet(soundvisionProject);
+
+    expect(flysheet.projectName).toBe("Gira & Festival");
+    expect(flysheet.arrays).toHaveLength(2);
+    expect(flysheet.arrays[0]).toMatchObject({
+      groupName: "PA principal",
+      arrayName: "MAIN L",
+      deployment: "flown",
+      azimuthDegrees: 12.5,
+      topHeightMeters: 11.2,
+      bottomHeightMeters: 4.35,
+      riggingFrame: "K2-BUMP",
+      flyingBarSetting: "Orificio A",
+      pickupConfiguration: "F: 5 / R: 21",
+      totalMassKg: 1180.6,
+      frontLoadKg: 640.2,
+      rearLoadKg: 540.4,
+      warnings: ["Factor de seguridad por debajo del mínimo."],
+    });
+    expect(flysheet.arrays[0].enclosures).toEqual([
+      { model: "K2", splayAngleDegrees: 5, siteAngleDegrees: -2.5, trimHeightMeters: 11.2 },
+      { model: "K2", splayAngleDegrees: 10, siteAngleDegrees: -7.5, trimHeightMeters: 9.8 },
+      { model: "K2", splayAngleDegrees: 0.25, siteAngleDegrees: -17.5, trimHeightMeters: 7.1 },
+      { model: "K2", splayAngleDegrees: null, siteAngleDegrees: -24.5, trimHeightMeters: 4.35 },
+    ]);
+    expect(flysheet.arrays[1]).toMatchObject({
+      arrayName: "SUB L",
+      deployment: "stacked",
+      azimuthDegrees: 0,
+      riggingFrame: "KS28-OUTRIG",
+      flyingBarSetting: "",
+      totalMassKg: null,
+      frontLoadKg: null,
+      rearLoadKg: null,
+    });
+    expect(flysheet.arrays[1].enclosures).toEqual([
+      { model: "KS28", splayAngleDegrees: 0, siteAngleDegrees: null, trimHeightMeters: null },
+      { model: "KS28", splayAngleDegrees: 0, siteAngleDegrees: null, trimHeightMeters: null },
+    ]);
+  });
+
+  it("returns no arrays for XMLP projects without serialized clusters", () => {
+    expect(parseSoundvisionFlysheet("<project name=\"Sala\"><scene /></project>")).toEqual({
+      projectName: "Sala",
+      arrays: [],
+    });
+  });
+
+  it("handles the nested physical-configuration shape and flying-bar variants from Soundvision", () => {
+    const realShape = `<project><physical_configuration><children>
+      <cluster><name>K2 simple</name><configuration>vertical_flown</configuration>
+        <rigging_element_index>0</rigging_element_index><elements>
+          <rigging_element><model>K2-BUMP_HoleA_1xK2-BAR</model><configuration>flown</configuration></rigging_element>
+          <enclosure><model>K2</model><physical_configuration>55/55</physical_configuration></enclosure>
+          <enclosure><model>K2</model><physical_configuration>55/55</physical_configuration></enclosure>
+        </elements><inter_angles><angle></angle><angle>0</angle><angle>0.25</angle></inter_angles>
+        <motor_positions>0 20</motor_positions><position>0 10 8</position><orientation>0 0 12</orientation>
+      </cluster>
+      <cluster><name>K2 doble</name><configuration>vertical_flown</configuration><elements>
+        <rigging_element><model>K2-BUMP_HoleA_2xK2-BAR</model></rigging_element>
+        <enclosure><model>K2</model></enclosure>
+      </elements><inter_angles><angle></angle><angle>0</angle></inter_angles>
+      <motor_positions>10 31</motor_positions><position>-2 10 9</position><orientation>6.5 0 0</orientation></cluster>
+      <cluster><name>K2 invertido</name><configuration>vertical_flown</configuration><elements>
+        <rigging_element><model>K2-BUMP_HoleA_1xK2-BAR_Inv</model></rigging_element>
+        <enclosure><model>K2</model></enclosure>
+      </elements><inter_angles><angle></angle><angle>0</angle></inter_angles>
+      <motor_positions>20 0</motor_positions></cluster>
+    </children></physical_configuration></project>`;
+
+    const flysheet = parseSoundvisionFlysheet(realShape, "muestra.xmlp");
+
+    expect(flysheet.projectName).toBe("muestra");
+    expect(flysheet.arrays).toHaveLength(3);
+    expect(flysheet.arrays[0]).toMatchObject({
+      arrayName: "K2 simple",
+      deployment: "flown",
+      azimuthDegrees: 12,
+      topSiteDegrees: 0,
+      bottomSiteDegrees: -0.25,
+      topHeightMeters: 8,
+      riggingFrame: "K2-BUMP",
+      flyingBarSetting: "1x K2-BAR · Orificio A",
+      pickupConfiguration: "Posiciones: 0 / 20",
+    });
+    expect(flysheet.arrays.map((array) => array.flyingBarSetting)).toEqual([
+      "1x K2-BAR · Orificio A",
+      "2x K2-BAR · Orificio A",
+      "1x K2-BAR · Orificio A · Invertido",
+    ]);
+  });
+
+  it("attaches flysheet data to the existing XMLP amplifier map", () => {
+    const xml = soundvisionProject.replace(
+      "</project>",
+      `<physical_configuration><amplification><units>
+        <unit><model>LA12X</model><ip>11</ip><channelSet><preset>K2 110</preset></channelSet></unit>
+      </units></amplification></physical_configuration>
+      <nwm_session><LAGROUP Name="MAIN L" role="source"><unit unitIp="11" /></LAGROUP></nwm_session>
+      </project>`,
+    );
+    const map = parseXmlpXml(xml, "fallback.xmlp");
+
+    expect(map.units).toHaveLength(1);
+    expect(map.flysheet?.arrays.map((array) => array.arrayName)).toEqual(["MAIN L", "SUB L"]);
   });
 });

--- a/supabase/functions/parse-la-session/parse.ts
+++ b/supabase/functions/parse-la-session/parse.ts
@@ -27,6 +27,38 @@ export interface NwmMap {
   sessionName: string;
   units: NwmUnit[];
   groups: NwmGroup[];
+  flysheet?: SoundvisionFlysheet;
+}
+
+export interface SoundvisionFlysheetEnclosure {
+  model: string;
+  splayAngleDegrees: number | null;
+  siteAngleDegrees: number | null;
+  trimHeightMeters: number | null;
+}
+
+export interface SoundvisionFlysheetArray {
+  groupName: string;
+  arrayName: string;
+  deployment: "flown" | "stacked" | "unknown";
+  azimuthDegrees: number | null;
+  topSiteDegrees: number | null;
+  bottomSiteDegrees: number | null;
+  topHeightMeters: number | null;
+  bottomHeightMeters: number | null;
+  riggingFrame: string;
+  flyingBarSetting: string;
+  pickupConfiguration: string;
+  totalMassKg: number | null;
+  frontLoadKg: number | null;
+  rearLoadKg: number | null;
+  enclosures: SoundvisionFlysheetEnclosure[];
+  warnings: string[];
+}
+
+export interface SoundvisionFlysheet {
+  projectName: string;
+  arrays: SoundvisionFlysheetArray[];
 }
 
 // L-Acoustics amplified-controller unitType → model. Only type 8 (LA12X, all
@@ -41,7 +73,7 @@ const UNIT_TYPE_MODEL: Record<string, string> = {
 
 function attrs(tag: string): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const m of tag.matchAll(/(\w+)="([^"]*)"/g)) out[m[1]] = m[2];
+  for (const m of tag.matchAll(/([\w:-]+)="([^"]*)"/g)) out[m[1]] = m[2];
   return out;
 }
 
@@ -56,8 +88,326 @@ function decodeXmlEntities(value: string): string {
 }
 
 function textOf(body: string, tag: string): string {
-  const m = body.match(new RegExp(`<${tag}>\\s*([^<]*?)\\s*</${tag}>`));
+  const m = body.match(new RegExp(`<${tag}>\\s*([^<]*?)\\s*</${tag}>`, "i"));
   return m ? decodeXmlEntities(m[1]) : "";
+}
+
+interface XmlBlock {
+  attributes: string;
+  body: string;
+}
+
+function extractXmlBlocks(xml: string, tag: string): XmlBlock[] {
+  const blocks: XmlBlock[] = [];
+  const stack: Array<{ attributes: string; bodyStart: number }> = [];
+  const tokenPattern = new RegExp(`<${tag}\\b([^>]*)>|</${tag}>`, "gi");
+  for (const match of xml.matchAll(tokenPattern)) {
+    if (match[0].startsWith("</")) {
+      const open = stack.pop();
+      if (open) {
+        blocks.push({
+          attributes: open.attributes,
+          body: xml.slice(open.bodyStart, match.index),
+        });
+      }
+    } else if (!match[0].endsWith("/>")) {
+      stack.push({
+        attributes: match[1] ?? "",
+        bodyStart: match.index + match[0].length,
+      });
+    }
+  }
+  return blocks;
+}
+
+function firstTextOf(body: string, tags: readonly string[]): string {
+  for (const tag of tags) {
+    const value = textOf(body, tag);
+    if (value) return value;
+  }
+  return "";
+}
+
+function firstNumberOf(body: string, tags: readonly string[]): number | null {
+  const text = firstTextOf(body, tags).trim();
+  if (!text) return null;
+  const value = Number(text);
+  return Number.isFinite(value) ? value : null;
+}
+
+function firstAttribute(
+  attributes: Record<string, string>,
+  names: readonly string[],
+): string {
+  for (const name of names) {
+    const match = Object.entries(attributes).find(
+      ([key]) => key.toLowerCase() === name.toLowerCase(),
+    );
+    if (match?.[1]) return decodeXmlEntities(match[1]);
+  }
+  return "";
+}
+
+function firstNumberAttribute(
+  attributes: Record<string, string>,
+  names: readonly string[],
+): number | null {
+  const text = firstAttribute(attributes, names).trim();
+  if (!text) return null;
+  const value = Number(text);
+  return Number.isFinite(value) ? value : null;
+}
+
+function parseNumericValues(body: string): number[] {
+  const values = [
+    ...[...body.matchAll(/>\s*(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)\s*</gi)].map(
+      (match) => ({ index: match.index, value: Number(match[1]) }),
+    ),
+    ...[...body.matchAll(/\b(?:value|angle)="(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)"/gi)].map(
+      (match) => ({ index: match.index, value: Number(match[1]) }),
+    ),
+  ];
+  return values
+    .filter(({ value }) => Number.isFinite(value))
+    .sort((a, b) => a.index - b.index)
+    .map(({ value }) => value);
+}
+
+function parseNumericTokens(value: string): number[] {
+  return [...value.matchAll(/-?\d+(?:\.\d+)?(?:e[+-]?\d+)?/gi)]
+    .map((match) => Number(match[0]))
+    .filter(Number.isFinite);
+}
+
+function parseDeployment(value: string): SoundvisionFlysheetArray["deployment"] {
+  const normalized = value.trim().toLowerCase();
+  if (normalized.includes("flown") || normalized.includes("fly")) return "flown";
+  if (normalized.includes("stack")) return "stacked";
+  return "unknown";
+}
+
+function parsePickupConfiguration(body: string): string {
+  const motorConfiguration = body.match(
+    /<motor_configuration>([\s\S]*?)<\/motor_configuration>/i,
+  )?.[1] ?? "";
+  const front = firstTextOf(motorConfiguration, ["front"]);
+  const rear = firstTextOf(motorConfiguration, ["rear"]);
+  const pullback = firstTextOf(motorConfiguration, ["pullback"]);
+  const parts = [
+    front ? `F: ${front}` : "",
+    rear ? `R: ${rear}` : "",
+    pullback ? `PB: ${pullback}` : "",
+  ].filter(Boolean);
+  if (parts.length > 0) return parts.join(" / ");
+
+  const motorPositions = firstTextOf(body, ["motor_positions"]);
+  const positions = parseNumericTokens(motorPositions);
+  if (positions.length > 0) return `Posiciones: ${positions.join(" / ")}`;
+
+  const motorCount = firstTextOf(body, ["motors", "num_motors"]);
+  return motorCount ? `${motorCount} motor${motorCount === "1" ? "" : "es"}` : "";
+}
+
+function parseFlyingBarSetting(
+  clusterMetadata: string,
+  clusterAttributes: Record<string, string>,
+  riggingBody: string,
+  riggingAttributes: Record<string, string>,
+  riggingModel: string,
+): string {
+  const embeddedParts: string[] = [];
+  const bar = riggingModel.match(/_(\d+)x([^_]*?-BAR)(?:_|$)/i);
+  if (bar) embeddedParts.push(`${bar[1]}x ${bar[2]}`);
+  const embeddedHole = riggingModel.match(/_Hole([^_]+)(?:_|$)/i);
+  if (embeddedHole) embeddedParts.push(`Orificio ${embeddedHole[1]}`);
+  if (/(?:^|_)Inv(?:_|$)/i.test(riggingModel)) embeddedParts.push("Invertido");
+  if (embeddedParts.length > 0) return embeddedParts.join(" · ");
+
+  const directSetting =
+    firstTextOf(riggingBody, ["flying_bar_setting", "bar_setting"]) ||
+    firstTextOf(clusterMetadata, ["flying_bar_setting", "bar_setting"]) ||
+    firstAttribute(riggingAttributes, ["flying_bar_setting", "bar_setting"]) ||
+    firstAttribute(clusterAttributes, ["flying_bar_setting", "bar_setting"]);
+  if (directSetting) return directSetting;
+
+  const hole =
+    firstTextOf(riggingBody, ["bar_hole", "hole"]) ||
+    firstTextOf(clusterMetadata, ["bar_hole", "hole"]) ||
+    firstAttribute(riggingAttributes, ["bar_hole", "hole"]) ||
+    firstAttribute(clusterAttributes, ["bar_hole", "hole"]);
+  if (hole) return `Orificio ${hole}`;
+
+  const index =
+    firstTextOf(riggingBody, ["rigging_element_index"]) ||
+    firstTextOf(clusterMetadata, ["rigging_element_index"]) ||
+    firstAttribute(riggingAttributes, ["rigging_element_index"]) ||
+    firstAttribute(clusterAttributes, ["rigging_element_index"]);
+  return index ? `Índice ${index}` : "";
+}
+
+function parseWarnings(body: string): string[] {
+  const warnings = [
+    ...body.matchAll(
+      /<(?:mechanical_warning|warning)\b[^>]*>([\s\S]*?)<\/(?:mechanical_warning|warning)>/gi,
+    ),
+  ]
+    .map((match) => match[1].replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim())
+    .map(decodeXmlEntities)
+    .filter(Boolean);
+  return [...new Set(warnings)];
+}
+
+function parseEnclosures(clusterBody: string): SoundvisionFlysheetEnclosure[] {
+  const elementsBody = extractXmlBlocks(clusterBody, "elements")[0]?.body ?? "";
+  const elementMatches = elementsBody
+    ? [
+        ...[...elementsBody.matchAll(/<(element|enclosure)\b([^>]*)>([\s\S]*?)<\/\1>/gi)].map(
+          (match) => ({ index: match.index, attributes: match[2], body: match[3] }),
+        ),
+        ...[...elementsBody.matchAll(/<(?:element|enclosure)\b([^>]*)\/>/gi)].map(
+          (match) => ({ index: match.index, attributes: match[1], body: "" }),
+        ),
+      ].sort((a, b) => a.index - b.index)
+    : [];
+
+  const interAnglesBody =
+    clusterBody.match(/<inter_angles>([\s\S]*?)<\/inter_angles>/i)?.[1] ?? "";
+  const interAngles = parseNumericValues(interAnglesBody);
+
+  return elementMatches.map((match, index) => {
+    const elementAttributes = attrs(match.attributes);
+    const elementBody = match.body;
+    const model =
+      firstAttribute(elementAttributes, ["type", "model", "refid", "name"]) ||
+      firstTextOf(elementBody, ["type", "model", "refid", "name", "enclosure_type"]);
+    return {
+      model: model || `RECINTO ${index + 1}`,
+      splayAngleDegrees:
+        firstNumberOf(elementBody, ["splay", "splay_angle", "inter_angle", "angle"]) ??
+        firstNumberAttribute(elementAttributes, ["splay", "splay_angle", "inter_angle", "angle"]) ??
+        interAngles[index] ??
+        null,
+      siteAngleDegrees:
+        firstNumberOf(elementBody, ["site", "site_angle"]) ??
+        firstNumberAttribute(elementAttributes, ["site", "site_angle"]),
+      trimHeightMeters:
+        firstNumberOf(elementBody, ["trim", "trim_height", "z"]) ??
+        firstNumberAttribute(elementAttributes, ["trim", "trim_height", "z"]),
+    };
+  });
+}
+
+/**
+ * Extracts the deployment data serialized in a Soundvision project. Loads and
+ * safety factors calculated by Soundvision's proprietary mechanical engine are
+ * intentionally left null unless they are explicitly present in the XML.
+ */
+export function parseSoundvisionFlysheet(
+  xml: string,
+  fallbackProjectName = "",
+): SoundvisionFlysheet {
+  const projectTag = xml.match(/<project\b([^>]*)>/i)?.[1] ?? "";
+  const projectName =
+    firstAttribute(attrs(projectTag), ["name", "projectName", "project_name"]) ||
+    firstTextOf(xml.slice(0, 20_000), ["project_name", "projectName"]) ||
+    fallbackProjectName;
+
+  const arrays: SoundvisionFlysheetArray[] = [];
+  const allConfigurations = extractXmlBlocks(xml, "physical_configuration");
+  const nestedConfigurations = allConfigurations.filter((block) =>
+    /<children\b/i.test(block.body)
+  );
+  const configurations = nestedConfigurations.length > 0
+    ? nestedConfigurations
+    : allConfigurations.filter((block) => /<cluster\b/i.test(block.body));
+
+  for (const configuration of configurations) {
+    const configurationAttributes = attrs(configuration.attributes);
+    const configurationBody = extractXmlBlocks(configuration.body, "children")[0]?.body ??
+      configuration.body;
+    const groupName =
+      firstAttribute(configurationAttributes, ["name", "id"]) ||
+      firstTextOf(configurationBody.split(/<cluster\b/i)[0], ["name", "label"]) ||
+      "SISTEMA";
+
+    for (const cluster of extractXmlBlocks(configurationBody, "cluster")) {
+      const clusterAttributes = attrs(cluster.attributes);
+      const clusterBody = cluster.body;
+      const elements = parseEnclosures(clusterBody);
+      if (elements.length === 0) continue;
+
+      const clusterMetadata = clusterBody
+        .replace(/<elements>[\s\S]*?<\/elements>/i, "")
+        .replace(/<connection_sets>[\s\S]*?<\/connection_sets>/i, "");
+      const arrayName =
+        firstAttribute(clusterAttributes, ["name", "id", "label"]) ||
+        firstTextOf(clusterMetadata, ["name", "label"]) ||
+        `ARRAY ${arrays.length + 1}`;
+      const riggingBlock = extractXmlBlocks(clusterBody, "rigging_element")[0];
+      const riggingBody = riggingBlock?.body ?? "";
+      const riggingAttributes = attrs(riggingBlock?.attributes ?? "");
+      const riggingModel =
+        firstAttribute(riggingAttributes, ["type", "model", "refid", "name"]) ||
+        firstTextOf(riggingBody, ["type", "model", "refid", "name"]);
+      const topElement = elements[0];
+      const bottomElement = elements[elements.length - 1];
+      const position = parseNumericTokens(firstTextOf(clusterMetadata, ["position"]));
+      const orientation = parseNumericTokens(firstTextOf(clusterMetadata, ["orientation"]));
+      const topSiteDegrees =
+        firstNumberOf(clusterMetadata, ["top_site", "top_site_angle"]) ??
+        topElement.siteAngleDegrees ??
+        orientation[0] ??
+        null;
+      const serializedSplay = elements
+        .map((element) => element.splayAngleDegrees)
+        .filter((angle): angle is number => angle !== null);
+
+      arrays.push({
+        groupName,
+        arrayName,
+        deployment: parseDeployment(
+          firstTextOf(clusterMetadata, ["configuration", "deployment", "deployment_orientation"]) ||
+            firstAttribute(clusterAttributes, ["deployment_orientation", "deployment", "configuration"]),
+        ),
+        azimuthDegrees:
+          firstNumberOf(clusterMetadata, ["azimuth", "azimuth_angle"]) ??
+          firstNumberAttribute(clusterAttributes, ["azimuth", "azimuth_angle"]) ??
+          orientation[2] ??
+          null,
+        topSiteDegrees,
+        bottomSiteDegrees:
+          firstNumberOf(clusterMetadata, ["bottom_site", "bottom_site_angle"]) ??
+          bottomElement.siteAngleDegrees ??
+          (topSiteDegrees !== null && serializedSplay.length > 0
+            ? topSiteDegrees - serializedSplay.reduce((sum, angle) => sum + angle, 0)
+            : null),
+        topHeightMeters:
+          firstNumberOf(clusterMetadata, ["top_height", "top_z", "top_elevation"]) ??
+          topElement.trimHeightMeters ??
+          position[2] ??
+          null,
+        bottomHeightMeters:
+          firstNumberOf(clusterMetadata, ["bottom_height", "bottom_z", "bottom_elevation"]) ??
+          bottomElement.trimHeightMeters,
+        riggingFrame: riggingModel.replace(/_Hole.*$/i, ""),
+        flyingBarSetting: parseFlyingBarSetting(
+          clusterMetadata,
+          clusterAttributes,
+          riggingBody,
+          riggingAttributes,
+          riggingModel,
+        ),
+        pickupConfiguration: parsePickupConfiguration(clusterBody),
+        totalMassKg: firstNumberOf(clusterMetadata, ["total_mass", "total_weight"]),
+        frontLoadKg: firstNumberOf(clusterMetadata, ["front_load", "front_pick_load"]),
+        rearLoadKg: firstNumberOf(clusterMetadata, ["rear_load", "rear_pick_load"]),
+        enclosures: elements,
+        warnings: parseWarnings(clusterBody),
+      });
+    }
+  }
+
+  return { projectName: projectName.replace(/\.xmlp$/i, ""), arrays };
 }
 
 /** Extracts LAGROUP definitions (shared by both NM and embedded Soundvision sessions). */
@@ -103,9 +453,10 @@ export function parseNwmXml(xml: string): NwmMap {
  * `<ip>` octet, first `<channelSet><preset>`); the sided groups come from the
  * embedded `<nwm_session>` block's LAGROUPs (same schema as a standalone `.nwm`).
  */
-export function parseXmlpXml(xml: string): NwmMap {
+export function parseXmlpXml(xml: string, fallbackProjectName = ""): NwmMap {
   const sessionMatch = xml.match(/<COMPONENTS[^>]*\bsessionName="([^"]*)"/);
-  const sessionName = (sessionMatch ? decodeXmlEntities(sessionMatch[1]) : "").replace(/\.xmlp$/i, "");
+  const sessionName = (sessionMatch ? decodeXmlEntities(sessionMatch[1]) : fallbackProjectName)
+    .replace(/\.xmlp$/i, "");
 
   const ampSection = xml.match(/<amplification>([\s\S]*?)<\/amplification>/)?.[1] ?? "";
   const unitsSection = ampSection.match(/<units>([\s\S]*?)<\/units>/)?.[1] ?? "";
@@ -129,5 +480,10 @@ export function parseXmlpXml(xml: string): NwmMap {
   }
 
   const embedded = xml.match(/<nwm_session>([\s\S]*?)<\/nwm_session>/)?.[1] ?? "";
-  return { sessionName, units, groups: parseGroups(embedded) };
+  return {
+    sessionName,
+    units,
+    groups: parseGroups(embedded),
+    flysheet: parseSoundvisionFlysheet(xml, sessionName),
+  };
 }

--- a/supabase/migrations/20260719120000_soundvision_tool_entitlement.sql
+++ b/supabase/migrations/20260719120000_soundvision_tool_entitlement.sql
@@ -1,0 +1,209 @@
+-- Permanent access to the standalone NM/SV amplifier-map and flysheet tool.
+-- A sound technician earns the entitlement the first time they are assigned a
+-- responsable (-R) sound role. Removing or downgrading that assignment does
+-- not revoke access; admin/management may still change it explicitly.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS soundvision_tool_access_enabled boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_soundvision_tool_access_sound_department_check
+  CHECK (
+    soundvision_tool_access_enabled = false
+    OR lower(btrim(COALESCE(department, ''))) = 'sound'
+  );
+
+COMMENT ON COLUMN public.profiles.soundvision_tool_access_enabled IS
+  'Permanent entitlement for the NM/SV amplifier-map designer and Soundvision flysheet generator. Granted automatically after a responsable sound assignment or manually by admin/management.';
+
+CREATE OR REPLACE FUNCTION public.grant_soundvision_tool_access_from_responsable()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_new jsonb := to_jsonb(NEW);
+  v_old jsonb := CASE WHEN TG_OP = 'UPDATE' THEN to_jsonb(OLD) ELSE NULL END;
+  v_department text;
+  v_role text;
+  v_technician_id uuid := NEW.technician_id;
+BEGIN
+  IF v_technician_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_TABLE_NAME = 'job_assignments' THEN
+    v_department := 'sound';
+    v_role := v_new ->> 'sound_role';
+
+    IF TG_OP = 'UPDATE'
+       AND v_role IS NOT DISTINCT FROM (v_old ->> 'sound_role')
+       AND (v_new ->> 'technician_id') IS NOT DISTINCT FROM (v_old ->> 'technician_id') THEN
+      RETURN NEW;
+    END IF;
+  ELSIF TG_TABLE_NAME = 'tour_assignments' THEN
+    v_department := v_new ->> 'department';
+    v_role := v_new ->> 'role';
+
+    IF TG_OP = 'UPDATE'
+       AND v_department IS NOT DISTINCT FROM (v_old ->> 'department')
+       AND v_role IS NOT DISTINCT FROM (v_old ->> 'role')
+       AND (v_new ->> 'technician_id') IS NOT DISTINCT FROM (v_old ->> 'technician_id') THEN
+      RETURN NEW;
+    END IF;
+  ELSE
+    RETURN NEW;
+  END IF;
+
+  IF lower(btrim(COALESCE(v_department, ''))) = 'sound'
+     AND upper(btrim(COALESCE(v_role, ''))) ~ '^[A-Z]{3}-[A-Z0-9_]+-R$' THEN
+    UPDATE public.profiles
+    SET soundvision_tool_access_enabled = true
+    WHERE id = v_technician_id
+      AND lower(btrim(COALESCE(department, ''))) = 'sound'
+      AND soundvision_tool_access_enabled IS DISTINCT FROM true;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.grant_soundvision_tool_access_from_responsable() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.grant_soundvision_tool_access_from_responsable()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.grant_soundvision_tool_access_from_responsable()
+  TO service_role;
+
+DROP TRIGGER IF EXISTS grant_soundvision_tool_access_from_job_responsable ON public.job_assignments;
+CREATE TRIGGER grant_soundvision_tool_access_from_job_responsable
+AFTER INSERT OR UPDATE ON public.job_assignments
+FOR EACH ROW
+EXECUTE FUNCTION public.grant_soundvision_tool_access_from_responsable();
+
+DROP TRIGGER IF EXISTS grant_soundvision_tool_access_from_tour_responsable ON public.tour_assignments;
+CREATE TRIGGER grant_soundvision_tool_access_from_tour_responsable
+AFTER INSERT OR UPDATE ON public.tour_assignments
+FOR EACH ROW
+EXECUTE FUNCTION public.grant_soundvision_tool_access_from_responsable();
+
+-- Honor already-recorded responsable assignments at rollout. This is the only
+-- broad backfill; a later manual revocation remains in force until a future
+-- responsable assignment event grants access again.
+UPDATE public.profiles p
+SET soundvision_tool_access_enabled = true
+WHERE p.soundvision_tool_access_enabled IS DISTINCT FROM true
+  AND lower(btrim(COALESCE(p.department, ''))) = 'sound'
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM public.job_assignments ja
+      WHERE ja.technician_id = p.id
+        AND upper(btrim(COALESCE(ja.sound_role, ''))) ~ '^[A-Z]{3}-[A-Z0-9_]+-R$'
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.tour_assignments ta
+      WHERE ta.technician_id = p.id
+        AND lower(btrim(ta.department)) = 'sound'
+        AND upper(btrim(ta.role)) ~ '^[A-Z]{3}-[A-Z0-9_]+-R$'
+    )
+  );
+
+-- profiles has intentionally broad authenticated UPDATE RLS plus a trigger
+-- privilege boundary. Guard this new entitlement explicitly so a technician
+-- cannot self-enable it. Nested writes (depth > 1) are only produced by the
+-- trusted assignment trigger above and are allowed to make the automatic grant.
+CREATE OR REPLACE FUNCTION public.enforce_soundvision_tool_access_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+  v_actor_department text;
+BEGIN
+  IF lower(btrim(COALESCE(NEW.department, ''))) <> 'sound'
+     AND NEW.soundvision_tool_access_enabled = true THEN
+    IF lower(btrim(COALESCE(OLD.department, ''))) = 'sound'
+       AND OLD.department IS DISTINCT FROM NEW.department
+       AND OLD.soundvision_tool_access_enabled = true THEN
+      -- A department move immediately removes eligibility, even when the
+      -- caller did not include the entitlement column in the update payload.
+      NEW.soundvision_tool_access_enabled := false;
+    ELSE
+      RAISE EXCEPTION 'Only sound department users are eligible for Soundvision tool access'
+        USING ERRCODE = '23514';
+    END IF;
+  END IF;
+
+  IF OLD.soundvision_tool_access_enabled IS NOT DISTINCT FROM NEW.soundvision_tool_access_enabled THEN
+    RETURN NEW;
+  END IF;
+
+  IF auth.role() = 'service_role' OR pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Authentication required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT p.role::text, p.department
+  INTO v_actor_role, v_actor_department
+  FROM public.profiles p
+  WHERE p.id = v_actor;
+
+  IF v_actor = OLD.id THEN
+    RAISE EXCEPTION 'Soundvision tool access cannot be changed on your own account'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_actor_role IS NULL OR v_actor_role NOT IN ('admin', 'management') THEN
+    RAISE EXCEPTION 'Only administrators and management may change Soundvision tool access'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_actor_role = 'management'
+     AND OLD.department IS DISTINCT FROM v_actor_department THEN
+    RAISE EXCEPTION 'Management may only change profiles in their department'
+      USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.security_audit_log (
+    user_id,
+    action,
+    resource,
+    severity,
+    metadata
+  ) VALUES (
+    v_actor,
+    'profile_privilege_change',
+    'profile:' || OLD.id::text,
+    'high',
+    jsonb_build_object(
+      'changed_fields', jsonb_build_array('soundvision_tool_access_enabled'),
+      'actor_role', v_actor_role,
+      'old_value', OLD.soundvision_tool_access_enabled,
+      'new_value', NEW.soundvision_tool_access_enabled
+    )
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.enforce_soundvision_tool_access_change() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.enforce_soundvision_tool_access_change()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enforce_soundvision_tool_access_change()
+  TO service_role;
+
+DROP TRIGGER IF EXISTS enforce_soundvision_tool_access_change ON public.profiles;
+CREATE TRIGGER enforce_soundvision_tool_access_change
+BEFORE UPDATE OF soundvision_tool_access_enabled, department ON public.profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_soundvision_tool_access_change();

--- a/supabase/tests/database/soundvision_tool_entitlement.sql
+++ b/supabase/tests/database/soundvision_tool_entitlement.sql
@@ -1,0 +1,308 @@
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+SET search_path TO public, extensions;
+
+SELECT plan(19);
+
+SELECT has_column(
+  'public',
+  'profiles',
+  'soundvision_tool_access_enabled',
+  'profiles stores the NM/SV tool entitlement'
+);
+
+SELECT col_default_is(
+  'public',
+  'profiles',
+  'soundvision_tool_access_enabled',
+  'false',
+  'the NM/SV tool entitlement defaults to false'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.profiles'::regclass
+      AND conname = 'profiles_soundvision_tool_access_sound_department_check'
+      AND contype = 'c'
+  ),
+  'only sound department profiles may hold the entitlement'
+);
+
+SELECT ok(
+  to_regprocedure('public.grant_soundvision_tool_access_from_responsable()') IS NOT NULL,
+  'the responsable-assignment grant trigger function exists'
+);
+
+SELECT ok(
+  COALESCE((
+    SELECT prosecdef
+      AND proconfig @> ARRAY['search_path=pg_catalog, public']::text[]
+    FROM pg_proc
+    WHERE oid = to_regprocedure('public.grant_soundvision_tool_access_from_responsable()')
+  ), false),
+  'the grant function is a pinned security definer'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.job_assignments'::regclass
+      AND tgname = 'grant_soundvision_tool_access_from_job_responsable'
+      AND NOT tgisinternal
+  ),
+  'job responsable assignments grant the entitlement'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.tour_assignments'::regclass
+      AND tgname = 'grant_soundvision_tool_access_from_tour_responsable'
+      AND NOT tgisinternal
+  ),
+  'tour responsable assignments grant the entitlement'
+);
+
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+
+INSERT INTO auth.users (
+  id, instance_id, email, encrypted_password, email_confirmed_at, created_at,
+  updated_at, raw_app_meta_data, raw_user_meta_data, aud, role
+) VALUES
+  (
+    'ca100000-0000-0000-0000-000000000001'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'sv-tool-manager@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'ca100000-0000-0000-0000-000000000002'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'sv-tool-tech-job@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'ca100000-0000-0000-0000-000000000003'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'sv-tool-tech-tour@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'ca100000-0000-0000-0000-000000000004'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'sv-tool-lights-tech@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.profiles (
+  id, email, first_name, last_name, role, department, soundvision_tool_access_enabled
+) VALUES
+  (
+    'ca100000-0000-0000-0000-000000000001'::uuid,
+    'sv-tool-manager@test.local', 'SV Tool', 'Manager', 'management', 'sound', false
+  ),
+  (
+    'ca100000-0000-0000-0000-000000000002'::uuid,
+    'sv-tool-tech-job@test.local', 'SV Tool', 'Job Tech', 'technician', 'sound', false
+  ),
+  (
+    'ca100000-0000-0000-0000-000000000003'::uuid,
+    'sv-tool-tech-tour@test.local', 'SV Tool', 'Tour Tech', 'technician', 'sound', false
+  ),
+  (
+    'ca100000-0000-0000-0000-000000000004'::uuid,
+    'sv-tool-lights-tech@test.local', 'SV Tool', 'Lights Tech', 'technician', 'lights', false
+  )
+ON CONFLICT (id) DO UPDATE
+SET email = excluded.email,
+    role = excluded.role,
+    department = excluded.department,
+    soundvision_tool_access_enabled = false;
+
+INSERT INTO public.activity_catalog (code, label, default_visibility, severity, toast_enabled)
+VALUES
+  ('job.created', 'Job created', 'management', 'info', false),
+  ('assignment.created', 'Assignment created', 'management', 'info', false),
+  ('assignment.updated', 'Assignment updated', 'management', 'info', false)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO public.jobs (id, title, start_time, end_time, job_type, status)
+VALUES (
+  'ca200000-0000-0000-0000-000000000001'::uuid,
+  'Soundvision Tool Entitlement Test',
+  '2026-07-20 08:00:00+02'::timestamptz,
+  '2026-07-20 18:00:00+02'::timestamptz,
+  'single',
+  'Confirmado'
+)
+ON CONFLICT (id) DO UPDATE SET title = excluded.title;
+
+INSERT INTO public.job_assignments (
+  id, job_id, technician_id, status, sound_role, assignment_source
+) VALUES (
+  'ca300000-0000-0000-0000-000000000001'::uuid,
+  'ca200000-0000-0000-0000-000000000001'::uuid,
+  'ca100000-0000-0000-0000-000000000002'::uuid,
+  'invited', 'SND-FOH-T', 'direct'
+)
+ON CONFLICT (id) DO UPDATE
+SET technician_id = excluded.technician_id,
+    sound_role = excluded.sound_role,
+    status = excluded.status;
+
+SELECT is(
+  (SELECT soundvision_tool_access_enabled FROM public.profiles WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid),
+  false,
+  'a non-responsable sound assignment does not grant access'
+);
+
+UPDATE public.job_assignments
+SET sound_role = 'SND-FOH-R'
+WHERE id = 'ca300000-0000-0000-0000-000000000001'::uuid;
+
+SELECT is(
+  (SELECT soundvision_tool_access_enabled FROM public.profiles WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid),
+  true,
+  'a responsable sound job assignment grants access'
+);
+
+UPDATE public.job_assignments
+SET sound_role = 'SND-FOH-T'
+WHERE id = 'ca300000-0000-0000-0000-000000000001'::uuid;
+
+SELECT is(
+  (SELECT soundvision_tool_access_enabled FROM public.profiles WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid),
+  true,
+  'downgrading or removing the responsable role does not revoke access'
+);
+
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+SELECT set_config('request.jwt.claim.sub', 'ca100000-0000-0000-0000-000000000001', false);
+SET ROLE authenticated;
+
+SELECT lives_ok(
+  $$
+    UPDATE public.profiles
+    SET soundvision_tool_access_enabled = false
+    WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid
+  $$,
+  'management can revoke the entitlement manually'
+);
+
+SELECT is(
+  (SELECT soundvision_tool_access_enabled FROM public.profiles WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid),
+  false,
+  'the manual revocation is stored'
+);
+
+UPDATE public.job_assignments
+SET status = 'confirmed'
+WHERE id = 'ca300000-0000-0000-0000-000000000001'::uuid;
+
+SELECT is(
+  (SELECT soundvision_tool_access_enabled FROM public.profiles WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid),
+  false,
+  'an unrelated assignment update does not undo a manual revocation'
+);
+
+UPDATE public.job_assignments
+SET sound_role = 'SND-FOH-R'
+WHERE id = 'ca300000-0000-0000-0000-000000000001'::uuid;
+
+SELECT is(
+  (SELECT soundvision_tool_access_enabled FROM public.profiles WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid),
+  true,
+  'a later responsable assignment grants access again'
+);
+
+RESET ROLE;
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+SELECT set_config('request.jwt.claim.sub', '', false);
+
+SELECT throws_ok(
+  $$
+    UPDATE public.profiles
+    SET soundvision_tool_access_enabled = true
+    WHERE id = 'ca100000-0000-0000-0000-000000000004'::uuid
+  $$,
+  '23514',
+  NULL,
+  'a non-sound profile cannot receive the entitlement'
+);
+
+UPDATE public.profiles
+SET department = 'lights'
+WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid;
+
+SELECT is(
+  (SELECT soundvision_tool_access_enabled FROM public.profiles WHERE id = 'ca100000-0000-0000-0000-000000000002'::uuid),
+  false,
+  'moving a user out of sound clears the entitlement'
+);
+
+INSERT INTO public.tours (id, name)
+VALUES ('ca400000-0000-0000-0000-000000000001'::uuid, 'Soundvision Entitlement Tour')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
+INSERT INTO public.tour_assignments (
+  id, tour_id, technician_id, department, role
+) VALUES (
+  'ca500000-0000-0000-0000-000000000001'::uuid,
+  'ca400000-0000-0000-0000-000000000001'::uuid,
+  'ca100000-0000-0000-0000-000000000003'::uuid,
+  'sound',
+  'SND-SYS-R'
+)
+ON CONFLICT (id) DO UPDATE
+SET technician_id = excluded.technician_id,
+    department = excluded.department,
+    role = excluded.role;
+
+SELECT is(
+  (SELECT soundvision_tool_access_enabled FROM public.profiles WHERE id = 'ca100000-0000-0000-0000-000000000003'::uuid),
+  true,
+  'a responsable sound tour assignment grants access'
+);
+
+UPDATE public.profiles
+SET soundvision_tool_access_enabled = false
+WHERE id = 'ca100000-0000-0000-0000-000000000003'::uuid;
+
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+SELECT set_config('request.jwt.claim.sub', 'ca100000-0000-0000-0000-000000000003', false);
+SET ROLE authenticated;
+
+SELECT throws_ok(
+  $$
+    UPDATE public.profiles
+    SET soundvision_tool_access_enabled = true
+    WHERE id = 'ca100000-0000-0000-0000-000000000003'::uuid
+  $$,
+  '42501',
+  NULL,
+  'a technician cannot self-enable the entitlement'
+);
+
+RESET ROLE;
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+SELECT set_config('request.jwt.claim.sub', '', false);
+
+SELECT ok(
+  NOT has_function_privilege(
+    'authenticated',
+    'public.grant_soundvision_tool_access_from_responsable()',
+    'EXECUTE'
+  ),
+  'authenticated users cannot invoke the automatic grant function directly'
+);
+
+SELECT * FROM finish();


### PR DESCRIPTION
## Summary

- add a **Generar flysheet** action to the NM/SV rack designer for Soundvision `.xmlp` projects
- generate Spanish A3 landscape flysheets with the same red-header/footer-logo branding as the amplifier requirements PDF
- show array geometry, enclosure order/splay, rigging frames, motor positions, translated warnings, and a highlighted **Ajuste flying bar** row with a pre-lift verification notice
- autofill **Predicción creada por** with the user who generates the PDF
- expose the full NM/SV designer (amplifier maps + flysheets) from the Technician Super App for eligible Sound users
- add a permanent, Sound-only technician entitlement: the first Sound `…-R` responsable assignment grants access; later downgrade/removal does not revoke it
- let admin/management enable or revoke the entitlement in Settings > User Manager; moving a profile out of Sound clears it
- preserve the privileged JWT/role boundary in `parse-la-session`; XMLP/NWM contents remain transient and decryption keys remain deployment secrets

## Access behavior

- admin/management: retain privileged tool access and may manage technician entitlements
- Sound house tech: always eligible
- Sound technician: eligible after a responsable job/tour assignment or a manual admin/management grant
- non-Sound users: cannot hold or use the technician entitlement
- manual revocation persists across unrelated assignment updates; a later responsable assignment grants access again

## Validation

- real encrypted XMLP sample parsed end to end, including 1x/2x K2-BAR, hole selection, and inverted flying-bar variants
- final branded A3 PDF rendered to PNG and visually inspected for alignment, clipping, creator attribution, logo placement, pagination, and pre-lift warnings
- focused parser/PDF/UI/access suite: 33 tests passed
- `npm run lint` — passed (existing warning baseline only)
- `npm run typecheck` — passed
- `npm run governance` — passed, including Edge exposure, SQL grants, file-size, dependency, and migration-ordering gates
- `npm run test:critical` — passed
- `npm run test:run` — passed
- `npm run build` — passed
- `npm run budget:bundle` — passed (+15.8 kB JS gzip, within budget)
- entitlement pgTAP coverage added for job/tour grants, persistence, revocation, Sound-only eligibility, department changes, and self-escalation denial

## Safety / known limitation

Soundvision's computed mechanical loads and safety factors are not serialized in the supplied XMLP. The PDF does not invent them: unavailable values are shown as `-`, each array is marked for verification, and flown arrays explicitly require confirmation of the flying-bar model, position, and hole in Soundvision before lifting.

This is a **high-risk authorization/database PR** because it adds a profile entitlement, protected triggers, and an Edge Function capability check.

## Deployment

1. A human must run a linked production migration dry-run and apply the new migration:
   - `supabase db push --linked --dry-run`
   - review, then apply through the normal production release process
2. Deploy the updated `parse-la-session` Edge Function with the application release.
3. Existing `SV_AES_KEY` / `SV_AES_IV` and `NWM_AES_KEY` / `NWM_AES_IV` deployment secrets are reused; no rotation is required.

## Rollback

Revert this PR, restore the previous `parse-la-session` deployment, and redeploy the frontend. If the migration has already been applied, use a reviewed forward migration to remove the entitlement triggers/column only after confirming no dependent release remains.