### PR TITLE
feat(sound): import PDU power requirements from XMLP amplifier groups

### DIFF
--- a/src/components/sound/amplifier-tool/rack-designer/nwm-import.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/nwm-import.ts
@@ -89,7 +89,8 @@ interface Bucket {
   units: NwmUnit[];
 }
 
-function toAmpModel(model: string): AmpModel {
+/** Exported for reuse by the Consumos XMLP amplifier-power importer. */
+export function toAmpModel(model: string): AmpModel {
   const normalized = model.trim().toUpperCase();
   if (normalized === 'LA4' || normalized === 'LA4X' || normalized === 'LA8') {
     return normalized;

--- a/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
+++ b/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
@@ -23,6 +23,7 @@ import {
 import { FIXTURE_PF, type ConsumosDepartmentConfig, type FixtureType } from "@/features/technical-tools/power/consumos/config";
 import { useConsumosTool } from "@/features/technical-tools/power/consumos/useConsumosTool";
 import { CustomComponentDialog } from "@/features/technical-tools/power/consumos/CustomComponentDialog";
+import { XmlpWeightImportButton } from "@/features/technical-tools/weights/XmlpWeightImportButton";
 import { PowerStagePlot } from "@/features/technical-tools/power/consumos/PowerStagePlot";
 import { CopyToStageMenu } from "@/features/technical-tools/table-presets/CopyToStageMenu";
 import { QuickPresetsMenu } from "@/features/technical-tools/table-presets/QuickPresetsMenu";
@@ -96,6 +97,8 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
     removeRow,
     updateInput,
     addComponentToRow,
+    isImportingXmlp,
+    importXmlpPower,
     selectedPosition,
     setSelectedPosition,
     customPosition,
@@ -217,6 +220,12 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
             </div>
           </div>
           <div className="flex flex-wrap items-center justify-end gap-2">
+            {isNormalMode && config.department === "sound" && (
+              <XmlpWeightImportButton
+                isImporting={isImportingXmlp}
+                onImport={(file) => void importXmlpPower(file)}
+              />
+            )}
             {isNormalMode && jobStages.length > 1 && activeTables.length > 0 && (
               <CopyToStageMenu
                 label={labels.copySetToStage}

--- a/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
+++ b/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
@@ -99,6 +99,7 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
     addComponentToRow,
     isImportingXmlp,
     importXmlpPower,
+    addPrebuiltMonitorPdu,
     selectedPosition,
     setSelectedPosition,
     customPosition,
@@ -224,7 +225,20 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
               <XmlpWeightImportButton
                 isImporting={isImportingXmlp}
                 onImport={(file) => void importXmlpPower(file)}
+                title="Crear tablas de potencia desde un proyecto Soundvision (.xmlp)"
               />
+            )}
+            {isNormalMode && config.department === "sound" && (
+              <Button
+                type="button"
+                variant="outline"
+                className="gap-2"
+                onClick={addPrebuiltMonitorPdu}
+                title="Añadir una PDU Monitores sin posición con Control Mon (L), RF Rack, Backline y Varios"
+              >
+                <Plus className="h-4 w-4" />
+                Añadir Monitores
+              </Button>
             )}
             {isNormalMode && jobStages.length > 1 && activeTables.length > 0 && (
               <CopyToStageMenu

--- a/src/features/technical-tools/power/consumos/__tests__/monitorPduPreset.test.ts
+++ b/src/features/technical-tools/power/consumos/__tests__/monitorPduPreset.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { SOUND_CONSUMOS_CONFIG } from "../departmentConfigs";
+import { createPrebuiltMonitorPdu } from "../monitorPduPreset";
+
+describe("createPrebuiltMonitorPdu", () => {
+  it("creates the requested unpositioned Monitores PDU for the active stage", () => {
+    const table = createPrebuiltMonitorPdu({
+      components: SOUND_CONSUMOS_CONFIG.components,
+      id: 123,
+      pduOptions: ["CEE16A 3P+N+G", "CEE32A 3P+N+G"],
+      settings: {
+        safetyMargin: 20,
+        phaseMode: "three",
+        voltage: 400,
+        powerFactor: 0.95,
+      },
+      stage: { name: "Escenario B", number: 2 },
+    });
+
+    expect(table).toEqual(
+      expect.objectContaining({
+        id: 123,
+        name: "Monitores",
+        position: undefined,
+        includesHoist: false,
+        stageName: "Escenario B",
+        stageNumber: 2,
+      }),
+    );
+    expect(table.rows).toEqual([
+      expect.objectContaining({ componentName: "Control Mon (L)", quantity: "1" }),
+      expect.objectContaining({ componentName: "RF Rack", quantity: "1" }),
+      expect.objectContaining({ componentName: "Backline", quantity: "1" }),
+      expect.objectContaining({ componentName: "Varios", quantity: "1" }),
+    ]);
+  });
+
+  it("fails loudly instead of creating a partial preset when a required component is missing", () => {
+    expect(() =>
+      createPrebuiltMonitorPdu({
+        components: SOUND_CONSUMOS_CONFIG.components.filter(
+          (component) => component.name !== "RF Rack",
+        ),
+        id: 123,
+        pduOptions: ["CEE16A 3P+N+G"],
+        settings: {
+          safetyMargin: 20,
+          phaseMode: "three",
+          voltage: 400,
+          powerFactor: 0.95,
+        },
+        stage: null,
+      }),
+    ).toThrow('Falta el componente "RF Rack"');
+  });
+});

--- a/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
+++ b/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
@@ -67,7 +67,7 @@ describe("buildXmlpPowerTables", () => {
 
     expect(result.tables).toHaveLength(1);
     const sidefill = result.tables[0];
-    expect(sidefill.name).toBe("Sidefill");
+    expect(sidefill.name).toBe("Monitores");
     expect(sidefill.includesHoist).toBe(false);
     expect(sidefill.position).toBeUndefined();
     expect(sidefill.rows).toEqual([
@@ -111,7 +111,7 @@ describe("buildXmlpPowerTables", () => {
     };
 
     const result = buildXmlpPowerTables(map, components);
-    expect(result.tables.map((table) => table.name)).toEqual(["Sidefill"]);
+    expect(result.tables.map((table) => table.name)).toEqual(["Monitores"]);
   });
 
   it("warns and drops amps whose model has no catalog equivalent", () => {
@@ -174,7 +174,7 @@ describe("buildXmlpPowerTables", () => {
     };
 
     const result = buildXmlpPowerTables(map, components);
-    expect(result.tables.map((table) => table.name)).toEqual(["Sidefill"]);
+    expect(result.tables.map((table) => table.name)).toEqual(["Monitores"]);
   });
 
   it("recognizes the 'DLY' abbreviation (vowel-dropped, not a prefix of DELAY) as a delay group", () => {

--- a/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
+++ b/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
@@ -128,16 +128,109 @@ describe("buildXmlpPowerTables", () => {
     );
   });
 
-  it("skips a PA-classified group when its side cannot be determined, with a warning", () => {
+  it("preserves unsided PA groups in one unpositioned Main PDU", () => {
     const map: XmlpAmpMap = {
-      units: [{ octet: 1, model: "LA12X" }],
-      groups: [{ name: "MAIN", role: "source", members: [1] }],
+      units: [
+        { octet: 1, model: "LA12X" },
+        { octet: 2, model: "LA12X" },
+        { octet: 3, model: "LA12X" },
+        { octet: 4, model: "LA12X" },
+      ],
+      groups: [
+        { name: "Main K2", role: "source", members: [1] },
+        { name: "SUBS", role: "source", members: [2] },
+        { name: "Outfill", role: "source", members: [3] },
+        { name: "Frontfill", role: "source", members: [4] },
+      ],
     };
 
     const result = buildXmlpPowerTables(map, components);
-    expect(result.tables).toEqual([]);
+    expect(result.tables).toHaveLength(1);
+    expect(result.tables[0]).toEqual(
+      expect.objectContaining({ name: "Main", includesHoist: true }),
+    );
+    expect(result.tables[0]).not.toHaveProperty("position");
+    expect(rowFor(result, "Main", "LA12X")).toEqual(
+      expect.objectContaining({ quantity: "4" }),
+    );
     expect(result.warnings).toEqual([
-      'No se pudo determinar el lado (L/R) del grupo "MAIN"; no se importó.',
+      "No se pudo determinar el lado (L/R) de 4 amplificador(es) de PA; se añadieron a \"Main\" sin posición.",
+    ]);
+  });
+
+  it("uses screenshot-style parent groups to classify cabinet-named source groups", () => {
+    const map: XmlpAmpMap = {
+      units: [
+        { octet: 11, model: "LA12X" },
+        { octet: 12, model: "LA12X" },
+        { octet: 21, model: "LA12X" },
+        { octet: 22, model: "LA12X" },
+      ],
+      groups: [
+        { name: "ALL", role: "parent", members: [11, 12, 21, 22] },
+        { name: "Main K2", role: "parent", members: [11, 12] },
+        { name: "SUBS", role: "parent", members: [21] },
+        { name: "Outfill", role: "parent", members: [22] },
+        { name: "K2 L", role: "source", members: [11] },
+        { name: "K2 R", role: "source", members: [12] },
+        { name: "KS28 L", role: "source", members: [21] },
+        { name: "KARA R", role: "source", members: [22] },
+      ],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name).sort()).toEqual(["Main L", "Main R"]);
+    expect(rowFor(result, "Main L", "LA12X")).toEqual(
+      expect.objectContaining({ quantity: "2" }),
+    );
+    expect(rowFor(result, "Main R", "LA12X")).toEqual(
+      expect.objectContaining({ quantity: "2" }),
+    );
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("uses independent LEFT/RIGHT membership when source names have no side", () => {
+    const map: XmlpAmpMap = {
+      units: [
+        { octet: 11, model: "LA12X" },
+        { octet: 12, model: "LA12X" },
+      ],
+      groups: [
+        { name: "Main K2", role: "parent", members: [11, 12] },
+        { name: "LEFT", role: "side", members: [11] },
+        { name: "RIGHT", role: "side", members: [12] },
+        { name: "K2", role: "source", members: [11, 12] },
+      ],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name).sort()).toEqual(["Main L", "Main R"]);
+    expect(rowFor(result, "Main L", "LA12X")?.quantity).toBe("1");
+    expect(rowFor(result, "Main R", "LA12X")?.quantity).toBe("1");
+  });
+
+  it("recognizes common PA, fill, sidefill, and delay abbreviations", () => {
+    const map: XmlpAmpMap = {
+      units: [
+        { octet: 1, model: "LA12X" },
+        { octet: 2, model: "LA12X" },
+        { octet: 3, model: "LA4X" },
+        { octet: 4, model: "LA8" },
+      ],
+      groups: [
+        { name: "PA L", role: "source", members: [1] },
+        { name: "FF R", role: "source", members: [2] },
+        { name: "SF", role: "source", members: [3] },
+        { name: "DLY 1", role: "source", members: [4] },
+      ],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name).sort()).toEqual([
+      "DLY 1",
+      "Main L",
+      "Main R",
+      "Monitores",
     ]);
   });
 
@@ -216,6 +309,19 @@ describe("buildXmlpPowerTables", () => {
 
     const result = buildXmlpPowerTables(map, components);
     expect(result.tables).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("maps legacy LA4 units to the bundled LA4X planning component instead of dropping them", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA4" }],
+      groups: [{ name: "SIDE L", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(rowFor(result, "Monitores", "LA4X")).toEqual(
+      expect.objectContaining({ quantity: "1", watts: "750" }),
+    );
     expect(result.warnings).toEqual([]);
   });
 });

--- a/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
+++ b/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
@@ -167,6 +167,47 @@ describe("buildXmlpPowerTables", () => {
     expect(result.tables.map((table) => table.name)).toEqual(["Main L"]);
   });
 
+  it("recognizes an abbreviated bare 'SIDE' group as sidefill", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA4X" }],
+      groups: [{ name: "SIDE L", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name)).toEqual(["Sidefill"]);
+  });
+
+  it("recognizes the 'DLY' abbreviation (vowel-dropped, not a prefix of DELAY) as a delay group", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA8" }],
+      groups: [{ name: "DLY 1 L", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name)).toEqual(["DLY 1 L"]);
+  });
+
+  it("classifies group names regardless of case (mixed/lowercase)", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA12X" }],
+      groups: [{ name: "main l", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name)).toEqual(["Main L"]);
+  });
+
+  it("reads the fully spelled-out side word (LEFT/RIGHT), not just L/R", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA12X" }],
+      groups: [{ name: "MAIN LEFT", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name)).toEqual(["Main L"]);
+    expect(result.tables[0].position).toBe("DOSL");
+  });
+
   it("ignores non-source-role groups entirely (parent/zoning groups)", () => {
     const map: XmlpAmpMap = {
       units: [{ octet: 1, model: "LA12X" }],

--- a/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
+++ b/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import { SOUND_CONSUMOS_CONFIG } from "../departmentConfigs";
+import { buildXmlpPowerTables, type XmlpAmpMap } from "../xmlpPowerImport";
+
+const components = SOUND_CONSUMOS_CONFIG.components;
+
+const rowFor = (result: ReturnType<typeof buildXmlpPowerTables>, tableName: string, componentName: string) =>
+  result.tables
+    .find((table) => table.name === tableName)
+    ?.rows.find((row) => row.componentName === componentName);
+
+describe("buildXmlpPowerTables", () => {
+  it("merges mains/subs/outfills/frontfills by side into Main L / Main R with hoist and a Varios row", () => {
+    const map: XmlpAmpMap = {
+      units: [
+        { octet: 11, model: "LA12X" },
+        { octet: 12, model: "LA12X" },
+        { octet: 21, model: "LA12X" },
+        { octet: 31, model: "LA12X" }, // sub
+        { octet: 41, model: "LA12X" }, // out fill
+        { octet: 51, model: "LA12X" }, // front fill
+      ],
+      groups: [
+        { name: "MAIN L", role: "source", members: [11, 12] },
+        { name: "MAIN R", role: "source", members: [21] },
+        { name: "SUB L", role: "source", members: [31] },
+        { name: "OUT R", role: "source", members: [41] },
+        { name: "FRONT FILL L", role: "source", members: [51] },
+      ],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+
+    expect(result.tables.map((table) => table.name).sort()).toEqual(["Main L", "Main R"]);
+
+    const mainL = result.tables.find((table) => table.name === "Main L")!;
+    expect(mainL.includesHoist).toBe(true);
+    expect(mainL.position).toBe("DOSL");
+    expect(mainL.rows).toEqual([
+      expect.objectContaining({ componentName: "LA12X", quantity: "4" }), // 11,12 (main) + 31 (sub) + 51 (front fill)
+      expect.objectContaining({ componentName: "Varios", quantity: "1" }),
+    ]);
+
+    const mainR = result.tables.find((table) => table.name === "Main R")!;
+    expect(mainR.includesHoist).toBe(true);
+    expect(mainR.position).toBe("DOSR");
+    expect(mainR.rows).toEqual([
+      expect.objectContaining({ componentName: "LA12X", quantity: "2" }), // 21 (main) + 41 (out)
+      expect.objectContaining({ componentName: "Varios", quantity: "1" }),
+    ]);
+  });
+
+  it("merges sidefill amps (both sides) into a single stage PDU with the monitor-world extras", () => {
+    const map: XmlpAmpMap = {
+      units: [
+        { octet: 61, model: "LA4X" },
+        { octet: 62, model: "LA4X" },
+      ],
+      groups: [
+        { name: "SIDEFILL L", role: "source", members: [61] },
+        { name: "SIDEFILL R", role: "source", members: [62] },
+      ],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+
+    expect(result.tables).toHaveLength(1);
+    const sidefill = result.tables[0];
+    expect(sidefill.name).toBe("Sidefill");
+    expect(sidefill.includesHoist).toBe(false);
+    expect(sidefill.position).toBeUndefined();
+    expect(sidefill.rows).toEqual([
+      expect.objectContaining({ componentName: "LA4X", quantity: "2" }),
+      expect.objectContaining({ componentName: "Control Mon (L)", quantity: "1" }),
+      expect.objectContaining({ componentName: "RF Rack", quantity: "1" }),
+      expect.objectContaining({ componentName: "Backline", quantity: "1" }),
+      expect.objectContaining({ componentName: "Varios", quantity: "1" }),
+    ]);
+  });
+
+  it("keeps every delay group as its own PDU, named as in the session file, each with a Varios row", () => {
+    const map: XmlpAmpMap = {
+      units: [
+        { octet: 71, model: "LA8" },
+        { octet: 72, model: "LA8" },
+      ],
+      groups: [
+        { name: "DELAY 1 L", role: "source", members: [71] },
+        { name: "DELAY 1 R", role: "source", members: [72] },
+      ],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+
+    expect(result.tables.map((table) => table.name).sort()).toEqual(["DELAY 1 L", "DELAY 1 R"]);
+    for (const table of result.tables) {
+      expect(table.includesHoist).toBe(false);
+      expect(table.position).toBeUndefined();
+      expect(table.rows).toEqual([
+        expect.objectContaining({ componentName: "LA8", quantity: "1" }),
+        expect.objectContaining({ componentName: "Varios", quantity: "1" }),
+      ]);
+    }
+  });
+
+  it("does not misclassify SIDEFILL as a front/out fill despite sharing the FILL keyword", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA12X" }],
+      groups: [{ name: "SIDEFILL L", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name)).toEqual(["Sidefill"]);
+  });
+
+  it("warns and drops amps whose model has no catalog equivalent", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "type99" }],
+      groups: [{ name: "MAIN L", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    // Only the forced Varios row survives; the unmatched amp is dropped.
+    expect(rowFor(result, "Main L", "Varios")).toBeDefined();
+    expect(result.warnings).toContain(
+      'Amplificador con modelo "type99" sin equivalencia en el catálogo de consumos; no se incluyó.',
+    );
+  });
+
+  it("skips a PA-classified group when its side cannot be determined, with a warning", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA12X" }],
+      groups: [{ name: "MAIN", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables).toEqual([]);
+    expect(result.warnings).toEqual([
+      'No se pudo determinar el lado (L/R) del grupo "MAIN"; no se importó.',
+    ]);
+  });
+
+  it("ignores and warns about groups that match none of the known sections", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA12X" }],
+      groups: [{ name: "KARA 1", role: "source", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables).toEqual([]);
+    expect(result.warnings).toEqual([
+      'Grupo "KARA 1" no coincide con mains/subs/outfills/frontfills/sidefill/delay; sus amplificadores no se incluyeron.',
+    ]);
+  });
+
+  it("assigns an amp shared across overlapping source groups to the first group only", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA12X" }],
+      groups: [
+        { name: "MAIN L", role: "source", members: [1] },
+        { name: "MAIN R", role: "source", members: [1] },
+      ],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables.map((table) => table.name)).toEqual(["Main L"]);
+  });
+
+  it("ignores non-source-role groups entirely (parent/zoning groups)", () => {
+    const map: XmlpAmpMap = {
+      units: [{ octet: 1, model: "LA12X" }],
+      groups: [{ name: "MAINS", role: "parent", members: [1] }],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+    expect(result.tables).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/src/features/technical-tools/power/consumos/monitorPduPreset.ts
+++ b/src/features/technical-tools/power/consumos/monitorPduPreset.ts
@@ -1,0 +1,87 @@
+import { createCalculatedPowerTable } from "@/features/technical-tools/power/powerCalculations";
+import type {
+  PowerElectricalSettings,
+  PowerTable,
+  PowerTableRow,
+} from "@/features/technical-tools/power/types";
+
+import type { ConsumosComponent } from "./config";
+
+export const MONITOR_PDU_NAME = "Monitores";
+
+const MONITOR_PDU_COMPONENT_NAMES = [
+  "Control Mon (L)",
+  "RF Rack",
+  "Backline",
+  "Varios",
+] as const;
+
+const normalizeComponentName = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+const findComponent = (name: string, components: ConsumosComponent[]) => {
+  const normalized = normalizeComponentName(name);
+  return components.find(
+    (component) => normalizeComponentName(component.name) === normalized,
+  );
+};
+
+export const buildMonitorPduRows = (components: ConsumosComponent[]) => {
+  const rows: PowerTableRow[] = [];
+  const missingComponents: string[] = [];
+
+  for (const componentName of MONITOR_PDU_COMPONENT_NAMES) {
+    const component = findComponent(componentName, components);
+    if (!component) {
+      missingComponents.push(componentName);
+      continue;
+    }
+    rows.push({
+      quantity: "1",
+      componentId: component.id.toString(),
+      watts: component.watts.toString(),
+      componentName: component.name,
+    });
+  }
+
+  return { rows, missingComponents };
+};
+
+export const createPrebuiltMonitorPdu = ({
+  components,
+  id,
+  pduOptions,
+  settings,
+  stage,
+}: {
+  components: ConsumosComponent[];
+  id: number | string;
+  pduOptions: string[];
+  settings: PowerElectricalSettings;
+  stage: { name: string; number: number } | null;
+}): PowerTable => {
+  const { rows, missingComponents } = buildMonitorPduRows(components);
+  if (missingComponents.length > 0) {
+    throw new Error(
+      `Falta el componente "${missingComponents[0]}" en el catálogo de consumos.`,
+    );
+  }
+
+  return createCalculatedPowerTable({
+    components,
+    currentTable: { rows, position: undefined },
+    id,
+    name: MONITOR_PDU_NAME,
+    pduOptions,
+    settings,
+    tablePatch: {
+      includesHoist: false,
+      stageName: stage?.name ?? null,
+      stageNumber: stage?.number ?? null,
+    },
+  }) as PowerTable;
+};

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -523,12 +523,13 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
   });
 
   // XMLP amplifier-power import (Soundvision projects, sound department only)
-  const { isImportingXmlp, importXmlpPower } = useXmlpPowerImport({
+  const { isImportingXmlp, importXmlpPower, addPrebuiltMonitorPdu } = useXmlpPowerImport({
     components,
     pduOptions,
     getSettings: getPowerSettings,
     selectedStage: selectedStage ?? null,
     onTablesImported: (importedTables) => setTables((prev) => [...prev, ...importedTables]),
+    onMonitorPduCreated: (table) => setTables((prev) => [...prev, table]),
   });
 
   // Builder row handlers
@@ -1772,6 +1773,7 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     addComponentToRow,
     isImportingXmlp,
     importXmlpPower,
+    addPrebuiltMonitorPdu,
     selectedPosition,
     setSelectedPosition,
     customPosition,

--- a/src/features/technical-tools/power/consumos/useConsumosTool.ts
+++ b/src/features/technical-tools/power/consumos/useConsumosTool.ts
@@ -77,6 +77,7 @@ import {
   useCustomPowerComponents,
 } from "./useCustomPowerComponents";
 import { useConsumosComponents } from "./useConsumosComponents";
+import { useXmlpPowerImport } from "./useXmlpPowerImport";
 import {
   downloadPdfBlob,
   type ConsumosJob,
@@ -519,6 +520,15 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
       : {
           powerFactor: table.calculation?.powerFactor ?? pf,
         }),
+  });
+
+  // XMLP amplifier-power import (Soundvision projects, sound department only)
+  const { isImportingXmlp, importXmlpPower } = useXmlpPowerImport({
+    components,
+    pduOptions,
+    getSettings: getPowerSettings,
+    selectedStage: selectedStage ?? null,
+    onTablesImported: (importedTables) => setTables((prev) => [...prev, ...importedTables]),
   });
 
   // Builder row handlers
@@ -1760,6 +1770,8 @@ export const useConsumosTool = (config: ConsumosDepartmentConfig) => {
     removeRow,
     updateInput,
     addComponentToRow,
+    isImportingXmlp,
+    importXmlpPower,
     selectedPosition,
     setSelectedPosition,
     customPosition,

--- a/src/features/technical-tools/power/consumos/useXmlpPowerImport.ts
+++ b/src/features/technical-tools/power/consumos/useXmlpPowerImport.ts
@@ -1,0 +1,96 @@
+import { useState } from "react";
+
+import { parseLaSessionFile } from "@/components/sound/amplifier-tool/rack-designer/parse-session-file";
+import { useToast } from "@/hooks/use-toast";
+import { createCalculatedPowerTable } from "@/features/technical-tools/power/powerCalculations";
+import type { PowerElectricalSettings, PowerTable } from "@/features/technical-tools/power/types";
+
+import type { ConsumosComponent } from "./config";
+import { buildXmlpPowerTables } from "./xmlpPowerImport";
+
+interface ImportStage {
+  name: string;
+  number: number;
+}
+
+interface UseXmlpPowerImportOptions {
+  components: ConsumosComponent[];
+  pduOptions: string[];
+  getSettings: () => PowerElectricalSettings;
+  selectedStage: ImportStage | null;
+  onTablesImported: (tables: PowerTable[]) => void;
+}
+
+export function useXmlpPowerImport({
+  components,
+  pduOptions,
+  getSettings,
+  selectedStage,
+  onTablesImported,
+}: UseXmlpPowerImportOptions) {
+  const [isImportingXmlp, setIsImportingXmlp] = useState(false);
+  const { toast } = useToast();
+
+  const importXmlpPower = async (file: File) => {
+    if (isImportingXmlp) return;
+    if (!file.name.toLowerCase().endsWith(".xmlp")) {
+      toast({
+        title: "Archivo no compatible",
+        description: "Selecciona un proyecto Soundvision (.xmlp).",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsImportingXmlp(true);
+    try {
+      const map = await parseLaSessionFile(file);
+      const result = buildXmlpPowerTables(map, components);
+      if (result.tables.length === 0) {
+        throw new Error(
+          result.warnings[0] || "El XMLP no contiene amplificadores reconocibles.",
+        );
+      }
+
+      const settings = getSettings();
+      const firstId = Date.now();
+      const builtTables = result.tables.map((table, index) =>
+        createCalculatedPowerTable({
+          components,
+          currentTable: { rows: table.rows, position: table.position },
+          id: firstId + index,
+          name: table.name,
+          pduOptions,
+          settings,
+          tablePatch: {
+            includesHoist: table.includesHoist,
+            stageName: selectedStage?.name ?? null,
+            stageNumber: selectedStage?.number ?? null,
+          },
+        }) as PowerTable,
+      );
+
+      onTablesImported(builtTables);
+
+      const warningSuffix =
+        result.warnings.length > 0
+          ? ` Aviso: ${result.warnings[0]}` +
+            (result.warnings.length > 1 ? ` (+${result.warnings.length - 1} más)` : "")
+          : "";
+      toast({
+        title: "PDUs extraídos del XMLP",
+        description: `${result.tables.length} PDU(s) añadidos.${warningSuffix}`,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "No se pudo extraer el consumo del proyecto Soundvision.";
+      toast({ title: "Error al extraer el XMLP", description: message, variant: "destructive" });
+    } finally {
+      setIsImportingXmlp(false);
+    }
+  };
+
+  return { isImportingXmlp, importXmlpPower };
+}

--- a/src/features/technical-tools/power/consumos/useXmlpPowerImport.ts
+++ b/src/features/technical-tools/power/consumos/useXmlpPowerImport.ts
@@ -6,6 +6,7 @@ import { createCalculatedPowerTable } from "@/features/technical-tools/power/pow
 import type { PowerElectricalSettings, PowerTable } from "@/features/technical-tools/power/types";
 
 import type { ConsumosComponent } from "./config";
+import { createPrebuiltMonitorPdu } from "./monitorPduPreset";
 import { buildXmlpPowerTables } from "./xmlpPowerImport";
 
 interface ImportStage {
@@ -19,6 +20,7 @@ interface UseXmlpPowerImportOptions {
   getSettings: () => PowerElectricalSettings;
   selectedStage: ImportStage | null;
   onTablesImported: (tables: PowerTable[]) => void;
+  onMonitorPduCreated: (table: PowerTable) => void;
 }
 
 export function useXmlpPowerImport({
@@ -27,6 +29,7 @@ export function useXmlpPowerImport({
   getSettings,
   selectedStage,
   onTablesImported,
+  onMonitorPduCreated,
 }: UseXmlpPowerImportOptions) {
   const [isImportingXmlp, setIsImportingXmlp] = useState(false);
   const { toast } = useToast();
@@ -92,5 +95,29 @@ export function useXmlpPowerImport({
     }
   };
 
-  return { isImportingXmlp, importXmlpPower };
+  const addPrebuiltMonitorPdu = () => {
+    try {
+      onMonitorPduCreated(
+        createPrebuiltMonitorPdu({
+          components,
+          id: Date.now(),
+          pduOptions,
+          settings: getSettings(),
+          stage: selectedStage,
+        }),
+      );
+      toast({ title: "Éxito", description: "PDU de Monitores añadida sin posición." });
+    } catch (error) {
+      toast({
+        title: "Error",
+        description:
+          error instanceof Error
+            ? error.message
+            : "No se pudo añadir la PDU de Monitores.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return { isImportingXmlp, importXmlpPower, addPrebuiltMonitorPdu };
 }

--- a/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
+++ b/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
@@ -1,0 +1,216 @@
+import { toAmpModel } from "@/components/sound/amplifier-tool/rack-designer/nwm-import";
+import type { PowerTableRow } from "@/features/technical-tools/power/types";
+import type { ConsumosComponent } from "./config";
+
+interface XmlpAmpUnit {
+  octet: number;
+  model: string;
+}
+
+interface XmlpAmpGroup {
+  name: string;
+  role: string;
+  members: number[];
+}
+
+export interface XmlpAmpMap {
+  units: XmlpAmpUnit[];
+  groups: XmlpAmpGroup[];
+}
+
+export interface XmlpPowerBuiltTable {
+  name: string;
+  rows: PowerTableRow[];
+  includesHoist: boolean;
+  position?: string;
+}
+
+export interface XmlpPowerImportResult {
+  tables: XmlpPowerBuiltTable[];
+  warnings: string[];
+}
+
+type Side = "L" | "R" | "C";
+type Section = "PA" | "SIDE" | "DELAY" | "OTHER";
+
+const normalizeName = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+
+const findComponent = (name: string, components: ConsumosComponent[]) => {
+  const normalized = normalizeName(name);
+  return components.find((component) => normalizeName(component.name) === normalized);
+};
+
+const sideFromName = (name: string): Side => {
+  const last = name.trim().slice(-1).toUpperCase();
+  return last === "L" ? "L" : last === "R" ? "R" : "C";
+};
+
+// SIDE is checked before the generic PA pattern so "SIDEFILL" (which also
+// contains "FILL") is not misclassified as a front/out fill.
+function classifySection(groupName: string): Section {
+  const normalized = normalizeName(groupName);
+  if (/SIDE/.test(normalized)) return "SIDE";
+  if (/DELAY/.test(normalized)) return "DELAY";
+  if (/MAIN|SUB|OUT|FRONT|FILL/.test(normalized)) return "PA";
+  return "OTHER";
+}
+
+const appendRow = (rows: PowerTableRow[], component: ConsumosComponent, quantity: number) => {
+  rows.push({
+    quantity: quantity.toString(),
+    componentId: component.id.toString(),
+    watts: component.watts.toString(),
+    componentName: component.name,
+  });
+};
+
+const countAmpsByComponent = (
+  units: XmlpAmpUnit[],
+  components: ConsumosComponent[],
+  warnings: string[],
+) => {
+  const counts = new Map<string, { component: ConsumosComponent; quantity: number }>();
+  for (const unit of units) {
+    const ampModel = toAmpModel(unit.model);
+    const component = findComponent(ampModel, components);
+    if (!component) {
+      warnings.push(
+        `Amplificador con modelo "${unit.model}" sin equivalencia en el catálogo de consumos; no se incluyó.`,
+      );
+      continue;
+    }
+    const key = component.id.toString();
+    const current = counts.get(key);
+    counts.set(key, { component, quantity: (current?.quantity ?? 0) + 1 });
+  }
+  return counts;
+};
+
+const rowsFromCounts = (counts: Map<string, { component: ConsumosComponent; quantity: number }>) => {
+  const rows: PowerTableRow[] = [];
+  for (const { component, quantity } of counts.values()) appendRow(rows, component, quantity);
+  return rows;
+};
+
+const addExtraRow = (
+  rows: PowerTableRow[],
+  componentName: string,
+  quantity: number,
+  components: ConsumosComponent[],
+  warnings: string[],
+  contextLabel: string,
+) => {
+  const component = findComponent(componentName, components);
+  if (!component) {
+    warnings.push(
+      `No se encontró el componente "${componentName}" en el catálogo; no se añadió esa fila a ${contextLabel}.`,
+    );
+    return;
+  }
+  appendRow(rows, component, quantity);
+};
+
+/**
+ * Builds Consumos PDU tables from an imported Soundvision `.xmlp` amplifier
+ * map. Mains/subs/outfills/front fills are merged by side into "Main L" /
+ * "Main R" PDUs (hoist power required); sidefill amps are merged into a
+ * single stage PDU with the usual monitor-world extras; each delay group
+ * keeps its own PDU, exactly as named in the session file.
+ */
+export function buildXmlpPowerTables(
+  map: XmlpAmpMap,
+  components: ConsumosComponent[],
+): XmlpPowerImportResult {
+  const warnings: string[] = [];
+  const unitByOctet = new Map(map.units.map((unit) => [unit.octet, unit]));
+  const sourceGroups = map.groups.filter((group) => group.role === "source");
+
+  // First source group wins for amps that appear in multiple overlapping groups.
+  const assignedGroup = new Map<number, string>();
+  for (const group of sourceGroups) {
+    for (const octet of group.members) {
+      if (unitByOctet.has(octet) && !assignedGroup.has(octet)) {
+        assignedGroup.set(octet, group.name);
+      }
+    }
+  }
+
+  const unitsByGroup = new Map<string, XmlpAmpUnit[]>();
+  for (const [octet, groupName] of assignedGroup) {
+    const unit = unitByOctet.get(octet)!;
+    if (!unitsByGroup.has(groupName)) unitsByGroup.set(groupName, []);
+    unitsByGroup.get(groupName)!.push(unit);
+  }
+
+  const paUnitsBySide: Record<"L" | "R", XmlpAmpUnit[]> = { L: [], R: [] };
+  const sidefillUnits: XmlpAmpUnit[] = [];
+  const delayGroups: Array<{ name: string; units: XmlpAmpUnit[] }> = [];
+
+  for (const [groupName, units] of unitsByGroup) {
+    const section = classifySection(groupName);
+    if (section === "PA") {
+      const side = sideFromName(groupName);
+      if (side === "C") {
+        warnings.push(
+          `No se pudo determinar el lado (L/R) del grupo "${groupName}"; no se importó.`,
+        );
+        continue;
+      }
+      paUnitsBySide[side].push(...units);
+    } else if (section === "SIDE") {
+      sidefillUnits.push(...units);
+    } else if (section === "DELAY") {
+      delayGroups.push({ name: groupName, units });
+    } else {
+      warnings.push(
+        `Grupo "${groupName}" no coincide con mains/subs/outfills/frontfills/sidefill/delay; sus amplificadores no se incluyeron.`,
+      );
+    }
+  }
+
+  const tables: XmlpPowerBuiltTable[] = [];
+
+  (["L", "R"] as const).forEach((side) => {
+    const units = paUnitsBySide[side];
+    if (units.length === 0) return;
+    const rows = rowsFromCounts(countAmpsByComponent(units, components, warnings));
+    addExtraRow(rows, "Varios", 1, components, warnings, `Main ${side}`);
+    if (rows.length === 0) return;
+    tables.push({
+      name: `Main ${side}`,
+      rows,
+      includesHoist: true,
+      position: side === "L" ? "DOSL" : "DOSR",
+    });
+  });
+
+  if (sidefillUnits.length > 0) {
+    const rows = rowsFromCounts(countAmpsByComponent(sidefillUnits, components, warnings));
+    const extras: Array<[string, number]> = [
+      ["Control Mon (L)", 1],
+      ["RF Rack", 1],
+      ["Backline", 1],
+      ["Varios", 1],
+    ];
+    for (const [name, quantity] of extras) {
+      addExtraRow(rows, name, quantity, components, warnings, "Sidefill");
+    }
+    if (rows.length > 0) {
+      tables.push({ name: "Sidefill", rows, includesHoist: false });
+    }
+  }
+
+  for (const { name, units } of delayGroups) {
+    const rows = rowsFromCounts(countAmpsByComponent(units, components, warnings));
+    addExtraRow(rows, "Varios", 1, components, warnings, `"${name}"`);
+    if (rows.length === 0) continue;
+    tables.push({ name: name.trim() || `Delay ${tables.length + 1}`, rows, includesHoist: false });
+  }
+
+  return { tables, warnings: [...new Set(warnings)] };
+}

--- a/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
+++ b/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
@@ -1,17 +1,14 @@
-import { toAmpModel } from "@/components/sound/amplifier-tool/rack-designer/nwm-import";
+import {
+  toAmpModel,
+  type NwmGroup,
+  type NwmUnit,
+} from "@/components/sound/amplifier-tool/rack-designer/nwm-import";
 import type { PowerTableRow } from "@/features/technical-tools/power/types";
 import type { ConsumosComponent } from "./config";
+import { buildMonitorPduRows, MONITOR_PDU_NAME } from "./monitorPduPreset";
 
-interface XmlpAmpUnit {
-  octet: number;
-  model: string;
-}
-
-interface XmlpAmpGroup {
-  name: string;
-  role: string;
-  members: number[];
-}
+type XmlpAmpUnit = Pick<NwmUnit, "octet" | "model">;
+type XmlpAmpGroup = Pick<NwmGroup, "name" | "role" | "members">;
 
 export interface XmlpAmpMap {
   units: XmlpAmpUnit[];
@@ -71,6 +68,9 @@ const tokenMatchesKeyword = (token: string, keyword: string) =>
   (keyword.length >= MIN_PARTIAL_TOKEN_LENGTH && token.startsWith(keyword));
 
 const PA_KEYWORDS = ["MAIN", "SUB", "OUT", "FRONT", "FILL"];
+const SIDE_KEYWORDS = ["SIDE", "MONITOR"];
+const PA_ALIASES = new Set(["PA", "FF", "OF"]);
+const SIDE_ALIASES = new Set(["SF"]);
 // Vowel-dropped shorthand that isn't a prefix of the full word, so it can't
 // be caught by tokenMatchesKeyword's prefix check.
 const DELAY_ALIASES = new Set(["DLY"]);
@@ -80,25 +80,40 @@ const DELAY_ALIASES = new Set(["DLY"]);
 // front/out fill.
 function classifySection(groupName: string): Section {
   const tokens = tokenize(groupName);
-  if (tokens.some((token) => tokenMatchesKeyword(token, "SIDE"))) return "SIDE";
+  if (
+    tokens.some(
+      (token) =>
+        SIDE_ALIASES.has(token) ||
+        SIDE_KEYWORDS.some((keyword) => tokenMatchesKeyword(token, keyword)),
+    )
+  ) {
+    return "SIDE";
+  }
   if (
     tokens.some((token) => tokenMatchesKeyword(token, "DELAY") || DELAY_ALIASES.has(token))
   ) {
     return "DELAY";
   }
-  if (tokens.some((token) => PA_KEYWORDS.some((keyword) => tokenMatchesKeyword(token, keyword)))) {
+  if (
+    tokens.some(
+      (token) =>
+        PA_ALIASES.has(token) ||
+        PA_KEYWORDS.some((keyword) => tokenMatchesKeyword(token, keyword)),
+    )
+  ) {
     return "PA";
   }
   return "OTHER";
 }
 
-// Reads the side off the group name's last token so "MAIN L", "MAIN LEFT"
-// and "MAIN-L" are all recognized the same way.
+// Reads a standalone side token anywhere in the group name so "MAIN L",
+// "LEFT MAIN" and "MAIN-L" are all recognized the same way.
 const sideFromName = (name: string): Side => {
   const tokens = tokenize(name);
-  const last = tokens[tokens.length - 1] ?? "";
-  if (last === "L" || last === "LEFT") return "L";
-  if (last === "R" || last === "RIGHT") return "R";
+  for (const token of [...tokens].reverse()) {
+    if (token === "L" || token === "LEFT") return "L";
+    if (token === "R" || token === "RIGHT") return "R";
+  }
   return "C";
 };
 
@@ -125,7 +140,10 @@ const countAmpsByComponent = (
   const counts = new Map<string, { component: ConsumosComponent; quantity: number }>();
   for (const unit of units) {
     const ampModel = toAmpModel(unit.model);
-    const component = findComponent(ampModel, components);
+    // The bundled planning catalog has no separate LA4 row. Reuse the LA4X
+    // planning entry so an older session never loses that amplifier entirely.
+    const catalogModel = ampModel === "LA4" ? "LA4X" : ampModel;
+    const component = findComponent(catalogModel, components);
     if (!component) {
       warnings.push(
         `Amplificador con modelo "${unit.model}" sin equivalencia en el catálogo de consumos; no se incluyó.`,
@@ -179,44 +197,65 @@ export function buildXmlpPowerTables(
   const sourceGroups = map.groups.filter((group) => group.role === "source");
 
   // First source group wins for amps that appear in multiple overlapping groups.
-  const assignedGroup = new Map<number, string>();
+  const assignedGroup = new Map<number, XmlpAmpGroup>();
   for (const group of sourceGroups) {
     for (const octet of group.members) {
       if (unitByOctet.has(octet) && !assignedGroup.has(octet)) {
-        assignedGroup.set(octet, group.name);
+        assignedGroup.set(octet, group);
       }
     }
   }
 
-  const unitsByGroup = new Map<string, XmlpAmpUnit[]>();
-  for (const [octet, groupName] of assignedGroup) {
-    const unit = unitByOctet.get(octet)!;
-    if (!unitsByGroup.has(groupName)) unitsByGroup.set(groupName, []);
-    unitsByGroup.get(groupName)!.push(unit);
+  // Category and side are not always repeated in a source group name. NM and
+  // some Soundvision projects instead expose parents such as "Main K2",
+  // "SUBS", "Outfill" and "Frontfill", plus separate LEFT/RIGHT membership.
+  // Index all non-source memberships so each amp can inherit that context.
+  const contextGroupsByOctet = new Map<number, XmlpAmpGroup[]>();
+  for (const group of map.groups) {
+    if (group.role === "source") continue;
+    for (const octet of group.members) {
+      if (!unitByOctet.has(octet)) continue;
+      const groups = contextGroupsByOctet.get(octet) ?? [];
+      groups.push(group);
+      contextGroupsByOctet.set(octet, groups);
+    }
   }
 
-  const paUnitsBySide: Record<"L" | "R", XmlpAmpUnit[]> = { L: [], R: [] };
+  const paUnitsBySide: Record<Side, XmlpAmpUnit[]> = { L: [], R: [], C: [] };
   const sidefillUnits: XmlpAmpUnit[] = [];
-  const delayGroups: Array<{ name: string; units: XmlpAmpUnit[] }> = [];
+  const delayGroups = new Map<string, XmlpAmpUnit[]>();
 
-  for (const [groupName, units] of unitsByGroup) {
-    const section = classifySection(groupName);
+  for (const [octet, sourceGroup] of assignedGroup) {
+    const unit = unitByOctet.get(octet)!;
+    const contextGroups = [...(contextGroupsByOctet.get(octet) ?? [])].sort(
+      (left, right) => left.members.length - right.members.length,
+    );
+    const directSection = classifySection(sourceGroup.name);
+    const section =
+      directSection === "OTHER"
+        ? contextGroups
+            .map((group) => classifySection(group.name))
+            .find((candidate) => candidate !== "OTHER") ?? "OTHER"
+        : directSection;
+    const directSide = sideFromName(sourceGroup.name);
+    const side =
+      directSide === "C"
+        ? contextGroups
+            .map((group) => sideFromName(group.name))
+            .find((candidate) => candidate !== "C") ?? "C"
+        : directSide;
+
     if (section === "PA") {
-      const side = sideFromName(groupName);
-      if (side === "C") {
-        warnings.push(
-          `No se pudo determinar el lado (L/R) del grupo "${groupName}"; no se importó.`,
-        );
-        continue;
-      }
-      paUnitsBySide[side].push(...units);
+      paUnitsBySide[side].push(unit);
     } else if (section === "SIDE") {
-      sidefillUnits.push(...units);
+      sidefillUnits.push(unit);
     } else if (section === "DELAY") {
-      delayGroups.push({ name: groupName, units });
+      const units = delayGroups.get(sourceGroup.name) ?? [];
+      units.push(unit);
+      delayGroups.set(sourceGroup.name, units);
     } else {
       warnings.push(
-        `Grupo "${groupName}" no coincide con mains/subs/outfills/frontfills/sidefill/delay; sus amplificadores no se incluyeron.`,
+        `Grupo "${sourceGroup.name}" no coincide con mains/subs/outfills/frontfills/sidefill/delay; sus amplificadores no se incluyeron.`,
       );
     }
   }
@@ -237,23 +276,33 @@ export function buildXmlpPowerTables(
     });
   });
 
-  if (sidefillUnits.length > 0) {
-    const rows = rowsFromCounts(countAmpsByComponent(sidefillUnits, components, warnings));
-    const extras: Array<[string, number]> = [
-      ["Control Mon (L)", 1],
-      ["RF Rack", 1],
-      ["Backline", 1],
-      ["Varios", 1],
-    ];
-    for (const [name, quantity] of extras) {
-      addExtraRow(rows, name, quantity, components, warnings, "Monitores");
-    }
+  const unsidedPaUnits = paUnitsBySide.C;
+  if (unsidedPaUnits.length > 0) {
+    const rows = rowsFromCounts(countAmpsByComponent(unsidedPaUnits, components, warnings));
+    addExtraRow(rows, "Varios", 1, components, warnings, "Main");
     if (rows.length > 0) {
-      tables.push({ name: "Monitores", rows, includesHoist: false });
+      tables.push({ name: "Main", rows, includesHoist: true });
+      warnings.push(
+        `No se pudo determinar el lado (L/R) de ${unsidedPaUnits.length} amplificador(es) de PA; se añadieron a "Main" sin posición.`,
+      );
     }
   }
 
-  for (const { name, units } of delayGroups) {
+  if (sidefillUnits.length > 0) {
+    const rows = rowsFromCounts(countAmpsByComponent(sidefillUnits, components, warnings));
+    const monitorRows = buildMonitorPduRows(components);
+    rows.push(...monitorRows.rows);
+    for (const componentName of monitorRows.missingComponents) {
+      warnings.push(
+        `No se encontró el componente "${componentName}" en el catálogo; no se añadió esa fila a ${MONITOR_PDU_NAME}.`,
+      );
+    }
+    if (rows.length > 0) {
+      tables.push({ name: MONITOR_PDU_NAME, rows, includesHoist: false });
+    }
+  }
+
+  for (const [name, units] of delayGroups) {
     const rows = rowsFromCounts(countAmpsByComponent(units, components, warnings));
     addExtraRow(rows, "Varios", 1, components, warnings, `"${name}"`);
     if (rows.length === 0) continue;

--- a/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
+++ b/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
@@ -45,20 +45,62 @@ const findComponent = (name: string, components: ConsumosComponent[]) => {
   return components.find((component) => normalizeName(component.name) === normalized);
 };
 
-const sideFromName = (name: string): Side => {
-  const last = name.trim().slice(-1).toUpperCase();
-  return last === "L" ? "L" : last === "R" ? "R" : "C";
-};
+// Session-file group names come straight from whoever built the Soundvision
+// project, so they show up in every case (SIDE, Side, side), split on spaces,
+// hyphens or underscores, and are often abbreviated or truncated (SIDE for
+// "sidefill", DLY/DEL for "delay"). Tokenizing on word boundaries \u2014 rather
+// than searching the whole raw string \u2014 keeps a compound name like
+// "SIDEFILL" from matching the PA keyword "FILL" out of position.
+const tokenize = (name: string): string[] =>
+  name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toUpperCase()
+    .split(/[^A-Z0-9]+/)
+    .filter(Boolean);
 
-// SIDE is checked before the generic PA pattern so "SIDEFILL" (which also
-// contains "FILL") is not misclassified as a front/out fill.
+const MIN_PARTIAL_TOKEN_LENGTH = 3;
+
+// True when `token` is the keyword itself, a truncated prefix of it (e.g.
+// "SID" or "DEL" for "DELAY"), or the keyword is a prefix of a compound token
+// (e.g. "SIDEFILL", "OUTFILL"). The length guard keeps short side/number
+// tokens ("L", "R", "1") from spuriously prefix-matching a keyword.
+const tokenMatchesKeyword = (token: string, keyword: string) =>
+  token === keyword ||
+  (token.length >= MIN_PARTIAL_TOKEN_LENGTH && keyword.startsWith(token)) ||
+  (keyword.length >= MIN_PARTIAL_TOKEN_LENGTH && token.startsWith(keyword));
+
+const PA_KEYWORDS = ["MAIN", "SUB", "OUT", "FRONT", "FILL"];
+// Vowel-dropped shorthand that isn't a prefix of the full word, so it can't
+// be caught by tokenMatchesKeyword's prefix check.
+const DELAY_ALIASES = new Set(["DLY"]);
+
+// SIDE and DELAY are checked before the generic PA pattern so "SIDEFILL"
+// (which also starts a compound containing "FILL") is not misclassified as a
+// front/out fill.
 function classifySection(groupName: string): Section {
-  const normalized = normalizeName(groupName);
-  if (/SIDE/.test(normalized)) return "SIDE";
-  if (/DELAY/.test(normalized)) return "DELAY";
-  if (/MAIN|SUB|OUT|FRONT|FILL/.test(normalized)) return "PA";
+  const tokens = tokenize(groupName);
+  if (tokens.some((token) => tokenMatchesKeyword(token, "SIDE"))) return "SIDE";
+  if (
+    tokens.some((token) => tokenMatchesKeyword(token, "DELAY") || DELAY_ALIASES.has(token))
+  ) {
+    return "DELAY";
+  }
+  if (tokens.some((token) => PA_KEYWORDS.some((keyword) => tokenMatchesKeyword(token, keyword)))) {
+    return "PA";
+  }
   return "OTHER";
 }
+
+// Reads the side off the group name's last token so "MAIN L", "MAIN LEFT"
+// and "MAIN-L" are all recognized the same way.
+const sideFromName = (name: string): Side => {
+  const tokens = tokenize(name);
+  const last = tokens[tokens.length - 1] ?? "";
+  if (last === "L" || last === "LEFT") return "L";
+  if (last === "R" || last === "RIGHT") return "R";
+  return "C";
+};
 
 const appendRow = (rows: PowerTableRow[], component: ConsumosComponent, quantity: number) => {
   rows.push({
@@ -69,6 +111,12 @@ const appendRow = (rows: PowerTableRow[], component: ConsumosComponent, quantity
   });
 };
 
+// Counts amplifier hardware units (LA12X, LA8, …) driving each PDU — never
+// the loudspeaker enclosures/boxes those amps power. `unit.model` comes from
+// the amp channel's own `<model>` tag in the session file (parseXmlpXml
+// defaults it to "LA12X" when that tag is absent, since that's virtually
+// always the true amp on a modern K/Kara/KS session), not from the box/preset
+// name a channel happens to be driving.
 const countAmpsByComponent = (
   units: XmlpAmpUnit[],
   components: ConsumosComponent[],

--- a/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
+++ b/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
@@ -167,8 +167,8 @@ const addExtraRow = (
  * Builds Consumos PDU tables from an imported Soundvision `.xmlp` amplifier
  * map. Mains/subs/outfills/front fills are merged by side into "Main L" /
  * "Main R" PDUs (hoist power required); sidefill amps are merged into a
- * single stage PDU with the usual monitor-world extras; each delay group
- * keeps its own PDU, exactly as named in the session file.
+ * single "Monitores" stage PDU with the usual monitor-world extras; each
+ * delay group keeps its own PDU, exactly as named in the session file.
  */
 export function buildXmlpPowerTables(
   map: XmlpAmpMap,
@@ -246,10 +246,10 @@ export function buildXmlpPowerTables(
       ["Varios", 1],
     ];
     for (const [name, quantity] of extras) {
-      addExtraRow(rows, name, quantity, components, warnings, "Sidefill");
+      addExtraRow(rows, name, quantity, components, warnings, "Monitores");
     }
     if (rows.length > 0) {
-      tables.push({ name: "Sidefill", rows, includesHoist: false });
+      tables.push({ name: "Monitores", rows, includesHoist: false });
     }
   }
 

--- a/src/features/technical-tools/weights/XmlpWeightImportButton.tsx
+++ b/src/features/technical-tools/weights/XmlpWeightImportButton.tsx
@@ -6,11 +6,13 @@ import { Button } from '@/components/ui/button';
 interface XmlpWeightImportButtonProps {
   isImporting: boolean;
   onImport: (file: File) => void;
+  title?: string;
 }
 
 export function XmlpWeightImportButton({
   isImporting,
   onImport,
+  title = 'Crear requisitos de peso desde un proyecto Soundvision (.xmlp)',
 }: XmlpWeightImportButtonProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -34,7 +36,7 @@ export function XmlpWeightImportButton({
         className="gap-2"
         disabled={isImporting}
         onClick={() => inputRef.current?.click()}
-        title="Crear requisitos de peso desde un proyecto Soundvision (.xmlp)"
+        title={title}
       >
         <FileInput className="h-4 w-4" />
         {isImporting ? 'Extrayendo XMLP…' : 'Extraer de XMLP'}

--- a/src/features/technical-tools/weights/__tests__/XmlpWeightImportButton.test.tsx
+++ b/src/features/technical-tools/weights/__tests__/XmlpWeightImportButton.test.tsx
@@ -20,4 +20,19 @@ describe('XmlpWeightImportButton', () => {
     rerender(<XmlpWeightImportButton isImporting onImport={onImport} />);
     expect(screen.getByRole('button', { name: 'Extrayendo XMLP…' })).toBeDisabled();
   });
+
+  it('allows power importers to supply context-specific help text', () => {
+    render(
+      <XmlpWeightImportButton
+        isImporting={false}
+        onImport={() => undefined}
+        title="Crear tablas de potencia desde un proyecto Soundvision (.xmlp)"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Extraer de XMLP' })).toHaveAttribute(
+      'title',
+      'Crear tablas de potencia desde un proyecto Soundvision (.xmlp)',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Import Soundvision/XMLP amplifier power requirements into sound Consumos tables.
- Classify varied group naming such as `Main K2`, `SUBS`, `Outfill`, `Frontfill`, LEFT/RIGHT membership, and common PA/fill/sidefill/delay abbreviations.
- Preserve unsided PA amplifiers in an unpositioned `Main` PDU instead of dropping them.
- Preserve legacy LA4 units through the existing LA4X planning-catalog entry.
- Add a one-click, unpositioned `Monitores` PDU with 1× Control Mon (L), 1× RF Rack, 1× Backline, and 1× Varios.
- Give the shared XMLP import button context-correct power/weight help text.

## Why

Soundvision project hierarchies and group labels vary between files. The importer needs to use both source-group names and parent/side membership so valid amplifier consumption is not silently omitted. Monitor-world power also needs a repeatable starter PDU when no sidefill group is present.

## Risk

**Standard risk.** The change is limited to the sound power-calculator UI and pure XMLP-to-table mapping. It does not modify money calculations, authorization, Supabase schema/RLS, Edge Functions, or persisted data formats.

## Impact

- [x] User-facing sound Consumos UI
- [x] XMLP parser/mapping behavior
- [ ] Database migration
- [ ] Supabase authorization/RLS
- [ ] Edge Function exposure
- [ ] Financial calculations

## Validation

- `npm run lint` — pass (0 errors; existing warnings remain below governance baseline)
- `npm run typecheck` — pass
- `npm run governance` — pass
- `npm run test:critical` — pass (22 files / 106 tests; coverage gate 5 files / 29 tests)
- `npm run test:run` — pass (272 files / 1,517 tests)
- Focused XMLP/preset/tooltip suite — pass (3 files / 21 tests)
- `npm run build` — pass
- `npm run budget:bundle` — pass
- Local Vite smoke test — HTTP 200 at `http://localhost:8080/`; unauthenticated protected route redirects to `/auth` with no browser console errors

## Rollback

Revert the PR merge commit. No data rollback or cleanup is required.

## Database / deployment

No migration and no production Supabase push are required. Merging to `main` follows the normal production deploy path.