### PR TITLE
feat: support multiple technical documents per job

### DIFF
--- a/docs/technical-pdf-sync.md
+++ b/docs/technical-pdf-sync.md
@@ -12,7 +12,9 @@ here — every gap in this table has historically produced stale documents.
 ### Storage layouts
 
 Generated PDFs can live under two layouts; **both must be treated as one
-logical slot** per job/category/stage:
+logical slot** per job/category/stage. Flex material-list and quote reports
+further scope that slot by the selected Flex Presupuesto element, so sibling
+department, extras, or stage budgets do not replace each other:
 
 | Layout | Written by |
 |---|---|
@@ -54,9 +56,12 @@ next successful regeneration.
 
 ### Consumers (what goes stale if the slot isn't cleaned)
 
-- **Memoria Técnica auto-fill** (`useMemoriaAutoFill` → `findLatestJobDocumentForStage`):
-  picks the newest `job_documents` row per category/stage, with a
+- **Memoria Técnica auto-fill** (`useMemoriaAutoFill` → `findJobDocumentsForStage`):
+  exposes every matching `job_documents` row per category/stage, with a
   department filter for power reports (`getTechnicalPowerDepartmentFromDocument`).
+  The newest row is selected by default, and the Sound/Lights/Video forms show
+  an inline selector when extras or repeated generations leave multiple valid
+  source PDFs.
 - **Power report readiness** (`getTechnicalPowerReportStatus`): latest report
   per department, used by hoja de ruta / power summary flows.
 - **Sound documentation duplication** (`selectSoundDocumentsForCopy`): copies
@@ -82,6 +87,18 @@ next successful regeneration.
 5. **Replacements are serialized per logical slot.** Concurrent regenerations
    for the same job/category/stage wait for each other, so an older generation
    cannot finish last and become the document consumers detect as newest.
+6. **Flex report cleanup is element-scoped.** `fetch-flex-material-report`
+   publishes a uniquely named object first, then retires only older direct-child
+   objects/rows for the same Flex element. The pre-element shared filename is
+   removed on the next successful generation, while PDFs from sibling
+   Presupuestos remain available. Memoria auto-fill defaults to the most recent
+   material list in the requested job/category/stage while allowing any sibling
+   Presupuesto PDF to be selected explicitly.
+
+Documentation generators that start without a job-card deep link use the shared
+`DocumentationJobPicker`. It searches job title/date and is backed by
+`useJobSelection`, which includes ongoing and future jobs only and excludes
+`Completado` and `Cancelado` jobs.
 
 ## Tour dates (`tour_documents` + `tour-documents` bucket)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.2.0",
-        "dompurify": "^3.3.0",
+        "dompurify": "^3.4.12",
         "embla-carousel-react": "^8.3.0",
         "exceljs": "^4.4.0",
         "file-saver": "^2.0.5",
@@ -8035,9 +8035,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.2.0",
-    "dompurify": "^3.3.0",
+    "dompurify": "^3.4.12",
     "embla-carousel-react": "^8.3.0",
     "exceljs": "^4.4.0",
     "file-saver": "^2.0.5",

--- a/scripts/governance/dependency-audit-baseline.json
+++ b/scripts/governance/dependency-audit-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-07-20T00:00:00Z",
+  "generatedAt": "2026-07-21T22:37:24.260Z",
   "note": "Current npm audit advisories are grandfathered only with an owner and non-expired review date. CI fails on new advisory IDs, increased severity counts, expired exceptions, or production high/critical vulnerabilities.",
   "advisoryIds": [
     "1112659",
@@ -18,7 +18,8 @@
     "1123939",
     "1123940",
     "1123941",
-    "1123942"
+    "1123942",
+    "1124066"
   ],
   "exceptions": [
     {
@@ -132,6 +133,13 @@
       "owner": "platform-security",
       "reviewBy": "2026-09-30",
       "rationale": "This remains only in local/build tooling through @capacitor/assets 3.0.5 -> @capacitor/cli 5.x -> tar 6.2.1. The production @capacitor/cli path was upgraded to tar 7.5.20; @capacitor/assets is already at its latest release and has no compatible fix, so remove this exception when its nested CLI is updated."
+    },
+    {
+      "advisoryId": "1124066",
+      "package": "sharp",
+      "owner": "platform-security",
+      "reviewBy": "2026-08-31",
+      "rationale": "The vulnerable sharp 0.32.6 copy is confined to local/build tooling through @capacitor/assets 3.0.5; the direct runtime sharp dependency is already 0.35.2. @capacitor/assets is at its latest release and npm audit reports no compatible fix for its nested sharp, so remove this exception when that package adopts sharp >=0.35.0 or the asset-generation toolchain is replaced."
     }
   ],
   "vulnerabilityCounts": {
@@ -141,5 +149,5 @@
     "high": 6,
     "critical": 1
   },
-  "total": 10
+  "total": 11
 }

--- a/scripts/governance/edge-function-exposure.json
+++ b/scripts/governance/edge-function-exposure.json
@@ -46,7 +46,7 @@
     "fetch-flex-material-report": {
       "class": "privileged-role",
       "verifyJwt": true,
-      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; requires requireAuthenticatedRole (admin/management/house_tech) before resolving a job's Flex quote element and fetching its materials-list report."
+      "internalGuard": "Uses the shared HTTP wrapper and bounded JSON parsing; requires requireAuthenticatedRole (admin/management/house_tech), validates overrides against job/department, permits untracked overrides only for admin/management, and replaces only the selected element's stored PDF."
     },
     "generate-lights-memoria-tecnica": { "class": "authenticated-user", "verifyJwt": true },
     "generate-memoria-tecnica": { "class": "authenticated-user", "verifyJwt": true },

