### PR TITLE
feat(sound): show Panflex dispersion settings on the Soundvision flysheet

### DIFF
--- a/src/components/sound/amplifier-tool/rack-designer/nwm-import.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/nwm-import.ts
@@ -30,6 +30,11 @@ export interface SoundvisionFlysheetEnclosure {
   splayAngleDegrees: number | null;
   siteAngleDegrees: number | null;
   trimHeightMeters: number | null;
+  /**
+   * Panflex horizontal-dispersion setting for variable-directivity enclosures
+   * (K2, K3, KARA II), e.g. "55/35"; null for fixed-directivity boxes.
+   */
+  dispersionSetting: string | null;
 }
 export interface SoundvisionFlysheetArray {
   groupName: string;

--- a/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
+++ b/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
@@ -35,6 +35,7 @@ const makeFlysheet = (arrayCount: number): SoundvisionFlysheet => ({
       splayAngleDegrees: enclosureIndex < 2 ? 5 : 0.25,
       siteAngleDegrees: -2.5 - enclosureIndex,
       trimHeightMeters: 10 - enclosureIndex * 0.45,
+      dispersionSetting: '55/55',
       }),
     ),
     warnings: arrayIndex === 0 ? ['Tipping hazard'] : [],
@@ -66,6 +67,7 @@ describe('generateSoundvisionFlysheetPdf', () => {
         splayAngleDegrees: 0.25,
         siteAngleDegrees: null,
         trimHeightMeters: null,
+        dispersionSetting: index % 2 === 0 ? '55/35' : null,
       }),
     );
 

--- a/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
+++ b/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
@@ -120,9 +120,11 @@ describe('classifyDispersionHighlight', () => {
     expect(classifyDispersionHighlight('45/45')).toBe('symmetric');
   });
 
