### PR TITLE
feat(sound): export Soundvision XMLP packages to job Flex documents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Detailed documentation for each major subsystem — key files, database tables, 
 - **[SoundVision Files](workflows/soundvision-files.md)** — File library with access request and review workflow
 - **[Technical PDF Sync](technical-pdf-sync.md)** — How generated technical PDFs (consumos, pesos, memorias, SV reports) stay in sync for jobs and tour dates; required triggers when adding generators/mutations
 - **[Consumos power calculations](technical-tools/power-calculations.md)** — canonical equations, assumptions, validation, PDU planning policy, persisted snapshots, report aggregation, and engineering limitations
+- **[Soundvision XMLP → Flex package](architecture/xmlp-flex-export.md)** — parse-once ownership, shared Pesos/Consumos derivation, exact equipment mapping, Pull Sheet/Presupuesto preview, and strict grouped writes
 
 
 ## Festival architecture (section-specific)

--- a/docs/architecture/xmlp-flex-export.md
+++ b/docs/architecture/xmlp-flex-export.md
@@ -1,0 +1,126 @@
+# Soundvision XMLP → Flex equipment package
+
+## Data flow and ownership
+
+```text
+Sound job-card XMLP action
+  ↓ transient parse-la-session Edge Function
+normalized NwmMap (React memory only)
+  ├─ Pesos tables + structured motors
+  ├─ Consumos tables + structured PDUs
+  └─ pure XMLP Flex export planner
+       ↓ exact equipment/resource resolution
+     inspectable selection preview
+       ↓ strict grouped writer
+     Pull Sheet or Presupuesto
+
+Separate NM/SV designer
+  ↓ same parse-la-session boundary
+rack layout + flysheet PDF (no Flex export action)
+```
+
+`parse-la-session` remains the only XMLP decryption/parser boundary. The browser keeps the normalized result only for the mounted rack-designer workflow. Raw uploads, decrypted XML, keys, and the complete normalized project are not written to localStorage or Supabase by this feature.
+
+The full package action is owned by the Sound tab's job-card actions in Project Management. It is rendered only for the `sound` department and passes that card's `job.id` into the workflow, so document discovery is scoped to the selected job. Clicking it opens a dedicated XMLP-only import screen and then the package review; it never mounts the NM/SV rack designer. The standalone Sound rack designer retains NM/SV layout and flysheet functions but does not expose Flex export.
+
+Within the job-scoped workflow, the full package action requires an imported XMLP with flysheet data. NWM continues to support rack-layout import but does not enable the package action.
+
+## Pure plan
+
+`src/features/technical-tools/flex/xmlpFlexExportPlan.ts` accepts a normalized `NwmMap` plus current `equipment` rows. It has no React, Supabase-query, or Flex-write dependency. Every candidate retains:
+
+- canonical identity and requested quantity;
+- destination group;
+- explicit or derived provenance;
+- source arrays/power tables;
+- resolved `equipment` row and `resource_id`;
+- mapped, missing-resource, missing-equipment, or ambiguous state;
+- safety warnings.
+
+Aggregation is `flexCategoryKey + resource_id`. The same resource may therefore remain separate in mains and outfill, while left/right instances within one subsystem merge.
+
+## Array classification
+
+`parse-la-session` preserves the closest named Soundvision ancestor for every cluster, including groups nested multiple levels below a broad `ALL` physical configuration. Classification is case-insensitive and conservative: the explicit Soundvision group is authoritative, followed by an explicit array-name category, known subwoofer/full-range models, and safe sided-model fallbacks. The common phrase `Copy of …` is not interpreted as the abbreviation `OF`. It recognizes mains, downfill, outfill/sidefill, subwoofers, frontfill, and delays. Unknown arrays are displayed under “Arrays sin clasificar” and cannot be pushed. Mixed subwoofer/full-range arrays receive a warning. Preview source labels show both group and array so the classification input remains inspectable.
+
+Group order is deterministic:
+
+1. `pa_mains`
+2. `pa_downfill`
+3. `pa_outfill`
+4. `pa_subs`
+5. `pa_frontfill`
+6. `pa_delays`
+7. `pa_amp`
+
+The group resource IDs remain owned by `FLEX_CATEGORY_MAP` in `src/services/flexPullsheets.ts`.
+
+## Shared technical derivation
+
+Rigging aliases and serialized bumper-piece quantities are owned by `xmlpRiggingRequirements.ts`. Both Pesos and Flex consume `resolveXmlpRiggingRequirement`; `2x K2-BAR`, for example, produces two BUMPER K2 requirements in both paths. Before Flex resolution, bumper pieces are aggregated per destination group and converted to the real physical cases:
+
+- K1: one dual case per pair, plus one single case for an odd remainder;
+- K2 and KARA: one dual case per two bumpers, rounded up for an odd remainder;
+- K3, KIVA, KS28, and supported TFS bumpers remain individual resources.
+
+Motor selection remains inside `buildXmlpWeightTables`:
+
+- flown arrays only;
+- existing pickup-point interpretation;
+- 120% required-capacity rule;
+- no fallback to an undersized motor;
+- structured requirements returned alongside Pesos tables.
+
+PDU selection remains inside the Consumos path. `buildCalculatedXmlpPowerRequirements` uses the Sound component catalog, 20% safety margin, 0.95 power factor, three-phase 400 V settings, existing PDU options, and the 80% planning-load recommendation. Flex consumes only its structured PDU result; XMLP amplifier units remain the only source of amplifier equipment lines.
+
+Compatible LA4/LA4X/LA8/LA12X units share one container-only packaging calculation:
+
+```ts
+laRackQuantity = Math.floor(compatibleAmplifierCount / 3)
+laCaseQuantity = compatibleAmplifierCount % 3
+```
+
+The compatible individual amplifier lines are not also exported, preventing double counting. PLM and other non-compatible units remain individual lines and do not contribute to LA-RAK II/LA-CASE packaging. Thus 20 LA12X becomes exactly 6 LA-RAK II plus 2 LA-CASE.
+
+## Equipment resolution
+
+The database source of truth is `public.equipment.resource_id`. The planner uses exact normalized aliases plus approved departments/categories; it never uses unrestricted substring matching. A resource ID assigned to different canonical identities is treated as ambiguous even when both rows are otherwise valid.
+
+The mapping migration adds the explicitly approved audit resources for K1-SB, rigging packages, LA-CASE II, sound PDUs, and the chosen 2T D8+ motor. K1 dual/single cases are selected deterministically from the bumper count, so their two approved resources are not an ambiguity. Remaining known gaps/ambiguities are visible in preview:
+
+- no approved IDs: LA4, LA4X, LA8, CEE16 sound PDU, and supported TFS speakers/rigging;
+- KS28 and BUMPER KS28: the migration corrects the legacy speaker/BUMP collision first, assigning the real KS28 speaker resource (`acbd4200-4fa3-11eb-815f-2a0a4490a7fb`) to the speaker and the former ID to `KS28 BUMP`; guarded assertions abort the migration if either ID belongs to unrelated equipment;
+- unknown XMLP models and arrays remain disabled rather than defaulting to mains.
+
+## Destination discovery and writes
+
+Job discovery includes only:
+
+- `pull_sheet` → Pull Sheet;
+- `comercial_presupuesto` → Presupuesto;
+- `dryhire_presupuesto` → Presupuesto.
+
+The `presupuestos_recibidos` container and unrelated financial documents are excluded. A pasted `#equipment-list` or `#fin-doc` URL identifies its type; generic URLs require the operator to select Pull Sheet or Presupuesto explicitly.
+
+If the job has no usable destination, “Crear documento Flex” delegates to the job card's existing create/add-folder selector instead of inventing a second folder-creation path. After that flow finishes, “Actualizar documentos” re-runs job-scoped discovery and auto-selects the new document when it is the only result.
+
+Transports are:
+
+- Pull Sheet: `/line-item/{document}/add-resource/{resource}`;
+- Presupuesto: `/financial-document-line-item/{document}/add-resource/{resource}`.
+
+For each selected non-empty group, the strict writer creates its header and captures the returned line-item ID before adding children with `parentLineItemId`. If the header fails, every child in that group is skipped and reported; children never fall back to the root. Other groups continue independently.
+
+## Duplicate behavior and security
+
+There is no reliable generic reader for existing Flex resource quantities and parent nesting. The operation is therefore additive and requires explicit confirmation. It does not reduce, delete, move, or claim to reconcile existing lines.
+
+All Flex requests continue through `flexApiFetch` and the authenticated `secure-flex-api` Edge Function. No Flex credential or new secret is exposed to browser code. The parser entitlement and existing server-side Flex authorization remain unchanged.
+
+## Deployment and rollback
+
+The migration must be reviewed and applied by a human with the normal production `supabase db push --linked --dry-run` and migration workflow. Changes to nested Soundvision group extraction require redeploying `parse-la-session`; no other Edge Function changes are involved.
+
+Application rollback: revert the feature PR. This removes the preview and writer without affecting previously created Flex lines; any already-added Flex lines require manual Flex cleanup.
+
+Mapping rollback, if the migration was applied: delete only the exact `equipment` rows introduced by `20260720230000_add_xmlp_flex_equipment_resources.sql`, matching both name and `resource_id`. The migration also corrects a pre-existing KS28 speaker row; reversing that correction requires deleting the exact `KS28 BUMP` row first and restoring the speaker's former ID in a reviewed forward migration. Do not delete pre-existing equipment rows. Applied Supabase migrations are not rolled back by rewriting migration history.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@capacitor/android": "^8.0.0",
-        "@capacitor/cli": "^8.0.0",
+        "@capacitor/cli": "^8.4.2",
         "@capacitor/core": "^8.0.0",
         "@capacitor/ios": "^8.0.0",
         "@capacitor/push-notifications": "^8.0.0",
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/@capacitor/assets/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -675,9 +675,9 @@
       }
     },
     "node_modules/@capacitor/cli": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.4.1.tgz",
-      "integrity": "sha512-t7F2s7fFHCq113xgrggrmK6ctV0/8E5YfLNVLfPHp4GCTDO+tly9fZvWPf2/sOI8lMm18dLT43qbXLRTz/OZgw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.4.2.tgz",
+      "integrity": "sha512-hE4HmpMdr5T8eQ++kGa1BKkdG2JLEvo1y1cj1kmFK78VB9dBp538oe1EZvzwupNGOl0ZueALotzL5wcXRD9w1Q==",
       "license": "MIT",
       "dependencies": {
         "@ionic/cli-framework-output": "^2.2.8",
@@ -5741,9 +5741,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6632,9 +6632,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -13677,9 +13677,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -14278,9 +14278,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -15133,9 +15133,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -15279,9 +15279,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15321,9 +15321,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.0.0",
-    "@capacitor/cli": "^8.0.0",
+    "@capacitor/cli": "^8.4.2",
     "@capacitor/core": "^8.0.0",
     "@capacitor/ios": "^8.0.0",
     "@capacitor/push-notifications": "^8.0.0",

--- a/scripts/governance/dependency-audit-baseline.json
+++ b/scripts/governance/dependency-audit-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-07-01T21:13:42Z",
+  "generatedAt": "2026-07-20T00:00:00Z",
   "note": "Current npm audit advisories are grandfathered only with an owner and non-expired review date. CI fails on new advisory IDs, increased severity counts, expired exceptions, or production high/critical vulnerabilities.",
   "advisoryIds": [
     "1112659",
@@ -14,7 +14,11 @@
     "1114680",
     "1116451",
     "1119441",
-    "1120782"
+    "1120782",
+    "1123939",
+    "1123940",
+    "1123941",
+    "1123942"
   ],
   "exceptions": [
     {
@@ -100,6 +104,34 @@
       "owner": "platform-security",
       "reviewBy": "2026-09-30",
       "rationale": "This is pulled through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x. @capacitor/assets is already at its latest release and npm audit reports no fixAvailable path for that nested CLI; remove this exception when @capacitor/assets publishes a compatible release that no longer depends on the vulnerable tar range."
+    },
+    {
+      "advisoryId": "1123939",
+      "package": "tar",
+      "owner": "platform-security",
+      "reviewBy": "2026-09-30",
+      "rationale": "This remains only in local/build tooling through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar 6.2.1. The production @capacitor/cli path was upgraded to tar 7.5.20; @capacitor/assets is already at its latest release and has no compatible fix, so remove this exception when its nested CLI is updated."
+    },
+    {
+      "advisoryId": "1123940",
+      "package": "tar",
+      "owner": "platform-security",
+      "reviewBy": "2026-09-30",
+      "rationale": "This remains only in local/build tooling through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar 6.2.1. The production @capacitor/cli path was upgraded to tar 7.5.20; @capacitor/assets is already at its latest release and has no compatible fix, so remove this exception when its nested CLI is updated."
+    },
+    {
+      "advisoryId": "1123941",
+      "package": "tar",
+      "owner": "platform-security",
+      "reviewBy": "2026-09-30",
+      "rationale": "This remains only in local/build tooling through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar 6.2.1. The production @capacitor/cli path was upgraded to tar 7.5.20; @capacitor/assets is already at its latest release and has no compatible fix, so remove this exception when its nested CLI is updated."
+    },
+    {
+      "advisoryId": "1123942",
+      "package": "tar",
+      "owner": "platform-security",
+      "reviewBy": "2026-09-30",
+      "rationale": "This remains only in local/build tooling through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar 6.2.1. The production @capacitor/cli path was upgraded to tar 7.5.20; @capacitor/assets is already at its latest release and has no compatible fix, so remove this exception when its nested CLI is updated."
     }
   ],
   "vulnerabilityCounts": {
@@ -107,7 +139,7 @@
     "low": 1,
     "moderate": 3,
     "high": 6,
-    "critical": 0
+    "critical": 1
   },
   "total": 10
 }