--- a/src/components/hoja-de-ruta/sections/ModernEventSection.tsx
+++ b/src/components/hoja-de-ruta/sections/ModernEventSection.tsx
@@ -6,12 +6,13 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { motion } from "framer-motion";
-import { Calendar, Plus, Sparkles, Trash2, Zap, Building2 } from "lucide-react";
+import { Plus, Sparkles, Trash2, Zap, Building2 } from "lucide-react";
 import type { AuxiliaryMachineryType, EventData } from "@/types/hoja-de-ruta";
 import { PlaceAutocomplete } from "@/components/maps/PlaceAutocomplete";
 import { AUXILIARY_MACHINERY_OPTIONS } from "@/constants/hojaDeRutaAuxiliaryNeeds";
 import { PrintSectionExclusionToggle } from "../components/PrintSectionExclusionToggle";
 import type { HojaDeRutaPrintSectionId } from "@/utils/hoja-de-ruta/pdf";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 
 interface ModernEventSectionProps {
   eventData: EventData;
@@ -139,21 +140,15 @@ export const ModernEventSection: React.FC<ModernEventSectionProps> = ({
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="job-select">Trabajo Base</Label>
-                  <Select value={selectedJobId} onValueChange={setSelectedJobId}>
-                    <SelectTrigger className="border-2">
-                      <SelectValue placeholder="Seleccionar trabajo..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {jobs?.map((job) => (
-                        <SelectItem key={job.id} value={job.id}>
-                          <div className="flex items-center gap-2">
-                            <Calendar className="w-4 h-4" />
-                            {job.title}
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <DocumentationJobPicker
+                    id="job-select"
+                    isLoading={isLoadingJobs}
+                    jobs={jobs}
+                    onValueChange={setSelectedJobId}
+                    placeholder="Seleccionar trabajo..."
+                    triggerClassName="border-2"
+                    value={selectedJobId}
+                  />
                 </div>
                 
                 <div className="flex items-end">

--- a/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
+++ b/src/components/jobs/cards/__tests__/JobCardActions.test.tsx
@@ -3,7 +3,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { JobCardActions } from '../JobCardActions';
 import { buildTechnicalPowerSummaryPackFilename } from '@/utils/pdf/technicalPowerSummaryPack';
-import type { FlatElementNode } from '@/utils/flex-folders';
+import type { FlatElementNode, FlexElementNode } from '@/utils/flex-folders';
+import { FLEX_FOLDER_IDS as FLEX_FOLDER_DEFINITION_IDS } from '@/utils/flex-folders/constants';
 import type { CombinedTechnicalPowerSummaryData } from '@/utils/technicalPowerTypes';
 import * as resolveFlexUrl from '@/utils/flex-folders/resolveFlexUrl';
 import * as useFlexUuidModule from '@/hooks/useFlexUuid';
@@ -22,6 +23,7 @@ const {
   dataLayerFunctionsInvokeMock,
   useIsMobileMock,
   useQueryMock,
+  flexElementTreeQueryState,
   jobDepartmentsQueryState,
   technicalPowerSummaryQueryState,
 } = vi.hoisted(() => ({
@@ -37,6 +39,12 @@ const {
   dataLayerFunctionsInvokeMock: vi.fn(),
   useIsMobileMock: vi.fn(() => false),
   useQueryMock: vi.fn(),
+  flexElementTreeQueryState: {
+    data: undefined as FlexElementNode[] | undefined,
+    isLoading: false,
+    isError: false,
+    error: null as Error | null,
+  },
   jobDepartmentsQueryState: {
     data: ['sound', 'lights', 'video'] as any,
     isLoading: false,
@@ -286,6 +294,10 @@ describe('JobCardActions', () => {
     technicalPowerSummaryQueryState.isLoading = false;
     technicalPowerSummaryQueryState.isError = false;
     technicalPowerSummaryQueryState.error = null;
+    flexElementTreeQueryState.data = undefined;
+    flexElementTreeQueryState.isLoading = false;
+    flexElementTreeQueryState.isError = false;
+    flexElementTreeQueryState.error = null;
     useQueryMock.mockImplementation((options: any) => {
       if (!options?.enabled) {
         return {
@@ -298,6 +310,16 @@ describe('JobCardActions', () => {
       }
 
       const queryKey = Array.isArray(options?.queryKey) ? options.queryKey : [];
+
+      if (queryKey.includes('flexElementTree')) {
+        return {
+          data: flexElementTreeQueryState.data,
+          isLoading: flexElementTreeQueryState.isLoading,
+          isError: flexElementTreeQueryState.isError,
+          error: flexElementTreeQueryState.error,
+          refetch: vi.fn(),
+        };
+      }
 
       if (queryKey.includes('technical-power-job-departments')) {
         return {
@@ -969,7 +991,7 @@ describe('JobCardActions', () => {
       render(<JobCardActions {...defaultProps} department="production" />);
 
       expect(screen.getByRole('button', { name: /Lista Material/i })).toBeDisabled();
-      expect(screen.getByTitle('No hay presupuesto de sonido o iluminación en Flex')).toBeTruthy();
+      expect(screen.getByTitle('No hay presupuestos disponibles en Flex')).toBeTruthy();
     });
 
     it('shows production technical-power department status dots', () => {
@@ -1018,7 +1040,7 @@ describe('JobCardActions', () => {
       render(<JobCardActions {...props} />);
 
       await user.click(screen.getByRole('button', { name: /Lista Material/i }));
-      await user.click(await screen.findByText('Sonido'));
+      await user.click(await screen.findByText(/Sonido · Presupuesto · sound-q/));
 
       await waitFor(() => {
         expect(dataLayerFunctionsInvokeMock).toHaveBeenCalledWith(
@@ -1027,6 +1049,7 @@ describe('JobCardActions', () => {
             body: expect.objectContaining({
               jobId: 'test-job-id',
               department: 'sound',
+              overrideElementId: 'sound-quote-element',
               reportType: 'material-list',
             }),
           })
@@ -1037,6 +1060,81 @@ describe('JobCardActions', () => {
         '_blank',
         'noopener,noreferrer'
       );
+    });
+
+    it('lists every presupuesto discovered in the Flex tree and prints the selected element', async () => {
+      const user = userEvent.setup();
+      flexElementTreeQueryState.data = [{
+        elementId: 'main-element',
+        displayName: 'Trabajo',
+        children: [{
+          elementId: 'sound-folder',
+          displayName: 'Sonido',
+          definitionId: FLEX_FOLDER_DEFINITION_IDS.subFolder,
+          children: [{
+            elementId: 'quote-main-element',
+            displayName: 'Presupuesto principal',
+            documentNumber: 'Q-100',
+            definitionId: FLEX_FOLDER_DEFINITION_IDS.presupuesto,
+          }, {
+            elementId: 'quote-extra-element',
+            displayName: 'Extra escenario B',
+            documentNumber: 'Q-101',
+            definitionId: FLEX_FOLDER_DEFINITION_IDS.presupuesto,
+          }],
+        }],
+      }];
+      dataLayerFunctionsInvokeMock.mockResolvedValueOnce({
+        data: {
+          url: 'https://example.test/extra-material-list.pdf',
+          fileName: 'Listado de Material - Sonido - Extra_escenario_B - Q-101.pdf',
+          elementId: 'quote-extra-element',
+          folderType: null,
+          elementValidated: true,
+          elementJobMismatch: false,
+          reportType: 'material-list',
+        },
+        error: null,
+      });
+
+      render(<JobCardActions
+        {...defaultProps}
+        department="production"
+        job={{
+          ...defaultProps.job,
+          flex_folders: [{
+            id: 'main-row',
+            department: null,
+            element_id: 'main-element',
+            folder_type: 'main_event',
+          }, {
+            id: 'sound-row',
+            department: 'sound',
+            element_id: 'sound-folder',
+            folder_type: 'department',
+          }],
+        }}
+      />);
+
+      await user.click(screen.getByRole('button', { name: /Lista Material/i }));
+      expect(await screen.findByText(/Presupuesto principal · Q-100/)).toBeInTheDocument();
+      await user.click(screen.getByText(/Extra escenario B · Q-101/));
+
+      await waitFor(() => {
+        expect(dataLayerFunctionsInvokeMock).toHaveBeenCalledWith(
+          'fetch-flex-material-report',
+          expect.objectContaining({
+            body: expect.objectContaining({
+              department: 'sound',
+              elementDisplayName: 'Extra escenario B',
+              elementDocumentNumber: 'Q-101',
+              jobId: 'test-job-id',
+              overrideElementId: 'quote-extra-element',
+              reportType: 'material-list',
+            }),
+          })
+        );
+      });
     });
 
     it('prints a scoped Flex material list directly from the sound project tab', async () => {
@@ -1079,10 +1177,10 @@ describe('JobCardActions', () => {
       render(<JobCardActions {...props} />);
 
       const materialButton = screen.getByRole('button', { name: /Lista Material/i });
-      expect(materialButton).toHaveAttribute('title', 'Imprimir lista de material de Sonido desde Flex');
-      expect(screen.queryByText('Sonido')).toBeNull();
+      expect(materialButton).toHaveAttribute('title', 'Elegir presupuesto para imprimir la lista de material de Flex');
 
       await user.click(materialButton);
+      await user.click(await screen.findByText(/Sonido · Presupuesto · sound-q/));
 
       await waitFor(() => {
         expect(dataLayerFunctionsInvokeMock).toHaveBeenCalledWith(
@@ -1091,6 +1189,7 @@ describe('JobCardActions', () => {
             body: expect.objectContaining({
               jobId: 'test-job-id',
               department: 'sound',
+              overrideElementId: 'sound-quote-element',
               reportType: 'material-list',
             }),
           })
@@ -1143,10 +1242,10 @@ describe('JobCardActions', () => {
       render(<JobCardActions {...props} />);
 
       const quoteButton = screen.getByRole('button', { name: /Presupuesto/i });
-      expect(quoteButton).toHaveAttribute('title', 'Imprimir presupuesto de Iluminación desde Flex');
-      expect(screen.queryByText('Iluminación')).toBeNull();
+      expect(quoteButton).toHaveAttribute('title', 'Elegir presupuesto de Flex para imprimir');
 
       await user.click(quoteButton);
+      await user.click(await screen.findByText(/Iluminación · Presupuesto · lights-q/));
 
       await waitFor(() => {
         expect(dataLayerFunctionsInvokeMock).toHaveBeenCalledWith(
@@ -1155,6 +1254,7 @@ describe('JobCardActions', () => {
             body: expect.objectContaining({
               jobId: 'test-job-id',
               department: 'lights',
+              overrideElementId: 'lights-quote-element',
               reportType: 'quote',
             }),
           })
@@ -1186,9 +1286,9 @@ describe('JobCardActions', () => {
 
       render(<JobCardActions {...props} />);
 
-      expect(screen.getByRole('button', { name: /Lista Material/i })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: /Lista Material/i })).toBeDisabled();
       expect(screen.getByRole('button', { name: /Presupuesto/i })).toBeDisabled();
-      expect(screen.getByTitle('No hay presupuesto de Iluminación en Flex')).toBeTruthy();
+      expect(screen.getAllByTitle('No hay presupuestos disponibles en Flex')).toHaveLength(2);
     });
 
     it('should render the technical power summary button for project management managers', () => {

--- a/src/components/jobs/cards/job-card-actions/PrintFlexReportAction.tsx
+++ b/src/components/jobs/cards/job-card-actions/PrintFlexReportAction.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useQuery } from "@tanstack/react-query";
 import { ChevronDown, Loader2, Printer } from "lucide-react";
 
+import type { JobCardJob } from "@/components/jobs/cards/job-card-actions/types";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -9,30 +11,21 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
-import type { JobCardJob } from "@/components/jobs/cards/job-card-actions/types";
+import { queryKeys } from "@/lib/react-query";
+import { getElementTree } from "@/utils/flex-folders";
 import {
   fetchFlexMaterialReport,
   type FlexMaterialReportDepartment,
   type FlexMaterialReportType,
 } from "@/utils/flexMaterialReport";
+import {
+  getFlexPresupuestoOptionLabel,
+  getFlexPresupuestoOptions,
+  getFlexReportRootElementId,
+  type FlexPresupuestoOption,
+} from "@/utils/flexReportPresupuestos";
 
 type PrintableDepartment = Extract<FlexMaterialReportDepartment, "sound" | "lights">;
-
-const MATERIAL_LIST_DEPARTMENTS: Array<{ department: PrintableDepartment; label: string }> = [
-  { department: "sound", label: "Sonido" },
-  { department: "lights", label: "Iluminación" },
-];
-
-const MATERIAL_LIST_FOLDER_TYPES = new Set([
-  "comercial_presupuesto",
-  "dryhire_presupuesto",
-  "presupuestos_recibidos",
-]);
-
-const PRINTABLE_QUOTE_FOLDER_TYPES = new Set([
-  "comercial_presupuesto",
-  "dryhire_presupuesto",
-]);
 
 type PrintFlexReportActionProps = {
   job: JobCardJob;
@@ -40,61 +33,35 @@ type PrintFlexReportActionProps = {
   reportType?: FlexMaterialReportType;
 };
 
-const getFolderElementId = (folder: NonNullable<JobCardJob["flex_folders"]>[number]) =>
-  folder.element_id || folder.elementId || null;
-
-const getReportFolderTypes = (reportType: FlexMaterialReportType) =>
-  reportType === "quote" ? PRINTABLE_QUOTE_FOLDER_TYPES : MATERIAL_LIST_FOLDER_TYPES;
-
-const hasReportForDepartment = (
-  job: JobCardJob,
-  department: PrintableDepartment,
-  reportType: FlexMaterialReportType
-) => {
-  const folderTypes = getReportFolderTypes(reportType);
-  return (job.flex_folders || []).some((folder) =>
-    folder.department === department &&
-    typeof folder.folder_type === "string" &&
-    folderTypes.has(folder.folder_type) &&
-    Boolean(getFolderElementId(folder))
-  );
-};
-
 const REPORT_COPY: Record<FlexMaterialReportType, {
   buttonLabel: string;
   dropdownTitle: string;
   errorTitle: string;
   fallbackError: string;
-  loadingLabel: (label: string) => string;
-  scopedTitle: (label: string) => string;
+  loadingLabel: string;
   successDescription: (label: string) => string;
   successTitle: string;
-  unavailableDropdownTitle: string;
-  unavailableScopedTitle: (label: string) => string;
+  unavailableTitle: string;
 }> = {
   "material-list": {
     buttonLabel: "Lista Material",
-    dropdownTitle: "Imprimir lista de material de Flex",
+    dropdownTitle: "Elegir presupuesto para imprimir la lista de material de Flex",
     errorTitle: "No se pudo imprimir la lista",
     fallbackError: "No se pudo obtener la lista de material de Flex.",
-    loadingLabel: (label) => `Lista ${label}`,
-    scopedTitle: (label) => `Imprimir lista de material de ${label} desde Flex`,
+    loadingLabel: "Generando lista",
     successDescription: (label) => `Se ha abierto la lista de material de ${label}.`,
     successTitle: "Lista de material generada",
-    unavailableDropdownTitle: "No hay presupuesto de sonido o iluminación en Flex",
-    unavailableScopedTitle: (label) => `No hay presupuesto de ${label} en Flex`,
+    unavailableTitle: "No hay presupuestos disponibles en Flex",
   },
   quote: {
     buttonLabel: "Presupuesto",
-    dropdownTitle: "Imprimir presupuesto de Flex",
+    dropdownTitle: "Elegir presupuesto de Flex para imprimir",
     errorTitle: "No se pudo imprimir el presupuesto",
     fallbackError: "No se pudo obtener el presupuesto de Flex.",
-    loadingLabel: (label) => `Presupuesto ${label}`,
-    scopedTitle: (label) => `Imprimir presupuesto de ${label} desde Flex`,
-    successDescription: (label) => `Se ha abierto el presupuesto de ${label}.`,
+    loadingLabel: "Generando presupuesto",
+    successDescription: (label) => `Se ha abierto ${label}.`,
     successTitle: "Presupuesto generado",
-    unavailableDropdownTitle: "No hay presupuesto de sonido o iluminación en Flex",
-    unavailableScopedTitle: (label) => `No hay presupuesto de ${label} en Flex`,
+    unavailableTitle: "No hay presupuestos disponibles en Flex",
   },
 };
 
@@ -116,37 +83,59 @@ export const PrintFlexReportAction = ({
   reportType = "material-list",
 }: PrintFlexReportActionProps) => {
   const { toast } = useToast();
-  const [loadingDepartment, setLoadingDepartment] = React.useState<PrintableDepartment | null>(null);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [loadingElementId, setLoadingElementId] = React.useState<string | null>(null);
   const copy = REPORT_COPY[reportType];
-  const scopedDepartmentOption = React.useMemo(
-    () => MATERIAL_LIST_DEPARTMENTS.find((option) => option.department === department) ?? null,
-    [department]
+  const mainElementId = React.useMemo(
+    () => getFlexReportRootElementId(job.flex_folders),
+    [job.flex_folders],
   );
-  const quoteAvailability = React.useMemo(
-    () => new Map(
-      MATERIAL_LIST_DEPARTMENTS.map(({ department: optionDepartment }) => [
-        optionDepartment,
-        hasReportForDepartment(job, optionDepartment, reportType),
-      ])
-    ),
-    [job, reportType]
-  );
-  const hasAnyQuote = Array.from(quoteAvailability.values()).some(Boolean);
 
-  const handlePrintReport = React.useCallback(async (department: PrintableDepartment, label: string) => {
-    if (!job.id || loadingDepartment || !quoteAvailability.get(department)) return;
+  const {
+    data: tree,
+    isError: treeError,
+    isLoading: treeLoading,
+  } = useQuery({
+    queryKey: queryKeys.scope("flexElementTree", mainElementId || "missing"),
+    queryFn: () => getElementTree(mainElementId!),
+    enabled: menuOpen && Boolean(mainElementId),
+    retry: 1,
+    staleTime: 5 * 60 * 1000,
+  });
 
-    setLoadingDepartment(department);
+  const presupuestoOptions = React.useMemo(() => {
+    const options = getFlexPresupuestoOptions(tree, job.flex_folders);
+    return department
+      ? options.filter((option) => option.department === department)
+      : options;
+  }, [department, job.flex_folders, tree]);
+
+  const canDiscoverPresupuestos = Boolean(mainElementId);
+  const hasKnownPresupuestos = presupuestoOptions.length > 0;
+  const canOpenMenu = canDiscoverPresupuestos || hasKnownPresupuestos;
+
+  const handlePrintReport = React.useCallback(async (option: FlexPresupuestoOption) => {
+    if (!job.id || loadingElementId) return;
+
+    const selectedDepartment = option.department || department || "production";
+    const optionLabel = getFlexPresupuestoOptionLabel(option);
+    setLoadingElementId(option.elementId);
+    setMenuOpen(false);
+
     // Open the tab synchronously (still within the click's user-gesture window) so
     // popup blockers don't drop the navigation once the async fetch resolves later.
     const reportWindow = window.open("", "_blank");
     try {
       const result = await fetchFlexMaterialReport(
         job.id,
-        department,
-        undefined,
+        selectedDepartment,
+        option.elementId,
         null,
-        reportType
+        reportType,
+        {
+          displayName: option.displayName,
+          documentNumber: option.documentNumber,
+        },
       );
 
       if (reportWindow) {
@@ -157,7 +146,7 @@ export const PrintFlexReportAction = ({
       }
       toast({
         title: copy.successTitle,
-        description: copy.successDescription(label),
+        description: copy.successDescription(optionLabel),
       });
     } catch (error: unknown) {
       reportWindow?.close();
@@ -167,77 +156,59 @@ export const PrintFlexReportAction = ({
         variant: "destructive",
       });
     } finally {
-      setLoadingDepartment(null);
+      setLoadingElementId(null);
     }
-  }, [copy, job.id, loadingDepartment, quoteAvailability, reportType, toast]);
-
-  const loadingLabel = MATERIAL_LIST_DEPARTMENTS.find(
-    (option) => option.department === loadingDepartment
-  )?.label;
-
-  if (scopedDepartmentOption) {
-    const isAvailable = quoteAvailability.get(scopedDepartmentOption.department) ?? false;
-    return (
-      <Button
-        variant="outline"
-        size="sm"
-        className="gap-2"
-        disabled={!!loadingDepartment || !isAvailable}
-        onClick={() => void handlePrintReport(scopedDepartmentOption.department, scopedDepartmentOption.label)}
-        title={
-          isAvailable
-            ? copy.scopedTitle(scopedDepartmentOption.label)
-            : copy.unavailableScopedTitle(scopedDepartmentOption.label)
-        }
-      >
-        <ReportAvailabilityLight available={isAvailable} />
-        {loadingDepartment ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <Printer className="h-4 w-4" />
-        )}
-        <span className="hidden sm:inline">{copy.buttonLabel}</span>
-      </Button>
-    );
-  }
+  }, [copy, department, job.id, loadingElementId, reportType, toast]);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
           size="sm"
           className="gap-2"
-          disabled={!!loadingDepartment || !hasAnyQuote}
-          title={hasAnyQuote ? copy.dropdownTitle : copy.unavailableDropdownTitle}
+          disabled={Boolean(loadingElementId) || !canOpenMenu}
+          title={canOpenMenu ? copy.dropdownTitle : copy.unavailableTitle}
         >
-          <ReportAvailabilityLight available={hasAnyQuote} />
-          {loadingDepartment ? (
+          <ReportAvailabilityLight available={hasKnownPresupuestos} />
+          {loadingElementId ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
             <Printer className="h-4 w-4" />
           )}
           <span className="hidden sm:inline">
-            {loadingLabel ? copy.loadingLabel(loadingLabel) : copy.buttonLabel}
+            {loadingElementId ? copy.loadingLabel : copy.buttonLabel}
           </span>
-          {!loadingDepartment && <ChevronDown className="h-3.5 w-3.5" />}
+          {!loadingElementId && <ChevronDown className="h-3.5 w-3.5" />}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" onClick={(event) => event.stopPropagation()}>
-        {MATERIAL_LIST_DEPARTMENTS.map(({ department, label }) => (
+        {treeLoading && (
+          <DropdownMenuItem disabled className="gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Buscando presupuestos en Flex…
+          </DropdownMenuItem>
+        )}
+        {!treeLoading && presupuestoOptions.map((option) => (
           <DropdownMenuItem
-            key={department}
+            key={option.elementId}
             className="gap-2"
-            disabled={!quoteAvailability.get(department)}
             onSelect={(event) => {
               event.preventDefault();
-              void handlePrintReport(department, label);
+              void handlePrintReport(option);
             }}
           >
-            <ReportAvailabilityLight available={quoteAvailability.get(department) ?? false} />
-            {label}
+            <ReportAvailabilityLight available />
+            <span>{getFlexPresupuestoOptionLabel(option)}</span>
           </DropdownMenuItem>
         ))}
+        {!treeLoading && presupuestoOptions.length === 0 && (
+          <DropdownMenuItem disabled>
+            {treeError
+              ? "No se pudo consultar el árbol de Flex"
+              : copy.unavailableTitle}
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/lights/LightMemoriaTecnica.tsx
+++ b/src/components/lights/LightMemoriaTecnica.tsx
@@ -12,7 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useLogoOptions, LogoOption } from "@/hooks/useLogoOptions";
 import { uploadStorageObject } from "@/utils/storageUpload";
 import { useMemoriaJobAndStage } from "@/features/technical-tools/memoria/useMemoriaJobAndStage";
-import { formatMemoriaUploadDate } from "@/features/technical-tools/memoria/dateFormat";
+import { MemoriaDetectedDocumentSelect } from "@/features/technical-tools/memoria/MemoriaDetectedDocumentSelect";
 import {
   useMemoriaAutoFill,
   type MemoriaAutoFillCategorySpec,
@@ -20,6 +20,7 @@ import {
 import { TechnicalStageSelector } from "@/features/technical-tools/stage/stageAllocation";
 import { upsertMemoriaTecnicaDocument } from "@/utils/memoriaTecnicaDocuments";
 import { fetchFlexMaterialReport } from "@/utils/flexMaterialReport";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 
 const AUTO_FILL_CATEGORIES: Record<string, MemoriaAutoFillCategorySpec> = {
   material: "calculators/lista-material/lights",
@@ -70,7 +71,12 @@ export const LightMemoriaTecnica = () => {
     }
   }, [selectedJob?.title]);
 
-  const { detected: detectedDocuments, refetch: refetchAutoFill } = useMemoriaAutoFill(
+  const {
+    candidates: detectedDocumentCandidates,
+    detected: detectedDocuments,
+    refetch: refetchAutoFill,
+    selectDocument: selectDetectedDocument,
+  } = useMemoriaAutoFill(
     selectedJobId,
     hasMultipleStages ? selectedStage : null,
     AUTO_FILL_CATEGORIES
@@ -107,7 +113,7 @@ export const LightMemoriaTecnica = () => {
       } else if (result.elementJobMismatch) {
         setFlexMaterialWarning("El ID de elemento de Flex indicado pertenece a otro trabajo. Verifique antes de usarlo.");
       }
-      refetchAutoFill();
+      refetchAutoFill("material");
       toast({ title: "Éxito", description: "Lista de material obtenida de Flex" });
     } catch (error) {
       console.error("Error fetching Flex material report:", error);
@@ -393,22 +399,13 @@ export const LightMemoriaTecnica = () => {
                 {!jobIdFromUrl && (
                   <div className="space-y-2">
                     <Label htmlFor="memoria-job-select">Trabajo</Label>
-                    <Select
+                    <DocumentationJobPicker
+                      id="memoria-job-select"
+                      isLoading={isLoadingJobs}
+                      jobs={jobs}
                       value={selectedJobId}
                       onValueChange={setSelectedJobId}
-                      disabled={isLoadingJobs}
-                    >
-                      <SelectTrigger id="memoria-job-select" className="w-full">
-                        <SelectValue placeholder="Seleccione un trabajo" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {jobs?.map((job) => (
-                          <SelectItem key={job.id} value={job.id}>
-                            {job.title}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    />
                   </div>
                 )}
                 <TechnicalStageSelector
@@ -547,10 +544,12 @@ export const LightMemoriaTecnica = () => {
                   <div key={doc.id} className="space-y-2">
                     <Label>{doc.title}</Label>
                     {!doc.file && detected && (
-                      <p className="text-xs text-muted-foreground">
-                        Detectado: {detected.fileName}
-                        {detected.uploadedAt ? ` (${formatMemoriaUploadDate(detected.uploadedAt)})` : ""}
-                      </p>
+                      <MemoriaDetectedDocumentSelect
+                        candidates={detectedDocumentCandidates[doc.id] ?? []}
+                        onSelect={(filePath) => selectDetectedDocument(doc.id, filePath)}
+                        sectionTitle={doc.title}
+                        selected={detected}
+                      />
                     )}
                     <div className="flex items-center gap-2">
                       <Input

--- a/src/components/sound/MemoriaTecnica.tsx
+++ b/src/components/sound/MemoriaTecnica.tsx
@@ -13,7 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useLogoOptions, LogoOption } from "@/hooks/useLogoOptions";
 import { isStorageNotFoundError, uploadStorageObject } from "@/utils/storageUpload";
 import { useMemoriaJobAndStage } from "@/features/technical-tools/memoria/useMemoriaJobAndStage";
-import { formatMemoriaUploadDate } from "@/features/technical-tools/memoria/dateFormat";
+import { MemoriaDetectedDocumentSelect } from "@/features/technical-tools/memoria/MemoriaDetectedDocumentSelect";
 import {
   useMemoriaAutoFill,
   type MemoriaAutoFillCategorySpec,
@@ -21,6 +21,7 @@ import {
 import { TechnicalStageSelector } from "@/features/technical-tools/stage/stageAllocation";
 import { upsertMemoriaTecnicaDocument } from "@/utils/memoriaTecnicaDocuments";
 import { fetchFlexMaterialReport } from "@/utils/flexMaterialReport";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 
 const AUTO_FILL_CATEGORIES: Record<string, MemoriaAutoFillCategorySpec> = {
   material: "calculators/lista-material/sound",
@@ -72,7 +73,12 @@ export const MemoriaTecnica = () => {
     }
   }, [selectedJob?.title]);
 
-  const { detected: detectedDocuments, refetch: refetchAutoFill } = useMemoriaAutoFill(
+  const {
+    candidates: detectedDocumentCandidates,
+    detected: detectedDocuments,
+    refetch: refetchAutoFill,
+    selectDocument: selectDetectedDocument,
+  } = useMemoriaAutoFill(
     selectedJobId,
     hasMultipleStages ? selectedStage : null,
     AUTO_FILL_CATEGORIES
@@ -109,7 +115,7 @@ export const MemoriaTecnica = () => {
       } else if (result.elementJobMismatch) {
         setFlexMaterialWarning("El ID de elemento de Flex indicado pertenece a otro trabajo. Verifique antes de usarlo.");
       }
-      refetchAutoFill();
+      refetchAutoFill("material");
       toast({ title: "Éxito", description: "Lista de material obtenida de Flex" });
     } catch (error) {
       console.error("Error fetching Flex material report:", error);
@@ -407,22 +413,13 @@ export const MemoriaTecnica = () => {
               {!jobIdFromUrl && (
                 <div className="space-y-2">
                   <Label htmlFor="memoria-job-select">Trabajo</Label>
-                  <Select
+                  <DocumentationJobPicker
+                    id="memoria-job-select"
+                    isLoading={isLoadingJobs}
+                    jobs={jobs}
                     value={selectedJobId}
                     onValueChange={setSelectedJobId}
-                    disabled={isLoadingJobs}
-                  >
-                    <SelectTrigger id="memoria-job-select" className="w-full">
-                      <SelectValue placeholder="Seleccione un trabajo" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {jobs?.map((job) => (
-                        <SelectItem key={job.id} value={job.id}>
-                          {job.title}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  />
                 </div>
               )}
               <TechnicalStageSelector
@@ -568,10 +565,12 @@ export const MemoriaTecnica = () => {
                 <div key={doc.id} className="space-y-2">
                   <Label>{doc.title}</Label>
                   {!doc.file && detected && (
-                    <p className="text-xs text-muted-foreground">
-                      Detectado: {detected.fileName}
-                      {detected.uploadedAt ? ` (${formatMemoriaUploadDate(detected.uploadedAt)})` : ""}
-                    </p>
+                    <MemoriaDetectedDocumentSelect
+                      candidates={detectedDocumentCandidates[doc.id] ?? []}
+                      onSelect={(filePath) => selectDetectedDocument(doc.id, filePath)}
+                      sectionTitle={doc.title}
+                      selected={detected}
+                    />
                   )}
                   <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
                     <Input

--- a/src/components/sound/ReportGenerator.tsx
+++ b/src/components/sound/ReportGenerator.tsx
@@ -3,7 +3,6 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useToast } from "@/hooks/use-toast";
 import { useJobSelection } from "@/hooks/useJobSelection";
@@ -22,6 +21,7 @@ import {
 } from "@/features/technical-tools/stage/stageAllocation";
 import { getTechnicalStageStorageScope } from "@/features/technical-tools/stage/stageUtils";
 import { uploadJobPdfWithCleanup } from "@/utils/jobDocumentsUpload";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 
 const reportSections = [
   {
@@ -449,18 +449,12 @@ export const ReportGenerator = () => {
           {/* Job Selection */}
           <div className="space-y-2">
             <Label htmlFor="jobSelect">Trabajo</Label>
-            <Select value={selectedJobId} onValueChange={setSelectedJobId}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Seleccione un trabajo" />
-              </SelectTrigger>
-              <SelectContent>
-                {jobs?.map(job => (
-                  <SelectItem key={job.id} value={job.id}>
-                    {job.title}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <DocumentationJobPicker
+              id="jobSelect"
+              jobs={jobs}
+              onValueChange={setSelectedJobId}
+              value={selectedJobId}
+            />
           </div>
 
           <TechnicalStageSelector

--- a/src/components/sound/tools/IncidentReport.tsx
+++ b/src/components/sound/tools/IncidentReport.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { FileText, PenTool, X, Check, Download, Camera, Trash2, Loader2 } from "lucide-react";
 import SignatureCanvas from "react-signature-canvas";
@@ -18,8 +17,7 @@ import {
   OPTIMIZED_MAX_DIMENSION,
   OPTIMIZED_QUALITY
 } from "@/utils/incident-report/photo-utils";
-import { format } from 'date-fns';
-import { toZonedTime } from 'date-fns-tz';
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 
 interface IncidentReportData {
   jobId: string;
@@ -247,18 +245,13 @@ export const IncidentReport = () => {
         <div className="space-y-4">
           <div>
             <Label htmlFor="jobSelect">Trabajo Asociado *</Label>
-            <Select value={formData.jobId} onValueChange={(value) => handleInputChange('jobId', value)}>
-              <SelectTrigger>
-                <SelectValue placeholder="Seleccionar trabajo..." />
-              </SelectTrigger>
-              <SelectContent>
-                {jobs?.map((job) => (
-                  <SelectItem key={job.id} value={job.id}>
-                    {job.title} - {format(toZonedTime(new Date(job.start_time), 'Europe/Madrid'), 'dd/MM/yyyy')}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <DocumentationJobPicker
+              id="jobSelect"
+              jobs={jobs}
+              onValueChange={(value) => handleInputChange('jobId', value)}
+              placeholder="Seleccionar trabajo..."
+              value={formData.jobId}
+            />
           </div>
         </div>
 

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -36,6 +36,8 @@ interface ComboboxProps {
   className?: string;
   triggerClassName?: string;
   disabled?: boolean;
+  triggerId?: string;
+  ariaLabel?: string;
 }
 
 export function Combobox({
@@ -49,6 +51,8 @@ export function Combobox({
   className,
   triggerClassName,
   disabled,
+  triggerId,
+  ariaLabel,
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false);
 
@@ -65,9 +69,11 @@ export function Combobox({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
+          id={triggerId}
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          aria-label={ariaLabel}
           disabled={disabled}
           className={cn('w-full justify-between font-normal', !value && 'text-muted-foreground', triggerClassName)}
         >

--- a/src/components/video/VideoMemoriaTecnica.tsx
+++ b/src/components/video/VideoMemoriaTecnica.tsx
@@ -12,7 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useLogoOptions, LogoOption } from "@/hooks/useLogoOptions";
 import { uploadStorageObject } from "@/utils/storageUpload";
 import { useMemoriaJobAndStage } from "@/features/technical-tools/memoria/useMemoriaJobAndStage";
-import { formatMemoriaUploadDate } from "@/features/technical-tools/memoria/dateFormat";
+import { MemoriaDetectedDocumentSelect } from "@/features/technical-tools/memoria/MemoriaDetectedDocumentSelect";
 import {
   useMemoriaAutoFill,
   type MemoriaAutoFillCategorySpec,
@@ -20,6 +20,7 @@ import {
 import { TechnicalStageSelector } from "@/features/technical-tools/stage/stageAllocation";
 import { upsertMemoriaTecnicaDocument } from "@/utils/memoriaTecnicaDocuments";
 import { fetchFlexMaterialReport } from "@/utils/flexMaterialReport";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 
 const AUTO_FILL_CATEGORIES: Record<string, MemoriaAutoFillCategorySpec> = {
   material: "calculators/lista-material/video",
@@ -70,7 +71,12 @@ export const VideoMemoriaTecnica = () => {
     }
   }, [selectedJob?.title]);
 
-  const { detected: detectedDocuments, refetch: refetchAutoFill } = useMemoriaAutoFill(
+  const {
+    candidates: detectedDocumentCandidates,
+    detected: detectedDocuments,
+    refetch: refetchAutoFill,
+    selectDocument: selectDetectedDocument,
+  } = useMemoriaAutoFill(
     selectedJobId,
     hasMultipleStages ? selectedStage : null,
     AUTO_FILL_CATEGORIES
@@ -107,7 +113,7 @@ export const VideoMemoriaTecnica = () => {
       } else if (result.elementJobMismatch) {
         setFlexMaterialWarning("El ID de elemento de Flex indicado pertenece a otro trabajo. Verifique antes de usarlo.");
       }
-      refetchAutoFill();
+      refetchAutoFill("material");
       toast({ title: "Éxito", description: "Lista de material obtenida de Flex" });
     } catch (error) {
       console.error("Error fetching Flex material report:", error);
@@ -385,22 +391,13 @@ export const VideoMemoriaTecnica = () => {
                 {!jobIdFromUrl && (
                   <div className="space-y-2">
                     <Label htmlFor="memoria-job-select">Trabajo</Label>
-                    <Select
+                    <DocumentationJobPicker
+                      id="memoria-job-select"
+                      isLoading={isLoadingJobs}
+                      jobs={jobs}
                       value={selectedJobId}
                       onValueChange={setSelectedJobId}
-                      disabled={isLoadingJobs}
-                    >
-                      <SelectTrigger id="memoria-job-select" className="w-full">
-                        <SelectValue placeholder="Seleccione un trabajo" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {jobs?.map((job) => (
-                          <SelectItem key={job.id} value={job.id}>
-                            {job.title}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    />
                   </div>
                 )}
                 <TechnicalStageSelector
@@ -539,10 +536,12 @@ export const VideoMemoriaTecnica = () => {
                   <div key={doc.id} className="space-y-2">
                     <Label>{doc.title}</Label>
                     {!doc.file && detected && (
-                      <p className="text-xs text-muted-foreground">
-                        Detectado: {detected.fileName}
-                        {detected.uploadedAt ? ` (${formatMemoriaUploadDate(detected.uploadedAt)})` : ""}
-                      </p>
+                      <MemoriaDetectedDocumentSelect
+                        candidates={detectedDocumentCandidates[doc.id] ?? []}
+                        onSelect={(filePath) => selectDetectedDocument(doc.id, filePath)}
+                        sectionTitle={doc.title}
+                        selected={detected}
+                      />
                     )}
                     <div className="flex items-center gap-2">
                       <Input

--- a/src/features/lights/LightsRiggingPlanner.tsx
+++ b/src/features/lights/LightsRiggingPlanner.tsx
@@ -14,6 +14,7 @@ import { supabase } from "@/lib/supabase";
 import { getStorageUploadErrorMessage, uploadStorageObject } from "@/utils/storageUpload";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useJobSelection } from "@/hooks/useJobSelection";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 
 import { TRUSS_MODELS } from "@/data/trussModels";
 import { HOIST_CATALOG } from "@/data/hoists";
@@ -309,15 +310,15 @@ const LightsRiggingPlanner: React.FC = () => {
 
         {!isTourDefaults && !jobIdFromUrl && (
           <div className="grid gap-2 max-w-sm">
-            <Label>Select Job</Label>
-            <Select value={selectedJobId} onValueChange={setSelectedJobId}>
-              <SelectTrigger><SelectValue placeholder="Select job" /></SelectTrigger>
-              <SelectContent>
-                {jobs?.map(job => (
-                  <SelectItem key={job.id} value={job.id}>{job.title}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Label htmlFor="lights-rigging-job">Seleccionar trabajo</Label>
+            <DocumentationJobPicker
+              ariaLabel="Seleccionar trabajo"
+              id="lights-rigging-job"
+              jobs={jobs}
+              onValueChange={setSelectedJobId}
+              placeholder="Seleccionar trabajo"
+              value={selectedJobId}
+            />
           </div>
         )}
       </CardHeader>

--- a/src/features/technical-tools/jobs/DocumentationJobPicker.test.tsx
+++ b/src/features/technical-tools/jobs/DocumentationJobPicker.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
+
+describe("DocumentationJobPicker", () => {
+  it("searches active jobs by title and selects the matching job", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <DocumentationJobPicker
+        jobs={[
+          { id: "job-1", title: "Festival Norte", start_time: "2026-08-01T10:00:00Z" },
+          { id: "job-2", title: "Gala Madrid", start_time: "2026-08-02T10:00:00Z" },
+        ]}
+        onValueChange={onValueChange}
+        value=""
+      />
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Trabajo" }));
+    await user.type(await screen.findByPlaceholderText("Buscar por nombre o fecha..."), "Gala");
+    await user.click(await screen.findByText(/Gala Madrid/));
+
+    expect(onValueChange).toHaveBeenCalledWith("job-2");
+  });
+});

--- a/src/features/technical-tools/jobs/DocumentationJobPicker.tsx
+++ b/src/features/technical-tools/jobs/DocumentationJobPicker.tsx
@@ -1,0 +1,59 @@
+import { formatInTimeZone } from "date-fns-tz";
+import { Combobox } from "@/components/ui/combobox";
+
+const MADRID_TIME_ZONE = "Europe/Madrid";
+
+export interface DocumentationJobOption {
+  id: string;
+  title: string;
+  start_time?: string | null;
+}
+
+interface DocumentationJobPickerProps {
+  ariaLabel?: string;
+  disabled?: boolean;
+  id?: string;
+  isLoading?: boolean;
+  jobs?: DocumentationJobOption[] | null;
+  onValueChange: (jobId: string) => void;
+  placeholder?: string;
+  triggerClassName?: string;
+  value: string;
+}
+
+const formatJobLabel = (job: DocumentationJobOption) => {
+  if (!job.start_time) return job.title;
+
+  try {
+    return `${job.title} · ${formatInTimeZone(job.start_time, MADRID_TIME_ZONE, "dd/MM/yyyy")}`;
+  } catch {
+    return job.title;
+  }
+};
+
+/** Searchable picker shared by the department tools that generate job documentation. */
+export const DocumentationJobPicker = ({
+  ariaLabel = "Trabajo",
+  disabled = false,
+  id,
+  isLoading = false,
+  jobs,
+  onValueChange,
+  placeholder = "Seleccionar trabajo",
+  triggerClassName,
+  value,
+}: DocumentationJobPickerProps) => (
+  <Combobox
+    ariaLabel={ariaLabel}
+    className="w-[var(--radix-popover-trigger-width)] min-w-72"
+    disabled={disabled || isLoading}
+    emptyMessage="No hay trabajos activos que coincidan."
+    items={(jobs ?? []).map((job) => ({ value: job.id, label: formatJobLabel(job) }))}
+    onValueChange={(nextValue) => onValueChange(nextValue || value)}
+    placeholder={isLoading ? "Cargando trabajos..." : placeholder}
+    searchPlaceholder="Buscar por nombre o fecha..."
+    triggerClassName={triggerClassName}
+    triggerId={id}
+    value={value}
+  />
+);

--- a/src/features/technical-tools/memoria/MemoriaDetectedDocumentSelect.tsx
+++ b/src/features/technical-tools/memoria/MemoriaDetectedDocumentSelect.tsx
@@ -1,0 +1,58 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { formatMemoriaUploadDate } from "@/features/technical-tools/memoria/dateFormat";
+import type { DetectedMemoriaDocument } from "@/features/technical-tools/memoria/useMemoriaAutoFill";
+
+interface MemoriaDetectedDocumentSelectProps {
+  candidates: DetectedMemoriaDocument[];
+  onSelect: (filePath: string) => void;
+  sectionTitle: string;
+  selected: DetectedMemoriaDocument;
+}
+
+const getDocumentLabel = (document: DetectedMemoriaDocument) => {
+  const date = document.uploadedAt ? formatMemoriaUploadDate(document.uploadedAt) : "";
+  return date ? `${document.fileName} (${date})` : document.fileName;
+};
+
+export const MemoriaDetectedDocumentSelect = ({
+  candidates,
+  onSelect,
+  sectionTitle,
+  selected,
+}: MemoriaDetectedDocumentSelectProps) => {
+  if (candidates.length <= 1) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Detectado: {getDocumentLabel(selected)}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs text-muted-foreground">Documento detectado</Label>
+      <Select value={selected.filePath} onValueChange={onSelect}>
+        <SelectTrigger aria-label={`Documento para ${sectionTitle}`} className="w-full text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {candidates.map((document) => (
+            <SelectItem key={document.filePath} value={document.filePath}>
+              {getDocumentLabel(document)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <p className="text-xs text-muted-foreground">
+        Se encontraron {candidates.length} documentos. Elige cuál incluir en la memoria.
+      </p>
+    </div>
+  );
+};

--- a/src/features/technical-tools/memoria/useMemoriaAutoFill.test.tsx
+++ b/src/features/technical-tools/memoria/useMemoriaAutoFill.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findJobDocumentsForStageMock } = vi.hoisted(() => ({
+  findJobDocumentsForStageMock: vi.fn(),
+}));
+
+vi.mock("@/utils/jobDocuments/stageAwareLookup", () => ({
+  findJobDocumentsForStage: findJobDocumentsForStageMock,
+}));
+
+import { useMemoriaAutoFill } from "@/features/technical-tools/memoria/useMemoriaAutoFill";
+
+const newestDocument = {
+  id: "doc-new",
+  file_name: "Lista material extra.pdf",
+  file_path: "job-1/calculators/lista-material/sound/new.pdf",
+  uploaded_at: "2026-07-21T10:00:00.000Z",
+};
+
+const olderDocument = {
+  id: "doc-old",
+  file_name: "Lista material principal.pdf",
+  file_path: "job-1/calculators/lista-material/sound/old.pdf",
+  uploaded_at: "2026-07-20T10:00:00.000Z",
+};
+
+describe("useMemoriaAutoFill", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findJobDocumentsForStageMock.mockResolvedValue([newestDocument, olderDocument]);
+  });
+
+  it("exposes every eligible document, defaults to newest, and keeps the user's selection", async () => {
+    const { result } = renderHook(() =>
+      useMemoriaAutoFill("job-1", null, {
+        material: "calculators/lista-material/sound",
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.candidates.material).toHaveLength(2);
+    });
+    expect(result.current.detected.material?.filePath).toBe(newestDocument.file_path);
+
+    act(() => result.current.selectDocument("material", olderDocument.file_path));
+    expect(result.current.detected.material?.filePath).toBe(olderDocument.file_path);
+
+    act(() => result.current.refetch());
+    await waitFor(() => expect(findJobDocumentsForStageMock).toHaveBeenCalledTimes(2));
+    expect(result.current.detected.material?.filePath).toBe(olderDocument.file_path);
+  });
+
+  it("selects a newly generated document when a section requests the latest candidate", async () => {
+    const { result } = renderHook(() =>
+      useMemoriaAutoFill("job-1", null, {
+        material: "calculators/lista-material/sound",
+      })
+    );
+
+    await waitFor(() => expect(result.current.detected.material).not.toBeNull());
+    act(() => result.current.selectDocument("material", olderDocument.file_path));
+
+    const generatedDocument = {
+      id: "doc-generated",
+      file_name: "Lista material presupuesto B.pdf",
+      file_path: "job-1/calculators/lista-material/sound/generated.pdf",
+      uploaded_at: "2026-07-21T12:00:00.000Z",
+    };
+    findJobDocumentsForStageMock.mockResolvedValue([
+      generatedDocument,
+      newestDocument,
+      olderDocument,
+    ]);
+
+    act(() => result.current.refetch("material"));
+    await waitFor(() => {
+      expect(result.current.detected.material?.filePath).toBe(generatedDocument.file_path);
+    });
+  });
+});

--- a/src/features/technical-tools/memoria/useMemoriaAutoFill.ts
+++ b/src/features/technical-tools/memoria/useMemoriaAutoFill.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TechnicalStage } from "@/features/technical-tools/stage/stageUtils";
-import { findLatestJobDocumentForStage } from "@/utils/jobDocuments/stageAwareLookup";
+import { findJobDocumentsForStage } from "@/utils/jobDocuments/stageAwareLookup";
 import { getTechnicalPowerDepartmentFromDocument } from "@/utils/powerReportReadiness";
 import type { TechnicalPowerDepartment } from "@/utils/technicalPowerTypes";
 
@@ -20,11 +20,19 @@ export type MemoriaAutoFillCategorySpec =
 const getAutoFillCategory = (spec: MemoriaAutoFillCategorySpec) =>
   typeof spec === "string" ? spec : spec.category;
 
+export interface MemoriaAutoFillResult {
+  candidates: Record<string, DetectedMemoriaDocument[]>;
+  detected: Record<string, DetectedMemoriaDocument | null>;
+  isLoading: boolean;
+  refetch: (preferLatestSectionId?: string) => void;
+  selectDocument: (sectionId: string, filePath: string) => void;
+}
+
 /**
- * Looks up the latest already-generated job_documents PDF (Pesos/Consumos/SV Report)
- * per Memoria Técnica section, scoped to the selected job + festival stage, so the
- * Memoria form can pre-fill those sections instead of asking the user to re-upload
- * documents the app already produced.
+ * Looks up every already-generated job_documents PDF (Pesos/Consumos/SV Report)
+ * per Memoria Técnica section, scoped to the selected job + festival stage. The
+ * newest candidate is selected by default, while callers can choose another when
+ * extras or multi-stage workflows produced more than one eligible document.
  *
  * `categoriesBySection` maps a Memoria document-section id (e.g. "weight") to the
  * job_documents storage category it should be looked up under (e.g. "calculators/pesos").
@@ -33,10 +41,13 @@ export const useMemoriaAutoFill = (
   jobId: string,
   stage: TechnicalStage | null,
   categoriesBySection: Record<string, MemoriaAutoFillCategorySpec>
-): { detected: Record<string, DetectedMemoriaDocument | null>; isLoading: boolean; refetch: () => void } => {
-  const [detected, setDetected] = useState<Record<string, DetectedMemoriaDocument | null>>({});
+): MemoriaAutoFillResult => {
+  const [candidates, setCandidates] = useState<Record<string, DetectedMemoriaDocument[]>>({});
+  const [selectedPaths, setSelectedPaths] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [refetchToken, setRefetchToken] = useState(0);
+  const preferLatestSectionRef = useRef<string | null>(null);
+  const selectionContextRef = useRef("");
   const categoriesKey = Object.entries(categoriesBySection)
     .map(([section, spec]) => {
       if (typeof spec === "string") return `${section}:${spec}`;
@@ -44,12 +55,22 @@ export const useMemoriaAutoFill = (
     })
     .sort()
     .join(",");
+  const selectionContextKey = `${jobId}:${stage?.number ?? "none"}:${stage?.name ?? ""}:${categoriesKey}`;
 
-  const refetch = useCallback(() => setRefetchToken((token) => token + 1), []);
+  const refetch = useCallback((preferLatestSectionId?: string) => {
+    preferLatestSectionRef.current = preferLatestSectionId ?? null;
+    setRefetchToken((token) => token + 1);
+  }, []);
+
+  const selectDocument = useCallback((sectionId: string, filePath: string) => {
+    setSelectedPaths((current) => ({ ...current, [sectionId]: filePath }));
+  }, []);
 
   useEffect(() => {
     if (!jobId) {
-      setDetected({});
+      setCandidates({});
+      setSelectedPaths({});
+      selectionContextRef.current = "";
       setIsLoading(false);
       return;
     }
@@ -62,7 +83,7 @@ export const useMemoriaAutoFill = (
         Object.entries(categoriesBySection).map(async ([sectionId, spec]) => {
           try {
             const category = getAutoFillCategory(spec);
-            const doc = await findLatestJobDocumentForStage(
+            const docs = await findJobDocumentsForStage(
               jobId,
               category,
               stage,
@@ -72,19 +93,42 @@ export const useMemoriaAutoFill = (
             );
             return [
               sectionId,
-              doc
-                ? { filePath: doc.file_path, fileName: doc.file_name, uploadedAt: doc.uploaded_at }
-                : null,
+              docs.map((doc) => ({
+                filePath: doc.file_path,
+                fileName: doc.file_name,
+                uploadedAt: doc.uploaded_at,
+              })),
             ] as const;
           } catch (error) {
             console.error(`Error looking up detected document for ${sectionId}:`, error);
-            return [sectionId, null] as const;
+            return [sectionId, []] as const;
           }
         })
       );
 
       if (!cancelled) {
-        setDetected(Object.fromEntries(entries));
+        const nextCandidates = Object.fromEntries(entries) as Record<
+          string,
+          DetectedMemoriaDocument[]
+        >;
+        const contextChanged = selectionContextRef.current !== selectionContextKey;
+        const preferLatestSection = preferLatestSectionRef.current;
+
+        setCandidates(nextCandidates);
+        setSelectedPaths((current) =>
+          Object.fromEntries(
+            Object.entries(nextCandidates).flatMap(([sectionId, documents]) => {
+              const currentPath = current[sectionId];
+              const shouldPreferLatest = contextChanged || preferLatestSection === sectionId;
+              const selected = shouldPreferLatest
+                ? documents[0]
+                : documents.find((document) => document.filePath === currentPath) ?? documents[0];
+              return selected ? [[sectionId, selected.filePath]] : [];
+            })
+          )
+        );
+        selectionContextRef.current = selectionContextKey;
+        preferLatestSectionRef.current = null;
         setIsLoading(false);
       }
     })();
@@ -93,7 +137,18 @@ export const useMemoriaAutoFill = (
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [jobId, stage?.number, categoriesKey, refetchToken]);
+  }, [jobId, stage?.number, stage?.name, categoriesKey, refetchToken, selectionContextKey]);
 
-  return { detected, isLoading, refetch };
+  const detected = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(candidates).map(([sectionId, documents]) => [
+          sectionId,
+          documents.find((document) => document.filePath === selectedPaths[sectionId]) ?? documents[0] ?? null,
+        ])
+      ),
+    [candidates, selectedPaths]
+  );
+
+  return { candidates, detected, isLoading, refetch, selectDocument };
 };

--- a/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
+++ b/src/features/technical-tools/power/consumos/ConsumosToolPage.tsx
@@ -29,6 +29,7 @@ import { CopyToStageMenu } from "@/features/technical-tools/table-presets/CopyTo
 import { QuickPresetsMenu } from "@/features/technical-tools/table-presets/QuickPresetsMenu";
 import type { PowerTable } from "@/features/technical-tools/power/types";
 import { GeneratedPowerTableCard } from "@/features/technical-tools/power/consumos/GeneratedPowerTableCard";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 import { PowerTableSummary } from "@/features/technical-tools/power/consumos/PowerTableSummary";
 import {
   TOUR_PACKAGE_LABELS,
@@ -630,18 +631,13 @@ export const ConsumosToolPage: React.FC<{ config: ConsumosDepartmentConfig }> = 
                 {isNormalMode && !jobIdFromUrl && (
                   <div className="space-y-2">
                     <Label htmlFor="jobSelect">{labels.selectJob}</Label>
-                    <Select value={selectedJobId} onValueChange={handleJobSelect}>
-                      <SelectTrigger>
-                        <SelectValue placeholder={labels.selectJobPlaceholder} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {jobs?.map((job) => (
-                          <SelectItem key={job.id} value={job.id}>
-                            {job.title}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <DocumentationJobPicker
+                      id="jobSelect"
+                      jobs={jobs}
+                      onValueChange={handleJobSelect}
+                      placeholder={labels.selectJobPlaceholder}
+                      value={selectedJobId}
+                    />
                   </div>
                 )}
 

--- a/src/hooks/useJobSelection.test.tsx
+++ b/src/hooks/useJobSelection.test.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestQueryClient } from "@/test/createTestQueryClient";
 import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
 
@@ -17,7 +17,13 @@ describe("useJobSelection", () => {
     vi.spyOn(console, "log").mockImplementation(() => undefined);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("requests ongoing/future non-terminal jobs for documentation tools", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-22T10:15:00.000Z"));
     const jobsBuilder = createMockQueryBuilder({ data: [], error: null });
     mockSupabase.from.mockReturnValue(jobsBuilder);
     const queryClient = createTestQueryClient();
@@ -28,7 +34,10 @@ describe("useJobSelection", () => {
     const { result } = renderHook(() => useJobSelection(), { wrapper });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(jobsBuilder.gte).toHaveBeenCalledWith("end_time", expect.any(String));
+    expect(jobsBuilder.gte).toHaveBeenCalledWith(
+      "end_time",
+      "2026-07-22T10:15:00.000Z"
+    );
     expect(jobsBuilder.or).toHaveBeenCalledWith(
       "status.is.null,status.in.(Tentativa,Confirmado)"
     );

--- a/src/hooks/useJobSelection.test.tsx
+++ b/src/hooks/useJobSelection.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestQueryClient } from "@/test/createTestQueryClient";
+import { createMockQueryBuilder, mockSupabase, resetMockSupabase } from "@/test/mockSupabase";
+
+vi.mock("@/lib/supabase", () => ({ supabase: mockSupabase }));
+
+import { useJobSelection } from "@/hooks/useJobSelection";
+
+describe("useJobSelection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockSupabase();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  it("requests ongoing/future non-terminal jobs for documentation tools", async () => {
+    const jobsBuilder = createMockQueryBuilder({ data: [], error: null });
+    mockSupabase.from.mockReturnValue(jobsBuilder);
+    const queryClient = createTestQueryClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useJobSelection(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(jobsBuilder.gte).toHaveBeenCalledWith("end_time", expect.any(String));
+    expect(jobsBuilder.or).toHaveBeenCalledWith(
+      "status.is.null,status.in.(Tentativa,Confirmado)"
+    );
+    expect(jobsBuilder.in).toHaveBeenCalledWith("job_type", [
+      "single",
+      "festival",
+      "ciclo",
+      "tourdate",
+    ]);
+  });
+});

--- a/src/hooks/useJobSelection.ts
+++ b/src/hooks/useJobSelection.ts
@@ -49,9 +49,9 @@ export const useJobSelection = () => {
             )
           )
         `)
-        .gte('start_time', today.toISOString()) // Filter to present/future jobs only
+        .gte('end_time', today.toISOString()) // Include ongoing jobs; exclude jobs that already ended
         .in('job_type', ['single', 'festival', 'ciclo', 'tourdate']) // Only include relevant job types
-        .neq('status', 'Completado') // Exclude completed/deleted jobs
+        .or('status.is.null,status.in.(Tentativa,Confirmado)') // Exclude completed/cancelled jobs
         .order("start_time", { ascending: true });
 
       if (error) {

--- a/src/hooks/useJobSelection.ts
+++ b/src/hooks/useJobSelection.ts
@@ -27,9 +27,7 @@ export const useJobSelection = () => {
     queryFn: async () => {
       console.log("Fetching jobs for selection...");
       
-      // Get today's date in ISO format to filter future/present jobs
-      const today = new Date();
-      today.setHours(0, 0, 0, 0); // Set to start of day
+      const activeJobCutoff = new Date().toISOString();
       
       const { data: jobs, error } = await supabase
         .from("jobs")
@@ -49,7 +47,7 @@ export const useJobSelection = () => {
             )
           )
         `)
-        .gte('end_time', today.toISOString()) // Include ongoing jobs; exclude jobs that already ended
+        .gte('end_time', activeJobCutoff) // Include ongoing jobs; exclude jobs that already ended
         .in('job_type', ['single', 'festival', 'ciclo', 'tourdate']) // Only include relevant job types
         .or('status.is.null,status.in.(Tentativa,Confirmado)') // Exclude completed/cancelled jobs
         .order("start_time", { ascending: true });

--- a/src/pages/VideoPesosTool.tsx
+++ b/src/pages/VideoPesosTool.tsx
@@ -10,6 +10,7 @@ import { FileText, ArrowLeft, Trash2 } from 'lucide-react';
 import { exportToPDF } from '@/utils/pdfExport';
 import { getJobTechnicalPdfFileName } from '@/utils/technicalPdfNames';
 import { useJobSelection } from '@/hooks/useJobSelection';
+import { DocumentationJobPicker } from '@/features/technical-tools/jobs/DocumentationJobPicker';
 import { useToast } from '@/hooks/use-toast';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { dataLayerClient } from '@/services/dataLayerClient';
@@ -424,19 +425,14 @@ const VideoPesosTool: React.FC = () => {
 
           {!jobIdFromUrl && (
             <div className="space-y-2">
-              <Label htmlFor="jobSelect">Select Job</Label>
-              <Select value={selectedJobId} onValueChange={handleJobSelect}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select a job" />
-                </SelectTrigger>
-                <SelectContent>
-                  {jobs?.map((job) => (
-                    <SelectItem key={job.id} value={job.id}>
-                      {job.title}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Label htmlFor="jobSelect">Seleccionar trabajo</Label>
+              <DocumentationJobPicker
+                id="jobSelect"
+                jobs={jobs}
+                onValueChange={handleJobSelect}
+                placeholder="Seleccionar trabajo"
+                value={selectedJobId}
+              />
             </div>
           )}
 

--- a/src/pages/pesos-tool/PesosToolView.tsx
+++ b/src/pages/pesos-tool/PesosToolView.tsx
@@ -12,6 +12,7 @@ import {
   TechnicalStageSelector,
   type TechnicalStage,
 } from "@/features/technical-tools/stage/stageAllocation";
+import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
 import {
   TOUR_PACKAGE_LABELS,
   TOUR_PACKAGE_SIZES,
@@ -312,19 +313,14 @@ export const PesosToolView: React.FC<PesosToolViewProps> = ({
                 {/* Hide job selection when coming from card (jobId in URL), or in tour defaults mode */}
                 {!isTourContext && !isTourDefaults && !jobIdFromUrl && (
                   <div className="space-y-2">
-                    <Label htmlFor="jobSelect">Select Job</Label>
-                    <Select value={selectedJobId} onValueChange={handleJobSelect}>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a job" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {jobs?.map((job) => (
-                          <SelectItem key={job.id} value={job.id}>
-                            {job.title}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <Label htmlFor="jobSelect">Seleccionar trabajo</Label>
+                    <DocumentationJobPicker
+                      id="jobSelect"
+                      jobs={jobs}
+                      onValueChange={handleJobSelect}
+                      placeholder="Seleccionar trabajo"
+                      value={selectedJobId}
+                    />
                   </div>
                 )}
 

--- a/src/utils/flexMaterialReport.ts
+++ b/src/utils/flexMaterialReport.ts
@@ -14,6 +14,11 @@ export interface FlexMaterialReportResult {
 export type FlexMaterialReportDepartment = "sound" | "lights" | "video" | "production";
 export type FlexMaterialReportType = "material-list" | "quote";
 
+export interface FlexMaterialReportElementDescriptor {
+  displayName?: string;
+  documentNumber?: string;
+}
+
 /**
  * Resolves the job's Flex quote (flex_folders.element_id) for the given department
  * and fetches Flex's own "Listado de Material" report, persisting it into
@@ -25,13 +30,16 @@ export const fetchFlexMaterialReport = async (
   department: FlexMaterialReportDepartment,
   overrideElementId?: string,
   stage?: TechnicalStage | null,
-  reportType: FlexMaterialReportType = "material-list"
+  reportType: FlexMaterialReportType = "material-list",
+  elementDescriptor?: FlexMaterialReportElementDescriptor,
 ): Promise<FlexMaterialReportResult> => {
   const { data, error } = await dataLayerClient.functions.invoke("fetch-flex-material-report", {
     body: {
       jobId,
       department,
       overrideElementId: overrideElementId || undefined,
+      elementDisplayName: elementDescriptor?.displayName || undefined,
+      elementDocumentNumber: elementDescriptor?.documentNumber || undefined,
       reportType,
       stageNumber: stage?.number,
       stageName: stage?.name,

--- a/src/utils/flexReportPresupuestos.test.ts
+++ b/src/utils/flexReportPresupuestos.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { FLEX_FOLDER_IDS } from "@/utils/flex-folders/constants";
+import type { FlexElementNode } from "@/utils/flex-folders/getElementTree";
+import {
+  getFlexPresupuestoOptions,
+  getFlexReportRootElementId,
+} from "@/utils/flexReportPresupuestos";
+
+describe("Flex report presupuesto discovery", () => {
+  it("finds every presupuesto in the tree and inherits its tracked department", () => {
+    const tree: FlexElementNode[] = [{
+      elementId: "job-root",
+      displayName: "Trabajo",
+      children: [{
+        elementId: "sound-folder",
+        displayName: "Sonido",
+        definitionId: FLEX_FOLDER_IDS.subFolder,
+        children: [{
+          elementId: "quote-main",
+          displayName: "Presupuesto principal",
+          documentNumber: "Q-100",
+          definitionId: FLEX_FOLDER_IDS.presupuesto,
+        }, {
+          elementId: "stage-extra",
+          displayName: "Escenario B",
+          definitionId: FLEX_FOLDER_IDS.subFolder,
+          children: [{
+            elementId: "quote-extra",
+            displayName: "Extra escenario B",
+            documentNumber: "Q-101",
+            definitionId: FLEX_FOLDER_IDS.presupuesto,
+          }],
+        }],
+      }, {
+        elementId: "lights-folder",
+        displayName: "Luces",
+        definitionId: FLEX_FOLDER_IDS.subFolder,
+        children: [{
+          elementId: "quote-lights",
+          displayName: "Presupuesto iluminación",
+          definitionId: FLEX_FOLDER_IDS.presupuestoDryHire,
+        }],
+      }],
+    }];
+
+    expect(getFlexPresupuestoOptions(tree, [
+      { element_id: "job-root", department: "production", folder_type: "main_event" },
+      { element_id: "sound-folder", department: "sound", folder_type: "department" },
+    ])).toEqual([
+      expect.objectContaining({ elementId: "quote-main", department: "sound", documentNumber: "Q-100" }),
+      expect.objectContaining({ elementId: "quote-extra", department: "sound", documentNumber: "Q-101" }),
+      expect.objectContaining({ elementId: "quote-lights", department: "lights" }),
+    ]);
+  });
+
+  it("excludes containers and pull sheets, deduplicates tracked rows, and keeps tracked fallbacks", () => {
+    const tree: FlexElementNode[] = [{
+      elementId: "container",
+      displayName: "Presupuestos Recibidos",
+      definitionId: FLEX_FOLDER_IDS.presupuestosRecibidos,
+      children: [{
+        elementId: "tracked-quote",
+        displayName: "Presupuesto desde Flex",
+        definitionId: FLEX_FOLDER_IDS.presupuesto,
+      }, {
+        elementId: "pull-sheet",
+        displayName: "Lista material",
+        definitionId: FLEX_FOLDER_IDS.pullSheet,
+      }],
+    }];
+
+    const options = getFlexPresupuestoOptions(tree, [{
+      element_id: "tracked-quote",
+      department: "sound",
+      folder_type: "comercial_presupuesto",
+    }, {
+      element_id: "db-only-quote",
+      department: "lights",
+      folder_type: "dryhire_presupuesto",
+    }]);
+
+    expect(options).toHaveLength(2);
+    expect(options.map((option) => option.elementId)).toEqual([
+      "tracked-quote",
+      "db-only-quote",
+    ]);
+    expect(options[0]).toMatchObject({ displayName: "Presupuesto desde Flex", department: "sound" });
+  });
+
+  it("uses the closest supported job root", () => {
+    expect(getFlexReportRootElementId([
+      { element_id: "quote", folder_type: "comercial_presupuesto" },
+      { element_id: "dryhire-root", folder_type: "dryhire" },
+      { element_id: "main-root", folder_type: "main_event" },
+    ])).toBe("main-root");
+  });
+});

--- a/src/utils/flexReportPresupuestos.ts
+++ b/src/utils/flexReportPresupuestos.ts
@@ -1,0 +1,161 @@
+import { getDepartmentLabel } from "@/types/department";
+import { FLEX_FOLDER_IDS } from "@/utils/flex-folders/constants";
+import type { FlexElementNode } from "@/utils/flex-folders/getElementTree";
+
+export type FlexReportDepartment = "sound" | "lights" | "video" | "production";
+
+export type FlexReportFolderReference = {
+  department?: string | null;
+  element_id?: string | null;
+  elementId?: string | null;
+  folder_type?: string | null;
+  name?: string | null;
+};
+
+export type FlexPresupuestoOption = {
+  department: FlexReportDepartment | null;
+  displayName: string;
+  documentNumber?: string;
+  elementId: string;
+};
+
+const REPORT_DEPARTMENTS = new Set<FlexReportDepartment>([
+  "sound",
+  "lights",
+  "video",
+  "production",
+]);
+
+const PRESUPUESTO_DEFINITION_IDS = new Set([
+  FLEX_FOLDER_IDS.presupuesto,
+  FLEX_FOLDER_IDS.presupuestoDryHire,
+]);
+
+const TRACKED_PRESUPUESTO_FOLDER_TYPES = new Set([
+  "comercial_presupuesto",
+  "dryhire_presupuesto",
+]);
+
+const REPORT_ROOT_FOLDER_TYPES = ["main_event", "main", "dryhire", "tourdate"];
+
+const getFolderElementId = (folder: FlexReportFolderReference): string | null => {
+  const value = folder.element_id || folder.elementId;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+};
+
+const normalizeDepartment = (value: string | null | undefined): FlexReportDepartment | null => {
+  const normalized = value?.trim().toLowerCase() as FlexReportDepartment | undefined;
+  return normalized && REPORT_DEPARTMENTS.has(normalized) ? normalized : null;
+};
+
+const inferDepartmentFromName = (value: string): FlexReportDepartment | null => {
+  const normalized = value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+  if (/\b(sonido|sound)\b/.test(normalized)) return "sound";
+  if (/\b(iluminacion|luces|lights?)\b/.test(normalized)) return "lights";
+  if (/\bvideo\b/.test(normalized)) return "video";
+  if (/\b(produccion|production)\b/.test(normalized)) return "production";
+  return null;
+};
+
+const getTrackedPresupuestoOptions = (
+  folders: FlexReportFolderReference[],
+): FlexPresupuestoOption[] => folders.flatMap((folder) => {
+  const elementId = getFolderElementId(folder);
+  if (
+    !elementId ||
+    !TRACKED_PRESUPUESTO_FOLDER_TYPES.has(folder.folder_type || "")
+  ) {
+    return [];
+  }
+
+  return [{
+    department: normalizeDepartment(folder.department),
+    displayName: folder.name?.trim() || "Presupuesto",
+    elementId,
+  }];
+});
+
+/**
+ * Finds every real Presupuesto element in the Flex tree. Department ownership
+ * is inherited from tracked ancestor folders, with department-folder names as
+ * a fallback for older Flex structures that were not fully mirrored locally.
+ */
+export const getFlexPresupuestoOptions = (
+  tree: FlexElementNode[] | undefined,
+  folders: FlexReportFolderReference[] | null | undefined,
+): FlexPresupuestoOption[] => {
+  const folderList = folders || [];
+  const trackedDepartmentByElementId = new Map<string, FlexReportDepartment>();
+
+  for (const folder of folderList) {
+    const elementId = getFolderElementId(folder);
+    const department = normalizeDepartment(folder.department);
+    if (elementId && department) trackedDepartmentByElementId.set(elementId, department);
+  }
+
+  const optionsByElementId = new Map<string, FlexPresupuestoOption>();
+
+  const visit = (nodes: FlexElementNode[], inheritedDepartment: FlexReportDepartment | null) => {
+    for (const node of nodes) {
+      const trackedDepartment = trackedDepartmentByElementId.get(node.elementId) || null;
+      const namedDepartment = node.definitionId === FLEX_FOLDER_IDS.subFolder
+        ? inferDepartmentFromName(node.displayName)
+        : null;
+      // A production-owned job root may contain untracked department folders in
+      // older jobs. Let those top-level names refine production, but do not let a
+      // nested name such as "Video wall" override an already-known Sound owner.
+      const department = trackedDepartment || (
+        inheritedDepartment === "production"
+          ? namedDepartment || inheritedDepartment
+          : inheritedDepartment || namedDepartment
+      );
+
+      if (
+        node.elementId &&
+        node.definitionId &&
+        PRESUPUESTO_DEFINITION_IDS.has(node.definitionId)
+      ) {
+        optionsByElementId.set(node.elementId, {
+          department,
+          displayName: node.displayName?.trim() || "Presupuesto",
+          documentNumber: node.documentNumber?.trim() || undefined,
+          elementId: node.elementId,
+        });
+      }
+
+      if (node.children?.length) visit(node.children, department);
+    }
+  };
+
+  if (tree?.length) visit(tree, null);
+
+  for (const option of getTrackedPresupuestoOptions(folderList)) {
+    if (!optionsByElementId.has(option.elementId)) {
+      optionsByElementId.set(option.elementId, option);
+    }
+  }
+
+  return Array.from(optionsByElementId.values());
+};
+
+export const getFlexReportRootElementId = (
+  folders: FlexReportFolderReference[] | null | undefined,
+): string | null => {
+  const folderList = folders || [];
+  for (const folderType of REPORT_ROOT_FOLDER_TYPES) {
+    const root = folderList.find((folder) => folder.folder_type === folderType);
+    const elementId = root ? getFolderElementId(root) : null;
+    if (elementId) return elementId;
+  }
+  return null;
+};
+
+export const getFlexPresupuestoOptionLabel = (option: FlexPresupuestoOption): string => {
+  const departmentLabel = getDepartmentLabel(option.department);
+  const detail = option.documentNumber || option.elementId.slice(0, 8);
+  return `${departmentLabel} · ${option.displayName} · ${detail}`;
+};

--- a/src/utils/jobDocuments/__tests__/stageAwareLookup.test.ts
+++ b/src/utils/jobDocuments/__tests__/stageAwareLookup.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { parseStageScopeSegment } from "@/utils/jobDocuments/stageAwareLookup";
+const { fromMock } = vi.hoisted(() => ({ fromMock: vi.fn() }));
+
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: { from: fromMock },
+}));
+
+import {
+  findJobDocumentsForStage,
+  parseStageScopeSegment,
+} from "@/utils/jobDocuments/stageAwareLookup";
 
 describe("stage-aware job document lookup helpers", () => {
   it("parses stage scopes from legacy and job-scoped generated document paths", () => {
@@ -27,5 +36,42 @@ describe("stage-aware job document lookup helpers", () => {
         "calculators/consumos"
       )
     ).toBeNull();
+  });
+
+  it("returns every matching stage document in server-provided newest-first order", async () => {
+    const documents = [
+      {
+        id: "new",
+        file_name: "new.pdf",
+        file_path: "job-1/calculators/pesos/new.pdf",
+        uploaded_at: "2026-07-21T10:00:00Z",
+      },
+      {
+        id: "old",
+        file_name: "old.pdf",
+        file_path: "calculators/pesos/job-1/old.pdf",
+        uploaded_at: "2026-07-20T10:00:00Z",
+      },
+      {
+        id: "other-stage",
+        file_name: "stage.pdf",
+        file_path: "job-1/calculators/pesos/stage-2-main/stage.pdf",
+        uploaded_at: "2026-07-22T10:00:00Z",
+      },
+    ];
+    const builder = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      or: vi.fn(),
+      order: vi.fn().mockResolvedValue({ data: documents, error: null }),
+    };
+    builder.select.mockReturnValue(builder);
+    builder.eq.mockReturnValue(builder);
+    builder.or.mockReturnValue(builder);
+    fromMock.mockReturnValue(builder);
+
+    const matches = await findJobDocumentsForStage("job-1", "calculators/pesos");
+
+    expect(matches.map((document) => document.id)).toEqual(["new", "old"]);
   });
 });

--- a/src/utils/jobDocuments/__tests__/stageAwareLookup.test.ts
+++ b/src/utils/jobDocuments/__tests__/stageAwareLookup.test.ts
@@ -74,4 +74,52 @@ describe("stage-aware job document lookup helpers", () => {
 
     expect(matches.map((document) => document.id)).toEqual(["new", "old"]);
   });
+
+  it("applies stage scope and custom filters without changing server order", async () => {
+    const documents = [
+      {
+        id: "video-new",
+        file_name: "video-new.pdf",
+        file_path: "job-1/calculators/pesos/stage-2-main/video-new.pdf",
+        uploaded_at: "2026-07-22T10:00:00Z",
+      },
+      {
+        id: "sound-same-stage",
+        file_name: "sound.pdf",
+        file_path: "job-1/calculators/pesos/stage-2-main/sound.pdf",
+        uploaded_at: "2026-07-22T09:00:00Z",
+      },
+      {
+        id: "video-old",
+        file_name: "video-old.pdf",
+        file_path: "calculators/pesos/job-1/stage-2-main/video-old.pdf",
+        uploaded_at: "2026-07-21T10:00:00Z",
+      },
+      {
+        id: "video-other-stage",
+        file_name: "video-other-stage.pdf",
+        file_path: "job-1/calculators/pesos/stage-3-secondary/video-other-stage.pdf",
+        uploaded_at: "2026-07-23T10:00:00Z",
+      },
+    ];
+    const builder = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      or: vi.fn(),
+      order: vi.fn().mockResolvedValue({ data: documents, error: null }),
+    };
+    builder.select.mockReturnValue(builder);
+    builder.eq.mockReturnValue(builder);
+    builder.or.mockReturnValue(builder);
+    fromMock.mockReturnValue(builder);
+
+    const matches = await findJobDocumentsForStage(
+      "job-1",
+      "calculators/pesos",
+      { number: 2, name: "Main" },
+      (document) => document.file_name.startsWith("video-")
+    );
+
+    expect(matches.map((document) => document.id)).toEqual(["video-new", "video-old"]);
+  });
 });

--- a/src/utils/jobDocuments/stageAwareLookup.ts
+++ b/src/utils/jobDocuments/stageAwareLookup.ts
@@ -40,15 +40,15 @@ export const parseStageScopeSegment = (
 };
 
 /**
- * Latest job_documents row for a job+category, scoped to a specific festival stage
- * (or the unscoped upload, for single-stage jobs / no stage selected).
+ * All job_documents rows for a job+category, scoped to a specific festival stage
+ * (or the unscoped uploads, for single-stage jobs / no stage selected), newest first.
  */
-export const findLatestJobDocumentForStage = async (
+export const findJobDocumentsForStage = async (
   jobId: string,
   category: string,
   stage?: TechnicalStage | null,
   filter?: StageAwareJobDocumentFilter
-): Promise<StageAwareJobDocument | null> => {
+): Promise<StageAwareJobDocument[]> => {
   const { data, error } = await dataLayerClient
     .from("job_documents")
     .select("id, file_name, file_path, uploaded_at")
@@ -60,11 +60,20 @@ export const findLatestJobDocumentForStage = async (
 
   const wantedScope = getTechnicalStageStorageScope(stage ?? null) ?? null;
 
-  const match = (data || []).find(
+  return (data || []).filter(
     (doc) =>
       parseStageScopeSegment(doc.file_path, jobId, category) === wantedScope &&
       (!filter || filter(doc))
   );
+};
 
-  return match ?? null;
+/** Backward-compatible helper for callers that only need the newest match. */
+export const findLatestJobDocumentForStage = async (
+  jobId: string,
+  category: string,
+  stage?: TechnicalStage | null,
+  filter?: StageAwareJobDocumentFilter
+): Promise<StageAwareJobDocument | null> => {
+  const documents = await findJobDocumentsForStage(jobId, category, stage, filter);
+  return documents[0] ?? null;
 };

--- a/supabase/functions/fetch-flex-material-report/index.ts
+++ b/supabase/functions/fetch-flex-material-report/index.ts
@@ -9,6 +9,10 @@ import {
   readBoundedJsonObject,
   requireEnvValues,
 } from "../_shared/http.ts";
+import {
+  buildFlexReportFileIdentity,
+  isFlexReportPredecessorObject,
+} from "./reportFiles.ts";
 
 // Fixed Flex report constants confirmed against the live Flex account. Only
 // PROJECT_ELEMENT_ID varies per job/department for the material-list report.
@@ -57,6 +61,8 @@ const REPORT_FOLDER_TYPES: Record<FlexReportType, string[]> = {
 };
 
 interface FetchFlexMaterialReportBody extends Record<string, unknown> {
+  elementDisplayName?: unknown;
+  elementDocumentNumber?: unknown;
   jobId?: unknown;
   department?: unknown;
   overrideElementId?: unknown;
@@ -64,9 +70,6 @@ interface FetchFlexMaterialReportBody extends Record<string, unknown> {
   stageName?: unknown;
   stageNumber?: unknown;
 }
-
-const sanitizeFileNameSegment = (value: string) =>
-  value.replace(/[^a-zA-Z0-9._-]/g, "_").replace(/_{2,}/g, "_").replace(/^_|_$/g, "") || "segment";
 
 const normalizePathSegment = (value: string) =>
   value
@@ -95,6 +98,12 @@ serve(createHttpHandler(async (req: Request) => {
   const jobId = typeof body.jobId === "string" ? body.jobId : null;
   const department = typeof body.department === "string" ? body.department : null;
   const overrideElementId = typeof body.overrideElementId === "string" ? body.overrideElementId : null;
+  const elementDisplayName = typeof body.elementDisplayName === "string" && body.elementDisplayName.trim()
+    ? body.elementDisplayName.trim().slice(0, 160)
+    : null;
+  const elementDocumentNumber = typeof body.elementDocumentNumber === "string" && body.elementDocumentNumber.trim()
+    ? body.elementDocumentNumber.trim().slice(0, 80)
+    : null;
   const reportType = typeof body.reportType === "string" && body.reportType.trim()
     ? body.reportType.trim()
     : DEFAULT_REPORT_TYPE;
@@ -260,29 +269,20 @@ serve(createHttpHandler(async (req: Request) => {
   const category = `${reportDefinition.storageCategory}/${department}`;
   const stageScope = stageNumber ? getTechnicalStageStorageScope(stageNumber, stageName) : null;
   const baseFolder = stageScope ? `${category}/${jobId}/${stageScope}` : `${category}/${jobId}`;
-  const fileName = `${reportDefinition.fileNamePrefix} - ${sanitizeFileNameSegment(department)}.pdf`;
-  const objectPath = `${baseFolder}/${fileName}`;
-
-  // Clean up any previous auto-fetched report for this exact job/department/stage
-  // scope before writing the new one. Scope both the storage removal and the
-  // job_documents delete to the same direct-children list -- baseFolder may have
-  // stage-scoped sibling subfolders (a non-stage caller like PrintFlexReportAction
-  // and a stage-aware Memoria form can both write under the same job/department),
-  // and storage.list() doesn't recurse into those, so a broader `LIKE baseFolder/%`
-  // delete on job_documents would drop sibling stage rows without removing their
-  // underlying storage objects.
-  const { data: existingObjects } = await supabase.storage.from(bucket).list(baseFolder);
-  const existingObjectPaths = (existingObjects || [])
-    .filter((entry) => entry.id)
-    .map((entry) => `${baseFolder}/${entry.name}`);
-  if (existingObjectPaths.length > 0) {
-    await supabase.storage.from(bucket).remove(existingObjectPaths);
-    await supabase.from("job_documents").delete().eq("job_id", jobId).in("file_path", existingObjectPaths);
-  }
+  const fileIdentity = buildFlexReportFileIdentity({
+    department,
+    displayName: elementDisplayName,
+    documentNumber: elementDocumentNumber,
+    elementId,
+    fileNamePrefix: reportDefinition.fileNamePrefix,
+    versionKey: `${Date.now()}-${crypto.randomUUID()}`,
+  });
+  const fileName = fileIdentity.fileName;
+  const objectPath = `${baseFolder}/${fileIdentity.objectName}`;
 
   const { error: uploadError } = await supabase.storage
     .from(bucket)
-    .upload(objectPath, pdfBytes, { contentType: "application/pdf", cacheControl: "0", upsert: true });
+    .upload(objectPath, pdfBytes, { contentType: "application/pdf", cacheControl: "0", upsert: false });
   if (uploadError) {
     throw new HttpError(500, `Failed to store the generated ${reportDefinition.displayName}`, {
       code: "storage_upload_failed",
@@ -290,17 +290,22 @@ serve(createHttpHandler(async (req: Request) => {
     });
   }
 
-  const { error: insertError } = await supabase.from("job_documents").insert({
-    job_id: jobId,
-    file_name: fileName,
-    file_path: objectPath,
-    file_type: "application/pdf",
-    file_size: pdfBytes.byteLength,
-    uploaded_by: caller.userId,
-    original_type: "pdf",
-    visible_to_tech: true,
-  });
-  if (insertError) {
+  const { data: insertedDocument, error: insertError } = await supabase
+    .from("job_documents")
+    .insert({
+      job_id: jobId,
+      file_name: fileName,
+      file_path: objectPath,
+      file_type: "application/pdf",
+      file_size: pdfBytes.byteLength,
+      uploaded_by: caller.userId,
+      original_type: "pdf",
+      visible_to_tech: true,
+    })
+    .select("id")
+    .single();
+  if (insertError || !insertedDocument) {
+    await supabase.storage.from(bucket).remove([objectPath]);
     throw new HttpError(500, `Failed to record the generated ${reportDefinition.displayName}`, {
       code: "job_document_insert_failed",
       exposeDetails: false,
@@ -311,16 +316,84 @@ serve(createHttpHandler(async (req: Request) => {
     .from(bucket)
     .createSignedUrl(objectPath, 3600, { cacheNonce: crypto.randomUUID() });
   if (signError || !signedUrlData) {
+    await supabase.from("job_documents").delete().eq("id", insertedDocument.id);
+    await supabase.storage.from(bucket).remove([objectPath]);
     throw new HttpError(500, `Failed to sign the generated ${reportDefinition.displayName} URL`, {
       code: "sign_url_failed",
       exposeDetails: false,
     });
   }
 
+  // The logical replacement slot includes the selected Flex element. Publish and
+  // sign the new object first, then retire only older versions of that element.
+  // Direct-child filtering preserves stage-scoped sibling folders. The legacy
+  // department-wide filename is retired once because it cannot be attributed to
+  // a specific Presupuesto.
+  const { data: existingObjects, error: listError } = await supabase.storage
+    .from(bucket)
+    .list(baseFolder);
+  if (listError) {
+    console.warn("[fetch-flex-material-report] Could not list predecessor objects", listError);
+  }
+
+  const predecessorObjectPaths = (existingObjects || [])
+    .filter((entry) =>
+      entry.id &&
+      entry.name !== fileIdentity.objectName &&
+      isFlexReportPredecessorObject(
+        entry.name,
+        fileIdentity.elementStoragePrefix,
+        fileIdentity.legacyFileName,
+      )
+    )
+    .map((entry) => `${baseFolder}/${entry.name}`);
+
+  const { data: scopedDocuments, error: scopedDocumentsError } = await supabase
+    .from("job_documents")
+    .select("id, file_path")
+    .eq("job_id", jobId)
+    .like("file_path", `${baseFolder}/%`);
+  if (scopedDocumentsError) {
+    console.warn("[fetch-flex-material-report] Could not list predecessor rows", scopedDocumentsError);
+  }
+
+  const directPathPrefix = `${baseFolder}/`;
+  const predecessorDocumentIds = (listError ? [] : (scopedDocuments || []))
+    .filter((document) => {
+      if (document.id === insertedDocument.id || !document.file_path.startsWith(directPathPrefix)) return false;
+      const objectName = document.file_path.slice(directPathPrefix.length);
+      return !objectName.includes("/") && isFlexReportPredecessorObject(
+        objectName,
+        fileIdentity.elementStoragePrefix,
+        fileIdentity.legacyFileName,
+      );
+    })
+    .map((document) => document.id);
+
+  let canRemovePredecessorObjects = !listError && !scopedDocumentsError;
+  if (predecessorDocumentIds.length > 0) {
+    const { error: deleteError } = await supabase
+      .from("job_documents")
+      .delete()
+      .in("id", predecessorDocumentIds);
+    if (deleteError) {
+      canRemovePredecessorObjects = false;
+      console.warn("[fetch-flex-material-report] Could not remove predecessor rows", deleteError);
+    }
+  }
+  if (canRemovePredecessorObjects && predecessorObjectPaths.length > 0) {
+    const { error: removeError } = await supabase.storage.from(bucket).remove(predecessorObjectPaths);
+    if (removeError) {
+      console.warn("[fetch-flex-material-report] Could not remove predecessor objects", removeError);
+    }
+  }
+
   return jsonResponse({
     url: signedUrlData.signedUrl,
     fileName,
     elementId,
+    elementDisplayName,
+    elementDocumentNumber,
     folderType,
     elementValidated,
     elementJobMismatch,

--- a/supabase/functions/fetch-flex-material-report/reportFiles.test.ts
+++ b/supabase/functions/fetch-flex-material-report/reportFiles.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFlexReportFileIdentity,
+  isFlexReportPredecessorObject,
+} from "./reportFiles.ts";
+
+describe("Flex material report file identity", () => {
+  it("builds readable names while keeping each Flex element in a distinct replacement slot", () => {
+    const first = buildFlexReportFileIdentity({
+      department: "sound",
+      displayName: "Extra Escenario Ágora",
+      documentNumber: "Q-100",
+      elementId: "11111111-aaaa-bbbb-cccc-111111111111",
+      fileNamePrefix: "Presupuesto",
+      versionKey: "version-1",
+    });
+    const second = buildFlexReportFileIdentity({
+      department: "sound",
+      displayName: "Extra Escenario Ágora",
+      documentNumber: "Q-100",
+      elementId: "22222222-aaaa-bbbb-cccc-222222222222",
+      fileNamePrefix: "Presupuesto",
+      versionKey: "version-1",
+    });
+
+    expect(first.fileName).toBe("Presupuesto - Sonido - Extra_Escenario_Agora - Q-100 - 11111111.pdf");
+    expect(second.fileName).not.toBe(first.fileName);
+    expect(first.elementStoragePrefix).toBe("11111111-aaaa-bbbb-cccc-111111111111--");
+    expect(first.objectName).toContain("--version-1--");
+  });
+
+  it("matches only predecessors for the selected element plus the one legacy shared slot", () => {
+    expect(isFlexReportPredecessorObject(
+      "quote-a--old--Presupuesto.pdf",
+      "quote-a--",
+      "Presupuesto - sound.pdf",
+    )).toBe(true);
+    expect(isFlexReportPredecessorObject(
+      "Presupuesto - sound.pdf",
+      "quote-a--",
+      "Presupuesto - sound.pdf",
+    )).toBe(true);
+    expect(isFlexReportPredecessorObject(
+      "quote-b--old--Presupuesto.pdf",
+      "quote-a--",
+      "Presupuesto - sound.pdf",
+    )).toBe(false);
+  });
+});

--- a/supabase/functions/fetch-flex-material-report/reportFiles.ts
+++ b/supabase/functions/fetch-flex-material-report/reportFiles.ts
@@ -1,0 +1,74 @@
+export interface FlexReportFileIdentityInput {
+  department: string;
+  displayName?: string | null;
+  documentNumber?: string | null;
+  elementId: string;
+  fileNamePrefix: string;
+  versionKey: string;
+}
+
+const DEPARTMENT_FILE_LABELS: Record<string, string> = {
+  lights: "Iluminacion",
+  production: "Produccion",
+  sound: "Sonido",
+  video: "Video",
+};
+
+export const sanitizeFlexReportFileNameSegment = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9._-]/g, "_")
+    .replace(/_{2,}/g, "_")
+    .slice(0, 80)
+    .replace(/^_|_$/g, "") || "segment";
+
+const isGenericDisplayName = (value: string) => {
+  const normalized = value.trim().toLowerCase();
+  return normalized === "presupuesto" || normalized === "unnamed";
+};
+
+export const buildFlexReportFileIdentity = ({
+  department,
+  displayName,
+  documentNumber,
+  elementId,
+  fileNamePrefix,
+  versionKey,
+}: FlexReportFileIdentityInput) => {
+  const descriptorParts = [DEPARTMENT_FILE_LABELS[department] || department];
+  if (displayName?.trim() && !isGenericDisplayName(displayName)) {
+    descriptorParts.push(displayName.trim());
+  }
+  if (
+    documentNumber?.trim() &&
+    !descriptorParts.some((part) => part.toLowerCase().includes(documentNumber.trim().toLowerCase()))
+  ) {
+    descriptorParts.push(documentNumber.trim());
+  }
+
+  // The short ID keeps otherwise-identical Flex names distinct for operators.
+  // The storage prefix below uses the full UUID as the authoritative identity.
+  descriptorParts.push(elementId.replace(/-/g, "").slice(0, 8) || elementId);
+
+  const safeDescriptor = descriptorParts
+    .map(sanitizeFlexReportFileNameSegment)
+    .filter(Boolean)
+    .join(" - ");
+  const fileName = `${fileNamePrefix} - ${safeDescriptor}.pdf`;
+  const elementStoragePrefix = `${sanitizeFlexReportFileNameSegment(elementId)}--`;
+  const objectName = `${elementStoragePrefix}${sanitizeFlexReportFileNameSegment(versionKey)}--${fileName}`;
+
+  return {
+    elementStoragePrefix,
+    fileName,
+    legacyFileName: `${fileNamePrefix} - ${sanitizeFlexReportFileNameSegment(department)}.pdf`,
+    objectName,
+  };
+};
+
+export const isFlexReportPredecessorObject = (
+  objectName: string,
+  elementStoragePrefix: string,
+  legacyFileName: string,
+) => objectName.startsWith(elementStoragePrefix) || objectName === legacyFileName;


### PR DESCRIPTION
## Summary

- Discover every eligible Flex Presupuesto in the existing element tree and let users choose which one Lista de Material or Presupuesto prints.
- Give generated Flex reports element-specific filenames/storage identities and clean up only prior versions of the selected element after the replacement is published successfully.
- Let Memoria Técnica choose among multiple detected source documents per section while preserving explicit selections across refreshes.
- Replace primitive documentation-tool job selects with a shared searchable picker that keeps ongoing jobs and excludes ended, cancelled, and completed jobs.
- Update DOMPurify from 3.4.11 to 3.4.12 after a newly published advisory blocked governance.
- Record an owned, expiring exception for a newly published no-fix sharp advisory confined to the dev-only @capacitor/assets chain.
- Document the new PDF synchronization and cleanup behavior.

## Root cause

The report actions relied on one tracked Presupuesto row and reused a department-wide filename, so multi-stage and extra Presupuestos could overwrite each other. Memoria auto-fill similarly collapsed each section to one newest document, and documentation tools exposed unfiltered primitive job lists.

During PR validation:

- advisory 1124022 identified DOMPurify 3.4.11, so the direct dependency was updated to 3.4.12;
- advisory 1124066 identified sharp@0.32.6 nested under the latest @capacitor/assets@3.0.5. The runtime sharp is already 0.35.2, npm reports no compatible fix for the nested dev-only path, and the exception is owned by platform-security with review due 2026-08-31.

## Impact

Production and department users can select the correct Presupuesto or Memoria source for multi-stage/extras workflows. Existing single-document jobs retain their direct behavior and tracked Flex rows remain as a compatibility fallback.

## Risk classification

Standard-risk. This changes UI, report selection, one authenticated Edge Function, one patch-level frontend dependency, and a time-bound dev-tooling audit exception, but does not change migrations, RLS, SQL/RPC behavior, timesheet calculations, rates, payouts, or payroll.

The Edge Function keeps its existing role checks. Override element IDs remain constrained to the same job/department unless the caller has the existing privileged role.

## Validation

- `npm run lint` — passed with existing repository warnings only.
- `npm run lint:functions` — passed with existing warnings only.
- `npm run typecheck` — passed after the final functional changes.
- `npm run test:critical` — 22 files / 106 tests passed.
- Changed-area tests — 60/60 passed after the dependency update.
- Review-fix tests — 4/4 passed for exact active-job cutoff and stage/filter document selection.
- `npm run test:run` — 1,611 tests passed; 8 load-related timeouts all passed when the affected files were rerun together (20/20).
- `npm run build` — passed after the dependency update.
- `npm run budget:bundle` — passed; all bundle budgets remain within limits.
- `npm run governance` — passed in full after the DOMPurify update and the owned, expiring dev-tooling exception.
- Targeted review-fix ESLint — passed with no findings.
- Staged dotenv/secret-pattern checks passed.
- No database migration is included or required.
- CodeRabbit’s two inline findings were fixed, acknowledged by the bot, and resolved; its test-coverage nit was also implemented.

## Rollback

Revert this PR and redeploy `main`. No data migration or backfill is involved. PDFs already generated with element-specific names can remain safely in storage; reverting restores the previous selection and cleanup behavior for future generations.