-  it('flags a setting where L and R differ as "asymmetric"', () => {
-    expect(classifyDispersionHighlight('55/35')).toBe('asymmetric');
-    expect(classifyDispersionHighlight('35/55')).toBe('asymmetric');
+  it('distinguishes which side is wider on an asymmetric setting, since 55/35 and 35/55 are mirror images', () => {
+    expect(classifyDispersionHighlight('55/35')).toBe('wideLeft');
+    expect(classifyDispersionHighlight('35/55')).toBe('wideRight');
+    expect(classifyDispersionHighlight('60/45')).toBe('wideLeft');
+    expect(classifyDispersionHighlight('45/60')).toBe('wideRight');
   });
 
   it('does not flag the default 55/55, a fixed-directivity box, or an unparsable value', () => {

--- a/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
+++ b/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
@@ -6,8 +6,8 @@ import type {
   SoundvisionFlysheetEnclosure,
 } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 import {
+  classifyDispersionHighlight,
   generateSoundvisionFlysheetPdf,
-  isHighlightedDispersion,
   soundvisionWarningSeverity,
   translateSoundvisionWarning,
 } from '@/utils/soundvisionFlysheetPdf';
@@ -114,18 +114,23 @@ describe('translateSoundvisionWarning', () => {
   });
 });
 
-describe('isHighlightedDispersion', () => {
-  it('flags any Panflex setting other than the default 55/55', () => {
-    expect(isHighlightedDispersion('35/35')).toBe(true);
-    expect(isHighlightedDispersion('55/35')).toBe(true);
-    expect(isHighlightedDispersion('35/55')).toBe(true);
+describe('classifyDispersionHighlight', () => {
+  it('flags a narrower-but-still-symmetric setting as "symmetric"', () => {
+    expect(classifyDispersionHighlight('35/35')).toBe('symmetric');
+    expect(classifyDispersionHighlight('45/45')).toBe('symmetric');
   });
 
-  it('does not flag the default 55/55 or a fixed-directivity box', () => {
-    expect(isHighlightedDispersion('55/55')).toBe(false);
-    expect(isHighlightedDispersion(' 55/55 ')).toBe(false);
-    expect(isHighlightedDispersion(null)).toBe(false);
-    expect(isHighlightedDispersion(undefined)).toBe(false);
-    expect(isHighlightedDispersion('')).toBe(false);
+  it('flags a setting where L and R differ as "asymmetric"', () => {
+    expect(classifyDispersionHighlight('55/35')).toBe('asymmetric');
+    expect(classifyDispersionHighlight('35/55')).toBe('asymmetric');
+  });
+
+  it('does not flag the default 55/55, a fixed-directivity box, or an unparsable value', () => {
+    expect(classifyDispersionHighlight('55/55')).toBeNull();
+    expect(classifyDispersionHighlight(' 55/55 ')).toBeNull();
+    expect(classifyDispersionHighlight(null)).toBeNull();
+    expect(classifyDispersionHighlight(undefined)).toBeNull();
+    expect(classifyDispersionHighlight('')).toBeNull();
+    expect(classifyDispersionHighlight('not-a-setting')).toBeNull();
   });
 });

--- a/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
+++ b/src/utils/__tests__/soundvisionFlysheetPdf.test.ts
@@ -7,6 +7,7 @@ import type {
 } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 import {
   generateSoundvisionFlysheetPdf,
+  isHighlightedDispersion,
   soundvisionWarningSeverity,
   translateSoundvisionWarning,
 } from '@/utils/soundvisionFlysheetPdf';
@@ -110,5 +111,21 @@ describe('translateSoundvisionWarning', () => {
     ).toBe('danger');
     expect(soundvisionWarningSeverity('Tipping hazard')).toBe('warning');
     expect(soundvisionWarningSeverity('Site angle is impossible.')).toBe('caution');
+  });
+});
+
+describe('isHighlightedDispersion', () => {
+  it('flags any Panflex setting other than the default 55/55', () => {
+    expect(isHighlightedDispersion('35/35')).toBe(true);
+    expect(isHighlightedDispersion('55/35')).toBe(true);
+    expect(isHighlightedDispersion('35/55')).toBe(true);
+  });
+
+  it('does not flag the default 55/55 or a fixed-directivity box', () => {
+    expect(isHighlightedDispersion('55/55')).toBe(false);
+    expect(isHighlightedDispersion(' 55/55 ')).toBe(false);
+    expect(isHighlightedDispersion(null)).toBe(false);
+    expect(isHighlightedDispersion(undefined)).toBe(false);
+    expect(isHighlightedDispersion('')).toBe(false);
   });
 });

--- a/src/utils/soundvisionFlysheetPdf.ts
+++ b/src/utils/soundvisionFlysheetPdf.ts
@@ -289,12 +289,67 @@ function drawWarnings(
   });
 }
 
-const DISPERSION_NOTE_HEIGHT = 20;
+const DISPERSION_NOTE_HEIGHT = 34;
 
 /**
- * Draws the variable-dispersion (Panflex) legend: a small top-view diagram of a
- * cabinet split into left/right halves seen from the box's own perspective, plus
- * a Spanish note on how to read the "L/R" setting (e.g. 55/35).
+ * The four canonical Panflex settings. The two numbers are the left/right
+ * half-apertures read from the enclosure's own perspective (facing the
+ * audience); their sum is the nominal horizontal coverage. Recreated as an
+ * original vector legend rather than embedding L-Acoustics' reference image.
+ */
+const PANFLEX_SETTINGS: Array<{
+  code: string;
+  left: number;
+  right: number;
+  name: string;
+}> = [
+  { code: '55 / 55', left: 55, right: 55, name: '110° · simétrico' },
+  { code: '35 / 35', left: 35, right: 35, name: '70° · simétrico' },
+  { code: '55 / 35', left: 55, right: 35, name: '90° · asimétrico' },
+  { code: '35 / 55', left: 35, right: 55, name: '90° · asimétrico' },
+];
+
+/**
+ * Draws a small top-view Panflex coverage fan (audience is "up") for one
+ * setting: a shaded wedge bounded by the left/right half-aperture edges, with
+ * the enclosure marked as a bar at the apex.
+ */
+function drawPanflexGlyph(
+  pdf: jsPDF,
+  cx: number,
+  bottomY: number,
+  leftDeg: number,
+  rightDeg: number,
+  radius: number,
+): void {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const lx = cx - radius * Math.sin(toRad(leftDeg));
+  const ly = bottomY - radius * Math.cos(toRad(leftDeg));
+  const rx = cx + radius * Math.sin(toRad(rightDeg));
+  const ry = bottomY - radius * Math.cos(toRad(rightDeg));
+  // Shaded coverage wedge (chord approximation of the fan).
+  pdf.setFillColor(250, 214, 214);
+  pdf.triangle(cx, bottomY, lx, ly, rx, ry, 'F');
+  // Coverage edges.
+  pdf.setDrawColor(...RED);
+  pdf.setLineWidth(0.4);
+  pdf.line(cx, bottomY, lx, ly);
+  pdf.line(cx, bottomY, rx, ry);
+  // Forward axis reference tick.
+  pdf.setDrawColor(...MEDIUM_GRAY);
+  pdf.setLineWidth(0.2);
+  pdf.line(cx, bottomY, cx, bottomY - radius);
+  // Enclosure marker.
+  pdf.setFillColor(...BLACK);
+  pdf.rect(cx - 2.4, bottomY, 4.8, 1.4, 'F');
+  pdf.setDrawColor(...BLACK);
+}
+
+/**
+ * Draws the variable-dispersion (Panflex) legend: a top-view diagram of a
+ * cabinet split into left/right halves seen from the box's own perspective, a
+ * mapping of the canonical settings (55/55, 35/35, 55/35, 35/55) to their named
+ * coverage patterns, and a Spanish note on how to read the "L/R" setting.
  */
 function drawDispersionNote(pdf: jsPDF, x: number, y: number, width: number): void {
   const height = DISPERSION_NOTE_HEIGHT;
@@ -309,12 +364,11 @@ function drawDispersionNote(pdf: jsPDF, x: number, y: number, width: number): vo
   pdf.setTextColor(...BLACK);
   pdf.text('DISPERSIÓN VARIABLE (PANFLEX · K2 / K3 / KARA II)', x + 3, y + 4.5);
 
-  // --- Diagram: cabinet seen from above, from the box's own perspective ---
-  const diagramW = 46;
-  const dx = x + 4;
-  const dyTop = y + 7;
-  const audienceY = dyTop + 1; // "toward audience" is up
-  const cabinetY = y + height - 5;
+  // --- Left: cabinet seen from above, from the box's own perspective ---
+  const diagramW = 48;
+  const dx = x + 3;
+  const audienceY = y + 9; // "toward audience" is up
+  const cabinetY = y + 21;
   const centerX = dx + diagramW / 2;
 
   pdf.setLineWidth(0.4);
@@ -347,18 +401,34 @@ function drawDispersionNote(pdf: jsPDF, x: number, y: number, width: number): vo
   );
   pdf.text('hacia el público', centerX + 3, audienceY - 1, { align: 'left' });
 
-  // --- Explanatory text ---
-  const textX = dx + diagramW + 4;
-  const textW = width - (diagramW + 11);
+  // --- Middle: settings-to-pattern mapping glyphs ---
+  const glyphZoneX = x + diagramW + 8;
+  const glyphZoneW = width - (diagramW + 12);
+  const cellW = glyphZoneW / PANFLEX_SETTINGS.length;
+  PANFLEX_SETTINGS.forEach((setting, index) => {
+    const cx = glyphZoneX + cellW * (index + 0.5);
+    pdf.setFont('helvetica', 'bold');
+    pdf.setFontSize(7);
+    pdf.setTextColor(...BLACK);
+    pdf.text(setting.code, cx, y + 8.5, { align: 'center' });
+    drawPanflexGlyph(pdf, cx, y + 21, setting.left, setting.right, 10.5);
+    pdf.setFont('helvetica', 'normal');
+    pdf.setFontSize(6);
+    pdf.text(setting.name, cx, y + 25.5, { align: 'center' });
+  });
+
+  // --- Explanatory text across the bottom ---
   pdf.setFont('helvetica', 'normal');
-  pdf.setFontSize(6.6);
+  pdf.setFontSize(6.4);
+  pdf.setTextColor(...BLACK);
   const note =
-    'Los recintos de directividad variable muestran su ajuste Panflex como IZQUIERDA/DERECHA ' +
-    '(p. ej. 55/35), leído desde la perspectiva del propio recinto mirando hacia el público: ' +
-    'el primer valor es la apertura horizontal (°) del lado izquierdo y el segundo la del lado derecho. ' +
+    'Los recintos de directividad variable muestran su ajuste Panflex como IZQUIERDA/DERECHA (p. ej. 55/35), ' +
+    'leído desde la perspectiva del propio recinto mirando hacia el público: cada cifra es la semiapertura (°) de ese lado ' +
+    'y su suma es la cobertura horizontal total (55/55 = 110°, 35/35 = 70°, 55/35 y 35/55 = 90° asimétrico). ' +
+    'Cada recinto puede llevar un ajuste distinto (configuración mixta, p. ej. 70°/110° en el mismo array). ' +
     'Los recintos de directividad fija (KS28, KARA, K1) no muestran ajuste. Confirme siempre en Soundvision.';
-  const lines = pdf.splitTextToSize(note, Math.max(1, textW));
-  pdf.text(lines, textX, y + 8);
+  const lines = pdf.splitTextToSize(note, Math.max(1, width - 6));
+  pdf.text(lines, x + 3, y + 29);
 }
 
 function drawHeader(

--- a/src/utils/soundvisionFlysheetPdf.ts
+++ b/src/utils/soundvisionFlysheetPdf.ts
@@ -26,6 +26,10 @@ const LIGHT_GRAY: PdfColor = [238, 238, 238];
 const MEDIUM_GRAY: PdfColor = [210, 210, 210];
 const YELLOW: PdfColor = [255, 235, 0];
 const RED: PdfColor = [222, 30, 30];
+// Non-default Panflex settings are colour-coded by pattern, echoing the
+// simétrico/asimétrico grouping in the dispersion legend below.
+const DISPERSION_SYMMETRIC: PdfColor = [186, 230, 253]; // narrower but still even (e.g. 35/35 -> 70°)
+const DISPERSION_ASYMMETRIC: PdfColor = [255, 200, 120]; // L/R differ (e.g. 55/35) -> orientation matters
 
 export interface SoundvisionFlysheetPdfOptions {
   sourceFileName: string;
@@ -41,13 +45,27 @@ const formatNumber = (value: number | null, suffix: string, digits = 1): string 
 const formatCompactNumber = (value: number | null, suffix: string): string =>
   value === null ? '-' : `${value.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
 
+export type DispersionHighlight = 'symmetric' | 'asymmetric' | null;
+
 /**
- * A variable-dispersion box is worth flagging on the flysheet when its Panflex
- * setting isn't the default symmetric 55/55 (110°). Fixed-directivity boxes
- * (no setting) are never flagged.
+ * Classifies a Panflex "L/R" setting for the flysheet's cabinet table: the
+ * default symmetric 55/55 (110°) and fixed-directivity boxes (no setting)
+ * are never flagged; any other symmetric setting (e.g. 35/35 -> 70°) is
+ * flagged as narrower-but-even, and an L != R setting (e.g. 55/35 -> 90°) is
+ * flagged as asymmetric, since getting the side wrong there misaims the box.
  */
-export const isHighlightedDispersion = (setting: string | null | undefined): boolean =>
-  !!setting && setting.trim() !== '55/55';
+export const classifyDispersionHighlight = (setting: string | null | undefined): DispersionHighlight => {
+  const match = setting?.trim().match(/^(\d{1,3})\s*\/\s*(\d{1,3})$/);
+  if (!match) return null;
+  const [, left, right] = match;
+  if (left === right) return left === '55' ? null : 'symmetric';
+  return 'asymmetric';
+};
+
+const DISPERSION_HIGHLIGHT_COLOR: Record<Exclude<DispersionHighlight, null>, PdfColor> = {
+  symmetric: DISPERSION_SYMMETRIC,
+  asymmetric: DISPERSION_ASYMMETRIC,
+};
 
 const deploymentLabel = (deployment: SoundvisionFlysheetArray['deployment']): string => {
   if (deployment === 'flown') return 'VOLADO';
@@ -229,9 +247,10 @@ function drawCabinetRows(
             enclosure.dispersionSetting ? `  |  ${enclosure.dispersionSetting}` : ''
           }`
         : '';
-      // Flag boxes whose Panflex setting isn't the default 55/55 so an
-      // asymmetric/narrow dispersion doesn't slip by unnoticed.
-      const highlight = enclosure ? isHighlightedDispersion(enclosure.dispersionSetting) : false;
+      // Flag boxes whose Panflex setting isn't the default 55/55, colour-coded
+      // by pattern so an asymmetric setting (orientation matters) reads
+      // differently from a merely narrower symmetric one.
+      const highlight = enclosure ? classifyDispersionHighlight(enclosure.dispersionSetting) : null;
       drawCell(
         pdf,
         value,
@@ -239,7 +258,11 @@ function drawCabinetRows(
         y,
         arrayWidth,
         CABINET_ROW_HEIGHT,
-        { fontSize: 7.2, fill: highlight ? YELLOW : undefined, bold: highlight },
+        {
+          fontSize: 7.2,
+          fill: highlight ? DISPERSION_HIGHLIGHT_COLOR[highlight] : undefined,
+          bold: !!highlight,
+        },
       );
     });
     y += CABINET_ROW_HEIGHT;
@@ -313,11 +336,12 @@ const PANFLEX_SETTINGS: Array<{
   left: number;
   right: number;
   name: string;
+  highlight: DispersionHighlight;
 }> = [
-  { code: '55 / 55', left: 55, right: 55, name: '110° · simétrico' },
-  { code: '35 / 35', left: 35, right: 35, name: '70° · simétrico' },
-  { code: '55 / 35', left: 55, right: 35, name: '90° · asimétrico' },
-  { code: '35 / 55', left: 35, right: 55, name: '90° · asimétrico' },
+  { code: '55 / 55', left: 55, right: 55, name: '110° · simétrico', highlight: null },
+  { code: '35 / 35', left: 35, right: 35, name: '70° · simétrico', highlight: 'symmetric' },
+  { code: '55 / 35', left: 55, right: 35, name: '90° · asimétrico', highlight: 'asymmetric' },
+  { code: '35 / 55', left: 35, right: 55, name: '90° · asimétrico', highlight: 'asymmetric' },
 ];
 
 /**
@@ -418,6 +442,12 @@ function drawDispersionNote(pdf: jsPDF, x: number, y: number, width: number): vo
   const cellW = glyphZoneW / PANFLEX_SETTINGS.length;
   PANFLEX_SETTINGS.forEach((setting, index) => {
     const cx = glyphZoneX + cellW * (index + 0.5);
+    // Swatch behind the code label mirrors the cabinet table's fill for this
+    // pattern, so the legend doubles as a colour key.
+    if (setting.highlight) {
+      pdf.setFillColor(...DISPERSION_HIGHLIGHT_COLOR[setting.highlight]);
+      pdf.rect(cx - 9, y + 5.8, 18, 3.4, 'F');
+    }
     pdf.setFont('helvetica', 'bold');
     pdf.setFontSize(7);
     pdf.setTextColor(...BLACK);
@@ -437,7 +467,8 @@ function drawDispersionNote(pdf: jsPDF, x: number, y: number, width: number): vo
     'leído desde la perspectiva del propio recinto mirando hacia el público: cada cifra es la semiapertura (°) de ese lado ' +
     'y su suma es la cobertura horizontal total (55/55 = 110°, 35/35 = 70°, 55/35 y 35/55 = 90° asimétrico). ' +
     'Cada recinto puede llevar un ajuste distinto (configuración mixta, p. ej. 70°/110° en el mismo array). ' +
-    'Se resaltan en amarillo los recintos cuyo ajuste difiere de 55/55 (110°). ' +
+    'Los recintos con ajuste distinto de 55/55 se resaltan por color: azul si es simétrico pero más estrecho ' +
+    '(p. ej. 35/35), naranja si es asimétrico (p. ej. 55/35), donde el lado importa. ' +
     'Los recintos de directividad fija (KS28, KARA, K1) no muestran ajuste. Confirme siempre en Soundvision.';
   const lines = pdf.splitTextToSize(note, Math.max(1, width - 6));
   pdf.text(lines, x + 3, y + 29);

--- a/src/utils/soundvisionFlysheetPdf.ts
+++ b/src/utils/soundvisionFlysheetPdf.ts
@@ -27,9 +27,12 @@ const MEDIUM_GRAY: PdfColor = [210, 210, 210];
 const YELLOW: PdfColor = [255, 235, 0];
 const RED: PdfColor = [222, 30, 30];
 // Non-default Panflex settings are colour-coded by pattern, echoing the
-// simétrico/asimétrico grouping in the dispersion legend below.
+// simétrico/asimétrico grouping in the dispersion legend below. The two
+// asymmetric directions get distinct colours too — 55/35 and 35/55 are
+// mirror images of each other, and mixing them up misaims the box.
 const DISPERSION_SYMMETRIC: PdfColor = [186, 230, 253]; // narrower but still even (e.g. 35/35 -> 70°)
-const DISPERSION_ASYMMETRIC: PdfColor = [255, 200, 120]; // L/R differ (e.g. 55/35) -> orientation matters
+const DISPERSION_WIDE_LEFT: PdfColor = [255, 200, 120]; // L > R (e.g. 55/35) -> coverage skews left
+const DISPERSION_WIDE_RIGHT: PdfColor = [216, 180, 254]; // R > L (e.g. 35/55) -> coverage skews right
 
 export interface SoundvisionFlysheetPdfOptions {
   sourceFileName: string;
@@ -45,26 +48,30 @@ const formatNumber = (value: number | null, suffix: string, digits = 1): string 
 const formatCompactNumber = (value: number | null, suffix: string): string =>
   value === null ? '-' : `${value.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
 
-export type DispersionHighlight = 'symmetric' | 'asymmetric' | null;
+export type DispersionHighlight = 'symmetric' | 'wideLeft' | 'wideRight' | null;
 
 /**
  * Classifies a Panflex "L/R" setting for the flysheet's cabinet table: the
  * default symmetric 55/55 (110°) and fixed-directivity boxes (no setting)
  * are never flagged; any other symmetric setting (e.g. 35/35 -> 70°) is
- * flagged as narrower-but-even, and an L != R setting (e.g. 55/35 -> 90°) is
- * flagged as asymmetric, since getting the side wrong there misaims the box.
+ * flagged as narrower-but-even; an asymmetric setting is split by which side
+ * is wider (55/35 -> "wideLeft", 35/55 -> "wideRight") since the two are
+ * mirror images and mixing them up misaims the box.
  */
 export const classifyDispersionHighlight = (setting: string | null | undefined): DispersionHighlight => {
   const match = setting?.trim().match(/^(\d{1,3})\s*\/\s*(\d{1,3})$/);
   if (!match) return null;
-  const [, left, right] = match;
-  if (left === right) return left === '55' ? null : 'symmetric';
-  return 'asymmetric';
+  const [, leftStr, rightStr] = match;
+  const left = Number(leftStr);
+  const right = Number(rightStr);
+  if (left === right) return left === 55 ? null : 'symmetric';
+  return left > right ? 'wideLeft' : 'wideRight';
 };
 
 const DISPERSION_HIGHLIGHT_COLOR: Record<Exclude<DispersionHighlight, null>, PdfColor> = {
   symmetric: DISPERSION_SYMMETRIC,
-  asymmetric: DISPERSION_ASYMMETRIC,
+  wideLeft: DISPERSION_WIDE_LEFT,
+  wideRight: DISPERSION_WIDE_RIGHT,
 };
 
 const deploymentLabel = (deployment: SoundvisionFlysheetArray['deployment']): string => {
@@ -323,7 +330,7 @@ function drawWarnings(
   });
 }
 
-const DISPERSION_NOTE_HEIGHT = 34;
+const DISPERSION_NOTE_HEIGHT = 39;
 
 /**
  * The four canonical Panflex settings. The two numbers are the left/right
@@ -340,8 +347,8 @@ const PANFLEX_SETTINGS: Array<{
 }> = [
   { code: '55 / 55', left: 55, right: 55, name: '110° · simétrico', highlight: null },
   { code: '35 / 35', left: 35, right: 35, name: '70° · simétrico', highlight: 'symmetric' },
-  { code: '55 / 35', left: 55, right: 35, name: '90° · asimétrico', highlight: 'asymmetric' },
-  { code: '35 / 55', left: 35, right: 55, name: '90° · asimétrico', highlight: 'asymmetric' },
+  { code: '55 / 35', left: 55, right: 35, name: '90° · asim. izq.', highlight: 'wideLeft' },
+  { code: '35 / 55', left: 35, right: 55, name: '90° · asim. der.', highlight: 'wideRight' },
 ];
 
 /**
@@ -468,7 +475,8 @@ function drawDispersionNote(pdf: jsPDF, x: number, y: number, width: number): vo
     'y su suma es la cobertura horizontal total (55/55 = 110°, 35/35 = 70°, 55/35 y 35/55 = 90° asimétrico). ' +
     'Cada recinto puede llevar un ajuste distinto (configuración mixta, p. ej. 70°/110° en el mismo array). ' +
     'Los recintos con ajuste distinto de 55/55 se resaltan por color: azul si es simétrico pero más estrecho ' +
-    '(p. ej. 35/35), naranja si es asimétrico (p. ej. 55/35), donde el lado importa. ' +
+    '(p. ej. 35/35); si es asimétrico se distingue además el lado más abierto — naranja cuando es el IZQUIERDO ' +
+    '(p. ej. 55/35) y morado cuando es el DERECHO (p. ej. 35/55) — para no confundir la orientación del recinto. ' +
     'Los recintos de directividad fija (KS28, KARA, K1) no muestran ajuste. Confirme siempre en Soundvision.';
   const lines = pdf.splitTextToSize(note, Math.max(1, width - 6));
   pdf.text(lines, x + 3, y + 29);

--- a/src/utils/soundvisionFlysheetPdf.ts
+++ b/src/utils/soundvisionFlysheetPdf.ts
@@ -41,6 +41,14 @@ const formatNumber = (value: number | null, suffix: string, digits = 1): string 
 const formatCompactNumber = (value: number | null, suffix: string): string =>
   value === null ? '-' : `${value.toFixed(2).replace(/\.?0+$/, '')}${suffix}`;
 
+/**
+ * A variable-dispersion box is worth flagging on the flysheet when its Panflex
+ * setting isn't the default symmetric 55/55 (110°). Fixed-directivity boxes
+ * (no setting) are never flagged.
+ */
+export const isHighlightedDispersion = (setting: string | null | undefined): boolean =>
+  !!setting && setting.trim() !== '55/55';
+
 const deploymentLabel = (deployment: SoundvisionFlysheetArray['deployment']): string => {
   if (deployment === 'flown') return 'VOLADO';
   if (deployment === 'stacked') return 'APILADO';
@@ -221,6 +229,9 @@ function drawCabinetRows(
             enclosure.dispersionSetting ? `  |  ${enclosure.dispersionSetting}` : ''
           }`
         : '';
+      // Flag boxes whose Panflex setting isn't the default 55/55 so an
+      // asymmetric/narrow dispersion doesn't slip by unnoticed.
+      const highlight = enclosure ? isHighlightedDispersion(enclosure.dispersionSetting) : false;
       drawCell(
         pdf,
         value,
@@ -228,7 +239,7 @@ function drawCabinetRows(
         y,
         arrayWidth,
         CABINET_ROW_HEIGHT,
-        { fontSize: 7.2 },
+        { fontSize: 7.2, fill: highlight ? YELLOW : undefined, bold: highlight },
       );
     });
     y += CABINET_ROW_HEIGHT;
@@ -426,6 +437,7 @@ function drawDispersionNote(pdf: jsPDF, x: number, y: number, width: number): vo
     'leído desde la perspectiva del propio recinto mirando hacia el público: cada cifra es la semiapertura (°) de ese lado ' +
     'y su suma es la cobertura horizontal total (55/55 = 110°, 35/35 = 70°, 55/35 y 35/55 = 90° asimétrico). ' +
     'Cada recinto puede llevar un ajuste distinto (configuración mixta, p. ej. 70°/110° en el mismo array). ' +
+    'Se resaltan en amarillo los recintos cuyo ajuste difiere de 55/55 (110°). ' +
     'Los recintos de directividad fija (KS28, KARA, K1) no muestran ajuste. Confirme siempre en Soundvision.';
   const lines = pdf.splitTextToSize(note, Math.max(1, width - 6));
   pdf.text(lines, x + 3, y + 29);

--- a/src/utils/soundvisionFlysheetPdf.ts
+++ b/src/utils/soundvisionFlysheetPdf.ts
@@ -200,7 +200,7 @@ function drawCabinetRows(
   arrays.forEach((array, index) => {
     drawCell(
       pdf,
-      `${array.arrayName} · Recinto / Ángulo`,
+      `${array.arrayName} · Recinto / Áng. / Disp.`,
       startX + LABEL_COLUMN_WIDTH + index * arrayWidth,
       y,
       arrayWidth,
@@ -217,7 +217,9 @@ function drawCabinetRows(
     arrays.forEach((array, index) => {
       const enclosure = array.enclosures[row];
       const value = enclosure
-        ? `${enclosure.model}  |  ${formatCompactNumber(enclosure.splayAngleDegrees, '°')}`
+        ? `${enclosure.model}  |  ${formatCompactNumber(enclosure.splayAngleDegrees, '°')}${
+            enclosure.dispersionSetting ? `  |  ${enclosure.dispersionSetting}` : ''
+          }`
         : '';
       drawCell(
         pdf,
@@ -285,6 +287,78 @@ function drawWarnings(
       fontSize: 6.7,
     });
   });
+}
+
+const DISPERSION_NOTE_HEIGHT = 20;
+
+/**
+ * Draws the variable-dispersion (Panflex) legend: a small top-view diagram of a
+ * cabinet split into left/right halves seen from the box's own perspective, plus
+ * a Spanish note on how to read the "L/R" setting (e.g. 55/35).
+ */
+function drawDispersionNote(pdf: jsPDF, x: number, y: number, width: number): void {
+  const height = DISPERSION_NOTE_HEIGHT;
+  pdf.setFillColor(...LIGHT_GRAY);
+  pdf.setDrawColor(...BLACK);
+  pdf.setLineWidth(0.35);
+  pdf.rect(x, y, width, height, 'FD');
+
+  // Title.
+  pdf.setFont('helvetica', 'bold');
+  pdf.setFontSize(7.8);
+  pdf.setTextColor(...BLACK);
+  pdf.text('DISPERSIÓN VARIABLE (PANFLEX · K2 / K3 / KARA II)', x + 3, y + 4.5);
+
+  // --- Diagram: cabinet seen from above, from the box's own perspective ---
+  const diagramW = 46;
+  const dx = x + 4;
+  const dyTop = y + 7;
+  const audienceY = dyTop + 1; // "toward audience" is up
+  const cabinetY = y + height - 5;
+  const centerX = dx + diagramW / 2;
+
+  pdf.setLineWidth(0.4);
+  // Cabinet body (a short bar) split into two halves.
+  pdf.setFillColor(255, 255, 255);
+  pdf.rect(dx + 6, cabinetY, diagramW - 12, 2.6, 'FD');
+  pdf.line(centerX, cabinetY, centerX, cabinetY + 2.6); // centre divider
+  // Coverage fans: left half wider than right to illustrate an asymmetric set.
+  pdf.setDrawColor(...RED);
+  pdf.line(centerX - 3, cabinetY, dx, audienceY); // left outer (wide)
+  pdf.line(centerX - 3, cabinetY, centerX - 1, audienceY); // left inner
+  pdf.line(centerX + 3, cabinetY, centerX + 1, audienceY); // right inner
+  pdf.line(centerX + 3, cabinetY, dx + diagramW - 8, audienceY); // right outer (narrow)
+  pdf.setDrawColor(...BLACK);
+
+  pdf.setFont('helvetica', 'bold');
+  pdf.setFontSize(6.2);
+  pdf.text('IZQ', dx + 4, cabinetY + 2, { align: 'center' });
+  pdf.text('DER', dx + diagramW - 4, cabinetY + 2, { align: 'center' });
+  pdf.setFont('helvetica', 'normal');
+  pdf.setFontSize(5.6);
+  pdf.triangle(
+    centerX - 1.2,
+    audienceY - 0.6,
+    centerX + 1.2,
+    audienceY - 0.6,
+    centerX,
+    audienceY - 2.4,
+    'F',
+  );
+  pdf.text('hacia el público', centerX + 3, audienceY - 1, { align: 'left' });
+
+  // --- Explanatory text ---
+  const textX = dx + diagramW + 4;
+  const textW = width - (diagramW + 11);
+  pdf.setFont('helvetica', 'normal');
+  pdf.setFontSize(6.6);
+  const note =
+    'Los recintos de directividad variable muestran su ajuste Panflex como IZQUIERDA/DERECHA ' +
+    '(p. ej. 55/35), leído desde la perspectiva del propio recinto mirando hacia el público: ' +
+    'el primer valor es la apertura horizontal (°) del lado izquierdo y el segundo la del lado derecho. ' +
+    'Los recintos de directividad fija (KS28, KARA, K1) no muestran ajuste. Confirme siempre en Soundvision.';
+  const lines = pdf.splitTextToSize(note, Math.max(1, textW));
+  pdf.text(lines, textX, y + 8);
 }
 
 function drawHeader(
@@ -428,7 +502,17 @@ export async function generateSoundvisionFlysheetPdf(
     const cabinetsStartY = drawSummaryRows(pdf, arrays, MARGIN, tableStartY, arrayWidth) + 2;
     const warningsStartY =
       drawCabinetRows(pdf, arrays, MARGIN, cabinetsStartY, arrayWidth, enclosureOffset) + 4;
-    drawWarnings(pdf, arrays, MARGIN, warningsStartY, arrayWidth, pageHeight - 27, continues);
+    // Reserve the legend strip only when this page actually shows a
+    // variable-dispersion enclosure, so pages without one keep the full height.
+    const hasDispersion = arrays.some((array) =>
+      array.enclosures.some((enclosure) => enclosure.dispersionSetting),
+    );
+    const footerTop = pageHeight - 27;
+    const warningsMaxY = hasDispersion ? footerTop - DISPERSION_NOTE_HEIGHT - 2 : footerTop;
+    drawWarnings(pdf, arrays, MARGIN, warningsStartY, arrayWidth, warningsMaxY, continues);
+    if (hasDispersion) {
+      drawDispersionNote(pdf, MARGIN, warningsMaxY + 2, contentWidth);
+    }
     drawFooter(pdf, generatedAt, sectorProLogo, pageIndex + 1, pages.length);
   });
 

--- a/supabase/functions/parse-la-session/parse.test.ts
+++ b/supabase/functions/parse-la-session/parse.test.ts
@@ -87,10 +87,10 @@ describe("parseSoundvisionFlysheet", () => {
       warnings: ["Factor de seguridad por debajo del mínimo."],
     });
     expect(flysheet.arrays[0].enclosures).toEqual([
-      { model: "K2", splayAngleDegrees: 5, siteAngleDegrees: -2.5, trimHeightMeters: 11.2 },
-      { model: "K2", splayAngleDegrees: 10, siteAngleDegrees: -7.5, trimHeightMeters: 9.8 },
-      { model: "K2", splayAngleDegrees: 0.25, siteAngleDegrees: -17.5, trimHeightMeters: 7.1 },
-      { model: "K2", splayAngleDegrees: null, siteAngleDegrees: -24.5, trimHeightMeters: 4.35 },
+      { model: "K2", splayAngleDegrees: 5, siteAngleDegrees: -2.5, trimHeightMeters: 11.2, dispersionSetting: null },
+      { model: "K2", splayAngleDegrees: 10, siteAngleDegrees: -7.5, trimHeightMeters: 9.8, dispersionSetting: null },
+      { model: "K2", splayAngleDegrees: 0.25, siteAngleDegrees: -17.5, trimHeightMeters: 7.1, dispersionSetting: null },
+      { model: "K2", splayAngleDegrees: null, siteAngleDegrees: -24.5, trimHeightMeters: 4.35, dispersionSetting: null },
     ]);
     expect(flysheet.arrays[1]).toMatchObject({
       arrayName: "SUB L",
@@ -103,8 +103,8 @@ describe("parseSoundvisionFlysheet", () => {
       rearLoadKg: null,
     });
     expect(flysheet.arrays[1].enclosures).toEqual([
-      { model: "KS28", splayAngleDegrees: 0, siteAngleDegrees: null, trimHeightMeters: null },
-      { model: "KS28", splayAngleDegrees: 0, siteAngleDegrees: null, trimHeightMeters: null },
+      { model: "KS28", splayAngleDegrees: 0, siteAngleDegrees: null, trimHeightMeters: null, dispersionSetting: null },
+      { model: "KS28", splayAngleDegrees: 0, siteAngleDegrees: null, trimHeightMeters: null, dispersionSetting: null },
     ]);
   });
 
@@ -157,6 +157,13 @@ describe("parseSoundvisionFlysheet", () => {
       "2x K2-BAR · Orificio A",
       "1x K2-BAR · Orificio A · Invertido",
     ]);
+    // Variable-dispersion Panflex setting is read from each enclosure's
+    // physical_configuration; enclosures without one report null.
+    expect(flysheet.arrays[0].enclosures.map((e) => e.dispersionSetting)).toEqual([
+      "55/55",
+      "55/55",
+    ]);
+    expect(flysheet.arrays[1].enclosures[0].dispersionSetting).toBeNull();
   });
 
   it("keeps arrays from mixed nested and flat physical configurations", () => {

--- a/supabase/functions/parse-la-session/parse.ts
+++ b/supabase/functions/parse-la-session/parse.ts
@@ -35,6 +35,11 @@ export interface SoundvisionFlysheetEnclosure {
   splayAngleDegrees: number | null;
   siteAngleDegrees: number | null;
   trimHeightMeters: number | null;
+  /**
+   * Panflex horizontal-dispersion setting for variable-directivity enclosures
+   * (K2, K3, KARA II), e.g. "55/35"; null for fixed-directivity boxes.
+   */
+  dispersionSetting: string | null;
 }
 
 export interface SoundvisionFlysheetArray {
@@ -262,6 +267,18 @@ function parseWarnings(body: string): string[] {
   return [...new Set(warnings)];
 }
 
+/**
+ * Extracts the Panflex horizontal-dispersion setting ("L/R", e.g. "55/35") from
+ * an enclosure body. Returns the first `physical_configuration` shaped like two
+ * slash-separated integers, or null for fixed-directivity enclosures.
+ */
+function parseDispersionSetting(elementBody: string): string | null {
+  const match = elementBody.match(
+    /<physical_configuration>\s*(\d{1,3}\s*\/\s*\d{1,3})\s*<\/physical_configuration>/i,
+  );
+  return match ? match[1].replace(/\s+/g, "") : null;
+}
+
 function parseEnclosures(clusterBody: string): SoundvisionFlysheetEnclosure[] {
   const elementsBody = extractXmlBlocks(clusterBody, "elements")
     .filter((block) => /<(?:element|enclosure)\b/i.test(block.body))
@@ -289,6 +306,10 @@ function parseEnclosures(clusterBody: string): SoundvisionFlysheetEnclosure[] {
       firstTextOf(elementBody, ["type", "model", "refid", "name", "enclosure_type"]);
     return {
       model: model || `RECINTO ${index + 1}`,
+      // Variable-directivity boxes serialize their Panflex setting as an
+      // "L/R" physical_configuration (e.g. 55/35) inside each acoustic way;
+      // fixed boxes (KS28, KARA, K1) have none.
+      dispersionSetting: parseDispersionSetting(elementBody),
       splayAngleDegrees:
         firstNumberOf(elementBody, ["splay", "splay_angle", "inter_angle", "angle"]) ??
         firstNumberAttribute(elementAttributes, ["splay", "splay_angle", "inter_angle", "angle"]) ??


### PR DESCRIPTION
Branched from `main`, clean diff (5 files). Surfaces the **Panflex horizontal-dispersion setting** for variable-directivity enclosures on the Soundvision flysheet, which was being dropped.

## Summary
- **Affected feature:** Sound → rack designer → Soundvision flysheet PDF.
- Variable-directivity boxes (**K2, K3, KARA II**) carry a Panflex setting in the `.xmlp` (`acoustic_way/physical_configuration`, e.g. `55/35`) that wasn't shown. Fixed boxes (KS28, KARA, K1) have none.

### What changed
- **Parser** (`parse-la-session/parse.ts`): extracts `dispersionSetting` per enclosure — the first `physical_configuration` shaped like `L/R` (two slash-separated integers); `null` for fixed boxes. Added to both the edge and client `SoundvisionFlysheetEnclosure` types.
- **PDF** (`soundvisionFlysheetPdf.ts`): each cabinet cell now reads **`model | angle | disp`** (e.g. `KARA II | 2° | 55/35`); the column header is relabeled `Recinto / Áng. / Disp.`. Fixed boxes render unchanged (`KS28 | 0°`).
- **Spanish legend band**, drawn only on pages that actually contain a variable-dispersion box, with a small top-view diagram (cabinet split IZQ/DER + a "hacia el público" arrow) explaining that the two numbers are the left/right horizontal apertures **read from the box's own perspective facing the audience** (first = left, second = right).

## Risk Assessment
- **Risk level:** low. Additive display of data already in the file; no schema/DB/money paths. No new safety numbers are computed — this only shows a setting that's literally in the `.xmlp`.
- Main risk: the L/R perspective wording — sourced from your "looked from the box perspective" note; easy to tweak the copy if you read it the other way.

## Impact Checklist
- [x] Migration impact — none.
- [x] Realtime/RLS/security — none (no function surface change beyond an added output field).
- [x] Performance — client bundle +19.4 kB gzip vs baseline (well within budget).

## Test Evidence
- `npm run typecheck` clean; `npm run lint` (app) + parse.ts clean.
- `npm run test:run` — parser test (7) asserts `55/55` extraction and `null` for fixed boxes; flysheet PDF tests (updated fixtures) pass.
- `npm run governance` — **PASS**. `npm run build` + `budget:bundle` — **PASS**.
- **Rendered a real A3 flysheet PDF** and verified: `K2 | 5° | 55/55`, `KARA II | 2° | 55/35` / `35/55` per box, KS28 unchanged, and the legend band + diagram appear only when a variable-dispersion box is present.

## Rollback Plan
- Additive, no data/schema changes. Revert the commit to remove the column value + legend; the rest of the flysheet is unchanged.

## Migration Impact
- **Migration required:** no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKgvRtgYPA6G3mbB5e3LAT)_