### PR TITLE
fix: handle larger memoria PDFs

### DIFF
--- a/src/components/lights/LightMemoriaTecnica.tsx
+++ b/src/components/lights/LightMemoriaTecnica.tsx
@@ -21,6 +21,7 @@ import { TechnicalStageSelector } from "@/features/technical-tools/stage/stageAl
 import { upsertMemoriaTecnicaDocument } from "@/utils/memoriaTecnicaDocuments";
 import { fetchFlexMaterialReport } from "@/utils/flexMaterialReport";
 import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
+import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 
 const AUTO_FILL_CATEGORIES: Record<string, MemoriaAutoFillCategorySpec> = {
   material: "calculators/lista-material/lights",
@@ -346,7 +347,10 @@ export const LightMemoriaTecnica = () => {
 
       if (response.error) {
         console.error('Error from edge function:', response.error);
-        throw new Error(response.error.message || 'Error al generar la memoria técnica');
+        throw new Error(await extractFunctionErrorMessage(
+          response.error,
+          "Error al generar la memoria técnica",
+        ));
       }
 
       setProgress(80);
@@ -379,7 +383,9 @@ export const LightMemoriaTecnica = () => {
       console.error("Error generating memoria tecnica:", error);
       toast({
         title: "Error",
-        description: error.message || "Error al generar la memoria técnica",
+        description: error instanceof Error && error.message
+          ? error.message
+          : "Error al generar la memoria técnica",
         variant: "destructive",
       });
     } finally {

--- a/src/components/sound/MemoriaTecnica.tsx
+++ b/src/components/sound/MemoriaTecnica.tsx
@@ -22,6 +22,7 @@ import { TechnicalStageSelector } from "@/features/technical-tools/stage/stageAl
 import { upsertMemoriaTecnicaDocument } from "@/utils/memoriaTecnicaDocuments";
 import { fetchFlexMaterialReport } from "@/utils/flexMaterialReport";
 import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
+import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 
 const AUTO_FILL_CATEGORIES: Record<string, MemoriaAutoFillCategorySpec> = {
   material: "calculators/lista-material/sound",
@@ -357,7 +358,10 @@ export const MemoriaTecnica = () => {
 
       if (response.error) {
         console.error('Error from edge function:', response.error);
-        throw new Error(response.error.message || 'Error al generar la memoria técnica');
+        throw new Error(await extractFunctionErrorMessage(
+          response.error,
+          "Error al generar la memoria técnica",
+        ));
       }
 
       setProgress(80);
@@ -390,7 +394,9 @@ export const MemoriaTecnica = () => {
       console.error("Error generating memoria tecnica:", error);
       toast({
         title: "Error",
-        description: error.message || "Error al generar la memoria técnica",
+        description: error instanceof Error && error.message
+          ? error.message
+          : "Error al generar la memoria técnica",
         variant: "destructive",
       });
     } finally {

--- a/src/components/sound/__tests__/MemoriaTecnica.test.tsx
+++ b/src/components/sound/__tests__/MemoriaTecnica.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/test/renderWithProviders";
+
+const {
+  createSignedUrlMock,
+  invokeMock,
+  toastMock,
+  upsertMemoriaTecnicaDocumentMock,
+  useMemoriaAutoFillMock,
+  useMemoriaJobAndStageMock,
+} = vi.hoisted(() => ({
+  createSignedUrlMock: vi.fn(),
+  invokeMock: vi.fn(),
+  toastMock: vi.fn(),
+  upsertMemoriaTecnicaDocumentMock: vi.fn(),
+  useMemoriaAutoFillMock: vi.fn(),
+  useMemoriaJobAndStageMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/services/dataLayerClient", () => ({
+  dataLayerClient: {
+    functions: { invoke: invokeMock },
+    storage: {
+      from: () => ({ createSignedUrl: createSignedUrlMock }),
+    },
+  },
+}));
+
+vi.mock("@/hooks/useLogoOptions", () => ({
+  useLogoOptions: () => ({
+    isLoading: false,
+    logoOptions: [] as Array<{ label: string; url: string; value: string }>,
+  }),
+}));
+
+vi.mock("@/features/technical-tools/memoria/useMemoriaJobAndStage", () => ({
+  useMemoriaJobAndStage: () => useMemoriaJobAndStageMock(),
+}));
+
+vi.mock("@/features/technical-tools/memoria/useMemoriaAutoFill", () => ({
+  useMemoriaAutoFill: () => useMemoriaAutoFillMock(),
+}));
+
+vi.mock("@/features/technical-tools/memoria/MemoriaDetectedDocumentSelect", () => ({
+  MemoriaDetectedDocumentSelect: (): null => null,
+}));
+
+vi.mock("@/features/technical-tools/stage/stageAllocation", () => ({
+  TechnicalStageSelector: (): null => null,
+}));
+
+vi.mock("@/features/technical-tools/jobs/DocumentationJobPicker", () => ({
+  DocumentationJobPicker: (): null => null,
+}));
+
+vi.mock("@/utils/memoriaTecnicaDocuments", () => ({
+  upsertMemoriaTecnicaDocument: (...args: unknown[]) =>
+    upsertMemoriaTecnicaDocumentMock(...args),
+}));
+
+vi.mock("@/utils/flexMaterialReport", () => ({
+  fetchFlexMaterialReport: vi.fn(),
+}));
+
+vi.mock("@/utils/storageUpload", () => ({
+  isStorageNotFoundError: () => false,
+  uploadStorageObject: vi.fn(),
+}));
+
+import { MemoriaTecnica } from "../MemoriaTecnica";
+
+describe("MemoriaTecnica", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    useMemoriaJobAndStageMock.mockReturnValue({
+      hasMultipleStages: false,
+      isLoadingJobs: false,
+      isLoadingStages: false,
+      jobIdFromUrl: "job-1",
+      jobs: [],
+      selectedJob: { id: "job-1", title: "KBS Music Bank" },
+      selectedJobId: "job-1",
+      selectedStage: null,
+      selectedStageNumber: null,
+      setSelectedJobId: vi.fn(),
+      setSelectedStageNumber: vi.fn(),
+      stages: [],
+    });
+    useMemoriaAutoFillMock.mockReturnValue({
+      candidates: {
+        material: [{
+          fileName: "material.pdf",
+          filePath: "calculators/lista-material/sound/job-1/material.pdf",
+          uploadedAt: "2026-07-24T08:45:34.000Z",
+        }],
+      },
+      detected: {
+        material: {
+          fileName: "material.pdf",
+          filePath: "calculators/lista-material/sound/job-1/material.pdf",
+          uploadedAt: "2026-07-24T08:45:34.000Z",
+        },
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+      selectDocument: vi.fn(),
+    });
+    createSignedUrlMock.mockResolvedValue({
+      data: { signedUrl: "https://project.supabase.co/storage/v1/object/sign/job-documents/material.pdf?token=test" },
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("shows the Spanish Edge Function error body in the failure toast", async () => {
+    const user = userEvent.setup();
+    invokeMock.mockResolvedValue({
+      data: null,
+      error: {
+        context: new Response(JSON.stringify({
+          code: "source_too_large",
+          error: "El documento «Informe SoundVision» supera el límite de 20 MB",
+        })),
+        message: "Edge Function returned a non-2xx status code",
+      },
+    });
+
+    renderWithProviders(<MemoriaTecnica />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Nombre del Proyecto")).toHaveValue("KBS Music Bank");
+    });
+    await user.click(screen.getByRole("button", { name: "Generar Memoria Técnica" }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "Error",
+        description: "El documento «Informe SoundVision» supera el límite de 20 MB",
+        variant: "destructive",
+      });
+    });
+    expect(upsertMemoriaTecnicaDocumentMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/video/VideoMemoriaTecnica.tsx
+++ b/src/components/video/VideoMemoriaTecnica.tsx
@@ -21,6 +21,7 @@ import { TechnicalStageSelector } from "@/features/technical-tools/stage/stageAl
 import { upsertMemoriaTecnicaDocument } from "@/utils/memoriaTecnicaDocuments";
 import { fetchFlexMaterialReport } from "@/utils/flexMaterialReport";
 import { DocumentationJobPicker } from "@/features/technical-tools/jobs/DocumentationJobPicker";
+import { extractFunctionErrorMessage } from "@/utils/supabaseFunctionError";
 
 const AUTO_FILL_CATEGORIES: Record<string, MemoriaAutoFillCategorySpec> = {
   material: "calculators/lista-material/video",
@@ -339,7 +340,10 @@ export const VideoMemoriaTecnica = () => {
 
       if (response.error) {
         console.error('Error from edge function:', response.error);
-        throw new Error(response.error.message || 'Error al generar la memoria técnica');
+        throw new Error(await extractFunctionErrorMessage(
+          response.error,
+          "Error al generar la memoria técnica",
+        ));
       }
 
       setProgress(80);
@@ -371,7 +375,9 @@ export const VideoMemoriaTecnica = () => {
       console.error("Error generating memoria tecnica:", error);
       toast({
         title: "Error",
-        description: error.message || "Error al generar la memoria técnica",
+        description: error instanceof Error && error.message
+          ? error.message
+          : "Error al generar la memoria técnica",
         variant: "destructive",
       });
     } finally {

--- a/supabase/functions/_shared/memoriaInput.ts
+++ b/supabase/functions/_shared/memoriaInput.ts
@@ -229,6 +229,14 @@ const getLimitInMiB = (value: unknown, fallback: number) => {
   return Math.round(bytes / (1024 * 1024));
 };
 
+const sanitizeMemoriaDiagnostic = (value: unknown) => {
+  if (typeof value !== "string") return undefined;
+
+  return value
+    .replace(/([?&](?:token|access_token|apikey)=)[^&\s]+/gi, "$1[redacted]")
+    .slice(0, 2_000);
+};
+
 /**
  * Converts a source-processing failure into a document-labelled client error and
  * emits a token-free structured record for Supabase Function logs.
@@ -239,6 +247,12 @@ export function reportMemoriaDocumentFailure(
   documentLabel: string,
   error: unknown,
 ): HttpError {
+  const originalMessage = error instanceof Error
+    ? sanitizeMemoriaDiagnostic(error.message)
+    : undefined;
+  const originalStack = error instanceof Error
+    ? sanitizeMemoriaDiagnostic(error.stack)
+    : undefined;
   const original = error instanceof HttpError
     ? error
     : new HttpError(422, getMemoriaPdfValidationMessage(documentLabel, "unreadable"), {
@@ -276,6 +290,8 @@ export function reportMemoriaDocumentFailure(
     maxBytes: details.maxBytes,
     message: normalized.message,
     measurement: details.measurement,
+    originalMessage,
+    originalStack,
     status: normalized.status,
     usedBytes: details.usedBytes,
   });

--- a/supabase/functions/_shared/memoriaInput.ts
+++ b/supabase/functions/_shared/memoriaInput.ts
@@ -3,9 +3,9 @@ import { HttpError } from "./http.ts";
 const MAX_PROJECT_NAME_LENGTH = 160;
 const MAX_SOURCE_URL_LENGTH = 4 * 1024;
 const MAX_DOCUMENTS = 5;
-const MAX_SINGLE_PDF_BYTES = 15 * 1024 * 1024;
+export const MAX_MEMORIA_PDF_BYTES = 20 * 1024 * 1024;
 const MAX_LOGO_BYTES = 3 * 1024 * 1024;
-const MAX_TOTAL_SOURCE_BYTES = 50 * 1024 * 1024;
+export const MAX_MEMORIA_TOTAL_SOURCE_BYTES = 50 * 1024 * 1024;
 const SOURCE_TIMEOUT_MS = 12_000;
 
 type UnknownRecord = Record<string, unknown>;
@@ -19,12 +19,17 @@ export interface MemoriaRequestInput {
 export class SourceByteBudget {
   private usedBytes = 0;
 
-  constructor(private readonly limitBytes = MAX_TOTAL_SOURCE_BYTES) {}
+  constructor(private readonly limitBytes = MAX_MEMORIA_TOTAL_SOURCE_BYTES) {}
 
   reserve(bytes: number) {
     if (bytes > this.limitBytes - this.usedBytes) {
       throw new HttpError(413, "Los documentos de origen superan el tamaño total permitido", {
         code: "source_total_too_large",
+        details: {
+          attemptedBytes: bytes,
+          maxBytes: this.limitBytes,
+          usedBytes: this.usedBytes,
+        },
       });
     }
     this.usedBytes += bytes;
@@ -124,7 +129,14 @@ export function parseMemoriaRequestInput(
 const readBoundedResponse = async (response: Response, maxBytes: number, budget: SourceByteBudget) => {
   const declaredLength = Number(response.headers.get("content-length"));
   if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-    throw new HttpError(413, "El archivo de origen es demasiado grande", { code: "source_too_large" });
+    throw new HttpError(413, "El archivo de origen es demasiado grande", {
+      code: "source_too_large",
+      details: {
+        actualBytes: declaredLength,
+        maxBytes,
+        measurement: "content-length",
+      },
+    });
   }
   if (!response.body) {
     throw new HttpError(422, "El archivo de origen no contiene datos", { code: "empty_source" });
@@ -139,7 +151,14 @@ const readBoundedResponse = async (response: Response, maxBytes: number, budget:
     total += value.byteLength;
     if (total > maxBytes) {
       await reader.cancel();
-      throw new HttpError(413, "El archivo de origen es demasiado grande", { code: "source_too_large" });
+      throw new HttpError(413, "El archivo de origen es demasiado grande", {
+        code: "source_too_large",
+        details: {
+          actualBytes: total,
+          maxBytes,
+          measurement: "stream",
+        },
+      });
     }
     chunks.push(value);
   }
@@ -171,7 +190,7 @@ export async function fetchMemoriaSource(
     if (!response.ok) {
       throw new HttpError(422, "No se pudo cargar el archivo de origen", { code: "source_fetch_failed" });
     }
-    return await readBoundedResponse(response, options.maxBytes ?? MAX_SINGLE_PDF_BYTES, budget);
+    return await readBoundedResponse(response, options.maxBytes ?? MAX_MEMORIA_PDF_BYTES, budget);
   } catch (error) {
     if (error instanceof HttpError) throw error;
     if (error instanceof DOMException && error.name === "AbortError") {
@@ -201,6 +220,68 @@ export const getMemoriaPdfValidationMessage = (
       return `No se puede leer el documento «${documentLabel}» como PDF`;
   }
 };
+
+const getErrorDetails = (error: HttpError): UnknownRecord =>
+  isRecord(error.details) ? error.details : {};
+
+const getLimitInMiB = (value: unknown, fallback: number) => {
+  const bytes = typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  return Math.round(bytes / (1024 * 1024));
+};
+
+/**
+ * Converts a source-processing failure into a document-labelled client error and
+ * emits a token-free structured record for Supabase Function logs.
+ */
+export function reportMemoriaDocumentFailure(
+  functionName: string,
+  documentKey: string,
+  documentLabel: string,
+  error: unknown,
+): HttpError {
+  const original = error instanceof HttpError
+    ? error
+    : new HttpError(422, getMemoriaPdfValidationMessage(documentLabel, "unreadable"), {
+      code: "invalid_pdf_source",
+    });
+  const details = getErrorDetails(original);
+
+  let normalized = original;
+
+  if (original.code === "source_too_large") {
+    normalized = new HttpError(
+      413,
+      `El documento «${documentLabel}» supera el límite de ${
+        getLimitInMiB(details.maxBytes, MAX_MEMORIA_PDF_BYTES)
+      } MB`,
+      { code: original.code },
+    );
+  } else if (original.code === "source_total_too_large") {
+    normalized = new HttpError(
+      413,
+      `Los documentos de origen superan el límite total de ${
+        getLimitInMiB(details.maxBytes, MAX_MEMORIA_TOTAL_SOURCE_BYTES)
+      } MB al procesar «${documentLabel}»`,
+      { code: original.code },
+    );
+  }
+
+  console.error("memoria_document_rejected", {
+    actualBytes: details.actualBytes,
+    attemptedBytes: details.attemptedBytes,
+    code: normalized.code ?? "unknown",
+    documentKey,
+    documentLabel,
+    functionName,
+    maxBytes: details.maxBytes,
+    message: normalized.message,
+    measurement: details.measurement,
+    status: normalized.status,
+    usedBytes: details.usedBytes,
+  });
+
+  return normalized;
+}
 
 export const getSupportedImageFormat = (bytes: Uint8Array): "png" | "jpg" | null => {
   const isPng =

--- a/supabase/functions/_shared/memoriaSecurity.test.ts
+++ b/supabase/functions/_shared/memoriaSecurity.test.ts
@@ -5,14 +5,19 @@ import {
   fetchMemoriaSource,
   getSupportedImageFormat,
   isPdfBytes,
+  MAX_MEMORIA_PDF_BYTES,
   parseMemoriaRequestInput,
+  reportMemoriaDocumentFailure,
   SourceByteBudget,
 } from "./memoriaInput.ts";
 
 const projectUrl = "https://project.supabase.co";
 const signedSource = `${projectUrl}/storage/v1/object/sign/memoria-tecnica/report.pdf?token=opaque-token`;
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("memoria PDF security boundary", () => {
   it("only accepts this project's supported Storage object URLs", () => {
@@ -65,5 +70,60 @@ describe("memoria PDF security boundary", () => {
       status: 413,
       code: "source_total_too_large",
     });
+  });
+
+  it("accepts the diagnosed 16.53 MiB PDF below the new 20 MiB limit", async () => {
+    const diagnosedSoundVisionBytes = 17_336_566;
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      new Response(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]), {
+        headers: { "content-length": String(diagnosedSoundVisionBytes) },
+      })
+    ));
+
+    await expect(
+      fetchMemoriaSource(signedSource, new SourceByteBudget()),
+    ).resolves.toHaveLength(5);
+    expect(MAX_MEMORIA_PDF_BYTES).toBe(20 * 1024 * 1024);
+  });
+
+  it("rejects and records a PDF above 20 MiB without logging its signed URL", async () => {
+    const oversizedBytes = MAX_MEMORIA_PDF_BYTES + 1;
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      new Response(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]), {
+        headers: { "content-length": String(oversizedBytes) },
+      })
+    ));
+
+    const sourceError = await fetchMemoriaSource(
+      signedSource,
+      new SourceByteBudget(),
+    ).catch((error) => error);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const reported = reportMemoriaDocumentFailure(
+      "generate-memoria-tecnica",
+      "soundvision",
+      "Informe SoundVision",
+      sourceError,
+    );
+
+    expect(reported).toMatchObject({
+      status: 413,
+      code: "source_too_large",
+      message: "El documento «Informe SoundVision» supera el límite de 20 MB",
+    });
+    expect(consoleError).toHaveBeenCalledWith("memoria_document_rejected", {
+      actualBytes: oversizedBytes,
+      attemptedBytes: undefined,
+      code: "source_too_large",
+      documentKey: "soundvision",
+      documentLabel: "Informe SoundVision",
+      functionName: "generate-memoria-tecnica",
+      maxBytes: MAX_MEMORIA_PDF_BYTES,
+      message: "El documento «Informe SoundVision» supera el límite de 20 MB",
+      measurement: "content-length",
+      status: 413,
+      usedBytes: undefined,
+    });
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("opaque-token");
   });
 });

--- a/supabase/functions/_shared/memoriaSecurity.test.ts
+++ b/supabase/functions/_shared/memoriaSecurity.test.ts
@@ -121,9 +121,70 @@ describe("memoria PDF security boundary", () => {
       maxBytes: MAX_MEMORIA_PDF_BYTES,
       message: "El documento «Informe SoundVision» supera el límite de 20 MB",
       measurement: "content-length",
+      originalMessage: "El archivo de origen es demasiado grande",
+      originalStack: expect.any(String),
       status: 413,
       usedBytes: undefined,
     });
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("opaque-token");
+  });
+
+  it("labels and records the combined source limit", () => {
+    const budget = new SourceByteBudget();
+    budget.reserve((50 * 1024 * 1024) - 1);
+    const sourceError = (() => {
+      try {
+        budget.reserve(2);
+      } catch (error) {
+        return error;
+      }
+    })();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const reported = reportMemoriaDocumentFailure(
+      "generate-video-memoria-tecnica",
+      "pixel",
+      "Pixel Map",
+      sourceError,
+    );
+
+    expect(reported).toMatchObject({
+      status: 413,
+      code: "source_total_too_large",
+      message: "Los documentos de origen superan el límite total de 50 MB al procesar «Pixel Map»",
+    });
+    expect(consoleError).toHaveBeenCalledWith("memoria_document_rejected", expect.objectContaining({
+      attemptedBytes: 2,
+      documentKey: "pixel",
+      maxBytes: 50 * 1024 * 1024,
+      status: 413,
+      usedBytes: (50 * 1024 * 1024) - 1,
+    }));
+  });
+
+  it("preserves redacted parser diagnostics while returning a safe unreadable message", () => {
+    const parserError = new Error(`Parser failed for ${signedSource}`);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const reported = reportMemoriaDocumentFailure(
+      "generate-lights-memoria-tecnica",
+      "rigging",
+      "Plano de Rigging",
+      parserError,
+    );
+
+    expect(reported).toMatchObject({
+      status: 422,
+      code: "invalid_pdf_source",
+      message: "No se puede leer el documento «Plano de Rigging» como PDF",
+    });
+    expect(consoleError).toHaveBeenCalledWith("memoria_document_rejected", expect.objectContaining({
+      code: "invalid_pdf_source",
+      documentKey: "rigging",
+      originalMessage: expect.stringContaining("token=[redacted]"),
+      originalStack: expect.stringContaining("token=[redacted]"),
+      status: 422,
+    }));
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain("opaque-token");
   });
 });

--- a/supabase/functions/_shared/memoriaSecurity.ts
+++ b/supabase/functions/_shared/memoriaSecurity.ts
@@ -11,7 +11,10 @@ export {
   getMemoriaPdfValidationMessage,
   getSupportedImageFormat,
   isPdfBytes,
+  MAX_MEMORIA_PDF_BYTES,
+  MAX_MEMORIA_TOTAL_SOURCE_BYTES,
   parseMemoriaRequestInput,
+  reportMemoriaDocumentFailure,
   SourceByteBudget,
 } from "./memoriaInput.ts";
 

--- a/supabase/functions/generate-lights-memoria-tecnica/index.ts
+++ b/supabase/functions/generate-lights-memoria-tecnica/index.ts
@@ -6,6 +6,7 @@ import {
   fetchOptionalMemoriaLogo,
   getMemoriaPdfValidationMessage,
   isPdfBytes,
+  reportMemoriaDocumentFailure,
   requireMemoriaContext,
   SourceByteBudget,
   uploadGeneratedMemoriaPdf,
@@ -130,21 +131,22 @@ serve(createHttpHandler(async (req) => {
       try {
         const sourceBytes = await fetchMemoriaSource(documentUrls.memoria_completa, sourceBudget);
         if (!isPdfBytes(sourceBytes)) {
-          throw new HttpError(422, getMemoriaPdfValidationMessage("memoria técnica completa", "invalid"), { code: "invalid_pdf_source" });
+          throw new HttpError(422, getMemoriaPdfValidationMessage("Memoria técnica completa", "invalid"), { code: "invalid_pdf_source" });
         }
         const pdf = await PDFDocument.load(sourceBytes);
         if (pdf.getPageCount() > 150) {
-          throw new HttpError(422, getMemoriaPdfValidationMessage("memoria técnica completa", "page_limit"), { code: "pdf_page_limit" });
+          throw new HttpError(422, getMemoriaPdfValidationMessage("Memoria técnica completa", "page_limit"), { code: "pdf_page_limit" });
         }
         const pages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
         pages.forEach(page => mergedPdf.addPage(page));
         console.log(`Added ${pages.length} pages from complete memoria`);
       } catch (error) {
-        if (error instanceof HttpError) throw error;
-        console.warn("Lights memoria rejected complete PDF");
-        throw new HttpError(422, getMemoriaPdfValidationMessage("memoria técnica completa", "unreadable"), {
-          code: "invalid_pdf_source",
-        });
+        throw reportMemoriaDocumentFailure(
+          "generate-lights-memoria-tecnica",
+          "memoria_completa",
+          "Memoria técnica completa",
+          error,
+        );
       }
     } else {
       // For regular memoria, create table of contents and append individual documents
@@ -194,21 +196,22 @@ serve(createHttpHandler(async (req) => {
         try {
           const sourceBytes = await fetchMemoriaSource(url, sourceBudget);
           if (!isPdfBytes(sourceBytes)) {
-            throw new HttpError(422, getMemoriaPdfValidationMessage(doc.id, "invalid"), { code: "invalid_pdf_source" });
+            throw new HttpError(422, getMemoriaPdfValidationMessage(doc.title, "invalid"), { code: "invalid_pdf_source" });
           }
           const pdf = await PDFDocument.load(sourceBytes);
           if (pdf.getPageCount() > 150) {
-            throw new HttpError(422, getMemoriaPdfValidationMessage(doc.id, "page_limit"), { code: "pdf_page_limit" });
+            throw new HttpError(422, getMemoriaPdfValidationMessage(doc.title, "page_limit"), { code: "pdf_page_limit" });
           }
           const pages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
           pages.forEach(page => mergedPdf.addPage(page));
           console.log(`Added ${pages.length} pages from ${doc.id}`);
         } catch (error) {
-          if (error instanceof HttpError) throw error;
-          console.warn("Lights memoria rejected PDF", { key: doc.id });
-          throw new HttpError(422, getMemoriaPdfValidationMessage(doc.id, "unreadable"), {
-            code: "invalid_pdf_source",
-          });
+          throw reportMemoriaDocumentFailure(
+            "generate-lights-memoria-tecnica",
+            doc.id,
+            doc.title,
+            error,
+          );
         }
       }
     }

--- a/supabase/functions/generate-memoria-tecnica/index.ts
+++ b/supabase/functions/generate-memoria-tecnica/index.ts
@@ -6,6 +6,7 @@ import {
   fetchOptionalMemoriaLogo,
   getMemoriaPdfValidationMessage,
   isPdfBytes,
+  reportMemoriaDocumentFailure,
   requireMemoriaContext,
   SourceByteBudget,
   uploadGeneratedMemoriaPdf,
@@ -211,7 +212,7 @@ serve(createHttpHandler(async (req) => {
       weight: "Informe de Pesos",
       power: "Informe de Consumos",
       rigging: "Plano de Rigging"
-    };
+    } as Record<string, string>;
 
     // Add index items
     let yOffset = height - 100;
@@ -233,24 +234,26 @@ serve(createHttpHandler(async (req) => {
     // Append every requested document. A malformed or unavailable document is
     // an explicit request failure rather than a silently incomplete PDF.
     for (const [key, url] of Object.entries(documentUrls)) {
+      const documentLabel = titles[key] ?? key;
       try {
         const sourceBytes = await fetchMemoriaSource(url, sourceBudget);
         if (!isPdfBytes(sourceBytes)) {
-          throw new HttpError(422, getMemoriaPdfValidationMessage(key, "invalid"), { code: "invalid_pdf_source" });
+          throw new HttpError(422, getMemoriaPdfValidationMessage(documentLabel, "invalid"), { code: "invalid_pdf_source" });
         }
         const pdfBytes = sourceBytes;
         const pdf = await PDFDocument.load(pdfBytes);
         if (pdf.getPageCount() > 150) {
-          throw new HttpError(422, getMemoriaPdfValidationMessage(key, "page_limit"), { code: "pdf_page_limit" });
+          throw new HttpError(422, getMemoriaPdfValidationMessage(documentLabel, "page_limit"), { code: "pdf_page_limit" });
         }
         const pages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
         pages.forEach((page) => mergedPdf.addPage(page));
       } catch (error) {
-        if (error instanceof HttpError) throw error;
-        console.warn("Sound memoria rejected PDF", { key });
-        throw new HttpError(422, getMemoriaPdfValidationMessage(key, "unreadable"), {
-          code: "invalid_pdf_source",
-        });
+        throw reportMemoriaDocumentFailure(
+          "generate-memoria-tecnica",
+          key,
+          documentLabel,
+          error,
+        );
       }
     }
 

--- a/supabase/functions/generate-video-memoria-tecnica/index.ts
+++ b/supabase/functions/generate-video-memoria-tecnica/index.ts
@@ -6,6 +6,7 @@ import {
   fetchOptionalMemoriaLogo,
   getMemoriaPdfValidationMessage,
   isPdfBytes,
+  reportMemoriaDocumentFailure,
   requireMemoriaContext,
   SourceByteBudget,
   uploadGeneratedMemoriaPdf,
@@ -239,24 +240,26 @@ serve(createHttpHandler(async (req) => {
     for (const key of preferredOrder) {
       const url = documentUrls[key];
       if (!url) continue;
+      const documentLabel = titles[key] ?? key;
 
       try {
         const sourceBytes = await fetchMemoriaSource(url, sourceBudget);
         if (!isPdfBytes(sourceBytes)) {
-          throw new HttpError(422, getMemoriaPdfValidationMessage(key, "invalid"), { code: "invalid_pdf_source" });
+          throw new HttpError(422, getMemoriaPdfValidationMessage(documentLabel, "invalid"), { code: "invalid_pdf_source" });
         }
         const pdf = await PDFDocument.load(sourceBytes);
         if (pdf.getPageCount() > 150) {
-          throw new HttpError(422, getMemoriaPdfValidationMessage(key, "page_limit"), { code: "pdf_page_limit" });
+          throw new HttpError(422, getMemoriaPdfValidationMessage(documentLabel, "page_limit"), { code: "pdf_page_limit" });
         }
         const pages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
         pages.forEach((page) => mergedPdf.addPage(page));
       } catch (error) {
-        if (error instanceof HttpError) throw error;
-        console.warn("Video memoria rejected PDF", { key });
-        throw new HttpError(422, getMemoriaPdfValidationMessage(key, "unreadable"), {
-          code: "invalid_pdf_source",
-        });
+        throw reportMemoriaDocumentFailure(
+          "generate-video-memoria-tecnica",
+          key,
+          documentLabel,
+          error,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

- [x] I described what changed and why.
- Affected route/feature: Sound, Lights, and Video Memoria Técnica generation.
- Raises the guarded per-PDF source ceiling from 15 MiB to 20 MiB while retaining the 50 MiB combined cap.
- Returns document-labelled Spanish errors, emits structured token-free diagnostics, and surfaces the Edge Function response in the failure toast.
- Adds regression coverage for the diagnosed 17,336,566-byte SoundVision PDF, both size boundaries, safe parser diagnostics, and the UI toast.

### Root cause

The failed SoundVision source PDF was 17,336,566 bytes (16.53 MiB), above the previous 15 MiB per-file guard. The browser then discarded the structured 413 response body and displayed the Supabase client’s generic non-2xx message.

## Risk Assessment

- [x] I assessed functional, data, and deployment risk.
- Risk level: medium
- Main risks: larger PDFs use up to 5 MiB more Edge Function memory per document; altered error propagation could expose unintended details. The 50 MiB aggregate cap remains in place, client errors are normalized, diagnostics redact signed-query credentials and are length-bounded, and regression tests cover the guarded paths.
- [x] This does not touch database or money paths, so the repository’s high-risk classification does not apply. CodeRabbit feedback was nevertheless audited and addressed or answered.

## Impact Checklist

- [x] Migration impact assessed: no database migration.
- [x] Realtime/subscription impact assessed: none.
- [x] RLS/security impact assessed: no RLS change; signed source URLs remain validated and logging tests assert tokens are not emitted.
- [x] Performance impact assessed: per-document memory ceiling increases to 20 MiB; the 50 MiB request-wide source budget and 150-page document cap remain unchanged.

## Test Evidence

- [x] I ran relevant tests and confirmed expected results.
- Commands/results:
  - `npm run lint` — pass (existing warning baseline only)
  - `npm run lint:functions` — pass (existing warning baseline only)
  - `npm run typecheck` — pass
  - `npm run governance` — pass
  - `npm run test:critical` — pass
  - `npm run test:run` — 313 files, 1,699 tests passed
  - focused regression suite — 3 files, 10 tests passed
  - `npm run build` — pass
  - `npm run budget:bundle` — pass
  - `git diff --check` — pass
  - `./scripts/check-staged-secrets.sh` — pass
  - GitHub CI — all required tests, database safety jobs, smoke suites, CodeQL, dependency review, and SBOM checks passed on `ed51b40b`
  - Cloudflare Pages preview — deployed successfully and returned HTTP 200

## Rollback Plan

- [x] I documented how to safely revert this change.
- [x] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert the merge/squash commit for PR #880, then redeploy `generate-memoria-tecnica`, `generate-lights-memoria-tecnica`, and `generate-video-memoria-tecnica` so the shared 15 MiB guard and previous client behavior are restored together. Verify an authenticated generation request and its Supabase logs after deployment.

## Migration Impact

- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no database migration.
- Edge deployment: after human merge, deploy the three changed Memoria Técnica Edge Functions listed in the rollback section. Supabase Preview is not configured for this repository, so no Edge Function preview deployment was available from the PR.