### PR TITLE
feat: add seasonal house tech payroll and availability

### DIFF
--- a/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
+++ b/src/components/jobs/__tests__/JobPayoutTotalsPanel.autonomo.test.tsx
@@ -132,4 +132,26 @@ describe("JobPayoutTotalsPanel autonomo badge", () => {
 
     expect(screen.getByText(NO_AUTONOMO_LABEL)).toBeInTheDocument();
   });
+
+  it("never renders or deducts the non-autonomo state for a house tech", () => {
+    const current = useJobPayoutDataMock();
+    const houseProfile = {
+      ...current.profilesWithEmail[0],
+      role: "house_tech",
+      is_house_tech: true,
+      autonomo: false,
+    };
+    useJobPayoutDataMock.mockReturnValue({
+      ...current,
+      profilesWithEmail: [houseProfile],
+      profileMap: new Map([["tech-1", houseProfile]]),
+      autonomoMap: new Map([["tech-1", null]]),
+      calculatedGrandTotal: 100,
+    });
+
+    renderWithProviders(<JobPayoutTotalsPanel jobId="job-1" />);
+
+    expect(screen.queryByText(NO_AUTONOMO_LABEL)).not.toBeInTheDocument();
+    expect(screen.queryByText(/-30/)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
+++ b/src/components/jobs/payout-totals/JobPayoutTotalsPanel.tsx
@@ -85,7 +85,9 @@ export function JobPayoutTotalsPanel({ jobId, technicianId }: JobPayoutTotalsPan
     return displayedPayouts.reduce((sum, payout) => {
       const override = data.getTechOverride(payout.technician_id);
       let deduction = 0;
-      const isNonAutonomo = data.autonomoMap.get(payout.technician_id) === false;
+      const isNonAutonomo =
+        data.profileMap.get(payout.technician_id)?.is_house_tech !== true
+        && data.autonomoMap.get(payout.technician_id) === false;
       if (isNonAutonomo && !override && !data.isTourDate) {
         const days = data.techDaysMap.get(payout.technician_id) || (payout.timesheets_total_eur > 0 ? 1 : 0);
         deduction = days * NON_AUTONOMO_DEDUCTION_EUR;

--- a/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
+++ b/src/components/jobs/payout-totals/TechnicianPayoutCard.tsx
@@ -117,9 +117,9 @@ export function TechnicianPayoutCard({
   const techId = payout.technician_id;
   const techName = getTechName(techId);
   const profile = profileMap.get(techId);
-  const autonomoStatus = autonomoMap.get(techId);
+  const autonomoStatus = profile?.is_house_tech ? null : autonomoMap.get(techId);
   const autonomoBadgeLabel = getAutonomoBadgeLabel(autonomoStatus);
-  const isNonAutonomo = autonomoStatus === false;
+  const isNonAutonomo = profile?.is_house_tech !== true && autonomoStatus === false;
 
   /* Deduction calc (standard jobs only) */
   let deduction = 0;

--- a/src/components/jobs/payout-totals/useJobPayoutData.ts
+++ b/src/components/jobs/payout-totals/useJobPayoutData.ts
@@ -492,16 +492,22 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
     enabled: techIds.length > 0,
     queryFn: async () => {
       const { data, error } = await dataLayerClient.from('profiles')
-        .select('id, first_name, last_name, email, autonomo, department')
+        .select('id, first_name, last_name, email, autonomo, department, role, seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date')
         .in('id', techIds);
       if (error) throw error;
-      return (data || []) as TechnicianProfileWithEmail[];
+      return (data || []).map((profile) => ({
+        ...profile,
+        is_house_tech: profile.role === 'house_tech',
+      })) as TechnicianProfileWithEmail[];
     },
     staleTime: 60_000,
   });
   const profilesWithEmail = profiles as TechnicianProfileWithEmail[];
   const autonomoMap = React.useMemo(
-    () => new Map(profilesWithEmail.map((p) => [p.id, p.autonomo ?? null])),
+    () => new Map(profilesWithEmail.map((p) => [
+      p.id,
+      p.is_house_tech ? null : (p.autonomo ?? null),
+    ])),
     [profilesWithEmail]
   );
   const profileMap = React.useMemo(() => new Map(profilesWithEmail.map((p) => [p.id, p])), [profilesWithEmail]);
@@ -639,7 +645,9 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
       const override = payoutOverrides.find(o => o.technician_id === payout.technician_id);
 
       let deduction = 0;
-      const isNonAutonomo = autonomoMap.get(payout.technician_id) === false;
+      const isNonAutonomo =
+        profileMap.get(payout.technician_id)?.is_house_tech !== true
+        && autonomoMap.get(payout.technician_id) === false;
       if (isNonAutonomo && !override && !isTourDate) {
         const days = techDaysMap.get(payout.technician_id) || (payout.timesheets_total_eur > 0 ? 1 : 0);
         deduction = days * NON_AUTONOMO_DEDUCTION_EUR;
@@ -648,7 +656,7 @@ export function useJobPayoutData(jobId: string, technicianId?: string): JobPayou
       const effectiveTotal = (override?.override_amount_eur ?? payout.total_eur) - (override ? 0 : deduction);
       return sum + effectiveTotal;
     }, 0);
-  }, [payoutTotalsWithPrep, payoutOverrides, autonomoMap, isTourDate, techDaysMap]);
+  }, [payoutTotalsWithPrep, payoutOverrides, profileMap, autonomoMap, isTourDate, techDaysMap]);
 
   return {
     jobMeta,

--- a/src/components/jobs/payout-totals/usePayoutActions.ts
+++ b/src/components/jobs/payout-totals/usePayoutActions.ts
@@ -68,10 +68,10 @@ export function usePayoutActions({
     tourContext: Awaited<ReturnType<typeof prepareTourJobEmailContext>>
   ) => {
     const map = new Map<string, TimesheetLine[]>(
-      Array.from(tourContext.timesheetDateMap.entries()).map(([techId, dates]) => [
+      Array.from(tourContext.hourlyTimesheetMap.entries()).map(([techId, lines]) => [
         techId,
-        Array.from(dates).sort().map((date) => ({ date, hours_rounded: 0 })),
-      ])
+        [...lines],
+      ]),
     );
 
     tourContext.prepTimesheetMap.forEach((prepLines, techId) => {
@@ -81,6 +81,16 @@ export function usePayoutActions({
         ...prepLines,
         ...existing.filter((line) => !prepDates.has(line.date)),
       ]);
+    });
+
+    tourContext.timesheetDateMap.forEach((dates, techId) => {
+      const existing = map.get(techId) || [];
+      const existingDates = new Set(existing.map((line) => line.date).filter(Boolean));
+      const missingDateLines = Array.from(dates)
+        .filter((date) => !existingDates.has(date))
+        .sort()
+        .map((date) => ({ date, hours_rounded: 0 }));
+      map.set(techId, [...existing, ...missingDateLines]);
     });
 
     return map;
@@ -177,6 +187,7 @@ export function usePayoutActions({
           {
             timesheetMap: tourContext.timesheetDateMap,
             prepTimesheetMap: tourContext.prepTimesheetMap,
+            hourlyTimesheetMap: tourContext.hourlyTimesheetMap,
           }
         );
         toast.success('PDF de tarifas generado');

--- a/src/components/personal/hooks/useTechnicianAvailability.ts
+++ b/src/components/personal/hooks/useTechnicianAvailability.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from '
 import { dataLayerClient } from '@/services/dataLayerClient';
 import { format } from 'date-fns';
 import { useToast } from '@/hooks/use-toast';
+import { buildSeasonalUnavailability, type SeasonalHouseTechProfile } from '@/utils/seasonalHouseTech';
 
 interface TechnicianAvailability {
   id: number;
@@ -124,6 +125,16 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
           return;
         }
 
+        const { data: seasonalProfiles, error: seasonalProfilesError } = await dataLayerClient.from('profiles')
+          .select('id, role, seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date')
+          .eq('role', 'house_tech')
+          .eq('seasonal_house_tech', true);
+
+        if (seasonalProfilesError) {
+          console.error('TechnicianAvailability: Error fetching seasonal profiles:', seasonalProfilesError);
+          return;
+        }
+
         console.log('TechnicianAvailability: Fetched availability data:', availabilityDataRaw);
         console.log('TechnicianAvailability: Fetched schedules data:', schedulesData);
 
@@ -150,6 +161,15 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
               availabilityMap[key] = 'unavailable';
             }
           }
+        });
+
+        buildSeasonalUnavailability(
+          (seasonalProfiles ?? []) as SeasonalHouseTechProfile[],
+          startOfMonthFormatted,
+          endOfMonthFormatted,
+        ).forEach((item) => {
+          const key = `${item.user_id}-${item.date}`;
+          if (!availabilityMap[key]) availabilityMap[key] = 'unavailable';
         });
 
         // Update global store instead of local state - no parent rerender
@@ -221,11 +241,24 @@ export const useTechnicianAvailability = (currentMonth: Date) => {
       )
       .subscribe();
 
+    const seasonalProfilesChannel = dataLayerClient.channel('seasonal-house-tech-profile-updates')
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'profiles',
+        },
+        () => debouncedRefetch(),
+      )
+      .subscribe();
+
     return () => {
       clearTimeout(refetchTimeout);
       dataLayerClient.removeChannel(availabilityChannel);
       dataLayerClient.removeChannel(schedulesChannel);
       dataLayerClient.removeChannel(vacationRequestsChannel);
+      dataLayerClient.removeChannel(seasonalProfilesChannel);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [monthKey]); // Only refetch when month boundary changes

--- a/src/components/tours/RequestTourAvailabilityDialog.tsx
+++ b/src/components/tours/RequestTourAvailabilityDialog.tsx
@@ -8,6 +8,7 @@ import { dataLayerClient } from '@/services/dataLayerClient';
 import { buildTourSchedulePdfBlob } from '@/lib/tourPdfExport';
 import { uploadTourPdfWithRecord } from '@/utils/tourDocumentsUpload';
 import { isDepartmentManagementRole, isTechnicianRole } from '@/utils/permissions';
+import { isWithinSeasonalAvailability, type SeasonalHouseTechProfile } from '@/utils/seasonalHouseTech';
 
 type TourDateLite = {
   id: string;
@@ -28,7 +29,9 @@ type Props = {
 
 export const RequestTourAvailabilityDialog: React.FC<Props> = ({ open, onOpenChange, tourId, tourDates }) => {
   const { toast } = useToast();
-  const [techOptions, setTechOptions] = React.useState<Array<{ id: string; name: string }>>([]);
+  const [technicianProfiles, setTechnicianProfiles] = React.useState<Array<
+    SeasonalHouseTechProfile & { name: string }
+  >>([]);
   const [selectedTechId, setSelectedTechId] = React.useState<string>('');
   const [channel, setChannel] = React.useState<'email' | 'whatsapp'>('email');
   const [loading, setLoading] = React.useState(false);
@@ -43,12 +46,19 @@ export const RequestTourAvailabilityDialog: React.FC<Props> = ({ open, onOpenCha
         if (error) throw error;
         const filtered = (data || [])
           .filter((t: any) => isTechnicianRole(t.role) || (isDepartmentManagementRole(t.role) && t.assignable_as_tech))
-          .map((t: any) => ({ id: t.id, name: `${t.first_name || ''} ${t.last_name || ''}`.trim() || t.email || t.id }))
+          .map((t: any) => ({
+            id: t.id,
+            role: t.role,
+            seasonal_house_tech: t.seasonal_house_tech,
+            seasonal_house_tech_start_date: t.seasonal_house_tech_start_date,
+            seasonal_house_tech_end_date: t.seasonal_house_tech_end_date,
+            name: `${t.first_name || ''} ${t.last_name || ''}`.trim() || t.email || t.id,
+          }))
           .sort((a: any, b: any) => a.name.localeCompare(b.name));
-        setTechOptions(filtered);
+        setTechnicianProfiles(filtered);
       } catch (e) {
         console.error('[RequestTourAvailability] Failed to fetch technicians', e);
-        setTechOptions([]);
+        setTechnicianProfiles([]);
       }
     })();
     // Load tour dates if not provided
@@ -67,6 +77,19 @@ export const RequestTourAvailabilityDialog: React.FC<Props> = ({ open, onOpenCha
       }
     })();
   }, [open]);