--- a/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
+++ b/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
@@ -20,6 +20,7 @@ const {
   loadTechnicalPowerSummaryDataMock,
   fetchJobLogoMock,
   dataLayerFunctionsInvokeMock,
+  useIsMobileMock,
   useQueryMock,
   jobDepartmentsQueryState,
   technicalPowerSummaryQueryState,
@@ -34,6 +35,7 @@ const {
   loadTechnicalPowerSummaryDataMock: vi.fn(),
   fetchJobLogoMock: vi.fn(),
   dataLayerFunctionsInvokeMock: vi.fn(),
+  useIsMobileMock: vi.fn(() => false),
   useQueryMock: vi.fn(),
   jobDepartmentsQueryState: {
     data: ['sound', 'lights', 'video'] as any,
@@ -143,7 +145,7 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('@/hooks/use-mobile', () => ({
-  useIsMobile: () => false,
+  useIsMobile: useIsMobileMock,
 }));
 
 vi.mock('@/hooks/useOptimizedAuth', () => ({
@@ -259,6 +261,7 @@ describe('JobCardActions', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useIsMobileMock.mockReturnValue(false);
     supabaseFromMock.mockImplementation((table: string) => {
       if (table === 'job_departments') {
         return createSupabaseBuilder({
@@ -362,6 +365,38 @@ describe('JobCardActions', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('Sound XMLP Flex job action', () => {
+    it('renders only on the Sound department job card', () => {
+      const { rerender } = render(<JobCardActions {...defaultProps} department="sound" />);
+
+      expect(screen.getByRole('button', { name: 'XMLP → Flex' })).toBeInTheDocument();
+
+      rerender(<JobCardActions {...defaultProps} department="lights" />);
+      expect(screen.queryByRole('button', { name: 'XMLP → Flex' })).not.toBeInTheDocument();
+
+      rerender(<JobCardActions {...defaultProps} department="video" />);
+      expect(screen.queryByRole('button', { name: 'XMLP → Flex' })).not.toBeInTheDocument();
+    });
+
+    it('opens the dedicated XMLP import workflow', async () => {
+      render(<JobCardActions {...defaultProps} department="sound" />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'XMLP → Flex' }));
+
+      expect(await screen.findByRole('heading', { name: 'Importar XMLP de Soundvision' })).toBeInTheDocument();
+      expect(screen.getByText(/elegir su Presupuesto o Pull Sheet/)).toBeInTheDocument();
+      expect(screen.queryByText(/Diseñador NM\/SV/)).not.toBeInTheDocument();
+    });
+
+    it('remains available on the mobile Sound job card', () => {
+      useIsMobileMock.mockReturnValue(true);
+
+      render(<JobCardActions {...defaultProps} department="sound" />);
+
+      expect(screen.getByRole('button', { name: 'XMLP → Flex' })).toBeInTheDocument();
+    });
   });
 
   describe('Open Flex button', () => {

--- a/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
+++ b/src/components/jobs/cards/job-card-actions/JobCardActionButtons.tsx
@@ -27,6 +27,7 @@ import { BackfillDocTecnicaAction } from "@/components/jobs/cards/job-card-actio
 import { MobileJobCardActions } from "@/components/jobs/cards/job-card-actions/MobileJobCardActions";
 import { MotorCertificateAction } from "@/components/jobs/cards/job-card-actions/MotorCertificateAction";
 import { PrintFlexReportAction } from "@/components/jobs/cards/job-card-actions/PrintFlexReportAction";
+import { SoundvisionXmlpFlexJobAction } from "@/components/jobs/cards/job-card-actions/SoundvisionXmlpFlexJobAction";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -402,6 +403,14 @@ export const JobCardActionButtons = (props: JobCardActionButtonsProps) => {
           </Button>
         )}
       </>
+    )}
+    {department === "sound" && isProjectManagementPage && isManagementUser && allowedJobType && job.job_type !== "dryhire" && (
+      <SoundvisionXmlpFlexJobAction
+        jobId={job.id}
+        jobName={job.job_name ?? job.name ?? job.title}
+        tourId={job.tour_id ?? job.tour?.id}
+        onCreateFlexTarget={canCreateFlexFolders ? onCreateFlexFolders : undefined}
+      />
     )}
     {flexReportDepartment && isProjectManagementPage && isManagementUser && (
       <>

--- a/src/components/jobs/cards/job-card-actions/MobileJobCardActions.tsx
+++ b/src/components/jobs/cards/job-card-actions/MobileJobCardActions.tsx
@@ -26,6 +26,7 @@ import { ArchiveToFlexAction } from "@/components/jobs/cards/job-card-actions/Ar
 import { BackfillDocTecnicaAction } from "@/components/jobs/cards/job-card-actions/BackfillDocTecnicaAction";
 import { MotorCertificateAction } from "@/components/jobs/cards/job-card-actions/MotorCertificateAction";
 import { PrintFlexReportAction } from "@/components/jobs/cards/job-card-actions/PrintFlexReportAction";
+import { SoundvisionXmlpFlexJobAction } from "@/components/jobs/cards/job-card-actions/SoundvisionXmlpFlexJobAction";
 import type {
   JobCardActionButtonsProps,
   JobCardActionsProps,
@@ -309,6 +310,14 @@ export const MobileJobCardActions = (props: JobCardActionButtonsProps) => {
         <Button variant="outline" size="sm" onClick={onJobDetailsClick} className="gap-2">
           <Info className="h-4 w-4" /> Detalles
         </Button>
+      )}
+      {department === "sound" && isManagementUser && allowedJobType && job.job_type !== "dryhire" && (
+        <SoundvisionXmlpFlexJobAction
+          jobId={job.id}
+          jobName={job.job_name ?? job.name ?? job.title}
+          tourId={job.tour_id ?? job.tour?.id}
+          onCreateFlexTarget={canCreateFlexFolders ? onCreateFlexFolders : undefined}
+        />
       )}
       <MobileActionSheet
         title="Más acciones"

--- a/src/components/jobs/cards/job-card-actions/SoundvisionXmlpFlexJobAction.tsx
+++ b/src/components/jobs/cards/job-card-actions/SoundvisionXmlpFlexJobAction.tsx
@@ -1,0 +1,164 @@
+import { useRef, useState, type ChangeEvent, type MouseEventHandler } from 'react';
+import { FileUp, Loader2, Send } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useToast } from '@/hooks/use-toast';
+import {
+  canExportCompleteXmlpPackage,
+  createImportedLaSession,
+  type ImportedLaSession,
+} from '@/components/sound/amplifier-tool/rack-designer/importedLaSession';
+import { parseLaSessionFile } from '@/components/sound/amplifier-tool/rack-designer/parse-session-file';
+import { XmlpFlexExportDialog } from '@/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog';
+
+interface SoundvisionXmlpFlexJobActionProps {
+  jobId: string;
+  jobName?: string | null;
+  tourId?: string | null;
+  onCreateFlexTarget?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export function SoundvisionXmlpFlexJobAction({
+  jobId,
+  jobName,
+  tourId,
+  onCreateFlexTarget,
+}: SoundvisionXmlpFlexJobActionProps) {
+  const { toast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [importOpen, setImportOpen] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [isParsing, setIsParsing] = useState(false);
+  const [session, setSession] = useState<ImportedLaSession | null>(null);
+
+  const resetFileInput = () => {
+    if (inputRef.current) inputRef.current.value = '';
+  };
+
+  const handleFile = async (file: File) => {
+    if (isParsing) return;
+    if (!file.name.toLowerCase().endsWith('.xmlp')) {
+      toast({
+        title: 'Archivo no compatible',
+        description: 'Selecciona un proyecto Soundvision con extensión .xmlp.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsParsing(true);
+    try {
+      const map = await parseLaSessionFile(file);
+      const imported = createImportedLaSession(file.name, map, {
+        jobId,
+        tourId: tourId ?? undefined,
+        storageScope: `xmlp-flex-job:${jobId}`,
+      });
+      if (!canExportCompleteXmlpPackage(imported)) {
+        throw new Error('El XMLP no contiene arrays de Soundvision exportables.');
+      }
+      setSession(imported);
+      setImportOpen(false);
+      setReviewOpen(true);
+    } catch (error) {
+      toast({
+        title: 'No se pudo leer el XMLP',
+        description: error instanceof Error ? error.message : 'El proyecto no se pudo procesar.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsParsing(false);
+      resetFileInput();
+    }
+  };
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) void handleFile(file);
+  };
+
+  const handleReviewOpenChange = (open: boolean) => {
+    setReviewOpen(open);
+    if (!open) setSession(null);
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="gap-2"
+        onClick={(event) => {
+          event.stopPropagation();
+          setImportOpen(true);
+        }}
+        title="Importar un XMLP y enviar el paquete técnico al Flex de este trabajo"
+      >
+        <Send className="h-4 w-4" />
+        <span className="hidden sm:inline">XMLP → Flex</span>
+      </Button>
+
+      <Dialog open={importOpen} onOpenChange={setImportOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Importar XMLP de Soundvision</DialogTitle>
+            <DialogDescription>
+              Selecciona el proyecto de {jobName || 'este trabajo'}. Se analizará una vez y después podrás revisar el paquete y elegir su Presupuesto o Pull Sheet.
+            </DialogDescription>
+          </DialogHeader>
+
+          <input
+            ref={inputRef}
+            type="file"
+            accept=".xmlp"
+            className="sr-only"
+            aria-label="Seleccionar XMLP de Soundvision"
+            onChange={handleInputChange}
+          />
+          <button
+            type="button"
+            className="flex min-h-48 w-full flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-6 text-center transition-colors hover:border-primary hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={isParsing}
+            onClick={() => inputRef.current?.click()}
+          >
+            {isParsing ? (
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            ) : (
+              <FileUp className="h-8 w-8 text-primary" />
+            )}
+            <span className="font-medium">
+              {isParsing ? 'Analizando proyecto…' : 'Seleccionar archivo .xmlp'}
+            </span>
+            <span className="text-sm text-muted-foreground">
+              El archivo y su XML descifrado no se guardarán en Supabase ni en el navegador.
+            </span>
+          </button>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setImportOpen(false)} disabled={isParsing}>
+              Cancelar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {session && (
+        <XmlpFlexExportDialog
+          open={reviewOpen}
+          onOpenChange={handleReviewOpenChange}
+          session={session}
+          onCreateFlexTarget={onCreateFlexTarget}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/jobs/cards/job-card-actions/__tests__/SoundvisionXmlpFlexJobAction.test.tsx
+++ b/src/components/jobs/cards/job-card-actions/__tests__/SoundvisionXmlpFlexJobAction.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { MouseEventHandler } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NwmMap } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+
+const { parseMock, reviewPropsMock, toastMock } = vi.hoisted(() => ({
+  parseMock: vi.fn(),
+  reviewPropsMock: vi.fn(),
+  toastMock: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastMock }) }));
+vi.mock('@/components/sound/amplifier-tool/rack-designer/parse-session-file', () => ({
+  parseLaSessionFile: parseMock,
+}));
+vi.mock('@/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog', () => ({
+  XmlpFlexExportDialog: (props: {
+    open: boolean;
+    session: { sourceFileName: string; jobId?: string };
+    onCreateFlexTarget?: MouseEventHandler<HTMLButtonElement>;
+  }) => {
+    reviewPropsMock(props);
+    return props.open ? (
+      <div data-testid="xmlp-review">
+        {props.session.sourceFileName} · {props.session.jobId}
+        <button type="button" onClick={props.onCreateFlexTarget}>Crear documento Flex</button>
+      </div>
+    ) : null;
+  },
+}));
+
+import { SoundvisionXmlpFlexJobAction } from '../SoundvisionXmlpFlexJobAction';
+
+const parsedMap: NwmMap = {
+  sessionName: 'Demo',
+  units: [],
+  groups: [],
+  flysheet: {
+    projectName: 'Demo',
+    arrays: [{
+      groupName: 'PA',
+      arrayName: 'MAIN L',
+      deployment: 'stacked',
+      azimuthDegrees: null,
+      topSiteDegrees: null,
+      bottomSiteDegrees: null,
+      topHeightMeters: null,
+      bottomHeightMeters: null,
+      riggingFrame: '',
+      flyingBarSetting: '',
+      pickupConfiguration: '',
+      totalMassKg: null,
+      frontLoadKg: null,
+      rearLoadKg: null,
+      enclosures: [{
+        model: 'K2',
+        splayAngleDegrees: null,
+        siteAngleDegrees: null,
+        trimHeightMeters: null,
+        dispersionSetting: null,
+      }],
+      warnings: [],
+    }],
+  },
+};
+
+describe('SoundvisionXmlpFlexJobAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    parseMock.mockResolvedValue(parsedMap);
+  });
+
+  it('parses one XMLP and opens the job-scoped review without the NM designer', async () => {
+    const onCreateFlexTarget = vi.fn();
+    render(
+      <SoundvisionXmlpFlexJobAction
+        jobId="job-123"
+        jobName="Festival Demo"
+        onCreateFlexTarget={onCreateFlexTarget}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'XMLP → Flex' }));
+    expect(screen.getByRole('heading', { name: 'Importar XMLP de Soundvision' })).toBeInTheDocument();
+    expect(screen.queryByText(/Diseñador NM\/SV/)).not.toBeInTheDocument();
+
+    const file = new File(['soundvision'], 'festival.xmlp', { type: 'application/octet-stream' });
+    fireEvent.change(screen.getByLabelText('Seleccionar XMLP de Soundvision'), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => expect(parseMock).toHaveBeenCalledWith(file));
+    expect(await screen.findByTestId('xmlp-review')).toHaveTextContent('festival.xmlp · job-123');
+    expect(reviewPropsMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      session: expect.objectContaining({ jobId: 'job-123', sourceType: 'xmlp' }),
+      onCreateFlexTarget,
+    }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Crear documento Flex' }));
+    expect(onCreateFlexTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects NWM files before invoking the parser', () => {
+    render(<SoundvisionXmlpFlexJobAction jobId="job-123" />);
+    fireEvent.click(screen.getByRole('button', { name: 'XMLP → Flex' }));
+    fireEvent.change(screen.getByLabelText('Seleccionar XMLP de Soundvision'), {
+      target: { files: [new File(['nwm'], 'session.nwm')] },
+    });
+
+    expect(parseMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Archivo no compatible',
+      variant: 'destructive',
+    }));
+  });
+});

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -7,6 +7,7 @@ import {
   Network,
   Plus,
   RefreshCw,
+  Send,
   Upload,
   UploadCloud,
   Wand2,
@@ -77,6 +78,12 @@ import {
   nwmMapToLayout,
 } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 import { parseLaSessionFile } from '@/components/sound/amplifier-tool/rack-designer/parse-session-file';
+import {
+  canExportCompleteXmlpPackage,
+  createImportedLaSession,
+  type ImportedLaSession,
+} from '@/components/sound/amplifier-tool/rack-designer/importedLaSession';
+import { XmlpFlexExportDialog } from '@/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog';
 
 const MADRID_TZ = 'Europe/Madrid';
 
@@ -120,6 +127,8 @@ export function AmpRackDesigner({
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
+  const [importedSession, setImportedSession] = useState<ImportedLaSession | null>(null);
+  const [flexExportOpen, setFlexExportOpen] = useState(false);
   const nwmInputRef = useRef<HTMLInputElement>(null);
   const dragDepthRef = useRef(0);
   const open = controlledOpen ?? internalOpen;
@@ -135,6 +144,11 @@ export function AmpRackDesigner({
 
   const scope =
     storageScope ?? (standalone ? 'sound-session-rack-designer' : jobId ?? tourId ?? 'standalone');
+
+  useEffect(() => {
+    setImportedSession(null);
+    setFlexExportOpen(false);
+  }, [scope]);
 
   useEffect(() => {
     if (!open) return;
@@ -306,6 +320,11 @@ export function AmpRackDesigner({
     try {
       const map = await parseLaSessionFile(file);
       if (!map.units?.length) throw new Error('La sesión no contiene amplificadores.');
+      setImportedSession(createImportedLaSession(file.name, map, {
+        jobId,
+        tourId,
+        storageScope: scope,
+      }));
       setLayout(nwmMapToLayout(map, results ? computeResultsFingerprint(results) : undefined));
       setSelectedBlockId(null);
       setAmpTarget(null);
@@ -519,9 +538,21 @@ export function AmpRackDesigner({
               {isImporting ? 'Importando…' : 'Importar NM/SV'}
             </Button>
             <SoundvisionFlysheetButton
-              parseSessionFile={parseLaSessionFile}
+              session={importedSession}
               createdBy={createdBy}
             />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-1"
+              disabled={!canExportCompleteXmlpPackage(importedSession)}
+              onClick={() => setFlexExportOpen(true)}
+              title="Revisar y enviar el paquete técnico del XMLP a Flex"
+            >
+              <Send className="h-3.5 w-3.5" />
+              Enviar a Flex
+            </Button>
             {results && (
               <AlertDialog>
                 <AlertDialogTrigger asChild>
@@ -795,6 +826,14 @@ export function AmpRackDesigner({
           <div className="max-h-[65dvh] overflow-y-auto pb-4">{blockEditor}</div>
         </SheetContent>
       </Sheet>
+
+      {importedSession && canExportCompleteXmlpPackage(importedSession) && (
+        <XmlpFlexExportDialog
+          open={flexExportOpen}
+          onOpenChange={setFlexExportOpen}
+          session={importedSession}
+        />
+      )}
     </>
   );
 }

--- a/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/AmpRackDesigner.tsx
@@ -7,8 +7,6 @@ import {
   Network,
   Plus,
   RefreshCw,
-  Send,
-  Upload,
   UploadCloud,
   Wand2,
   X,
@@ -69,7 +67,8 @@ import {
 import { useAmpJoin } from '@/components/sound/amplifier-tool/rack-designer/useAmpJoin';
 import { useRackDragMerge } from '@/components/sound/amplifier-tool/rack-designer/useRackDragMerge';
 import { RackBlockCard } from '@/components/sound/amplifier-tool/rack-designer/RackBlockCard';
-import { SoundvisionFlysheetButton } from '@/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton';
+import { ImportedXmlpActions } from '@/components/sound/amplifier-tool/rack-designer/ImportedXmlpActions';
+import { LaSessionImportButton } from '@/components/sound/amplifier-tool/rack-designer/LaSessionImportButton';
 import { BlockEditorPanel } from '@/components/sound/amplifier-tool/rack-designer/BlockEditorPanel';
 import { AmpEditFields } from '@/components/sound/amplifier-tool/rack-designer/AmpEditFields';
 import { useCanvasZoom } from '@/components/sound/amplifier-tool/rack-designer/useCanvasZoom';
@@ -79,11 +78,9 @@ import {
 } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 import { parseLaSessionFile } from '@/components/sound/amplifier-tool/rack-designer/parse-session-file';
 import {
-  canExportCompleteXmlpPackage,
   createImportedLaSession,
   type ImportedLaSession,
 } from '@/components/sound/amplifier-tool/rack-designer/importedLaSession';
-import { XmlpFlexExportDialog } from '@/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog';
 
 const MADRID_TZ = 'Europe/Madrid';
 
@@ -128,7 +125,6 @@ export function AmpRackDesigner({
   const [isImporting, setIsImporting] = useState(false);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const [importedSession, setImportedSession] = useState<ImportedLaSession | null>(null);
-  const [flexExportOpen, setFlexExportOpen] = useState(false);
   const nwmInputRef = useRef<HTMLInputElement>(null);
   const dragDepthRef = useRef(0);
   const open = controlledOpen ?? internalOpen;
@@ -147,7 +143,6 @@ export function AmpRackDesigner({
 
   useEffect(() => {
     setImportedSession(null);
-    setFlexExportOpen(false);
   }, [scope]);
 
   useEffect(() => {
@@ -319,7 +314,9 @@ export function AmpRackDesigner({
     setIsImporting(true);
     try {
       const map = await parseLaSessionFile(file);
-      if (!map.units?.length) throw new Error('La sesión no contiene amplificadores.');
+      if (!map.units?.length && !map.flysheet?.arrays.length) {
+        throw new Error('La sesión no contiene amplificadores ni arrays exportables.');
+      }
       setImportedSession(createImportedLaSession(file.name, map, {
         jobId,
         tourId,
@@ -330,7 +327,7 @@ export function AmpRackDesigner({
       setAmpTarget(null);
       toast({
         title: 'Sesión importada',
-        description: `${map.units.length} amplificadores cargados desde ${file.name}.`,
+        description: `${map.units.length} amplificadores y ${map.flysheet?.arrays.length ?? 0} arrays cargados desde ${file.name}.`,
       });
     } catch (error) {
       const message =
@@ -514,45 +511,15 @@ export function AmpRackDesigner({
               <Layers className="h-3.5 w-3.5" />
               Unir amps
             </Button>
-            <input
-              ref={nwmInputRef}
-              type="file"
-              accept=".nwm,.xmlp"
-              className="hidden"
-              onChange={(event) => {
-                const file = event.target.files?.[0];
-                event.target.value = '';
-                if (file) void importSession(file);
-              }}
+            <LaSessionImportButton
+              inputRef={nwmInputRef}
+              isImporting={isImporting}
+              onImport={(file) => void importSession(file)}
             />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="gap-1"
-              disabled={isImporting}
-              onClick={() => nwmInputRef.current?.click()}
-              title="Importar sesión de L-Acoustics: Network Manager (.nwm) o Soundvision (.xmlp)"
-            >
-              <Upload className="h-3.5 w-3.5" />
-              {isImporting ? 'Importando…' : 'Importar NM/SV'}
-            </Button>
-            <SoundvisionFlysheetButton
+            <ImportedXmlpActions
               session={importedSession}
               createdBy={createdBy}
             />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="gap-1"
-              disabled={!canExportCompleteXmlpPackage(importedSession)}
-              onClick={() => setFlexExportOpen(true)}
-              title="Revisar y enviar el paquete técnico del XMLP a Flex"
-            >
-              <Send className="h-3.5 w-3.5" />
-              Enviar a Flex
-            </Button>
             {results && (
               <AlertDialog>
                 <AlertDialogTrigger asChild>
@@ -827,13 +794,6 @@ export function AmpRackDesigner({
         </SheetContent>
       </Sheet>
 
-      {importedSession && canExportCompleteXmlpPackage(importedSession) && (
-        <XmlpFlexExportDialog
-          open={flexExportOpen}
-          onOpenChange={setFlexExportOpen}
-          session={importedSession}
-        />
-      )}
     </>
   );
 }

--- a/src/components/sound/amplifier-tool/rack-designer/ImportedXmlpActions.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/ImportedXmlpActions.tsx
@@ -1,0 +1,14 @@
+import type { ImportedLaSession } from './importedLaSession';
+import { SoundvisionFlysheetButton } from './SoundvisionFlysheetButton';
+
+interface ImportedXmlpActionsProps {
+  session: ImportedLaSession | null;
+  createdBy?: string;
+}
+
+export function ImportedXmlpActions({
+  session,
+  createdBy,
+}: ImportedXmlpActionsProps) {
+  return <SoundvisionFlysheetButton session={session} createdBy={createdBy} />;
+}

--- a/src/components/sound/amplifier-tool/rack-designer/ImportedXmlpActions.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/ImportedXmlpActions.tsx
@@ -1,5 +1,5 @@
-import type { ImportedLaSession } from './importedLaSession';
-import { SoundvisionFlysheetButton } from './SoundvisionFlysheetButton';
+import type { ImportedLaSession } from '@/components/sound/amplifier-tool/rack-designer/importedLaSession';
+import { SoundvisionFlysheetButton } from '@/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton';
 
 interface ImportedXmlpActionsProps {
   session: ImportedLaSession | null;

--- a/src/components/sound/amplifier-tool/rack-designer/LaSessionImportButton.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/LaSessionImportButton.tsx
@@ -1,0 +1,44 @@
+import type { RefObject } from 'react';
+import { Upload } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+interface LaSessionImportButtonProps {
+  inputRef: RefObject<HTMLInputElement | null>;
+  isImporting: boolean;
+  onImport: (file: File) => void;
+}
+
+export function LaSessionImportButton({
+  inputRef,
+  isImporting,
+  onImport,
+}: LaSessionImportButtonProps) {
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".nwm,.xmlp"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          event.target.value = '';
+          if (file) onImport(file);
+        }}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="gap-1"
+        disabled={isImporting}
+        onClick={() => inputRef.current?.click()}
+        title="Importar sesión de L-Acoustics: Network Manager (.nwm) o Soundvision (.xmlp)"
+      >
+        <Upload className="h-3.5 w-3.5" />
+        {isImporting ? 'Importando…' : 'Importar NM/SV'}
+      </Button>
+    </>
+  );
+}

--- a/src/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton.tsx
@@ -7,7 +7,7 @@ import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { generateSoundvisionFlysheetPdf } from '@/utils/soundvisionFlysheetPdf';
 import { formatUserName } from '@/utils/userName';
-import type { ImportedLaSession } from './importedLaSession';
+import type { ImportedLaSession } from '@/components/sound/amplifier-tool/rack-designer/importedLaSession';
 
 const MADRID_TZ = 'Europe/Madrid';
 

--- a/src/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/SoundvisionFlysheetButton.tsx
@@ -1,27 +1,26 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { formatInTimeZone } from 'date-fns-tz';
 import { FileDown } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
-import type { NwmMap } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 import { supabase } from '@/integrations/supabase/client';
 import { generateSoundvisionFlysheetPdf } from '@/utils/soundvisionFlysheetPdf';
 import { formatUserName } from '@/utils/userName';
+import type { ImportedLaSession } from './importedLaSession';
 
 const MADRID_TZ = 'Europe/Madrid';
 
 interface SoundvisionFlysheetButtonProps {
-  parseSessionFile: (file: File) => Promise<NwmMap>;
+  session: ImportedLaSession | null;
   createdBy?: string;
 }
 
 export function SoundvisionFlysheetButton({
-  parseSessionFile,
+  session,
   createdBy,
 }: SoundvisionFlysheetButtonProps) {
   const [isGenerating, setIsGenerating] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
 
   const resolvePredictionCreator = async (): Promise<string> => {
@@ -45,12 +44,12 @@ export function SoundvisionFlysheetButton({
     }
   };
 
-  const generateFlysheet = async (file: File) => {
+  const generateFlysheet = async () => {
     if (isGenerating) return;
-    if (!file.name.toLowerCase().endsWith('.xmlp')) {
+    if (session?.sourceType !== 'xmlp' || !session.flysheet?.arrays.length) {
       toast({
-        title: 'Archivo no compatible',
-        description: 'El flysheet se genera a partir de un proyecto Soundvision (.xmlp).',
+        title: 'Importa primero un XMLP',
+        description: 'El flysheet usa el mismo proyecto Soundvision ya cargado en el diseñador.',
         variant: 'destructive',
       });
       return;
@@ -58,18 +57,14 @@ export function SoundvisionFlysheetButton({
 
     setIsGenerating(true);
     try {
-      const map = await parseSessionFile(file);
-      if (!map.flysheet?.arrays.length) {
-        throw new Error('El proyecto no contiene arrays compatibles con el flysheet.');
-      }
       const predictionCreator = await resolvePredictionCreator();
-      const blob = await generateSoundvisionFlysheetPdf(map.flysheet, {
-        sourceFileName: file.name,
+      const blob = await generateSoundvisionFlysheetPdf(session.flysheet, {
+        sourceFileName: session.sourceFileName,
         createdBy: predictionCreator,
       });
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
-      const projectSlug = (map.flysheet.projectName || file.name.replace(/\.xmlp$/i, ''))
+      const projectSlug = (session.flysheet.projectName || session.sourceFileName.replace(/\.xmlp$/i, ''))
         .normalize('NFD')
         .replace(/[\u0300-\u036f]/g, '')
         .replace(/[^a-zA-Z0-9]+/g, '-')
@@ -83,7 +78,7 @@ export function SoundvisionFlysheetButton({
       URL.revokeObjectURL(url);
       toast({
         title: 'Flysheet generado',
-        description: `${map.flysheet.arrays.length} arrays incluidos en el PDF en español.`,
+        description: `${session.flysheet.arrays.length} arrays incluidos en el PDF en español.`,
       });
     } catch (error) {
       const message =
@@ -95,30 +90,17 @@ export function SoundvisionFlysheetButton({
   };
 
   return (
-    <>
-      <input
-        ref={inputRef}
-        type="file"
-        accept=".xmlp"
-        className="hidden"
-        onChange={(event) => {
-          const file = event.target.files?.[0];
-          event.target.value = '';
-          if (file) void generateFlysheet(file);
-        }}
-      />
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="gap-1"
-        disabled={isGenerating}
-        onClick={() => inputRef.current?.click()}
-        title="Generar un flysheet en español desde un proyecto Soundvision (.xmlp)"
-      >
-        <FileDown className="h-3.5 w-3.5" />
-        {isGenerating ? 'Generando flysheet…' : 'Generar flysheet'}
-      </Button>
-    </>
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="gap-1"
+      disabled={isGenerating || session?.sourceType !== 'xmlp' || !session.flysheet?.arrays.length}
+      onClick={() => void generateFlysheet()}
+      title="Generar el flysheet desde el XMLP ya importado"
+    >
+      <FileDown className="h-3.5 w-3.5" />
+      {isGenerating ? 'Generando flysheet…' : 'Generar flysheet'}
+    </Button>
   );
 }

--- a/src/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, Loader2, Send } from 'lucide-react';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  buildXmlpFlexExportPlan,
+  type XmlpEquipmentRow,
+  type XmlpFlexExportPlan,
+} from '@/features/technical-tools/flex/xmlpFlexExportPlan';
+import { useToast } from '@/hooks/use-toast';
+import { supabase } from '@/integrations/supabase/client';
+import {
+  getJobFlexEquipmentTargets,
+  pushEquipmentToFlexDocumentStrict,
+  type FlexEquipmentDocumentType,
+  type JobFlexEquipmentTarget,
+  type StrictGroupedPushResult,
+} from '@/services/flexPullsheets';
+import {
+  extractFlexElementId,
+  extractFlexEquipmentDocumentType,
+} from '@/utils/flexUrlParser';
+
+import type { ImportedLaSession } from './importedLaSession';
+import { XmlpFlexPlanPreview } from './XmlpFlexPlanPreview';
+
+interface XmlpFlexExportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  session: ImportedLaSession;
+}
+
+export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexExportDialogProps) {
+  const { toast } = useToast();
+  const [plan, setPlan] = useState<XmlpFlexExportPlan | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [targets, setTargets] = useState<JobFlexEquipmentTarget[]>([]);
+  const [selectedTargetKey, setSelectedTargetKey] = useState('');
+  const [targetMode, setTargetMode] = useState<'job' | 'url'>(session.jobId ? 'job' : 'url');
+  const [url, setUrl] = useState('');
+  const [urlDocumentType, setUrlDocumentType] = useState<FlexEquipmentDocumentType>('pullsheet');
+  const [confirmedAdditive, setConfirmedAdditive] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isPushing, setIsPushing] = useState(false);
+  const [result, setResult] = useState<StrictGroupedPushResult | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let active = true;
+    setIsLoading(true);
+    setPlan(null);
+    setResult(null);
+    setConfirmedAdditive(false);
+    Promise.all([
+      supabase.from('equipment').select('id, name, department, category, resource_id').limit(1000),
+      session.jobId ? getJobFlexEquipmentTargets(session.jobId) : Promise.resolve([]),
+    ])
+      .then(([equipmentResult, discoveredTargets]) => {
+        if (!active) return;
+        if (equipmentResult.error) throw equipmentResult.error;
+        const nextPlan = buildXmlpFlexExportPlan(
+          session.map,
+          (equipmentResult.data ?? []) as XmlpEquipmentRow[],
+        );
+        setPlan(nextPlan);
+        setSelectedIds(new Set(
+          nextPlan.groups.flatMap((group) =>
+            group.items
+              .filter((item) => item.mappingStatus === 'mapped')
+              .map((item) => item.id),
+          ),
+        ));
+        setTargets(discoveredTargets);
+        if (discoveredTargets.length === 1) {
+          setSelectedTargetKey(`${discoveredTargets[0].document_type}:${discoveredTargets[0].element_id}`);
+        }
+        if (session.jobId && discoveredTargets.length === 0) setTargetMode('url');
+      })
+      .catch((error) => {
+        if (!active) return;
+        toast({
+          title: 'No se pudo preparar el envío',
+          description: error instanceof Error ? error.message : 'Error al resolver el paquete XMLP.',
+          variant: 'destructive',
+        });
+      })
+      .finally(() => active && setIsLoading(false));
+    return () => { active = false; };
+  }, [open, session, toast]);
+
+  useEffect(() => {
+    const detected = extractFlexEquipmentDocumentType(url);
+    if (detected) setUrlDocumentType(detected);
+  }, [url]);
+
+  const selectedCandidates = useMemo(
+    () => plan?.groups.flatMap((group) => group.items).filter(
+      (item) => selectedIds.has(item.id) && item.mappingStatus === 'mapped' && item.resourceId,
+    ) ?? [],
+    [plan, selectedIds],
+  );
+  const allCandidates = plan?.groups.flatMap((group) => group.items) ?? [];
+  const mapped = allCandidates.filter((item) => item.mappingStatus === 'mapped' && item.flexCategoryKey);
+  const selectedQuantity = selectedCandidates.reduce((sum, item) => sum + item.quantity, 0);
+  const urlElementId = extractFlexElementId(url);
+  const selectedJobTarget = targets.find(
+    (target) => `${target.document_type}:${target.element_id}` === selectedTargetKey,
+  );
+  const target = targetMode === 'job' && selectedJobTarget
+    ? { elementId: selectedJobTarget.element_id, documentType: selectedJobTarget.document_type }
+    : targetMode === 'url' && urlElementId
+      ? { elementId: urlElementId, documentType: urlDocumentType }
+      : null;
+
+  const handlePush = async () => {
+    if (!target || selectedCandidates.length === 0 || !confirmedAdditive) return;
+    setIsPushing(true);
+    setResult(null);
+    try {
+      const pushed = await pushEquipmentToFlexDocumentStrict(
+        target,
+        selectedCandidates.map((item) => ({
+          resourceId: item.resourceId!,
+          quantity: item.quantity,
+          name: item.displayName,
+          flexCategoryKey: item.flexCategoryKey!,
+        })),
+      );
+      setResult(pushed);
+      const failed = pushed.groupsFailed.length + pushed.failedChildItems.length;
+      toast({
+        title: failed === 0 ? 'Paquete enviado a Flex' : 'Envío parcial a Flex',
+        description: `${pushed.equipmentLinesAdded} líneas y ${pushed.totalQuantitiesRepresented} unidades añadidas.`,
+        variant: pushed.equipmentLinesAdded === 0 ? 'destructive' : 'default',
+      });
+    } catch (error) {
+      toast({
+        title: 'Error al enviar a Flex',
+        description: error instanceof Error ? error.message : 'El envío no pudo completarse.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsPushing(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[92vh] max-w-5xl flex-col">
+        <DialogHeader>
+          <DialogTitle>Enviar paquete XMLP a Flex</DialogTitle>
+          <DialogDescription>
+            Revisa el paquete de {session.sourceFileName}; solo se enviarán líneas mapeadas y seleccionadas.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading && <div className="flex items-center gap-2 py-8"><Loader2 className="h-4 w-4 animate-spin" /> Preparando vista previa…</div>}
+        {plan && (
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+            <div className="flex flex-wrap gap-2">
+              <Badge>{mapped.length} líneas mapeadas</Badge>
+              <Badge variant="secondary">{mapped.reduce((sum, item) => sum + item.quantity, 0)} unidades mapeadas</Badge>
+              <Badge variant="destructive">{plan.missingMappings.length} sin resolver</Badge>
+              <Badge variant="outline">{allCandidates.length - selectedCandidates.length} excluidas</Badge>
+              <Badge variant="outline">{plan.warnings.length} avisos</Badge>
+            </div>
+
+            <Alert>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Envío aditivo</AlertTitle>
+              <AlertDescription>
+                Flex no ofrece aquí una lectura fiable para reconciliar líneas y anidación existentes. Repetir el envío puede duplicar cantidades.
+              </AlertDescription>
+            </Alert>
+
+            <XmlpFlexPlanPreview plan={plan} selectedIds={selectedIds} onSelectedIdsChange={setSelectedIds} />
+
+            <Tabs value={targetMode} onValueChange={(value) => setTargetMode(value as 'job' | 'url')}>
+              <TabsList>
+                <TabsTrigger value="job" disabled={!session.jobId}>Documentos del trabajo</TabsTrigger>
+                <TabsTrigger value="url">URL de Flex</TabsTrigger>
+              </TabsList>
+              <TabsContent value="job" className="space-y-2">
+                <Label>Pull Sheet o Presupuesto</Label>
+                <Select value={selectedTargetKey} onValueChange={setSelectedTargetKey}>
+                  <SelectTrigger><SelectValue placeholder="Selecciona un documento" /></SelectTrigger>
+                  <SelectContent>
+                    {targets.map((item) => (
+                      <SelectItem key={`${item.document_type}:${item.element_id}`} value={`${item.document_type}:${item.element_id}`}>
+                        {item.document_type === 'pullsheet' ? 'Pull Sheet' : 'Presupuesto'} · {item.display_name ?? item.department ?? item.element_id}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </TabsContent>
+              <TabsContent value="url" className="space-y-2">
+                <Label htmlFor="xmlp-flex-url">URL de Pull Sheet o Presupuesto</Label>
+                <Input id="xmlp-flex-url" value={url} onChange={(event) => setUrl(event.target.value)} placeholder="https://…#equipment-list/… o #fin-doc/…" />
+                <Select value={urlDocumentType} onValueChange={(value) => setUrlDocumentType(value as FlexEquipmentDocumentType)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="pullsheet">Pull Sheet</SelectItem>
+                    <SelectItem value="presupuesto">Presupuesto</SelectItem>
+                  </SelectContent>
+                </Select>
+                {url && !urlElementId && <p className="text-sm text-destructive">La URL no contiene un ID Flex válido.</p>}
+              </TabsContent>
+            </Tabs>
+
+            <div className="flex items-start gap-2 rounded-md border p-3">
+              <Checkbox id="confirm-additive" checked={confirmedAdditive} onCheckedChange={(value) => setConfirmedAdditive(value === true)} />
+              <Label htmlFor="confirm-additive" className="leading-5">
+                Entiendo que el envío es aditivo, que las líneas sin mapear se omitirán y que solo se enviarán las {selectedCandidates.length} líneas seleccionadas ({selectedQuantity} unidades).
+              </Label>
+            </div>
+
+            {result && (
+              <Alert variant={result.equipmentLinesAdded === 0 ? 'destructive' : 'default'}>
+                <Send className="h-4 w-4" />
+                <AlertTitle>{result.equipmentLinesAdded > 0 ? 'Resultado del envío' : 'No se añadió equipo'}</AlertTitle>
+                <AlertDescription>
+                  {result.groupsCreated.length} grupos creados; {result.equipmentLinesAdded} líneas añadidas; {result.groupsFailed.length} grupos fallidos; {result.failedChildItems.length} líneas hijas fallidas; {result.childrenSkippedBecauseParentFailed.length} hijas omitidas por fallo de cabecera.
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPushing}>Cerrar</Button>
+          <Button onClick={() => void handlePush()} disabled={!target || selectedCandidates.length === 0 || !confirmedAdditive || isPushing}>
+            {isPushing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Send className="mr-2 h-4 w-4" />}
+            Enviar seleccionados a Flex
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, Loader2, Send } from 'lucide-react';
+import { useEffect, useMemo, useState, type MouseEventHandler } from 'react';
+import { AlertTriangle, Loader2, Plus, RefreshCw, Send } from 'lucide-react';
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -19,6 +19,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   buildXmlpFlexExportPlan,
+  type XmlpFlexCandidate,
   type XmlpEquipmentRow,
   type XmlpFlexExportPlan,
 } from '@/features/technical-tools/flex/xmlpFlexExportPlan';
@@ -43,9 +44,20 @@ interface XmlpFlexExportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   session: ImportedLaSession;
+  onCreateFlexTarget?: MouseEventHandler<HTMLButtonElement>;
 }
 
-export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexExportDialogProps) {
+interface XmlpFlexPushOutcome extends StrictGroupedPushResult {
+  skippedUnmappedItems: XmlpFlexCandidate[];
+  skippedAmbiguousItems: XmlpFlexCandidate[];
+}
+
+export function XmlpFlexExportDialog({
+  open,
+  onOpenChange,
+  session,
+  onCreateFlexTarget,
+}: XmlpFlexExportDialogProps) {
   const { toast } = useToast();
   const [plan, setPlan] = useState<XmlpFlexExportPlan | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -56,8 +68,9 @@ export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexEx
   const [urlDocumentType, setUrlDocumentType] = useState<FlexEquipmentDocumentType>('pullsheet');
   const [confirmedAdditive, setConfirmedAdditive] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [isRefreshingTargets, setIsRefreshingTargets] = useState(false);
   const [isPushing, setIsPushing] = useState(false);
-  const [result, setResult] = useState<StrictGroupedPushResult | null>(null);
+  const [result, setResult] = useState<XmlpFlexPushOutcome | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -89,7 +102,6 @@ export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexEx
         if (discoveredTargets.length === 1) {
           setSelectedTargetKey(`${discoveredTargets[0].document_type}:${discoveredTargets[0].element_id}`);
         }
-        if (session.jobId && discoveredTargets.length === 0) setTargetMode('url');
       })
       .catch((error) => {
         if (!active) return;
@@ -114,8 +126,14 @@ export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexEx
     ) ?? [],
     [plan, selectedIds],
   );
-  const allCandidates = plan?.groups.flatMap((group) => group.items) ?? [];
+  const allCandidates = plan
+    ? [...plan.groups.flatMap((group) => group.items), ...plan.unassignedItems]
+    : [];
   const mapped = allCandidates.filter((item) => item.mappingStatus === 'mapped' && item.flexCategoryKey);
+  const unmapped = allCandidates.filter(
+    (item) => item.mappingStatus === 'missing-equipment' || item.mappingStatus === 'missing-resource-id',
+  );
+  const ambiguous = allCandidates.filter((item) => item.mappingStatus === 'ambiguous');
   const selectedQuantity = selectedCandidates.reduce((sum, item) => sum + item.quantity, 0);
   const urlElementId = extractFlexElementId(url);
   const selectedJobTarget = targets.find(
@@ -126,6 +144,40 @@ export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexEx
     : targetMode === 'url' && urlElementId
       ? { elementId: urlElementId, documentType: urlDocumentType }
       : null;
+
+  const handleRefreshTargets = async () => {
+    if (!session.jobId || isRefreshingTargets) return;
+    setIsRefreshingTargets(true);
+    try {
+      const discoveredTargets = await getJobFlexEquipmentTargets(session.jobId);
+      setTargets(discoveredTargets);
+      setSelectedTargetKey((current) => {
+        if (discoveredTargets.some(
+          (item) => `${item.document_type}:${item.element_id}` === current,
+        )) return current;
+        return discoveredTargets.length === 1
+          ? `${discoveredTargets[0].document_type}:${discoveredTargets[0].element_id}`
+          : '';
+      });
+      if (discoveredTargets.length > 0) setTargetMode('job');
+      toast({
+        title: 'Documentos Flex actualizados',
+        description: discoveredTargets.length > 0
+          ? discoveredTargets.length === 1
+            ? '1 destino disponible.'
+            : `${discoveredTargets.length} destinos disponibles.`
+          : 'Todavía no hay Pull Sheets ni Presupuestos disponibles para este trabajo.',
+      });
+    } catch (error) {
+      toast({
+        title: 'No se pudieron actualizar los documentos',
+        description: error instanceof Error ? error.message : 'Error consultando Flex.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsRefreshingTargets(false);
+    }
+  };
 
   const handlePush = async () => {
     if (!target || selectedCandidates.length === 0 || !confirmedAdditive) return;
@@ -141,7 +193,11 @@ export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexEx
           flexCategoryKey: item.flexCategoryKey!,
         })),
       );
-      setResult(pushed);
+      setResult({
+        ...pushed,
+        skippedUnmappedItems: unmapped,
+        skippedAmbiguousItems: ambiguous,
+      });
       const failed = pushed.groupsFailed.length + pushed.failedChildItems.length;
       toast({
         title: failed === 0 ? 'Paquete enviado a Flex' : 'Envío parcial a Flex',
@@ -175,7 +231,8 @@ export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexEx
             <div className="flex flex-wrap gap-2">
               <Badge>{mapped.length} líneas mapeadas</Badge>
               <Badge variant="secondary">{mapped.reduce((sum, item) => sum + item.quantity, 0)} unidades mapeadas</Badge>
-              <Badge variant="destructive">{plan.missingMappings.length} sin resolver</Badge>
+              <Badge variant="destructive">{unmapped.length} sin mapear</Badge>
+              <Badge variant="outline">{ambiguous.length} ambiguas</Badge>
               <Badge variant="outline">{allCandidates.length - selectedCandidates.length} excluidas</Badge>
               <Badge variant="outline">{plan.warnings.length} avisos</Badge>
             </div>
@@ -207,6 +264,31 @@ export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexEx
                     ))}
                   </SelectContent>
                 </Select>
+                <div className="flex flex-wrap gap-2">
+                  {onCreateFlexTarget && (
+                    <Button type="button" variant="outline" size="sm" onClick={onCreateFlexTarget}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      Crear documento Flex
+                    </Button>
+                  )}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={isRefreshingTargets}
+                    onClick={() => void handleRefreshTargets()}
+                  >
+                    {isRefreshingTargets
+                      ? <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      : <RefreshCw className="mr-2 h-4 w-4" />}
+                    Actualizar documentos
+                  </Button>
+                </div>
+                {onCreateFlexTarget && (
+                  <p className="text-xs text-muted-foreground">
+                    “Crear documento Flex” abre el selector de carpetas del trabajo. Al terminar, vuelve aquí y actualiza la lista.
+                  </p>
+                )}
               </TabsContent>
               <TabsContent value="url" className="space-y-2">
                 <Label htmlFor="xmlp-flex-url">URL de Pull Sheet o Presupuesto</Label>
@@ -232,9 +314,17 @@ export function XmlpFlexExportDialog({ open, onOpenChange, session }: XmlpFlexEx
             {result && (
               <Alert variant={result.equipmentLinesAdded === 0 ? 'destructive' : 'default'}>
                 <Send className="h-4 w-4" />
-                <AlertTitle>{result.equipmentLinesAdded > 0 ? 'Resultado del envío' : 'No se añadió equipo'}</AlertTitle>
+                <AlertTitle>
+                  {result.equipmentLinesAdded === 0 && result.groupsFailed.length > 0
+                    ? 'Fallo de cabecera'
+                    : result.equipmentLinesAdded === 0
+                      ? 'No se añadió equipo'
+                      : result.groupsFailed.length > 0 || result.failedChildItems.length > 0
+                        ? 'Envío parcial'
+                        : 'Envío completo'}
+                </AlertTitle>
                 <AlertDescription>
-                  {result.groupsCreated.length} grupos creados; {result.equipmentLinesAdded} líneas añadidas; {result.groupsFailed.length} grupos fallidos; {result.failedChildItems.length} líneas hijas fallidas; {result.childrenSkippedBecauseParentFailed.length} hijas omitidas por fallo de cabecera.
+                  {result.groupsCreated.length} grupos creados; {result.equipmentLinesAdded} líneas añadidas; {result.groupsFailed.length} grupos fallidos; {result.failedChildItems.length} líneas hijas fallidas; {result.childrenSkippedBecauseParentFailed.length} hijas omitidas por fallo de cabecera; {result.skippedUnmappedItems.length} sin mapear omitidas; {result.skippedAmbiguousItems.length} ambiguas omitidas.
                 </AlertDescription>
               </Alert>
             )}

--- a/src/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/XmlpFlexExportDialog.tsx
@@ -40,6 +40,26 @@ import {
 import type { ImportedLaSession } from './importedLaSession';
 import { XmlpFlexPlanPreview } from './XmlpFlexPlanPreview';
 
+const XMLP_EQUIPMENT_PAGE_SIZE = 1000;
+
+async function fetchXmlpEquipmentRows(): Promise<XmlpEquipmentRow[]> {
+  const equipment: XmlpEquipmentRow[] = [];
+
+  for (let from = 0; ; from += XMLP_EQUIPMENT_PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('equipment')
+      .select('id, name, department, category, resource_id')
+      .in('department', ['sound', 'lights'])
+      .order('id', { ascending: true })
+      .range(from, from + XMLP_EQUIPMENT_PAGE_SIZE - 1);
+
+    if (error) throw error;
+    const page = (data ?? []) as XmlpEquipmentRow[];
+    equipment.push(...page);
+    if (page.length < XMLP_EQUIPMENT_PAGE_SIZE) return equipment;
+  }
+}
+
 interface XmlpFlexExportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -80,15 +100,14 @@ export function XmlpFlexExportDialog({
     setResult(null);
     setConfirmedAdditive(false);
     Promise.all([
-      supabase.from('equipment').select('id, name, department, category, resource_id').limit(1000),
+      fetchXmlpEquipmentRows(),
       session.jobId ? getJobFlexEquipmentTargets(session.jobId) : Promise.resolve([]),
     ])
-      .then(([equipmentResult, discoveredTargets]) => {
+      .then(([equipmentRows, discoveredTargets]) => {
         if (!active) return;
-        if (equipmentResult.error) throw equipmentResult.error;
         const nextPlan = buildXmlpFlexExportPlan(
           session.map,
-          (equipmentResult.data ?? []) as XmlpEquipmentRow[],
+          equipmentRows,
         );
         setPlan(nextPlan);
         setSelectedIds(new Set(
@@ -198,6 +217,8 @@ export function XmlpFlexExportDialog({
         skippedUnmappedItems: unmapped,
         skippedAmbiguousItems: ambiguous,
       });
+      setConfirmedAdditive(false);
+      setSelectedIds(new Set());
       const failed = pushed.groupsFailed.length + pushed.failedChildItems.length;
       toast({
         title: failed === 0 ? 'Paquete enviado a Flex' : 'Envío parcial a Flex',

--- a/src/components/sound/amplifier-tool/rack-designer/XmlpFlexPlanPreview.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/XmlpFlexPlanPreview.tsx
@@ -5,6 +5,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import type {
   XmlpFlexCandidate,
   XmlpFlexExportPlan,
+  XmlpFlexMappingStatus,
 } from '@/features/technical-tools/flex/xmlpFlexExportPlan';
 
 interface XmlpFlexPlanPreviewProps {
@@ -12,6 +13,13 @@ interface XmlpFlexPlanPreviewProps {
   selectedIds: Set<string>;
   onSelectedIdsChange: (ids: Set<string>) => void;
 }
+
+const MAPPING_STATUS_LABELS: Record<XmlpFlexMappingStatus, string> = {
+  mapped: 'Mapeado',
+  'missing-resource-id': 'Sin recurso Flex',
+  'missing-equipment': 'Sin equipo',
+  ambiguous: 'Ambiguo',
+};
 
 const MappingIcon = ({ item }: { item: XmlpFlexCandidate }) => {
   if (item.mappingStatus === 'mapped' && item.flexCategoryKey) {
@@ -48,16 +56,16 @@ const CandidateRow = ({
             <span className="font-semibold">{item.quantity} × {item.displayName}</span>
             <Badge variant="outline">{item.inference === 'explicit' ? 'Explícito' : 'Inferido'}</Badge>
             <Badge variant={item.mappingStatus === 'mapped' ? 'secondary' : 'destructive'}>
-              {item.mappingStatus}
+              {MAPPING_STATUS_LABELS[item.mappingStatus]}
             </Badge>
           </div>
           <p className="mt-1 break-all text-muted-foreground">Clave: {item.canonicalKey}</p>
           <p className="text-muted-foreground">Origen: {item.sources.join(', ')}</p>
           <p className="text-muted-foreground">Arrays/tablas: {item.sourceArrays.join(', ') || '—'}</p>
           <p className="text-muted-foreground">
-            Equipment: {item.equipmentName ?? 'sin fila'}{item.equipmentId ? ` (${item.equipmentId})` : ''}
+            Equipo: {item.equipmentName ?? 'sin fila'}{item.equipmentId ? ` (${item.equipmentId})` : ''}
           </p>
-          <p className="break-all text-muted-foreground">Flex resource: {item.resourceId ?? 'sin resource_id'}</p>
+          <p className="break-all text-muted-foreground">Recurso Flex: {item.resourceId ?? 'sin resource_id'}</p>
           {item.warning && <p className="mt-1 text-amber-700 dark:text-amber-400">{item.warning}</p>}
         </div>
       </div>

--- a/src/components/sound/amplifier-tool/rack-designer/XmlpFlexPlanPreview.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/XmlpFlexPlanPreview.tsx
@@ -1,0 +1,128 @@
+import { AlertTriangle, CheckCircle2, HelpCircle } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import type {
+  XmlpFlexCandidate,
+  XmlpFlexExportPlan,
+} from '@/features/technical-tools/flex/xmlpFlexExportPlan';
+
+interface XmlpFlexPlanPreviewProps {
+  plan: XmlpFlexExportPlan;
+  selectedIds: Set<string>;
+  onSelectedIdsChange: (ids: Set<string>) => void;
+}
+
+const MappingIcon = ({ item }: { item: XmlpFlexCandidate }) => {
+  if (item.mappingStatus === 'mapped' && item.flexCategoryKey) {
+    return <CheckCircle2 className="h-4 w-4 text-green-600" aria-label="Mapeado" />;
+  }
+  if (item.mappingStatus === 'ambiguous') {
+    return <HelpCircle className="h-4 w-4 text-amber-600" aria-label="Ambiguo" />;
+  }
+  return <AlertTriangle className="h-4 w-4 text-destructive" aria-label="Sin mapear" />;
+};
+
+const CandidateRow = ({
+  item,
+  checked,
+  onCheckedChange,
+}: {
+  item: XmlpFlexCandidate;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) => {
+  const selectable = item.mappingStatus === 'mapped' && item.flexCategoryKey !== null;
+  return (
+    <div className="rounded-md border p-2 text-xs">
+      <div className="flex items-start gap-2">
+        <Checkbox
+          checked={checked}
+          disabled={!selectable}
+          onCheckedChange={(value) => onCheckedChange(value === true)}
+          aria-label={`Seleccionar ${item.displayName}`}
+        />
+        <MappingIcon item={item} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="font-semibold">{item.quantity} × {item.displayName}</span>
+            <Badge variant="outline">{item.inference === 'explicit' ? 'Explícito' : 'Inferido'}</Badge>
+            <Badge variant={item.mappingStatus === 'mapped' ? 'secondary' : 'destructive'}>
+              {item.mappingStatus}
+            </Badge>
+          </div>
+          <p className="mt-1 break-all text-muted-foreground">Clave: {item.canonicalKey}</p>
+          <p className="text-muted-foreground">Origen: {item.sources.join(', ')}</p>
+          <p className="text-muted-foreground">Arrays/tablas: {item.sourceArrays.join(', ') || '—'}</p>
+          <p className="text-muted-foreground">
+            Equipment: {item.equipmentName ?? 'sin fila'}{item.equipmentId ? ` (${item.equipmentId})` : ''}
+          </p>
+          <p className="break-all text-muted-foreground">Flex resource: {item.resourceId ?? 'sin resource_id'}</p>
+          {item.warning && <p className="mt-1 text-amber-700 dark:text-amber-400">{item.warning}</p>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export function XmlpFlexPlanPreview({
+  plan,
+  selectedIds,
+  onSelectedIdsChange,
+}: XmlpFlexPlanPreviewProps) {
+  const updateItem = (id: string, checked: boolean) => {
+    const next = new Set(selectedIds);
+    if (checked) next.add(id);
+    else next.delete(id);
+    onSelectedIdsChange(next);
+  };
+
+  return (
+    <div className="space-y-3">
+      {plan.groups.map((group) => {
+        const selectableIds = group.items
+          .filter((item) => item.mappingStatus === 'mapped')
+          .map((item) => item.id);
+        const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selectedIds.has(id));
+        return (
+          <section key={group.flexCategoryKey} className="space-y-2 rounded-lg border p-3">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                checked={allSelected}
+                disabled={selectableIds.length === 0}
+                onCheckedChange={(value) => {
+                  const next = new Set(selectedIds);
+                  for (const id of selectableIds) value === true ? next.add(id) : next.delete(id);
+                  onSelectedIdsChange(next);
+                }}
+                aria-label={`Seleccionar grupo ${group.label}`}
+              />
+              <h3 className="font-semibold">{group.label}</h3>
+              <Badge variant="outline">{group.items.length} líneas</Badge>
+            </div>
+            {group.items.length === 0 ? (
+              <p className="text-xs text-muted-foreground">Sin requisitos.</p>
+            ) : (
+              group.items.map((item) => (
+                <CandidateRow
+                  key={item.id}
+                  item={item}
+                  checked={selectedIds.has(item.id)}
+                  onCheckedChange={(checked) => updateItem(item.id, checked)}
+                />
+              ))
+            )}
+          </section>
+        );
+      })}
+      {plan.unassignedItems.length > 0 && (
+        <section className="space-y-2 rounded-lg border border-amber-500/50 p-3">
+          <h3 className="font-semibold text-amber-700 dark:text-amber-400">Arrays sin clasificar</h3>
+          {plan.unassignedItems.map((item) => (
+            <CandidateRow key={item.id} item={item} checked={false} onCheckedChange={() => undefined} />
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/sound/amplifier-tool/rack-designer/XmlpFlexPlanPreview.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/XmlpFlexPlanPreview.tsx
@@ -92,7 +92,10 @@ export function XmlpFlexPlanPreview({
                 disabled={selectableIds.length === 0}
                 onCheckedChange={(value) => {
                   const next = new Set(selectedIds);
-                  for (const id of selectableIds) value === true ? next.add(id) : next.delete(id);
+                  for (const id of selectableIds) {
+                    if (value === true) next.add(id);
+                    else next.delete(id);
+                  }
                   onSelectedIdsChange(next);
                 }}
                 aria-label={`Seleccionar grupo ${group.label}`}

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AmplifierResults } from '@/components/sound/amplifier-tool/types';
-import type { NwmMap } from '../nwm-import';
+import type { NwmMap } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 import { mockSupabase } from '@/test/mockSupabase';
 import { AmpRackDesigner } from '../AmpRackDesigner';
 

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/AmpRackDesigner.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AmplifierResults } from '@/components/sound/amplifier-tool/types';
+import type { NwmMap } from '../nwm-import';
 import { mockSupabase } from '@/test/mockSupabase';
 import { AmpRackDesigner } from '../AmpRackDesigner';
 
@@ -28,9 +29,7 @@ const calculatorResults: AmplifierResults = {
   },
 };
 
-const parsedSessionResponse = {
-  data: {
-    map: {
+const parsedSessionMap: NwmMap = {
       sessionName: 'GIRA 2026',
       units: [
         {
@@ -44,7 +43,38 @@ const parsedSessionResponse = {
         },
       ],
       groups: [{ name: 'K2 L', role: 'source', members: [11] }],
-    },
+      flysheet: {
+        projectName: 'GIRA 2026',
+        arrays: [{
+          groupName: 'PA',
+          arrayName: 'K2 L',
+          deployment: 'stacked' as const,
+          azimuthDegrees: null,
+          topSiteDegrees: null,
+          bottomSiteDegrees: null,
+          topHeightMeters: null,
+          bottomHeightMeters: null,
+          riggingFrame: '',
+          flyingBarSetting: '',
+          pickupConfiguration: '',
+          totalMassKg: null,
+          frontLoadKg: null,
+          rearLoadKg: null,
+          enclosures: [{
+            model: 'K2',
+            splayAngleDegrees: null,
+            siteAngleDegrees: null,
+            trimHeightMeters: null,
+            dispersionSetting: null,
+          }],
+          warnings: [],
+        }],
+      },
+};
+
+const parsedSessionResponse = {
+  data: {
+    map: parsedSessionMap,
   },
   error: null as null,
 };
@@ -66,9 +96,26 @@ describe('AmpRackDesigner — modo independiente', () => {
     );
 
     expect(await screen.findByText('Suelta aquí una sesión NM o Soundvision')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Generar flysheet' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Generar flysheet' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Enviar a Flex' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Regenerar' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Exportar PDF' })).toBeDisabled();
+  });
+
+  it('keeps Flex export out of the NM/SV designer even when it is job-scoped', async () => {
+    render(
+      <AmpRackDesigner
+        standalone
+        hideTrigger
+        open
+        onOpenChange={vi.fn()}
+        jobId="job-123"
+        storageScope="job-scoped-test"
+      />,
+    );
+
+    expect(await screen.findByText('Suelta aquí una sesión NM o Soundvision')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Enviar a Flex' })).not.toBeInTheDocument();
   });
 
   it('allows starting a design manually and persists it in the standalone scope', async () => {
@@ -99,6 +146,7 @@ describe('AmpRackDesigner — modo independiente', () => {
         hideTrigger
         open
         onOpenChange={vi.fn()}
+        jobId="job-123"
         storageScope="standalone-drop-test"
       />,
     );
@@ -119,6 +167,8 @@ describe('AmpRackDesigner — modo independiente', () => {
     });
     expect(await screen.findByText('K2 L')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Exportar PDF' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Generar flysheet' })).toBeEnabled();
+    expect(screen.queryByRole('button', { name: 'Enviar a Flex' })).not.toBeInTheDocument();
   });
 
   it('ignores a second dropped session while an import is already in progress', async () => {

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/SoundvisionFlysheetButton.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/SoundvisionFlysheetButton.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SoundvisionFlysheet } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import type { NwmMap, SoundvisionFlysheet } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 import { mockSupabase, resetMockSupabase } from '@/test/mockSupabase';
 
 const { generateFlysheetPdfMock, toastMock } = vi.hoisted(() => ({
@@ -61,22 +61,27 @@ describe('SoundvisionFlysheetButton', () => {
         warnings: [],
       }],
     };
-    const parseSessionFile = vi.fn().mockResolvedValue({
+    const map: NwmMap = {
       sessionName: 'Gira 2026',
       units: [],
       groups: [],
       flysheet,
-    });
-    const { container } = render(
+    };
+    render(
       <SoundvisionFlysheetButton
-        parseSessionFile={parseSessionFile}
+        session={{
+          sourceFileName: 'gira.xmlp',
+          sourceType: 'xmlp',
+          importedAt: '2026-07-20T20:00:00.000Z',
+          map,
+          flysheet,
+          units: [],
+          storageScope: 'test',
+        }}
         createdBy="Pat Jones"
       />,
     );
-    const input = container.querySelector('input[type="file"]');
-    const file = new File(['encrypted'], 'gira.xmlp', { type: 'application/octet-stream' });
-
-    fireEvent.change(input!, { target: { files: [file] } });
+    fireEvent.click(screen.getByRole('button', { name: 'Generar flysheet' }));
 
     await waitFor(() => {
       expect(generateFlysheetPdfMock).toHaveBeenCalledWith(

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/XmlpFlexExportDialog.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/XmlpFlexExportDialog.test.tsx
@@ -98,7 +98,7 @@ describe('XmlpFlexExportDialog', () => {
     expect(await screen.findByText(/1 líneas mapeadas/)).toBeInTheDocument();
     expect(screen.getByText('1 sin mapear')).toBeInTheDocument();
     expect(screen.getByText('0 ambiguas')).toBeInTheDocument();
-    expect(screen.getByText('missing-resource-id')).toBeInTheDocument();
+    expect(screen.getByText('Sin recurso Flex')).toBeInTheDocument();
     expect(screen.getAllByText(/MAIN L/)).toHaveLength(2);
     const send = screen.getByRole('button', { name: 'Enviar seleccionados a Flex' });
     expect(send).toBeDisabled();

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/XmlpFlexExportDialog.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/XmlpFlexExportDialog.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ImportedLaSession } from '../importedLaSession';
+import type { StrictGroupedPushResult } from '@/services/flexPullsheets';
+
+const { getTargetsMock, pushMock, toastMock, equipmentRows } = vi.hoisted(() => ({
+  getTargetsMock: vi.fn(),
+  pushMock: vi.fn(),
+  toastMock: vi.fn(),
+  equipmentRows: [
+    { id: 'k2-row', name: 'K2', department: 'sound', category: 'speakers', resource_id: 'k2-resource' },
+    { id: 'k1-row', name: "L'Acoustics K1", department: 'sound', category: 'speakers', resource_id: null },
+  ],
+}));
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastMock }) }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({ limit: vi.fn().mockResolvedValue({ data: equipmentRows, error: null }) }),
+    }),
+  },
+}));
+vi.mock('@/services/flexPullsheets', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/flexPullsheets')>();
+  return {
+    ...actual,
+    getJobFlexEquipmentTargets: getTargetsMock,
+    pushEquipmentToFlexDocumentStrict: pushMock,
+  };
+});
+
+import { XmlpFlexExportDialog } from '../XmlpFlexExportDialog';
+
+const session = (jobId?: string): ImportedLaSession => {
+  const map: ImportedLaSession['map'] = {
+    sessionName: 'Demo',
+    units: [],
+    groups: [],
+    flysheet: {
+      projectName: 'Demo',
+      arrays: [
+        {
+          groupName: 'PA', arrayName: 'MAIN L', deployment: 'stacked',
+          azimuthDegrees: null, topSiteDegrees: null, bottomSiteDegrees: null,
+          topHeightMeters: null, bottomHeightMeters: null, riggingFrame: '',
+          flyingBarSetting: '', pickupConfiguration: '', totalMassKg: null,
+          frontLoadKg: null, rearLoadKg: null, warnings: [],
+          enclosures: ['K2', 'K1'].map((model): NonNullable<ImportedLaSession['flysheet']>['arrays'][number]['enclosures'][number] => ({
+            model, splayAngleDegrees: null, siteAngleDegrees: null,
+            trimHeightMeters: null, dispersionSetting: null,
+          })),
+        },
+      ],
+    },
+  };
+  return {
+    sourceFileName: 'demo.xmlp',
+    sourceType: 'xmlp',
+    importedAt: '2026-07-20T20:00:00.000Z',
+    map,
+    flysheet: map.flysheet,
+    units: map.units,
+    storageScope: 'test',
+    jobId,
+  };
+};
+
+const successfulResult: StrictGroupedPushResult = {
+  groupsCreated: ['pa_mains'],
+  groupsReused: [],
+  groupsFailed: [],
+  equipmentLinesAdded: 1,
+  totalQuantitiesRepresented: 1,
+  childrenSkippedBecauseParentFailed: [],
+  failedChildItems: [],
+  warnings: ['aditivo'],
+};
+
+describe('XmlpFlexExportDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTargetsMock.mockResolvedValue([
+      {
+        id: 'quote-id', element_id: 'quote-id', department: 'sound',
+        created_at: '2026-07-20T20:00:00.000Z', display_name: 'Presupuesto Sx',
+        source: 'database', document_type: 'presupuesto',
+      },
+    ]);
+    pushMock.mockResolvedValue(successfulResult);
+  });
+
+  it('previews mapped/unmapped lines, auto-selects one Presupuesto, and sends only confirmed selections', async () => {
+    render(<XmlpFlexExportDialog open onOpenChange={vi.fn()} session={session('job-id')} />);
+
+    expect(await screen.findByText(/1 líneas mapeadas/)).toBeInTheDocument();
+    expect(screen.getByText('1 sin mapear')).toBeInTheDocument();
+    expect(screen.getByText('0 ambiguas')).toBeInTheDocument();
+    expect(screen.getByText('missing-resource-id')).toBeInTheDocument();
+    expect(screen.getAllByText(/MAIN L/)).toHaveLength(2);
+    const send = screen.getByRole('button', { name: 'Enviar seleccionados a Flex' });
+    expect(send).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Seleccionar K2' }));
+    expect(send).toBeDisabled();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Seleccionar K2' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /Entiendo que el envío es aditivo/ }));
+    expect(send).toBeEnabled();
+    fireEvent.click(send);
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith(
+      { elementId: 'quote-id', documentType: 'presupuesto' },
+      [{ resourceId: 'k2-resource', quantity: 1, name: 'K2', flexCategoryKey: 'pa_mains' }],
+    ));
+    expect(await screen.findByText('Envío completo')).toBeInTheDocument();
+    expect(screen.getByText(/1 grupos creados; 1 líneas añadidas/)).toBeInTheDocument();
+  });
+
+  it('allows deselecting a complete group', async () => {
+    render(<XmlpFlexExportDialog open onOpenChange={vi.fn()} session={session('job-id')} />);
+    await screen.findByText(/1 líneas mapeadas/);
+
+    const group = screen.getByRole('checkbox', { name: 'Seleccionar grupo Sistema de PA' });
+    expect(group).toBeChecked();
+    fireEvent.click(group);
+
+    expect(screen.getByRole('checkbox', { name: 'Seleccionar K2' })).not.toBeChecked();
+    fireEvent.click(screen.getByRole('checkbox', { name: /Entiendo que el envío es aditivo/ }));
+    expect(screen.getByRole('button', { name: 'Enviar seleccionados a Flex' })).toBeDisabled();
+  });
+
+  it('renders a category-parent failure distinctly', async () => {
+    pushMock.mockResolvedValueOnce({
+      ...successfulResult,
+      groupsCreated: [],
+      groupsFailed: [{ flexCategoryKey: 'pa_mains', name: 'pa_mains', error: 'upstream failed' }],
+      equipmentLinesAdded: 0,
+      totalQuantitiesRepresented: 0,
+      childrenSkippedBecauseParentFailed: [
+        { flexCategoryKey: 'pa_mains', name: 'K2', error: 'upstream failed' },
+      ],
+    });
+    render(<XmlpFlexExportDialog open onOpenChange={vi.fn()} session={session('job-id')} />);
+    await screen.findByText(/1 líneas mapeadas/);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Entiendo que el envío es aditivo/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar seleccionados a Flex' }));
+
+    expect(await screen.findByText('Fallo de cabecera')).toBeInTheDocument();
+    expect(screen.getByText(/1 grupos fallidos; 0 líneas hijas fallidas; 1 hijas omitidas/)).toBeInTheDocument();
+  });
+
+  it('keeps URL fallback available and detects a fin-doc Presupuesto URL', async () => {
+    getTargetsMock.mockResolvedValue([]);
+    render(<XmlpFlexExportDialog open onOpenChange={vi.fn()} session={session()} />);
+    await screen.findByText(/1 líneas mapeadas/);
+
+    fireEvent.change(screen.getByLabelText('URL de Pull Sheet o Presupuesto'), {
+      target: { value: 'https://example.flexrentalsolutions.com/f5/ui/?desktop#fin-doc/11111111-1111-4111-8111-111111111111/view' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: /Entiendo que el envío es aditivo/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar seleccionados a Flex' }));
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith(
+      { elementId: '11111111-1111-4111-8111-111111111111', documentType: 'presupuesto' },
+      expect.any(Array),
+    ));
+  });
+
+  it('can open the existing Flex creation flow and refresh newly created job documents', async () => {
+    const onCreateFlexTarget = vi.fn();
+    getTargetsMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{
+        id: 'pullsheet-id', element_id: 'pullsheet-id', department: 'sound',
+        created_at: '2026-07-20T20:00:00.000Z', display_name: 'Pull Sheet Sx',
+        source: 'database', document_type: 'pullsheet',
+      }]);
+    render(
+      <XmlpFlexExportDialog
+        open
+        onOpenChange={vi.fn()}
+        session={session('job-id')}
+        onCreateFlexTarget={onCreateFlexTarget}
+      />,
+    );
+    await screen.findByText(/1 líneas mapeadas/);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Crear documento Flex' }));
+    expect(onCreateFlexTarget).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actualizar documentos' }));
+    await waitFor(() => expect(getTargetsMock).toHaveBeenCalledTimes(2));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Documentos Flex actualizados',
+      description: '1 destino disponible.',
+    }));
+  });
+});

--- a/src/components/sound/amplifier-tool/rack-designer/__tests__/XmlpFlexExportDialog.test.tsx
+++ b/src/components/sound/amplifier-tool/rack-designer/__tests__/XmlpFlexExportDialog.test.tsx
@@ -5,10 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ImportedLaSession } from '../importedLaSession';
 import type { StrictGroupedPushResult } from '@/services/flexPullsheets';
 
-const { getTargetsMock, pushMock, toastMock, equipmentRows } = vi.hoisted(() => ({
+const { getTargetsMock, pushMock, toastMock, equipmentRangeMock, equipmentRows } = vi.hoisted(() => ({
   getTargetsMock: vi.fn(),
   pushMock: vi.fn(),
   toastMock: vi.fn(),
+  equipmentRangeMock: vi.fn(),
   equipmentRows: [
     { id: 'k2-row', name: 'K2', department: 'sound', category: 'speakers', resource_id: 'k2-resource' },
     { id: 'k1-row', name: "L'Acoustics K1", department: 'sound', category: 'speakers', resource_id: null },
@@ -19,7 +20,11 @@ vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastMock }) }))
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
     from: () => ({
-      select: () => ({ limit: vi.fn().mockResolvedValue({ data: equipmentRows, error: null }) }),
+      select: () => ({
+        in: () => ({
+          order: () => ({ range: equipmentRangeMock }),
+        }),
+      }),
     }),
   },
 }));
@@ -82,6 +87,7 @@ const successfulResult: StrictGroupedPushResult = {
 describe('XmlpFlexExportDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    equipmentRangeMock.mockResolvedValue({ data: equipmentRows, error: null });
     getTargetsMock.mockResolvedValue([
       {
         id: 'quote-id', element_id: 'quote-id', department: 'sound',
@@ -116,6 +122,48 @@ describe('XmlpFlexExportDialog', () => {
     ));
     expect(await screen.findByText('Envío completo')).toBeInTheDocument();
     expect(screen.getByText(/1 grupos creados; 1 líneas añadidas/)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Seleccionar K2' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Entiendo que el envío es aditivo/ })).not.toBeChecked();
+    expect(send).toBeDisabled();
+  });
+
+  it('paginates equipment rows so mappings beyond the first 1000 records are available', async () => {
+    const firstPage = Array.from({ length: 1000 }, (_, index) => ({
+      id: `unrelated-${index}`,
+      name: `Unrelated ${index}`,
+      department: 'sound',
+      category: 'speakers',
+      resource_id: `unrelated-resource-${index}`,
+    }));
+    equipmentRangeMock
+      .mockResolvedValueOnce({ data: firstPage, error: null })
+      .mockResolvedValueOnce({ data: equipmentRows, error: null });
+
+    render(<XmlpFlexExportDialog open onOpenChange={vi.fn()} session={session('job-id')} />);
+
+    expect(await screen.findByText(/1 líneas mapeadas/)).toBeInTheDocument();
+    expect(equipmentRangeMock).toHaveBeenNthCalledWith(1, 0, 999);
+    expect(equipmentRangeMock).toHaveBeenNthCalledWith(2, 1000, 1999);
+  });
+
+  it('preserves the selection and additive confirmation when a push rejects', async () => {
+    pushMock.mockRejectedValueOnce(new Error('upstream failed'));
+    render(<XmlpFlexExportDialog open onOpenChange={vi.fn()} session={session('job-id')} />);
+    await screen.findByText(/1 líneas mapeadas/);
+
+    const selected = screen.getByRole('checkbox', { name: 'Seleccionar K2' });
+    const confirmation = screen.getByRole('checkbox', { name: /Entiendo que el envío es aditivo/ });
+    const send = screen.getByRole('button', { name: 'Enviar seleccionados a Flex' });
+    fireEvent.click(confirmation);
+    fireEvent.click(send);
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Error al enviar a Flex',
+      variant: 'destructive',
+    })));
+    expect(selected).toBeChecked();
+    expect(confirmation).toBeChecked();
+    expect(send).toBeEnabled();
   });
 
   it('allows deselecting a complete group', async () => {

--- a/src/components/sound/amplifier-tool/rack-designer/importedLaSession.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/importedLaSession.ts
@@ -1,0 +1,34 @@
+import type { NwmMap } from './nwm-import';
+
+export interface ImportedLaSession {
+  sourceFileName: string;
+  sourceType: 'xmlp' | 'nwm';
+  importedAt: string;
+  map: NwmMap;
+  flysheet: NwmMap['flysheet'];
+  units: NwmMap['units'];
+  jobId?: string;
+  tourId?: string;
+  storageScope: string;
+}
+
+export function createImportedLaSession(
+  fileName: string,
+  map: NwmMap,
+  context: Pick<ImportedLaSession, 'jobId' | 'tourId' | 'storageScope'>,
+): ImportedLaSession {
+  return {
+    sourceFileName: fileName,
+    sourceType: fileName.toLowerCase().endsWith('.xmlp') ? 'xmlp' : 'nwm',
+    importedAt: new Date().toISOString(),
+    map,
+    flysheet: map.flysheet,
+    units: map.units,
+    ...context,
+  };
+}
+
+export const canExportCompleteXmlpPackage = (session: ImportedLaSession | null) =>
+  session?.sourceType === 'xmlp' &&
+  Boolean(session.flysheet?.arrays.length) &&
+  Boolean(session.units.length || session.flysheet?.arrays.some((array) => array.enclosures.length));

--- a/src/components/sound/amplifier-tool/rack-designer/importedLaSession.ts
+++ b/src/components/sound/amplifier-tool/rack-designer/importedLaSession.ts
@@ -1,4 +1,4 @@
-import type { NwmMap } from './nwm-import';
+import type { NwmMap } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
 
 export interface ImportedLaSession {
   sourceFileName: string;

--- a/src/features/technical-tools/flex/__tests__/xmlpFlexExportPlan.test.ts
+++ b/src/features/technical-tools/flex/__tests__/xmlpFlexExportPlan.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  NwmMap,
+  SoundvisionFlysheetArray,
+} from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import {
+  buildXmlpFlexExportPlan,
+  calculateLaAmplifierPackaging,
+  classifyXmlpArray,
+  type XmlpEquipmentRow,
+} from '../xmlpFlexExportPlan';
+import { resolveXmlpRiggingRequirement } from '@/features/technical-tools/weights/xmlpRiggingRequirements';
+
+const array = (
+  arrayName: string,
+  models: string[],
+  patch: Partial<SoundvisionFlysheetArray> = {},
+): SoundvisionFlysheetArray => ({
+  groupName: '',
+  arrayName,
+  deployment: 'stacked',
+  azimuthDegrees: null,
+  topSiteDegrees: null,
+  bottomSiteDegrees: null,
+  topHeightMeters: null,
+  bottomHeightMeters: null,
+  riggingFrame: '',
+  flyingBarSetting: '',
+  pickupConfiguration: '',
+  totalMassKg: null,
+  frontLoadKg: null,
+  rearLoadKg: null,
+  enclosures: models.map((model): SoundvisionFlysheetArray['enclosures'][number] => ({
+    model,
+    splayAngleDegrees: null,
+    siteAngleDegrees: null,
+    trimHeightMeters: null,
+    dispersionSetting: null,
+  })),
+  warnings: [],
+  ...patch,
+});
+
+const map = (
+  arrays: SoundvisionFlysheetArray[],
+  patch: Partial<NwmMap> = {},
+): NwmMap => ({
+  sessionName: 'Test XMLP',
+  units: [],
+  groups: [],
+  flysheet: { projectName: 'Test', arrays },
+  ...patch,
+});
+
+const equipment = (
+  name: string,
+  resourceId: string | null,
+  department = 'sound',
+  category = 'speakers',
+  id = name,
+): XmlpEquipmentRow => ({ id, name, department, category, resource_id: resourceId });
+
+describe('classifyXmlpArray', () => {
+  it.each([
+    ['MAIN L', ['K2'], 'pa_mains'],
+    ['MAIN R', ['K2'], 'pa_mains'],
+    ['MAIN C', ['K2'], 'pa_mains'],
+    ['K2 L', ['K2'], 'pa_mains'],
+    ['K2 R', ['K2'], 'pa_mains'],
+    ['KS28 L', ['KS28'], 'pa_subs'],
+    ['KS28 R', ['KS28'], 'pa_subs'],
+    ['TFS900B', ['TFS900B'], 'pa_subs'],
+    ['TFS550L', ['TFS550L'], 'pa_subs'],
+    ['TFS600A L', ['TFS600A'], 'pa_mains'],
+    ['boxes', ['K1-SB'], 'pa_subs'],
+    ['OUT L', ['K2'], 'pa_outfill'],
+    ['OUT R', ['K2'], 'pa_outfill'],
+    ['SIDE', ['K2'], 'pa_outfill'],
+    ['SIDEFILL R', ['K2'], 'pa_outfill'],
+    ['FRONT', ['Kiva'], 'pa_frontfill'],
+    ['FRONTS', ['Kiva'], 'pa_frontfill'],
+    ['FF', ['Kiva'], 'pa_frontfill'],
+    ['DELAY 1', ['Kara II'], 'pa_delays'],
+    ['DELAYS', ['Kara II'], 'pa_delays'],
+    ['DOWN', ['Kara II'], 'pa_downfill'],
+    ['DOWNFILL', ['Kara II'], 'pa_downfill'],
+  ])('%s classifies as %s', (name, models, expected) => {
+    expect(classifyXmlpArray(array(name, models)).category).toBe(expected);
+  });
+
+  it('does not silently classify an unknown array as mains', () => {
+    expect(classifyXmlpArray(array('Choir balcony', ['Unknown 12'])).category).toBeNull();
+    expect(classifyXmlpArray(array('OUTSIDE', ['Unknown 12'])).category).toBeNull();
+  });
+
+  it('warns about mixed full-range and subwoofer enclosures', () => {
+    expect(classifyXmlpArray(array('MAIN L', ['K2', 'KS28'])).warning).toMatch(/mezcla sospechosa/i);
+  });
+
+  it('treats the explicit Soundvision group as authoritative', () => {
+    expect(classifyXmlpArray(array('Copy of KARA II 1', ['Kara II'], {
+      groupName: 'Frontfill',
+    })).category).toBe('pa_frontfill');
+    expect(classifyXmlpArray(array('Copy of K1 L', ['K2'], {
+      groupName: 'Sistema de PA',
+    })).category).toBe('pa_mains');
+  });
+
+  it('does not mistake the preposition in Copy of for an outfill abbreviation', () => {
+    expect(classifyXmlpArray(array('Copy of K1 L', ['K2'], { groupName: 'ALL' })).category)
+      .toBe('pa_mains');
+  });
+});
+
+describe('XMLP speaker, rigging and motor extraction', () => {
+  it('preserves the explicit Main, SUB, Outfill and Frontfill totals from nested groups', () => {
+    const groupedArrays = [
+      array('Copy of K1 L', Array(12).fill('K2'), { groupName: 'Main' }),
+      array('YZ Sym of Copy of K1 L', Array(12).fill('K2'), { groupName: 'Main' }),
+      array('Sub L', Array(8).fill('KS28'), { groupName: 'SUB' }),
+      array('Sub R', Array(8).fill('KS28'), { groupName: 'SUB' }),
+      array('KARA II 1', Array(6).fill('Kara II'), { groupName: 'Outfill' }),
+      array('KARA II 1_YZ Sym', Array(6).fill('Kara II'), { groupName: 'Outfill' }),
+      ...Array.from({ length: 6 }, (_, index) =>
+        array(`Frontfill ${index + 1}`, Array(2).fill('Kara II'), { groupName: 'Frontfill' })),
+    ];
+    const plan = buildXmlpFlexExportPlan(map(groupedArrays), [
+      equipment('K2', 'resource-k2'),
+      equipment('KS28', 'resource-ks28'),
+      equipment('Kara II', 'resource-kara'),
+    ]);
+    const quantity = (groupKey: string, canonicalKey: string) =>
+      plan.groups.find((group) => group.flexCategoryKey === groupKey)?.items
+        .find((item) => item.canonicalKey === canonicalKey)?.quantity;
+
+    expect(quantity('pa_mains', 'K2')).toBe(24);
+    expect(quantity('pa_outfill', 'KARA II')).toBe(12);
+    expect(quantity('pa_subs', 'KS28')).toBe(16);
+    expect(quantity('pa_frontfill', 'KARA II')).toBe(12);
+  });
+
+  it('merges left/right quantities while retaining array traceability', () => {
+    const plan = buildXmlpFlexExportPlan(
+      map([array('MAIN L', Array(12).fill('K2')), array('MAIN R', Array(12).fill('K2'))]),
+      [equipment('K2', 'resource-k2')],
+    );
+    const k2 = plan.groups.find((group) => group.flexCategoryKey === 'pa_mains')?.items
+      .find((item) => item.canonicalKey === 'K2');
+    expect(k2).toEqual(expect.objectContaining({ quantity: 24, resourceId: 'resource-k2' }));
+    expect(k2?.sourceArrays).toEqual(['MAIN L', 'MAIN R']);
+  });
+
+  it('keeps the same model separate across Flex groups', () => {
+    const plan = buildXmlpFlexExportPlan(
+      map([array('MAIN L', ['K2']), array('OUT L', ['K2'])]),
+      [equipment('K2', 'resource-k2')],
+    );
+    expect(plan.groups.find((group) => group.flexCategoryKey === 'pa_mains')?.items[0].quantity).toBe(1);
+    expect(plan.groups.find((group) => group.flexCategoryKey === 'pa_outfill')?.items[0].quantity).toBe(1);
+  });
+
+  it('uses the shared rigging resolver and packages two K2 bumpers in one dual case', () => {
+    const source = array('MAIN L', ['K2'], {
+      riggingFrame: 'K2-BUMP',
+      flyingBarSetting: '2x K2-BAR · A',
+    });
+    expect(resolveXmlpRiggingRequirement(source, 0)).toEqual(
+      expect.objectContaining({ canonicalKey: 'BUMPER K2', quantity: 2 }),
+    );
+    const plan = buildXmlpFlexExportPlan(map([source]), [
+      equipment('Dual K2 Rigging Flight Case', 'resource-bumper', 'lights', 'rigging'),
+    ]);
+    expect(plan.groups[0].items.find((item) => item.canonicalKey === 'BUMPER K2 DUAL CASE'))
+      .toEqual(expect.objectContaining({ quantity: 1, resourceId: 'resource-bumper' }));
+  });
+
+  it('packages K1 bumpers into dual cases plus an odd single case', () => {
+    const plan = buildXmlpFlexExportPlan(map([array('MAIN L', ['K1'], {
+      riggingFrame: 'K1-BUMP',
+      flyingBarSetting: '3x K1-BAR',
+    })]), [
+      equipment('Dual K1 Rigging Flight Case', 'resource-k1-dual', 'lights', 'rigging'),
+      equipment('K1 Rigging Flight Case', 'resource-k1-single', 'lights', 'rigging'),
+    ]);
+
+    expect(plan.groups[0].items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ canonicalKey: 'BUMPER K1 DUAL CASE', quantity: 1, resourceId: 'resource-k1-dual' }),
+      expect.objectContaining({ canonicalKey: 'BUMPER K1 SINGLE CASE', quantity: 1, resourceId: 'resource-k1-single' }),
+    ]));
+  });
+
+  it('rounds an odd Kara bumper count up to complete dual cases', () => {
+    const plan = buildXmlpFlexExportPlan(map([array('FRONTFILL', ['Kara II'], {
+      riggingFrame: 'KARA-BUMP',
+      flyingBarSetting: '3x KARA-BAR',
+    })]), [
+      equipment('Dual Kara Rigging Flight Case', 'resource-kara-dual', 'lights', 'rigging'),
+    ]);
+
+    const frontfill = plan.groups.find((group) => group.flexCategoryKey === 'pa_frontfill');
+    expect(frontfill?.items.find((item) => item.canonicalKey === 'BUMPER KARA DUAL CASE'))
+      .toEqual(expect.objectContaining({ quantity: 2, resourceId: 'resource-kara-dual' }));
+  });
+
+  it('infers motors only for flown arrays with the existing 120% Pesos rule', () => {
+    const flown = array('MAIN L', ['K2'], {
+      deployment: 'flown',
+      totalMassKg: 600,
+      pickupConfiguration: 'F: 1 / R: 2',
+    });
+    const stacked = array('MAIN R', ['K2'], { deployment: 'stacked', totalMassKg: 600 });
+    const plan = buildXmlpFlexExportPlan(map([flown, stacked]), [
+      equipment(
+        'Motor Elevacion ChainMaster D8+ 750kg - 24 m',
+        'resource-750',
+        'lights',
+        'rigging',
+      ),
+    ]);
+    const motors = plan.groups[0].items.filter((item) => item.sources.includes('pesos-motor'));
+    expect(motors).toEqual([
+      expect.objectContaining({ canonicalKey: 'MOTOR 750KG', quantity: 2, resourceId: 'resource-750' }),
+    ]);
+  });
+});
+
+describe('amplifiers, packaging and PDU derivation', () => {
+  it.each([
+    [0, 0, 0],
+    [1, 0, 1],
+    [2, 0, 2],
+    [3, 1, 0],
+    [4, 1, 1],
+    [5, 1, 2],
+    [6, 2, 0],
+    [7, 2, 1],
+  ])('packages %i compatible amps as %i racks and %i cases', (count, racks, cases) => {
+    expect(calculateLaAmplifierPackaging(count)).toEqual({
+      laRackQuantity: racks,
+      laCaseQuantity: cases,
+    });
+  });
+
+  it('exports compatible LA amplifiers only through their rack/case containers', () => {
+    const unit = (octet: number, model: string) => ({
+      octet,
+      model,
+      ip: `192.168.1.${octet}`,
+      presetName: '',
+      familyName: '',
+      x: 0,
+      y: 0,
+    });
+    const plan = buildXmlpFlexExportPlan(
+      map([], {
+        units: [unit(1, 'LA12X'), unit(1, 'LA12X'), unit(2, 'PLM 20000D')],
+        groups: [
+          { name: 'MAIN L', role: 'source', members: [1, 2] },
+          { name: 'ALL', role: 'parent', members: [1, 2] },
+        ],
+      }),
+      [],
+    );
+    const amps = plan.groups.find((group) => group.flexCategoryKey === 'pa_amp')!.items;
+    expect(amps.some((item) => item.canonicalKey === 'LA12X')).toBe(false);
+    expect(amps.find((item) => item.canonicalKey === 'PLM20000D')?.quantity).toBe(1);
+    expect(amps.find((item) => item.canonicalKey === 'LA-CASE')?.quantity).toBe(1);
+    expect(amps.some((item) => item.sources.includes('consumos-pdu'))).toBe(true);
+  });
+
+  it('packages 20 LA12X as 6 LA-RAK II plus 2 LA-CASE without amplifier lines', () => {
+    const units = Array.from({ length: 20 }, (_, index) => ({
+      octet: index + 1,
+      model: 'LA12X',
+      ip: `192.168.1.${index + 1}`,
+      presetName: '',
+      familyName: '',
+      x: 0,
+      y: 0,
+    }));
+    const plan = buildXmlpFlexExportPlan(map([], { units }), [
+      equipment("L'Acoustics LA-RAK II", 'resource-la-rak', 'sound', 'amplificacion'),
+      equipment("L'Acoustics LA-CASE II", 'resource-la-case', 'sound', 'amplificacion'),
+    ]);
+    const amps = plan.groups.find((group) => group.flexCategoryKey === 'pa_amp')!.items;
+
+    expect(amps.some((item) => item.canonicalKey === 'LA12X')).toBe(false);
+    expect(amps.find((item) => item.canonicalKey === 'LA-RAK II'))
+      .toEqual(expect.objectContaining({ quantity: 6, resourceId: 'resource-la-rak' }));
+    expect(amps.find((item) => item.canonicalKey === 'LA-CASE'))
+      .toEqual(expect.objectContaining({ quantity: 2, resourceId: 'resource-la-case' }));
+  });
+});
+
+describe('safe equipment resolution', () => {
+  it('resolves the approved real KS28 speaker name and resource ID', () => {
+    const plan = buildXmlpFlexExportPlan(map([array('KS28 L', ['KS28'])]), [
+      equipment("L'Acoustics KS 28", 'acbd4200-4fa3-11eb-815f-2a0a4490a7fb'),
+    ]);
+
+    expect(plan.groups.find((group) => group.flexCategoryKey === 'pa_subs')?.items).toContainEqual(
+      expect.objectContaining({
+        canonicalKey: 'KS28',
+        mappingStatus: 'mapped',
+        resourceId: 'acbd4200-4fa3-11eb-815f-2a0a4490a7fb',
+      }),
+    );
+  });
+
+  it('does not match K2 to an unrelated lighting K20', () => {
+    const plan = buildXmlpFlexExportPlan(map([array('MAIN L', ['K2'])]), [
+      equipment('Clay Paky K20', 'lighting-k20', 'lights', 'robotica'),
+    ]);
+    expect(plan.groups[0].items.find((item) => item.canonicalKey === 'K2')).toEqual(
+      expect.objectContaining({ mappingStatus: 'missing-equipment', resourceId: null }),
+    );
+  });
+
+  it('reports null resource IDs and allows other mapped lines to proceed', () => {
+    const plan = buildXmlpFlexExportPlan(map([array('MAIN L', ['K1', 'K2'])]), [
+      equipment("L'Acoustics K1", null),
+      equipment('K2', 'resource-k2'),
+    ]);
+    expect(plan.groups[0].items.find((item) => item.canonicalKey === 'K1')?.mappingStatus).toBe('missing-resource-id');
+    expect(plan.groups[0].items.find((item) => item.canonicalKey === 'K2')?.mappingStatus).toBe('mapped');
+  });
+
+  it('fails closed when one Flex resource ID represents two canonical identities', () => {
+    const plan = buildXmlpFlexExportPlan(map([array('SUB L', ['KS28'], {
+      riggingFrame: 'KS28 BUMP',
+    })]), [
+      equipment('KS28', 'shared-resource'),
+      equipment('KS28 BUMP', 'shared-resource', 'lights', 'rigging'),
+    ]);
+    expect(plan.groups.find((group) => group.flexCategoryKey === 'pa_subs')?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ canonicalKey: 'KS28', mappingStatus: 'ambiguous' }),
+        expect.objectContaining({ canonicalKey: 'BUMPER KS28', mappingStatus: 'ambiguous' }),
+      ]),
+    );
+  });
+});

--- a/src/features/technical-tools/flex/xmlpFlexExportPlan.ts
+++ b/src/features/technical-tools/flex/xmlpFlexExportPlan.ts
@@ -120,9 +120,19 @@ const normalizedTokens = (value: string) =>
     .filter(Boolean);
 
 const hasToken = (tokens: string[], ...words: string[]) =>
-  tokens.some((token) => words.some((word) => token === word || token.startsWith(word)));
+  tokens.some((token) => words.includes(token));
 
-const SUB_MODELS = new Set(['KS28', 'K1SB', 'SB18', 'SB15', 'SB10', 'SB28']);
+const SUB_MODELS = new Set([
+  'KS28',
+  'KS21',
+  'K1SB',
+  'SB28',
+  'SB18',
+  'SB15',
+  'SB10',
+  'TFS900B',
+  'TFS550L',
+]);
 const FULL_RANGE_MODELS = new Set([
   'K1',
   'K2',
@@ -132,26 +142,26 @@ const FULL_RANGE_MODELS = new Set([
   'KIVA',
   'TFS900H',
   'TFA600',
+  'TFS600A',
   'TFS550H',
-  'TFS550L',
 ]);
 
 const explicitCategory = (value: string): XmlpFlexCategoryKey | null => {
   const tokens = normalizedTokens(value);
-  if (hasToken(tokens, 'DOWNFILL') || hasToken(tokens, 'DOWN') || value.match(/DOWN\s+FILL/i)) {
+  if (hasToken(tokens, 'DOWNFILL', 'DOWNFILLS', 'DOWN') || value.match(/DOWN\s+FILL/i)) {
     return 'pa_downfill';
   }
-  if (hasToken(tokens, 'OUTFILL', 'SIDEFILL') || hasToken(tokens, 'OUT', 'SIDE') || tokens.includes('OF')) {
+  if (hasToken(tokens, 'OUTFILL', 'OUTFILLS', 'SIDEFILL', 'SIDEFILLS', 'OUT', 'SIDE')) {
     return 'pa_outfill';
   }
-  if (hasToken(tokens, 'FRONTFILL') || hasToken(tokens, 'FRONT') || tokens.includes('FF')) {
+  if (hasToken(tokens, 'FRONTFILL', 'FRONTFILLS', 'FRONT', 'FRONTS') || tokens.includes('FF')) {
     return 'pa_frontfill';
   }
-  if (hasToken(tokens, 'DELAY') || tokens.includes('DLY')) return 'pa_delays';
-  if (hasToken(tokens, 'SUBWOOFER') || hasToken(tokens, 'SUB') || tokens.includes('SB')) {
+  if (hasToken(tokens, 'DELAY', 'DELAYS') || tokens.includes('DLY')) return 'pa_delays';
+  if (hasToken(tokens, 'SUBWOOFER', 'SUBWOOFERS', 'SUB', 'SUBS') || tokens.includes('SB')) {
     return 'pa_subs';
   }
-  if (hasToken(tokens, 'MAIN', 'MAINS', 'SYSTEM', 'SISTEMA') || tokens.includes('PA')) {
+  if (hasToken(tokens, 'MAIN', 'MAINS', 'SYSTEM', 'SYSTEMS', 'SISTEMA', 'SISTEMAS') || tokens.includes('PA')) {
     return 'pa_mains';
   }
   return null;
@@ -166,10 +176,10 @@ export function classifyXmlpArray(array: SoundvisionFlysheetArray): XmlpArrayCla
       ? `${array.arrayName || array.groupName}: mezcla sospechosa de subgraves y recintos full-range.`
       : undefined;
 
-  const fromArrayName = explicitCategory(array.arrayName);
-  if (fromArrayName) return { category: fromArrayName, warning: mixedWarning };
   const fromGroupName = explicitCategory(array.groupName);
   if (fromGroupName) return { category: fromGroupName, warning: mixedWarning };
+  const fromArrayName = explicitCategory(array.arrayName);
+  if (fromArrayName) return { category: fromArrayName, warning: mixedWarning };
   if (hasSubs && !hasFullRange) return { category: 'pa_subs', warning: mixedWarning };
 
   const nameTokens = normalizedTokens(`${array.arrayName} ${array.groupName}`);
@@ -211,7 +221,13 @@ const aliases: XmlpEquipmentAlias[] = [
   { canonicalKey: 'K3', acceptedNames: ["L'Acoustics K3", 'K3'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
   { canonicalKey: 'KARA II', acceptedNames: ["L'Acoustics Kara", "L'Acoustics Kara II", 'Kara', 'Kara II'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
   { canonicalKey: 'KIVA', acceptedNames: ["L'Acoustics Kiva", 'Kiva'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
-  { canonicalKey: 'KS28', acceptedNames: ["L'Acoustics KS28", 'KS28'], departments: ['sound'], categories: ['speakers', 'pa_subs'] },
+  { canonicalKey: 'KS28', acceptedNames: ["L'Acoustics KS 28", "L'Acoustics KS28", 'KS28'], departments: ['sound'], categories: ['speakers', 'pa_subs'] },
+  { canonicalKey: 'KS21', acceptedNames: ["L'Acoustics KS21", 'KS21'], departments: ['sound'], categories: ['speakers', 'pa_subs'] },
+  { canonicalKey: 'TFS900B', acceptedNames: ['Turbosound TFS-900B', 'TFS900B'], departments: ['sound'], categories: ['speakers', 'pa_subs'] },
+  { canonicalKey: 'TFS550L', acceptedNames: ['Turbosound TFS-550L', 'TFS550L'], departments: ['sound'], categories: ['speakers', 'pa_subs'] },
+  { canonicalKey: 'TFS900H', acceptedNames: ['Turbosound TFS-900H', 'TFS900H'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
+  { canonicalKey: 'TFA600', acceptedNames: ['Turbosound TFA-600', 'TFA600', 'Turbosound TFS-600A', 'TFS600A'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
+  { canonicalKey: 'TFS550H', acceptedNames: ['Turbosound TFS-550H', 'TFS550H'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
   { canonicalKey: 'LA12X', acceptedNames: ["L'Acoustics LA12X", 'LA12X'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
   { canonicalKey: 'LA8', acceptedNames: ["L'Acoustics LA8", 'LA8'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
   { canonicalKey: 'LA4X', acceptedNames: ["L'Acoustics LA4X", 'LA4X'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
@@ -219,12 +235,15 @@ const aliases: XmlpEquipmentAlias[] = [
   { canonicalKey: 'PLM20000D', acceptedNames: ['PLM 20000DP', 'PLM20000D'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
   { canonicalKey: 'LA-RAK II', acceptedNames: ["L'Acoustics LA-RAK II", 'LA-RAK II'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
   { canonicalKey: 'LA-CASE', acceptedNames: ["L'Acoustics LA-CASE II", 'LA-CASE II'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
-  { canonicalKey: 'BUMPER K1', acceptedNames: ['Dual K1 Rigging Flight Case', 'K1 Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
-  { canonicalKey: 'BUMPER K2', acceptedNames: ['Dual K2 Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER K1 DUAL CASE', acceptedNames: ['Dual K1 Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER K1 SINGLE CASE', acceptedNames: ['K1 Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER K2 DUAL CASE', acceptedNames: ['Dual K2 Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
   { canonicalKey: 'BUMPER K3', acceptedNames: ['K3-BUMP'], departments: ['lights'], categories: ['rigging'] },
-  { canonicalKey: 'BUMPER KARA', acceptedNames: ['Dual Kara Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER KARA DUAL CASE', acceptedNames: ['Dual Kara Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
   { canonicalKey: 'BUMPER KIVA', acceptedNames: ["L'Acoustics KIBU", 'KIBU'], departments: ['lights'], categories: ['rigging'] },
   { canonicalKey: 'BUMPER KS28', acceptedNames: ['KS28 BUMP'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER TFS900', acceptedNames: ['TFS900 Bumper', 'TFS900 BUMP'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER TFS550', acceptedNames: ['TFS550 Bumper', 'TFS550 BUMP'], departments: ['lights'], categories: ['rigging'] },
   { canonicalKey: 'MOTOR 2T', acceptedNames: ['Motor Elevacion 2T D8+ - 25 m'], departments: ['lights'], categories: ['rigging'] },
   { canonicalKey: 'MOTOR 1T', acceptedNames: ['Motor Electrico de Elevación ChainMaster D8 1000kg - 30 m'], departments: ['lights'], categories: ['rigging'] },
   { canonicalKey: 'MOTOR 750KG', acceptedNames: ['Motor Elevacion ChainMaster D8+ 750kg - 24 m'], departments: ['lights'], categories: ['rigging'] },
@@ -239,6 +258,7 @@ const canonicalSpeaker = (model: string) => {
   const normalized = normalizeXmlpEquipmentName(model);
   if (normalized === 'KARA' || normalized === 'KARAII') return 'KARA II';
   if (normalized === 'K1SB') return 'K1-SB';
+  if (normalized === 'TFS600A') return 'TFA600';
   return normalized;
 };
 
@@ -256,17 +276,109 @@ interface RawCandidate {
   warning?: string;
 }
 
+interface PackagedRiggingCandidate extends RawCandidate {
+  canonicalKey:
+    | 'BUMPER K1'
+    | 'BUMPER K2'
+    | 'BUMPER KARA';
+}
+
+const packagedRiggingKeys = new Set<PackagedRiggingCandidate['canonicalKey']>([
+  'BUMPER K1',
+  'BUMPER K2',
+  'BUMPER KARA',
+]);
+
+const isPackagedRiggingCandidate = (
+  candidate: RawCandidate,
+): candidate is PackagedRiggingCandidate =>
+  candidate.source === 'xmlp-rigging' &&
+  packagedRiggingKeys.has(candidate.canonicalKey as PackagedRiggingCandidate['canonicalKey']);
+
+/**
+ * Converts serialized bumper pieces into the physical flight cases used by
+ * Flex. Pieces are aggregated per destination group before the dual-case
+ * calculation so left/right arrays share a case when appropriate.
+ */
+function packageRiggingCandidates(candidates: RawCandidate[]): RawCandidate[] {
+  const aggregated = new Map<string, PackagedRiggingCandidate>();
+  for (const candidate of candidates) {
+    if (!isPackagedRiggingCandidate(candidate)) continue;
+    const key = `${candidate.flexCategoryKey ?? 'unassigned'}:${candidate.canonicalKey}`;
+    const existing = aggregated.get(key);
+    if (!existing) {
+      aggregated.set(key, {
+        ...candidate,
+        sourceArrays: [...candidate.sourceArrays],
+      });
+      continue;
+    }
+    existing.quantity += candidate.quantity;
+    existing.sourceArrays = [...new Set([...existing.sourceArrays, ...candidate.sourceArrays])];
+    existing.warning = [existing.warning, candidate.warning].filter(Boolean).join(' ') || undefined;
+  }
+
+  const emitted = new Set<string>();
+  const packaged: RawCandidate[] = [];
+  for (const candidate of candidates) {
+    if (!isPackagedRiggingCandidate(candidate)) {
+      packaged.push(candidate);
+      continue;
+    }
+    const key = `${candidate.flexCategoryKey ?? 'unassigned'}:${candidate.canonicalKey}`;
+    if (emitted.has(key)) continue;
+    emitted.add(key);
+    const total = aggregated.get(key)!;
+
+    if (candidate.canonicalKey === 'BUMPER K1') {
+      const dualCases = Math.floor(total.quantity / 2);
+      if (dualCases > 0) {
+        packaged.push({
+          ...total,
+          canonicalKey: 'BUMPER K1 DUAL CASE',
+          displayName: 'Dual K1 Rigging Flight Case',
+          quantity: dualCases,
+        });
+      }
+      if (total.quantity % 2 === 1) {
+        packaged.push({
+          ...total,
+          canonicalKey: 'BUMPER K1 SINGLE CASE',
+          displayName: 'K1 Rigging Flight Case',
+          quantity: 1,
+        });
+      }
+      continue;
+    }
+
+    const isK2 = candidate.canonicalKey === 'BUMPER K2';
+    packaged.push({
+      ...total,
+      canonicalKey: isK2 ? 'BUMPER K2 DUAL CASE' : 'BUMPER KARA DUAL CASE',
+      displayName: isK2 ? 'Dual K2 Rigging Flight Case' : 'Dual Kara Rigging Flight Case',
+      quantity: Math.ceil(total.quantity / 2),
+    });
+  }
+  return packaged;
+}
+
 function resolveCandidate(raw: RawCandidate, equipment: XmlpEquipmentRow[]): XmlpFlexCandidate {
   const alias = aliasFor(raw.canonicalKey);
-  const base = {
+  const base: Omit<XmlpFlexCandidate, 'mappingStatus'> = {
     id: `${raw.flexCategoryKey ?? 'unassigned'}:${raw.canonicalKey}:${raw.source}`,
-    ...raw,
+    canonicalKey: raw.canonicalKey,
+    displayName: raw.displayName,
+    quantity: raw.quantity,
+    flexCategoryKey: raw.flexCategoryKey,
     sources: [raw.source],
+    sourceArrays: raw.sourceArrays,
+    inference: raw.inference,
     equipmentId: null,
     equipmentName: null,
     resourceId: null,
     expectedDepartment: alias?.departments.join(', ') ?? 'sound/lights',
     expectedCategories: alias?.categories ?? [],
+    warning: raw.warning,
   };
   if (!alias) return { ...base, mappingStatus: 'missing-equipment' };
 
@@ -286,7 +398,8 @@ function resolveCandidate(raw: RawCandidate, equipment: XmlpEquipmentRow[]): Xml
       warning: raw.warning ?? `Hay ${matches.length} recursos físicos aprobados para ${raw.canonicalKey}.`,
     };
   }
-  const match = matches[0];
+  const resolvedResourceId = [...resources][0];
+  const match = matches.find((row) => row.resource_id === resolvedResourceId) ?? matches[0];
   if (!match) return { ...base, mappingStatus: 'missing-equipment' };
   if (!match.resource_id) {
     return {
@@ -308,7 +421,11 @@ function resolveCandidate(raw: RawCandidate, equipment: XmlpEquipmentRow[]): Xml
 const mergeCandidates = (candidates: XmlpFlexCandidate[]) => {
   const merged = new Map<string, XmlpFlexCandidate>();
   for (const candidate of candidates) {
-    const key = `${candidate.flexCategoryKey ?? 'unassigned'}:${candidate.resourceId ?? candidate.canonicalKey}:${candidate.mappingStatus}`;
+    const identity =
+      candidate.mappingStatus === 'mapped' && candidate.resourceId
+        ? candidate.resourceId
+        : candidate.canonicalKey;
+    const key = `${candidate.flexCategoryKey ?? 'unassigned'}:${identity}:${candidate.mappingStatus}`;
     const existing = merged.get(key);
     if (!existing) {
       merged.set(key, { ...candidate, sourceArrays: [...candidate.sourceArrays], sources: [...candidate.sources] });
@@ -347,6 +464,9 @@ export function buildXmlpFlexExportPlan(
     const classification = classifications[index];
     if (classification.warning) warnings.push(classification.warning);
     const arrayName = array.arrayName.trim() || array.groupName.trim() || `Array ${index + 1}`;
+    const sourceArray = [array.groupName.trim(), arrayName]
+      .filter((value, sourceIndex, values) => value && values.indexOf(value) === sourceIndex)
+      .join(' / ');
     const counts = new Map<string, number>();
     for (const enclosure of array.enclosures) {
       const canonicalKey = canonicalSpeaker(enclosure.model);
@@ -359,7 +479,7 @@ export function buildXmlpFlexExportPlan(
         quantity,
         flexCategoryKey: classification.category,
         source: 'xmlp-speaker',
-        sourceArrays: [arrayName],
+        sourceArrays: [sourceArray],
         inference: 'explicit',
         warning: classification.warning,
       });
@@ -401,8 +521,11 @@ export function buildXmlpFlexExportPlan(
   for (const unit of uniqueUnits) {
     const model = toAmpModel(unit.model);
     const canonicalKey = model === 'OTRO' ? normalizeXmlpEquipmentName(unit.model) : model;
-    ampCounts.set(canonicalKey, (ampCounts.get(canonicalKey) ?? 0) + 1);
-    if (['LA4', 'LA4X', 'LA8', 'LA12X'].includes(model)) compatibleLaAmplifierCount += 1;
+    if (['LA4', 'LA4X', 'LA8', 'LA12X'].includes(model)) {
+      compatibleLaAmplifierCount += 1;
+    } else {
+      ampCounts.set(canonicalKey, (ampCounts.get(canonicalKey) ?? 0) + 1);
+    }
   }
   for (const [canonicalKey, quantity] of ampCounts) {
     raw.push({
@@ -451,22 +574,16 @@ export function buildXmlpFlexExportPlan(
     });
   }
 
-  const resolved = mergeCandidates(raw.map((candidate) => resolveCandidate(candidate, equipment)));
-  for (const candidate of resolved) {
-    if (candidate.flexCategoryKey === null) {
-      candidate.mappingStatus = 'ambiguous';
-      candidate.warning =
-        candidate.warning ?? 'El array necesita una asignación de grupo antes de poder enviarse.';
-    }
-  }
+  const individuallyResolved = packageRiggingCandidates(raw)
+    .map((candidate) => resolveCandidate(candidate, equipment));
   const canonicalKeysByResource = new Map<string, Set<string>>();
-  for (const candidate of resolved) {
+  for (const candidate of individuallyResolved) {
     if (!candidate.resourceId) continue;
     const keys = canonicalKeysByResource.get(candidate.resourceId) ?? new Set<string>();
     keys.add(candidate.canonicalKey);
     canonicalKeysByResource.set(candidate.resourceId, keys);
   }
-  for (const candidate of resolved) {
+  for (const candidate of individuallyResolved) {
     const keys = candidate.resourceId
       ? canonicalKeysByResource.get(candidate.resourceId)
       : undefined;
@@ -474,6 +591,14 @@ export function buildXmlpFlexExportPlan(
     candidate.mappingStatus = 'ambiguous';
     candidate.warning = `El resource_id ${candidate.resourceId} está asignado a identidades canónicas distintas (${[...keys].join(', ')}).`;
     warnings.push(candidate.warning);
+  }
+  const resolved = mergeCandidates(individuallyResolved);
+  for (const candidate of resolved) {
+    if (candidate.flexCategoryKey === null) {
+      candidate.mappingStatus = 'ambiguous';
+      candidate.warning =
+        candidate.warning ?? 'El array necesita una asignación de grupo antes de poder enviarse.';
+    }
   }
   const groups = XMLP_FLEX_GROUP_ORDER.map((flexCategoryKey) => ({
     flexCategoryKey,

--- a/src/features/technical-tools/flex/xmlpFlexExportPlan.ts
+++ b/src/features/technical-tools/flex/xmlpFlexExportPlan.ts
@@ -1,0 +1,503 @@
+import {
+  toAmpModel,
+  type NwmMap,
+  type SoundvisionFlysheetArray,
+} from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import { SOUND_CONSUMOS_CONFIG } from '@/features/technical-tools/power/consumos/departmentConfigs';
+import { buildCalculatedXmlpPowerRequirements } from '@/features/technical-tools/power/consumos/xmlpPowerRequirements';
+import {
+  getPowerPduOptions,
+  getVoltageForPhase,
+} from '@/features/technical-tools/power/powerCalculations';
+import { soundWeightComponents } from '@/features/technical-tools/weights/soundWeightComponents';
+import { buildXmlpWeightTables } from '@/features/technical-tools/weights/xmlpWeightImport';
+import { normalizeXmlpEquipmentName } from '@/features/technical-tools/weights/xmlpRiggingRequirements';
+
+export type XmlpFlexCategoryKey =
+  | 'pa_mains'
+  | 'pa_downfill'
+  | 'pa_outfill'
+  | 'pa_subs'
+  | 'pa_frontfill'
+  | 'pa_delays'
+  | 'pa_amp';
+
+export type XmlpFlexSource =
+  | 'xmlp-speaker'
+  | 'xmlp-rigging'
+  | 'xmlp-amplifier'
+  | 'derived-amplifier-packaging'
+  | 'pesos-motor'
+  | 'consumos-pdu';
+
+export type XmlpFlexMappingStatus =
+  | 'mapped'
+  | 'missing-resource-id'
+  | 'missing-equipment'
+  | 'ambiguous';
+
+export const XMLP_FLEX_GROUP_ORDER: XmlpFlexCategoryKey[] = [
+  'pa_mains',
+  'pa_downfill',
+  'pa_outfill',
+  'pa_subs',
+  'pa_frontfill',
+  'pa_delays',
+  'pa_amp',
+];
+
+export const XMLP_FLEX_GROUP_LABELS: Record<XmlpFlexCategoryKey, string> = {
+  pa_mains: 'Sistema de PA',
+  pa_downfill: 'Downfill',
+  pa_outfill: 'Outfill',
+  pa_subs: 'Subwoofers',
+  pa_frontfill: 'Frontfill',
+  pa_delays: 'Delays',
+  pa_amp: 'Amplificación',
+};
+
+export interface XmlpEquipmentRow {
+  id: string;
+  name: string;
+  department: string;
+  category: string | null;
+  resource_id: string | null;
+}
+
+export interface XmlpFlexCandidate {
+  id: string;
+  canonicalKey: string;
+  displayName: string;
+  quantity: number;
+  flexCategoryKey: XmlpFlexCategoryKey | null;
+  sources: XmlpFlexSource[];
+  sourceArrays: string[];
+  equipmentId: string | null;
+  equipmentName: string | null;
+  resourceId: string | null;
+  inference: 'explicit' | 'derived';
+  mappingStatus: XmlpFlexMappingStatus;
+  expectedDepartment: string;
+  expectedCategories: string[];
+  warning?: string;
+}
+
+export interface XmlpFlexExportGroup {
+  flexCategoryKey: XmlpFlexCategoryKey;
+  label: string;
+  items: XmlpFlexCandidate[];
+}
+
+export interface XmlpFlexMissingMapping {
+  canonicalKey: string;
+  displayName: string;
+  sources: XmlpFlexSource[];
+  requestedQuantity: number;
+  sourceArrays: string[];
+  expectedDepartment: string;
+  expectedCategories: string[];
+  reason: string;
+}
+
+export interface XmlpFlexExportPlan {
+  groups: XmlpFlexExportGroup[];
+  unassignedItems: XmlpFlexCandidate[];
+  missingMappings: XmlpFlexMissingMapping[];
+  warnings: string[];
+}
+
+export interface XmlpArrayClassification {
+  category: XmlpFlexCategoryKey | null;
+  warning?: string;
+}
+
+const normalizedTokens = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toUpperCase()
+    .split(/[^A-Z0-9]+/)
+    .filter(Boolean);
+
+const hasToken = (tokens: string[], ...words: string[]) =>
+  tokens.some((token) => words.some((word) => token === word || token.startsWith(word)));
+
+const SUB_MODELS = new Set(['KS28', 'K1SB', 'SB18', 'SB15', 'SB10', 'SB28']);
+const FULL_RANGE_MODELS = new Set([
+  'K1',
+  'K2',
+  'K3',
+  'KARA',
+  'KARAII',
+  'KIVA',
+  'TFS900H',
+  'TFA600',
+  'TFS550H',
+  'TFS550L',
+]);
+
+const explicitCategory = (value: string): XmlpFlexCategoryKey | null => {
+  const tokens = normalizedTokens(value);
+  if (hasToken(tokens, 'DOWNFILL') || hasToken(tokens, 'DOWN') || value.match(/DOWN\s+FILL/i)) {
+    return 'pa_downfill';
+  }
+  if (hasToken(tokens, 'OUTFILL', 'SIDEFILL') || hasToken(tokens, 'OUT', 'SIDE') || tokens.includes('OF')) {
+    return 'pa_outfill';
+  }
+  if (hasToken(tokens, 'FRONTFILL') || hasToken(tokens, 'FRONT') || tokens.includes('FF')) {
+    return 'pa_frontfill';
+  }
+  if (hasToken(tokens, 'DELAY') || tokens.includes('DLY')) return 'pa_delays';
+  if (hasToken(tokens, 'SUBWOOFER') || hasToken(tokens, 'SUB') || tokens.includes('SB')) {
+    return 'pa_subs';
+  }
+  if (hasToken(tokens, 'MAIN', 'MAINS', 'SYSTEM', 'SISTEMA') || tokens.includes('PA')) {
+    return 'pa_mains';
+  }
+  return null;
+};
+
+export function classifyXmlpArray(array: SoundvisionFlysheetArray): XmlpArrayClassification {
+  const models = new Set(array.enclosures.map((box) => normalizeXmlpEquipmentName(box.model)));
+  const hasSubs = [...models].some((model) => SUB_MODELS.has(model) || model.endsWith('SB'));
+  const hasFullRange = [...models].some((model) => FULL_RANGE_MODELS.has(model));
+  const mixedWarning =
+    hasSubs && hasFullRange
+      ? `${array.arrayName || array.groupName}: mezcla sospechosa de subgraves y recintos full-range.`
+      : undefined;
+
+  const fromArrayName = explicitCategory(array.arrayName);
+  if (fromArrayName) return { category: fromArrayName, warning: mixedWarning };
+  const fromGroupName = explicitCategory(array.groupName);
+  if (fromGroupName) return { category: fromGroupName, warning: mixedWarning };
+  if (hasSubs && !hasFullRange) return { category: 'pa_subs', warning: mixedWarning };
+
+  const nameTokens = normalizedTokens(`${array.arrayName} ${array.groupName}`);
+  const hasSide = nameTokens.some((token) => ['L', 'R', 'C', 'LEFT', 'RIGHT', 'CENTER'].includes(token));
+  const namesKnownModel = [...models].some((model) =>
+    normalizeXmlpEquipmentName(`${array.arrayName} ${array.groupName}`).includes(model),
+  );
+  if (hasFullRange && (hasSide || namesKnownModel)) {
+    return { category: 'pa_mains', warning: mixedWarning };
+  }
+
+  return {
+    category: null,
+    warning:
+      mixedWarning ??
+      `${array.arrayName || array.groupName}: no se pudo asignar el array a un grupo Flex de forma segura.`,
+  };
+}
+
+export function calculateLaAmplifierPackaging(compatibleAmplifierCount: number) {
+  const safeCount = Math.max(0, Math.floor(compatibleAmplifierCount));
+  return {
+    laRackQuantity: Math.floor(safeCount / 3),
+    laCaseQuantity: safeCount % 3,
+  };
+}
+
+interface XmlpEquipmentAlias {
+  canonicalKey: string;
+  acceptedNames: string[];
+  departments: string[];
+  categories: string[];
+}
+
+const aliases: XmlpEquipmentAlias[] = [
+  { canonicalKey: 'K1', acceptedNames: ["L'Acoustics K1", 'K1'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
+  { canonicalKey: 'K1-SB', acceptedNames: ["L'Acoustics K1-SB", 'K1-SB'], departments: ['sound'], categories: ['speakers', 'pa_subs'] },
+  { canonicalKey: 'K2', acceptedNames: ["L'Acoustics K2", 'K2'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
+  { canonicalKey: 'K3', acceptedNames: ["L'Acoustics K3", 'K3'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
+  { canonicalKey: 'KARA II', acceptedNames: ["L'Acoustics Kara", "L'Acoustics Kara II", 'Kara', 'Kara II'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
+  { canonicalKey: 'KIVA', acceptedNames: ["L'Acoustics Kiva", 'Kiva'], departments: ['sound'], categories: ['speakers', 'pa_mains'] },
+  { canonicalKey: 'KS28', acceptedNames: ["L'Acoustics KS28", 'KS28'], departments: ['sound'], categories: ['speakers', 'pa_subs'] },
+  { canonicalKey: 'LA12X', acceptedNames: ["L'Acoustics LA12X", 'LA12X'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
+  { canonicalKey: 'LA8', acceptedNames: ["L'Acoustics LA8", 'LA8'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
+  { canonicalKey: 'LA4X', acceptedNames: ["L'Acoustics LA4X", 'LA4X'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
+  { canonicalKey: 'LA4', acceptedNames: ["L'Acoustics LA4", 'LA4'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
+  { canonicalKey: 'PLM20000D', acceptedNames: ['PLM 20000DP', 'PLM20000D'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
+  { canonicalKey: 'LA-RAK II', acceptedNames: ["L'Acoustics LA-RAK II", 'LA-RAK II'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
+  { canonicalKey: 'LA-CASE', acceptedNames: ["L'Acoustics LA-CASE II", 'LA-CASE II'], departments: ['sound'], categories: ['amplificacion', 'pa_amp'] },
+  { canonicalKey: 'BUMPER K1', acceptedNames: ['Dual K1 Rigging Flight Case', 'K1 Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER K2', acceptedNames: ['Dual K2 Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER K3', acceptedNames: ['K3-BUMP'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER KARA', acceptedNames: ['Dual Kara Rigging Flight Case'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER KIVA', acceptedNames: ["L'Acoustics KIBU", 'KIBU'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'BUMPER KS28', acceptedNames: ['KS28 BUMP'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'MOTOR 2T', acceptedNames: ['Motor Elevacion 2T D8+ - 25 m'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'MOTOR 1T', acceptedNames: ['Motor Electrico de Elevación ChainMaster D8 1000kg - 30 m'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'MOTOR 750KG', acceptedNames: ['Motor Elevacion ChainMaster D8+ 750kg - 24 m'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'MOTOR 500KG', acceptedNames: ['Motor Electrico de Elevacion   500 KG  - 25 m'], departments: ['lights'], categories: ['rigging'] },
+  { canonicalKey: 'PDU CEE32A 3P+N+G', acceptedNames: ['PDU Sound CEE32A 3P+N+G'], departments: ['sound'], categories: ['pa_amp'] },
+  { canonicalKey: 'PDU CEE63A 3P+N+G MAIN', acceptedNames: ['PDU Sound Main CEE63A 3P+N+G'], departments: ['sound'], categories: ['pa_amp'] },
+  { canonicalKey: 'PDU CEE63A 3P+N+G MONITORES', acceptedNames: ['PDU Sound Monitores CEE63A 3P+N+G'], departments: ['sound'], categories: ['pa_amp'] },
+  { canonicalKey: 'PDU CEE125A 3P+N+G', acceptedNames: ['PDU Sound CEE125A 3P+N+G'], departments: ['sound'], categories: ['pa_amp'] },
+];
+
+const canonicalSpeaker = (model: string) => {
+  const normalized = normalizeXmlpEquipmentName(model);
+  if (normalized === 'KARA' || normalized === 'KARAII') return 'KARA II';
+  if (normalized === 'K1SB') return 'K1-SB';
+  return normalized;
+};
+
+const aliasFor = (canonicalKey: string) =>
+  aliases.find((entry) => entry.canonicalKey === canonicalKey);
+
+interface RawCandidate {
+  canonicalKey: string;
+  displayName: string;
+  quantity: number;
+  flexCategoryKey: XmlpFlexCategoryKey | null;
+  source: XmlpFlexSource;
+  sourceArrays: string[];
+  inference: 'explicit' | 'derived';
+  warning?: string;
+}
+
+function resolveCandidate(raw: RawCandidate, equipment: XmlpEquipmentRow[]): XmlpFlexCandidate {
+  const alias = aliasFor(raw.canonicalKey);
+  const base = {
+    id: `${raw.flexCategoryKey ?? 'unassigned'}:${raw.canonicalKey}:${raw.source}`,
+    ...raw,
+    sources: [raw.source],
+    equipmentId: null,
+    equipmentName: null,
+    resourceId: null,
+    expectedDepartment: alias?.departments.join(', ') ?? 'sound/lights',
+    expectedCategories: alias?.categories ?? [],
+  };
+  if (!alias) return { ...base, mappingStatus: 'missing-equipment' };
+
+  const accepted = new Set(alias.acceptedNames.map(normalizeXmlpEquipmentName));
+  const matches = equipment.filter(
+    (row) =>
+      accepted.has(normalizeXmlpEquipmentName(row.name)) &&
+      alias.departments.includes(row.department) &&
+      row.category !== null &&
+      alias.categories.includes(row.category),
+  );
+  const resources = new Set(matches.map((row) => row.resource_id).filter(Boolean));
+  if (matches.length > 1 && resources.size > 1) {
+    return {
+      ...base,
+      mappingStatus: 'ambiguous',
+      warning: raw.warning ?? `Hay ${matches.length} recursos físicos aprobados para ${raw.canonicalKey}.`,
+    };
+  }
+  const match = matches[0];
+  if (!match) return { ...base, mappingStatus: 'missing-equipment' };
+  if (!match.resource_id) {
+    return {
+      ...base,
+      equipmentId: match.id,
+      equipmentName: match.name,
+      mappingStatus: 'missing-resource-id',
+    };
+  }
+  return {
+    ...base,
+    equipmentId: match.id,
+    equipmentName: match.name,
+    resourceId: match.resource_id,
+    mappingStatus: 'mapped',
+  };
+}
+
+const mergeCandidates = (candidates: XmlpFlexCandidate[]) => {
+  const merged = new Map<string, XmlpFlexCandidate>();
+  for (const candidate of candidates) {
+    const key = `${candidate.flexCategoryKey ?? 'unassigned'}:${candidate.resourceId ?? candidate.canonicalKey}:${candidate.mappingStatus}`;
+    const existing = merged.get(key);
+    if (!existing) {
+      merged.set(key, { ...candidate, sourceArrays: [...candidate.sourceArrays], sources: [...candidate.sources] });
+      continue;
+    }
+    existing.quantity += candidate.quantity;
+    existing.sourceArrays = [...new Set([...existing.sourceArrays, ...candidate.sourceArrays])];
+    existing.sources = [...new Set([...existing.sources, ...candidate.sources])];
+    existing.inference =
+      existing.inference === 'derived' || candidate.inference === 'derived' ? 'derived' : 'explicit';
+    existing.warning = [existing.warning, candidate.warning].filter(Boolean).join(' ' ) || undefined;
+  }
+  return [...merged.values()].map((candidate, index) => ({ ...candidate, id: `${candidate.id}:${index}` }));
+};
+
+const pduCanonicalKey = (pdu: string, sourceTable: string) => {
+  const normalized = pdu.toUpperCase();
+  if (normalized.includes('CEE63A')) {
+    return sourceTable.toUpperCase().includes('MONITOR')
+      ? 'PDU CEE63A 3P+N+G MONITORES'
+      : 'PDU CEE63A 3P+N+G MAIN';
+  }
+  return `PDU ${normalized}`;
+};
+
+export function buildXmlpFlexExportPlan(
+  map: NwmMap,
+  equipment: XmlpEquipmentRow[],
+): XmlpFlexExportPlan {
+  const raw: RawCandidate[] = [];
+  const warnings: string[] = [];
+  const flysheet = map.flysheet;
+  const classifications = flysheet?.arrays.map(classifyXmlpArray) ?? [];
+
+  flysheet?.arrays.forEach((array, index) => {
+    const classification = classifications[index];
+    if (classification.warning) warnings.push(classification.warning);
+    const arrayName = array.arrayName.trim() || array.groupName.trim() || `Array ${index + 1}`;
+    const counts = new Map<string, number>();
+    for (const enclosure of array.enclosures) {
+      const canonicalKey = canonicalSpeaker(enclosure.model);
+      counts.set(canonicalKey, (counts.get(canonicalKey) ?? 0) + 1);
+    }
+    for (const [canonicalKey, quantity] of counts) {
+      raw.push({
+        canonicalKey,
+        displayName: canonicalKey,
+        quantity,
+        flexCategoryKey: classification.category,
+        source: 'xmlp-speaker',
+        sourceArrays: [arrayName],
+        inference: 'explicit',
+        warning: classification.warning,
+      });
+    }
+  });
+
+  if (flysheet) {
+    const weights = buildXmlpWeightTables(flysheet, soundWeightComponents);
+    warnings.push(...weights.warnings);
+    for (const rigging of weights.riggingRequirements) {
+      raw.push({
+        canonicalKey: rigging.canonicalKey,
+        displayName: rigging.displayName,
+        quantity: rigging.quantity,
+        flexCategoryKey: classifications[rigging.sourceArrayIndex]?.category ?? null,
+        source: 'xmlp-rigging',
+        sourceArrays: [rigging.sourceArray],
+        inference: 'explicit',
+        warning: classifications[rigging.sourceArrayIndex]?.warning,
+      });
+    }
+    for (const motor of weights.motorRequirements) {
+      raw.push({
+        canonicalKey: motor.canonicalKey,
+        displayName: motor.displayName,
+        quantity: motor.quantity,
+        flexCategoryKey: classifications[motor.sourceArrayIndex]?.category ?? null,
+        source: 'pesos-motor',
+        sourceArrays: [motor.sourceArray],
+        inference: 'derived',
+        warning: classifications[motor.sourceArrayIndex]?.warning,
+      });
+    }
+  }
+
+  const uniqueUnits = [...new Map(map.units.map((unit) => [unit.octet, unit])).values()];
+  const ampCounts = new Map<string, number>();
+  let compatibleLaAmplifierCount = 0;
+  for (const unit of uniqueUnits) {
+    const model = toAmpModel(unit.model);
+    const canonicalKey = model === 'OTRO' ? normalizeXmlpEquipmentName(unit.model) : model;
+    ampCounts.set(canonicalKey, (ampCounts.get(canonicalKey) ?? 0) + 1);
+    if (['LA4', 'LA4X', 'LA8', 'LA12X'].includes(model)) compatibleLaAmplifierCount += 1;
+  }
+  for (const [canonicalKey, quantity] of ampCounts) {
+    raw.push({
+      canonicalKey,
+      displayName: canonicalKey,
+      quantity,
+      flexCategoryKey: 'pa_amp',
+      source: 'xmlp-amplifier',
+      sourceArrays: ['Unidades físicas XMLP'],
+      inference: 'explicit',
+    });
+  }
+
+  const packaging = calculateLaAmplifierPackaging(compatibleLaAmplifierCount);
+  if (packaging.laRackQuantity > 0) {
+    raw.push({ canonicalKey: 'LA-RAK II', displayName: 'LA-RAK II', quantity: packaging.laRackQuantity, flexCategoryKey: 'pa_amp', source: 'derived-amplifier-packaging', sourceArrays: ['Total amplificadores L-Acoustics XMLP'], inference: 'derived' });
+  }
+  if (packaging.laCaseQuantity > 0) {
+    raw.push({ canonicalKey: 'LA-CASE', displayName: 'LA-CASE', quantity: packaging.laCaseQuantity, flexCategoryKey: 'pa_amp', source: 'derived-amplifier-packaging', sourceArrays: ['Resto amplificadores L-Acoustics XMLP'], inference: 'derived' });
+  }
+
+  const power = buildCalculatedXmlpPowerRequirements({
+    map,
+    components: SOUND_CONSUMOS_CONFIG.components,
+    pduOptions: getPowerPduOptions('sound', 'three'),
+    settings: {
+      safetyMargin: SOUND_CONSUMOS_CONFIG.defaultSafetyMargin,
+      phaseMode: 'three',
+      voltage: getVoltageForPhase('three'),
+      powerFactor: SOUND_CONSUMOS_CONFIG.defaultPowerFactor,
+    },
+  });
+  warnings.push(...power.warnings);
+  for (const pdu of power.pduRequirements) {
+    raw.push({
+      canonicalKey: pdu.recommendedPdu
+        ? pduCanonicalKey(pdu.recommendedPdu, pdu.sourceTable)
+        : pdu.canonicalKey,
+      displayName: pdu.displayName,
+      quantity: pdu.quantity,
+      flexCategoryKey: 'pa_amp',
+      source: 'consumos-pdu',
+      sourceArrays: [pdu.sourceTable],
+      inference: 'derived',
+      warning: pdu.warning,
+    });
+  }
+
+  const resolved = mergeCandidates(raw.map((candidate) => resolveCandidate(candidate, equipment)));
+  for (const candidate of resolved) {
+    if (candidate.flexCategoryKey === null) {
+      candidate.mappingStatus = 'ambiguous';
+      candidate.warning =
+        candidate.warning ?? 'El array necesita una asignación de grupo antes de poder enviarse.';
+    }
+  }
+  const canonicalKeysByResource = new Map<string, Set<string>>();
+  for (const candidate of resolved) {
+    if (!candidate.resourceId) continue;
+    const keys = canonicalKeysByResource.get(candidate.resourceId) ?? new Set<string>();
+    keys.add(candidate.canonicalKey);
+    canonicalKeysByResource.set(candidate.resourceId, keys);
+  }
+  for (const candidate of resolved) {
+    const keys = candidate.resourceId
+      ? canonicalKeysByResource.get(candidate.resourceId)
+      : undefined;
+    if (!keys || keys.size < 2) continue;
+    candidate.mappingStatus = 'ambiguous';
+    candidate.warning = `El resource_id ${candidate.resourceId} está asignado a identidades canónicas distintas (${[...keys].join(', ')}).`;
+    warnings.push(candidate.warning);
+  }
+  const groups = XMLP_FLEX_GROUP_ORDER.map((flexCategoryKey) => ({
+    flexCategoryKey,
+    label: XMLP_FLEX_GROUP_LABELS[flexCategoryKey],
+    items: resolved.filter((item) => item.flexCategoryKey === flexCategoryKey),
+  }));
+  const unassignedItems = resolved.filter((item) => item.flexCategoryKey === null);
+  const missingMappings = resolved
+    .filter((item) => item.mappingStatus !== 'mapped')
+    .map((item) => ({
+      canonicalKey: item.canonicalKey,
+      displayName: item.displayName,
+      sources: item.sources,
+      requestedQuantity: item.quantity,
+      sourceArrays: item.sourceArrays,
+      expectedDepartment: item.expectedDepartment,
+      expectedCategories: item.expectedCategories,
+      reason:
+        item.mappingStatus === 'ambiguous'
+          ? item.warning ?? 'Más de un recurso físico coincide.'
+          : item.mappingStatus === 'missing-resource-id'
+            ? 'La fila de equipment no tiene resource_id.'
+            : 'No existe una fila equipment exacta dentro del departamento y categoría aprobados.',
+    }));
+
+  return { groups, unassignedItems, missingMappings, warnings: [...new Set(warnings)] };
+}

--- a/src/features/technical-tools/power/consumos/useXmlpPowerImport.ts
+++ b/src/features/technical-tools/power/consumos/useXmlpPowerImport.ts
@@ -2,12 +2,11 @@ import { useState } from "react";
 
 import { parseLaSessionFile } from "@/components/sound/amplifier-tool/rack-designer/parse-session-file";
 import { useToast } from "@/hooks/use-toast";
-import { createCalculatedPowerTable } from "@/features/technical-tools/power/powerCalculations";
 import type { PowerElectricalSettings, PowerTable } from "@/features/technical-tools/power/types";
 
 import type { ConsumosComponent } from "./config";
 import { createPrebuiltMonitorPdu } from "./monitorPduPreset";
-import { buildXmlpPowerTables } from "./xmlpPowerImport";
+import { buildCalculatedXmlpPowerRequirements } from "./xmlpPowerRequirements";
 
 interface ImportStage {
   name: string;
@@ -48,32 +47,21 @@ export function useXmlpPowerImport({
     setIsImportingXmlp(true);
     try {
       const map = await parseLaSessionFile(file);
-      const result = buildXmlpPowerTables(map, components);
+      const result = buildCalculatedXmlpPowerRequirements({
+        map,
+        components,
+        pduOptions,
+        settings: getSettings(),
+        firstId: Date.now(),
+        stage: selectedStage,
+      });
       if (result.tables.length === 0) {
         throw new Error(
           result.warnings[0] || "El XMLP no contiene amplificadores reconocibles.",
         );
       }
 
-      const settings = getSettings();
-      const firstId = Date.now();
-      const builtTables = result.tables.map((table, index) =>
-        createCalculatedPowerTable({
-          components,
-          currentTable: { rows: table.rows, position: table.position },
-          id: firstId + index,
-          name: table.name,
-          pduOptions,
-          settings,
-          tablePatch: {
-            includesHoist: table.includesHoist,
-            stageName: selectedStage?.name ?? null,
-            stageNumber: selectedStage?.number ?? null,
-          },
-        }) as PowerTable,
-      );
-
-      onTablesImported(builtTables);
+      onTablesImported(result.tables);
 
       const warningSuffix =
         result.warnings.length > 0

--- a/src/features/technical-tools/power/consumos/xmlpPowerRequirements.ts
+++ b/src/features/technical-tools/power/consumos/xmlpPowerRequirements.ts
@@ -1,0 +1,89 @@
+import type { NwmMap } from '@/components/sound/amplifier-tool/rack-designer/nwm-import';
+import { createCalculatedPowerTable } from '@/features/technical-tools/power/powerCalculations';
+import type {
+  PowerElectricalSettings,
+  PowerTable,
+} from '@/features/technical-tools/power/types';
+
+import type { ConsumosComponent } from './config';
+import { buildXmlpPowerTables } from './xmlpPowerImport';
+
+export interface InferredPduRequirement {
+  canonicalKey: string;
+  displayName: string;
+  quantity: number;
+  sourceTable: string;
+  recommendedPdu: string | null;
+  currentPerPhase: number | null;
+  warning?: string;
+}
+
+export interface CalculatedXmlpPowerResult {
+  tables: PowerTable[];
+  pduRequirements: InferredPduRequirement[];
+  warnings: string[];
+}
+
+interface BuildCalculatedXmlpPowerOptions {
+  map: Pick<NwmMap, 'units' | 'groups'>;
+  components: ConsumosComponent[];
+  pduOptions: string[];
+  settings: PowerElectricalSettings;
+  firstId?: number;
+  stage?: { name: string; number: number } | null;
+}
+
+/**
+ * Shared XMLP power adapter. Consumos consumes its calculated tables while the
+ * Flex planner consumes only the structured PDU requirements.
+ */
+export function buildCalculatedXmlpPowerRequirements({
+  map,
+  components,
+  pduOptions,
+  settings,
+  firstId = 1,
+  stage = null,
+}: BuildCalculatedXmlpPowerOptions): CalculatedXmlpPowerResult {
+  const built = buildXmlpPowerTables(map, components);
+  const tables = built.tables.map((table, index) =>
+    createCalculatedPowerTable({
+      components,
+      currentTable: { rows: table.rows, position: table.position },
+      id: firstId + index,
+      name: table.name,
+      pduOptions,
+      settings,
+      tablePatch: {
+        includesHoist: table.includesHoist,
+        stageName: stage?.name ?? null,
+        stageNumber: stage?.number ?? null,
+      },
+    }) as PowerTable,
+  );
+
+  const warnings = [...built.warnings];
+  const pduRequirements = tables.map((table): InferredPduRequirement => {
+    const recommendedPdu = table.pduType?.trim() || null;
+    const warning = recommendedPdu
+      ? undefined
+      : `${table.name}: la carga no tiene una PDU compatible dentro del límite de planificación del 80 %.`;
+    if (warning) warnings.push(warning);
+    return {
+      canonicalKey: recommendedPdu
+        ? `PDU ${recommendedPdu.toUpperCase()}`
+        : `PDU SIN RECOMENDACIÓN (${table.name.toUpperCase()})`,
+      displayName: recommendedPdu ?? 'PDU sin recomendación',
+      quantity: 1,
+      sourceTable: table.name,
+      recommendedPdu,
+      currentPerPhase:
+        typeof table.currentPerPhase === 'number' && Number.isFinite(table.currentPerPhase)
+          ? table.currentPerPhase
+          : null,
+      warning,
+    };
+  });
+
+  return { tables, pduRequirements, warnings: [...new Set(warnings)] };
+}

--- a/src/features/technical-tools/weights/__tests__/xmlpWeightImport.test.ts
+++ b/src/features/technical-tools/weights/__tests__/xmlpWeightImport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { soundWeightComponents } from '@/features/technical-tools/weights/soundWeightComponents';
+import { resolveXmlpRiggingRequirement } from '@/features/technical-tools/weights/xmlpRiggingRequirements';
 import { buildXmlpWeightTables } from '@/features/technical-tools/weights/xmlpWeightImport';
 
 type XmlpArrayInput = Parameters<typeof buildXmlpWeightTables>[0]['arrays'][number];
@@ -16,6 +17,30 @@ const makeArray = (overrides: Partial<XmlpArrayInput> = {}): XmlpArrayInput => (
   rearLoadKg: null,
   enclosures: [{ model: 'K2' }, { model: 'K2' }],
   ...overrides,
+});
+
+describe('resolveXmlpRiggingRequirement', () => {
+  it.each([
+    ['K1-BUMP', 'BUMPER K1'],
+    ['K1 BAR', 'BUMPER K1'],
+    ['K2-BUMP', 'BUMPER K2'],
+    ['K3 BAR', 'BUMPER K3'],
+    ['M-BUMP', 'BUMPER KARA'],
+    ['KARA MINI-BU', 'BUMPER KARA'],
+    ['KIVA-BAR', 'BUMPER KIVA'],
+    ['KS28 OUTRIG', 'BUMPER KS28'],
+    ['TFS900 BUMP', 'BUMPER TFS900'],
+    ['TFS550 BAR', 'BUMPER TFS550'],
+  ])('maps %s to %s', (riggingFrame, canonicalKey) => {
+    expect(resolveXmlpRiggingRequirement(makeArray({ riggingFrame }), 0)).toMatchObject({
+      canonicalKey,
+      quantity: 1,
+    });
+  });
+
+  it('does not treat a different numbered model as K1 or K2 rigging', () => {
+    expect(resolveXmlpRiggingRequirement(makeArray({ riggingFrame: 'K20-BUMP' }), 0)).toBeNull();
+  });
 });
 
 describe('buildXmlpWeightTables', () => {

--- a/src/features/technical-tools/weights/xmlpRiggingRequirements.ts
+++ b/src/features/technical-tools/weights/xmlpRiggingRequirements.ts
@@ -1,0 +1,107 @@
+import type { WeightComponent } from './weightCalculations';
+
+export interface XmlpRiggingArray {
+  arrayName: string;
+  groupName: string;
+  riggingFrame: string;
+  flyingBarSetting?: string;
+}
+
+export interface XmlpRiggingRequirement {
+  canonicalKey: string;
+  displayName: string;
+  quantity: number;
+  sourceArray: string;
+  sourceArrayIndex: number;
+  serializedValue: string;
+}
+
+export const normalizeXmlpEquipmentName = (value: string) =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '');
+
+const RIGGING_FRAME_ALIASES: Array<{ pattern: RegExp; canonicalKey: string }> = [
+  { pattern: /K1.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER K1' },
+  { pattern: /K2.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER K2' },
+  { pattern: /K3.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER K3' },
+  { pattern: /^MBUMP$/, canonicalKey: 'BUMPER KARA' },
+  { pattern: /KARA.*(?:BUMP|MINIBU|BAR)/, canonicalKey: 'BUMPER KARA' },
+  { pattern: /KIVA.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER KIVA' },
+  { pattern: /KS28.*(?:BUMP|OUTRIG|BAR)/, canonicalKey: 'BUMPER KS28' },
+  { pattern: /TFS900.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER TFS900' },
+  { pattern: /TFS550.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER TFS550' },
+];
+
+const serializedQuantity = (value: string) => {
+  const match = value.match(/(?:^|\s)(\d+)\s*[x×]\s*/i);
+  if (!match) return 1;
+  const quantity = Number.parseInt(match[1], 10);
+  return Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+};
+
+const aliasFor = (value: string) => {
+  const normalized = normalizeXmlpEquipmentName(value);
+  return RIGGING_FRAME_ALIASES.find(({ pattern }) => pattern.test(normalized))?.canonicalKey;
+};
+
+/**
+ * Resolves the one serialized rigging-frame requirement for an XMLP array.
+ * Both Pesos and Flex consume this function so aliases and explicit quantities
+ * such as `2x K2-BAR` cannot drift between the two outputs.
+ */
+export function resolveXmlpRiggingRequirement(
+  array: XmlpRiggingArray,
+  sourceArrayIndex: number,
+): XmlpRiggingRequirement | null {
+  const values = [array.riggingFrame, array.flyingBarSetting ?? '']
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  for (const value of values) {
+    const canonicalKey = aliasFor(value);
+    if (!canonicalKey) continue;
+    return {
+      canonicalKey,
+      displayName: canonicalKey,
+      quantity: serializedQuantity(value),
+      sourceArray: array.arrayName.trim() || array.groupName.trim() || `Array ${sourceArrayIndex + 1}`,
+      sourceArrayIndex,
+      serializedValue: value,
+    };
+  }
+
+  return null;
+}
+
+export function findWeightComponentByName<Component extends WeightComponent>(
+  name: string,
+  components: Component[],
+): Component | undefined {
+  const normalized = normalizeXmlpEquipmentName(name);
+  return components.find(
+    (component) => normalizeXmlpEquipmentName(component.name) === normalized,
+  );
+}
+
+export function getXmlpMotorCapacityKg(componentName: string) {
+  const match = normalizeXmlpEquipmentName(componentName).match(/^MOTOR(\d+)(T|KG)$/);
+  if (!match) return null;
+  const capacity = Number.parseInt(match[1], 10);
+  return match[2] === 'T' ? capacity * 1000 : capacity;
+}
+
+export function findXmlpMotorForLoad<Component extends WeightComponent>(
+  loadKg: number,
+  components: Component[],
+) {
+  return components
+    .map((component) => ({ component, capacityKg: getXmlpMotorCapacityKg(component.name) }))
+    .filter(
+      (candidate): candidate is { component: Component; capacityKg: number } =>
+        candidate.capacityKg !== null && candidate.capacityKg >= loadKg,
+    )
+    .sort((left, right) => left.capacityKg - right.capacityKg)[0];
+}

--- a/src/features/technical-tools/weights/xmlpRiggingRequirements.ts
+++ b/src/features/technical-tools/weights/xmlpRiggingRequirements.ts
@@ -24,15 +24,15 @@ export const normalizeXmlpEquipmentName = (value: string) =>
     .replace(/[^A-Z0-9]/g, '');
 
 const RIGGING_FRAME_ALIASES: Array<{ pattern: RegExp; canonicalKey: string }> = [
-  { pattern: /K1.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER K1' },
-  { pattern: /K2.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER K2' },
-  { pattern: /K3.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER K3' },
+  { pattern: /K1(?:BUMP|BAR)/, canonicalKey: 'BUMPER K1' },
+  { pattern: /K2(?:BUMP|BAR)/, canonicalKey: 'BUMPER K2' },
+  { pattern: /K3(?:BUMP|BAR)/, canonicalKey: 'BUMPER K3' },
   { pattern: /^MBUMP$/, canonicalKey: 'BUMPER KARA' },
-  { pattern: /KARA.*(?:BUMP|MINIBU|BAR)/, canonicalKey: 'BUMPER KARA' },
-  { pattern: /KIVA.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER KIVA' },
-  { pattern: /KS28.*(?:BUMP|OUTRIG|BAR)/, canonicalKey: 'BUMPER KS28' },
-  { pattern: /TFS900.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER TFS900' },
-  { pattern: /TFS550.*(?:BUMP|BAR)/, canonicalKey: 'BUMPER TFS550' },
+  { pattern: /KARA(?:BUMP|MINIBU|BAR)/, canonicalKey: 'BUMPER KARA' },
+  { pattern: /KIVA(?:BUMP|BAR)/, canonicalKey: 'BUMPER KIVA' },
+  { pattern: /KS28(?:BUMP|OUTRIG|BAR)/, canonicalKey: 'BUMPER KS28' },
+  { pattern: /TFS900(?:BUMP|BAR)/, canonicalKey: 'BUMPER TFS900' },
+  { pattern: /TFS550(?:BUMP|BAR)/, canonicalKey: 'BUMPER TFS550' },
 ];
 
 const serializedQuantity = (value: string) => {
@@ -60,16 +60,24 @@ export function resolveXmlpRiggingRequirement(
     .map((value) => value.trim())
     .filter(Boolean);
 
-  for (const value of values) {
-    const canonicalKey = aliasFor(value);
-    if (!canonicalKey) continue;
+  const resolved = values
+    .map((value) => ({ value, canonicalKey: aliasFor(value) }))
+    .filter(
+      (entry): entry is { value: string; canonicalKey: string } =>
+        entry.canonicalKey !== undefined,
+    );
+  const first = resolved[0];
+  if (first) {
+    const matchingValues = resolved.filter((entry) => entry.canonicalKey === first.canonicalKey);
+    const quantity = Math.max(...matchingValues.map((entry) => serializedQuantity(entry.value)));
+    const serialized = matchingValues.find((entry) => serializedQuantity(entry.value) === quantity)!;
     return {
-      canonicalKey,
-      displayName: canonicalKey,
-      quantity: serializedQuantity(value),
+      canonicalKey: first.canonicalKey,
+      displayName: first.canonicalKey,
+      quantity,
       sourceArray: array.arrayName.trim() || array.groupName.trim() || `Array ${sourceArrayIndex + 1}`,
       sourceArrayIndex,
-      serializedValue: value,
+      serializedValue: serialized.value,
     };
   }
 

--- a/src/features/technical-tools/weights/xmlpWeightImport.ts
+++ b/src/features/technical-tools/weights/xmlpWeightImport.ts
@@ -1,4 +1,11 @@
 import type { WeightComponent, WeightTableRow } from './weightCalculations';
+import {
+  findWeightComponentByName,
+  findXmlpMotorForLoad,
+  getXmlpMotorCapacityKg,
+  resolveXmlpRiggingRequirement,
+  type XmlpRiggingRequirement,
+} from './xmlpRiggingRequirements';
 
 interface XmlpEnclosure {
   model: string;
@@ -9,6 +16,7 @@ interface XmlpArray {
   groupName: string;
   deployment: 'flown' | 'stacked' | 'unknown';
   riggingFrame: string;
+  flyingBarSetting?: string;
   pickupConfiguration: string;
   totalMassKg: number | null;
   frontLoadKg: number | null;
@@ -32,49 +40,23 @@ export interface XmlpWeightImportResult {
   tables: ImportedXmlpWeightTable[];
   warnings: string[];
   exactMassTableCount: number;
+  riggingRequirements: XmlpRiggingRequirement[];
+  motorRequirements: InferredMotorRequirement[];
 }
 
-const normalizeModel = (value: string) =>
-  value
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toUpperCase()
-    .replace(/[^A-Z0-9]/g, '');
-
-const RIGGING_FRAME_ALIASES: Array<{ pattern: RegExp; component: string }> = [
-  { pattern: /K1.*(?:BUMP|BAR)/, component: 'BUMPER K1' },
-  { pattern: /K2.*(?:BUMP|BAR)/, component: 'BUMPER K2' },
-  { pattern: /K3.*(?:BUMP|BAR)/, component: 'BUMPER K3' },
-  { pattern: /^MBUMP$/, component: 'BUMPER KARA' },
-  { pattern: /KARA.*(?:BUMP|MINIBU|BAR)/, component: 'BUMPER KARA' },
-  { pattern: /KIVA.*(?:BUMP|BAR)/, component: 'BUMPER KIVA' },
-  { pattern: /KS28.*(?:BUMP|OUTRIG|BAR)/, component: 'BUMPER KS28' },
-  { pattern: /TFS900.*(?:BUMP|BAR)/, component: 'BUMPER TFS900' },
-  { pattern: /TFS550.*(?:BUMP|BAR)/, component: 'BUMPER TFS550' },
-];
 const MOTOR_CAPACITY_SAFETY_FACTOR = 1.2;
 
+export interface InferredMotorRequirement {
+  canonicalKey: string;
+  displayName: string;
+  quantity: number;
+  sourceArray: string;
+  sourceArrayIndex: number;
+  requiredCapacityKg: number;
+  selectedCapacityKg: number;
+}
+
 const formatWeight = (value: number) => Number(value.toFixed(3)).toString();
-
-const findComponentByName = <Component extends WeightComponent>(
-  name: string,
-  components: Component[],
-): Component | undefined => {
-  const normalized = normalizeModel(name);
-  return components.find((component) => normalizeModel(component.name) === normalized);
-};
-
-const findRiggingComponent = <Component extends WeightComponent>(
-  riggingFrame: string,
-  components: Component[],
-): Component | undefined => {
-  const exact = findComponentByName(riggingFrame, components);
-  if (exact) return exact;
-
-  const normalized = normalizeModel(riggingFrame);
-  const alias = RIGGING_FRAME_ALIASES.find(({ pattern }) => pattern.test(normalized));
-  return alias ? findComponentByName(alias.component, components) : undefined;
-};
 
 const getPickupPointCount = (array: XmlpArray) => {
   const serializedLoadCount = [array.frontLoadKg, array.rearLoadKg]
@@ -98,23 +80,6 @@ const getPickupPointCount = (array: XmlpArray) => {
     Number.isFinite(explicitMotorCount) ? explicitMotorCount : 0,
   );
 };
-
-const getMotorCapacityKg = (componentName: string) => {
-  const match = normalizeModel(componentName).match(/^MOTOR(\d+)(T|KG)$/);
-  if (!match) return null;
-
-  const capacity = Number.parseInt(match[1], 10);
-  return match[2] === 'T' ? capacity * 1000 : capacity;
-};
-
-const findMotorForLoad = <Component extends WeightComponent>(
-  loadKg: number,
-  components: Component[],
-) => components
-  .map((component) => ({ component, capacityKg: getMotorCapacityKg(component.name) }))
-  .filter((candidate): candidate is { component: Component; capacityKg: number } =>
-    candidate.capacityKg !== null && candidate.capacityKg >= loadKg)
-  .sort((left, right) => left.capacityKg - right.capacityKg)[0]?.component;
 
 const summarizeArray = (array: XmlpArray) => {
   const counts = new Map<string, number>();
@@ -157,6 +122,10 @@ export function buildXmlpWeightTables<Component extends WeightComponent>(
 ): XmlpWeightImportResult {
   const tables: ImportedXmlpWeightTable[] = [];
   const warnings: string[] = [];
+  const riggingRequirements = flysheet.arrays
+    .map((array, index) => resolveXmlpRiggingRequirement(array, index))
+    .filter((requirement): requirement is XmlpRiggingRequirement => requirement !== null);
+  const motorRequirements: InferredMotorRequirement[] = [];
   let exactMassTableCount = 0;
 
   for (const [index, array] of flysheet.arrays.entries()) {
@@ -175,7 +144,7 @@ export function buildXmlpWeightTables<Component extends WeightComponent>(
       const counts = new Map<string, { component: Component; quantity: number }>();
       const unknownModels = new Set<string>();
       for (const enclosure of array.enclosures) {
-        const component = findComponentByName(enclosure.model, components);
+        const component = findWeightComponentByName(enclosure.model, components);
         if (!component) {
           unknownModels.add(enclosure.model.trim() || 'modelo sin nombre');
           continue;
@@ -185,17 +154,18 @@ export function buildXmlpWeightTables<Component extends WeightComponent>(
         counts.set(key, { component, quantity: (current?.quantity ?? 0) + 1 });
       }
 
-      const riggingFrame = array.riggingFrame.trim();
-      const riggingComponent = riggingFrame
-        ? findRiggingComponent(riggingFrame, components)
+      const riggingRequirement = resolveXmlpRiggingRequirement(array, index);
+      const serializedRigging = array.riggingFrame.trim() || array.flyingBarSetting?.trim() || '';
+      const riggingComponent = riggingRequirement
+        ? findWeightComponentByName(riggingRequirement.canonicalKey, components)
         : undefined;
-      if (riggingFrame && !riggingComponent) unknownModels.add(riggingFrame);
-      if (riggingComponent) {
+      if (serializedRigging && !riggingComponent) unknownModels.add(serializedRigging);
+      if (riggingComponent && riggingRequirement) {
         const key = riggingComponent.id.toString();
         const current = counts.get(key);
         counts.set(key, {
           component: riggingComponent,
-          quantity: (current?.quantity ?? 0) + 1,
+          quantity: (current?.quantity ?? 0) + riggingRequirement.quantity,
         });
       }
 
@@ -219,8 +189,8 @@ export function buildXmlpWeightTables<Component extends WeightComponent>(
     // Select against 120% of the complete suspended load even when two pickup
     // points share it, so either motor independently includes the safety margin.
     const requiredMotorCapacity = loadWeight * MOTOR_CAPACITY_SAFETY_FACTOR;
-    const motor = findMotorForLoad(requiredMotorCapacity, components);
-    if (!motor) {
+    const selectedMotor = findXmlpMotorForLoad(requiredMotorCapacity, components);
+    if (!selectedMotor) {
       warnings.push(
         `${name}: ningún motor del catálogo puede soportar por sí solo ${formatWeight(loadWeight)} kg con un margen del 20 %; no se importó.`,
       );
@@ -228,7 +198,17 @@ export function buildXmlpWeightTables<Component extends WeightComponent>(
     }
 
     const pickupPointCount = getPickupPointCount(array);
-    rows.push(componentRow(motor, pickupPointCount));
+    rows.push(componentRow(selectedMotor.component, pickupPointCount));
+    motorRequirements.push({
+      canonicalKey: selectedMotor.component.name.trim().toUpperCase(),
+      displayName: selectedMotor.component.name.trim(),
+      quantity: pickupPointCount,
+      sourceArray: name,
+      sourceArrayIndex: index,
+      requiredCapacityKg: requiredMotorCapacity,
+      selectedCapacityKg:
+        getXmlpMotorCapacityKg(selectedMotor.component.name) ?? selectedMotor.capacityKg,
+    });
     const totalWeight = rows.reduce((sum, row) => sum + row.totalWeight, 0);
     if (!hasExactMass) warnings.push(`${name}: peso derivado del catálogo; revisa el cableado.`);
     tables.push({
@@ -241,5 +221,5 @@ export function buildXmlpWeightTables<Component extends WeightComponent>(
     if (hasExactMass) exactMassTableCount += 1;
   }
 
-  return { tables, warnings, exactMassTableCount };
+  return { tables, warnings, exactMassTableCount, riggingRequirements, motorRequirements };
 }

--- a/src/services/__tests__/flexPullsheets.strict.test.ts
+++ b/src/services/__tests__/flexPullsheets.strict.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { flexApiFetch } from '@/lib/flex-api-client';
+import {
+  FLEX_CATEGORY_MAP,
+  pushEquipmentToFlexDocumentStrict,
+} from '../flexPullsheets';
+
+vi.mock('@/lib/flex-api-client', () => ({ flexApiFetch: vi.fn() }));
+vi.mock('@/integrations/supabase/client', () => ({ supabase: {} }));
+
+const response = (ok: boolean, lineItemId?: string) => ({
+  ok,
+  status: ok ? 200 : 500,
+  statusText: ok ? 'OK' : 'Error',
+  headers: new Headers(),
+  json: vi.fn().mockResolvedValue(lineItemId ? { addedResourceLineIds: [lineItemId] } : {}),
+  text: vi.fn().mockResolvedValue(ok ? '' : 'upstream failed'),
+});
+
+describe('pushEquipmentToFlexDocumentStrict', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a Pull Sheet header before children and passes its line ID as parent', async () => {
+    vi.mocked(flexApiFetch)
+      .mockResolvedValueOnce(response(true, 'main-header'))
+      .mockResolvedValueOnce(response(true, 'k2-line'));
+
+    const result = await pushEquipmentToFlexDocumentStrict(
+      { elementId: 'pullsheet-1', documentType: 'pullsheet' },
+      [{ resourceId: 'k2-resource', quantity: 24, name: 'K2', flexCategoryKey: 'pa_mains' }],
+    );
+
+    expect(flexApiFetch).toHaveBeenNthCalledWith(
+      1,
+      `/line-item/pullsheet-1/add-resource/${FLEX_CATEGORY_MAP.get('pa_mains')}`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(flexApiFetch).toHaveBeenNthCalledWith(
+      2,
+      '/line-item/pullsheet-1/add-resource/k2-resource',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('parentLineItemId=main-header'),
+      }),
+    );
+    expect(result).toEqual(expect.objectContaining({
+      groupsCreated: ['pa_mains'],
+      equipmentLinesAdded: 1,
+      totalQuantitiesRepresented: 24,
+    }));
+  });
+
+  it('uses the financial-document transport for Presupuestos', async () => {
+    vi.mocked(flexApiFetch)
+      .mockResolvedValueOnce(response(true, 'amp-header'))
+      .mockResolvedValueOnce(response(true, 'amp-line'));
+
+    await pushEquipmentToFlexDocumentStrict(
+      { elementId: 'quote-1', documentType: 'presupuesto' },
+      [{ resourceId: 'amp-resource', quantity: 3, name: 'LA12X', flexCategoryKey: 'pa_amp' }],
+    );
+
+    expect(vi.mocked(flexApiFetch).mock.calls[0][0]).toMatch(
+      /^\/financial-document-line-item\/quote-1\/add-resource\//,
+    );
+    expect(vi.mocked(flexApiFetch).mock.calls[1][0]).toContain(
+      '/financial-document-line-item/quote-1/add-resource/amp-resource?',
+    );
+    expect(vi.mocked(flexApiFetch).mock.calls[1][1]?.body).toContain(
+      'parentLineItemId=amp-header',
+    );
+  });
+
+  it('never sends children to root when their category header fails', async () => {
+    vi.mocked(flexApiFetch).mockResolvedValueOnce(response(false));
+
+    const result = await pushEquipmentToFlexDocumentStrict(
+      { elementId: 'pullsheet-1', documentType: 'pullsheet' },
+      [{ resourceId: 'sub-resource', quantity: 12, name: 'KS28', flexCategoryKey: 'pa_subs' }],
+    );
+
+    expect(flexApiFetch).toHaveBeenCalledTimes(1);
+    expect(result.groupsFailed).toHaveLength(1);
+    expect(result.childrenSkippedBecauseParentFailed).toEqual([
+      expect.objectContaining({ name: 'KS28', flexCategoryKey: 'pa_subs' }),
+    ]);
+    expect(result.equipmentLinesAdded).toBe(0);
+  });
+
+  it('continues independent groups after one parent failure', async () => {
+    vi.mocked(flexApiFetch)
+      .mockResolvedValueOnce(response(false))
+      .mockResolvedValueOnce(response(true, 'amp-header'))
+      .mockResolvedValueOnce(response(true, 'amp-line'));
+
+    const result = await pushEquipmentToFlexDocumentStrict(
+      { elementId: 'pullsheet-1', documentType: 'pullsheet' },
+      [
+        { resourceId: 'k2-resource', quantity: 2, name: 'K2', flexCategoryKey: 'pa_mains' },
+        { resourceId: 'amp-resource', quantity: 1, name: 'LA12X', flexCategoryKey: 'pa_amp' },
+      ],
+    );
+
+    expect(result.groupsFailed).toHaveLength(1);
+    expect(result.groupsCreated).toEqual(['pa_amp']);
+    expect(result.equipmentLinesAdded).toBe(1);
+  });
+
+  it('aggregates only within category plus resource and creates no empty headers', async () => {
+    vi.mocked(flexApiFetch)
+      .mockResolvedValueOnce(response(true, 'main-header'))
+      .mockResolvedValueOnce(response(true, 'main-child'))
+      .mockResolvedValueOnce(response(true, 'out-header'))
+      .mockResolvedValueOnce(response(true, 'out-child'));
+
+    const result = await pushEquipmentToFlexDocumentStrict(
+      { elementId: 'pullsheet-1', documentType: 'pullsheet' },
+      [
+        { resourceId: 'k2-resource', quantity: 2, name: 'K2 L', flexCategoryKey: 'pa_mains' },
+        { resourceId: 'k2-resource', quantity: 3, name: 'K2 R', flexCategoryKey: 'pa_mains' },
+        { resourceId: 'k2-resource', quantity: 1, name: 'K2 Out', flexCategoryKey: 'pa_outfill' },
+      ],
+    );
+
+    expect(flexApiFetch).toHaveBeenCalledTimes(4);
+    expect(result.equipmentLinesAdded).toBe(2);
+    expect(result.totalQuantitiesRepresented).toBe(6);
+    expect(vi.mocked(flexApiFetch).mock.calls[1][1]?.body).toContain('quantity=5');
+  });
+});

--- a/src/services/__tests__/flexPullsheets.strict.test.ts
+++ b/src/services/__tests__/flexPullsheets.strict.test.ts
@@ -4,7 +4,7 @@ import { flexApiFetch } from '@/lib/flex-api-client';
 import {
   FLEX_CATEGORY_MAP,
   pushEquipmentToFlexDocumentStrict,
-} from '../flexPullsheets';
+} from '@/services/flexPullsheets';
 
 vi.mock('@/lib/flex-api-client', () => ({ flexApiFetch: vi.fn() }));
 vi.mock('@/integrations/supabase/client', () => ({ supabase: {} }));

--- a/src/services/flexPullsheets.ts
+++ b/src/services/flexPullsheets.ts
@@ -1,6 +1,9 @@
 import { supabase } from '@/integrations/supabase/client';
 import { flexApiFetch } from '@/lib/flex-api-client';
 import type { PresetSubsystem } from '@/types/equipment';
+import { FLEX_FOLDER_IDS } from '@/utils/flex-folders/constants';
+
+export type FlexEquipmentDocumentType = 'pullsheet' | 'presupuesto';
 
 // Material de sonido is a root-only grouping in Flex and intentionally omitted here.
 export const FLEX_CATEGORY_MAP = new Map<string, string>([
@@ -34,9 +37,18 @@ async function addResourceLineItem(options: {
   quantity: number;
   parentLineItemId?: string;
   nextSiblingId?: string;
+  documentType?: FlexEquipmentDocumentType;
 }): Promise<{ success: boolean; error?: string; lineItemId?: string }> {
-  const { documentId, resourceId, quantity, parentLineItemId = '', nextSiblingId = '' } = options;
-  const endpoint = `/line-item/${encodeURIComponent(documentId)}/add-resource/${encodeURIComponent(resourceId)}`;
+  const {
+    documentId,
+    resourceId,
+    quantity,
+    parentLineItemId = '',
+    nextSiblingId = '',
+    documentType = 'pullsheet',
+  } = options;
+  const path = documentType === 'presupuesto' ? 'financial-document-line-item' : 'line-item';
+  const baseEndpoint = `/${path}/${encodeURIComponent(documentId)}/add-resource/${encodeURIComponent(resourceId)}`;
 
   const headers = {
     accept: '*/*',
@@ -50,6 +62,14 @@ async function addResourceLineItem(options: {
     parentLineItemId: parentLineItemId,
     nextSiblingId: nextSiblingId,
   });
+  const endpoint =
+    documentType === 'presupuesto'
+      ? `${baseEndpoint}?${new URLSearchParams({
+          resourceParentId: '',
+          managedResourceLineItemType: 'inventory-model',
+          quantity: String(quantity),
+        }).toString()}`
+      : baseEndpoint;
 
   try {
     const res = await flexApiFetch(endpoint, {
@@ -141,6 +161,107 @@ export interface PushResult {
   failed: Array<{ name: string; error: string }>;
 }
 
+export interface StrictGroupedPushFailure {
+  flexCategoryKey: string;
+  name: string;
+  error: string;
+}
+
+export interface StrictGroupedPushResult {
+  groupsCreated: string[];
+  groupsReused: string[];
+  groupsFailed: StrictGroupedPushFailure[];
+  equipmentLinesAdded: number;
+  totalQuantitiesRepresented: number;
+  childrenSkippedBecauseParentFailed: StrictGroupedPushFailure[];
+  failedChildItems: StrictGroupedPushFailure[];
+  warnings: string[];
+}
+
+export interface StrictFlexDocumentTarget {
+  elementId: string;
+  documentType: FlexEquipmentDocumentType;
+}
+
+/**
+ * Strict XMLP-package writer. Unlike the legacy preset writer, a failed group
+ * header can never cause its children to fall back to the document root.
+ */
+export async function pushEquipmentToFlexDocumentStrict(
+  target: StrictFlexDocumentTarget,
+  equipment: EquipmentItem[],
+): Promise<StrictGroupedPushResult> {
+  const result: StrictGroupedPushResult = {
+    groupsCreated: [],
+    groupsReused: [],
+    groupsFailed: [],
+    equipmentLinesAdded: 0,
+    totalQuantitiesRepresented: 0,
+    childrenSkippedBecauseParentFailed: [],
+    failedChildItems: [],
+    warnings: ['La integración actual no permite reconciliar líneas existentes; el envío es aditivo.'],
+  };
+  const normalized = normalizeEquipmentItems(equipment).filter(
+    (item) => item.quantity > 0 && Boolean(item.resourceId),
+  );
+  const byCategory = new Map<string, Array<EquipmentItem & { flexCategoryKey: string }>>();
+  for (const item of normalized) {
+    const items = byCategory.get(item.flexCategoryKey) ?? [];
+    items.push(item);
+    byCategory.set(item.flexCategoryKey, items);
+  }
+
+  for (const [flexCategoryKey, items] of byCategory) {
+    const headerResourceId = FLEX_CATEGORY_MAP.get(flexCategoryKey);
+    if (!headerResourceId) {
+      const error = 'No existe un recurso de cabecera Flex aprobado para este grupo.';
+      result.groupsFailed.push({ flexCategoryKey, name: flexCategoryKey, error });
+      result.childrenSkippedBecauseParentFailed.push(
+        ...items.map((item) => ({ flexCategoryKey, name: item.name, error })),
+      );
+      continue;
+    }
+
+    const header = await addResourceLineItem({
+      documentId: target.elementId,
+      documentType: target.documentType,
+      resourceId: headerResourceId,
+      quantity: 1,
+    });
+    if (!header.success || !header.lineItemId) {
+      const error = header.error ?? 'Flex no devolvió el ID de la cabecera creada.';
+      result.groupsFailed.push({ flexCategoryKey, name: flexCategoryKey, error });
+      result.childrenSkippedBecauseParentFailed.push(
+        ...items.map((item) => ({ flexCategoryKey, name: item.name, error })),
+      );
+      continue;
+    }
+
+    result.groupsCreated.push(flexCategoryKey);
+    for (const item of items) {
+      const child = await addResourceLineItem({
+        documentId: target.elementId,
+        documentType: target.documentType,
+        resourceId: item.resourceId,
+        quantity: item.quantity,
+        parentLineItemId: header.lineItemId,
+      });
+      if (!child.success) {
+        result.failedChildItems.push({
+          flexCategoryKey,
+          name: item.name,
+          error: child.error ?? 'Error desconocido al crear la línea hija.',
+        });
+        continue;
+      }
+      result.equipmentLinesAdded += 1;
+      result.totalQuantitiesRepresented += item.quantity;
+    }
+  }
+
+  return result;
+}
+
 export async function pushEquipmentToPullsheet(
   pullsheetElementId: string,
   equipment: EquipmentItem[]
@@ -226,8 +347,17 @@ export interface JobPullsheet {
   source?: 'database' | 'flex_api';
 }
 
+export interface JobFlexEquipmentTarget extends JobPullsheet {
+  document_type: FlexEquipmentDocumentType;
+  folder_type?: string;
+}
+
 // Pullsheet definition ID from Flex API
-const PULLSHEET_DEFINITION_ID = 'a220432c-af33-11df-b8d5-00e08175e43e';
+const PULLSHEET_DEFINITION_ID = FLEX_FOLDER_IDS.pullSheet;
+const PRESUPUESTO_DEFINITION_IDS = new Set([
+  FLEX_FOLDER_IDS.presupuesto,
+  FLEX_FOLDER_IDS.presupuestoDryHire,
+]);
 // Some Flex tree responses omit definitionId; pullsheets still have this domainId.
 const PULLSHEET_DOMAIN_ID = 'equipment-list';
 
@@ -420,4 +550,87 @@ function extractPullsheetsFromTree(node: FlexTreeNode | FlexTreeNode[], depth: n
   }
 
   return results;
+}
+
+function extractPresupuestosFromTree(
+  node: FlexTreeNode | FlexTreeNode[],
+  depth: number = 0,
+): JobFlexEquipmentTarget[] {
+  if (depth > MAX_TREE_DEPTH || !node) return [];
+  if (Array.isArray(node)) {
+    return node.flatMap((item) => extractPresupuestosFromTree(item, depth));
+  }
+  const results: JobFlexEquipmentTarget[] = [];
+  const elementId = node.elementId || node.nodeId || node.id;
+  const definitionId = node.definitionId || node.elementDefinitionId;
+  if (elementId && definitionId && PRESUPUESTO_DEFINITION_IDS.has(definitionId)) {
+    results.push({
+      id: elementId,
+      element_id: elementId,
+      department: null,
+      created_at:
+        node.createdAt || node.created_at || node.dateCreated || node.date_created ||
+        '2000-01-01T00:00:00.000Z',
+      display_name: node.displayName || node.name || node.documentNumber || 'Presupuesto',
+      source: 'flex_api',
+      document_type: 'presupuesto',
+    });
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      results.push(...extractPresupuestosFromTree(child, depth + 1));
+    }
+  }
+  return results;
+}
+
+/** Discovers both equipment-list Pull Sheets and actual quote documents. */
+export async function getJobFlexEquipmentTargets(jobId: string): Promise<JobFlexEquipmentTarget[]> {
+  const { data, error } = await supabase
+    .from('flex_folders')
+    .select('id, element_id, department, created_at, folder_type')
+    .eq('job_id', jobId)
+    .in('folder_type', ['pull_sheet', 'comercial_presupuesto', 'dryhire_presupuesto'])
+    .order('created_at', { ascending: true })
+    .limit(100);
+  if (error) throw new Error(`Failed to query Flex equipment targets: ${error.message}`);
+
+  const dbTargets: JobFlexEquipmentTarget[] = (data ?? []).map((row) => ({
+    ...row,
+    document_type: row.folder_type === 'pull_sheet' ? 'pullsheet' : 'presupuesto',
+    display_name:
+      row.folder_type === 'pull_sheet'
+        ? row.department ? `${row.department} Pull Sheet` : 'Pull Sheet'
+        : row.department ? `${row.department} Presupuesto` : 'Presupuesto',
+    source: 'database' as const,
+  }));
+
+  const { data: mainFolder } = await supabase
+    .from('flex_folders')
+    .select('element_id')
+    .eq('job_id', jobId)
+    .or('folder_type.eq.main_event,folder_type.eq.main')
+    .maybeSingle();
+  if (!mainFolder?.element_id) return dbTargets;
+
+  try {
+    const response = await flexApiFetch(
+      `/element/${encodeURIComponent(mainFolder.element_id)}/tree`,
+      { method: 'GET', headers: { 'Content-Type': 'application/json' } },
+    );
+    if (!response.ok) return dbTargets;
+    const tree = await response.json<FlexTreeNode | FlexTreeNode[]>();
+    const apiTargets: JobFlexEquipmentTarget[] = [
+      ...extractPullsheetsFromTree(tree).map((target) => ({ ...target, document_type: 'pullsheet' as const })),
+      ...extractPresupuestosFromTree(tree),
+    ];
+    const byElementId = new Map(dbTargets.map((target) => [target.element_id, target]));
+    for (const target of apiTargets) {
+      if (!byElementId.has(target.element_id)) byElementId.set(target.element_id, target);
+    }
+    return [...byElementId.values()];
+  } catch (fetchError) {
+    console.warn('[FlexPullsheets] Could not augment equipment targets from Flex tree:', fetchError);
+    return dbTargets;
+  }
 }

--- a/src/utils/flexUrlParser.ts
+++ b/src/utils/flexUrlParser.ts
@@ -49,6 +49,19 @@ export function extractFlexElementId(url: string): string | null {
   }
 }
 
+export type FlexEquipmentUrlDocumentType = 'pullsheet' | 'presupuesto';
+
+/** Returns a document type only when the Flex URL schema states it explicitly. */
+export function extractFlexEquipmentDocumentType(
+  url: string,
+): FlexEquipmentUrlDocumentType | null {
+  if (!url || typeof url !== 'string') return null;
+  const normalized = url.trim().toLowerCase();
+  if (normalized.includes('#equipment-list/')) return 'pullsheet';
+  if (normalized.includes('#fin-doc/')) return 'presupuesto';
+  return null;
+}
+
 /**
  * Validates if a string looks like a Flex URL
  *

--- a/supabase/functions/parse-la-session/parse.test.ts
+++ b/supabase/functions/parse-la-session/parse.test.ts
@@ -202,6 +202,31 @@ describe("parseSoundvisionFlysheet", () => {
     ]);
   });
 
+  it("uses the closest explicit Soundvision group below an ALL configuration", () => {
+    const groupedShape = `<project name="Grouped">
+      <physical_configuration><name>ALL</name><children>
+        <group><name>SISTEMA DE PA</name><children>
+          <cluster name="Copy of K1 L"><elements><enclosure model="K2" /></elements></cluster>
+        </children></group>
+        <source_group name="Outfill"><children>
+          <cluster name="KARA II 1"><elements><enclosure model="KARA" /></elements></cluster>
+        </children></source_group>
+        <source_group><label>Frontfill</label><children>
+          <cluster name="Copy of KARA II 1"><elements><enclosure model="KARA" /></elements></cluster>
+        </children></source_group>
+      </children></physical_configuration>
+    </project>`;
+
+    expect(parseSoundvisionFlysheet(groupedShape).arrays.map((array) => ({
+      groupName: array.groupName,
+      arrayName: array.arrayName,
+    }))).toEqual([
+      { groupName: "SISTEMA DE PA", arrayName: "Copy of K1 L" },
+      { groupName: "Outfill", arrayName: "KARA II 1" },
+      { groupName: "Frontfill", arrayName: "Copy of KARA II 1" },
+    ]);
+  });
+
   it("attaches flysheet data to the existing XMLP amplifier map", () => {
     const xml = soundvisionProject.replace(
       "</project>",

--- a/supabase/functions/parse-la-session/parse.ts
+++ b/supabase/functions/parse-la-session/parse.ts
@@ -130,6 +130,71 @@ function extractXmlBlocks(xml: string, tag: string): XmlBlock[] {
   return blocks;
 }
 
+interface NamedXmlAncestor {
+  tagName: string;
+  name: string;
+}
+
+/**
+ * Soundvision can nest clusters inside named scene groups below one broad
+ * physical_configuration (commonly named "ALL"). Capture the closest named
+ * ancestor for each cluster without requiring a fixed group tag name; project
+ * files from different Soundvision versions use slightly different wrappers.
+ */
+function closestNamedAncestors(
+  xml: string,
+  targetStarts: readonly number[],
+): Map<number, string> {
+  const targets = new Set(targetStarts);
+  const result = new Map<number, string>();
+  const stack: NamedXmlAncestor[] = [];
+  const tags = /<!--[\s\S]*?-->|<\?[\s\S]*?\?>|<!\[CDATA\[[\s\S]*?\]\]>|<![^>]*>|<\/[A-Za-z_][\w:.-]*\s*>|<[A-Za-z_][\w:.-]*\b[^>]*>/g;
+
+  for (const match of xml.matchAll(tags)) {
+    const start = match.index;
+    const raw = match[0];
+    if (targets.has(start)) {
+      const ancestor = [...stack]
+        .reverse()
+        .find((entry) => entry.name && entry.tagName !== "project");
+      if (ancestor) result.set(start, ancestor.name);
+    }
+
+    if (raw.startsWith("<!--") || raw.startsWith("<?") || raw.startsWith("<!")) {
+      continue;
+    }
+
+    const closing = raw.match(/^<\/([A-Za-z_][\w:.-]*)/);
+    if (closing) {
+      const tagName = closing[1].split(":").pop()!.toLowerCase();
+      while (stack.length > 0) {
+        const entry = stack.pop()!;
+        if (entry.tagName === tagName) break;
+      }
+      continue;
+    }
+
+    const opening = raw.match(/^<([A-Za-z_][\w:.-]*)\b([^>]*)>/);
+    if (!opening) continue;
+    const tagName = opening[1].split(":").pop()!.toLowerCase();
+    if (tagName === "name" || tagName === "label") {
+      const directText = xml
+        .slice(start + raw.length)
+        .match(new RegExp(`^\\s*([^<]*?)\\s*</(?:[\\w.-]+:)?${tagName}\\s*>`, "i"))?.[1];
+      const parent = stack[stack.length - 1];
+      if (parent && directText?.trim()) parent.name = decodeXmlEntities(directText.trim());
+    }
+
+    if (raw.endsWith("/>")) continue;
+    stack.push({
+      tagName,
+      name: firstAttribute(attrs(opening[2]), ["name", "label"]),
+    });
+  }
+
+  return result;
+}
+
 function firstTextOf(body: string, tags: readonly string[]): string {
   for (const tag of tags) {
     const value = textOf(body, tag);
@@ -343,6 +408,7 @@ export function parseSoundvisionFlysheet(
   const arrays: SoundvisionFlysheetArray[] = [];
   const allConfigurations = extractXmlBlocks(xml, "physical_configuration");
   const clusters = extractXmlBlocks(xml, "cluster");
+  const namedAncestors = closestNamedAncestors(xml, clusters.map((cluster) => cluster.start));
 
   for (const cluster of clusters) {
     const configuration = allConfigurations
@@ -353,6 +419,7 @@ export function parseSoundvisionFlysheet(
     const configurationAttributes = attrs(configuration.attributes);
     const configurationBody = configuration.body;
     const groupName =
+      namedAncestors.get(cluster.start) ||
       firstAttribute(configurationAttributes, ["name", "id"]) ||
       firstTextOf(configurationBody.split(/<cluster\b/i)[0], ["name", "label"]) ||
       "SISTEMA";

--- a/supabase/migrations/20260720230000_add_xmlp_flex_equipment_resources.sql
+++ b/supabase/migrations/20260720230000_add_xmlp_flex_equipment_resources.sql
@@ -1,9 +1,73 @@
 -- Explicitly approved Flex resource mappings supplied for the Soundvision XMLP
--- package exporter. This migration only adds mapping metadata; it does not
--- change authorization or inventory quantities.
+-- package exporter. This migration only corrects/adds mapping metadata; it does
+-- not change authorization or inventory quantities.
 
-WITH approved(name, department, category, resource_id) AS (
-  VALUES
+-- Production historically assigned the KS28 BUMP resource to the KS28 speaker.
+-- Correct that exact canonical row before the BUMP resource is registered. Fail
+-- closed if either identifier is claimed by an unrelated item.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.equipment
+    WHERE resource_id = 'acbd4200-4fa3-11eb-815f-2a0a4490a7fb'
+      AND NOT (
+        department = 'sound'
+        AND category = 'speakers'
+        AND lower(trim(name)) IN ('ks28', 'l''acoustics ks28', 'l''acoustics ks 28')
+      )
+  ) THEN
+    RAISE EXCEPTION 'KS28 speaker resource is already claimed by unrelated equipment';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.equipment
+    WHERE resource_id = '83662cb0-31f6-11ec-bc23-f23c925290b3'
+      AND NOT (
+        department = 'sound'
+        AND category = 'speakers'
+        AND lower(trim(name)) IN ('ks28', 'l''acoustics ks28', 'l''acoustics ks 28')
+      )
+  ) THEN
+    RAISE EXCEPTION 'KS28 BUMP resource is already claimed by unrelated equipment';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.equipment
+    WHERE department = 'sound'
+      AND category = 'speakers'
+      AND lower(trim(name)) IN ('ks28', 'l''acoustics ks28', 'l''acoustics ks 28')
+      AND resource_id IS NOT NULL
+      AND resource_id NOT IN (
+        '83662cb0-31f6-11ec-bc23-f23c925290b3',
+        'acbd4200-4fa3-11eb-815f-2a0a4490a7fb'
+      )
+  ) THEN
+    RAISE EXCEPTION 'KS28 speaker row has an unexpected Flex resource mapping';
+  END IF;
+
+  UPDATE public.equipment
+  SET resource_id = 'acbd4200-4fa3-11eb-815f-2a0a4490a7fb',
+      updated_at = timezone('utc'::text, now())
+  WHERE department = 'sound'
+    AND category = 'speakers'
+    AND lower(trim(name)) IN ('ks28', 'l''acoustics ks28', 'l''acoustics ks 28')
+    AND resource_id = '83662cb0-31f6-11ec-bc23-f23c925290b3';
+END;
+$$;
+
+CREATE TEMP TABLE xmlp_approved_equipment_resources (
+  name text NOT NULL,
+  department text NOT NULL,
+  category public.equipment_category NOT NULL,
+  resource_id text NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO xmlp_approved_equipment_resources (name, department, category, resource_id)
+VALUES
+    ('KS28', 'sound', 'speakers', 'acbd4200-4fa3-11eb-815f-2a0a4490a7fb'),
     ('L''Acoustics K1-SB', 'sound', 'speakers', 'acbf3dd0-4fa3-11eb-815f-2a0a4490a7fb'),
     ('Dual K1 Rigging Flight Case', 'lights', 'rigging', '1053a212-9725-4273-9c1f-6ff23976bd03'),
     ('K1 Rigging Flight Case', 'lights', 'rigging', 'ece64810-f375-11eb-87a1-f23c925290b3'),
@@ -17,16 +81,85 @@ WITH approved(name, department, category, resource_id) AS (
     ('PDU Sound Main CEE63A 3P+N+G', 'sound', 'pa_amp', '1f1aa1a0-5b37-11eb-966a-2a0a4490a7fb'),
     ('PDU Sound Monitores CEE63A 3P+N+G', 'sound', 'pa_amp', '1f08c750-5b37-11eb-966a-2a0a4490a7fb'),
     ('PDU Sound CEE125A 3P+N+G', 'sound', 'pa_amp', '1f06cb80-5b37-11eb-966a-2a0a4490a7fb'),
-    ('Motor Elevacion 2T D8+ - 25 m', 'lights', 'rigging', '83f6c04b-1835-48fd-9f75-f02181ca362b')
-)
+    ('Motor Elevacion 2T D8+ - 25 m', 'lights', 'rigging', '83f6c04b-1835-48fd-9f75-f02181ca362b');
+
+-- Do not silently overwrite an existing physical mapping or leave an approved
+-- resource attached to a different equipment row. Any linked-project drift
+-- must be reviewed explicitly before this migration can proceed.
+DO $$
+DECLARE
+  conflicting_row record;
+BEGIN
+  SELECT approved.*, existing.resource_id AS existing_resource_id
+  INTO conflicting_row
+  FROM xmlp_approved_equipment_resources AS approved
+  JOIN public.equipment AS existing
+    ON lower(trim(existing.name)) = lower(trim(approved.name))
+   AND existing.department = approved.department
+   AND existing.category = approved.category
+  WHERE existing.resource_id IS NOT NULL
+    AND existing.resource_id <> approved.resource_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RAISE EXCEPTION 'Approved XMLP mapping for % conflicts with existing resource %',
+      conflicting_row.name, conflicting_row.existing_resource_id;
+  END IF;
+
+  SELECT approved.*, claimed.name AS claimed_name
+  INTO conflicting_row
+  FROM xmlp_approved_equipment_resources AS approved
+  JOIN public.equipment AS claimed
+    ON claimed.resource_id = approved.resource_id
+  WHERE NOT (
+    lower(trim(claimed.name)) = lower(trim(approved.name))
+    AND claimed.department = approved.department
+    AND claimed.category = approved.category
+  )
+  AND NOT (
+    approved.resource_id = 'acbd4200-4fa3-11eb-815f-2a0a4490a7fb'
+    AND claimed.department = 'sound'
+    AND claimed.category = 'speakers'
+    AND lower(trim(claimed.name)) IN ('ks28', 'l''acoustics ks28', 'l''acoustics ks 28')
+  )
+  LIMIT 1;
+
+  IF FOUND THEN
+    RAISE EXCEPTION 'Approved XMLP resource % is already claimed by %',
+      conflicting_row.resource_id, conflicting_row.claimed_name;
+  END IF;
+END;
+$$;
+
+-- Prefer completing an existing exact canonical row over creating a duplicate.
+UPDATE public.equipment AS existing
+SET resource_id = approved.resource_id,
+    updated_at = timezone('utc'::text, now())
+FROM xmlp_approved_equipment_resources AS approved
+WHERE lower(trim(existing.name)) = lower(trim(approved.name))
+  AND existing.department = approved.department
+  AND existing.category = approved.category
+  AND existing.resource_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.equipment claimed
+    WHERE claimed.resource_id = approved.resource_id
+  );
+
 INSERT INTO public.equipment (name, department, category, resource_id)
-SELECT name, department, category::public.equipment_category, resource_id::uuid
-FROM approved
+SELECT name, department, category, resource_id
+FROM xmlp_approved_equipment_resources AS approved
 WHERE NOT EXISTS (
   SELECT 1
   FROM public.equipment existing
-  WHERE existing.resource_id = approved.resource_id::uuid
-    AND lower(trim(existing.name)) = lower(trim(approved.name))
+  WHERE existing.resource_id = approved.resource_id
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM public.equipment existing
+  WHERE lower(trim(existing.name)) = lower(trim(approved.name))
+    AND existing.department = approved.department
+    AND existing.category = approved.category
 );
 
 COMMENT ON COLUMN public.equipment.resource_id IS

--- a/supabase/migrations/20260720230000_add_xmlp_flex_equipment_resources.sql
+++ b/supabase/migrations/20260720230000_add_xmlp_flex_equipment_resources.sql
@@ -1,0 +1,33 @@
+-- Explicitly approved Flex resource mappings supplied for the Soundvision XMLP
+-- package exporter. This migration only adds mapping metadata; it does not
+-- change authorization or inventory quantities.
+
+WITH approved(name, department, category, resource_id) AS (
+  VALUES
+    ('L''Acoustics K1-SB', 'sound', 'speakers', 'acbf3dd0-4fa3-11eb-815f-2a0a4490a7fb'),
+    ('Dual K1 Rigging Flight Case', 'lights', 'rigging', '1053a212-9725-4273-9c1f-6ff23976bd03'),
+    ('K1 Rigging Flight Case', 'lights', 'rigging', 'ece64810-f375-11eb-87a1-f23c925290b3'),
+    ('Dual K2 Rigging Flight Case', 'lights', 'rigging', 'af1cb730-f375-11eb-87a1-f23c925290b3'),
+    ('K3-BUMP', 'lights', 'rigging', '4a6e59ad-35f7-404e-9f0a-097876667524'),
+    ('Dual Kara Rigging Flight Case', 'lights', 'rigging', 'dc4e3c10-f375-11eb-87a1-f23c925290b3'),
+    ('L''Acoustics KIBU', 'lights', 'rigging', 'acf80110-4fa3-11eb-815f-2a0a4490a7fb'),
+    ('KS28 BUMP', 'lights', 'rigging', '83662cb0-31f6-11ec-bc23-f23c925290b3'),
+    ('L''Acoustics LA-CASE II', 'sound', 'amplificacion', 'ad0a2980-4fa3-11eb-815f-2a0a4490a7fb'),
+    ('PDU Sound CEE32A 3P+N+G', 'sound', 'pa_amp', '1f146010-5b37-11eb-966a-2a0a4490a7fb'),
+    ('PDU Sound Main CEE63A 3P+N+G', 'sound', 'pa_amp', '1f1aa1a0-5b37-11eb-966a-2a0a4490a7fb'),
+    ('PDU Sound Monitores CEE63A 3P+N+G', 'sound', 'pa_amp', '1f08c750-5b37-11eb-966a-2a0a4490a7fb'),
+    ('PDU Sound CEE125A 3P+N+G', 'sound', 'pa_amp', '1f06cb80-5b37-11eb-966a-2a0a4490a7fb'),
+    ('Motor Elevacion 2T D8+ - 25 m', 'lights', 'rigging', '83f6c04b-1835-48fd-9f75-f02181ca362b')
+)
+INSERT INTO public.equipment (name, department, category, resource_id)
+SELECT name, department, category::public.equipment_category, resource_id::uuid
+FROM approved
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.equipment existing
+  WHERE existing.resource_id = approved.resource_id::uuid
+    AND lower(trim(existing.name)) = lower(trim(approved.name))
+);
+
+COMMENT ON COLUMN public.equipment.resource_id IS
+  'Flex inventory-model resource identifier used by approved document integrations.';


### PR DESCRIPTION
> [!WARNING]
> **High-risk PR:** includes a Supabase data migration that maps Soundvision/Flex equipment resources. A human must run `supabase db push --linked --dry-run`, review the statements, apply the migration before merge/release, and perform a deliberate second read of the full diff.

## What changed

- adds a Sound-only job-card action with the dedicated flow: select XMLP → review extracted package → choose an existing job Presupuesto/Pull Sheet or create one → push
- parses the closest named Soundvision ancestor so explicit groups such as Main, SUB, Outfill, and Frontfill remain authoritative even when arrays are nested more deeply
- exports the fixture as 24 K2 mains, 12 KARA outfill, 16 KS28 subs, and 12 KARA frontfill
- packages 20 LA12X as 6 LA-RAK II + 2 LA-CASE without also exporting 20 loose amplifiers
- applies the supplied dual/single bumper-case rules and Flex resource IDs, including the real KS28 ID `acbd4200-4fa3-11eb-815f-2a0a4490a7fb`
- supports both Pull Sheet and Presupuesto writers, creating category parents before equipment children and failing closed when a parent cannot be created
- documents the workflow, data mapping, deployment, migration, and rollback steps
- upgrades the direct Capacitor CLI path to `tar 7.5.20`; the remaining legacy tar findings are build-tool-only through the latest `@capacitor/assets` and have owned exceptions expiring 2026-09-30

## Root cause

The XMLP parser previously returned the outer `ALL` group for every cluster. The fallback classifier then treated the word `of` in names such as `Copy of K1 L` as an Outfill abbreviation, producing the incorrect 14/10 split. Amplifier resources were also emitted before rack/case packaging, causing double counting.

## Validation

- live fixture preview: exact 24 K2 PA / 12 KARA Outfill / 16 KS28 Subs / 12 KARA Frontfill
- live packaging preview: 6 LA-RAK II + 2 LA-CASE, no loose LA12X; 1 K1 dual case, 1 KARA outfill dual case, 3 KARA frontfill dual cases
- `npx vitest run src/features/technical-tools/flex/__tests__/xmlpFlexExportPlan.test.ts` — 47 passed
- `npx vitest run supabase/functions/parse-la-session/parse.test.ts` — 8 passed
- `npx vitest run src/components/sound/amplifier-tool/rack-designer/__tests__/XmlpFlexExportDialog.test.tsx` — 5 passed
- `npm run lint` — pass (existing warnings only)
- `npm run typecheck` — pass
- `npm run governance` — pass
- `npm run test:critical` — pass
- `npm run test:run` — pass
- `npm run build` — pass
- `npm run budget:bundle` — pass
- `npm run test:e2e` — 22 passed, 3 intentionally skipped
- staged secret scan — no staged dotenv files or secret signatures

Docker was unavailable locally, so `supabase db reset`, local DB lint, and pgTAP were not run. CI must prove `migration_apply`, `db_lint`, and `rls_rpc_security_tests`.

## Deployment and release handoff

- `parse-la-session` was deployed to linked project `syldobdcdsgfgjtbuwxm` so the signed-in dev preview could exercise the real XMLP
- the database migration has **not** been applied to the linked/production database; until it is applied, the new case/LA-CASE/PDU mappings correctly appear as unmapped
- merging `main` deploys the web application after the migration is reviewed/applied

## Rollback

Revert this PR to remove the UI/planner/writer changes and redeploy the previous `parse-la-session` function if required. The migration is additive data mapping; reverse it with a reviewed forward migration scoped to the inserted/updated rows. Any Flex lines already pushed by a user require manual removal in Flex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “XMLP → Flex” job action and an XMLP import/review/export dialog for Sound projects (with plan preview and selectable mapped items).
  - Added strict pushing of mapped equipment into Flex pull sheets and budgets, including target discovery and category grouping.
  - Added shared XMLP planning for rigging/motors, and consolidated XMLP power requirement building.
  - Added NM/SV session import controls and XMLP-based flysheet generation from imported sessions.
- **Bug Fixes**
  - Improved Soundvision XML parsing for nested “ALL” group naming and added safer handling for unsupported files, missing data, and ambiguous mappings.
- **Documentation**
  - Added architecture documentation for the XMLP → Flex workflow.
- **Tests / Chores**
  - Expanded coverage for dialog flows, strict Flex pushing, and planning utilities; updated Capacitor CLI version and dependency audit baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->