### PR TITLE
fix(flex): pool XMLP bumpers per model into shared dual cases

### DIFF
--- a/src/features/technical-tools/flex/__tests__/xmlpFlexExportPlan.test.ts
+++ b/src/features/technical-tools/flex/__tests__/xmlpFlexExportPlan.test.ts
@@ -175,6 +175,25 @@ describe('XMLP speaker, rigging and motor extraction', () => {
       .toEqual(expect.objectContaining({ quantity: 1, resourceId: 'resource-bumper' }));
   });
 
+  it('pools same-model bumpers across Flex groups into one shared dual case', () => {
+    const plan = buildXmlpFlexExportPlan(
+      map([
+        array('MAIN L', ['K2'], { riggingFrame: 'K2-BUMP' }),
+        array('OUT L', ['K2'], { riggingFrame: 'K2-BUMP' }),
+      ]),
+      [equipment('Dual K2 Rigging Flight Case', 'resource-bumper', 'lights', 'rigging')],
+    );
+    const cases = plan.groups
+      .flatMap((group) => group.items)
+      .filter((item) => item.canonicalKey === 'BUMPER K2 DUAL CASE');
+    // One dual case holds both lone bumpers instead of one case per PA group.
+    expect(cases).toHaveLength(1);
+    expect(cases[0]).toEqual(
+      expect.objectContaining({ quantity: 1, resourceId: 'resource-bumper', flexCategoryKey: 'pa_mains' }),
+    );
+    expect(cases[0].sourceArrays).toEqual(expect.arrayContaining(['MAIN L', 'OUT L']));
+  });
+
   it('packages K1 bumpers into dual cases plus an odd single case', () => {
     const plan = buildXmlpFlexExportPlan(map([array('MAIN L', ['K1'], {
       riggingFrame: 'K1-BUMP',

--- a/src/features/technical-tools/flex/__tests__/xmlpFlexExportPlan.test.ts
+++ b/src/features/technical-tools/flex/__tests__/xmlpFlexExportPlan.test.ts
@@ -171,7 +171,8 @@ describe('XMLP speaker, rigging and motor extraction', () => {
     const plan = buildXmlpFlexExportPlan(map([source]), [
       equipment('Dual K2 Rigging Flight Case', 'resource-bumper', 'lights', 'rigging'),
     ]);
-    expect(plan.groups[0].items.find((item) => item.canonicalKey === 'BUMPER K2 DUAL CASE'))
+    const rigging = plan.groups.find((group) => group.flexCategoryKey === 'rigging_hardware');
+    expect(rigging?.items.find((item) => item.canonicalKey === 'BUMPER K2 DUAL CASE'))
       .toEqual(expect.objectContaining({ quantity: 1, resourceId: 'resource-bumper' }));
   });
 
@@ -186,10 +187,11 @@ describe('XMLP speaker, rigging and motor extraction', () => {
     const cases = plan.groups
       .flatMap((group) => group.items)
       .filter((item) => item.canonicalKey === 'BUMPER K2 DUAL CASE');
-    // One dual case holds both lone bumpers instead of one case per PA group.
+    // One dual case holds both lone bumpers, filed under Rigging Hardware
+    // rather than one case per PA speaker group.
     expect(cases).toHaveLength(1);
     expect(cases[0]).toEqual(
-      expect.objectContaining({ quantity: 1, resourceId: 'resource-bumper', flexCategoryKey: 'pa_mains' }),
+      expect.objectContaining({ quantity: 1, resourceId: 'resource-bumper', flexCategoryKey: 'rigging_hardware' }),
     );
     expect(cases[0].sourceArrays).toEqual(expect.arrayContaining(['MAIN L', 'OUT L']));
   });
@@ -203,7 +205,8 @@ describe('XMLP speaker, rigging and motor extraction', () => {
       equipment('K1 Rigging Flight Case', 'resource-k1-single', 'lights', 'rigging'),
     ]);
 
-    expect(plan.groups[0].items).toEqual(expect.arrayContaining([
+    const rigging = plan.groups.find((group) => group.flexCategoryKey === 'rigging_hardware');
+    expect(rigging?.items).toEqual(expect.arrayContaining([
       expect.objectContaining({ canonicalKey: 'BUMPER K1 DUAL CASE', quantity: 1, resourceId: 'resource-k1-dual' }),
       expect.objectContaining({ canonicalKey: 'BUMPER K1 SINGLE CASE', quantity: 1, resourceId: 'resource-k1-single' }),
     ]));
@@ -217,9 +220,34 @@ describe('XMLP speaker, rigging and motor extraction', () => {
       equipment('Dual Kara Rigging Flight Case', 'resource-kara-dual', 'lights', 'rigging'),
     ]);
 
-    const frontfill = plan.groups.find((group) => group.flexCategoryKey === 'pa_frontfill');
-    expect(frontfill?.items.find((item) => item.canonicalKey === 'BUMPER KARA DUAL CASE'))
+    const rigging = plan.groups.find((group) => group.flexCategoryKey === 'rigging_hardware');
+    expect(rigging?.items.find((item) => item.canonicalKey === 'BUMPER KARA DUAL CASE'))
       .toEqual(expect.objectContaining({ quantity: 2, resourceId: 'resource-kara-dual' }));
+  });
+
+  it('nests bumpers and motors under their own headers, never a PA speaker group', () => {
+    const plan = buildXmlpFlexExportPlan(
+      map([array('MAIN L', ['K2'], {
+        deployment: 'flown',
+        totalMassKg: 600,
+        riggingFrame: 'K2-BUMP',
+        pickupConfiguration: 'F: 1 / R: 2',
+      })]),
+      [
+        equipment('K2', 'resource-k2'),
+        equipment('Dual K2 Rigging Flight Case', 'resource-bumper', 'lights', 'rigging'),
+        equipment('Motor Elevacion ChainMaster D8+ 750kg - 24 m', 'resource-750', 'lights', 'rigging'),
+      ],
+    );
+    const groupOf = (canonicalKey: string) =>
+      plan.groups.find((group) => group.items.some((item) => item.canonicalKey === canonicalKey))
+        ?.flexCategoryKey;
+    expect(groupOf('K2')).toBe('pa_mains');
+    expect(groupOf('BUMPER K2 DUAL CASE')).toBe('rigging_hardware');
+    expect(groupOf('MOTOR 750KG')).toBe('motores_controles');
+    // No rigging/motor items leaked into the PA speaker group.
+    const paMains = plan.groups.find((group) => group.flexCategoryKey === 'pa_mains');
+    expect(paMains?.items.every((item) => item.sources.includes('xmlp-speaker'))).toBe(true);
   });
 
   it('infers motors only for flown arrays with the existing 120% Pesos rule', () => {
@@ -237,7 +265,8 @@ describe('XMLP speaker, rigging and motor extraction', () => {
         'rigging',
       ),
     ]);
-    const motors = plan.groups[0].items.filter((item) => item.sources.includes('pesos-motor'));
+    const motorGroup = plan.groups.find((group) => group.flexCategoryKey === 'motores_controles');
+    const motors = motorGroup?.items.filter((item) => item.sources.includes('pesos-motor'));
     expect(motors).toEqual([
       expect.objectContaining({ canonicalKey: 'MOTOR 750KG', quantity: 2, resourceId: 'resource-750' }),
     ]);
@@ -352,10 +381,17 @@ describe('safe equipment resolution', () => {
       equipment('KS28', 'shared-resource'),
       equipment('KS28 BUMP', 'shared-resource', 'lights', 'rigging'),
     ]);
+    const allItems = plan.groups.flatMap((group) => group.items);
+    // The speaker stays in its PA group and the bumper in Rigging Hardware, but
+    // both must fail closed because they share one Flex resource ID.
     expect(plan.groups.find((group) => group.flexCategoryKey === 'pa_subs')?.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ canonicalKey: 'KS28', mappingStatus: 'ambiguous' }),
-        expect.objectContaining({ canonicalKey: 'BUMPER KS28', mappingStatus: 'ambiguous' }),
+      ]),
+    );
+    expect(allItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ canonicalKey: 'BUMPER KS28', flexCategoryKey: 'rigging_hardware', mappingStatus: 'ambiguous' }),
       ]),
     );
   });