+
+  const techOptions = React.useMemo(
+    () => technicianProfiles.filter((profile) =>
+      dates.every((tourDate) => isWithinSeasonalAvailability(profile, tourDate.date))
+    ),
+    [dates, technicianProfiles],
+  );
+
+  React.useEffect(() => {
+    if (selectedTechId && !techOptions.some((option) => option.id === selectedTechId)) {
+      setSelectedTechId('');
+    }
+  }, [selectedTechId, techOptions]);
 
   const handleSend = async () => {
     if (!selectedTechId) {

--- a/src/components/users/EditUserDialog.tsx
+++ b/src/components/users/EditUserDialog.tsx
@@ -18,6 +18,7 @@ import { formatUserName } from "@/utils/userName";
 import { CityAutocomplete } from "@/components/maps/CityAutocomplete";
 import { ProfilePictureUpload } from "@/components/profile/ProfilePictureUpload";
 import { isAdminRole, isManagementRole } from "@/utils/permissions";
+import { isSeasonalDateRangeValid } from "@/utils/seasonalHouseTech";
 
 interface EditUserDialogProps {
   user: Profile | null;
@@ -102,7 +103,7 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
     const nextIsSoundHouseTech = nextDepartment === 'sound' && nextRole === 'house_tech';
     const nextIsSeasonalHouseTech = nextRole === 'house_tech' && isSeasonalHouseTech;
 
-    if (nextIsSeasonalHouseTech && (!seasonalStartDate || !seasonalEndDate || seasonalStartDate > seasonalEndDate)) {
+    if (nextIsSeasonalHouseTech && !isSeasonalDateRangeValid(seasonalStartDate, seasonalEndDate)) {
       toast({
         title: "Rango de temporada no válido",
         description: "Indica una fecha de inicio y fin, con la fecha de inicio anterior o igual a la de fin.",

--- a/src/components/users/EditUserDialog.tsx
+++ b/src/components/users/EditUserDialog.tsx
@@ -17,7 +17,7 @@ import { useOptimizedAuth } from "@/hooks/useOptimizedAuth";
 import { formatUserName } from "@/utils/userName";
 import { CityAutocomplete } from "@/components/maps/CityAutocomplete";
 import { ProfilePictureUpload } from "@/components/profile/ProfilePictureUpload";
-import { isManagementRole } from "@/utils/permissions";
+import { isAdminRole, isManagementRole } from "@/utils/permissions";
 
 interface EditUserDialogProps {
   user: Profile | null;
@@ -32,9 +32,13 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
   const [soundvisionAccessEnabled, setSoundvisionAccessEnabled] = useState<boolean>(!!user?.soundvision_access_enabled);
   const [soundvisionToolAccessEnabled, setSoundvisionToolAccessEnabled] = useState<boolean>(!!user?.soundvision_tool_access_enabled);
   const [isAutonomo, setIsAutonomo] = useState<boolean>(user?.autonomo !== false);
+  const [isSeasonalHouseTech, setIsSeasonalHouseTech] = useState<boolean>(!!user?.seasonal_house_tech);
+  const [seasonalStartDate, setSeasonalStartDate] = useState<string>(user?.seasonal_house_tech_start_date || "");
+  const [seasonalEndDate, setSeasonalEndDate] = useState<string>(user?.seasonal_house_tech_end_date || "");
   const [selectedRole, setSelectedRole] = useState<string>(user?.role || "technician");
   const { userRole } = useOptimizedAuth();
   const isManagementUser = isManagementRole(userRole);
+  const isAdminUser = isAdminRole(userRole);
   const [flexUrl, setFlexUrl] = useState<string>("");
   const [flexResourceId, setFlexResourceId] = useState<string>(user?.flex_resource_id || "");
   const [isSendingOnboarding, setIsSendingOnboarding] = useState(false);
@@ -54,6 +58,9 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
     setFlexResourceId(user?.flex_resource_id || "");
     setFlexUrl("");
     setIsAutonomo(user?.autonomo !== false);
+    setIsSeasonalHouseTech(!!user?.seasonal_house_tech);
+    setSeasonalStartDate(user?.seasonal_house_tech_start_date || "");
+    setSeasonalEndDate(user?.seasonal_house_tech_end_date || "");
     setResidencia(user?.residencia || "");
     setHomeLatitude(user?.home_latitude ?? null);
     setHomeLongitude(user?.home_longitude ?? null);
@@ -93,6 +100,16 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
     const nextDepartment = formData.get('department') as Department;
     const nextRole = formData.get('role') as string;
     const nextIsSoundHouseTech = nextDepartment === 'sound' && nextRole === 'house_tech';
+    const nextIsSeasonalHouseTech = nextRole === 'house_tech' && isSeasonalHouseTech;
+
+    if (nextIsSeasonalHouseTech && (!seasonalStartDate || !seasonalEndDate || seasonalStartDate > seasonalEndDate)) {
+      toast({
+        title: "Rango de temporada no válido",
+        description: "Indica una fecha de inicio y fin, con la fecha de inicio anterior o igual a la de fin.",
+        variant: "destructive",
+      });
+      return;
+    }
 
     const updatedData: Partial<Profile> = {
       id: user.id,
@@ -115,7 +132,12 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
         nextDepartment === 'sound'
           ? nextIsSoundHouseTech || soundvisionToolAccessEnabled
           : false,
-      autonomo: isAutonomo,
+      // House tech payroll never uses autónomo status. Normalizing the stored
+      // value also prevents stale technician state leaking into older readers.
+      autonomo: nextRole === 'house_tech' ? true : isAutonomo,
+      seasonal_house_tech: nextIsSeasonalHouseTech,
+      seasonal_house_tech_start_date: nextIsSeasonalHouseTech ? seasonalStartDate : null,
+      seasonal_house_tech_end_date: nextIsSeasonalHouseTech ? seasonalEndDate : null,
     };
 
     console.log("Submitting user update with data:", updatedData);
@@ -338,18 +360,63 @@ export const EditUserDialog = ({ user, onOpenChange, onSave }: EditUserDialogPro
               </Select>
             </div>
             {selectedRole === 'house_tech' && (
-              <div className="space-y-2">
-                <Label htmlFor="warehouseDutyExempt">Exento de almacén</Label>
-                <div className="flex items-center gap-3">
-                  <Checkbox
-                    id="warehouseDutyExempt"
-                    checked={warehouseDutyExempt}
-                    onCheckedChange={(value) => setWarehouseDutyExempt(!!value)}
-                  />
-                  <span className="text-sm text-muted-foreground">
-                    Excluir a este house tech de las guardias de almacén en la agenda Personal y en los resúmenes de almacén.
-                  </span>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="warehouseDutyExempt">Exento de almacén</Label>
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      id="warehouseDutyExempt"
+                      checked={warehouseDutyExempt}
+                      onCheckedChange={(value) => setWarehouseDutyExempt(!!value)}
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      Excluir a este house tech de las guardias de almacén en la agenda Personal y en los resúmenes de almacén.
+                    </span>
+                  </div>
                 </div>
+                {isAdminUser && (
+                  <div className="space-y-2">
+                    <Label htmlFor="seasonalHouseTech">House tech de temporada</Label>
+                    <div className="flex items-center gap-3">
+                      <Checkbox
+                        id="seasonalHouseTech"
+                        checked={isSeasonalHouseTech}
+                        onCheckedChange={(value) => setIsSeasonalHouseTech(!!value)}
+                      />
+                      <span className="text-sm text-muted-foreground">
+                        Sin tarifa base ni plus. Solo cobra las horas que superen las 12 h, usando su tarifa de horas extra.
+                      </span>
+                    </div>
+                    {isSeasonalHouseTech && (
+                      <div className="grid grid-cols-1 gap-3 pt-2 sm:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor="seasonalStartDate">Disponible desde</Label>
+                          <Input
+                            id="seasonalStartDate"
+                            type="date"
+                            value={seasonalStartDate}
+                            onChange={(event) => setSeasonalStartDate(event.target.value)}
+                            required
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="seasonalEndDate">Disponible hasta</Label>
+                          <Input
+                            id="seasonalEndDate"
+                            type="date"
+                            value={seasonalEndDate}
+                            min={seasonalStartDate || undefined}
+                            onChange={(event) => setSeasonalEndDate(event.target.value)}
+                            required
+                          />
+                        </div>
+                        <p className="text-xs text-muted-foreground sm:col-span-2">
+                          El rango es inclusivo y se usa en la matriz y en los selectores de personal disponible.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             )}
             {selectedRole === 'technician' && (

--- a/src/components/users/UsersList.tsx
+++ b/src/components/users/UsersList.tsx
@@ -87,7 +87,7 @@ export const UsersList = ({
       
       try {
         let query = dataLayerClient.from('profiles')
-          .select('id, first_name, nickname, last_name, email, role, phone, department, dni, residencia, assignable_as_tech, warehouse_duty_exempt, flex_resource_id, soundvision_access_enabled, soundvision_tool_access_enabled, autonomo', { count: 'exact' });
+          .select('id, first_name, nickname, last_name, email, role, phone, department, dni, residencia, assignable_as_tech, warehouse_duty_exempt, flex_resource_id, soundvision_access_enabled, soundvision_tool_access_enabled, autonomo, seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date', { count: 'exact' });
 
         // Apply filters
         if (roleFilter) {

--- a/src/components/users/__tests__/EditUserDialog.test.tsx
+++ b/src/components/users/__tests__/EditUserDialog.test.tsx
@@ -223,6 +223,46 @@ describe("EditUserDialog", () => {
     expect(screen.queryByRole("checkbox", { name: /nm\/sv designer access/i })).not.toBeInTheDocument();
   });
 
+  it("lets only an admin enable a seasonal house tech with an inclusive date range", async () => {
+    useOptimizedAuthMock.mockReturnValue({ userRole: "admin" });
+    const user = userEvent.setup();
+    const { onSave } = renderDialog(
+      createUserProfile({
+        id: "seasonal-house-1",
+        role: "house_tech",
+        department: "lights",
+        autonomo: false,
+      }),
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: /house tech de temporada/i }));
+    await user.type(screen.getByLabelText(/disponible desde/i), "2026-06-01");
+    await user.type(screen.getByLabelText(/disponible hasta/i), "2026-08-31");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+        id: "seasonal-house-1",
+        role: "house_tech",
+        autonomo: true,
+        seasonal_house_tech: true,
+        seasonal_house_tech_start_date: "2026-06-01",
+        seasonal_house_tech_end_date: "2026-08-31",
+      }));
+    });
+  });
+
+  it("does not expose seasonal payroll controls to management users", () => {
+    useOptimizedAuthMock.mockReturnValue({ userRole: "management" });
+    renderDialog(createUserProfile({
+      id: "managed-house-1",
+      role: "house_tech",
+      department: "sound",
+    }));
+
+    expect(screen.queryByRole("checkbox", { name: /house tech de temporada/i })).not.toBeInTheDocument();
+  });
+
   it("sends onboarding emails and surfaces both success and failure toasts", async () => {
     const user = userEvent.setup();
     renderDialog(

--- a/src/components/users/types.ts
+++ b/src/components/users/types.ts
@@ -20,5 +20,8 @@ export type Profile = {
   soundvision_access_enabled?: boolean | null;
   soundvision_tool_access_enabled?: boolean | null;
   autonomo?: boolean | null;
+  seasonal_house_tech?: boolean | null;
+  seasonal_house_tech_start_date?: string | null;
+  seasonal_house_tech_end_date?: string | null;
   bg_color?: string | null;
 };

--- a/src/hooks/useOptimizedMatrixData.ts
+++ b/src/hooks/useOptimizedMatrixData.ts
@@ -6,6 +6,7 @@ import { formatInTimeZone } from 'date-fns-tz';
 
 
 import { queryKeys } from "@/lib/react-query";
+import { buildSeasonalUnavailability, type SeasonalHouseTechProfile } from "@/utils/seasonalHouseTech";
 const MADRID_TIMEZONE = 'Europe/Madrid';
 
 function toMadridDateKey(date: Date | undefined): string {
@@ -47,7 +48,7 @@ export interface MatrixTimesheetAssignment {
 }
 
 interface OptimizedMatrixDataProps {
-  technicians: Array<{ id: string; first_name: string; nickname?: string | null; last_name: string; email: string; department: string; role: string; profile_picture_url?: string | null; }>;
+  technicians: Array<SeasonalHouseTechProfile & { first_name: string; nickname?: string | null; last_name: string; email: string; department: string; role: string; profile_picture_url?: string | null; }>;
   dates: Date[];
   jobs: MatrixJob[];
 }
@@ -301,6 +302,9 @@ export const useOptimizedMatrixData = ({ technicians, dates, jobs }: OptimizedMa
 
       // Build per-day unavailable marks in the visible range
       const perDay: Map<string, AvailabilityDay> = new Map();
+      buildSeasonalUnavailability(technicians, dateStart, dateEnd).forEach((row) => {
+        perDay.set(`${row.user_id}-${row.date}`, row);
+      });
       const startDay = new Date(dateRange.start);
       startDay.setHours(0,0,0,0);
       const endDay = new Date(dateRange.end);

--- a/src/hooks/useOptimizedMatrixData.ts
+++ b/src/hooks/useOptimizedMatrixData.ts
@@ -284,12 +284,32 @@ export const useOptimizedMatrixData = ({ technicians, dates, jobs }: OptimizedMa
   });
 
   // Availability (unavailability) merged from per-day schedules and legacy table
+  const seasonalAvailabilityKey = useMemo(
+    () => technicians
+      .filter((technician) => technician.seasonal_house_tech === true)
+      .map((technician) => [
+        technician.id,
+        technician.role ?? '',
+        technician.seasonal_house_tech_start_date ?? '',
+        technician.seasonal_house_tech_end_date ?? '',
+      ].join(':'))
+      .sort()
+      .join('|'),
+    [technicians],
+  );
+
   const {
     data: availabilityData = [],
     isLoading: availabilityInitialLoading,
     isFetching: availabilityFetching,
   } = useQuery({
-    queryKey: queryKeys.scope('optimized-matrix-availability', technicianIds, toMadridDateKey(dateRange.start), toMadridDateKey(dateRange.end)),
+    queryKey: queryKeys.scope(
+      'optimized-matrix-availability',
+      technicianIds,
+      seasonalAvailabilityKey,
+      toMadridDateKey(dateRange.start),
+      toMadridDateKey(dateRange.end),
+    ),
     queryFn: async () => {
       if (technicianIds.length === 0 || !dateRange.start || !dateRange.end) return [] as Array<{ user_id: string; date: string; status: string; notes?: string }>;
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -6109,6 +6109,9 @@ export type Database = {
           role: Database["public"]["Enums"]["user_role"]
           selected_job_statuses: string[] | null
           selected_job_types: string[] | null
+          seasonal_house_tech: boolean
+          seasonal_house_tech_end_date: string | null
+          seasonal_house_tech_start_date: string | null
           soundvision_access_enabled: boolean | null
           soundvision_tool_access_enabled: boolean
           time_span: string | null
@@ -6147,6 +6150,9 @@ export type Database = {
           role?: Database["public"]["Enums"]["user_role"]
           selected_job_statuses?: string[] | null
           selected_job_types?: string[] | null
+          seasonal_house_tech?: boolean
+          seasonal_house_tech_end_date?: string | null
+          seasonal_house_tech_start_date?: string | null
           soundvision_access_enabled?: boolean | null
           soundvision_tool_access_enabled?: boolean
           time_span?: string | null
@@ -6185,6 +6191,9 @@ export type Database = {
           role?: Database["public"]["Enums"]["user_role"]
           selected_job_statuses?: string[] | null
           selected_job_types?: string[] | null
+          seasonal_house_tech?: boolean
+          seasonal_house_tech_end_date?: string | null
+          seasonal_house_tech_start_date?: string | null
           soundvision_access_enabled?: boolean | null
           soundvision_tool_access_enabled?: boolean
           time_span?: string | null
@@ -11398,6 +11407,9 @@ export type Database = {
           phone: string
           profile_picture_url: string
           role: string
+          seasonal_house_tech: boolean
+          seasonal_house_tech_end_date: string
+          seasonal_house_tech_start_date: string
           skills: Json
         }[]
       }

--- a/src/lib/__tests__/job-payout-data.test.ts
+++ b/src/lib/__tests__/job-payout-data.test.ts
@@ -116,6 +116,7 @@ describe('prepareJobPayoutData', () => {
                         last_name: 'Lopez',
                         email: 'ana@example.com',
                         autonomo: false,
+                        role: 'house_tech',
                       },
                     ]
                   : [
@@ -141,13 +142,7 @@ describe('prepareJobPayoutData', () => {
 
         throw new Error(`Unexpected table lookup: ${table}`);
       }),
-      rpc: vi.fn(async (fn: string, args: { _profile_id: string }) => {
-        if (fn !== 'is_house_tech') {
-          throw new Error(`Unexpected RPC: ${fn}`);
-        }
-
-        return { data: args._profile_id === 'tech-1', error: null };
-      }),
+      rpc: vi.fn(),
     };
 
     const result = await prepareJobPayoutData({
@@ -183,7 +178,6 @@ describe('prepareJobPayoutData', () => {
   });
 
   it('does not short-circuit on partial provided profiles when more technician ids are required', async () => {
-    const rpcCalls: string[] = [];
     const supabase = {
       from: vi.fn((table: string) => {
         if (table === 'jobs') {
@@ -268,6 +262,7 @@ describe('prepareJobPayoutData', () => {
                         last_name: 'One',
                         email: 'one@example.com',
                         autonomo: false,
+                        role: 'house_tech',
                       },
                       {
                         id: 'tech-2',
@@ -275,6 +270,7 @@ describe('prepareJobPayoutData', () => {
                         last_name: 'Two',
                         email: 'two@example.com',
                         autonomo: true,
+                        role: 'technician',
                       },
                     ]
                   : [],
@@ -293,14 +289,7 @@ describe('prepareJobPayoutData', () => {
 
         throw new Error(`Unexpected table lookup: ${table}`);
       }),
-      rpc: vi.fn(async (fn: string, args: { _profile_id: string }) => {
-        if (fn !== 'is_house_tech') {
-          throw new Error(`Unexpected RPC: ${fn}`);
-        }
-
-        rpcCalls.push(args._profile_id);
-        return { data: args._profile_id === 'tech-1', error: null };
-      }),
+      rpc: vi.fn(),
     };
 
     const result = await prepareJobPayoutData({
@@ -332,7 +321,7 @@ describe('prepareJobPayoutData', () => {
         is_house_tech: false,
       }),
     ]);
-    expect(rpcCalls.sort()).toEqual(['tech-1', 'tech-2']);
+    expect(supabase.rpc).not.toHaveBeenCalled();
   });
 
   it('falls back to provided profiles when the profile lookup fails', async () => {

--- a/src/lib/__tests__/tour-payout-email-prep-days.test.ts
+++ b/src/lib/__tests__/tour-payout-email-prep-days.test.ts
@@ -65,6 +65,7 @@ describe("tour payout prep-day timesheet documentation", () => {
       {
         technician_id: "explicit-hourly",
         date: "2026-06-01",
+        approved_by_manager: true,
         amount_breakdown: {
           hours_rounded: 14,
           base_day_eur: 0,
@@ -77,6 +78,7 @@ describe("tour payout prep-day timesheet documentation", () => {
       {
         technician_id: "seasonal-house",
         date: "2026-06-02",
+        approved_by_manager: true,
         amount_breakdown: {
           hours_rounded: 12,
           base_day_eur: 0,
@@ -91,7 +93,14 @@ describe("tour payout prep-day timesheet documentation", () => {
       {
         technician_id: "standard-tech",
         date: "2026-06-02",
+        approved_by_manager: true,
         amount_breakdown: { hours_rounded: 10, total_eur: 180 },
+      },
+      {
+        technician_id: "seasonal-house",
+        date: "2026-06-03",
+        approved_by_manager: false,
+        amount_breakdown: { hours_rounded: 16, total_eur: 80 },
       },
     ];
 

--- a/src/lib/__tests__/tour-payout-email-prep-days.test.ts
+++ b/src/lib/__tests__/tour-payout-email-prep-days.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildHourlyTimesheetMap,
   buildPrepTimesheetDateMap,
   buildPrepTimesheetMap,
   fetchTourJobEmailTimesheets,
@@ -57,6 +58,63 @@ describe("tour payout prep-day timesheet documentation", () => {
       ["is_active", true],
     ]);
     expect(rows).toHaveLength(1);
+  });
+
+  it("documents every hourly tour row, including profile-driven seasonal rows", () => {
+    const rows = [
+      {
+        technician_id: "explicit-hourly",
+        date: "2026-06-01",
+        amount_breakdown: {
+          hours_rounded: 14,
+          base_day_eur: 0,
+          overtime_hours: 2,
+          overtime_hour_eur: 20,
+          overtime_amount_eur: 40,
+          total_eur: 40,
+        },
+      },
+      {
+        technician_id: "seasonal-house",
+        date: "2026-06-02",
+        amount_breakdown: {
+          hours_rounded: 12,
+          base_day_eur: 0,
+          overtime_hours: 0,
+          overtime_hour_eur: 15,
+          overtime_amount_eur: 0,
+          total_eur: 0,
+          is_seasonal_house_tech: true,
+          seasonal_overtime_only: true,
+        },
+      },
+      {
+        technician_id: "standard-tech",
+        date: "2026-06-02",
+        amount_breakdown: { hours_rounded: 10, total_eur: 180 },
+      },
+    ];
+
+    const map = buildHourlyTimesheetMap(
+      rows,
+      [{ technician_id: "explicit-hourly", date: "2026-06-01" }],
+      new Set(["seasonal-house"]),
+    );
+
+    expect(map.get("explicit-hourly")).toEqual([
+      expect.objectContaining({ date: "2026-06-01", hours_rounded: 14, overtime_hours: 2, total_eur: 40 }),
+    ]);
+    expect(map.get("seasonal-house")).toEqual([
+      expect.objectContaining({
+        date: "2026-06-02",
+        hours_rounded: 12,
+        base_day_eur: 0,
+        total_eur: 0,
+        is_seasonal_house_tech: true,
+        seasonal_overtime_only: true,
+      }),
+    ]);
+    expect(map.has("standard-tech")).toBe(false);
   });
 
   it("keeps only approved prep-day rows in the prep timesheet map", () => {

--- a/src/lib/job-payout-data.ts
+++ b/src/lib/job-payout-data.ts
@@ -8,7 +8,11 @@ export interface TechnicianProfileWithEmail {
   email?: string | null;
   autonomo?: boolean | null;
   is_house_tech?: boolean | null;
+  role?: string | null;
   department?: string | null;
+  seasonal_house_tech?: boolean | null;
+  seasonal_house_tech_start_date?: string | null;
+  seasonal_house_tech_end_date?: string | null;
 }
 
 export interface JobPayoutDocumentJobDetails {
@@ -196,7 +200,7 @@ async function fetchProfiles(
 
   const { data, error } = await client
     .from('profiles')
-    .select('id, first_name, last_name, email, autonomo')
+    .select('id, first_name, last_name, email, autonomo, role, seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date')
     .in('id', techIds);
 
   if (error) {
@@ -215,14 +219,8 @@ async function fetchProfiles(
       const mergedProfile: TechnicianProfileWithEmail = {
         ...profileMap.get(profile.id),
         ...profile,
+        is_house_tech: profile.role === 'house_tech',
       };
-
-      try {
-        const { data: isHouseTech } = await client.rpc('is_house_tech', { _profile_id: profile.id });
-        mergedProfile.is_house_tech = isHouseTech ?? false;
-      } catch {
-        mergedProfile.is_house_tech = mergedProfile.is_house_tech ?? false;
-      }
 
       return mergedProfile;
     })

--- a/src/lib/tour-payout-email.ts
+++ b/src/lib/tour-payout-email.ts
@@ -37,6 +37,7 @@ export interface TourJobEmailContextResult {
   lpoMap?: Map<string, string | null>;
   timesheetDateMap: Map<string, Set<string>>;
   prepTimesheetMap: Map<string, TimesheetLine[]>;
+  hourlyTimesheetMap: Map<string, TimesheetLine[]>;
   expenseMap: Map<string, number>;
   attachments: TourJobEmailAttachment[];
   missingEmails: string[];
@@ -47,6 +48,15 @@ export interface TourJobEmailInput {
   supabase: SupabaseClient;
   quotes: TourJobRateQuote[];
   profiles: (TechnicianProfile & { email?: string | null })[];
+}
+
+interface TourEmailTimesheetRow {
+  technician_id?: string | null;
+  job_id?: string | null;
+  date?: string | null;
+  approved_by_manager?: boolean | null;
+  amount_breakdown?: unknown;
+  amount_breakdown_visible?: unknown;
 }
 
 // Backward-compatible no-op for stale dev/HMR imports. Multi-day rehearsal math
@@ -96,7 +106,10 @@ async function fetchLpoMap(
   return new Map((data || []).map((row: any) => [row.technician_id, row.lpo_number || null]));
 }
 
-export async function fetchTourJobEmailTimesheets(client: SupabaseClient, jobId: string): Promise<any[]> {
+export async function fetchTourJobEmailTimesheets(
+  client: SupabaseClient,
+  jobId: string,
+): Promise<TourEmailTimesheetRow[]> {
   const { data, error } = await client
     .from('timesheets')
     .select('technician_id, job_id, date, approved_by_manager, amount_breakdown')
@@ -106,27 +119,58 @@ export async function fetchTourJobEmailTimesheets(client: SupabaseClient, jobId:
   return data || [];
 }
 
-export function buildPrepTimesheetMap(rows: any[]): Map<string, TimesheetLine[]> {
+export async function fetchTourJobHourlyRateModes(
+  client: SupabaseClient,
+  jobId: string,
+): Promise<Array<{ job_id: string; technician_id: string; date: string }>> {
+  const { data, error } = await client.rpc('get_hourly_rate_mode_dates_for_timesheets', {
+    _job_ids: [jobId],
+  });
+  if (error) throw error;
+  return (data || []) as Array<{ job_id: string; technician_id: string; date: string }>;
+}
+
+function buildTimesheetLine(row: TourEmailTimesheetRow): TimesheetLine {
+  const breakdown = (row.amount_breakdown || row.amount_breakdown_visible || {}) as Record<string, unknown>;
+  return {
+    date: row.date ?? null,
+    hours_rounded: Number(breakdown.hours_rounded ?? breakdown.worked_hours_rounded ?? 0) || 0,
+    base_day_eur: breakdown.base_day_eur != null ? Number(breakdown.base_day_eur) : undefined,
+    plus_10_12_hours:
+      breakdown.plus_10_12_hours != null ? Number(breakdown.plus_10_12_hours) : undefined,
+    plus_10_12_amount_eur:
+      breakdown.plus_10_12_amount_eur != null ? Number(breakdown.plus_10_12_amount_eur) : undefined,
+    overtime_hours: breakdown.overtime_hours != null ? Number(breakdown.overtime_hours) : undefined,
+    overtime_hour_eur:
+      breakdown.overtime_hour_eur != null ? Number(breakdown.overtime_hour_eur) : undefined,
+    overtime_amount_eur:
+      breakdown.overtime_amount_eur != null ? Number(breakdown.overtime_amount_eur) : undefined,
+    total_eur: breakdown.total_eur != null ? Number(breakdown.total_eur) : undefined,
+    is_prep_day: breakdown.is_prep_day === true,
+    is_seasonal_house_tech: breakdown.is_seasonal_house_tech === true,
+    seasonal_overtime_only: breakdown.seasonal_overtime_only === true,
+    prep_day_hourly_rate_eur:
+      breakdown.prep_day_hourly_rate_eur != null ? Number(breakdown.prep_day_hourly_rate_eur) : undefined,
+  };
+}
+
+export function buildPrepTimesheetMap(rows: TourEmailTimesheetRow[]): Map<string, TimesheetLine[]> {
   const map = new Map<string, TimesheetLine[]>();
 
   rows.forEach((row) => {
+    if (!row.technician_id) return;
     if (row.approved_by_manager !== true) return;
-    const breakdown = (row.amount_breakdown || row.amount_breakdown_visible || {}) as Record<string, any>;
+    const breakdown = (row.amount_breakdown || row.amount_breakdown_visible || {}) as Record<string, unknown>;
     if (breakdown.is_prep_day !== true) return;
 
     const line: TimesheetLine = {
-      date: row.date ?? null,
-      hours_rounded: Number(breakdown.hours_rounded ?? breakdown.worked_hours_rounded ?? 0) || 0,
-      base_day_eur: breakdown.base_day_eur != null ? Number(breakdown.base_day_eur) : undefined,
+      ...buildTimesheetLine(row),
       plus_10_12_hours: 0,
       plus_10_12_amount_eur: 0,
       overtime_hours: 0,
       overtime_hour_eur: 0,
       overtime_amount_eur: 0,
-      total_eur: breakdown.total_eur != null ? Number(breakdown.total_eur) : undefined,
       is_prep_day: true,
-      prep_day_hourly_rate_eur:
-        breakdown.prep_day_hourly_rate_eur != null ? Number(breakdown.prep_day_hourly_rate_eur) : undefined,
     };
 
     const existing = map.get(row.technician_id) || [];
@@ -137,32 +181,83 @@ export function buildPrepTimesheetMap(rows: any[]): Map<string, TimesheetLine[]>
   return map;
 }
 
-export function buildPrepTimesheetDateMap(
-  prepTimesheetMap: Map<string, TimesheetLine[]>
-): Map<string, Set<string>> {
-  const map = new Map<string, Set<string>>();
+export function buildHourlyTimesheetMap(
+  rows: TourEmailTimesheetRow[],
+  hourlyRateModes: Array<{ technician_id: string; date: string }>,
+  seasonalTechnicianIds: Set<string> = new Set(),
+): Map<string, TimesheetLine[]> {
+  const hourlyKeys = new Set(
+    hourlyRateModes.map((row) => `${row.technician_id}:${row.date}`),
+  );
+  const map = new Map<string, TimesheetLine[]>();
 
-  prepTimesheetMap.forEach((lines, technicianId) => {
-    const dates = lines
-      .map((line) => line.date)
-      .filter((date): date is string => Boolean(date));
+  rows.forEach((row) => {
+    if (!row.technician_id || !row.date) return;
+    if (!hourlyKeys.has(`${row.technician_id}:${row.date}`)
+      && !seasonalTechnicianIds.has(row.technician_id)) return;
 
-    if (dates.length > 0) {
-      map.set(technicianId, new Set(dates));
-    }
+    const line = buildTimesheetLine(row);
+    const existing = map.get(row.technician_id) || [];
+    existing.push(line);
+    map.set(row.technician_id, existing);
+  });
+
+  map.forEach((lines) => {
+    lines.sort((left, right) => String(left.date ?? '').localeCompare(String(right.date ?? '')));
   });
 
   return map;
+}
+
+export function buildTourTimesheetDateMap(
+  prepTimesheetMap: Map<string, TimesheetLine[]>,
+  hourlyTimesheetMap: Map<string, TimesheetLine[]>,
+): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
+
+  [prepTimesheetMap, hourlyTimesheetMap].forEach((sourceMap) => {
+    sourceMap.forEach((lines, technicianId) => {
+      const dates = lines
+        .map((line) => line.date)
+        .filter((date): date is string => Boolean(date));
+      if (dates.length === 0) return;
+
+      const existing = map.get(technicianId) || new Set<string>();
+      dates.forEach((date) => existing.add(date));
+      map.set(technicianId, existing);
+    });
+  });
+
+  return map;
+}
+
+export function buildPrepTimesheetDateMap(
+  prepTimesheetMap: Map<string, TimesheetLine[]>
+): Map<string, Set<string>> {
+  return buildTourTimesheetDateMap(prepTimesheetMap, new Map());
 }
 
 export async function prepareTourJobEmailContext(
   input: TourJobEmailInput
 ): Promise<TourJobEmailContextResult> {
   const { jobId, supabase, quotes, profiles } = input;
-  const job = await fetchJobDetails(supabase, jobId);
-  const lpoMap = await fetchLpoMap(supabase, jobId);
-  const timesheetRows = await fetchTourJobEmailTimesheets(supabase, jobId);
+  const [job, lpoMap, timesheetRows, hourlyRateModes] = await Promise.all([
+    fetchJobDetails(supabase, jobId),
+    fetchLpoMap(supabase, jobId),
+    fetchTourJobEmailTimesheets(supabase, jobId),
+    fetchTourJobHourlyRateModes(supabase, jobId),
+  ]);
   const prepTimesheetMap = buildPrepTimesheetMap(timesheetRows);
+  const seasonalTechnicianIds = new Set(
+    profiles
+      .filter((profile) => profile.role === 'house_tech' && profile.seasonal_house_tech === true)
+      .map((profile) => profile.id),
+  );
+  const hourlyTimesheetMap = buildHourlyTimesheetMap(
+    timesheetRows,
+    hourlyRateModes,
+    seasonalTechnicianIds,
+  );
 
   // Fetch expenses for tour date jobs
   const expenseMap = new Map<string, number>();
@@ -180,7 +275,7 @@ export async function prepareTourJobEmailContext(
     console.warn('[tour-payout-email] Failed to fetch expenses:', e);
   }
 
-  const timesheetDateMap = buildPrepTimesheetDateMap(prepTimesheetMap);
+  const timesheetDateMap = buildTourTimesheetDateMap(prepTimesheetMap, hourlyTimesheetMap);
 
   const profileMap = new Map(profiles.map((p) => [p.id, p]));
   const attachments: TourJobEmailAttachment[] = [];
@@ -209,6 +304,7 @@ export async function prepareTourJobEmailContext(
           download: false,
           timesheetMap: timesheetDateMap,
           prepTimesheetMap,
+          hourlyTimesheetMap,
         }
       )) as Blob | void;
     } catch (error) {
@@ -255,6 +351,7 @@ export async function prepareTourJobEmailContext(
     lpoMap,
     timesheetDateMap,
     prepTimesheetMap,
+    hourlyTimesheetMap,
     expenseMap,
     attachments,
     missingEmails,

--- a/src/lib/tour-payout-email.ts
+++ b/src/lib/tour-payout-email.ts
@@ -193,6 +193,7 @@ export function buildHourlyTimesheetMap(
 
   rows.forEach((row) => {
     if (!row.technician_id || !row.date) return;
+    if (row.approved_by_manager !== true) return;
     if (!hourlyKeys.has(`${row.technician_id}:${row.date}`)
       && !seasonalTechnicianIds.has(row.technician_id)) return;
 

--- a/src/pages/MorningSummary.tsx
+++ b/src/pages/MorningSummary.tsx
@@ -50,6 +50,7 @@ type MorningSummaryData = {
   travel: string[];
   sick: string[];
   dayOff: string[];
+  seasonal: string[];
   totalTechs: number;
   availableTechs: number;
 };
@@ -123,7 +124,7 @@ export default function MorningSummary() {
 
         // Get all house techs (population)
       const { data: allTechs } = await dataLayerClient.from('profiles')
-        .select('id, first_name, last_name, nickname')
+        .select('id, first_name, last_name, nickname, role, seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date')
         .eq('department', dept)
         .eq('role', 'house_tech')
         .eq('warehouse_duty_exempt', false);
@@ -171,6 +172,33 @@ export default function MorningSummary() {
           // Legacy table may not exist in some environments
         }
 
+        const alreadyUnavailable = new Set(unavailableMerged.map((row) => row.user_id));
+        for (const tech of allTechs || []) {
+          if (
+            tech.seasonal_house_tech === true
+            && (
+              !tech.seasonal_house_tech_start_date
+              || !tech.seasonal_house_tech_end_date
+              || date < tech.seasonal_house_tech_start_date
+              || date > tech.seasonal_house_tech_end_date
+            )
+            && !alreadyUnavailable.has(tech.id)
+          ) {
+            unavailableMerged.push({
+              user_id: tech.id,
+              source: 'seasonal',
+              profile: {
+                first_name: tech.first_name || '',
+                last_name: tech.last_name || '',
+                nickname: tech.nickname,
+                department: dept,
+                role: 'house_tech',
+              },
+            });
+            alreadyUnavailable.add(tech.id);
+          }
+        }
+
         // Process data
         const jobGroups: Record<string, string[]> = {};
         for (const timesheet of timesheetData || []) {
@@ -203,6 +231,7 @@ export default function MorningSummary() {
           travel: bySource.travel || [],
           sick: bySource.sick || [],
           dayOff: bySource.day_off || [],
+          seasonal: bySource.seasonal || [],
           totalTechs: (allTechs || []).length,
           availableTechs: warehouse.length,
         });
@@ -357,6 +386,18 @@ export default function MorningSummary() {
                     </div>
                     <div className="pl-7">
                       <p>{summary.dayOff.join(', ')}</p>
+                    </div>
+                  </div>
+                )}
+
+                {summary.seasonal.length > 0 && (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 font-semibold text-lg">
+                      <Calendar className="h-5 w-5" />
+                      <span>Fuera de temporada</span>
+                    </div>
+                    <div className="pl-7">
+                      <p>{summary.seasonal.join(', ')}</p>
                     </div>
                   </div>
                 )}

--- a/src/pages/MorningSummary.tsx
+++ b/src/pages/MorningSummary.tsx
@@ -8,6 +8,7 @@ import { Loading } from '@/components/ui/loading';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import { formatMadridDateKey } from '@/utils/timezoneUtils';
+import { isWithinSeasonalAvailability } from '@/utils/seasonalHouseTech';
 
 type TimesheetWithRelations = {
   technician_id: string;
@@ -175,13 +176,7 @@ export default function MorningSummary() {
         const alreadyUnavailable = new Set(unavailableMerged.map((row) => row.user_id));
         for (const tech of allTechs || []) {
           if (
-            tech.seasonal_house_tech === true
-            && (
-              !tech.seasonal_house_tech_start_date
-              || !tech.seasonal_house_tech_end_date
-              || date < tech.seasonal_house_tech_start_date
-              || date > tech.seasonal_house_tech_end_date
-            )
+            !isWithinSeasonalAvailability(tech, date)
             && !alreadyUnavailable.has(tech.id)
           ) {
             unavailableMerged.push({

--- a/src/pages/job-assignment-matrix/utils.ts
+++ b/src/pages/job-assignment-matrix/utils.ts
@@ -295,15 +295,20 @@ export async function fetchAvailabilityForWindow(technicianIds: string[], start:
   const startDateKey = toMadridDateKey(start);
   const endDateKey = toMadridDateKey(end);
 
-  const { data: seasonalProfiles, error: seasonalProfilesError } = await dataLayerClient
-    .from("profiles")
-    .select("id, role, seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date")
-    .in("id", technicianIds)
-    .eq("seasonal_house_tech", true);
-  if (seasonalProfilesError) throw seasonalProfilesError;
+  const seasonalProfiles = (
+    await Promise.all(techBatches.map(async (batch) => {
+      const { data, error } = await dataLayerClient
+        .from("profiles")
+        .select("id, role, seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date")
+        .in("id", batch)
+        .eq("seasonal_house_tech", true);
+      if (error) throw error;
+      return (data ?? []) as SeasonalHouseTechProfile[];
+    }))
+  ).flat();
 
   buildSeasonalUnavailability(
-    (seasonalProfiles ?? []) as SeasonalHouseTechProfile[],
+    seasonalProfiles,
     startDateKey,
     endDateKey,
   ).forEach((row) => {

--- a/src/pages/job-assignment-matrix/utils.ts
+++ b/src/pages/job-assignment-matrix/utils.ts
@@ -1,6 +1,7 @@
 import { addDays } from "date-fns";
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { dataLayerClient } from "@/services/dataLayerClient";
+import { buildSeasonalUnavailability, type SeasonalHouseTechProfile } from "@/utils/seasonalHouseTech";
 const MADRID_TIMEZONE = "Europe/Madrid";
 
 function toMadridDateKey(date: Date): string {
@@ -293,6 +294,21 @@ export async function fetchAvailabilityForWindow(technicianIds: string[], start:
   const perDay = new Map<string, { user_id: string; date: string; status: string; notes?: string }>();
   const startDateKey = toMadridDateKey(start);
   const endDateKey = toMadridDateKey(end);
+
+  const { data: seasonalProfiles, error: seasonalProfilesError } = await dataLayerClient
+    .from("profiles")
+    .select("id, role, seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date")
+    .in("id", technicianIds)
+    .eq("seasonal_house_tech", true);
+  if (seasonalProfilesError) throw seasonalProfilesError;
+
+  buildSeasonalUnavailability(
+    (seasonalProfiles ?? []) as SeasonalHouseTechProfile[],
+    startDateKey,
+    endDateKey,
+  ).forEach((row) => {
+    perDay.set(`${row.user_id}-${row.date}`, row);
+  });
 
   for (const batch of techBatches) {
     const { data: schedRows, error: schedErr } = await dataLayerClient.from("availability_schedules")

--- a/src/utils/__tests__/seasonal-house-tech.test.ts
+++ b/src/utils/__tests__/seasonal-house-tech.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildSeasonalUnavailability,
+  isWithinSeasonalAvailability,
+} from '@/utils/seasonalHouseTech';
+
+const seasonalProfile = {
+  id: 'seasonal-1',
+  role: 'house_tech',
+  seasonal_house_tech: true,
+  seasonal_house_tech_start_date: '2026-06-01',
+  seasonal_house_tech_end_date: '2026-08-31',
+};
+
+describe('seasonal house tech availability', () => {
+  it('treats both range endpoints as available', () => {
+    expect(isWithinSeasonalAvailability(seasonalProfile, '2026-06-01')).toBe(true);
+    expect(isWithinSeasonalAvailability(seasonalProfile, '2026-08-31')).toBe(true);
+    expect(isWithinSeasonalAvailability(seasonalProfile, '2026-05-31')).toBe(false);
+    expect(isWithinSeasonalAvailability(seasonalProfile, '2026-09-01')).toBe(false);
+  });
+
+  it('adds matrix unavailability only outside the configured season', () => {
+    expect(buildSeasonalUnavailability(
+      [seasonalProfile],
+      '2026-05-30',
+      '2026-06-02',
+    )).toEqual([
+      {
+        user_id: 'seasonal-1',
+        date: '2026-05-30',
+        status: 'unavailable',
+        notes: 'Fuera de temporada',
+      },
+      {
+        user_id: 'seasonal-1',
+        date: '2026-05-31',
+        status: 'unavailable',
+        notes: 'Fuera de temporada',
+      },
+    ]);
+  });
+
+  it('does not restrict ordinary house techs', () => {
+    expect(isWithinSeasonalAvailability({
+      ...seasonalProfile,
+      seasonal_house_tech: false,
+    }, '2026-01-01')).toBe(true);
+  });
+});

--- a/src/utils/__tests__/seasonal-house-tech.test.ts
+++ b/src/utils/__tests__/seasonal-house-tech.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildSeasonalUnavailability,
+  isSeasonalDateRangeValid,
   isWithinSeasonalAvailability,
 } from '@/utils/seasonalHouseTech';
 
@@ -47,5 +48,20 @@ describe('seasonal house tech availability', () => {
       ...seasonalProfile,
       seasonal_house_tech: false,
     }, '2026-01-01')).toBe(true);
+  });
+
+  it('treats a seasonal profile without a configured range as unavailable', () => {
+    expect(isWithinSeasonalAvailability({
+      ...seasonalProfile,
+      seasonal_house_tech_start_date: null,
+      seasonal_house_tech_end_date: null,
+    }, '2026-07-01')).toBe(false);
+  });
+
+  it('validates complete Madrid date ranges without accepting normalized invalid dates', () => {
+    expect(isSeasonalDateRangeValid('2026-06-01', '2026-08-31')).toBe(true);
+    expect(isSeasonalDateRangeValid('2026-08-31', '2026-06-01')).toBe(false);
+    expect(isSeasonalDateRangeValid('2026-02-31', '2026-08-31')).toBe(false);
+    expect(isSeasonalDateRangeValid('', '2026-08-31')).toBe(false);
   });
 });

--- a/src/utils/pdf/generateJobPayoutPdf.ts
+++ b/src/utils/pdf/generateJobPayoutPdf.ts
@@ -197,8 +197,8 @@ export async function generateJobPayoutPDF(
   });
 
   const anyDeductionApplied = payouts.some(p => {
-      const { autonomo } = getTechName(p.technician_id);
-      return !autonomo;
+      const { autonomo, is_house_tech } = getTechName(p.technician_id);
+      return !autonomo && !is_house_tech;
   });
 
   const anyOverride = payouts.some(p => p.has_override);
@@ -323,7 +323,7 @@ export async function generateJobPayoutPDF(
           ? `${format(new Date(ln.date), 'P', { locale: es })}${ln.is_prep_day ? '\nDía preparación' : ''}`
           : (ln.is_prep_day ? 'Día preparación' : '—'),
         `${ln.hours_rounded ?? 0}h`,
-        ln.is_prep_day
+        ln.is_prep_day && !ln.seasonal_overtime_only
           ? `${formatCurrency(ln.base_day_eur ?? 0)}\n${formatCurrency(ln.prep_day_hourly_rate_eur ?? 15)}/h`
           : formatCurrency(ln.base_day_eur ?? 0),
         ln.plus_10_12_amount_eur ? `${ln.plus_10_12_hours ?? 0}h = ${formatCurrency(ln.plus_10_12_amount_eur)}` : '—',

--- a/src/utils/pdf/generateRateQuotePdf.ts
+++ b/src/utils/pdf/generateRateQuotePdf.ts
@@ -48,6 +48,7 @@ export async function generateRateQuotePDF(
     download?: boolean;
     timesheetMap?: Map<string, Set<string>>;
     prepTimesheetMap?: Map<string, TimesheetLine[]>;
+    hourlyTimesheetMap?: Map<string, TimesheetLine[]>;
   }
 ): Promise<Blob | void> {
   const { jsPDF, autoTable } = await loadPdfLibs();
@@ -88,6 +89,7 @@ export async function generateRateQuotePDF(
 
   const getTechName = getTechNameFactory(profiles);
   const getPrepLines = (technicianId: string) => options?.prepTimesheetMap?.get(technicianId) || [];
+  const getHourlyLines = (technicianId: string) => options?.hourlyTimesheetMap?.get(technicianId) || [];
   const getPrepTotal = (technicianId: string) => (
     getPrepLines(technicianId).reduce((sum, line) => sum + Number(line.total_eur ?? 0), 0)
   );
@@ -111,6 +113,9 @@ export async function generateRateQuotePDF(
     // Manual overrides are applied server-side (see v_tour_job_rate_quotes_2025).
     const effectiveTotal = resolveEffectiveTotal(quote, computed);
     const prepLines = getPrepLines(quote.technician_id);
+    const hourlyLines = getHourlyLines(quote.technician_id);
+    const hourlyDates = new Set(hourlyLines.map((line) => line.date).filter(Boolean));
+    const separatelyDisplayedPrepLines = prepLines.filter((line) => !hourlyDates.has(line.date));
     const prepTotal = getPrepTotal(quote.technician_id);
     const effectiveTotalWithPrep = effectiveTotal + prepTotal;
 
@@ -134,7 +139,7 @@ export async function generateRateQuotePDF(
     // Show autonomo discount from server breakdown if applicable
     let nameCellContent = withLpo(nameWithStatus, lpo);
     const autonomoDiscount = quote.autonomo_discount_eur;
-    if (autonomoDiscount && autonomoDiscount > 0) {
+    if (!is_house_tech && autonomoDiscount && autonomoDiscount > 0) {
       nameCellContent += `\n(Deducción IRPF ya aplicada: -${formatCurrency(autonomoDiscount)})`;
     }
 
@@ -159,14 +164,30 @@ export async function generateRateQuotePDF(
       }
     }
 
-    if (prepLines.length > 0) {
-      const prepSummary = prepLines
+    if (separatelyDisplayedPrepLines.length > 0) {
+      const prepSummary = separatelyDisplayedPrepLines
         .map((line) => {
           const dateLabel = line.date ? format(new Date(line.date), 'P', { locale: es }) : '—';
           return `${dateLabel}: ${line.hours_rounded ?? 0}h = ${formatCurrency(line.total_eur ?? 0)}`;
         })
         .join(' · ');
       nameCellContent += `\nDía(s) preparación: ${prepSummary}`;
+    }
+
+    if (hourlyLines.length > 0) {
+      const hourlySummary = hourlyLines
+        .map((line) => {
+          const dateLabel = line.date ? format(new Date(line.date), 'P', { locale: es }) : '—';
+          const overtimeHours = Number(line.overtime_hours ?? 0);
+          const overtimeRate = Number(line.overtime_hour_eur ?? 0);
+          const overtimeAmount = Number(line.overtime_amount_eur ?? 0);
+          const overtimeText = overtimeHours > 0
+            ? ` · HE ${overtimeHours}h × ${formatCurrency(overtimeRate)} = ${formatCurrency(overtimeAmount)}`
+            : '';
+          return `${dateLabel}: ${line.hours_rounded ?? 0}h · base ${formatCurrency(line.base_day_eur ?? 0)}${overtimeText} · total ${formatCurrency(line.total_eur ?? 0)}`;
+        })
+        .join('\n');
+      nameCellContent += `\nDesglose por horas:\n${hourlySummary}`;
     }
 
     return [
@@ -231,7 +252,10 @@ export async function generateRateQuotePDF(
 
   // Check if any quotes have autonomo discount applied by server
   const anyDeductionApplied = quotesWithComputed.some(({ quote }) => {
-      return quote.autonomo_discount_eur && quote.autonomo_discount_eur > 0;
+      const techInfo = getTechName(quote.technician_id);
+      return !techInfo.is_house_tech
+        && quote.autonomo_discount_eur
+        && quote.autonomo_discount_eur > 0;
   });
 
   // Check if any quotes have manual override

--- a/src/utils/pdf/generateTourRatesSummaryPdf.ts
+++ b/src/utils/pdf/generateTourRatesSummaryPdf.ts
@@ -227,8 +227,13 @@ export async function generateTourRatesSummaryPDF(
         const plus = Number(quote.breakdown?.single_plus_10_12_total_eur ?? 0);
         const otH = Number(quote.breakdown?.single_overtime_hours_total ?? 0);
         const otAmt = Number(quote.breakdown?.single_overtime_amount_total_eur ?? 0);
+        const isHourly = Number(quote.breakdown?.hourly_days ?? 0) > 0 || quote.category === 'hourly';
         const parts: string[] = [];
-        if (hrs > 0) parts.push(`Horas: ${hrs}h`);
+        if (isHourly) {
+          parts.push(`Por horas: ${hrs}h`);
+        } else if (hrs > 0) {
+          parts.push(`Horas: ${hrs}h`);
+        }
         if (plus > 0) parts.push(`+10–12: ${formatCurrency(plus)}`);
         if (otH > 0) parts.push(`HE: ${otH}h = ${formatCurrency(otAmt)}`);
         if (parts.length) {

--- a/src/utils/pdf/ratesPdfSupport.ts
+++ b/src/utils/pdf/ratesPdfSupport.ts
@@ -23,6 +23,7 @@ export interface TechnicianProfile {
   role?: string | null;
   autonomo?: boolean | null;
   is_house_tech?: boolean | null;
+  seasonal_house_tech?: boolean | null;
 }
 
 export interface JobDetails {
@@ -88,6 +89,8 @@ export interface TimesheetLine {
   total_eur?: number;
   is_evento?: boolean;
   is_prep_day?: boolean;
+  is_seasonal_house_tech?: boolean;
+  seasonal_overtime_only?: boolean;
   prep_day_hourly_rate_eur?: number;
 }
 
@@ -106,7 +109,7 @@ export const getTechNameFactory = (profiles: TechnicianProfile[]) => {
       return { name: 'Unknown', profile: undefined, autonomo: true, is_house_tech: false };
     }
     const name = `${profile.first_name ?? ''} ${profile.last_name ?? ''}`.trim() || 'Unknown';
-    const is_house_tech = profile.is_house_tech === true;
+    const is_house_tech = profile.is_house_tech === true || profile.role === 'house_tech';
     // autonomo field reflects profile setting - deduction logic handles house techs separately
     const autonomo = profile.autonomo !== false;
     return { name, profile, autonomo, is_house_tech };

--- a/src/utils/seasonalHouseTech.ts
+++ b/src/utils/seasonalHouseTech.ts
@@ -1,0 +1,63 @@
+export interface SeasonalHouseTechProfile {
+  id: string;
+  role?: string | null;
+  seasonal_house_tech?: boolean | null;
+  seasonal_house_tech_start_date?: string | null;
+  seasonal_house_tech_end_date?: string | null;
+}
+
+export interface SeasonalUnavailabilityDay {
+  user_id: string;
+  date: string;
+  status: 'unavailable';
+  notes: string;
+}
+
+export const isSeasonalHouseTech = (profile: SeasonalHouseTechProfile): boolean =>
+  profile.role === 'house_tech' && profile.seasonal_house_tech === true;
+
+export const isWithinSeasonalAvailability = (
+  profile: SeasonalHouseTechProfile,
+  dateKey: string,
+): boolean => {
+  if (!isSeasonalHouseTech(profile)) return true;
+
+  const startDate = profile.seasonal_house_tech_start_date;
+  const endDate = profile.seasonal_house_tech_end_date;
+  return Boolean(startDate && endDate && dateKey >= startDate && dateKey <= endDate);
+};
+
+const nextDateKey = (dateKey: string): string => {
+  const date = new Date(`${dateKey}T12:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString().slice(0, 10);
+};
+
+export const buildSeasonalUnavailability = (
+  profiles: SeasonalHouseTechProfile[],
+  startDateKey: string,
+  endDateKey: string,
+): SeasonalUnavailabilityDay[] => {
+  if (!startDateKey || !endDateKey || startDateKey > endDateKey) return [];
+
+  const unavailable: SeasonalUnavailabilityDay[] = [];
+  for (const profile of profiles.filter(isSeasonalHouseTech)) {
+    let dateKey = startDateKey;
+    while (dateKey <= endDateKey) {
+      if (!isWithinSeasonalAvailability(profile, dateKey)) {
+        unavailable.push({
+          user_id: profile.id,
+          date: dateKey,
+          status: 'unavailable',
+          notes: 'Fuera de temporada',
+        });
+      }
+
+      const next = nextDateKey(dateKey);
+      if (next === dateKey) break;
+      dateKey = next;
+    }
+  }
+
+  return unavailable;
+};

--- a/src/utils/seasonalHouseTech.ts
+++ b/src/utils/seasonalHouseTech.ts
@@ -1,3 +1,8 @@
+import { addDays, isAfter, isValid } from 'date-fns';
+import { formatInTimeZone, fromZonedTime } from 'date-fns-tz';
+
+const MADRID_TIMEZONE = 'Europe/Madrid';
+
 export interface SeasonalHouseTechProfile {
   id: string;
   role?: string | null;
@@ -27,10 +32,28 @@ export const isWithinSeasonalAvailability = (
   return Boolean(startDate && endDate && dateKey >= startDate && dateKey <= endDate);
 };
 
+const parseMadridDateKey = (dateKey: string): Date =>
+  fromZonedTime(`${dateKey}T12:00:00`, MADRID_TIMEZONE);
+
+const isValidMadridDateKey = (dateKey: string, date: Date): boolean =>
+  /^\d{4}-\d{2}-\d{2}$/.test(dateKey)
+  && isValid(date)
+  && formatInTimeZone(date, MADRID_TIMEZONE, 'yyyy-MM-dd') === dateKey;
+
+export const isSeasonalDateRangeValid = (startDateKey: string, endDateKey: string): boolean => {
+  if (!startDateKey || !endDateKey) return false;
+
+  const startDate = parseMadridDateKey(startDateKey);
+  const endDate = parseMadridDateKey(endDateKey);
+  return isValidMadridDateKey(startDateKey, startDate)
+    && isValidMadridDateKey(endDateKey, endDate)
+    && !isAfter(startDate, endDate);
+};
+
 const nextDateKey = (dateKey: string): string => {
-  const date = new Date(`${dateKey}T12:00:00Z`);
-  date.setUTCDate(date.getUTCDate() + 1);
-  return date.toISOString().slice(0, 10);
+  const madridNoonUtc = parseMadridDateKey(dateKey);
+  if (!isValid(madridNoonUtc)) return dateKey;
+  return formatInTimeZone(addDays(madridNoonUtc, 1), MADRID_TIMEZONE, 'yyyy-MM-dd');
 };
 
 export const buildSeasonalUnavailability = (

--- a/src/utils/technicianAvailability.ts
+++ b/src/utils/technicianAvailability.ts
@@ -6,6 +6,7 @@ import {
   getDateKeyRange,
   normalizeDateKey,
 } from "@/utils/assignmentWorkDates";
+import { isWithinSeasonalAvailability } from "@/utils/seasonalHouseTech";
 
 export interface TechnicianJobConflict {
   id: string;
@@ -77,6 +78,9 @@ type TechnicianProfile = {
   dni?: string | null;
   bg_color?: string | null;
   profile_picture_url?: string | null;
+  seasonal_house_tech?: boolean | null;
+  seasonal_house_tech_start_date?: string | null;
+  seasonal_house_tech_end_date?: string | null;
   skills?: unknown;
 };
 
@@ -177,6 +181,10 @@ export async function getAvailableTechnicians(
 
     // Filter out technicians who have conflicts
     const availableTechnicians = eligibleTechnicians.filter((technician) => {
+      if (jobDateKeys.some((dateKey) => !isWithinSeasonalAvailability(technician, dateKey))) {
+        return false;
+      }
+
       // Check if already assigned to current job
       const assignedJobs = technicianJobs.get(technician.id);
       if (assignedJobs?.has(jobId)) {

--- a/supabase/migrations/20260730120000_add_seasonal_house_tech_finance.sql
+++ b/supabase/migrations/20260730120000_add_seasonal_house_tech_finance.sql
@@ -41,9 +41,15 @@ ALTER TABLE public.profiles
       AND seasonal_house_tech_end_date IS NOT NULL
       AND seasonal_house_tech_start_date <= seasonal_house_tech_end_date
     )
-  ),
+  ) NOT VALID,
   ADD CONSTRAINT profiles_house_tech_autonomo_ignored_check
-  CHECK (role <> 'house_tech' OR autonomo IS DISTINCT FROM false);
+  CHECK (role <> 'house_tech' OR autonomo IS DISTINCT FROM false) NOT VALID;
+
+ALTER TABLE public.profiles
+  VALIDATE CONSTRAINT profiles_seasonal_house_tech_range_check;
+
+ALTER TABLE public.profiles
+  VALIDATE CONSTRAINT profiles_house_tech_autonomo_ignored_check;
 
 CREATE OR REPLACE FUNCTION public.normalize_house_tech_finance_profile()
 RETURNS trigger
@@ -76,10 +82,24 @@ AS $$
 DECLARE
   v_actor uuid := auth.uid();
   v_actor_role text;
+  v_target_id uuid := NEW.id;
+  v_old_seasonal_house_tech boolean := false;
+  v_old_start_date date;
+  v_old_end_date date;
 BEGIN
-  IF OLD.seasonal_house_tech IS NOT DISTINCT FROM NEW.seasonal_house_tech
-     AND OLD.seasonal_house_tech_start_date IS NOT DISTINCT FROM NEW.seasonal_house_tech_start_date
-     AND OLD.seasonal_house_tech_end_date IS NOT DISTINCT FROM NEW.seasonal_house_tech_end_date THEN
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.seasonal_house_tech IS NOT DISTINCT FROM NEW.seasonal_house_tech
+       AND OLD.seasonal_house_tech_start_date IS NOT DISTINCT FROM NEW.seasonal_house_tech_start_date
+       AND OLD.seasonal_house_tech_end_date IS NOT DISTINCT FROM NEW.seasonal_house_tech_end_date THEN
+      RETURN NEW;
+    END IF;
+
+    v_old_seasonal_house_tech := OLD.seasonal_house_tech;
+    v_old_start_date := OLD.seasonal_house_tech_start_date;
+    v_old_end_date := OLD.seasonal_house_tech_end_date;
+  ELSIF NEW.seasonal_house_tech = false
+        AND NEW.seasonal_house_tech_start_date IS NULL
+        AND NEW.seasonal_house_tech_end_date IS NULL THEN
     RETURN NEW;
   END IF;
 
@@ -96,8 +116,8 @@ BEGIN
   FROM public.profiles p
   WHERE p.id = v_actor;
 
-  IF v_actor = OLD.id THEN
-    RAISE EXCEPTION 'Seasonal house tech settings cannot be changed on your own account'
+  IF v_actor = v_target_id THEN
+    RAISE EXCEPTION 'Seasonal house tech settings cannot be set or changed on your own account'
       USING ERRCODE = '42501';
   END IF;
 
@@ -115,7 +135,7 @@ BEGIN
   ) VALUES (
     v_actor,
     'profile_privilege_change',
-    'profile:' || OLD.id::text,
+    'profile:' || v_target_id::text,
     'high',
     jsonb_build_object(
       'changed_fields', jsonb_build_array(
@@ -124,11 +144,11 @@ BEGIN
         'seasonal_house_tech_end_date'
       ),
       'actor_role', v_actor_role,
-      'old_seasonal_house_tech', OLD.seasonal_house_tech,
+      'old_seasonal_house_tech', v_old_seasonal_house_tech,
       'new_seasonal_house_tech', NEW.seasonal_house_tech,
-      'old_start_date', OLD.seasonal_house_tech_start_date,
+      'old_start_date', v_old_start_date,
       'new_start_date', NEW.seasonal_house_tech_start_date,
-      'old_end_date', OLD.seasonal_house_tech_end_date,
+      'old_end_date', v_old_end_date,
       'new_end_date', NEW.seasonal_house_tech_end_date
     )
   );
@@ -146,6 +166,12 @@ DROP TRIGGER IF EXISTS enforce_seasonal_house_tech_change ON public.profiles;
 CREATE TRIGGER enforce_seasonal_house_tech_change
 BEFORE UPDATE OF seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date
 ON public.profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_seasonal_house_tech_change();
+
+DROP TRIGGER IF EXISTS enforce_seasonal_house_tech_insert ON public.profiles;
+CREATE TRIGGER enforce_seasonal_house_tech_insert
+BEFORE INSERT ON public.profiles
 FOR EACH ROW
 EXECUTE FUNCTION public.enforce_seasonal_house_tech_change();
 
@@ -857,9 +883,8 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.trg_apply_prep_day_rate() FROM PUBLIC;
 
--- Profile finance-mode changes must also refresh already-created timesheets.
--- Without this, enabling seasonal mode could leave historical base/plus amounts
--- stored on active timesheets until somebody edited each timesheet manually.
+-- Profile finance-mode changes must refresh open timesheets that can still affect
+-- payroll. Manager-approved payouts are treated as immutable historical records.
 CREATE OR REPLACE FUNCTION public.recompute_timesheets_after_profile_finance_change()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -874,6 +899,7 @@ BEGIN
     FROM public.timesheets t
     WHERE t.technician_id = NEW.id
       AND t.is_active = true
+      AND t.approved_by_manager IS DISTINCT FROM true
       AND t.start_time IS NOT NULL
       AND t.end_time IS NOT NULL
   LOOP

--- a/supabase/migrations/20260730120000_add_seasonal_house_tech_finance.sql
+++ b/supabase/migrations/20260730120000_add_seasonal_house_tech_finance.sql
@@ -1,0 +1,2353 @@
+-- Seasonal house tech payroll and availability.
+--
+-- The profile checkbox controls payroll on every job. The inclusive date range
+-- controls scheduling availability; it does not silently change the pay rule.
+
+ALTER TABLE public.profiles
+  ADD COLUMN seasonal_house_tech boolean NOT NULL DEFAULT false,
+  ADD COLUMN seasonal_house_tech_start_date date,
+  ADD COLUMN seasonal_house_tech_end_date date;
+
+COMMENT ON COLUMN public.profiles.seasonal_house_tech IS
+  'Admin-controlled house-tech profile mode: no base/plus; only overtime above 12 rounded hours.';
+COMMENT ON COLUMN public.profiles.seasonal_house_tech_start_date IS
+  'Inclusive first date on which a seasonal house tech is available for staffing.';
+COMMENT ON COLUMN public.profiles.seasonal_house_tech_end_date IS
+  'Inclusive last date on which a seasonal house tech is available for staffing.';
+
+ALTER TABLE public.profiles
+  DISABLE TRIGGER enforce_profile_privilege_changes;
+
+UPDATE public.profiles
+SET autonomo = true
+WHERE role = 'house_tech'
+  AND autonomo IS DISTINCT FROM true;
+
+ALTER TABLE public.profiles
+  ENABLE TRIGGER enforce_profile_privilege_changes;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT profiles_seasonal_house_tech_range_check
+  CHECK (
+    (
+      seasonal_house_tech = false
+      AND seasonal_house_tech_start_date IS NULL
+      AND seasonal_house_tech_end_date IS NULL
+    )
+    OR (
+      seasonal_house_tech = true
+      AND role = 'house_tech'
+      AND seasonal_house_tech_start_date IS NOT NULL
+      AND seasonal_house_tech_end_date IS NOT NULL
+      AND seasonal_house_tech_start_date <= seasonal_house_tech_end_date
+    )
+  ),
+  ADD CONSTRAINT profiles_house_tech_autonomo_ignored_check
+  CHECK (role <> 'house_tech' OR autonomo IS DISTINCT FROM false);
+
+CREATE OR REPLACE FUNCTION public.normalize_house_tech_finance_profile()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF NEW.role = 'house_tech' THEN
+    NEW.autonomo := true;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.normalize_house_tech_finance_profile()
+  FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS normalize_house_tech_finance_profile ON public.profiles;
+CREATE TRIGGER normalize_house_tech_finance_profile
+BEFORE INSERT OR UPDATE OF role, autonomo ON public.profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.normalize_house_tech_finance_profile();
+
+CREATE OR REPLACE FUNCTION public.enforce_seasonal_house_tech_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_actor uuid := auth.uid();
+  v_actor_role text;
+BEGIN
+  IF OLD.seasonal_house_tech IS NOT DISTINCT FROM NEW.seasonal_house_tech
+     AND OLD.seasonal_house_tech_start_date IS NOT DISTINCT FROM NEW.seasonal_house_tech_start_date
+     AND OLD.seasonal_house_tech_end_date IS NOT DISTINCT FROM NEW.seasonal_house_tech_end_date THEN
+    RETURN NEW;
+  END IF;
+
+  IF auth.role() = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  IF v_actor IS NULL THEN
+    RAISE EXCEPTION 'Authentication required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT p.role::text INTO v_actor_role
+  FROM public.profiles p
+  WHERE p.id = v_actor;
+
+  IF v_actor = OLD.id THEN
+    RAISE EXCEPTION 'Seasonal house tech settings cannot be changed on your own account'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_actor_role IS DISTINCT FROM 'admin' THEN
+    RAISE EXCEPTION 'Only administrators may change seasonal house tech settings'
+      USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.security_audit_log (
+    user_id,
+    action,
+    resource,
+    severity,
+    metadata
+  ) VALUES (
+    v_actor,
+    'profile_privilege_change',
+    'profile:' || OLD.id::text,
+    'high',
+    jsonb_build_object(
+      'changed_fields', jsonb_build_array(
+        'seasonal_house_tech',
+        'seasonal_house_tech_start_date',
+        'seasonal_house_tech_end_date'
+      ),
+      'actor_role', v_actor_role,
+      'old_seasonal_house_tech', OLD.seasonal_house_tech,
+      'new_seasonal_house_tech', NEW.seasonal_house_tech,
+      'old_start_date', OLD.seasonal_house_tech_start_date,
+      'new_start_date', NEW.seasonal_house_tech_start_date,
+      'old_end_date', OLD.seasonal_house_tech_end_date,
+      'new_end_date', NEW.seasonal_house_tech_end_date
+    )
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enforce_seasonal_house_tech_change()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enforce_seasonal_house_tech_change()
+  TO service_role;
+
+DROP TRIGGER IF EXISTS enforce_seasonal_house_tech_change ON public.profiles;
+CREATE TRIGGER enforce_seasonal_house_tech_change
+BEFORE UPDATE OF seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date
+ON public.profiles
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_seasonal_house_tech_change();
+
+DROP FUNCTION public.get_profiles_with_skills();
+
+CREATE FUNCTION public.get_profiles_with_skills()
+RETURNS TABLE(
+  id text,
+  first_name text,
+  last_name text,
+  nickname text,
+  email text,
+  phone text,
+  dni text,
+  department text,
+  role text,
+  bg_color text,
+  assignable_as_tech boolean,
+  skills json,
+  profile_picture_url text,
+  seasonal_house_tech boolean,
+  seasonal_house_tech_start_date date,
+  seasonal_house_tech_end_date date
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.id::text,
+    p.first_name::text,
+    p.last_name::text,
+    p.nickname::text,
+    p.email::text,
+    COALESCE(p.phone, '')::text,
+    COALESCE(p.dni, '')::text,
+    COALESCE(p.department, '')::text,
+    p.role::text,
+    p.bg_color::text,
+    p.assignable_as_tech,
+    COALESCE(
+      (
+        SELECT json_agg(
+          json_build_object(
+            'id', s.id,
+            'name', s.name,
+            'category', s.category,
+            'proficiency', ps.proficiency,
+            'is_primary', ps.is_primary,
+            'notes', ps.notes
+          )
+          ORDER BY ps.is_primary DESC, ps.proficiency DESC NULLS LAST, s.name
+        )
+        FROM public.profile_skills ps
+        INNER JOIN public.skills s ON s.id = ps.skill_id
+        WHERE ps.profile_id = p.id
+          AND s.active = true
+      ),
+      '[]'::json
+    ),
+    p.profile_picture_url::text,
+    p.seasonal_house_tech,
+    p.seasonal_house_tech_start_date,
+    p.seasonal_house_tech_end_date
+  FROM public.profiles p
+  ORDER BY p.department, p.last_name, p.first_name;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_profiles_with_skills() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_profiles_with_skills() TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.get_hourly_rate_mode_dates_for_timesheets(
+  _job_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  job_id uuid,
+  technician_id uuid,
+  date date
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    override_row.job_id,
+    override_row.technician_id,
+    override_row.date
+  FROM public.job_technician_rate_mode_dates AS override_row
+  WHERE override_row.rate_mode = 'hourly'
+    AND (_job_ids IS NULL OR override_row.job_id = ANY(_job_ids))
+    AND (
+      public.is_admin_or_management()
+      OR override_row.technician_id = (SELECT auth.uid())
+    )
+  UNION
+  SELECT
+    timesheet.job_id,
+    timesheet.technician_id,
+    timesheet.date
+  FROM public.timesheets AS timesheet
+  JOIN public.jobs AS job ON job.id = timesheet.job_id
+  JOIN public.profiles AS profile ON profile.id = timesheet.technician_id
+  WHERE job.job_type = 'tourdate'
+    AND timesheet.is_active = true
+    AND profile.role = 'house_tech'
+    AND profile.seasonal_house_tech = true
+    AND (_job_ids IS NULL OR timesheet.job_id = ANY(_job_ids))
+    AND (
+      public.is_admin_or_management()
+      OR timesheet.technician_id = (SELECT auth.uid())
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.get_hourly_rate_mode_dates_for_timesheets(uuid[])
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_hourly_rate_mode_dates_for_timesheets(uuid[])
+  TO authenticated, service_role;
+
+
+-- Canonical standard-job/timesheet pricing with seasonal overtime-only mode.
+CREATE OR REPLACE FUNCTION public.compute_timesheet_amount_2025(
+  _timesheet_id uuid,
+  _persist boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_timesheet RECORD;
+  v_job_type TEXT;
+  v_category TEXT;
+  v_rate_card RECORD;
+  v_worked_hours NUMERIC;
+  v_raw_worked_hours NUMERIC;
+  v_billable_hours NUMERIC;
+  v_base_day_amount NUMERIC := 0;
+  v_plus_10_12_hours NUMERIC := 0;
+  v_plus_10_12_amount NUMERIC := 0;
+  v_overtime_hours NUMERIC := 0;
+  v_overtime_amount NUMERIC := 0;
+  v_total_amount NUMERIC := 0;
+  v_breakdown JSONB;
+  v_result JSONB;
+  v_is_rehearsal BOOLEAN := FALSE;
+  v_is_extended_shift BOOLEAN := FALSE;
+  v_rehearsal_flat_rate NUMERIC := NULL;
+  v_is_autonomo BOOLEAN := TRUE;
+  v_is_house_tech BOOLEAN := FALSE;
+  v_is_seasonal_house_tech BOOLEAN := FALSE;
+  v_is_reduced_rehearsal BOOLEAN := FALSE;
+  v_autonomo_discount NUMERIC := 0;
+  v_forced_rehearsal BOOLEAN := FALSE;
+  v_technician_rate_mode_override BOOLEAN := NULL;
+  v_has_technician_rate_mode_override BOOLEAN := FALSE;
+  v_rate_mode_source TEXT := 'standard';
+  v_rate_mode TEXT := NULL;
+  v_fixed_amount NUMERIC := NULL;
+BEGIN
+  -- Fetch timesheet with job info, category, autonomo status, and role-based flags
+  SELECT
+    t.*,
+    j.job_type,
+    CASE WHEN p.role = 'technician' THEN COALESCE(p.autonomo, true) ELSE true END as is_autonomo,
+    COALESCE(p.role = 'house_tech', false) as is_house_tech,
+    COALESCE(p.role = 'house_tech' AND p.seasonal_house_tech, false) as is_seasonal_house_tech,
+    COALESCE(p.role IN ('house_tech', 'admin', 'management'), false) as is_reduced_rehearsal,
+    COALESCE(
+      t.category,
+      CASE
+        WHEN a.sound_role LIKE '%-R' OR a.lights_role LIKE '%-R' OR a.video_role LIKE '%-R' THEN 'responsable'
+        WHEN a.sound_role LIKE '%-E' OR a.lights_role LIKE '%-E' OR a.video_role LIKE '%-E' THEN 'especialista'
+        WHEN a.sound_role LIKE '%-T' OR a.lights_role LIKE '%-T' OR a.video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END,
+      'tecnico'
+    ) as category
+  INTO v_timesheet
+  FROM public.timesheets t
+  LEFT JOIN public.jobs j ON t.job_id = j.id
+  LEFT JOIN public.job_assignments a ON t.job_id = a.job_id AND t.technician_id = a.technician_id
+  LEFT JOIN public.profiles p ON t.technician_id = p.id
+  WHERE t.id = _timesheet_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Timesheet not found: %', _timesheet_id;
+  END IF;
+
+  IF NOT (
+    auth.role() = 'service_role'
+    OR public.is_admin_or_management()
+    OR auth.uid() = v_timesheet.technician_id
+  ) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  v_job_type := v_timesheet.job_type;
+  v_category := v_timesheet.category;
+
+  -- Rehearsal/fixed pricing uses technician/date overrides first, then the
+  -- job-wide rehearsal toggle table.
+  IF v_timesheet.date IS NOT NULL AND v_timesheet.job_id IS NOT NULL THEN
+    SELECT trmd.use_rehearsal_rate, trmd.rate_mode, trmd.fixed_amount_eur
+    INTO v_technician_rate_mode_override, v_rate_mode, v_fixed_amount
+    FROM public.job_technician_rate_mode_dates trmd
+    WHERE trmd.job_id = v_timesheet.job_id
+      AND trmd.technician_id = v_timesheet.technician_id
+      AND trmd.date = v_timesheet.date;
+
+    IF FOUND THEN
+      v_has_technician_rate_mode_override := TRUE;
+      v_rate_mode := COALESCE(
+        v_rate_mode,
+        CASE WHEN COALESCE(v_technician_rate_mode_override, FALSE) THEN 'rehearsal' ELSE 'standard' END
+      );
+      v_forced_rehearsal := v_rate_mode = 'rehearsal';
+      v_rate_mode_source := 'technician_override';
+    ELSE
+      SELECT EXISTS (
+        SELECT 1 FROM public.job_rehearsal_dates
+        WHERE job_id = v_timesheet.job_id AND date = v_timesheet.date
+      ) INTO v_forced_rehearsal;
+
+      v_rate_mode_source := CASE
+        WHEN v_forced_rehearsal THEN 'job_rehearsal_date'
+        ELSE 'standard'
+      END;
+    END IF;
+  END IF;
+
+  v_is_rehearsal := v_forced_rehearsal;
+
+  -- Get autonomo / house_tech / reduced rehearsal status from the main query
+  v_is_autonomo := v_timesheet.is_autonomo;
+  v_is_house_tech := v_timesheet.is_house_tech;
+  v_is_seasonal_house_tech := v_timesheet.is_seasonal_house_tech;
+
+  -- Seasonal house techs always use overtime-only hourly pricing. This profile
+  -- rule intentionally takes precedence over per-date fixed/rehearsal modes.
+  IF v_is_seasonal_house_tech THEN
+    v_is_rehearsal := FALSE;
+    v_forced_rehearsal := FALSE;
+    v_rate_mode := 'hourly';
+    v_fixed_amount := NULL;
+    v_rate_mode_source := 'seasonal_house_tech_profile';
+  END IF;
+  v_is_reduced_rehearsal := v_timesheet.is_reduced_rehearsal;
+
+  -- Calculate worked hours once for both rehearsal and standard paths
+  IF v_timesheet.end_time < v_timesheet.start_time OR COALESCE(v_timesheet.ends_next_day, false) THEN
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      v_timesheet.end_time - v_timesheet.start_time + INTERVAL '24 hours'
+    )) / 3600.0 - (COALESCE(v_timesheet.break_minutes, 0) / 60.0);
+  ELSE
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      v_timesheet.end_time - v_timesheet.start_time
+    )) / 3600.0 - (COALESCE(v_timesheet.break_minutes, 0) / 60.0);
+  END IF;
+  -- Preserve raw fractional hours for audit trail, then round to nearest whole hour
+  -- IMPORTANT: Do NOT change this to half-hour rounding (ROUND(x*2)/2). See PR #467.
+  v_raw_worked_hours := v_worked_hours;
+  v_worked_hours := ROUND(v_worked_hours);
+
+  -- Fixed-amount override short-circuits both rehearsal and standard pricing.
+  IF v_rate_mode = 'fixed' AND NOT v_is_seasonal_house_tech THEN
+    IF v_fixed_amount IS NULL OR v_fixed_amount < 0 THEN
+      RAISE EXCEPTION 'Invalid fixed amount for timesheet %', _timesheet_id;
+    END IF;
+
+    v_total_amount := v_fixed_amount;
+    v_billable_hours := v_worked_hours;
+
+    v_breakdown := jsonb_build_object(
+      'worked_hours', v_raw_worked_hours,
+      'worked_hours_rounded', v_worked_hours,
+      'hours_rounded', v_worked_hours,
+      'billable_hours', v_billable_hours,
+      'is_fixed_amount', true,
+      'fixed_amount_eur', v_total_amount,
+      'base_amount_eur', v_total_amount,
+      'base_day_eur', v_total_amount,
+      'plus_10_12_hours', 0,
+      'plus_10_12_eur', 0,
+      'plus_10_12_amount_eur', 0,
+      'overtime_hours', 0,
+      'overtime_hour_eur', 0,
+      'overtime_amount_eur', 0,
+      'total_eur', v_total_amount,
+      'category', v_category,
+      'forced_rehearsal_rate', false,
+      'rate_mode_source', 'technician_override',
+      'has_technician_rate_mode_override', true,
+      'technician_rate_mode', 'fixed'
+    );
+
+    v_result := jsonb_build_object(
+      'timesheet_id', _timesheet_id,
+      'amount_eur', v_total_amount,
+      'amount_breakdown', v_breakdown
+    );
+
+    IF _persist THEN
+      UPDATE public.timesheets
+      SET
+        amount_eur = v_total_amount,
+        amount_breakdown = v_breakdown,
+        category = v_category,
+        updated_at = NOW()
+      WHERE id = _timesheet_id;
+    END IF;
+
+    RETURN v_result;
+  END IF;
+
+  -- Handle rehearsal flat rate
+  IF v_is_rehearsal AND NOT v_is_seasonal_house_tech THEN
+    -- Check for custom rehearsal rate first
+    SELECT rehearsal_day_eur INTO v_rehearsal_flat_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = v_timesheet.technician_id;
+
+    -- If no custom rate, use role-based defaults:
+    -- house_tech / admin / management -> EUR 60, regular technicians -> EUR 180
+    IF v_rehearsal_flat_rate IS NULL THEN
+      IF v_is_reduced_rehearsal THEN
+        v_rehearsal_flat_rate := 60.00;
+      ELSE
+        v_rehearsal_flat_rate := 180.00;
+      END IF;
+    END IF;
+
+    -- Apply discount for non-autonomo regular technicians only.
+    -- House techs, admin, and management are exempt from the autonomo discount.
+    IF NOT v_is_autonomo AND NOT v_is_reduced_rehearsal THEN
+      v_autonomo_discount := 30.00;
+      v_rehearsal_flat_rate := v_rehearsal_flat_rate - v_autonomo_discount;
+    END IF;
+
+    v_total_amount := v_rehearsal_flat_rate;
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rehearsal_flat_rate;
+
+    v_breakdown := jsonb_build_object(
+      'worked_hours', v_raw_worked_hours,
+      'worked_hours_rounded', v_worked_hours,
+      'hours_rounded', v_worked_hours,
+      'billable_hours', v_billable_hours,
+      'is_rehearsal', true,
+      'is_rehearsal_flat_rate', true,
+      'rehearsal_rate_eur', v_rehearsal_flat_rate,
+      'autonomo_discount_eur', v_autonomo_discount,
+      'base_day_before_discount_eur', CASE WHEN v_autonomo_discount > 0 THEN v_rehearsal_flat_rate + v_autonomo_discount ELSE v_rehearsal_flat_rate END,
+      'base_amount_eur', v_rehearsal_flat_rate,
+      'base_day_eur', v_rehearsal_flat_rate,
+      'plus_10_12_hours', 0,
+      'plus_10_12_eur', 0,
+      'plus_10_12_amount_eur', 0,
+      'overtime_hours', 0,
+      'overtime_hour_eur', 0,
+      'overtime_amount_eur', 0,
+      'total_eur', v_total_amount,
+      'category', 'rehearsal',
+      'forced_rehearsal_rate', v_forced_rehearsal,
+      'rate_mode_source', v_rate_mode_source,
+      'has_technician_rate_mode_override', v_has_technician_rate_mode_override,
+      'technician_rate_mode_override_rehearsal', v_technician_rate_mode_override,
+      'technician_rate_mode', CASE WHEN v_is_seasonal_house_tech THEN 'hourly' ELSE v_rate_mode END
+    );
+
+    v_result := jsonb_build_object(
+      'timesheet_id', _timesheet_id,
+      'amount_eur', v_total_amount,
+      'amount_breakdown', v_breakdown
+    );
+
+    IF _persist THEN
+      UPDATE public.timesheets
+      SET
+        amount_eur = v_total_amount,
+        amount_breakdown = v_breakdown,
+        category = v_category,
+        updated_at = NOW()
+      WHERE id = _timesheet_id;
+    END IF;
+
+    RETURN v_result;
+  END IF;
+
+  -- Standard rate card lookup (non-rehearsal).
+  -- House-tech OT is category-aware; non-house roles preserve legacy behavior.
+  SELECT
+    COALESCE(
+      CASE
+        WHEN v_category = 'responsable' THEN COALESCE(ctr.base_day_responsable_eur, ctr.base_day_especialista_eur, ctr.base_day_eur)
+        WHEN v_category = 'especialista' THEN COALESCE(ctr.base_day_especialista_eur, ctr.base_day_eur)
+        ELSE ctr.base_day_eur
+      END,
+      (SELECT rc.base_day_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)
+    ) AS base_day_eur,
+    COALESCE(ctr.plus_10_12_eur, (SELECT rc.plus_10_12_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)) as plus_10_12_eur,
+    COALESCE(
+      CASE
+        WHEN v_is_house_tech AND v_category = 'tecnico' THEN ctr.overtime_hour_eur
+        WHEN v_is_house_tech AND v_category = 'especialista' THEN COALESCE(ctr.overtime_hour_especialista_eur, ctr.overtime_hour_eur)
+        WHEN v_is_house_tech AND v_category = 'responsable' THEN COALESCE(
+          ctr.overtime_hour_responsable_eur,
+          CASE WHEN ctr.overtime_hour_eur = 15.00 THEN 20.00 END,
+          ctr.overtime_hour_eur
+        )
+        ELSE ctr.overtime_hour_eur
+      END,
+      (SELECT rc.overtime_hour_eur FROM public.rate_cards_2025 rc WHERE rc.category = v_category)
+    ) as overtime_hour_eur
+  INTO v_rate_card
+  FROM public.custom_tech_rates ctr
+  WHERE ctr.profile_id = v_timesheet.technician_id;
+
+  IF NOT FOUND THEN
+    SELECT * INTO v_rate_card
+    FROM public.rate_cards_2025
+    WHERE category = v_category;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Rate card not found for category: %', v_category;
+    END IF;
+  END IF;
+
+  -- Seasonal house techs earn only category-aware overtime above 12 rounded hours.
+  IF v_is_seasonal_house_tech THEN
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := 0;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := 0;
+    v_overtime_hours := GREATEST(v_worked_hours - 12, 0);
+    v_overtime_amount := v_rate_card.overtime_hour_eur * v_overtime_hours;
+    v_total_amount := v_overtime_amount;
+  -- Handle evento jobs (fixed 12-hour rate)
+  ELSIF v_job_type = 'evento' THEN
+    v_billable_hours := 12.0;
+    v_base_day_amount := v_rate_card.base_day_eur;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+    v_overtime_hours := 0;
+    v_overtime_amount := 0;
+    v_total_amount := v_base_day_amount + v_plus_10_12_amount;
+  -- Handle extended shifts (21+ hours / over 20.5 hrs): double base rate only
+  ELSIF v_worked_hours > 20.5 THEN
+    v_is_extended_shift := TRUE;
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rate_card.base_day_eur * 2;
+    v_plus_10_12_hours := 0;
+    v_plus_10_12_amount := 0;
+    v_overtime_hours := 0;
+    v_overtime_amount := 0;
+    v_total_amount := v_base_day_amount;
+  ELSE
+    -- Standard rate calculation tiers
+    v_billable_hours := v_worked_hours;
+    v_base_day_amount := v_rate_card.base_day_eur;
+
+    IF v_worked_hours <= 10.5 THEN
+      v_total_amount := v_base_day_amount;
+    ELSIF v_worked_hours <= 12.5 THEN
+      v_plus_10_12_hours := 0;
+      v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+      v_total_amount := v_base_day_amount + v_plus_10_12_amount;
+    ELSE
+      v_plus_10_12_hours := 0;
+      v_plus_10_12_amount := v_rate_card.plus_10_12_eur;
+
+      v_overtime_hours := v_worked_hours - 12;
+
+      v_overtime_amount := v_rate_card.overtime_hour_eur * v_overtime_hours;
+      v_total_amount := v_base_day_amount + v_plus_10_12_amount + v_overtime_amount;
+    END IF;
+  END IF;
+
+  v_breakdown := jsonb_build_object(
+    'worked_hours', v_raw_worked_hours,
+    'worked_hours_rounded', v_worked_hours,
+    'hours_rounded', v_worked_hours,
+    'billable_hours', v_billable_hours,
+    'is_evento', (v_job_type = 'evento' AND NOT v_is_seasonal_house_tech),
+    'is_seasonal_house_tech', v_is_seasonal_house_tech,
+    'seasonal_overtime_only', v_is_seasonal_house_tech,
+    'is_extended_shift', v_is_extended_shift,
+    'is_double_base_rate', v_is_extended_shift,
+    'base_amount_eur', COALESCE(v_base_day_amount, 0),
+    'base_day_eur', COALESCE(v_base_day_amount, 0),
+    'single_base_day_eur', CASE WHEN v_is_extended_shift THEN v_rate_card.base_day_eur ELSE v_base_day_amount END,
+    'plus_10_12_hours', COALESCE(v_plus_10_12_hours, 0),
+    'plus_10_12_eur', v_rate_card.plus_10_12_eur,
+    'plus_10_12_amount_eur', COALESCE(v_plus_10_12_amount, 0),
+    'overtime_hours', COALESCE(v_overtime_hours, 0),
+    'overtime_hour_eur', v_rate_card.overtime_hour_eur,
+    'overtime_amount_eur', COALESCE(v_overtime_amount, 0),
+    'total_eur', v_total_amount,
+    'category', v_category,
+    'forced_rehearsal_rate', false,
+    'rate_mode_source', v_rate_mode_source,
+    'has_technician_rate_mode_override', v_has_technician_rate_mode_override,
+    'technician_rate_mode_override_rehearsal', v_technician_rate_mode_override,
+    'technician_rate_mode', CASE WHEN v_is_seasonal_house_tech THEN 'hourly' ELSE v_rate_mode END
+  );
+
+  v_result := jsonb_build_object(
+    'timesheet_id', _timesheet_id,
+    'amount_eur', v_total_amount,
+    'amount_breakdown', v_breakdown
+  );
+
+  IF _persist THEN
+    UPDATE public.timesheets
+    SET
+      amount_eur = v_total_amount,
+      amount_breakdown = v_breakdown,
+      category = v_category,
+      updated_at = NOW()
+    WHERE id = _timesheet_id;
+  END IF;
+
+  RETURN v_result;
+END;
+$function$;
+
+-- Prep days normally use the dedicated EUR 15/hour rule. Seasonal house techs
+-- are the exception: their profile-level overtime-only rule applies to every
+-- timesheet, including dates labelled as prep days.
+CREATE OR REPLACE FUNCTION public.trg_apply_prep_day_rate()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_is_prep_day boolean := false;
+  v_is_seasonal_house_tech boolean := false;
+  v_worked_hours numeric := 0;
+  v_raw_worked_hours numeric := 0;
+  v_rate numeric := 15.00;
+  v_category text;
+  v_overtime_hours numeric := 0;
+BEGIN
+  IF NEW.job_id IS NULL OR NEW.date IS NULL OR NEW.start_time IS NULL OR NEW.end_time IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.job_date_types jdt
+    WHERE jdt.job_id = NEW.job_id
+      AND jdt.date = NEW.date
+      AND jdt.type = 'prep_day'
+  ) INTO v_is_prep_day;
+
+  IF NOT v_is_prep_day THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT
+    COALESCE(p.role = 'house_tech' AND p.seasonal_house_tech, false),
+    CASE
+      WHEN p.default_timesheet_category IN ('tecnico', 'especialista', 'responsable')
+        THEN p.default_timesheet_category
+      ELSE NULL
+    END
+  INTO v_is_seasonal_house_tech, v_category
+  FROM public.profiles p
+  WHERE p.id = NEW.technician_id;
+
+  IF NEW.end_time < NEW.start_time OR COALESCE(NEW.ends_next_day, false) THEN
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      NEW.end_time - NEW.start_time + INTERVAL '24 hours'
+    )) / 3600.0 - (COALESCE(NEW.break_minutes, 0) / 60.0);
+  ELSE
+    v_worked_hours := EXTRACT(EPOCH FROM (
+      NEW.end_time - NEW.start_time
+    )) / 3600.0 - (COALESCE(NEW.break_minutes, 0) / 60.0);
+  END IF;
+
+  v_worked_hours := GREATEST(v_worked_hours, 0);
+  v_raw_worked_hours := v_worked_hours;
+  v_worked_hours := ROUND(v_worked_hours);
+
+  IF v_is_seasonal_house_tech THEN
+    v_category := CASE
+      WHEN NEW.category IN ('tecnico', 'especialista', 'responsable') THEN NEW.category
+      ELSE NULL
+    END;
+
+    IF v_category IS NULL THEN
+      SELECT CASE
+        WHEN a.sound_role LIKE '%-R' OR a.lights_role LIKE '%-R' OR a.video_role LIKE '%-R' THEN 'responsable'
+        WHEN a.sound_role LIKE '%-E' OR a.lights_role LIKE '%-E' OR a.video_role LIKE '%-E' THEN 'especialista'
+        WHEN a.sound_role LIKE '%-T' OR a.lights_role LIKE '%-T' OR a.video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+      INTO v_category
+      FROM public.job_assignments a
+      WHERE a.job_id = NEW.job_id
+        AND a.technician_id = NEW.technician_id
+      ORDER BY a.assigned_at DESC
+      LIMIT 1;
+    END IF;
+
+    IF v_category IS NULL THEN
+      SELECT CASE
+        WHEN p.default_timesheet_category IN ('tecnico', 'especialista', 'responsable')
+          THEN p.default_timesheet_category
+        ELSE 'tecnico'
+      END
+      INTO v_category
+      FROM public.profiles p
+      WHERE p.id = NEW.technician_id;
+    END IF;
+
+    v_category := COALESCE(v_category, 'tecnico');
+
+    SELECT COALESCE(
+      CASE
+        WHEN v_category = 'responsable' THEN COALESCE(
+          ctr.overtime_hour_responsable_eur,
+          CASE WHEN ctr.overtime_hour_eur = 15.00 THEN 20.00 END,
+          ctr.overtime_hour_eur
+        )
+        WHEN v_category = 'especialista' THEN COALESCE(
+          ctr.overtime_hour_especialista_eur,
+          ctr.overtime_hour_eur
+        )
+        ELSE ctr.overtime_hour_eur
+      END,
+      (
+        SELECT rc.overtime_hour_eur
+        FROM public.rate_cards_2025 rc
+        WHERE rc.category = v_category
+      )
+    )
+    INTO v_rate
+    FROM public.custom_tech_rates ctr
+    WHERE ctr.profile_id = NEW.technician_id;
+
+    IF NOT FOUND OR v_rate IS NULL THEN
+      SELECT rc.overtime_hour_eur
+      INTO v_rate
+      FROM public.rate_cards_2025 rc
+      WHERE rc.category = v_category;
+    END IF;
+
+    IF v_rate IS NULL THEN
+      RAISE EXCEPTION 'Overtime rate card not found for seasonal prep-day category: %', v_category;
+    END IF;
+
+    v_overtime_hours := GREATEST(v_worked_hours - 12, 0);
+    NEW.amount_eur := v_overtime_hours * v_rate;
+    NEW.amount_breakdown := jsonb_build_object(
+      'worked_hours', v_raw_worked_hours,
+      'worked_hours_rounded', v_worked_hours,
+      'hours_rounded', v_worked_hours,
+      'billable_hours', v_worked_hours,
+      'is_prep_day', true,
+      'is_seasonal_house_tech', true,
+      'seasonal_overtime_only', true,
+      'rate_mode_source', 'seasonal_house_tech_profile',
+      'technician_rate_mode', 'hourly',
+      'base_amount_eur', 0,
+      'base_day_eur', 0,
+      'plus_10_12_hours', 0,
+      'plus_10_12_eur', 0,
+      'plus_10_12_amount_eur', 0,
+      'overtime_hours', v_overtime_hours,
+      'overtime_hour_eur', v_rate,
+      'overtime_amount_eur', NEW.amount_eur,
+      'total_eur', NEW.amount_eur,
+      'category', v_category
+    );
+    NEW.category := v_category;
+    RETURN NEW;
+  END IF;
+
+  NEW.amount_eur := v_worked_hours * v_rate;
+  NEW.amount_breakdown := jsonb_build_object(
+    'worked_hours', v_raw_worked_hours,
+    'worked_hours_rounded', v_worked_hours,
+    'hours_rounded', v_worked_hours,
+    'billable_hours', v_worked_hours,
+    'is_prep_day', true,
+    'prep_day_hourly_rate_eur', v_rate,
+    'base_amount_eur', NEW.amount_eur,
+    'base_day_eur', NEW.amount_eur,
+    'plus_10_12_hours', 0,
+    'plus_10_12_eur', 0,
+    'plus_10_12_amount_eur', 0,
+    'overtime_hours', 0,
+    'overtime_hour_eur', 0,
+    'overtime_amount_eur', 0,
+    'total_eur', NEW.amount_eur,
+    'category', 'prep_day'
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.trg_apply_prep_day_rate() FROM PUBLIC;
+
+-- Profile finance-mode changes must also refresh already-created timesheets.
+-- Without this, enabling seasonal mode could leave historical base/plus amounts
+-- stored on active timesheets until somebody edited each timesheet manually.
+CREATE OR REPLACE FUNCTION public.recompute_timesheets_after_profile_finance_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_timesheet RECORD;
+BEGIN
+  FOR v_timesheet IN
+    SELECT t.id
+    FROM public.timesheets t
+    WHERE t.technician_id = NEW.id
+      AND t.is_active = true
+      AND t.start_time IS NOT NULL
+      AND t.end_time IS NOT NULL
+  LOOP
+    PERFORM public.compute_timesheet_amount_2025(v_timesheet.id, true);
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.recompute_timesheets_after_profile_finance_change()
+  FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS recompute_timesheets_after_profile_finance_change ON public.profiles;
+CREATE TRIGGER recompute_timesheets_after_profile_finance_change
+AFTER UPDATE OF role, autonomo, seasonal_house_tech,
+  seasonal_house_tech_start_date, seasonal_house_tech_end_date
+ON public.profiles
+FOR EACH ROW
+WHEN (
+  OLD.role IS DISTINCT FROM NEW.role
+  OR OLD.autonomo IS DISTINCT FROM NEW.autonomo
+  OR OLD.seasonal_house_tech IS DISTINCT FROM NEW.seasonal_house_tech
+  OR OLD.seasonal_house_tech_start_date IS DISTINCT FROM NEW.seasonal_house_tech_start_date
+  OR OLD.seasonal_house_tech_end_date IS DISTINCT FROM NEW.seasonal_house_tech_end_date
+)
+EXECUTE FUNCTION public.recompute_timesheets_after_profile_finance_change();
+
+
+
+-- Canonical tour quote pricing: every seasonal date is hourly.
+CREATE OR REPLACE FUNCTION public.compute_tour_job_rate_quote_2025(_job_id uuid, _tech_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  jtype job_type;
+  st timestamptz;
+  et timestamptz;
+  job_start_date date;
+  job_end_date date;
+  tour_group uuid;
+  tour_date_ref uuid;
+  schedule_start date;
+  schedule_end date;
+  scheduled_days int := 1;
+  rehearsal_days int := 0;
+  standard_days int := 0;
+  technician_override_days int := 0;
+  hourly_days int := 0;
+  fixed_days int := 0;
+  hourly_total numeric(10,2) := 0;
+  fixed_total numeric(10,2) := 0;
+  forced_multiplier_days int := 0;
+  no_multiplier_days int := 0;
+  cat text;
+  house boolean := false;
+  seasonal boolean := false;
+  is_autonomo boolean := true;
+  is_reduced_rehearsal boolean := false;
+  standard_discount_per_day numeric(10,2) := 0;
+  rehearsal_discount_per_day numeric(10,2) := 0;
+  total_autonomo_discount numeric(10,2) := 0;
+  standard_base_before_discount numeric(10,2) := 0;
+  standard_after_discount numeric(10,2) := 0;
+  standard_multiplier_bonus numeric(10,2) := 0;
+  multiplied_standard_days int := 0;
+  rehearsal_base_before_discount numeric(10,2) := 0;
+  team_member boolean := false;
+  has_override boolean := false;
+  standard_base numeric(10,2);
+  standard_day_rate numeric(10,2) := 0;
+  rehearsal_day_rate numeric(10,2) := 0;
+  standard_total numeric(10,2) := 0;
+  rehearsal_total numeric(10,2) := 0;
+  total_base numeric(10,2) := 0;
+  base_calculation_total numeric(10,2) := 0;
+  after_discount_total numeric(10,2) := 0;
+  mult numeric(6,3) := 1.0;
+  per_job_multiplier numeric(6,3) := 1.0;
+  display_multiplier numeric(6,3) := 1.0;
+  display_per_job_multiplier numeric(6,3) := 1.0;
+  cnt int := 1;
+  y int := NULL;
+  w int := NULL;
+  extras jsonb;
+  extras_total numeric(10,2);
+  final_total numeric(10,2);
+  disclaimer boolean;
+  has_custom_standard_rate boolean := FALSE;
+  has_custom_rehearsal_rate boolean := FALSE;
+  has_custom_rate boolean := FALSE;
+  display_category text := 'rehearsal';
+  job_date_type_start date;
+  job_date_type_end date;
+  tour_date_start date;
+  tour_date_end date;
+  tour_date_legacy_date date;
+BEGIN
+  IF NOT (auth.role() = 'service_role' OR public.is_admin_or_management()) THEN
+    RAISE EXCEPTION 'permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT job_type, start_time, end_time, tour_id, tour_date_id
+  INTO jtype, st, et, tour_group, tour_date_ref
+  FROM public.jobs
+  WHERE id = _job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','job_not_found');
+  END IF;
+
+  IF jtype <> 'tourdate' THEN
+    RETURN jsonb_build_object('error','not_tour_date');
+  END IF;
+
+  SELECT COALESCE(p.role = 'house_tech' AND p.seasonal_house_tech, FALSE)
+  INTO seasonal
+  FROM public.profiles p
+  WHERE p.id = _tech_id;
+
+  job_start_date := (st AT TIME ZONE 'Europe/Madrid')::date;
+  job_end_date := COALESCE((et AT TIME ZONE 'Europe/Madrid')::date, job_start_date);
+
+  SELECT MIN(jdt.date), MAX(jdt.date)
+  INTO job_date_type_start, job_date_type_end
+  FROM public.job_date_types jdt
+  WHERE jdt.job_id = _job_id
+    AND jdt.type <> 'prep_day';
+
+  SELECT td.start_date, td.end_date, td.date
+  INTO tour_date_start, tour_date_end, tour_date_legacy_date
+  FROM public.tour_dates td
+  WHERE td.id = tour_date_ref;
+
+  schedule_start := COALESCE(
+    job_date_type_start,
+    tour_date_start,
+    job_start_date,
+    tour_date_legacy_date
+  );
+  schedule_end := COALESCE(
+    job_date_type_end,
+    tour_date_end,
+    job_end_date,
+    tour_date_start,
+    tour_date_legacy_date,
+    job_start_date
+  );
+
+  schedule_start := COALESCE(schedule_start, job_start_date);
+  schedule_end := COALESCE(schedule_end, schedule_start, job_end_date, job_start_date);
+  IF schedule_end < schedule_start THEN
+    schedule_end := schedule_start;
+  END IF;
+
+  WITH raw_scheduled_job_date_type_dates AS (
+    SELECT DISTINCT jdt.date AS payable_date, jdt.type
+    FROM public.job_date_types jdt
+    WHERE jdt.job_id = _job_id
+      AND jdt.type <> 'prep_day'
+  ),
+  scheduled_job_date_type_dates AS (
+    SELECT raw.payable_date
+    FROM raw_scheduled_job_date_type_dates raw
+    WHERE raw.type <> 'rigging'
+       OR EXISTS (
+          SELECT 1
+          FROM public.job_assignments rja
+          WHERE rja.job_id = _job_id
+            AND rja.technician_id = _tech_id
+            AND COALESCE(rja.single_day, FALSE)
+            AND rja.assignment_date = raw.payable_date
+        )
+       OR EXISTS (
+          SELECT 1
+          FROM public.timesheets rt
+          WHERE rt.job_id = _job_id
+            AND rt.technician_id = _tech_id
+            AND rt.date = raw.payable_date
+            AND COALESCE(rt.is_active, TRUE)
+        )
+  ),
+  active_timesheet_dates AS (
+    SELECT DISTINCT t.date AS payable_date
+    FROM public.timesheets t
+    WHERE t.job_id = _job_id
+      AND t.technician_id = _tech_id
+      AND COALESCE(t.is_active, TRUE)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = t.job_id
+          AND prep_jdt.date = t.date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  single_day_assignment_dates AS (
+    SELECT DISTINCT ja.assignment_date AS payable_date
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id
+      AND ja.technician_id = _tech_id
+      AND COALESCE(ja.single_day, FALSE)
+      AND ja.assignment_date IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = ja.job_id
+          AND prep_jdt.date = ja.assignment_date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  fallback_schedule_dates AS (
+    SELECT generated_series.date_value::date AS payable_date
+    FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS generated_series(date_value)
+    WHERE NOT EXISTS (SELECT 1 FROM raw_scheduled_job_date_type_dates)
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.job_date_types prep_jdt
+        WHERE prep_jdt.job_id = _job_id
+          AND prep_jdt.date = generated_series.date_value::date
+          AND prep_jdt.type = 'prep_day'
+      )
+  ),
+  payable_dates AS (
+    SELECT payable_date
+    FROM active_timesheet_dates
+    UNION
+    SELECT payable_date
+    FROM single_day_assignment_dates
+    UNION
+    SELECT payable_date
+    FROM scheduled_job_date_type_dates
+    WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+    UNION
+    SELECT payable_date
+    FROM fallback_schedule_dates
+    WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+  ),
+  classified_payable_dates AS (
+    SELECT
+      pd.payable_date,
+      (trmd.job_id IS NOT NULL) AS has_override,
+      CASE
+        WHEN seasonal THEN 'hourly'
+        ELSE COALESCE(
+          trmd.rate_mode,
+          CASE
+            WHEN COALESCE(trmd.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+            WHEN jrd.job_id IS NOT NULL THEN 'rehearsal'
+            ELSE 'standard'
+          END
+        )
+      END AS eff_mode,
+      trmd.fixed_amount_eur,
+      (
+        SELECT COALESCE(SUM(COALESCE(t.amount_eur, 0)), 0)
+        FROM public.timesheets t
+        WHERE t.job_id = _job_id
+          AND t.technician_id = _tech_id
+          AND t.date = pd.payable_date
+          AND COALESCE(t.is_active, TRUE)
+      ) AS ts_amount
+    FROM payable_dates pd
+    LEFT JOIN public.job_technician_rate_mode_dates trmd
+      ON trmd.job_id = _job_id
+     AND trmd.technician_id = _tech_id
+     AND trmd.date = pd.payable_date
+    LEFT JOIN public.job_rehearsal_dates jrd
+      ON jrd.job_id = _job_id
+     AND jrd.date = pd.payable_date
+  )
+  SELECT
+    COUNT(*)::int,
+    COUNT(*) FILTER (WHERE cpd.eff_mode = 'rehearsal')::int,
+    COUNT(*) FILTER (WHERE cpd.has_override)::int,
+    COUNT(*) FILTER (WHERE cpd.eff_mode = 'hourly')::int,
+    COUNT(*) FILTER (WHERE cpd.eff_mode = 'fixed')::int,
+    ROUND(COALESCE(SUM(cpd.ts_amount) FILTER (WHERE cpd.eff_mode = 'hourly'), 0), 2),
+    ROUND(COALESCE(SUM(cpd.fixed_amount_eur) FILTER (WHERE cpd.eff_mode = 'fixed'), 0), 2)
+  INTO scheduled_days, rehearsal_days, technician_override_days, hourly_days, fixed_days, hourly_total, fixed_total
+  FROM classified_payable_dates cpd;
+
+  scheduled_days := COALESCE(scheduled_days, 0);
+  rehearsal_days := LEAST(COALESCE(rehearsal_days, 0), scheduled_days);
+  hourly_days := COALESCE(hourly_days, 0);
+  fixed_days := COALESCE(fixed_days, 0);
+  standard_days := GREATEST(0, scheduled_days - rehearsal_days - hourly_days - fixed_days);
+
+  SELECT
+    (role = 'house_tech'),
+    CASE WHEN role = 'technician' THEN COALESCE(autonomo, true) ELSE true END,
+    COALESCE(role IN ('house_tech', 'admin', 'management'), false)
+  INTO house, is_autonomo, is_reduced_rehearsal
+  FROM public.profiles
+  WHERE id = _tech_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error','profile_not_found','technician_id',_tech_id);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(bool_or(ja.use_tour_multipliers), FALSE)
+    INTO has_override
+    FROM public.job_assignments ja
+    WHERE ja.job_id = _job_id AND ja.technician_id = _tech_id;
+
+    has_override := COALESCE(has_override, FALSE);
+  END IF;
+
+  IF tour_group IS NOT NULL THEN
+    SELECT COALESCE(
+      EXISTS (
+        SELECT 1
+        FROM public.tour_assignments ta
+        WHERE ta.tour_id = tour_group
+          AND ta.technician_id = _tech_id
+      ) OR has_override,
+      FALSE
+    )
+    INTO team_member;
+
+    team_member := COALESCE(team_member, FALSE);
+  END IF;
+
+  SELECT iso_year, iso_week INTO y, w
+  FROM public.iso_year_week_madrid(st);
+
+  IF standard_days > 0 THEN
+    SELECT
+      CASE
+        WHEN sound_role LIKE '%-R' OR lights_role LIKE '%-R' OR video_role LIKE '%-R' THEN 'responsable'
+        WHEN sound_role LIKE '%-E' OR lights_role LIKE '%-E' OR video_role LIKE '%-E' THEN 'especialista'
+        WHEN sound_role LIKE '%-T' OR lights_role LIKE '%-T' OR video_role LIKE '%-T' THEN 'tecnico'
+        ELSE NULL
+      END
+    INTO cat
+    FROM public.job_assignments
+    WHERE job_id = _job_id AND technician_id = _tech_id
+    ORDER BY assigned_at DESC
+    LIMIT 1;
+
+    IF cat IS NULL THEN
+      SELECT default_timesheet_category INTO cat
+      FROM public.profiles
+      WHERE id = _tech_id AND default_timesheet_category IN ('tecnico','especialista','responsable');
+    END IF;
+
+    IF cat IS NULL THEN
+      RETURN jsonb_build_object('error','category_missing','profile_id',_tech_id,'job_id',_job_id);
+    END IF;
+
+    IF cat = 'responsable' THEN
+      SELECT COALESCE(
+        tour_base_responsable_eur,
+        base_day_responsable_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSIF cat = 'especialista' THEN
+      SELECT COALESCE(
+        tour_base_especialista_eur,
+        tour_base_other_eur,
+        base_day_especialista_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    ELSE
+      SELECT COALESCE(
+        tour_base_other_eur,
+        base_day_eur
+      ) INTO standard_base
+      FROM public.custom_tech_rates
+      WHERE profile_id = _tech_id;
+    END IF;
+
+    IF standard_base IS NOT NULL THEN
+      has_custom_standard_rate := TRUE;
+      has_custom_rate := TRUE;
+    ELSE
+      SELECT base_day_eur INTO standard_base
+      FROM public.rate_cards_tour_2025
+      WHERE category = cat;
+
+      IF standard_base IS NULL THEN
+        RETURN jsonb_build_object('error','tour_base_missing','category',cat);
+      END IF;
+    END IF;
+
+    standard_base_before_discount := standard_base;
+
+    IF NOT house AND NOT is_autonomo THEN
+      standard_discount_per_day := 30.00;
+      standard_base := standard_base - standard_discount_per_day;
+    END IF;
+
+    standard_after_discount := standard_base;
+    standard_day_rate := ROUND(standard_base * per_job_multiplier, 2);
+    standard_total := ROUND(standard_day_rate * standard_days, 2);
+
+    -- This deliberately duplicates the canonical payable-date CTEs above
+    -- because PL/pgSQL CTEs cannot be reused across separate statements. Keep
+    -- raw_scheduled_job_date_type_dates, scheduled_job_date_type_dates,
+    -- active_timesheet_dates, single_day_assignment_dates, and
+    -- fallback_schedule_dates in sync with the first copy, or refactor them
+    -- into a shared SQL function.
+    WITH raw_scheduled_job_date_type_dates AS (
+      SELECT DISTINCT jdt.date AS payable_date, jdt.type
+      FROM public.job_date_types jdt
+      WHERE jdt.job_id = _job_id
+        AND jdt.type <> 'prep_day'
+    ),
+    scheduled_job_date_type_dates AS (
+      SELECT raw.payable_date
+      FROM raw_scheduled_job_date_type_dates raw
+      WHERE raw.type <> 'rigging'
+         OR EXISTS (
+            SELECT 1
+            FROM public.job_assignments rja
+            WHERE rja.job_id = _job_id
+              AND rja.technician_id = _tech_id
+              AND COALESCE(rja.single_day, FALSE)
+              AND rja.assignment_date = raw.payable_date
+          )
+         OR EXISTS (
+            SELECT 1
+            FROM public.timesheets rt
+            WHERE rt.job_id = _job_id
+              AND rt.technician_id = _tech_id
+              AND rt.date = raw.payable_date
+              AND COALESCE(rt.is_active, TRUE)
+          )
+    ),
+    active_timesheet_dates AS (
+      SELECT DISTINCT t.date AS payable_date
+      FROM public.timesheets t
+      WHERE t.job_id = _job_id
+        AND t.technician_id = _tech_id
+        AND COALESCE(t.is_active, TRUE)
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = t.job_id
+            AND prep_jdt.date = t.date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    single_day_assignment_dates AS (
+      SELECT DISTINCT ja.assignment_date AS payable_date
+      FROM public.job_assignments ja
+      WHERE ja.job_id = _job_id
+        AND ja.technician_id = _tech_id
+        AND COALESCE(ja.single_day, FALSE)
+        AND ja.assignment_date IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = ja.job_id
+            AND prep_jdt.date = ja.assignment_date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    fallback_schedule_dates AS (
+      SELECT generated_series.date_value::date AS payable_date
+      FROM generate_series(schedule_start, schedule_end, INTERVAL '1 day') AS generated_series(date_value)
+      WHERE NOT EXISTS (SELECT 1 FROM raw_scheduled_job_date_type_dates)
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.job_date_types prep_jdt
+          WHERE prep_jdt.job_id = _job_id
+            AND prep_jdt.date = generated_series.date_value::date
+            AND prep_jdt.type = 'prep_day'
+        )
+    ),
+    payable_dates AS (
+      SELECT payable_date
+      FROM active_timesheet_dates
+      UNION
+      SELECT payable_date
+      FROM single_day_assignment_dates
+      UNION
+      SELECT payable_date
+      FROM scheduled_job_date_type_dates
+      WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+      UNION
+      SELECT payable_date
+      FROM fallback_schedule_dates
+      WHERE NOT EXISTS (SELECT 1 FROM single_day_assignment_dates)
+    ),
+    standard_payable_dates AS (
+      SELECT
+        pd.payable_date,
+        COALESCE(
+          trmd.rate_mode,
+          CASE
+            WHEN COALESCE(trmd.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+            WHEN jrd.job_id IS NOT NULL THEN 'rehearsal'
+            ELSE 'standard'
+          END
+        ) AS eff_mode
+      FROM payable_dates pd
+      LEFT JOIN public.job_technician_rate_mode_dates trmd
+        ON trmd.job_id = _job_id
+       AND trmd.technician_id = _tech_id
+       AND trmd.date = pd.payable_date
+      LEFT JOIN public.job_rehearsal_dates jrd
+        ON jrd.job_id = _job_id
+       AND jrd.date = pd.payable_date
+      WHERE COALESCE(
+              trmd.rate_mode,
+              CASE
+                WHEN COALESCE(trmd.use_rehearsal_rate, FALSE) THEN 'rehearsal'
+                WHEN jrd.job_id IS NOT NULL THEN 'rehearsal'
+                ELSE 'standard'
+              END
+            ) IN ('standard','tour_multipliers','no_multipliers')
+    ),
+    date_multipliers AS (
+      SELECT
+        spd.payable_date,
+        spd.eff_mode,
+        CASE
+          WHEN NOT team_member AND spd.eff_mode <> 'tour_multipliers' THEN 1
+          ELSE GREATEST(COALESCE(weekly_counts.cnt, 0), 1)
+        END AS week_count,
+        CASE
+          WHEN spd.eff_mode = 'no_multipliers' THEN 1.0::numeric
+          WHEN NOT team_member AND spd.eff_mode <> 'tour_multipliers' THEN 1.0::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 1 THEN 1.5::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 2 THEN 1.125::numeric
+          ELSE 1.0::numeric
+        END AS week_multiplier,
+        CASE
+          WHEN spd.eff_mode = 'no_multipliers' THEN 1.0::numeric
+          WHEN NOT team_member AND spd.eff_mode <> 'tour_multipliers' THEN 1.0::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 1 THEN 1.5::numeric
+          WHEN GREATEST(COALESCE(weekly_counts.cnt, 0), 1) = 2 THEN 1.125::numeric
+          ELSE 1.0::numeric
+        END AS date_multiplier
+      FROM standard_payable_dates spd
+      CROSS JOIN LATERAL public.iso_year_week_madrid(spd.payable_date::timestamptz) iw
+      LEFT JOIN LATERAL (
+        WITH tour_jobs AS (
+          SELECT
+            j.id AS job_id,
+            j.start_time,
+            j.end_time,
+            j.tour_date_id
+          FROM public.jobs j
+          WHERE j.job_type = 'tourdate'
+            AND j.tour_id = tour_group
+            AND j.status != 'Cancelado'
+        ),
+        technician_job_assignments AS (
+          SELECT DISTINCT ja.job_id
+          FROM public.job_assignments ja
+          JOIN tour_jobs tj
+            ON tj.job_id = ja.job_id
+          WHERE ja.technician_id = _tech_id
+        ),
+        raw_scheduled_job_date_type_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            jdt.date AS payable_date,
+            jdt.type
+          FROM tour_jobs tj
+          JOIN public.job_date_types jdt
+            ON jdt.job_id = tj.job_id
+           AND jdt.type <> 'prep_day'
+        ),
+        scheduled_job_date_type_dates AS (
+          SELECT raw.job_id, raw.payable_date
+          FROM raw_scheduled_job_date_type_dates raw
+          JOIN technician_job_assignments tja
+            ON tja.job_id = raw.job_id
+          WHERE raw.type <> 'rigging'
+             OR EXISTS (
+                SELECT 1
+                FROM public.job_assignments rja
+                WHERE rja.job_id = raw.job_id
+                  AND rja.technician_id = _tech_id
+                  AND COALESCE(rja.single_day, FALSE)
+                  AND rja.assignment_date = raw.payable_date
+              )
+             OR EXISTS (
+                SELECT 1
+                FROM public.timesheets rt
+                WHERE rt.job_id = raw.job_id
+                  AND rt.technician_id = _tech_id
+                  AND rt.date = raw.payable_date
+                  AND COALESCE(rt.is_active, TRUE)
+              )
+        ),
+        active_timesheet_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            t.date AS payable_date
+          FROM tour_jobs tj
+          JOIN public.timesheets t
+            ON t.job_id = tj.job_id
+           AND t.technician_id = _tech_id
+           AND COALESCE(t.is_active, TRUE)
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM public.job_date_types prep_jdt
+            WHERE prep_jdt.job_id = t.job_id
+              AND prep_jdt.date = t.date
+              AND prep_jdt.type = 'prep_day'
+          )
+        ),
+        single_day_assignment_dates AS (
+          SELECT DISTINCT
+            tj.job_id,
+            ja.assignment_date AS payable_date
+          FROM tour_jobs tj
+          JOIN public.job_assignments ja
+            ON ja.job_id = tj.job_id
+           AND ja.technician_id = _tech_id
+           AND COALESCE(ja.single_day, FALSE)
+           AND ja.assignment_date IS NOT NULL
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM public.job_date_types prep_jdt
+            WHERE prep_jdt.job_id = ja.job_id
+              AND prep_jdt.date = ja.assignment_date
+              AND prep_jdt.type = 'prep_day'
+          )
+        ),
+        jobs_with_single_day_assignments AS (
+          SELECT DISTINCT job_id
+          FROM single_day_assignment_dates
+        ),
+        job_ranges AS (
+          SELECT
+            tj.job_id,
+            COALESCE(
+              MIN(raw.payable_date),
+              td.start_date,
+              (tj.start_time AT TIME ZONE 'Europe/Madrid')::date,
+              td.date
+            ) AS schedule_start,
+            COALESCE(
+              MAX(raw.payable_date),
+              td.end_date,
+              (tj.end_time AT TIME ZONE 'Europe/Madrid')::date,
+              td.start_date,
+              td.date,
+              (tj.start_time AT TIME ZONE 'Europe/Madrid')::date
+            ) AS schedule_end
+          FROM tour_jobs tj
+          LEFT JOIN public.tour_dates td
+            ON td.id = tj.tour_date_id
+          LEFT JOIN raw_scheduled_job_date_type_dates raw
+            ON raw.job_id = tj.job_id
+          GROUP BY
+            tj.job_id,
+            tj.start_time,
+            tj.end_time,
+            td.start_date,
+            td.end_date,
+            td.date
+        ),
+        fallback_schedule_dates AS (
+          SELECT
+            jr.job_id,
+            generated_series.date_value::date AS payable_date
+          FROM job_ranges jr
+          JOIN technician_job_assignments tja
+            ON tja.job_id = jr.job_id
+          CROSS JOIN LATERAL generate_series(
+            jr.schedule_start,
+            GREATEST(jr.schedule_start, jr.schedule_end),
+            INTERVAL '1 day'
+          ) AS generated_series(date_value)
+          WHERE NOT EXISTS (
+              SELECT 1
+              FROM raw_scheduled_job_date_type_dates raw
+              WHERE raw.job_id = jr.job_id
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.job_date_types prep_jdt
+              WHERE prep_jdt.job_id = jr.job_id
+                AND prep_jdt.date = generated_series.date_value::date
+                AND prep_jdt.type = 'prep_day'
+            )
+        ),
+        counted_payable_dates AS (
+          SELECT job_id, payable_date
+          FROM active_timesheet_dates
+          UNION
+          SELECT job_id, payable_date
+          FROM single_day_assignment_dates
+          UNION
+          SELECT job_id, payable_date
+          FROM scheduled_job_date_type_dates scheduled
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM jobs_with_single_day_assignments single_day_jobs
+            WHERE single_day_jobs.job_id = scheduled.job_id
+          )
+          UNION
+          SELECT job_id, payable_date
+          FROM fallback_schedule_dates fallback
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM jobs_with_single_day_assignments single_day_jobs
+            WHERE single_day_jobs.job_id = fallback.job_id
+          )
+        )
+        SELECT COUNT(DISTINCT cpd.payable_date)::int AS cnt
+        FROM counted_payable_dates cpd
+        CROSS JOIN LATERAL public.iso_year_week_madrid(cpd.payable_date::timestamptz) other_iw
+        WHERE other_iw.iso_year = iw.iso_year
+          AND other_iw.iso_week = iw.iso_week
+      ) weekly_counts ON TRUE
+    )
+    SELECT
+      ROUND(COALESCE(SUM(standard_after_discount * dm.date_multiplier), 0), 2),
+      ROUND(COALESCE(SUM((standard_after_discount * dm.date_multiplier) - standard_after_discount), 0), 2),
+      COUNT(*) FILTER (WHERE dm.date_multiplier > 1.0)::int,
+      COUNT(*) FILTER (WHERE dm.eff_mode = 'tour_multipliers')::int,
+      COUNT(*) FILTER (WHERE dm.eff_mode = 'no_multipliers')::int,
+      GREATEST(COALESCE(MAX(dm.week_count), 1), 1)::int,
+      COALESCE(ROUND(SUM(dm.week_multiplier * dm.week_count) / NULLIF(SUM(dm.week_count), 0), 3), 1.0),
+      COALESCE(ROUND(SUM(dm.date_multiplier * dm.week_count) / NULLIF(SUM(dm.week_count), 0), 3), 1.0)
+    INTO standard_total, standard_multiplier_bonus, multiplied_standard_days, forced_multiplier_days, no_multiplier_days, cnt, display_multiplier, display_per_job_multiplier
+    FROM date_multipliers dm;
+
+    per_job_multiplier := display_per_job_multiplier;
+    mult := display_multiplier;
+    standard_day_rate := ROUND(standard_total / GREATEST(standard_days, 1), 2);
+    display_category := cat;
+  ELSE
+    cnt := 1;
+    mult := 1.0;
+    per_job_multiplier := 1.0;
+    display_multiplier := 1.0;
+    display_per_job_multiplier := 1.0;
+  END IF;
+
+  IF rehearsal_days > 0 THEN
+    SELECT rehearsal_day_eur INTO rehearsal_day_rate
+    FROM public.custom_tech_rates
+    WHERE profile_id = _tech_id;
+
+    IF rehearsal_day_rate IS NOT NULL THEN
+      has_custom_rehearsal_rate := TRUE;
+      has_custom_rate := TRUE;
+      rehearsal_base_before_discount := rehearsal_day_rate;
+    ELSE
+      IF is_reduced_rehearsal THEN
+        rehearsal_day_rate := 60.00;
+        rehearsal_base_before_discount := 60.00;
+      ELSE
+        rehearsal_day_rate := 180.00;
+        rehearsal_base_before_discount := 180.00;
+      END IF;
+    END IF;
+
+    IF NOT is_autonomo AND NOT is_reduced_rehearsal THEN
+      rehearsal_discount_per_day := 30.00;
+      rehearsal_day_rate := rehearsal_day_rate - rehearsal_discount_per_day;
+    END IF;
+
+    rehearsal_total := ROUND(rehearsal_day_rate * rehearsal_days, 2);
+
+    IF standard_days = 0 THEN
+      display_category := 'rehearsal';
+    END IF;
+  END IF;
+
+  IF standard_days = 0 AND rehearsal_days = 0 THEN
+    display_category := CASE
+      WHEN hourly_days > 0 AND fixed_days > 0 THEN 'mixed'
+      WHEN hourly_days > 0 THEN 'hourly'
+      WHEN fixed_days > 0 THEN 'fixed'
+      ELSE display_category
+    END;
+  END IF;
+
+  total_base := ROUND(standard_total + rehearsal_total + hourly_total + fixed_total, 2);
+  total_autonomo_discount := ROUND(
+    (standard_discount_per_day * standard_days) + (rehearsal_discount_per_day * rehearsal_days),
+    2
+  );
+  base_calculation_total := ROUND(
+    (standard_base_before_discount * standard_days) + (rehearsal_base_before_discount * rehearsal_days)
+      + hourly_total + fixed_total,
+    2
+  );
+
+  IF standard_days > 0 THEN
+    after_discount_total := ROUND(
+      (standard_after_discount * standard_days) + (rehearsal_day_rate * rehearsal_days)
+        + hourly_total + fixed_total,
+      2
+    );
+  ELSE
+    after_discount_total := ROUND(
+      (rehearsal_day_rate * rehearsal_days) + hourly_total + fixed_total,
+      2
+    );
+  END IF;
+
+  extras := public.extras_total_for_job_tech(_job_id, _tech_id);
+  extras_total := COALESCE((extras->>'total_eur')::numeric, 0);
+  final_total := ROUND(total_base + extras_total, 2);
+
+  disclaimer := public.needs_vehicle_disclaimer(_tech_id);
+
+  RETURN jsonb_build_object(
+    'job_id', _job_id,
+    'technician_id', _tech_id,
+    'start_time', st,
+    'job_type', jtype,
+    'tour_id', tour_group,
+    'is_house_tech', house,
+    'is_seasonal_house_tech', seasonal,
+    'is_tour_team_member', team_member,
+    'use_tour_multipliers', has_override,
+    'category', display_category,
+    'base_day_eur', total_base,
+    'has_custom_rate', has_custom_rate,
+    'autonomo_discount_eur', total_autonomo_discount,
+    'base_day_before_discount_eur', base_calculation_total,
+    'week_count', cnt,
+    'multiplier', ROUND(display_multiplier, 3),
+    'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+    'iso_year', y,
+    'iso_week', w,
+    'total_eur', total_base,
+    'extras', extras,
+    'extras_total_eur', ROUND(extras_total, 2),
+    'total_with_extras_eur', final_total,
+    'vehicle_disclaimer', disclaimer,
+    'vehicle_disclaimer_text', CASE WHEN disclaimer THEN 'Se requiere vehículo propio' ELSE NULL END,
+    'breakdown', jsonb_build_object(
+      'base_calculation', base_calculation_total,
+      'autonomo_discount', total_autonomo_discount,
+      'after_discount', after_discount_total,
+      'multiplier', ROUND(display_multiplier, 3),
+      'per_job_multiplier', ROUND(display_per_job_multiplier, 3),
+      'final_base', total_base,
+      'has_custom_rate', has_custom_rate,
+      'has_custom_standard_rate', has_custom_standard_rate,
+      'has_custom_rehearsal_rate', has_custom_rehearsal_rate,
+      'scheduled_days', scheduled_days,
+      'rehearsal_days', rehearsal_days,
+      'standard_days', standard_days,
+      'technician_override_days', technician_override_days,
+      'multiplied_standard_days', multiplied_standard_days,
+      'standard_multiplier_bonus_eur', standard_multiplier_bonus,
+      'hourly_days', hourly_days,
+      'seasonal_overtime_only', seasonal,
+      'hourly_total_eur', hourly_total,
+      'fixed_days', fixed_days,
+      'fixed_total_eur', fixed_total,
+      'forced_multiplier_days', forced_multiplier_days,
+      'no_multiplier_days', no_multiplier_days,
+      'rehearsal_rate_eur', CASE WHEN rehearsal_days > 0 THEN rehearsal_day_rate ELSE NULL END,
+      'standard_day_rate_eur', CASE WHEN standard_days > 0 THEN standard_day_rate ELSE NULL END,
+      'forced_rehearsal_rate', (rehearsal_days > 0),
+      'prep_days_excluded_from_multiplier', true,
+      'rigging_dates_scoped_to_assigned_techs', true,
+      'weekly_multiplier_rule', '1_date_1_5x__2_dates_1_125x__3_plus_1x',
+      'per_payable_date_weekly_multipliers', true,
+      'weekly_multiplier_count_uses_timesheets', true
+    )
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) FROM PUBLIC;
+
+COMMENT ON FUNCTION public.compute_tour_job_rate_quote_2025(uuid,uuid) IS
+  'Calculates tour job rate quotes. Seasonal house tech profiles force every payable date into hourly mode. Each payable date resolves an effective rate_mode from job_technician_rate_mode_dates (rehearsal, standard, tour_multipliers, no_multipliers, hourly, fixed) then job_rehearsal_dates. Standard-family dates use the per-payable-date weekly multipliers (1 date 1.5x, 2 dates 1.125x each, 3+ dates 1x); tour_multipliers forces those multipliers even off-team, no_multipliers forces 1x. Hourly dates add the technician timesheet amount; fixed dates add fixed_amount_eur. Prep days are excluded.';
+
+
+-- Include the seasonal range in assignment conflict checks.
+CREATE OR REPLACE FUNCTION public.check_technician_conflicts(
+  _technician_id uuid,
+  _target_job_id uuid,
+  _target_date date DEFAULT NULL::date,
+  _single_day boolean DEFAULT false,
+  _include_pending boolean DEFAULT true
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_result JSONB;
+  v_target_job RECORD;
+  v_start_date DATE;
+  v_end_date DATE;
+  v_hard_conflicts JSONB := '[]'::JSONB;
+  v_soft_conflicts JSONB := '[]'::JSONB;
+  v_unavailability JSONB := '[]'::JSONB;
+  v_seasonal_unavailability JSONB := '[]'::JSONB;
+BEGIN
+  -- Get target job details
+  SELECT start_time::DATE, end_time::DATE
+  INTO v_target_job
+  FROM jobs
+  WHERE id = _target_job_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'hasHardConflict', false,
+      'hasSoftConflict', false,
+      'hardConflicts', '[]'::JSONB,
+      'softConflicts', '[]'::JSONB,
+      'unavailabilityConflicts', '[]'::JSONB
+    );
+  END IF;
+
+  -- Determine date range to check
+  IF _target_date IS NOT NULL THEN
+    v_start_date := _target_date;
+    v_end_date := _target_date;
+  ELSE
+    v_start_date := v_target_job.start_time;
+    v_end_date := v_target_job.end_time;
+  END IF;
+
+  -- Check for hard conflicts (confirmed assignments via ACTIVE timesheets)
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', j.id,
+      'title', j.title,
+      'start_time', j.start_time,
+      'end_time', j.end_time,
+      'status', 'confirmed'
+    )
+  ), '[]'::JSONB)
+  INTO v_hard_conflicts
+  FROM timesheets ts
+  JOIN jobs j ON j.id = ts.job_id
+  WHERE ts.technician_id = _technician_id
+    AND ts.is_active = true
+    AND ts.job_id != _target_job_id
+    AND ts.date >= v_start_date
+    AND ts.date <= v_end_date;
+
+  -- Check for soft conflicts (pending invitations) if requested
+  IF _include_pending THEN
+    SELECT COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', j.id,
+        'title', j.title,
+        'start_time', j.start_time,
+        'end_time', j.end_time,
+        'status', 'pending'
+      )
+    ), '[]'::JSONB)
+    INTO v_soft_conflicts
+    FROM job_assignments ja
+    JOIN jobs j ON j.id = ja.job_id
+    WHERE ja.technician_id = _technician_id
+      AND ja.job_id != _target_job_id
+      AND ja.status = 'invited'
+      AND (
+        (_target_date IS NOT NULL AND EXISTS (
+          SELECT 1 FROM timesheets ts
+          WHERE ts.job_id = ja.job_id
+            AND ts.technician_id = _technician_id
+            AND ts.is_active = true
+            AND ts.date = _target_date
+        ))
+        OR (_target_date IS NULL AND (
+          j.start_time::DATE <= v_end_date AND
+          j.end_time::DATE >= v_start_date
+        ))
+      );
+  END IF;
+
+  -- Check for unavailability conflicts.
+  -- technician_availability.technician_id is legacy varchar, so compare as text.
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'date', ta.date,
+      'reason', CASE
+        WHEN ta.status = 'day_off' THEN 'Day Off'
+        WHEN ta.status = 'travel' THEN 'Travel'
+        WHEN ta.status = 'sick' THEN 'Sick'
+        WHEN ta.status = 'vacation' THEN 'Vacation'
+        ELSE 'Unavailable'
+      END,
+      'source', 'technician_availability'
+    )
+  ), '[]'::JSONB)
+  INTO v_unavailability
+  FROM technician_availability ta
+  WHERE ta.technician_id = _technician_id::text
+    AND ta.date >= v_start_date
+    AND ta.date <= v_end_date;
+
+  -- A seasonal house tech is unavailable outside the inclusive profile range.
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'date', generated_date::date,
+      'reason', 'Fuera de temporada',
+      'source', 'seasonal_house_tech_profile',
+      'notes', 'Fuera del rango de disponibilidad de temporada'
+    ) ORDER BY generated_date
+  ), '[]'::jsonb)
+  INTO v_seasonal_unavailability
+  FROM public.profiles p
+  CROSS JOIN LATERAL generate_series(v_start_date, v_end_date, interval '1 day') generated_date
+  WHERE p.id = _technician_id
+    AND p.role = 'house_tech'
+    AND p.seasonal_house_tech = true
+    AND (generated_date::date < p.seasonal_house_tech_start_date
+      OR generated_date::date > p.seasonal_house_tech_end_date);
+
+  v_unavailability := v_unavailability || v_seasonal_unavailability;
+
+  v_result := jsonb_build_object(
+    'hasHardConflict', jsonb_array_length(v_hard_conflicts) > 0,
+    'hasSoftConflict', jsonb_array_length(v_soft_conflicts) > 0,
+    'hardConflicts', v_hard_conflicts,
+    'softConflicts', v_soft_conflicts,
+    'unavailabilityConflicts', v_unavailability
+  );
+
+  RETURN v_result;
+END;
+$function$;
+
+
+-- Exclude out-of-season profiles from staffing recommendations.
+CREATE OR REPLACE FUNCTION public.rank_staffing_candidates(
+  p_job_id uuid,
+  p_department text,
+  p_role_code text,
+  p_mode text,
+  p_policy jsonb
+) RETURNS TABLE (
+  profile_id uuid,
+  full_name text,
+  department text,
+  skills_score int,
+  distance_to_madrid_km double precision,
+  proximity_score int,
+  experience_score int,
+  reliability_score int,
+  fairness_score int,
+  soft_conflict boolean,
+  hard_conflict boolean,
+  final_score int,
+  reasons jsonb
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  w_skills numeric := COALESCE((p_policy->'weights'->>'skills')::numeric, 0.5);
+  w_proximity numeric := COALESCE((p_policy->'weights'->>'proximity')::numeric, 0.1);
+  w_reliability numeric := COALESCE((p_policy->'weights'->>'reliability')::numeric, 0.2);
+  w_fairness numeric := COALESCE((p_policy->'weights'->>'fairness')::numeric, 0.1);
+  w_experience numeric := COALESCE((p_policy->'weights'->>'experience')::numeric, 0.1);
+  w_sum numeric;
+  v_soft_conflict_policy text := COALESCE(p_policy->>'soft_conflict_policy', 'warn');
+  v_exclude_fridge boolean := COALESCE((p_policy->>'exclude_fridge')::boolean, true);
+  v_job_start timestamptz;
+  v_job_end timestamptz;
+  v_normalized_role_code text := NULLIF(BTRIM(p_role_code), '');
+  v_role_prefix text;
+  v_base_lat double precision := 40.4168;
+  v_base_lng double precision := -3.7038;
+BEGIN
+  IF auth.role() <> 'service_role' THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM profiles p
+      WHERE p.id = auth.uid()
+        AND p.role IN ('admin', 'management', 'logistics')
+        AND (
+          p.role IN ('admin', 'logistics')
+          OR p.department IS NULL
+          OR p.department = p_department
+          OR (p_department = 'production' AND p.department = 'logistics')
+        )
+    ) THEN
+      RAISE EXCEPTION 'Not authorized to rank candidates';
+    END IF;
+  END IF;
+
+  SELECT j.start_time, j.end_time
+  INTO v_job_start, v_job_end
+  FROM jobs j
+  WHERE j.id = p_job_id;
+
+  IF v_job_start IS NULL THEN
+    RAISE EXCEPTION 'Job not found';
+  END IF;
+
+  v_role_prefix := public.staffing_role_prefix(v_normalized_role_code);
+
+  w_sum := w_skills + w_proximity + w_reliability + w_fairness + w_experience;
+  IF w_sum <= 0 THEN
+    w_skills := 0.5;
+    w_proximity := 0.1;
+    w_reliability := 0.2;
+    w_fairness := 0.1;
+    w_experience := 0.1;
+    w_sum := 1;
+  END IF;
+
+  w_skills := w_skills / w_sum;
+  w_proximity := w_proximity / w_sum;
+  w_reliability := w_reliability / w_sum;
+  w_fairness := w_fairness / w_sum;
+  w_experience := w_experience / w_sum;
+
+  RETURN QUERY
+  WITH target_dates AS (
+    SELECT generate_series(v_job_start::date, v_job_end::date, interval '1 day')::date AS target_date
+  ),
+  base AS (
+    SELECT
+      p.id AS profile_id,
+      NULLIF(TRIM(CONCAT_WS(' ', p.first_name, p.last_name)), '') AS full_name,
+      COALESCE(p.department, '') AS department,
+      p.role AS user_role,
+      p.home_latitude,
+      p.home_longitude,
+      COALESCE(tf.in_fridge, false) AS in_fridge,
+      (
+        SELECT MAX(ts.date)::date
+        FROM timesheets ts
+        WHERE ts.technician_id = p.id
+          AND ts.is_active = true
+      ) AS last_work_date,
+      (
+        SELECT COUNT(DISTINCT ts.job_id)
+        FROM timesheets ts
+        WHERE ts.technician_id = p.id
+          AND ts.is_active = true
+      ) AS jobs_worked,
+      (
+        SELECT COUNT(*)
+        FROM timesheets ts
+        WHERE ts.technician_id = p.id
+          AND ts.is_active = true
+          AND ts.date >= date_trunc('month', now())::date
+          AND ts.date < (date_trunc('month', now()) + interval '1 month')::date
+      ) AS current_month_days,
+      EXISTS (
+        SELECT 1
+        FROM job_assignments ja2
+        JOIN jobs j2 ON j2.id = ja2.job_id
+        WHERE ja2.technician_id = p.id
+          AND ja2.job_id IS DISTINCT FROM p_job_id
+          AND COALESCE(ja2.status, 'invited') <> 'declined'
+          AND EXISTS (
+            SELECT 1
+            FROM target_dates td
+            WHERE td.target_date BETWEEN j2.start_time::date AND j2.end_time::date
+          )
+          AND NOT (j2.time_range && tstzrange(v_job_start, v_job_end, '[]'))
+      ) AS has_same_day_job
+    FROM profiles p
+    LEFT JOIN technician_fridge tf ON tf.technician_id = p.id
+    WHERE
+      (
+        p.role IN ('technician', 'house_tech')
+        OR (p.role NOT IN ('technician', 'house_tech') AND p.assignable_as_tech = true)
+      )
+      AND (
+        (p_department <> 'production' AND p.department = p_department)
+        OR (p_department = 'production' AND p.department IN ('production', 'logistics'))
+      )
+      AND (NOT v_exclude_fridge OR COALESCE(tf.in_fridge, false) = false)
+      AND (
+        p.role <> 'house_tech'
+        OR p.seasonal_house_tech = false
+        OR NOT EXISTS (
+          SELECT 1
+          FROM target_dates seasonal_target
+          WHERE seasonal_target.target_date < p.seasonal_house_tech_start_date
+             OR seasonal_target.target_date > p.seasonal_house_tech_end_date
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM job_assignments ja
+        WHERE ja.job_id = p_job_id
+          AND ja.technician_id = p.id
+          AND COALESCE(ja.status, 'invited') <> 'declined'
+      )
+      AND (
+        v_normalized_role_code IS NULL
+        OR NOT EXISTS (
+          SELECT 1
+          FROM staffing_requests sr
+          WHERE sr.job_id = p_job_id
+            AND sr.profile_id = p.id
+            AND NULLIF(BTRIM(sr.role_code), '') = v_normalized_role_code
+            AND sr.phase IN ('availability', 'offer')
+            AND sr.status IN ('pending', 'confirmed', 'declined')
+        )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM staffing_requests sr
+        WHERE sr.job_id = p_job_id
+          AND sr.profile_id = p.id
+          AND NULLIF(BTRIM(sr.role_code), '') IS NULL
+          AND sr.phase IN ('availability', 'offer')
+          AND sr.status = 'declined'
+          AND (
+            sr.single_day = false
+            OR sr.target_date IS NULL
+            OR sr.target_date BETWEEN v_job_start::date AND v_job_end::date
+          )
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM technician_availability ta
+        JOIN target_dates td ON td.target_date = ta.date
+        WHERE ta.technician_id = p.id::text
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM timesheets ts
+        JOIN target_dates td ON td.target_date = ts.date
+        WHERE ts.technician_id = p.id
+          AND ts.job_id IS DISTINCT FROM p_job_id
+          AND ts.is_active = true
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM job_assignments ja2
+        JOIN jobs j2 ON j2.id = ja2.job_id
+        WHERE ja2.technician_id = p.id
+          AND ja2.job_id IS DISTINCT FROM p_job_id
+          AND COALESCE(ja2.status, 'invited') <> 'declined'
+          AND j2.time_range && tstzrange(v_job_start, v_job_end, '[]')
+      )
+  ),
+  skill_scores AS (
+    SELECT
+      b.profile_id,
+      COALESCE(
+        (
+          SELECT MAX(
+            LEAST(100,
+              (CASE WHEN ps.is_primary THEN 60 ELSE 40 END) +
+              (COALESCE(ps.proficiency, 0) * 8)
+            ) * rsm.weight
+          )::int
+          FROM profile_skills ps
+          JOIN skills s ON s.id = ps.skill_id AND s.active = true
+          JOIN role_skill_mapping rsm ON LOWER(rsm.skill_name) = LOWER(s.name)
+          WHERE ps.profile_id = b.profile_id
+            AND rsm.role_prefix = v_role_prefix
+            AND COALESCE(ps.proficiency, 0) > 0
+        ),
+        0
+      ) AS manual_skill_score,
+      (
+        SELECT jsonb_build_object(
+          'name', s.name,
+          'proficiency', ps.proficiency,
+          'is_primary', ps.is_primary,
+          'weight', rsm.weight
+        )
+        FROM profile_skills ps
+        JOIN skills s ON s.id = ps.skill_id AND s.active = true
+        JOIN role_skill_mapping rsm ON LOWER(rsm.skill_name) = LOWER(s.name)
+        WHERE ps.profile_id = b.profile_id
+          AND rsm.role_prefix = v_role_prefix
+          AND COALESCE(ps.proficiency, 0) > 0
+        ORDER BY
+          LEAST(100, (CASE WHEN ps.is_primary THEN 60 ELSE 40 END) + (COALESCE(ps.proficiency, 0) * 8)) * rsm.weight DESC
+        LIMIT 1
+      ) AS best_skill
+    FROM base b
+  ),
+  role_experience AS (
+    SELECT
+      b.profile_id,
+      COUNT(DISTINCT ja.job_id)::int AS role_completed_jobs
+    FROM base b
+    JOIN job_assignments ja ON ja.technician_id = b.profile_id
+      AND ja.status = 'confirmed'
+    JOIN jobs j ON j.id = ja.job_id
+      AND j.status = 'Completado'
+    WHERE public.staffing_role_prefix(
+      CASE p_department
+        WHEN 'sound' THEN ja.sound_role
+        WHEN 'lights' THEN ja.lights_role
+        WHEN 'video' THEN ja.video_role
+        WHEN 'production' THEN ja.production_role
+        ELSE COALESCE(ja.sound_role, ja.lights_role, ja.video_role, ja.production_role)
+      END
+    ) = v_role_prefix
+    GROUP BY b.profile_id
+  ),
+  reliability_stats AS (
+    SELECT
+      sr.profile_id,
+      COUNT(*) FILTER (WHERE sr.phase = 'availability' AND sr.status = 'confirmed') AS avail_yes,
+      COUNT(*) FILTER (WHERE sr.phase = 'availability' AND sr.status IN ('confirmed', 'declined')) AS avail_total,
+      COUNT(*) FILTER (WHERE sr.phase = 'offer' AND sr.status = 'confirmed') AS offer_yes,
+      COUNT(*) FILTER (WHERE sr.phase = 'offer' AND sr.status IN ('confirmed', 'declined')) AS offer_total
+    FROM staffing_requests sr
+    GROUP BY sr.profile_id
+  ),
+  with_reliability AS (
+    SELECT
+      b.*,
+      ss.manual_skill_score,
+      ss.best_skill,
+      COALESCE(re.role_completed_jobs, 0)::int AS role_completed_jobs,
+      (
+        CASE
+          WHEN COALESCE(re.role_completed_jobs, 0) >= 11 THEN 80
+          WHEN COALESCE(re.role_completed_jobs, 0) >= 7 THEN 65
+          WHEN COALESCE(re.role_completed_jobs, 0) >= 4 THEN 50
+          WHEN COALESCE(re.role_completed_jobs, 0) >= 2 THEN 35
+          WHEN COALESCE(re.role_completed_jobs, 0) = 1 THEN 20
+          ELSE 0
+        END
+      )::int AS role_experience_score,
+      COALESCE(rs.avail_yes, 0) AS avail_yes,
+      COALESCE(rs.avail_total, 0) AS avail_total,
+      COALESCE(rs.offer_yes, 0) AS offer_yes,
+      COALESCE(rs.offer_total, 0) AS offer_total
+    FROM base b
+    LEFT JOIN skill_scores ss ON ss.profile_id = b.profile_id
+    LEFT JOIN role_experience re ON re.profile_id = b.profile_id
+    LEFT JOIN reliability_stats rs ON rs.profile_id = b.profile_id
+  ),
+  scored AS (
+    SELECT
+      wr.profile_id,
+      wr.full_name,
+      wr.department,
+      wr.user_role,
+      GREATEST(wr.manual_skill_score, wr.role_experience_score)::int AS skills_score,
+      wr.manual_skill_score,
+      wr.best_skill,
+      wr.role_completed_jobs,
+      wr.role_experience_score,
+      wr.jobs_worked,
+      wr.current_month_days,
+      CASE
+        WHEN wr.home_latitude IS NOT NULL
+          AND wr.home_longitude IS NOT NULL
+        THEN distance_km(wr.home_latitude, wr.home_longitude, v_base_lat, v_base_lng)
+        ELSE NULL
+      END AS distance_to_base_km,
+      LEAST(wr.jobs_worked, 10)::int AS experience_score,
+      (
+        CASE
+          WHEN wr.avail_total > 0 OR wr.offer_total > 0 THEN
+            ROUND(
+              COALESCE(wr.avail_yes::numeric / NULLIF(wr.avail_total, 0), 0) * 5 +
+              COALESCE(wr.offer_yes::numeric / NULLIF(wr.offer_total, 0), 0) * 5
+            )
+          ELSE 5
+        END
+      )::int AS reliability_score,
+      (
+        CASE
+          WHEN wr.user_role = 'house_tech' AND wr.current_month_days < 4 THEN 10
+          WHEN wr.last_work_date IS NULL THEN 10
+          WHEN (now()::date - wr.last_work_date) > 30 THEN 10
+          WHEN (now()::date - wr.last_work_date) > 14 THEN 7
+          ELSE 3
+        END
+      )::int AS fairness_score,
+      wr.has_same_day_job AS soft_conflict,
+      false AS hard_conflict
+    FROM with_reliability wr
+  ),
+  with_proximity AS (
+    SELECT
+      s.*,
+      CASE
+        WHEN s.distance_to_base_km IS NULL THEN 5
+        WHEN s.distance_to_base_km <= 25 THEN 10
+        WHEN s.distance_to_base_km <= 50 THEN 8
+        WHEN s.distance_to_base_km <= 100 THEN 6
+        WHEN s.distance_to_base_km <= 200 THEN 4
+        WHEN s.distance_to_base_km <= 400 THEN 2
+        ELSE 1
+      END AS proximity_score
+    FROM scored s
+  ),
+  filtered AS (
+    SELECT s.*
+    FROM with_proximity s
+    WHERE s.hard_conflict = false
+      AND (v_soft_conflict_policy <> 'block' OR s.soft_conflict = false)
+  )
+  SELECT
+    f.profile_id,
+    COALESCE(f.full_name, 'Unknown') AS full_name,
+    f.department,
+    f.skills_score,
+    f.distance_to_base_km AS distance_to_madrid_km,
+    f.proximity_score,
+    f.experience_score,
+    f.reliability_score,
+    f.fairness_score,
+    f.soft_conflict,
+    f.hard_conflict,
+    LEAST(
+      100,
+      ROUND(
+        (
+          (f.skills_score::numeric) * w_skills +
+          (f.proximity_score::numeric * 10) * w_proximity +
+          (f.reliability_score::numeric * 10) * w_reliability +
+          (f.fairness_score::numeric * 10) * w_fairness +
+          (f.experience_score::numeric * 10) * w_experience
+        ) * (
+          CASE
+            WHEN f.user_role = 'house_tech' AND f.current_month_days < 4 THEN 1.3
+            ELSE 1.0
+          END
+        )
+      )::int
+    ) AS final_score,
+    jsonb_build_array(
+      CASE
+        WHEN f.manual_skill_score > 0 AND f.best_skill IS NOT NULL THEN
+          (CASE WHEN (f.best_skill->>'is_primary')::boolean THEN 'Primary skill: ' ELSE 'Skill: ' END) ||
+          (f.best_skill->>'name') || ' (lvl ' || (f.best_skill->>'proficiency') || ')' ||
+          (CASE WHEN (f.best_skill->>'weight')::numeric < 1 THEN ' [related]' ELSE '' END)
+        ELSE 'No matching manual skill for ' || COALESCE(v_role_prefix, p_role_code)
+      END,
+      CASE
+        WHEN f.distance_to_base_km IS NOT NULL THEN
+          'Proximity: ' || ROUND(f.distance_to_base_km::numeric, 1) || 'km (' || f.proximity_score || '/10)'
+        ELSE 'Proximity: No location data'
+      END,
+      'Reliability: ' || f.reliability_score || '/10',
+      'Fairness: ' || f.fairness_score || '/10',
+      'Experience: ' || f.experience_score || '/10'
+    ) ||
+    (CASE
+      WHEN f.role_completed_jobs > 0
+      THEN jsonb_build_array('Role experience: ' || f.role_completed_jobs || ' completed ' || COALESCE(v_role_prefix, p_role_code) || ' jobs')
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE
+      WHEN f.role_experience_score > f.manual_skill_score
+      THEN jsonb_build_array('Skill score boosted by completed role history')
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE
+      WHEN f.user_role = 'house_tech' AND f.current_month_days < 4
+      THEN jsonb_build_array('House tech boost (+30%)')
+      ELSE '[]'::jsonb
+    END) ||
+    (CASE WHEN f.soft_conflict THEN jsonb_build_array('Same-day job (different time)') ELSE '[]'::jsonb END) AS reasons
+  FROM filtered f
+  ORDER BY final_score DESC, f.profile_id
+  LIMIT 50;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rank_staffing_candidates(uuid, text, text, text, jsonb) TO service_role;

--- a/supabase/tests/database/seasonal_house_tech_finance.sql
+++ b/supabase/tests/database/seasonal_house_tech_finance.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
 
 SET search_path TO public, extensions;
 
-SELECT plan(25);
+SELECT plan(28);
 
 SELECT has_column('public', 'profiles', 'seasonal_house_tech', 'profiles stores the seasonal house-tech flag');
 SELECT has_column('public', 'profiles', 'seasonal_house_tech_start_date', 'profiles stores the season start');
@@ -35,6 +35,16 @@ SELECT ok(
       AND NOT tgisinternal
   ),
   'seasonal profile changes have a dedicated privilege guard'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.profiles'::regclass
+      AND tgname = 'enforce_seasonal_house_tech_insert'
+      AND NOT tgisinternal
+  ),
+  'seasonal settings on newly inserted profiles use the same privilege guard'
 );
 
 SELECT ok(
@@ -90,6 +100,13 @@ INSERT INTO auth.users (
     'role-change-house@test.local', 'test', now(), now(), now(),
     '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
     'authenticated', 'authenticated'
+  ),
+  (
+    'dc100000-0000-0000-0000-000000000005'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'seasonal-self-insert@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
   )
 ON CONFLICT (id) DO NOTHING;
 
@@ -129,6 +146,26 @@ ON CONFLICT (id) DO UPDATE SET
 SELECT set_config('request.jwt.claim.role', 'authenticated', false);
 SELECT set_config('request.jwt.claim.sub', 'dc100000-0000-0000-0000-000000000002', false);
 SET ROLE authenticated;
+
+SELECT set_config('request.jwt.claim.sub', 'dc100000-0000-0000-0000-000000000005', false);
+
+SELECT throws_ok(
+  $$
+    INSERT INTO public.profiles (
+      id, email, first_name, last_name, role, department, autonomo,
+      seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date
+    ) VALUES (
+      'dc100000-0000-0000-0000-000000000005'::uuid,
+      'seasonal-self-insert@test.local', 'Seasonal', 'Self Insert',
+      'house_tech', 'sound', true, true, '2026-06-01', '2026-08-31'
+    )
+  $$,
+  '42501',
+  'Seasonal house tech settings cannot be set or changed on your own account',
+  'a caller cannot bypass the admin guard by inserting a seasonal own-profile row'
+);
+
+SELECT set_config('request.jwt.claim.sub', 'dc100000-0000-0000-0000-000000000002', false);
 
 SELECT throws_ok(
   $$
@@ -182,7 +219,9 @@ SELECT is(
 );
 
 INSERT INTO public.activity_catalog (code, label, default_visibility, severity, toast_enabled)
-VALUES ('job.created', 'Job created', 'management', 'info', false)
+VALUES
+  ('job.created', 'Job created', 'management', 'info', false),
+  ('timesheet.approved', 'Timesheet approved', 'job_participants', 'info', false)
 ON CONFLICT (code) DO NOTHING;
 
 INSERT INTO public.jobs (id, title, start_time, end_time, job_type, status)
@@ -230,6 +269,12 @@ INSERT INTO public.timesheets (
     'dc200000-0000-0000-0000-000000000001'::uuid,
     'dc100000-0000-0000-0000-000000000003'::uuid,
     '2026-07-12', '08:00', '22:00', 0, 'responsable', true
+  ),
+  (
+    'dc300000-0000-0000-0000-000000000004'::uuid,
+    'dc200000-0000-0000-0000-000000000001'::uuid,
+    'dc100000-0000-0000-0000-000000000003'::uuid,
+    '2026-07-13', '08:00', '22:00', 0, 'responsable', true
   )
 ON CONFLICT (id) DO UPDATE SET
   start_time = excluded.start_time,
@@ -248,6 +293,12 @@ ON CONFLICT (job_id, date) DO UPDATE SET type = excluded.type;
 UPDATE public.timesheets
 SET updated_at = now()
 WHERE id = 'dc300000-0000-0000-0000-000000000003'::uuid;
+
+UPDATE public.timesheets
+SET approved_by_manager = true,
+    amount_eur = 777,
+    amount_breakdown = '{"locked_for_review_test":true}'::jsonb
+WHERE id = 'dc300000-0000-0000-0000-000000000004'::uuid;
 
 SELECT is(
   (public.compute_timesheet_amount_2025('dc300000-0000-0000-0000-000000000001'::uuid, true)->>'amount_eur')::numeric,
@@ -331,6 +382,16 @@ SELECT is(
   ),
   50::numeric,
   'enabling seasonal mode automatically removes stored base and plus amounts'
+);
+
+SELECT is(
+  (
+    SELECT amount_eur
+    FROM public.timesheets
+    WHERE id = 'dc300000-0000-0000-0000-000000000004'::uuid
+  ),
+  777::numeric,
+  'profile changes do not rewrite a manager-approved historical payout'
 );
 
 SELECT is(

--- a/supabase/tests/database/seasonal_house_tech_finance.sql
+++ b/supabase/tests/database/seasonal_house_tech_finance.sql
@@ -1,0 +1,373 @@
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+SET search_path TO public, extensions;
+
+SELECT plan(25);
+
+SELECT has_column('public', 'profiles', 'seasonal_house_tech', 'profiles stores the seasonal house-tech flag');
+SELECT has_column('public', 'profiles', 'seasonal_house_tech_start_date', 'profiles stores the season start');
+SELECT has_column('public', 'profiles', 'seasonal_house_tech_end_date', 'profiles stores the season end');
+SELECT col_default_is('public', 'profiles', 'seasonal_house_tech', 'false', 'seasonal mode defaults off');
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.profiles'::regclass
+      AND conname = 'profiles_seasonal_house_tech_range_check'
+  ),
+  'seasonal profiles require a valid inclusive date range'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.profiles'::regclass
+      AND conname = 'profiles_house_tech_autonomo_ignored_check'
+  ),
+  'house tech profiles cannot retain non-autonomo payroll state'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.profiles'::regclass
+      AND tgname = 'enforce_seasonal_house_tech_change'
+      AND NOT tgisinternal
+  ),
+  'seasonal profile changes have a dedicated privilege guard'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.profiles'::regclass
+      AND tgname = 'recompute_timesheets_after_profile_finance_change'
+      AND NOT tgisinternal
+  ),
+  'profile finance changes refresh existing active timesheets'
+);
+
+SELECT ok(
+  NOT has_function_privilege('authenticated', 'public.enforce_seasonal_house_tech_change()', 'EXECUTE'),
+  'authenticated callers cannot invoke the seasonal guard directly'
+);
+
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.get_profiles_with_skills()', 'EXECUTE'),
+  'profile matrix RPC remains unavailable to anonymous callers'
+);
+
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+
+INSERT INTO auth.users (
+  id, instance_id, email, encrypted_password, email_confirmed_at, created_at,
+  updated_at, raw_app_meta_data, raw_user_meta_data, aud, role
+) VALUES
+  (
+    'dc100000-0000-0000-0000-000000000001'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'seasonal-admin@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'dc100000-0000-0000-0000-000000000002'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'seasonal-manager@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'dc100000-0000-0000-0000-000000000003'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'seasonal-house@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  ),
+  (
+    'dc100000-0000-0000-0000-000000000004'::uuid,
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    'role-change-house@test.local', 'test', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    'authenticated', 'authenticated'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.profiles (
+  id, email, first_name, last_name, role, department, autonomo,
+  seasonal_house_tech, seasonal_house_tech_start_date, seasonal_house_tech_end_date
+) VALUES
+  (
+    'dc100000-0000-0000-0000-000000000001'::uuid,
+    'seasonal-admin@test.local', 'Seasonal', 'Admin', 'admin', 'sound', true,
+    false, null, null
+  ),
+  (
+    'dc100000-0000-0000-0000-000000000002'::uuid,
+    'seasonal-manager@test.local', 'Seasonal', 'Manager', 'management', 'sound', true,
+    false, null, null
+  ),
+  (
+    'dc100000-0000-0000-0000-000000000003'::uuid,
+    'seasonal-house@test.local', 'Seasonal', 'House', 'house_tech', 'sound', true,
+    false, null, null
+  ),
+  (
+    'dc100000-0000-0000-0000-000000000004'::uuid,
+    'role-change-house@test.local', 'Role', 'Change', 'technician', 'sound', false,
+    false, null, null
+  )
+ON CONFLICT (id) DO UPDATE SET
+  email = excluded.email,
+  role = excluded.role,
+  department = excluded.department,
+  autonomo = excluded.autonomo,
+  seasonal_house_tech = excluded.seasonal_house_tech,
+  seasonal_house_tech_start_date = excluded.seasonal_house_tech_start_date,
+  seasonal_house_tech_end_date = excluded.seasonal_house_tech_end_date;
+
+SELECT set_config('request.jwt.claim.role', 'authenticated', false);
+SELECT set_config('request.jwt.claim.sub', 'dc100000-0000-0000-0000-000000000002', false);
+SET ROLE authenticated;
+
+SELECT throws_ok(
+  $$
+    UPDATE public.profiles
+    SET seasonal_house_tech = true,
+        seasonal_house_tech_start_date = '2026-06-01',
+        seasonal_house_tech_end_date = '2026-08-31'
+    WHERE id = 'dc100000-0000-0000-0000-000000000003'::uuid
+  $$,
+  '42501',
+  'Only administrators may change seasonal house tech settings',
+  'management cannot enable seasonal payroll'
+);
+
+RESET ROLE;
+SELECT set_config('request.jwt.claim.sub', 'dc100000-0000-0000-0000-000000000001', false);
+SET ROLE authenticated;
+
+SELECT lives_ok(
+  $$
+    UPDATE public.profiles
+    SET seasonal_house_tech = true,
+        seasonal_house_tech_start_date = '2026-06-01',
+        seasonal_house_tech_end_date = '2026-08-31'
+    WHERE id = 'dc100000-0000-0000-0000-000000000003'::uuid
+  $$,
+  'admin can enable seasonal payroll with a valid range'
+);
+
+SELECT is(
+  (
+    SELECT seasonal_house_tech_start_date
+    FROM public.profiles
+    WHERE id = 'dc100000-0000-0000-0000-000000000003'::uuid
+  ),
+  '2026-06-01'::date,
+  'the inclusive season start is stored'
+);
+
+RESET ROLE;
+SELECT set_config('request.jwt.claim.role', 'service_role', false);
+
+UPDATE public.profiles
+SET role = 'house_tech', autonomo = false
+WHERE id = 'dc100000-0000-0000-0000-000000000004'::uuid;
+
+SELECT is(
+  (SELECT autonomo FROM public.profiles WHERE id = 'dc100000-0000-0000-0000-000000000004'::uuid),
+  true,
+  'changing a technician to house tech normalizes autonomo to true'
+);
+
+INSERT INTO public.activity_catalog (code, label, default_visibility, severity, toast_enabled)
+VALUES ('job.created', 'Job created', 'management', 'info', false)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO public.jobs (id, title, start_time, end_time, job_type, status)
+VALUES (
+  'dc200000-0000-0000-0000-000000000001'::uuid,
+  'Seasonal overtime-only test',
+  '2026-07-10 08:00:00+02'::timestamptz,
+  '2026-07-10 23:00:00+02'::timestamptz,
+  'evento',
+  'Confirmado'
+)
+ON CONFLICT (id) DO UPDATE SET job_type = excluded.job_type;
+
+INSERT INTO public.custom_tech_rates (
+  profile_id, base_day_eur, plus_10_12_eur, overtime_hour_eur,
+  overtime_hour_responsable_eur
+) VALUES (
+  'dc100000-0000-0000-0000-000000000003'::uuid,
+  200, 100, 15, 25
+)
+ON CONFLICT (profile_id) DO UPDATE SET
+  base_day_eur = excluded.base_day_eur,
+  plus_10_12_eur = excluded.plus_10_12_eur,
+  overtime_hour_eur = excluded.overtime_hour_eur,
+  overtime_hour_responsable_eur = excluded.overtime_hour_responsable_eur;
+
+INSERT INTO public.timesheets (
+  id, job_id, technician_id, date, start_time, end_time, break_minutes,
+  category, is_active
+) VALUES
+  (
+    'dc300000-0000-0000-0000-000000000001'::uuid,
+    'dc200000-0000-0000-0000-000000000001'::uuid,
+    'dc100000-0000-0000-0000-000000000003'::uuid,
+    '2026-07-10', '08:00', '20:00', 0, 'responsable', true
+  ),
+  (
+    'dc300000-0000-0000-0000-000000000002'::uuid,
+    'dc200000-0000-0000-0000-000000000001'::uuid,
+    'dc100000-0000-0000-0000-000000000003'::uuid,
+    '2026-07-11', '08:00', '22:00', 0, 'responsable', true
+  ),
+  (
+    'dc300000-0000-0000-0000-000000000003'::uuid,
+    'dc200000-0000-0000-0000-000000000001'::uuid,
+    'dc100000-0000-0000-0000-000000000003'::uuid,
+    '2026-07-12', '08:00', '22:00', 0, 'responsable', true
+  )
+ON CONFLICT (id) DO UPDATE SET
+  start_time = excluded.start_time,
+  end_time = excluded.end_time,
+  category = excluded.category,
+  is_active = true;
+
+INSERT INTO public.job_date_types (job_id, date, type)
+VALUES (
+  'dc200000-0000-0000-0000-000000000001'::uuid,
+  '2026-07-12',
+  'prep_day'
+)
+ON CONFLICT (job_id, date) DO UPDATE SET type = excluded.type;
+
+UPDATE public.timesheets
+SET updated_at = now()
+WHERE id = 'dc300000-0000-0000-0000-000000000003'::uuid;
+
+SELECT is(
+  (public.compute_timesheet_amount_2025('dc300000-0000-0000-0000-000000000001'::uuid, true)->>'amount_eur')::numeric,
+  0::numeric,
+  'a 12-hour seasonal evento pays no base or plus'
+);
+
+SELECT is(
+  (public.compute_timesheet_amount_2025('dc300000-0000-0000-0000-000000000002'::uuid, true)->>'amount_eur')::numeric,
+  50::numeric,
+  'a 14-hour seasonal shift pays two category-aware overtime hours only'
+);
+
+SELECT is(
+  (
+    SELECT amount_breakdown->>'rate_mode_source'
+    FROM public.timesheets
+    WHERE id = 'dc300000-0000-0000-0000-000000000002'::uuid
+  ),
+  'seasonal_house_tech_profile',
+  'the stored audit breakdown identifies the profile-driven rate mode'
+);
+
+SELECT is(
+  (
+    SELECT amount_breakdown->>'seasonal_overtime_only'
+    FROM public.timesheets
+    WHERE id = 'dc300000-0000-0000-0000-000000000002'::uuid
+  ),
+  'true',
+  'the stored audit breakdown marks overtime-only pricing'
+);
+
+SELECT is(
+  (
+    SELECT amount_eur
+    FROM public.timesheets
+    WHERE id = 'dc300000-0000-0000-0000-000000000003'::uuid
+  ),
+  50::numeric,
+  'a seasonal prep day also pays only category-aware overtime above 12 hours'
+);
+
+SELECT is(
+  (
+    SELECT amount_breakdown->>'technician_rate_mode'
+    FROM public.timesheets
+    WHERE id = 'dc300000-0000-0000-0000-000000000003'::uuid
+  ),
+  'hourly',
+  'the prep-day trigger preserves the seasonal hourly reporting mode'
+);
+
+UPDATE public.profiles
+SET seasonal_house_tech = false,
+    seasonal_house_tech_start_date = null,
+    seasonal_house_tech_end_date = null
+WHERE id = 'dc100000-0000-0000-0000-000000000003'::uuid;
+
+SELECT is(
+  (
+    SELECT amount_eur
+    FROM public.timesheets
+    WHERE id = 'dc300000-0000-0000-0000-000000000002'::uuid
+  ),
+  300::numeric,
+  'disabling seasonal mode automatically restores normal stored pricing'
+);
+
+UPDATE public.profiles
+SET seasonal_house_tech = true,
+    seasonal_house_tech_start_date = '2026-06-01',
+    seasonal_house_tech_end_date = '2026-08-31'
+WHERE id = 'dc100000-0000-0000-0000-000000000003'::uuid;
+
+SELECT is(
+  (
+    SELECT amount_eur
+    FROM public.timesheets
+    WHERE id = 'dc300000-0000-0000-0000-000000000002'::uuid
+  ),
+  50::numeric,
+  'enabling seasonal mode automatically removes stored base and plus amounts'
+);
+
+SELECT is(
+  jsonb_array_length(
+    public.check_technician_conflicts(
+      'dc100000-0000-0000-0000-000000000003'::uuid,
+      'dc200000-0000-0000-0000-000000000001'::uuid,
+      '2026-09-01'::date
+    )->'unavailabilityConflicts'
+  ),
+  1,
+  'assignment conflict checks report dates after the configured season as unavailable'
+);
+
+SELECT is(
+  jsonb_array_length(
+    public.check_technician_conflicts(
+      'dc100000-0000-0000-0000-000000000003'::uuid,
+      'dc200000-0000-0000-0000-000000000001'::uuid,
+      '2026-08-31'::date
+    )->'unavailabilityConflicts'
+  ),
+  0,
+  'assignment conflict checks treat the inclusive season end as available'
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.get_profiles_with_skills()
+    WHERE id = 'dc100000-0000-0000-0000-000000000003'
+      AND seasonal_house_tech = true
+      AND seasonal_house_tech_start_date = '2026-06-01'
+      AND seasonal_house_tech_end_date = '2026-08-31'
+  ),
+  1,
+  'the matrix profile RPC exposes the seasonal availability range'
+);
+
+SELECT * FROM finish();


### PR DESCRIPTION
## Summary

- adds an admin-only **House tech de temporada** profile checkbox with a required inclusive availability range
- treats seasonal house-tech timesheets as overtime-only on every job type: no base or 10–12h plus, only rounded hours above 12 at the technician's category-aware overtime rate
- shows per-date hourly breakdowns in tour payout PDFs whenever a technician/date is hourly
- removes autónomo badges and the €30 deduction from all house-tech payout paths, including stale profiles changed from technician to house tech

## Behavior and implementation

- the profile flag controls payroll globally; the date range controls scheduling availability only
- out-of-season profiles are excluded or marked unavailable in the assignment matrix, technician selectors, personal calendar, morning summary, tour availability requests, staffing ranking, and conflict checks
- enabling/disabling seasonal mode or changing the finance-relevant profile state recalculates existing active timesheets, including prep days
- house-tech profiles are normalized to `autonomo = true`, while payout/UI/PDF code independently ignores autónomo for house techs as defense in depth
- tour payout PDFs include rounded hours, zero/actual base, overtime hours × rate, and date total for hourly rows

## Database and security

Risk classification: **high** (payroll logic and additive database migration). This diff warrants a deliberate second read by the maintainer before merge.

Migration `20260730120000_add_seasonal_house_tech_finance.sql` adds the profile fields, range and house-tech constraints, admin-only audited seasonal-setting enforcement, recalculation triggers, canonical payroll/tour quote updates, and availability integration. Seasonal profile changes are rejected for management users and allowed only for admins/service role.

Production rollout requires a human to run `supabase db push --linked --dry-run`, review the plan, and then apply the migration. This PR does not perform a production database push.

## Rollback

Before production migration, revert this commit. After the additive migration is applied, disable seasonal flags and clear their ranges, redeploy the prior app if needed, and forward-fix the schema/functions rather than dropping columns or payroll audit data.

## Validation

- `npm run lint` (passes with repository-baseline warnings)
- `npm run typecheck`
- `npm run governance`
- `npm run test:critical`
- `npm run test:run` — 1,752 tests passed
- focused seasonal/profile/payout/PDF tests — 19 passed
- `npm run build`
- `npm run budget:bundle`
- `npm run test:e2e` — 22 passed, 3 skipped
- `supabase db reset --local --no-seed`
- `supabase db lint --local --fail-on error --schema public,auth`
- `supabase test db supabase/tests/database` — 296 tests passed
- generated a representative seasonal tour payout PDF, rendered it, and visually verified its hourly breakdown and layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seasonal house technician configuration with administrator-controlled start and end dates.
  * Availability, staffing, assignments, payroll, and pricing now respect seasonal windows.
  * Added seasonal status to morning summaries and technician availability views.
  * Tour PDFs and payout summaries now include hourly breakdowns and improved preparation-day details.

* **Bug Fixes**
  * House technicians no longer receive non-applicable autonomo deductions.
  * Tour timesheets and hourly entries are now represented more accurately in previews and exports.
  * Technician selections are cleared when availability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->