### PR TITLE
fix(db): preserve profile guard during Soundvision backfill

### DIFF
--- a/supabase/migrations/20260719120000_soundvision_tool_entitlement.sql
+++ b/supabase/migrations/20260719120000_soundvision_tool_entitlement.sql
@@ -90,6 +90,16 @@ EXECUTE FUNCTION public.grant_soundvision_tool_access_from_responsable();
 -- Honor already-recorded responsable assignments at rollout. This is the only
 -- broad backfill; a later manual revocation remains in force until a future
 -- responsable assignment event grants access again.
+--
+-- Production already has the profile privilege guard from
+-- 20260623160000_phase0_authorization_hardening.sql. The migration connection
+-- has no PostgREST JWT claims, so that guard rejects a root-level UPDATE even
+-- though the migration owns the table. Disable only that exact guard for this
+-- trusted backfill and immediately restore it. PostgreSQL rolls both ALTERs
+-- back with the migration if any statement fails.
+ALTER TABLE public.profiles
+  DISABLE TRIGGER enforce_profile_privilege_changes;
+
 UPDATE public.profiles p
 SET soundvision_tool_access_enabled = true
 WHERE p.soundvision_tool_access_enabled IS DISTINCT FROM true
@@ -109,6 +119,9 @@ WHERE p.soundvision_tool_access_enabled IS DISTINCT FROM true
         AND upper(btrim(ta.role)) ~ '^[A-Z]{3}-[A-Z0-9_]+-R$'
     )
   );
+
+ALTER TABLE public.profiles
+  ENABLE TRIGGER enforce_profile_privilege_changes;
 
 -- profiles has intentionally broad authenticated UPDATE RLS plus a trigger
 -- privilege boundary. Guard this new entitlement explicitly so a technician

--- a/supabase/tests/database/soundvision_tool_entitlement.sql
+++ b/supabase/tests/database/soundvision_tool_entitlement.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(19);
+SELECT plan(20);
 
 SELECT has_column(
   'public',
@@ -28,6 +28,18 @@ SELECT ok(
       AND contype = 'c'
   ),
   'only sound department profiles may hold the entitlement'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.profiles'::regclass
+      AND tgname = 'enforce_profile_privilege_changes'
+      AND tgenabled = 'O'
+      AND NOT tgisinternal
+  ),
+  'the existing profile privilege guard is re-enabled after the rollout backfill'
 );
 
 SELECT ok(


### PR DESCRIPTION
## High risk

This is a database migration hotfix. The first linked production apply of `20260719120000_soundvision_tool_entitlement.sql` rolled back because the existing `enforce_profile_privilege_changes` trigger rejects migration-session profile updates when production rows make the rollout backfill fire.

## Fix

- disable only `enforce_profile_privilege_changes` for the trusted rollout backfill
- immediately re-enable it in the same transactional migration
- assert with pgTAP that the privilege trigger is enabled after migration

PostgreSQL rolls back both trigger state changes if any migration statement fails. No production schema/data change was committed by the failed attempt, and the Edge Function was not deployed.

## Validation

- observed negative control: production apply failed at the backfill before this fix
- `npm run ci:db:migrations` — passed
- `npm run governance:sql-grants` — passed
- `git diff --check` — passed
- full ephemeral migration reset, db lint, and pgTAP authorization suite delegated to this PR's CI because Docker Desktop is not running locally

## Deployment

After this PR is merged:

1. rerun `supabase db push --linked --dry-run`
2. apply `20260719120000_soundvision_tool_entitlement.sql`
3. verify a second dry-run reports production current
4. deploy `parse-la-session`

## Rollback

Before apply: revert this PR. During apply: the migration transaction rolls back automatically on error. After apply: prefer a reviewed forward-fix migration; do not leave the profile privilege trigger disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the SoundVision access rollout to safely honor existing assignments while temporarily bypassing the relevant profile-change guard.
  - Ensured the guard is restored after the rollout, including through transactional rollback behavior if an error occurs.

- **Tests**
  - Added coverage confirming the profile-change guard exists, remains enabled, and is restored after the rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->