--- a/src/features/technical-tools/flex/xmlpFlexExportPlan.ts
+++ b/src/features/technical-tools/flex/xmlpFlexExportPlan.ts
@@ -20,7 +20,9 @@ export type XmlpFlexCategoryKey =
   | 'pa_subs'
   | 'pa_frontfill'
   | 'pa_delays'
-  | 'pa_amp';
+  | 'pa_amp'
+  | 'rigging_hardware'
+  | 'motores_controles';
 
 export type XmlpFlexSource =
   | 'xmlp-speaker'
@@ -44,6 +46,8 @@ export const XMLP_FLEX_GROUP_ORDER: XmlpFlexCategoryKey[] = [
   'pa_frontfill',
   'pa_delays',
   'pa_amp',
+  'rigging_hardware',
+  'motores_controles',
 ];
 
 export const XMLP_FLEX_GROUP_LABELS: Record<XmlpFlexCategoryKey, string> = {
@@ -54,6 +58,8 @@ export const XMLP_FLEX_GROUP_LABELS: Record<XmlpFlexCategoryKey, string> = {
   pa_frontfill: 'Frontfill',
   pa_delays: 'Delays',
   pa_amp: 'Amplificación',
+  rigging_hardware: 'Rigging Hardware',
+  motores_controles: 'Motores y Controles',
 };
 
 export interface XmlpEquipmentRow {
@@ -504,28 +510,31 @@ export function buildXmlpFlexExportPlan(
   if (flysheet) {
     const weights = buildXmlpWeightTables(flysheet, soundWeightComponents);
     warnings.push(...weights.warnings);
+    // Bumpers/frames are rigging hardware, not part of a speaker group; they
+    // all nest under the single "Rigging Hardware" Flex header regardless of
+    // which PA array they fly, so a dual case can be shared across arrays.
     for (const rigging of weights.riggingRequirements) {
       raw.push({
         canonicalKey: rigging.canonicalKey,
         displayName: rigging.displayName,
         quantity: rigging.quantity,
-        flexCategoryKey: classifications[rigging.sourceArrayIndex]?.category ?? null,
+        flexCategoryKey: 'rigging_hardware',
         source: 'xmlp-rigging',
         sourceArrays: [rigging.sourceArray],
         inference: 'explicit',
-        warning: classifications[rigging.sourceArrayIndex]?.warning,
       });
     }
+    // Motors belong under their own "Motores y Controles" header, not under the
+    // speaker group of the array they lift.
     for (const motor of weights.motorRequirements) {
       raw.push({
         canonicalKey: motor.canonicalKey,
         displayName: motor.displayName,
         quantity: motor.quantity,
-        flexCategoryKey: classifications[motor.sourceArrayIndex]?.category ?? null,
+        flexCategoryKey: 'motores_controles',
         source: 'pesos-motor',
         sourceArrays: [motor.sourceArray],
         inference: 'derived',
-        warning: classifications[motor.sourceArrayIndex]?.warning,
       });
     }
   }

--- a/src/features/technical-tools/flex/xmlpFlexExportPlan.ts
+++ b/src/features/technical-tools/flex/xmlpFlexExportPlan.ts
@@ -297,17 +297,29 @@ const isPackagedRiggingCandidate = (
 
 /**
  * Converts serialized bumper pieces into the physical flight cases used by
- * Flex. Pieces are aggregated per destination group before the dual-case
- * calculation so left/right arrays share a case when appropriate.
+ * Flex. A dual case physically holds two bumpers of the same model regardless
+ * of which PA array each one flies, so pieces are pooled per model across the
+ * whole system (not per destination group) before the dual-case calculation.
+ * Two lone arrays that each need one bumper therefore share a single dual case
+ * instead of ordering one apiece. The consolidated case is filed under the most
+ * prominent PA group (by XMLP_FLEX_GROUP_ORDER) that contributed a bumper of
+ * that model.
  */
 function packageRiggingCandidates(candidates: RawCandidate[]): RawCandidate[] {
-  const aggregated = new Map<string, PackagedRiggingCandidate>();
+  // Rank a destination group so the shared case is filed under the most
+  // prominent one; unassigned/unknown groups sort last.
+  const groupRank = (key: XmlpFlexCategoryKey | null): number => {
+    if (key === null) return XMLP_FLEX_GROUP_ORDER.length;
+    const index = XMLP_FLEX_GROUP_ORDER.indexOf(key);
+    return index === -1 ? XMLP_FLEX_GROUP_ORDER.length : index;
+  };
+
+  const aggregated = new Map<PackagedRiggingCandidate['canonicalKey'], PackagedRiggingCandidate>();
   for (const candidate of candidates) {
     if (!isPackagedRiggingCandidate(candidate)) continue;
-    const key = `${candidate.flexCategoryKey ?? 'unassigned'}:${candidate.canonicalKey}`;
-    const existing = aggregated.get(key);
+    const existing = aggregated.get(candidate.canonicalKey);
     if (!existing) {
-      aggregated.set(key, {
+      aggregated.set(candidate.canonicalKey, {
         ...candidate,
         sourceArrays: [...candidate.sourceArrays],
       });
@@ -316,19 +328,22 @@ function packageRiggingCandidates(candidates: RawCandidate[]): RawCandidate[] {
     existing.quantity += candidate.quantity;
     existing.sourceArrays = [...new Set([...existing.sourceArrays, ...candidate.sourceArrays])];
     existing.warning = [existing.warning, candidate.warning].filter(Boolean).join(' ') || undefined;
+    // File the pooled case under the highest-priority contributing group.
+    if (groupRank(candidate.flexCategoryKey) < groupRank(existing.flexCategoryKey)) {
+      existing.flexCategoryKey = candidate.flexCategoryKey;
+    }
   }
 
-  const emitted = new Set<string>();
+  const emitted = new Set<PackagedRiggingCandidate['canonicalKey']>();
   const packaged: RawCandidate[] = [];
   for (const candidate of candidates) {
     if (!isPackagedRiggingCandidate(candidate)) {
       packaged.push(candidate);
       continue;
     }
-    const key = `${candidate.flexCategoryKey ?? 'unassigned'}:${candidate.canonicalKey}`;
-    if (emitted.has(key)) continue;
-    emitted.add(key);
-    const total = aggregated.get(key)!;
+    if (emitted.has(candidate.canonicalKey)) continue;
+    emitted.add(candidate.canonicalKey);
+    const total = aggregated.get(candidate.canonicalKey)!;
 
     if (candidate.canonicalKey === 'BUMPER K1') {
       const dualCases = Math.floor(total.quantity / 2);

--- a/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
+++ b/src/features/technical-tools/power/consumos/__tests__/xmlpPowerImport.test.ts
@@ -11,7 +11,7 @@ const rowFor = (result: ReturnType<typeof buildXmlpPowerTables>, tableName: stri
     ?.rows.find((row) => row.componentName === componentName);
 
 describe("buildXmlpPowerTables", () => {
-  it("merges mains/subs/outfills/frontfills by side into Main L / Main R with hoist and a Varios row", () => {
+  it("pools mains/subs/outfills/frontfills and splits them evenly into Main L / Main R with hoist and a Varios row", () => {
     const map: XmlpAmpMap = {
       units: [
         { octet: 11, model: "LA12X" },
@@ -34,11 +34,12 @@ describe("buildXmlpPowerTables", () => {
 
     expect(result.tables.map((table) => table.name).sort()).toEqual(["Main L", "Main R"]);
 
+    // All 6 PA amps pool and split evenly, regardless of the L/R labels above.
     const mainL = result.tables.find((table) => table.name === "Main L")!;
     expect(mainL.includesHoist).toBe(true);
     expect(mainL.position).toBe("DOSL");
     expect(mainL.rows).toEqual([
-      expect.objectContaining({ componentName: "LA12X", quantity: "4" }), // 11,12 (main) + 31 (sub) + 51 (front fill)
+      expect.objectContaining({ componentName: "LA12X", quantity: "3" }),
       expect.objectContaining({ componentName: "Varios", quantity: "1" }),
     ]);
 
@@ -46,9 +47,49 @@ describe("buildXmlpPowerTables", () => {
     expect(mainR.includesHoist).toBe(true);
     expect(mainR.position).toBe("DOSR");
     expect(mainR.rows).toEqual([
-      expect.objectContaining({ componentName: "LA12X", quantity: "2" }), // 21 (main) + 41 (out)
+      expect.objectContaining({ componentName: "LA12X", quantity: "3" }),
       expect.objectContaining({ componentName: "Varios", quantity: "1" }),
     ]);
+  });
+
+  it("pools every non-sidefill, non-delay amp and splits it half to Main L, half to Main R", () => {
+    const map: XmlpAmpMap = {
+      units: [
+        { octet: 11, model: "LA12X" }, // main
+        { octet: 12, model: "LA12X" }, // main
+        { octet: 21, model: "LA12X" }, // sub
+        { octet: 22, model: "LA12X" }, // outfill
+        { octet: 31, model: "LA4X" }, // sidefill (excluded from the pool)
+        { octet: 41, model: "LA8" }, // delay (excluded from the pool)
+      ],
+      groups: [
+        { name: "MAIN L", role: "source", members: [11] },
+        { name: "MAIN R", role: "source", members: [12] },
+        { name: "SUBS", role: "source", members: [21] },
+        { name: "OUTFILL", role: "source", members: [22] },
+        { name: "SIDEFILL", role: "source", members: [31] },
+        { name: "DELAY 1", role: "source", members: [41] },
+      ],
+    };
+
+    const result = buildXmlpPowerTables(map, components);
+
+    // 4 main-PA amps split 2/2; sidefill -> Monitores, delay -> its own PDU.
+    expect(result.tables.map((table) => table.name).sort()).toEqual([
+      "DELAY 1",
+      "Main L",
+      "Main R",
+      "Monitores",
+    ]);
+    const mainL = result.tables.find((table) => table.name === "Main L")!;
+    const mainR = result.tables.find((table) => table.name === "Main R")!;
+    expect(mainL.includesHoist).toBe(true);
+    expect(mainR.includesHoist).toBe(true);
+    expect(rowFor(result, "Main L", "LA12X")?.quantity).toBe("2");
+    expect(rowFor(result, "Main R", "LA12X")?.quantity).toBe("2");
+    // The sidefill/delay amps never leak into the main pool.
+    expect(rowFor(result, "Main L", "LA4X")).toBeUndefined();
+    expect(rowFor(result, "Main R", "LA8")).toBeUndefined();
   });
 
   it("merges sidefill amps (both sides) into a single stage PDU with the monitor-world extras", () => {
@@ -128,7 +169,7 @@ describe("buildXmlpPowerTables", () => {
     );
   });
 
-  it("preserves unsided PA groups in one unpositioned Main PDU", () => {
+  it("splits unsided PA groups evenly across Main L and Main R", () => {
     const map: XmlpAmpMap = {
       units: [
         { octet: 1, model: "LA12X" },
@@ -145,17 +186,12 @@ describe("buildXmlpPowerTables", () => {
     };
 
     const result = buildXmlpPowerTables(map, components);
-    expect(result.tables).toHaveLength(1);
-    expect(result.tables[0]).toEqual(
-      expect.objectContaining({ name: "Main", includesHoist: true }),
-    );
-    expect(result.tables[0]).not.toHaveProperty("position");
-    expect(rowFor(result, "Main", "LA12X")).toEqual(
-      expect.objectContaining({ quantity: "4" }),
-    );
-    expect(result.warnings).toEqual([
-      "No se pudo determinar el lado (L/R) de 4 amplificador(es) de PA; se añadieron a \"Main\" sin posición.",
-    ]);
+    expect(result.tables.map((table) => table.name).sort()).toEqual(["Main L", "Main R"]);
+    expect(rowFor(result, "Main L", "LA12X")).toEqual(expect.objectContaining({ quantity: "2" }));
+    expect(rowFor(result, "Main R", "LA12X")).toEqual(expect.objectContaining({ quantity: "2" }));
+    expect(result.tables.find((table) => table.name === "Main L")?.position).toBe("DOSL");
+    expect(result.tables.find((table) => table.name === "Main R")?.position).toBe("DOSR");
+    expect(result.warnings).toEqual([]);
   });
 
   it("uses screenshot-style parent groups to classify cabinet-named source groups", () => {
@@ -234,17 +270,18 @@ describe("buildXmlpPowerTables", () => {
     ]);
   });
 
-  it("ignores and warns about groups that match none of the known sections", () => {
+  it("folds unrecognized (non-sidefill, non-delay) groups into the main PA pool with a note", () => {
     const map: XmlpAmpMap = {
       units: [{ octet: 1, model: "LA12X" }],
       groups: [{ name: "KARA 1", role: "source", members: [1] }],
     };
 
     const result = buildXmlpPowerTables(map, components);
-    expect(result.tables).toEqual([]);
-    expect(result.warnings).toEqual([
-      'Grupo "KARA 1" no coincide con mains/subs/outfills/frontfills/sidefill/delay; sus amplificadores no se incluyeron.',
-    ]);
+    expect(result.tables.map((table) => table.name).sort()).toEqual(["Main L", "Main R"]);
+    expect(rowFor(result, "Main L", "LA12X")).toEqual(expect.objectContaining({ quantity: "1" }));
+    expect(result.warnings).toContain(
+      'Grupo "KARA 1" no se identificó como sidefill ni delay; sus amplificadores se añadieron al PA principal.',
+    );
   });
 
   it("assigns an amp shared across overlapping source groups to the first group only", () => {
@@ -257,7 +294,14 @@ describe("buildXmlpPowerTables", () => {
     };
 
     const result = buildXmlpPowerTables(map, components);
-    expect(result.tables.map((table) => table.name)).toEqual(["Main L"]);
+    // The shared amp is assigned to the first source group only, so it is
+    // counted once across the pooled Main L / Main R split (not double-added).
+    const mainLA12X = result.tables
+      .filter((table) => table.name.startsWith("Main "))
+      .flatMap((table) => table.rows)
+      .filter((row) => row.componentName === "LA12X")
+      .reduce((sum, row) => sum + Number(row.quantity), 0);
+    expect(mainLA12X).toBe(1);
   });
 
   it("recognizes an abbreviated bare 'SIDE' group as sidefill", () => {
@@ -287,18 +331,20 @@ describe("buildXmlpPowerTables", () => {
     };
 
     const result = buildXmlpPowerTables(map, components);
-    expect(result.tables.map((table) => table.name)).toEqual(["Main L"]);
+    // Recognized as main PA (not dropped) and routed into the pooled split.
+    expect(result.tables.map((table) => table.name).sort()).toEqual(["Main L", "Main R"]);
   });
 
-  it("reads the fully spelled-out side word (LEFT/RIGHT), not just L/R", () => {
+  it("recognizes the fully spelled-out MAIN keyword as main PA", () => {
     const map: XmlpAmpMap = {
       units: [{ octet: 1, model: "LA12X" }],
       groups: [{ name: "MAIN LEFT", role: "source", members: [1] }],
     };
 
     const result = buildXmlpPowerTables(map, components);
-    expect(result.tables.map((table) => table.name)).toEqual(["Main L"]);
-    expect(result.tables[0].position).toBe("DOSL");
+    expect(result.tables.map((table) => table.name).sort()).toEqual(["Main L", "Main R"]);
+    expect(result.tables.find((table) => table.name === "Main L")?.position).toBe("DOSL");
+    expect(result.tables.find((table) => table.name === "Main R")?.position).toBe("DOSR");
   });
 
   it("ignores non-source-role groups entirely (parent/zoning groups)", () => {

--- a/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
+++ b/src/features/technical-tools/power/consumos/xmlpPowerImport.ts
@@ -27,7 +27,6 @@ export interface XmlpPowerImportResult {
   warnings: string[];
 }
 
-type Side = "L" | "R" | "C";
 type Section = "PA" | "SIDE" | "DELAY" | "OTHER";
 
 const normalizeName = (value: string) =>
@@ -105,17 +104,6 @@ function classifySection(groupName: string): Section {
   }
   return "OTHER";
 }
-
-// Reads a standalone side token anywhere in the group name so "MAIN L",
-// "LEFT MAIN" and "MAIN-L" are all recognized the same way.
-const sideFromName = (name: string): Side => {
-  const tokens = tokenize(name);
-  for (const token of [...tokens].reverse()) {
-    if (token === "L" || token === "LEFT") return "L";
-    if (token === "R" || token === "RIGHT") return "R";
-  }
-  return "C";
-};
 
 const appendRow = (rows: PowerTableRow[], component: ConsumosComponent, quantity: number) => {
   rows.push({
@@ -221,7 +209,12 @@ export function buildXmlpPowerTables(
     }
   }
 
-  const paUnitsBySide: Record<Side, XmlpAmpUnit[]> = { L: [], R: [], C: [] };
+  // Every amplifier that isn't a sidefill or a delay is main PA and goes into
+  // one shared pool — mains, subs, outfills, frontfills, and cabinet-named or
+  // otherwise unrecognized groups alike. The pool is split evenly across the
+  // two main power drops (Main L / Main R); per-amp L/R labels in the session
+  // don't determine which drop feeds them.
+  const mainsPool: XmlpAmpUnit[] = [];
   const sidefillUnits: XmlpAmpUnit[] = [];
   const delayGroups = new Map<string, XmlpAmpUnit[]>();
 
@@ -237,55 +230,55 @@ export function buildXmlpPowerTables(
             .map((group) => classifySection(group.name))
             .find((candidate) => candidate !== "OTHER") ?? "OTHER"
         : directSection;
-    const directSide = sideFromName(sourceGroup.name);
-    const side =
-      directSide === "C"
-        ? contextGroups
-            .map((group) => sideFromName(group.name))
-            .find((candidate) => candidate !== "C") ?? "C"
-        : directSide;
 
-    if (section === "PA") {
-      paUnitsBySide[side].push(unit);
-    } else if (section === "SIDE") {
+    if (section === "SIDE") {
       sidefillUnits.push(unit);
     } else if (section === "DELAY") {
       const units = delayGroups.get(sourceGroup.name) ?? [];
       units.push(unit);
       delayGroups.set(sourceGroup.name, units);
     } else {
-      warnings.push(
-        `Grupo "${sourceGroup.name}" no coincide con mains/subs/outfills/frontfills/sidefill/delay; sus amplificadores no se incluyeron.`,
-      );
+      mainsPool.push(unit);
+      if (section === "OTHER") {
+        warnings.push(
+          `Grupo "${sourceGroup.name}" no se identificó como sidefill ni delay; sus amplificadores se añadieron al PA principal.`,
+        );
+      }
     }
   }
 
   const tables: XmlpPowerBuiltTable[] = [];
 
-  (["L", "R"] as const).forEach((side) => {
-    const units = paUnitsBySide[side];
-    if (units.length === 0) return;
-    const rows = rowsFromCounts(countAmpsByComponent(units, components, warnings));
-    addExtraRow(rows, "Varios", 1, components, warnings, `Main ${side}`);
-    if (rows.length === 0) return;
-    tables.push({
-      name: `Main ${side}`,
-      rows,
-      includesHoist: true,
-      position: side === "L" ? "DOSL" : "DOSR",
-    });
-  });
-
-  const unsidedPaUnits = paUnitsBySide.C;
-  if (unsidedPaUnits.length > 0) {
-    const rows = rowsFromCounts(countAmpsByComponent(unsidedPaUnits, components, warnings));
-    addExtraRow(rows, "Varios", 1, components, warnings, "Main");
-    if (rows.length > 0) {
-      tables.push({ name: "Main", rows, includesHoist: true });
-      warnings.push(
-        `No se pudo determinar el lado (L/R) de ${unsidedPaUnits.length} amplificador(es) de PA; se añadieron a "Main" sin posición.`,
-      );
+  // Split the pooled amplifiers as evenly as possible into a Main L and a Main
+  // R PDU, balancing each model between them and alternating which side gets
+  // the odd unit so the two hoist-powered drops carry the same load.
+  if (mainsPool.length > 0) {
+    const mainsCounts = countAmpsByComponent(mainsPool, components, warnings);
+    const leftCounts = new Map<string, { component: ConsumosComponent; quantity: number }>();
+    const rightCounts = new Map<string, { component: ConsumosComponent; quantity: number }>();
+    let oddGoesLeft = true;
+    for (const [key, { component, quantity }] of mainsCounts) {
+      let left = Math.floor(quantity / 2);
+      let right = left;
+      if (quantity % 2 === 1) {
+        if (oddGoesLeft) left += 1;
+        else right += 1;
+        oddGoesLeft = !oddGoesLeft;
+      }
+      if (left > 0) leftCounts.set(key, { component, quantity: left });
+      if (right > 0) rightCounts.set(key, { component, quantity: right });
     }
+
+    (["L", "R"] as const).forEach((side) => {
+      const rows = rowsFromCounts(side === "L" ? leftCounts : rightCounts);
+      addExtraRow(rows, "Varios", 1, components, warnings, `Main ${side}`);
+      tables.push({
+        name: `Main ${side}`,
+        rows,
+        includesHoist: true,
+        position: side === "L" ? "DOSL" : "DOSR",
+      });
+    });
   }
 
   if (sidefillUnits.length > 0) {

--- a/src/services/flexPullsheets.ts
+++ b/src/services/flexPullsheets.ts
@@ -19,6 +19,8 @@ export const FLEX_CATEGORY_MAP = new Map<string, string>([
   ['pa_frontfill', 'd9b588e6-b9a8-4327-baa5-fecf104a6775'],
   ['pa_delays', 'e38db281-4b27-40eb-a846-e4a27db3961f'],
   ['pa_amp', '9d463da6-40f1-4ab0-9a96-123fd0025f88'],
+  ['rigging_hardware', '65fa6a64-927e-400d-af45-c6f56b7cc38e'], // Rigging Hardware
+  ['motores_controles', 'f5c6a972-2f03-433c-95e8-c3b7e1c57df7'], // Motores y Controles
 ]);
 
 const SUBSYSTEM_TO_FLEX_CATEGORY: Record<PresetSubsystem, string> = {


### PR DESCRIPTION
Bumper flight cases were counted per Flex destination group, so a dual
case (which physically holds two bumpers of the same model regardless of
which array flies them) was ordered once per group. Two lone arrays that
each needed one K2/KARA bumper produced two dual cases instead of one.

Pool packaged bumpers globally by model before the dual-case calculation
and file the consolidated case under the highest-priority contributing
PA group. Adds a regression test for the cross-group case.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YQCxtUATNFpFN3scLw9EFr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Flex export sections for **Rigging Hardware** and **Motores y Controles**.
  * Improved pooling and categorization of rigging, bumper, and motor requirements.
  * Updated power imports to pool main amplifier groups and split them evenly between Main L and Main R.
  * Preserved separate handling for monitor and delay amplifier groups.
  * Added support for creating pull-sheet headers for the new Flex categories.

* **Bug Fixes**
  * Prevented duplicate amplifier counting and incorrect equipment placement across export groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->