### PR TITLE
Rediseñar informes PDF de Potencia y Pesos

### DIFF
--- a/src/utils/__tests__/pdfExport.test.ts
+++ b/src/utils/__tests__/pdfExport.test.ts
@@ -35,13 +35,21 @@ const makePdf = () => {
     addPage: vi.fn(() => {
       pdf.internal.pages.push({});
     }),
+    circle: vi.fn(),
+    getNumberOfPages: vi.fn(() => pdf.internal.pages.length - 1),
+    getTextWidth: vi.fn((text: string) => text.length * 1.8),
+    line: vi.fn(),
     output: vi.fn(() => new Blob(['pdf'], { type: 'application/pdf' })),
     rect: vi.fn(),
+    roundedRect: vi.fn(),
+    setDrawColor: vi.fn(),
     setFillColor: vi.fn(),
     setFont: vi.fn(),
     setFontSize: vi.fn(),
+    setLineWidth: vi.fn(),
     setPage: vi.fn(),
     setTextColor: vi.fn(),
+    splitTextToSize: vi.fn((text: string) => [text]),
     text: vi.fn(),
     lastAutoTable: {
       finalY: 80,
@@ -104,8 +112,8 @@ describe('exportToPDF', () => {
     expect(pdfMocks.autoTable).toHaveBeenCalledWith(
       pdf,
       expect.objectContaining({
-        head: [['Truss', 'Motores', 'Peso Total (kg)']],
-        body: [['Main PA', '2', '250.00']],
+        head: [['Punto / conjunto', 'Motores', 'Peso total']],
+        body: [['Main PA', '2', '250,0 kg']],
       })
     );
   });
@@ -141,11 +149,10 @@ describe('exportToPDF', () => {
       true
     );
 
-    expect(pdf.text).toHaveBeenCalledWith(
-      expect.stringContaining('formato schuko hembra'),
-      14,
-      expect.any(Number)
-    );
+    const renderedText = pdf.text.mock.calls
+      .flatMap(([text]) => Array.isArray(text) ? text : [text])
+      .join('\n');
+    expect(renderedText).toContain('formato Schuko hembra');
   });
 
   it('uses each table snapshot and withholds invalid single-phase aggregate totals', async () => {
@@ -194,46 +201,25 @@ describe('exportToPDF', () => {
       '2026-07-10',
     );
 
-    expect(pdf.text).toHaveBeenCalledWith(
-      'Potencia: 100.00 W; ajustada (10%): 110.00 W',
-      14,
-      expect.any(Number),
-    );
-    expect(pdf.text).toHaveBeenCalledWith(
-      'Potencia: 100.00 W; ajustada (20%): 120.00 W',
-      14,
-      expect.any(Number),
-    );
-    expect(pdf.text).toHaveBeenCalledWith(
-      expect.stringContaining('no agregables'),
-      14,
-      expect.any(Number),
-    );
-    expect(pdf.text).toHaveBeenCalledWith(
-      expect.stringContaining('1φ'),
-      14,
-      expect.any(Number),
-    );
-    expect(pdf.text).toHaveBeenCalledWith(
-      expect.stringContaining('ΣP/ΣQ'),
-      14,
-      expect.any(Number),
-    );
-    expect(pdf.text).toHaveBeenCalledWith(
-      'Aparente: 0.11 kVA; corriente de línea: 0.48 A',
-      14,
-      expect.any(Number),
-    );
-    expect(pdf.text).toHaveBeenCalledWith(
-      'PDU: Schuko 16A; límite 80% 12.8 A; OK',
-      14,
-      expect.any(Number),
-    );
+    const renderedText = pdf.text.mock.calls
+      .flatMap(([text]) => Array.isArray(text) ? text : [text])
+      .join('\n');
+    expect(renderedText).toContain('Potencia de cálculo (10 %): 110 W');
+    expect(renderedText).toContain('Potencia de cálculo (20 %): 120 W');
+    expect(renderedText).toContain('La corriente global no es agregable');
+    expect(renderedText).toContain('monofásico 230 V');
+    expect(renderedText).toContain('Factor de potencia: Vectorial por componente');
+    expect(renderedText).toContain('Aparente: 0,11 kVA');
+    expect(renderedText).toContain('Corriente: 0,48 A');
+    expect(renderedText).toContain('referencia 80 %: 12,8 A');
+    expect(renderedText).not.toContain('Corriente: 99');
     const unicodeFontCallIndex = pdf.setFont.mock.calls.findIndex(
       ([family]) => family === 'NotoSansPdf',
     );
     const unicodeTextCallIndex = pdf.text.mock.calls.findIndex(
-      ([text]) => typeof text === 'string' && text.includes('1φ'),
+      ([text]) =>
+        (typeof text === 'string' && text.includes('√3')) ||
+        (Array.isArray(text) && text.some((line) => line.includes('√3'))),
     );
     expect(unicodeFontCallIndex).toBeGreaterThanOrEqual(0);
     expect(unicodeTextCallIndex).toBeGreaterThanOrEqual(0);
@@ -243,7 +229,7 @@ describe('exportToPDF', () => {
     expect(pdfMocks.autoTable).toHaveBeenCalledWith(
       pdf,
       expect.objectContaining({
-        head: [['Cantidad', 'Componente', 'Vatios (por unidad)', 'PF', 'Vatios Totales']],
+        head: [['Cant.', 'Componente', 'W / unidad', 'FP', 'W totales']],
       }),
     );
   });

--- a/src/utils/pdf/__tests__/technicalDataReportModel.test.ts
+++ b/src/utils/pdf/__tests__/technicalDataReportModel.test.ts
@@ -12,6 +12,8 @@ describe("technicalDataReportModel", () => {
     expect(formatTechnicalReportNumber(42100, 0)).toBe("42.100");
     expect(formatTechnicalReportNumber(49.53, 2)).toBe("49,53");
     expect(formatTechnicalReportDate("2026-07-10")).toBe("10 julio 2026");
+    expect(formatTechnicalReportDate("24/07/2026")).toBe("24 julio 2026");
+    expect(formatTechnicalReportDate("31/02/2026")).toBe("No disponible");
     expect(formatTechnicalReportDate("not-a-date")).toBe("No disponible");
   });
 

--- a/src/utils/pdf/__tests__/technicalDataReportModel.test.ts
+++ b/src/utils/pdf/__tests__/technicalDataReportModel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPowerReportSummary,
+  formatTechnicalReportDate,
+  formatTechnicalReportNumber,
+} from "@/utils/pdf/technicalDataReportModel";
+import { buildPowerCalculationSnapshot } from "@/features/technical-tools/power/powerCalculations";
+
+describe("technicalDataReportModel", () => {
+  it("formats report numbers and dates in Spanish", () => {
+    expect(formatTechnicalReportNumber(42100, 0)).toBe("42.100");
+    expect(formatTechnicalReportNumber(49.53, 2)).toBe("49,53");
+    expect(formatTechnicalReportDate("2026-07-10")).toBe("10 julio 2026");
+    expect(formatTechnicalReportDate("not-a-date")).toBe("No disponible");
+  });
+
+  it("does not invent a global current for multiple single-phase circuits", () => {
+    const calculation = buildPowerCalculationSnapshot({
+      powerFactorSource: "global",
+      settings: {
+        phaseMode: "single",
+        powerFactor: 0.95,
+        safetyMargin: 20,
+        voltage: 230,
+      },
+      totalWatts: 1000,
+    });
+    const summary = buildPowerReportSummary([
+      { calculation, name: "A", rows: [] },
+      { calculation, name: "B", rows: [] },
+    ]);
+
+    expect(summary.currentLine).toBeNull();
+    expect(summary.aggregationReason).toContain("asignación de fase");
+    expect(summary.totalWatts).toBe(2000);
+  });
+});

--- a/src/utils/pdf/powerStagePlotPdf.ts
+++ b/src/utils/pdf/powerStagePlotPdf.ts
@@ -65,6 +65,7 @@ const drawZoneEntries = (
   y: number,
   width: number,
   entryColorFor?: (entry: StagePlotEntry) => StagePlotRgb,
+  annotationColor: StagePlotRgb = [150, 100, 0],
 ) => {
   let entryY = y + ZONE_HEADER_HEIGHT;
   entries.forEach((entry) => {
@@ -82,7 +83,7 @@ const drawZoneEntries = (
     }
     if (entry.includesHoist) {
       doc.setFontSize(6);
-      doc.setTextColor(150, 100, 0);
+      doc.setTextColor(...annotationColor);
       doc.setFont("helvetica", "italic");
       doc.text(
         fitText(doc, "+ Motor: CEE32A 3P+N+G", width - 4),
@@ -105,6 +106,7 @@ const drawZoneBox = (
   width: number,
   height: number,
   entryColorFor?: (entry: StagePlotEntry) => StagePlotRgb,
+  annotationColor?: StagePlotRgb,
 ) => {
   doc.setDrawColor(120, 120, 120);
   if (entries.length === 0) {
@@ -116,7 +118,7 @@ const drawZoneBox = (
   doc.setFontSize(6);
   doc.setTextColor(140, 140, 140);
   doc.text(zone, x + 1.5, y + 3.5);
-  drawZoneEntries(doc, entries, x, y, width, entryColorFor);
+  drawZoneEntries(doc, entries, x, y, width, entryColorFor, annotationColor);
 };
 
 const formatEntryList = (entries: StagePlotEntry[]) =>
@@ -194,6 +196,15 @@ export const drawPowerStagePlot = (
     entryColorFor?: (entry: StagePlotEntry) => StagePlotRgb;
     /** Color legend drawn under the title when provided. */
     legend?: StagePlotLegendItem[];
+    /** Accent color for the section title. */
+    titleColor?: StagePlotRgb;
+    /** Content start used when the plot needs a fresh page. */
+    pageBreakY?: number;
+    /** Left and right content insets; defaults preserve the legacy layout. */
+    contentLeft?: number;
+    contentRight?: number;
+    /** Accent used for auxiliary power and hoist annotations. */
+    annotationColor?: StagePlotRgb;
   },
 ): number => {
   const {
@@ -204,6 +215,11 @@ export const drawPowerStagePlot = (
     title = "Distribución en Escenario",
     entryColorFor,
     legend,
+    titleColor = [125, 1, 1],
+    pageBreakY = 20,
+    contentLeft = 14,
+    contentRight = 14,
+    annotationColor = [150, 100, 0],
   } = options;
   let y = options.startY;
 
@@ -214,17 +230,17 @@ export const drawPowerStagePlot = (
   );
   if (y + totalHeight > pageHeight - footerSpace) {
     doc.addPage();
-    y = 20;
+    y = pageBreakY;
   }
 
   doc.setFontSize(14);
-  doc.setTextColor(125, 1, 1);
-  doc.text(title, 14, y);
+  doc.setTextColor(...titleColor);
+  doc.text(title, contentLeft, y);
   y += 8;
 
   // Color legend (one swatch + label per department)
   if (legend && legend.length > 0) {
-    let legendX = 14;
+    let legendX = contentLeft;
     doc.setFontSize(8);
     legend.forEach(({ label, color }) => {
       const [red, green, blue] = color;
@@ -238,18 +254,25 @@ export const drawPowerStagePlot = (
     y += LEGEND_HEIGHT;
   }
 
-  const totalWidth = STAGE_WIDTH + 2 * (WING_WIDTH + WING_GAP);
-  const wingLeftX = (pageWidth - totalWidth) / 2;
-  const stageX = wingLeftX + WING_WIDTH + WING_GAP;
-  const wingRightX = stageX + STAGE_WIDTH + WING_GAP;
-  const cellWidth = STAGE_WIDTH / 3;
+  const availableWidth = pageWidth - contentLeft - contentRight;
+  const baseTotalWidth = STAGE_WIDTH + 2 * (WING_WIDTH + WING_GAP);
+  const widthScale = Math.min(1, availableWidth / baseTotalWidth);
+  const stageWidth = STAGE_WIDTH * widthScale;
+  const wingWidth = WING_WIDTH * widthScale;
+  const wingGap = WING_GAP * widthScale;
+  const totalWidth = stageWidth + 2 * (wingWidth + wingGap);
+  const plotCenterX = contentLeft + availableWidth / 2;
+  const wingLeftX = plotCenterX - totalWidth / 2;
+  const stageX = wingLeftX + wingWidth + wingGap;
+  const wingRightX = stageX + stageWidth + wingGap;
+  const cellWidth = stageWidth / 3;
 
   doc.setLineWidth(0.4);
 
   // Backstage band behind the stage
   doc.setFontSize(8);
   doc.setTextColor(120, 120, 120);
-  doc.text("BACKSTAGE", pageWidth / 2, y, { align: "center" });
+  doc.text("TRAS ESCENA", plotCenterX, y, { align: "center" });
   y += 2;
   const backstageBandHeight = backstageHeight(plot);
   const backstageCellWidth = totalWidth / STAGE_PLOT_BACKSTAGE_ROW.length;
@@ -263,13 +286,14 @@ export const drawPowerStagePlot = (
       backstageCellWidth,
       backstageBandHeight,
       entryColorFor,
+      annotationColor,
     );
   });
   y += backstageBandHeight + 2;
 
   doc.setFontSize(8);
   doc.setTextColor(120, 120, 120);
-  doc.text("ESCENARIO", pageWidth / 2, y + 2, { align: "center" });
+  doc.text("ESCENARIO", plotCenterX, y + 2, { align: "center" });
   y += 4;
 
   // Stage grid with offstage wings (split up/center/down) aligned per row
@@ -283,9 +307,10 @@ export const drawPowerStagePlot = (
       plot.zones[STAGE_PLOT_WING_LEFT_COLUMN[rowIndex]],
       wingLeftX,
       rowY,
-      WING_WIDTH,
+      wingWidth,
       rowHeight,
       entryColorFor,
+      annotationColor,
     );
     drawZoneBox(
       doc,
@@ -293,9 +318,10 @@ export const drawPowerStagePlot = (
       plot.zones[STAGE_PLOT_WING_RIGHT_COLUMN[rowIndex]],
       wingRightX,
       rowY,
-      WING_WIDTH,
+      wingWidth,
       rowHeight,
       entryColorFor,
+      annotationColor,
     );
     row.forEach((zone, columnIndex) => {
       drawZoneBox(
@@ -307,6 +333,7 @@ export const drawPowerStagePlot = (
         cellWidth,
         rowHeight,
         entryColorFor,
+        annotationColor,
       );
     });
     rowY += rowHeight;
@@ -317,12 +344,12 @@ export const drawPowerStagePlot = (
   y += 3;
   doc.setFontSize(8);
   doc.setTextColor(120, 120, 120);
-  doc.text("PÚBLICO", pageWidth / 2, y + 4, { align: "center" });
+  doc.text("PÚBLICO", plotCenterX, y + 4, { align: "center" });
   y += AUDIENCE_LABEL_HEIGHT;
 
   const fohEntries = plot.zones[STAGE_PLOT_FOH];
-  const fohWidth = (STAGE_WIDTH * 2) / 3;
-  const fohX = (pageWidth - fohWidth) / 2;
+  const fohWidth = (stageWidth * 2) / 3;
+  const fohX = plotCenterX - fohWidth / 2;
   const fohHeight = fohBoxHeight(plot, fohSchukoRequired);
   doc.setDrawColor(120, 120, 120);
   try {
@@ -344,13 +371,21 @@ export const drawPowerStagePlot = (
   doc.setFontSize(6);
   doc.setTextColor(140, 140, 140);
   doc.text(STAGE_PLOT_FOH, fohX + 1.5, y + 3.5);
-  drawZoneEntries(doc, fohEntries, fohX, y, fohWidth, entryColorFor);
+  drawZoneEntries(
+    doc,
+    fohEntries,
+    fohX,
+    y,
+    fohWidth,
+    entryColorFor,
+    annotationColor,
+  );
   if (fohSchukoRequired) {
     doc.setFontSize(7);
-    doc.setTextColor(150, 100, 0);
+    doc.setTextColor(...annotationColor);
     doc.setFont("helvetica", "italic");
     doc.text(
-      fitText(doc, "Se requiere schuko 16A hembra", fohWidth - 4),
+      fitText(doc, "Se requiere Schuko hembra de 16 A", fohWidth - 4),
       fohX + fohWidth / 2,
       y + fohHeight - 2.5,
       { align: "center" },
@@ -361,23 +396,23 @@ export const drawPowerStagePlot = (
 
   doc.setFontSize(8);
   doc.setTextColor(120, 120, 120);
-  doc.text("PÚBLICO", pageWidth / 2, y + 4, { align: "center" });
+  doc.text("PÚBLICO", plotCenterX, y + 4, { align: "center" });
   y += AUDIENCE_LABEL_HEIGHT + 2;
 
   doc.setFontSize(9);
   doc.setTextColor(60, 60, 60);
   plot.custom.forEach((group) => {
     doc.text(
-      fitText(doc, `${group.position}: ${formatEntryList(group.entries)}`, pageWidth - 28),
-      14,
+      fitText(doc, `${group.position}: ${formatEntryList(group.entries)}`, availableWidth),
+      contentLeft,
       y + 4,
     );
     y += 6;
   });
   if (plot.unpositioned.length > 0) {
     doc.text(
-      fitText(doc, `Sin posición: ${formatEntryList(plot.unpositioned)}`, pageWidth - 28),
-      14,
+      fitText(doc, `Sin posición: ${formatEntryList(plot.unpositioned)}`, availableWidth),
+      contentLeft,
       y + 4,
     );
     y += 6;

--- a/src/utils/pdf/technicalDataReportLayout.ts
+++ b/src/utils/pdf/technicalDataReportLayout.ts
@@ -1,0 +1,404 @@
+import type jsPDF from "jspdf";
+
+import {
+  formatTechnicalReportNumber,
+  type TechnicalReportKind,
+} from "@/utils/pdf/technicalDataReportModel";
+
+export const REPORT_PAGE = {
+  bottom: 274,
+  contentTop: 40,
+  footerY: 282,
+  height: 297,
+  left: 25.4,
+  right: 193.6,
+  width: 210,
+} as const;
+
+export const REPORT_COLORS = {
+  accent: [125, 1, 1] as const,
+  danger: [145, 46, 38] as const,
+  ink: [23, 20, 15] as const,
+  paperTint: [249, 247, 243] as const,
+  rule: [228, 223, 214] as const,
+  soft: [122, 115, 106] as const,
+} as const;
+
+export type ReportMetaItem = {
+  label: string;
+  value: string;
+};
+
+const setText = (
+  doc: jsPDF,
+  color: readonly [number, number, number],
+  size: number,
+  style: "bold" | "normal" = "normal",
+) => {
+  doc.setFont("helvetica", style);
+  doc.setFontSize(size);
+  doc.setTextColor(...color);
+};
+
+const drawTypeMark = (
+  doc: jsPDF,
+  kind: TechnicalReportKind,
+  x: number,
+  y: number,
+) => {
+  doc.setDrawColor(...REPORT_COLORS.accent);
+  doc.setLineWidth(0.55);
+  if (kind === "power") {
+    doc.roundedRect(x, y, 8, 8, 0.7, 0.7, "S");
+    doc.circle(x + 2.4, y + 2.4, 0.55, "S");
+    doc.circle(x + 5.6, y + 2.4, 0.55, "S");
+    doc.line(x + 2.2, y + 5.9, x + 5.8, y + 5.9);
+  } else {
+    doc.circle(x + 4, y + 2.1, 1.5, "S");
+    doc.line(x + 4, y + 3.6, x + 4, y + 7.7);
+    doc.line(x + 1.5, y + 7.7, x + 6.5, y + 7.7);
+  }
+};
+
+export const drawReportChrome = ({
+  doc,
+  emittedDate,
+  jobName,
+  kind,
+  pageNumber,
+  sectorLogo,
+  totalPages,
+}: {
+  doc: jsPDF;
+  emittedDate: string;
+  jobName: string;
+  kind: TechnicalReportKind;
+  pageNumber: number;
+  sectorLogo: HTMLImageElement | null;
+  totalPages: number;
+}) => {
+  doc.setPage(pageNumber);
+  if (sectorLogo) {
+    const width = 34;
+    const height = width * sectorLogo.height / Math.max(sectorLogo.width, 1);
+    try {
+      doc.addImage(sectorLogo, "PNG", REPORT_PAGE.left, 13.2, width, height);
+    } catch {
+      setText(doc, REPORT_COLORS.ink, 7, "bold");
+      doc.text("SECTOR-PRO", REPORT_PAGE.left, 17.5);
+    }
+  } else {
+    setText(doc, REPORT_COLORS.ink, 7, "bold");
+    doc.text("SECTOR-PRO", REPORT_PAGE.left, 17.5);
+  }
+
+  const markX = 146;
+  drawTypeMark(doc, kind, markX, 11);
+  setText(doc, REPORT_COLORS.soft, 6.5, "bold");
+  doc.text(
+    kind === "power" ? "DISTRIBUCIÓN DE POTENCIA" : "DISTRIBUCIÓN DE PESOS",
+    markX + 11,
+    16.2,
+  );
+
+  doc.setDrawColor(...REPORT_COLORS.rule);
+  doc.setLineWidth(0.35);
+  doc.line(REPORT_PAGE.left, 26, REPORT_PAGE.right, 26);
+  doc.line(15.5, REPORT_PAGE.contentTop, 15.5, REPORT_PAGE.bottom);
+
+  const railText = `${jobName || "Trabajo sin título"}  ·  ${emittedDate}`;
+  setText(doc, REPORT_COLORS.soft, 5.8);
+  doc.text(railText, 12.3, REPORT_PAGE.bottom, { angle: 90 });
+
+  doc.line(REPORT_PAGE.left, 278.5, REPORT_PAGE.right, 278.5);
+  setText(doc, REPORT_COLORS.soft, 6);
+  doc.text("Sector-Pro  ·  Documentación técnica", REPORT_PAGE.left, REPORT_PAGE.footerY);
+  doc.text(
+    `${String(pageNumber).padStart(2, "0")} / ${String(totalPages).padStart(2, "0")}`,
+    REPORT_PAGE.right,
+    REPORT_PAGE.footerY,
+    { align: "right" },
+  );
+};
+
+export const drawTitleBlock = ({
+  clientLogo,
+  doc,
+  jobName,
+  kind,
+  projectName,
+}: {
+  clientLogo: HTMLImageElement | null;
+  doc: jsPDF;
+  jobName: string;
+  kind: TechnicalReportKind;
+  projectName: string;
+}) => {
+  setText(doc, REPORT_COLORS.accent, 6.8, "bold");
+  doc.text(
+    `${kind === "power" ? "DISTRIBUCIÓN DE POTENCIA" : "DISTRIBUCIÓN DE PESOS"}  ·  REV. A`,
+    REPORT_PAGE.left,
+    43,
+  );
+
+  const title = jobName.trim() || projectName.trim() || "Trabajo sin título";
+  const titleWidth = clientLogo ? 134 : REPORT_PAGE.right - REPORT_PAGE.left;
+  setText(doc, REPORT_COLORS.ink, 24, "bold");
+  const titleLines = doc.splitTextToSize(title, titleWidth).slice(0, 2) as string[];
+  doc.text(titleLines, REPORT_PAGE.left, 56, { lineHeightFactor: 0.88 });
+  const y = 56 + Math.max(1, titleLines.length) * 7.6;
+
+  const subtitle = projectName.trim() && projectName.trim() !== title
+    ? projectName.trim()
+    : "Informe técnico";
+  setText(doc, REPORT_COLORS.soft, 8.5);
+  doc.text(subtitle, REPORT_PAGE.left, y);
+
+  if (clientLogo) {
+    const maxWidth = 25;
+    const maxHeight = 11;
+    const ratio = clientLogo.width / Math.max(clientLogo.height, 1);
+    const width = Math.min(maxWidth, maxHeight * ratio);
+    const height = width / Math.max(ratio, 0.01);
+    try {
+      doc.addImage(
+        clientLogo,
+        "PNG",
+        REPORT_PAGE.right - width,
+        45,
+        width,
+        height,
+      );
+    } catch {
+      // The client mark is optional; the report remains complete without it.
+    }
+  }
+
+  return y + 9;
+};
+
+export const drawMetaGrid = (
+  doc: jsPDF,
+  items: ReportMetaItem[],
+  startY: number,
+) => {
+  const width = (REPORT_PAGE.right - REPORT_PAGE.left) / items.length;
+  items.forEach((item, index) => {
+    const x = REPORT_PAGE.left + width * index;
+    setText(doc, REPORT_COLORS.soft, 5.8, "bold");
+    doc.text(item.label.toUpperCase(), x, startY);
+    setText(doc, REPORT_COLORS.ink, 8.2);
+    const lines = doc.splitTextToSize(item.value, width - 4).slice(0, 2) as string[];
+    doc.text(lines, x, startY + 5, { lineHeightFactor: 1.05 });
+  });
+  return startY + 15;
+};
+
+export const drawSectionHeading = (
+  doc: jsPDF,
+  number: number,
+  title: string,
+  y: number,
+) => {
+  const sectionNumber = String(number).padStart(2, "0");
+  setText(doc, REPORT_COLORS.accent, 6.5, "bold");
+  doc.text(sectionNumber, REPORT_PAGE.left, y);
+  setText(doc, REPORT_COLORS.ink, 8.5, "bold");
+  const titleX = REPORT_PAGE.left + 9;
+  doc.text(title.toUpperCase(), titleX, y);
+  const titleWidth = doc.getTextWidth(title.toUpperCase());
+  doc.setDrawColor(...REPORT_COLORS.rule);
+  doc.setLineWidth(0.35);
+  doc.line(
+    Math.min(titleX + titleWidth + 5, REPORT_PAGE.right - 4),
+    y - 1,
+    REPORT_PAGE.right,
+    y - 1,
+  );
+  return y + 6;
+};
+
+const drawGauge = ({
+  doc,
+  max,
+  value,
+  y,
+}: {
+  doc: jsPDF;
+  max: number;
+  value: number;
+  y: number;
+}) => {
+  const x = REPORT_PAGE.left;
+  const width = 75;
+  const ratio = Math.max(0, Math.min(value / max, 1));
+  doc.setDrawColor(...REPORT_COLORS.rule);
+  doc.setLineWidth(1.4);
+  doc.line(x, y, x + width, y);
+  doc.setDrawColor(...REPORT_COLORS.accent);
+  doc.line(x, y, x + width * Math.min(ratio, 0.8), y);
+  if (ratio > 0.8) {
+    doc.setDrawColor(...REPORT_COLORS.danger);
+    doc.line(x + width * 0.8, y, x + width * ratio, y);
+  }
+  doc.setDrawColor(...REPORT_COLORS.ink);
+  doc.setLineWidth(0.35);
+  doc.line(x + width * 0.8, y - 2, x + width * 0.8, y + 2);
+  setText(doc, REPORT_COLORS.soft, 5.5);
+  doc.text("0 A", x, y + 5);
+  doc.text("Referencia 80 %", x + width * 0.8, y + 5, { align: "center" });
+  doc.text(`${formatTechnicalReportNumber(max, 0)} A`, x + width, y + 5, {
+    align: "right",
+  });
+};
+
+export const drawPowerHeadline = ({
+  adjustedWatts,
+  currentLine,
+  currentSupportingText,
+  doc,
+  pduRating,
+  supportingText,
+}: {
+  adjustedWatts: number;
+  currentLine: number | null;
+  currentSupportingText: string;
+  doc: jsPDF;
+  pduRating: number | null;
+  supportingText: string;
+}) => {
+  const startY = 105;
+  setText(doc, REPORT_COLORS.soft, 6.4, "bold");
+  doc.text("CORRIENTE RESULTANTE", REPORT_PAGE.left, startY);
+  if (currentLine === null) {
+    setText(doc, REPORT_COLORS.ink, 17, "bold");
+    doc.text("No agregable", REPORT_PAGE.left, startY + 11);
+  } else {
+    setText(doc, REPORT_COLORS.ink, 24, "bold");
+    doc.text(
+      `${formatTechnicalReportNumber(currentLine, 2)} A`,
+      REPORT_PAGE.left,
+      startY + 12,
+    );
+  }
+  if (currentLine !== null && pduRating) {
+    drawGauge({ doc, max: pduRating, value: currentLine, y: startY + 19 });
+  } else {
+    setText(doc, REPORT_COLORS.soft, 6.5);
+    doc.text(currentSupportingText, REPORT_PAGE.left, startY + 20);
+  }
+
+  const rightX = 117;
+  setText(doc, REPORT_COLORS.soft, 6.4, "bold");
+  doc.text("POTENCIA DE CÁLCULO", rightX, startY);
+  setText(doc, REPORT_COLORS.ink, 24, "bold");
+  doc.text(
+    `${formatTechnicalReportNumber(adjustedWatts / 1000, 2)} kW`,
+    rightX,
+    startY + 12,
+  );
+  setText(doc, REPORT_COLORS.soft, 6.5);
+  const supportLines = doc.splitTextToSize(supportingText, 72).slice(0, 3) as string[];
+  doc.text(supportLines, rightX, startY + 20, { lineHeightFactor: 1.15 });
+  return 142;
+};
+
+export const drawWeightHeadline = ({
+  componentCount,
+  doc,
+  pointCount,
+  totalWeight,
+}: {
+  componentCount: number;
+  doc: jsPDF;
+  pointCount: number;
+  totalWeight: number;
+}) => {
+  const startY = 105;
+  setText(doc, REPORT_COLORS.soft, 6.4, "bold");
+  doc.text("PESO TOTAL SUSPENDIDO", REPORT_PAGE.left, startY);
+  setText(doc, REPORT_COLORS.ink, 24, "bold");
+  doc.text(
+    `${formatTechnicalReportNumber(totalWeight, 1)} kg`,
+    REPORT_PAGE.left,
+    startY + 12,
+  );
+  setText(doc, REPORT_COLORS.soft, 6.5);
+  doc.text(
+    `${formatTechnicalReportNumber(totalWeight * 2.2046226218, 1)} lb  ·  ${pointCount} puntos  ·  ${componentCount} componentes`,
+    REPORT_PAGE.left,
+    startY + 20,
+  );
+
+  const rightX = 117;
+  setText(doc, REPORT_COLORS.soft, 6.4, "bold");
+  doc.text("CARGA SOBRE EL PUNTO", rightX, startY);
+  doc.setDrawColor(...REPORT_COLORS.rule);
+  doc.setLineWidth(1.4);
+  doc.line(rightX, startY + 12, REPORT_PAGE.right, startY + 12);
+  setText(doc, REPORT_COLORS.soft, 5.5);
+  doc.text("0 kg", rightX, startY + 17);
+  doc.text("Capacidad sin definir", REPORT_PAGE.right, startY + 17, {
+    align: "right",
+  });
+  setText(doc, REPORT_COLORS.soft, 6.2);
+  const note = doc.splitTextToSize(
+    "La capacidad admisible del punto no se recoge actualmente; por ello no se calcula su porcentaje de utilización.",
+    REPORT_PAGE.right - rightX,
+  ) as string[];
+  doc.text(note, rightX, startY + 23, { lineHeightFactor: 1.12 });
+  return 142;
+};
+
+export const ensureReportSpace = (
+  doc: jsPDF,
+  y: number,
+  requiredHeight: number,
+) => {
+  if (y + requiredHeight <= REPORT_PAGE.bottom) return y;
+  doc.addPage();
+  return REPORT_PAGE.contentTop + 4;
+};
+
+export const drawNotice = (
+  doc: jsPDF,
+  text: string,
+  y: number,
+  tone: "danger" | "neutral" = "neutral",
+  fontFamily?: string,
+) => {
+  const lines = doc.splitTextToSize(text, REPORT_PAGE.right - REPORT_PAGE.left - 8) as string[];
+  const height = 8 + lines.length * 3.5;
+  doc.setFillColor(...REPORT_COLORS.paperTint);
+  doc.rect(REPORT_PAGE.left, y, REPORT_PAGE.right - REPORT_PAGE.left, height, "F");
+  setText(
+    doc,
+    tone === "danger" ? REPORT_COLORS.danger : REPORT_COLORS.soft,
+    6.6,
+  );
+  if (fontFamily) doc.setFont(fontFamily, "normal");
+  doc.text(lines, REPORT_PAGE.left + 4, y + 5, { lineHeightFactor: 1.1 });
+  return y + height;
+};
+
+export const drawBasisGrid = (
+  doc: jsPDF,
+  items: ReportMetaItem[],
+  y: number,
+) => {
+  const columnWidth = (REPORT_PAGE.right - REPORT_PAGE.left) / 2;
+  items.slice(0, 4).forEach((item, index) => {
+    const column = index % 2;
+    const row = Math.floor(index / 2);
+    const x = REPORT_PAGE.left + column * columnWidth;
+    const itemY = y + row * 11;
+    doc.setDrawColor(...REPORT_COLORS.rule);
+    doc.setLineWidth(0.25);
+    doc.line(x, itemY, x + columnWidth - 4, itemY);
+    setText(doc, REPORT_COLORS.soft, 5.8);
+    doc.text(item.label, x, itemY + 4.5);
+    setText(doc, REPORT_COLORS.ink, 7.2, "bold");
+    doc.text(item.value, x + columnWidth - 6, itemY + 4.5, { align: "right" });
+  });
+  return y + 23;
+};

--- a/src/utils/pdf/technicalDataReportModel.ts
+++ b/src/utils/pdf/technicalDataReportModel.ts
@@ -1,0 +1,216 @@
+import { aggregatePowerCalculations } from "@/features/technical-tools/power/powerAggregation";
+import {
+  getPowerPduAmpRating,
+  POWER_PDU_PLANNING_LOAD_FACTOR,
+} from "@/features/technical-tools/power/powerCalculations";
+import { getResolvedPowerPosition } from "@/utils/powerPositions";
+import type {
+  ExportTable,
+  PowerPdfSummary,
+  SummaryRow,
+} from "@/utils/pdfExport";
+
+export type TechnicalReportKind = "power" | "weight";
+
+export type PowerCircuitSummary = {
+  currentLine: number | null;
+  margin: number | null;
+  name: string;
+  pduLabel: string;
+  pduLimit: number | null;
+  pduStatus: "ok" | "over" | "unknown";
+  positionLabel: string;
+  totalVa: number | null;
+  totalWatts: number;
+  adjustedWatts: number;
+};
+
+export type PowerReportSummary = {
+  adjustedWatts: number;
+  aggregationReason?: string;
+  currentLine: number | null;
+  circuits: PowerCircuitSummary[];
+  pduLabel: string;
+  pduRating: number | null;
+  totalVa: number | null;
+  totalWatts: number;
+};
+
+export type WeightPointSummary = {
+  motorCount: string;
+  name: string;
+  totalWeight: number;
+};
+
+const numberFormatterCache = new Map<string, Intl.NumberFormat>();
+
+export const formatTechnicalReportNumber = (
+  value: number,
+  minimumFractionDigits = 0,
+  maximumFractionDigits = minimumFractionDigits,
+) => {
+  if (!Number.isFinite(value)) return "—";
+  const key = `${minimumFractionDigits}:${maximumFractionDigits}`;
+  let formatter = numberFormatterCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat("es-ES", {
+      minimumFractionDigits,
+      maximumFractionDigits,
+      useGrouping: true,
+    });
+    numberFormatterCache.set(key, formatter);
+  }
+  return formatter.format(value);
+};
+
+const parseDate = (value?: string | Date | null) => {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (!value) return null;
+
+  const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (dateOnly) {
+    const [, year, month, day] = dateOnly;
+    const parsed = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day), 12));
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+export const formatTechnicalReportDate = (value?: string | Date | null) => {
+  const parsed = parseDate(value);
+  if (!parsed) return "No disponible";
+  const parts = new Intl.DateTimeFormat("es-ES", {
+    day: "2-digit",
+    month: "long",
+    timeZone: "Europe/Madrid",
+    year: "numeric",
+  }).formatToParts(parsed);
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((candidate) => candidate.type === type)?.value ?? "";
+  return `${part("day")} ${part("month")} ${part("year")}`.trim();
+};
+
+export const getWeightMotorCount = (table: ExportTable) => {
+  const explicitPoints = table.riggingPoint
+    ?.split(",")
+    .filter((point) => point.trim().length > 0).length;
+  if (explicitPoints && explicitPoints > 0) return String(explicitPoints);
+  if (table.dualMotors) return "2";
+  return (table.totalWeight ?? 0) > 0 ? "1" : "—";
+};
+
+export const buildWeightPointSummaries = (
+  tables: ExportTable[],
+  suppliedRows?: SummaryRow[],
+): WeightPointSummary[] => {
+  if (suppliedRows?.length) {
+    return suppliedRows.map((row) => ({
+      motorCount: row.riggingPoints || "—",
+      name: row.clusterName || "Punto sin nombre",
+      totalWeight: Number.isFinite(row.clusterWeight) ? row.clusterWeight : 0,
+    }));
+  }
+
+  return tables.map((table) => ({
+    motorCount: getWeightMotorCount(table),
+    name: table.name || "Punto sin nombre",
+    totalWeight: Number.isFinite(table.totalWeight) ? table.totalWeight ?? 0 : 0,
+  }));
+};
+
+const buildCircuitSummary = (
+  table: ExportTable,
+  fallbackMargin?: number,
+): PowerCircuitSummary => {
+  const calculation = table.calculation;
+  const totalWatts = calculation?.totalWatts ?? table.totalWatts ?? 0;
+  const margin = calculation?.safetyMargin ?? fallbackMargin ?? null;
+  const adjustedWatts =
+    calculation?.adjustedWatts ??
+    table.adjustedWatts ??
+    totalWatts * (1 + (margin ?? 0) / 100);
+  const currentLine =
+    calculation?.currentLine ?? table.currentPerPhase ?? null;
+  const pduLabel = table.customPduType || table.pduType || "Sin asignar";
+  const pduRating = getPowerPduAmpRating(pduLabel);
+  const pduLimit =
+    pduRating === undefined
+      ? null
+      : pduRating * POWER_PDU_PLANNING_LOAD_FACTOR;
+
+  return {
+    adjustedWatts,
+    currentLine,
+    margin,
+    name: table.name || "Circuito sin nombre",
+    pduLabel,
+    pduLimit,
+    pduStatus:
+      pduLimit === null || currentLine === null
+        ? "unknown"
+        : currentLine <= pduLimit
+          ? "ok"
+          : "over",
+    positionLabel:
+      getResolvedPowerPosition(table.position, table.customPosition) ||
+      "Sin posición",
+    totalVa: calculation?.totalVa ?? table.totalVa ?? null,
+    totalWatts,
+  };
+};
+
+export const buildPowerReportSummary = (
+  tables: ExportTable[],
+  suppliedSummary?: PowerPdfSummary,
+  fallbackMargin?: number,
+): PowerReportSummary => {
+  const calculated = aggregatePowerCalculations(tables);
+  const hasReproducibleSnapshots =
+    tables.length > 0 && tables.every((table) => Boolean(table.calculation));
+  const summary = hasReproducibleSnapshots || !suppliedSummary
+    ? {
+        adjustedWatts: calculated.adjustedWatts,
+        aggregationReason: calculated.reason,
+        currentLine: calculated.currentLine,
+        totalVa: calculated.totalVa,
+        totalWatts: calculated.totalWatts,
+      }
+    : {
+        adjustedWatts:
+          suppliedSummary.adjustedSystemWatts ??
+          suppliedSummary.totalSystemWatts,
+        aggregationReason: suppliedSummary.aggregationReason,
+        currentLine: suppliedSummary.totalSystemAmps,
+        totalVa:
+          suppliedSummary.totalSystemKva == null
+            ? null
+            : suppliedSummary.totalSystemKva * 1000,
+        totalWatts: suppliedSummary.totalSystemWatts,
+      };
+  const circuits = tables.map((table) =>
+    buildCircuitSummary(table, fallbackMargin));
+  const pduLabels = new Set(
+    circuits.map((circuit) => circuit.pduLabel).filter((label) => label !== "Sin asignar"),
+  );
+  const pduLabel =
+    circuits.length === 1 && pduLabels.size === 1
+      ? [...pduLabels][0]
+      : circuits.length > 1
+        ? "Por circuito"
+        : "Sin asignar";
+  const pduRating =
+    circuits.length === 1 && pduLabels.size === 1
+      ? getPowerPduAmpRating(pduLabel) ?? null
+      : null;
+
+  return {
+    ...summary,
+    circuits,
+    pduLabel,
+    pduRating,
+  };
+};

--- a/src/utils/pdf/technicalDataReportModel.ts
+++ b/src/utils/pdf/technicalDataReportModel.ts
@@ -76,6 +76,17 @@ const parseDate = (value?: string | Date | null) => {
     return Number.isNaN(parsed.getTime()) ? null : parsed;
   }
 
+  const dayFirstDate = value.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (dayFirstDate) {
+    const [, day, month, year] = dayFirstDate;
+    const parsed = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day), 12));
+    const isExactDate =
+      parsed.getUTCFullYear() === Number(year) &&
+      parsed.getUTCMonth() === Number(month) - 1 &&
+      parsed.getUTCDate() === Number(day);
+    return isExactDate ? parsed : null;
+  }
+
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 };

--- a/src/utils/pdf/technicalDataReportPdf.ts
+++ b/src/utils/pdf/technicalDataReportPdf.ts
@@ -1,0 +1,579 @@
+import type jsPDF from "jspdf";
+
+import { buildPowerStagePlot } from "@/utils/powerStagePlot";
+import { loadPdfLibs, type AutoTableFn } from "@/utils/pdf/lazyPdf";
+import { getCompanyLogo } from "@/utils/pdf/logoUtils";
+import { registerPdfUnicodeFont } from "@/utils/pdf/pdfUnicodeFont";
+import { drawPowerStagePlot } from "@/utils/pdf/powerStagePlotPdf";
+import {
+  REPORT_COLORS,
+  REPORT_PAGE,
+  drawBasisGrid,
+  drawMetaGrid,
+  drawNotice,
+  drawPowerHeadline,
+  drawReportChrome,
+  drawSectionHeading,
+  drawTitleBlock,
+  drawWeightHeadline,
+  ensureReportSpace,
+  type ReportMetaItem,
+} from "@/utils/pdf/technicalDataReportLayout";
+import {
+  buildPowerReportSummary,
+  buildWeightPointSummaries,
+  formatTechnicalReportDate,
+  formatTechnicalReportNumber,
+  type PowerCircuitSummary,
+  type TechnicalReportKind,
+} from "@/utils/pdf/technicalDataReportModel";
+import type {
+  ExportTable,
+  PowerPdfSummary,
+  SummaryRow,
+} from "@/utils/pdfExport";
+
+type TechnicalReportInput = {
+  customLogoUrl?: string;
+  fohSchukoRequired?: boolean;
+  jobDate: string;
+  jobName: string;
+  powerSummary?: PowerPdfSummary;
+  projectName: string;
+  safetyMargin?: number;
+  summaryRows?: SummaryRow[];
+  tables: ExportTable[];
+  type: TechnicalReportKind;
+};
+
+type PdfWithLastTable = jsPDF & {
+  lastAutoTable?: { finalY?: number };
+};
+
+const NBSP = "\u00A0";
+
+const loadImage = (src?: string): Promise<HTMLImageElement | null> =>
+  new Promise((resolve) => {
+    if (!src || typeof Image === "undefined") {
+      resolve(null);
+      return;
+    }
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    image.onload = () => resolve(image);
+    image.onerror = () => resolve(null);
+    image.src = src;
+  });
+
+const loadSectorProLogo = async () =>
+  (await loadImage("/sector%20pro%20logo.png")) ?? getCompanyLogo();
+
+const tableEndY = (doc: jsPDF, fallback: number) =>
+  (doc as PdfWithLastTable).lastAutoTable?.finalY ?? fallback;
+
+const formatParsedNumber = (
+  value: string | number | undefined,
+  digits: number,
+) => {
+  if (value === undefined || value === "") return "—";
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed)
+    ? formatTechnicalReportNumber(parsed, digits)
+    : String(value);
+};
+
+const tableStyles = (fontFamily: string) => ({
+  alternateRowStyles: { fillColor: [249, 247, 243] as [number, number, number] },
+  bodyStyles: { textColor: [...REPORT_COLORS.ink] as [number, number, number] },
+  footStyles: {
+    fillColor: [255, 255, 255] as [number, number, number],
+    fontStyle: "bold" as const,
+    lineColor: [...REPORT_COLORS.ink] as [number, number, number],
+    lineWidth: { top: 0.35 },
+    textColor: [...REPORT_COLORS.ink] as [number, number, number],
+  },
+  headStyles: {
+    fillColor: [255, 255, 255] as [number, number, number],
+    fontStyle: "bold" as const,
+    lineColor: [...REPORT_COLORS.rule] as [number, number, number],
+    lineWidth: { bottom: 0.35 },
+    textColor: [...REPORT_COLORS.soft] as [number, number, number],
+  },
+  margin: {
+    bottom: REPORT_PAGE.height - REPORT_PAGE.bottom + 4,
+    left: REPORT_PAGE.left,
+    right: REPORT_PAGE.width - REPORT_PAGE.right,
+    top: REPORT_PAGE.contentTop,
+  },
+  showHead: "everyPage" as const,
+  styles: {
+    cellPadding: { bottom: 2.2, left: 1.5, right: 1.5, top: 2.2 },
+    font: fontFamily,
+    fontSize: 7.2,
+    lineColor: [...REPORT_COLORS.rule] as [number, number, number],
+    lineWidth: { bottom: 0.18 },
+    overflow: "linebreak" as const,
+  },
+  theme: "plain" as const,
+});
+
+const drawOverviewTable = ({
+  autoTable,
+  doc,
+  fontFamily,
+  powerCircuits,
+  startY,
+  type,
+  weightRows,
+}: {
+  autoTable: AutoTableFn;
+  doc: jsPDF;
+  fontFamily: string;
+  powerCircuits: PowerCircuitSummary[];
+  startY: number;
+  type: TechnicalReportKind;
+  weightRows: ReturnType<typeof buildWeightPointSummaries>;
+}) => {
+  if (type === "power") {
+    const body = powerCircuits.length
+      ? powerCircuits.map((circuit) => [
+          circuit.name,
+          circuit.pduLabel,
+          circuit.positionLabel,
+          `${formatTechnicalReportNumber(circuit.adjustedWatts / 1000, 2)}${NBSP}kW`,
+          circuit.currentLine === null
+            ? "No agregable"
+            : `${formatTechnicalReportNumber(circuit.currentLine, 2)}${NBSP}A`,
+        ])
+      : [["Sin circuitos guardados", "—", "—", "0,00 kW", "—"]];
+    autoTable(doc, {
+      ...tableStyles(fontFamily),
+      body,
+      columnStyles: {
+        3: { halign: "right" },
+        4: { halign: "right" },
+      },
+      head: [["Circuito", "PDU", "Posición", "Potencia", "Corriente"]],
+      startY,
+    });
+  } else {
+    const body = weightRows.length
+      ? weightRows.map((row) => [
+          row.name,
+          row.motorCount,
+          `${formatTechnicalReportNumber(row.totalWeight, 1)}${NBSP}kg`,
+        ])
+      : [["Sin puntos guardados", "—", "0,0 kg"]];
+    autoTable(doc, {
+      ...tableStyles(fontFamily),
+      body,
+      columnStyles: {
+        1: { halign: "center" },
+        2: { halign: "right" },
+      },
+      head: [["Punto / conjunto", "Motores", "Peso total"]],
+      startY,
+    });
+  }
+  return tableEndY(doc, startY) + 8;
+};
+
+const powerFactorLabel = (circuit: ExportTable["calculation"]) => {
+  if (!circuit) return "No reproducible";
+  if (circuit.powerFactorSource === "per-row") return "Vectorial por componente";
+  if (circuit.powerFactor === undefined) return "No disponible";
+  return formatTechnicalReportNumber(circuit.powerFactor, 2);
+};
+
+const buildPowerBasis = (
+  tables: ExportTable[],
+  circuits: PowerCircuitSummary[],
+): ReportMetaItem[] => {
+  const phaseLabels = new Set(
+    tables.map((table) =>
+      table.calculation?.phaseMode === "three"
+        ? "Trifásico equilibrado"
+        : table.calculation?.phaseMode === "single"
+          ? "Monofásico"
+          : "No identificado"),
+  );
+  const voltages = new Set(
+    tables
+      .map((table) => table.calculation?.voltage)
+      .filter((value): value is number => value !== undefined),
+  );
+  const margins = new Set(
+    circuits
+      .map((circuit) => circuit.margin)
+      .filter((value): value is number => value !== null),
+  );
+  const powerFactors = new Set(
+    tables.map((table) => powerFactorLabel(table.calculation)),
+  );
+  return [
+    {
+      label: "Tensión de referencia",
+      value:
+        voltages.size === 1
+          ? `${formatTechnicalReportNumber([...voltages][0], 0)} V`
+          : voltages.size > 1
+            ? "Varias"
+            : "No disponible",
+    },
+    {
+      label: "Sistema",
+      value: phaseLabels.size === 1 ? [...phaseLabels][0] : "Varios",
+    },
+    {
+      label: "Factor de potencia",
+      value: powerFactors.size === 1 ? [...powerFactors][0] : "Por circuito",
+    },
+    {
+      label: "Margen de seguridad",
+      value:
+        margins.size === 1
+          ? `${formatTechnicalReportNumber([...margins][0], 0)} %`
+          : margins.size > 1
+            ? "Por circuito"
+            : "No disponible",
+    },
+  ];
+};
+
+const detailHeaders = (table: ExportTable, type: TechnicalReportKind) => {
+  const hasLineNames =
+    type === "power" && table.rows.some((row) => row.lineName?.trim());
+  const hasPowerFactors =
+    type === "power" && table.rows.some((row) => row.pf?.trim());
+  if (type === "weight") {
+    return ["Cant.", "Componente", "kg / unidad", "kg totales"];
+  }
+  return [
+    "Cant.",
+    ...(hasLineNames ? ["Línea"] : []),
+    "Componente",
+    "W / unidad",
+    ...(hasPowerFactors ? ["FP"] : []),
+    "W totales",
+  ];
+};
+
+const detailRows = (table: ExportTable, type: TechnicalReportKind) => {
+  const hasLineNames =
+    type === "power" && table.rows.some((row) => row.lineName?.trim());
+  const hasPowerFactors =
+    type === "power" && table.rows.some((row) => row.pf?.trim());
+  return table.rows.map((row) => {
+    if (type === "weight") {
+      return [
+        formatParsedNumber(row.quantity, 0),
+        row.componentName || "Componente sin nombre",
+        formatParsedNumber(row.weight, 1),
+        formatParsedNumber(row.totalWeight, 1),
+      ];
+    }
+    return [
+      formatParsedNumber(row.quantity, 0),
+      ...(hasLineNames ? [row.lineName || "—"] : []),
+      row.componentName || "Componente sin nombre",
+      formatParsedNumber(row.watts, 0),
+      ...(hasPowerFactors ? [formatParsedNumber(row.pf, 2)] : []),
+      formatParsedNumber(row.totalWatts, 0),
+    ];
+  });
+};
+
+const drawPowerCircuitNote = (
+  doc: jsPDF,
+  circuit: PowerCircuitSummary,
+  table: ExportTable,
+  y: number,
+) => {
+  const calculation = table.calculation;
+  if (!calculation) {
+    return drawNotice(
+      doc,
+      "Cálculo heredado sin instantánea reproducible. Revise tensión, fases y factor de potencia antes de utilizar estos valores.",
+      y,
+      "danger",
+    );
+  }
+  const pduState =
+    circuit.pduStatus === "ok"
+      ? "Conforme"
+      : circuit.pduStatus === "over"
+        ? "Supera la referencia"
+        : "No verificable";
+  const line =
+    `Potencia base: ${formatTechnicalReportNumber(circuit.totalWatts, 0)} W  ·  ` +
+    `Potencia de cálculo (${formatTechnicalReportNumber(calculation.safetyMargin, 0)} %): ` +
+    `${formatTechnicalReportNumber(circuit.adjustedWatts, 0)} W  ·  ` +
+    `Aparente: ${formatTechnicalReportNumber(calculation.totalVa / 1000, 2)} kVA  ·  ` +
+    `Corriente: ${formatTechnicalReportNumber(calculation.currentLine, 2)} A\n` +
+    `Suministro: ${calculation.phaseMode === "three" ? "trifásico equilibrado" : "monofásico"} ` +
+    `${formatTechnicalReportNumber(calculation.voltage, 0)} V  ·  ` +
+    `Factor de potencia: ${powerFactorLabel(calculation)}  ·  ` +
+    `PDU: ${circuit.pduLabel}` +
+    `${circuit.pduLimit === null ? "" : ` (referencia 80 %: ${formatTechnicalReportNumber(circuit.pduLimit, 1)} A)`}` +
+    `  ·  ${pduState}`;
+  return drawNotice(
+    doc,
+    line,
+    y,
+    circuit.pduStatus === "over" ? "danger" : "neutral",
+  );
+};
+
+const drawDetailTables = ({
+  autoTable,
+  doc,
+  fontFamily,
+  powerCircuits,
+  tables,
+  type,
+}: {
+  autoTable: AutoTableFn;
+  doc: jsPDF;
+  fontFamily: string;
+  powerCircuits: PowerCircuitSummary[];
+  tables: ExportTable[];
+  type: TechnicalReportKind;
+}) => {
+  const populated = tables
+    .map((table, tableIndex) => ({
+      circuit: powerCircuits[tableIndex],
+      table,
+    }))
+    .filter(({ table }) => table.rows.length > 0);
+  if (populated.length === 0) return;
+  doc.addPage();
+  let y = REPORT_PAGE.contentTop + 5;
+
+  populated.forEach(({ circuit, table }, index) => {
+    y = ensureReportSpace(doc, y, 42);
+    y = drawSectionHeading(
+      doc,
+      index + 3,
+      `${type === "power" ? "Circuito" : "Punto"} ${String(index + 1).padStart(2, "0")}  —  ${table.name}`,
+      y,
+    );
+    autoTable(doc, {
+      ...tableStyles(fontFamily),
+      body: detailRows(table, type),
+      foot: [[
+        "",
+        type === "power" ? "Total del circuito" : "Total del punto",
+        ...Array(Math.max(0, detailHeaders(table, type).length - 3)).fill(""),
+        type === "power"
+          ? `${formatTechnicalReportNumber(table.totalWatts ?? 0, 0)} W`
+          : `${formatTechnicalReportNumber(table.totalWeight ?? 0, 1)} kg`,
+      ]],
+      head: [detailHeaders(table, type)],
+      startY: y,
+    });
+    y = tableEndY(doc, y) + 5;
+
+    if (type === "power") {
+      y = ensureReportSpace(doc, y, 26);
+      y = drawPowerCircuitNote(doc, circuit, table, y) + 7;
+      if (table.includesHoist) {
+        y = drawNotice(
+          doc,
+          `Suministro auxiliar de motores para ${table.name}: CEE32A 3P+N+G, excluido de los totales.`,
+          y,
+        ) + 7;
+      }
+    }
+  });
+};
+
+export const exportTechnicalDataReportPdf = async ({
+  customLogoUrl,
+  fohSchukoRequired = false,
+  jobDate,
+  jobName,
+  powerSummary: suppliedPowerSummary,
+  projectName,
+  safetyMargin,
+  summaryRows,
+  tables,
+  type,
+}: TechnicalReportInput): Promise<Blob> => {
+  const { jsPDF, autoTable } = await loadPdfLibs();
+  const doc = new jsPDF({ format: "a4", unit: "mm" });
+  const [fontFamily, clientLogo, sectorLogo] = await Promise.all([
+    registerPdfUnicodeFont(doc),
+    loadImage(customLogoUrl),
+    loadSectorProLogo(),
+  ]);
+  const reportFont = fontFamily ?? "helvetica";
+  const emittedDate = formatTechnicalReportDate(new Date());
+  const workDate = formatTechnicalReportDate(jobDate);
+  const powerSummary =
+    type === "power"
+      ? buildPowerReportSummary(tables, suppliedPowerSummary, safetyMargin)
+      : null;
+  const weightRows =
+    type === "weight" ? buildWeightPointSummaries(tables, summaryRows) : [];
+  const totalWeight = weightRows.reduce((sum, row) => sum + row.totalWeight, 0);
+  const weightPointCount = weightRows.filter(
+    (row) => row.motorCount !== "—",
+  ).length;
+
+  let y = drawTitleBlock({
+    clientLogo,
+    doc,
+    jobName,
+    kind: type,
+    projectName,
+  });
+  const powerMargins = new Set(
+    powerSummary?.circuits
+      .map((circuit) => circuit.margin)
+      .filter((value): value is number => value !== null) ?? [],
+  );
+  y = drawMetaGrid(
+    doc,
+    type === "power"
+      ? [
+          { label: "Fecha del trabajo", value: workDate },
+          { label: "Emitido", value: emittedDate },
+          {
+            label: "Margen aplicado",
+            value:
+              powerMargins.size === 1
+                ? `${formatTechnicalReportNumber([...powerMargins][0], 0)} %`
+                : powerMargins.size > 1
+                  ? "Por circuito"
+                  : "No disponible",
+          },
+          { label: "Suministro", value: powerSummary?.pduLabel ?? "Sin asignar" },
+        ]
+      : [
+          { label: "Fecha del trabajo", value: workDate },
+          { label: "Emitido", value: emittedDate },
+          { label: "Partidas resumidas", value: String(weightRows.length) },
+          { label: "Capacidad del punto", value: "Sin definir" },
+        ],
+    y,
+  );
+
+  if (type === "power" && powerSummary) {
+    y = drawPowerHeadline({
+      adjustedWatts: powerSummary.adjustedWatts,
+      currentLine: powerSummary.currentLine,
+      currentSupportingText:
+        powerSummary.currentLine === null
+          ? "Revise la compatibilidad de los circuitos"
+          : powerSummary.pduRating === null
+            ? "Sin PDU global  ·  ver detalle por circuito"
+            : "",
+      doc,
+      pduRating: powerSummary.pduRating,
+      supportingText:
+        `${powerSummary.circuits.length} circuitos  ·  ` +
+        `${powerSummary.totalVa === null ? "Potencia aparente no agregable" : `${formatTechnicalReportNumber(powerSummary.totalVa / 1000, 2)} kVA`}`,
+    });
+  } else {
+    y = drawWeightHeadline({
+      componentCount: tables.reduce((sum, table) => sum + table.rows.length, 0),
+      doc,
+      pointCount: weightPointCount,
+      totalWeight,
+    });
+  }
+
+  y = drawSectionHeading(
+    doc,
+    1,
+    type === "power" ? "Resumen de circuitos" : "Resumen por punto",
+    y + 7,
+  );
+  y = drawOverviewTable({
+    autoTable,
+    doc,
+    fontFamily: reportFont,
+    powerCircuits: powerSummary?.circuits ?? [],
+    startY: y,
+    type,
+    weightRows,
+  });
+  y = ensureReportSpace(doc, y, 42);
+  y = drawSectionHeading(doc, 2, "Base de cálculo", y);
+  y = drawBasisGrid(
+    doc,
+    type === "power"
+      ? buildPowerBasis(tables, powerSummary?.circuits ?? [])
+      : [
+          { label: "Pesos por unidad", value: "Datos introducidos" },
+          { label: "Factor dinámico", value: "No aplicado" },
+          { label: "Bumper y motores", value: "Según componentes" },
+          { label: "Cableado", value: "Solo si figura" },
+        ],
+    y,
+  );
+  const formula =
+    type === "power"
+      ? `${fontFamily ? "I = S / (√3 × U) en trifásica; I = S / U en monofásica." : "I = S / (raíz de 3 x U) en trifásica; I = S / U en monofásica."} La suma global solo se muestra con suministros compatibles.`
+      : "Peso total = suma de (cantidad × peso unitario). Este informe no sustituye el cálculo de cargas del responsable de rigging.";
+  y = drawNotice(doc, formula, y, "neutral", reportFont);
+  if (type === "power" && powerSummary?.currentLine === null) {
+    y = drawNotice(
+      doc,
+      `La corriente global no es agregable: ${powerSummary.aggregationReason || "faltan datos eléctricos compatibles."}`,
+      y + 3,
+    );
+  }
+  if (type === "power" && fohSchukoRequired) {
+    drawNotice(
+      doc,
+      "Suministro auxiliar de FOH: 16 A en formato Schuko hembra, excluido de los totales.",
+      y + 3,
+    );
+  }
+
+  drawDetailTables({
+    autoTable,
+    doc,
+    fontFamily: reportFont,
+    powerCircuits: powerSummary?.circuits ?? [],
+    tables,
+    type,
+  });
+
+  if (type === "power") {
+    const stagePlot = buildPowerStagePlot(tables);
+    if (stagePlot.hasPositionedEntries) {
+      doc.addPage();
+      drawPowerStagePlot(doc, stagePlot, {
+        annotationColor: REPORT_COLORS.accent,
+        entryColorFor: () => REPORT_COLORS.accent,
+        fohSchukoRequired,
+        footerSpace: REPORT_PAGE.height - REPORT_PAGE.bottom + 4,
+        pageBreakY: REPORT_PAGE.contentTop + 4,
+        contentLeft: REPORT_PAGE.left,
+        contentRight: REPORT_PAGE.width - REPORT_PAGE.right,
+        pageHeight: REPORT_PAGE.height,
+        pageWidth: REPORT_PAGE.width,
+        startY: REPORT_PAGE.contentTop + 7,
+        title: "Distribución en escenario",
+        titleColor: REPORT_COLORS.accent,
+      });
+    }
+  }
+
+  const totalPages = doc.getNumberOfPages();
+  for (let pageNumber = 1; pageNumber <= totalPages; pageNumber += 1) {
+    drawReportChrome({
+      doc,
+      emittedDate,
+      jobName: jobName || projectName,
+      kind: type,
+      pageNumber,
+      sectorLogo,
+      totalPages,
+    });
+  }
+  doc.setPage(totalPages);
+  return doc.output("blob");
+};

--- a/src/utils/pdf/technicalDataReportPdf.ts
+++ b/src/utils/pdf/technicalDataReportPdf.ts
@@ -432,7 +432,7 @@ export const exportTechnicalDataReportPdf = async ({
       .map((circuit) => circuit.margin)
       .filter((value): value is number => value !== null) ?? [],
   );
-  y = drawMetaGrid(
+  drawMetaGrid(
     doc,
     type === "power"
       ? [

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -13,8 +13,9 @@ import {
 import type {
   PowerCalculationSnapshot,
 } from '@/features/technical-tools/power/types';
+import { exportTechnicalDataReportPdf } from '@/utils/pdf/technicalDataReportPdf';
 
-interface ExportTableRow {
+export interface ExportTableRow {
   quantity?: string;
   lineName?: string;
   componentName?: string;
@@ -29,7 +30,7 @@ interface ExportTableRow {
   hoistName?: string;
 }
 
-interface ExportTable {
+export interface ExportTable {
   name: string;
   rows: ExportTableRow[];
   totalWeight?: number;
@@ -91,6 +92,21 @@ export const exportToPDF = async (
   customLogoUrl?: string,
   fohSchukoRequired?: boolean
 ): Promise<Blob> => {
+  if (['power', 'weight'].includes(type)) {
+    return exportTechnicalDataReportPdf({
+      customLogoUrl,
+      fohSchukoRequired,
+      jobDate,
+      jobName,
+      powerSummary,
+      projectName,
+      safetyMargin,
+      summaryRows,
+      tables,
+      type: type as 'power' | 'weight',
+    });
+  }
+
   const { jsPDF, autoTable } = await loadPdfLibs();
   const doc = new jsPDF();
   const unicodeFontFamily =


### PR DESCRIPTION
## Resumen
- aplica la nueva identidad editorial a los informes de Potencia y Pesos
- incrusta el logotipo real de Sector-Pro y usa el rojo corporativo
- mantiene todo el contenido visible en español
- corrige la colisión del plano de distribución con el carril lateral
- muestra límites PDU y estados no agregables sin inventar totales

## Verificación
- npm run lint -- --quiet
- npm run typecheck
- npm run test:run (315 archivos, 1709 tests)
- npm run build
- npm run governance
- npm run budget:bundle
- generación real en Chromium y revisión visual de todas las páginas PDF

## Base de datos
Sin migraciones ni cambios de esquema.