### PR TITLE
Fix artist actions, date navigation, and extras budgets

### DIFF
--- a/src/components/festival/ArtistTable.tsx
+++ b/src/components/festival/ArtistTable.tsx
@@ -50,6 +50,7 @@ export const ArtistTable = ({
   searchTerm,
   stageFilter,
   riderFilter,
+  dayStartTime,
   jobId,
   selectedDate,
   crossDateSearch = false,
@@ -59,7 +60,10 @@ export const ArtistTable = ({
 }: ArtistTableProps) => {
   const [sortBy, setSortBy] = useState<ArtistSortField>('chronological');
   const confirm = useConfirm();
-  const { createExtrasPresupuesto, isCreatingExtrasFor } = useCreateExtrasPresupuesto(jobId);
+  const { createExtrasPresupuesto, isCreatingExtrasFor } = useCreateExtrasPresupuesto(
+    jobId,
+    dayStartTime,
+  );
   const [deletingArtistId, setDeletingArtistId] = useState<string | null>(null);
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const [linksDialogOpen, setLinksDialogOpen] = useState(false);

--- a/src/components/festival/FestivalDateNavigation.tsx
+++ b/src/components/festival/FestivalDateNavigation.tsx
@@ -4,18 +4,9 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { DateTypeContextMenu } from "@/components/dashboard/DateTypeContextMenu";
 import { ChevronLeft, ChevronRight, Calendar, CalendarCheck2, Filter } from "lucide-react";
-import {
-  addWeeks,
-  endOfWeek,
-  format,
-  isBefore,
-  isSameWeek,
-  parseISO,
-  startOfDay,
-  startOfWeek,
-  subWeeks,
-} from "date-fns";
+import { format, parseISO } from "date-fns";
 import { es } from "date-fns/locale";
+import { formatInTimeZone } from "date-fns-tz";
 import {
   Popover,
   PopoverContent,
@@ -26,6 +17,31 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { getDateTypeMeta, getEffectiveFestivalDateType, isKeyFestivalDateType } from "@/constants/dateTypes";
+import {
+  addMadridCalendarDays,
+  formatMadridDateKey,
+  fromMadridDateKey,
+  MADRID_TIMEZONE,
+} from "@/utils/timezoneUtils";
+
+const FESTIVAL_DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const getFestivalWeekStartKey = (dateKey: string): string => {
+  const safeDateKey = FESTIVAL_DATE_KEY_PATTERN.test(dateKey)
+    ? dateKey
+    : formatMadridDateKey(new Date());
+  const madridNoon = fromMadridDateKey(safeDateKey, "12:00:00");
+  const isoWeekday = Number(formatInTimeZone(madridNoon, MADRID_TIMEZONE, "i"));
+
+  return addMadridCalendarDays(safeDateKey, -(isoWeekday - 1));
+};
+
+const formatFestivalDateKey = (dateKey: string, formatPattern: string): string =>
+  formatInTimeZone(
+    fromMadridDateKey(dateKey, "12:00:00"),
+    MADRID_TIMEZONE,
+    formatPattern,
+  );
 
 interface FestivalDateNavigationProps {
   jobDates: Date[];
@@ -56,71 +72,88 @@ export const FestivalDateNavigation = ({
   maxStages = 3
 }: FestivalDateNavigationProps) => {
   const [currentWeekStart, setCurrentWeekStart] = useState(() => {
-    const selected = new Date(selectedDate);
-    return startOfWeek(selected, { weekStartsOn: 1 }); // Start week on Monday
+    return getFestivalWeekStartKey(selectedDate);
   });
   const [showOnlyShowDates, setShowOnlyShowDates] = useState(true);
   const [showPastDates, setShowPastDates] = useState(false);
   const [viewMode, setViewMode] = useState<'week' | 'all'>('all');
+  const todayDateKey = formatMadridDateKey(new Date());
   const selectedDateLabel = useMemo(() => {
-    if (!selectedDate) return "";
-    const parsedSelectedDate = parseISO(selectedDate);
-    if (Number.isNaN(parsedSelectedDate.getTime())) return selectedDate;
-    return format(parsedSelectedDate, "EEEE, d 'de' MMMM 'de' yyyy", { locale: es });
+    if (!FESTIVAL_DATE_KEY_PATTERN.test(selectedDate)) return selectedDate;
+    return formatInTimeZone(
+      fromMadridDateKey(selectedDate, "12:00:00"),
+      MADRID_TIMEZONE,
+      "EEEE, d 'de' MMMM 'de' yyyy",
+      { locale: es },
+    );
   }, [selectedDate]);
 
   const hasPastDates = useMemo(() => {
-    const today = startOfDay(new Date());
-    return jobDates.some((date) => isBefore(startOfDay(date), today));
-  }, [jobDates]);
+    return jobDates.some((date) => formatMadridDateKey(date) < todayDateKey);
+  }, [jobDates, todayDateKey]);
 
   // Filter dates based on preferences. Keep a selected historical date visible
   // so the navigation never loses the day the user is inspecting.
   const filteredDates = useMemo(() => {
-    const today = startOfDay(new Date());
-
     return jobDates.filter(date => {
-      const formattedDate = format(date, 'yyyy-MM-dd');
+      const formattedDate = formatMadridDateKey(date);
       if (formattedDate === selectedDate) return true;
-      if (!showPastDates && isBefore(startOfDay(date), today)) return false;
+      if (!showPastDates && formattedDate < todayDateKey) return false;
       if (!showOnlyShowDates) return true;
 
       const key = `${jobId}-${formattedDate}`;
       const dateType = getEffectiveFestivalDateType(dateTypes[key]);
       return isKeyFestivalDateType(dateType);
     });
-  }, [jobDates, selectedDate, showPastDates, showOnlyShowDates, dateTypes, jobId]);
+  }, [
+    jobDates,
+    selectedDate,
+    showPastDates,
+    showOnlyShowDates,
+    dateTypes,
+    jobId,
+    todayDateKey,
+  ]);
 
   // Get dates for current week
   const weekDates = useMemo(() => {
     if (viewMode === 'all') return filteredDates;
-    
-    const weekEnd = endOfWeek(currentWeekStart, { weekStartsOn: 1 });
-    return filteredDates.filter(date => 
-      date >= currentWeekStart && date <= weekEnd
-    );
+
+    const weekEnd = addMadridCalendarDays(currentWeekStart, 6);
+    return filteredDates.filter(date => {
+      const dateKey = formatMadridDateKey(date);
+      return dateKey >= currentWeekStart && dateKey <= weekEnd;
+    });
   }, [currentWeekStart, filteredDates, viewMode]);
 
   const canGoToPrevWeek = useMemo(() => {
-    const prevWeek = subWeeks(currentWeekStart, 1);
-    return filteredDates.some(date => isSameWeek(date, prevWeek, { weekStartsOn: 1 }));
+    const prevWeekStart = addMadridCalendarDays(currentWeekStart, -7);
+    const prevWeekEnd = addMadridCalendarDays(prevWeekStart, 6);
+    return filteredDates.some(date => {
+      const dateKey = formatMadridDateKey(date);
+      return dateKey >= prevWeekStart && dateKey <= prevWeekEnd;
+    });
   }, [currentWeekStart, filteredDates]);
 
   const canGoToNextWeek = useMemo(() => {
-    const nextWeek = addWeeks(currentWeekStart, 1);
-    return filteredDates.some(date => isSameWeek(date, nextWeek, { weekStartsOn: 1 }));
+    const nextWeekStart = addMadridCalendarDays(currentWeekStart, 7);
+    const nextWeekEnd = addMadridCalendarDays(nextWeekStart, 6);
+    return filteredDates.some(date => {
+      const dateKey = formatMadridDateKey(date);
+      return dateKey >= nextWeekStart && dateKey <= nextWeekEnd;
+    });
   }, [currentWeekStart, filteredDates]);
 
   const handlePrevWeek = () => {
-    setCurrentWeekStart(prev => subWeeks(prev, 1));
+    setCurrentWeekStart(prev => addMadridCalendarDays(prev, -7));
   };
 
   const handleNextWeek = () => {
-    setCurrentWeekStart(prev => addWeeks(prev, 1));
+    setCurrentWeekStart(prev => addMadridCalendarDays(prev, 7));
   };
 
   const getDateTypeColor = (date: Date) => {
-    const formattedDate = format(date, 'yyyy-MM-dd');
+    const formattedDate = formatMadridDateKey(date);
     const key = `${jobId}-${formattedDate}`;
     const meta = getDateTypeMeta(getEffectiveFestivalDateType(dateTypes[key]));
     if (!meta) return "border-gray-300";
@@ -128,7 +161,7 @@ export const FestivalDateNavigation = ({
   };
 
   const getDateTypeBadge = (date: Date) => {
-    const formattedDate = format(date, 'yyyy-MM-dd');
+    const formattedDate = formatMadridDateKey(date);
     const key = `${jobId}-${formattedDate}`;
     const meta = getDateTypeMeta(getEffectiveFestivalDateType(dateTypes[key]));
     if (!meta) return null;
@@ -147,21 +180,23 @@ export const FestivalDateNavigation = ({
     if (!date) return;
     
     const formattedDate = format(date, 'yyyy-MM-dd');
-    const isValidDate = jobDates.some(jobDate => format(jobDate, 'yyyy-MM-dd') === formattedDate);
+    const isValidDate = jobDates.some(
+      jobDate => formatMadridDateKey(jobDate) === formattedDate,
+    );
     
     if (isValidDate) {
       onDateChange(formattedDate);
-      setCurrentWeekStart(startOfWeek(date, { weekStartsOn: 1 }));
+      setCurrentWeekStart(getFestivalWeekStartKey(formattedDate));
     }
   };
 
   const formatTabDate = (date: Date) => {
-    return format(date, 'EEE, MMM d');
+    return formatInTimeZone(date, MADRID_TIMEZONE, 'EEE, MMM d');
   };
 
   const getWeekRange = () => {
-    const weekEnd = endOfWeek(currentWeekStart, { weekStartsOn: 1 });
-    return `${format(currentWeekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`;
+    const weekEnd = addMadridCalendarDays(currentWeekStart, 6);
+    return `${formatFestivalDateKey(currentWeekStart, 'MMM d')} - ${formatFestivalDateKey(weekEnd, 'MMM d')}`;
   };
 
   // Show simplified view for long festivals (7+ days)
@@ -297,11 +332,11 @@ export const FestivalDateNavigation = ({
             <PopoverContent className="w-auto p-0" align="end">
               <CalendarComponent
                 mode="single"
-                selected={new Date(selectedDate)}
+                selected={parseISO(selectedDate)}
                 onSelect={handleDateJump}
                 disabled={(date) =>
                   !jobDates.some(jobDate =>
-                    format(jobDate, 'yyyy-MM-dd') === format(date, 'yyyy-MM-dd')
+                    formatMadridDateKey(jobDate) === format(date, 'yyyy-MM-dd')
                   )
                 }
                 initialFocus
@@ -317,11 +352,11 @@ export const FestivalDateNavigation = ({
             <PopoverContent className="w-auto p-0" align="end">
               <CalendarComponent
                 mode="single"
-                selected={new Date(selectedDate)}
+                selected={parseISO(selectedDate)}
                 onSelect={handleDateJump}
                 disabled={(date) => 
                   !jobDates.some(jobDate => 
-                    format(jobDate, 'yyyy-MM-dd') === format(date, 'yyyy-MM-dd')
+                    formatMadridDateKey(jobDate) === format(date, 'yyyy-MM-dd')
                   )
                 }
                 initialFocus
@@ -349,7 +384,7 @@ export const FestivalDateNavigation = ({
         <div className="overflow-x-auto -mx-2 px-2 touch-pan-x">
           <TabsList className="mb-4 inline-flex h-auto p-1 w-auto min-w-full">
             {weekDates.map((date) => {
-              const formattedDateValue = format(date, 'yyyy-MM-dd');
+              const formattedDateValue = formatMadridDateKey(date);
               const dateTypeColor = getDateTypeColor(date);
               const isSelectedDate = formattedDateValue === selectedDate;
               
@@ -357,7 +392,7 @@ export const FestivalDateNavigation = ({
                 <DateTypeContextMenu 
                   key={formattedDateValue}
                   jobId={jobId}
-                  date={date}
+                  date={parseISO(formattedDateValue)}
                   onTypeChange={onTypeChange}
                 >
                   <TooltipProvider>
@@ -393,8 +428,8 @@ export const FestivalDateNavigation = ({
         
         {weekDates.map((date) => (
           <TabsContent
-            key={format(date, 'yyyy-MM-dd')}
-            value={format(date, 'yyyy-MM-dd')}
+            key={formatMadridDateKey(date)}
+            value={formatMadridDateKey(date)}
             className="mt-0"
           >
             {/* Content will be rendered by parent component */}

--- a/src/components/festival/FestivalDateNavigation.tsx
+++ b/src/components/festival/FestivalDateNavigation.tsx
@@ -3,8 +3,19 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { DateTypeContextMenu } from "@/components/dashboard/DateTypeContextMenu";
-import { ChevronLeft, ChevronRight, Calendar, Filter } from "lucide-react";
-import { format, startOfWeek, endOfWeek, eachDayOfInterval, addWeeks, subWeeks, isSameWeek } from "date-fns";
+import { ChevronLeft, ChevronRight, Calendar, CalendarCheck2, Filter } from "lucide-react";
+import {
+  addWeeks,
+  endOfWeek,
+  format,
+  isBefore,
+  isSameWeek,
+  parseISO,
+  startOfDay,
+  startOfWeek,
+  subWeeks,
+} from "date-fns";
+import { es } from "date-fns/locale";
 import {
   Popover,
   PopoverContent,
@@ -49,19 +60,36 @@ export const FestivalDateNavigation = ({
     return startOfWeek(selected, { weekStartsOn: 1 }); // Start week on Monday
   });
   const [showOnlyShowDates, setShowOnlyShowDates] = useState(true);
+  const [showPastDates, setShowPastDates] = useState(false);
   const [viewMode, setViewMode] = useState<'week' | 'all'>('all');
+  const selectedDateLabel = useMemo(() => {
+    if (!selectedDate) return "";
+    const parsedSelectedDate = parseISO(selectedDate);
+    if (Number.isNaN(parsedSelectedDate.getTime())) return selectedDate;
+    return format(parsedSelectedDate, "EEEE, d 'de' MMMM 'de' yyyy", { locale: es });
+  }, [selectedDate]);
 
-  // Filter dates based on preferences
+  const hasPastDates = useMemo(() => {
+    const today = startOfDay(new Date());
+    return jobDates.some((date) => isBefore(startOfDay(date), today));
+  }, [jobDates]);
+
+  // Filter dates based on preferences. Keep a selected historical date visible
+  // so the navigation never loses the day the user is inspecting.
   const filteredDates = useMemo(() => {
-    if (!showOnlyShowDates) return jobDates;
-    
+    const today = startOfDay(new Date());
+
     return jobDates.filter(date => {
       const formattedDate = format(date, 'yyyy-MM-dd');
+      if (formattedDate === selectedDate) return true;
+      if (!showPastDates && isBefore(startOfDay(date), today)) return false;
+      if (!showOnlyShowDates) return true;
+
       const key = `${jobId}-${formattedDate}`;
       const dateType = getEffectiveFestivalDateType(dateTypes[key]);
       return isKeyFestivalDateType(dateType);
     });
-  }, [jobDates, showOnlyShowDates, dateTypes, jobId]);
+  }, [jobDates, selectedDate, showPastDates, showOnlyShowDates, dateTypes, jobId]);
 
   // Get dates for current week
   const weekDates = useMemo(() => {
@@ -106,7 +134,10 @@ export const FestivalDateNavigation = ({
     if (!meta) return null;
     
     return (
-      <span className={`absolute -top-1 -right-1 w-4 h-4 ${meta.festivalBadgeColorClassName} text-white text-xs rounded-full flex items-center justify-center font-bold`}>
+      <span
+        aria-hidden="true"
+        className={`absolute -top-1 -right-1 w-4 h-4 ${meta.festivalBadgeColorClassName} text-white text-xs rounded-full flex items-center justify-center font-bold`}
+      >
         {meta.shortLabel}
       </span>
     );
@@ -191,6 +222,19 @@ export const FestivalDateNavigation = ({
                 <Label htmlFor="show-filter" className="text-sm whitespace-nowrap">Solo fechas clave</Label>
               </div>
             </>
+          )}
+
+          {hasPastDates && (
+            <div className="flex items-center gap-2">
+              <Switch
+                id="show-past-dates"
+                checked={showPastDates}
+                onCheckedChange={setShowPastDates}
+              />
+              <Label htmlFor="show-past-dates" className="text-sm whitespace-nowrap">
+                Mostrar fechas pasadas
+              </Label>
+            </div>
           )}
 
           {/* Stage Filter */}
@@ -287,6 +331,19 @@ export const FestivalDateNavigation = ({
         </div>
       </div>
 
+      {selectedDate && (
+        <div
+          className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-primary/40 bg-primary/10 px-3 py-2 text-sm"
+          aria-live="polite"
+        >
+          <CalendarCheck2 className="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+          <span className="font-medium">Fecha seleccionada:</span>
+          <time dateTime={selectedDate} className="font-semibold capitalize">
+            {selectedDateLabel}
+          </time>
+        </div>
+      )}
+
       {/* Date Tabs */}
       <Tabs value={selectedDate} onValueChange={onDateChange} className="w-full">
         <div className="overflow-x-auto -mx-2 px-2 touch-pan-x">
@@ -294,6 +351,7 @@ export const FestivalDateNavigation = ({
             {weekDates.map((date) => {
               const formattedDateValue = format(date, 'yyyy-MM-dd');
               const dateTypeColor = getDateTypeColor(date);
+              const isSelectedDate = formattedDateValue === selectedDate;
               
               return (
                 <DateTypeContextMenu 
@@ -307,7 +365,12 @@ export const FestivalDateNavigation = ({
                       <TooltipTrigger asChild>
                         <TabsTrigger
                           value={formattedDateValue}
-                          className={`relative border-b-2 ${dateTypeColor} min-w-[100px] h-12 touch-manipulation`}
+                          aria-current={isSelectedDate ? "date" : undefined}
+                          className={`relative border-b-2 ${dateTypeColor} min-w-[100px] h-12 touch-manipulation ${
+                            isSelectedDate
+                              ? "z-10 ring-2 ring-primary ring-offset-2 !bg-primary !text-primary-foreground font-semibold"
+                              : ""
+                          }`}
                         >
                           {formatTabDate(date)}
                           {getDateTypeBadge(date)}

--- a/src/components/festival/__tests__/FestivalDateNavigation.test.tsx
+++ b/src/components/festival/__tests__/FestivalDateNavigation.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FestivalDateNavigation } from "@/components/festival/FestivalDateNavigation";
 
@@ -10,6 +10,15 @@ vi.mock("@/components/dashboard/DateTypeContextMenu", () => ({
 }));
 
 describe("FestivalDateNavigation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 1, 12));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("keeps unconfigured festival dates visible as default show dates", () => {
     render(
       <FestivalDateNavigation
@@ -32,5 +41,65 @@ describe("FestivalDateNavigation", () => {
     expect(screen.getByText("Thu, Jun 4")).toBeInTheDocument();
     expect(screen.getByText("Fri, Jun 5")).toBeInTheDocument();
     expect(screen.getByText("Sat, Jun 6")).toBeInTheDocument();
+  });
+
+  it("makes the selected date explicit in both the summary and active tab", () => {
+    render(
+      <FestivalDateNavigation
+        jobDates={[
+          new Date(2026, 7, 4),
+          new Date(2026, 7, 5),
+          new Date(2026, 7, 6),
+        ]}
+        selectedDate="2026-08-05"
+        onDateChange={vi.fn()}
+        dateTypes={{}}
+        jobId="job-1"
+        onTypeChange={vi.fn()}
+        dayStartTime="07:00"
+      />,
+    );
+
+    expect(screen.getByText("Fecha seleccionada:")).toBeInTheDocument();
+    expect(screen.getByText("miércoles, 5 de agosto de 2026")).toBeInTheDocument();
+    const selectedTab = screen.getByRole("tab", { name: "Wed, Aug 5" });
+    expect(selectedTab).toHaveAttribute("aria-current", "date");
+    expect(selectedTab).toHaveClass(
+      "!bg-primary",
+      "!text-primary-foreground",
+      "font-semibold",
+    );
+  });
+
+  it("hides past dates by default and reveals them on request", () => {
+    vi.setSystemTime(new Date(2026, 7, 3, 12));
+
+    render(
+      <FestivalDateNavigation
+        jobDates={[
+          new Date(2026, 7, 1),
+          new Date(2026, 7, 3),
+          new Date(2026, 7, 4),
+        ]}
+        selectedDate="2026-08-04"
+        onDateChange={vi.fn()}
+        dateTypes={{}}
+        jobId="job-1"
+        onTypeChange={vi.fn()}
+        dayStartTime="07:00"
+      />,
+    );
+
+    expect(screen.queryByRole("tab", { name: "Sat, Aug 1" })).not.toBeInTheDocument();
+
+    const showPastDates = screen.getByRole("switch", {
+      name: "Mostrar fechas pasadas",
+    });
+    expect(showPastDates).not.toBeChecked();
+
+    fireEvent.click(showPastDates);
+
+    expect(showPastDates).toBeChecked();
+    expect(screen.getByRole("tab", { name: "Sat, Aug 1" })).toBeInTheDocument();
   });
 });

--- a/src/components/festival/__tests__/FestivalDateNavigation.test.tsx
+++ b/src/components/festival/__tests__/FestivalDateNavigation.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@/components/dashboard/DateTypeContextMenu", () => ({
 describe("FestivalDateNavigation", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 4, 1, 12));
+    vi.setSystemTime(new Date("2026-05-01T10:00:00.000Z"));
   });
 
   afterEach(() => {
@@ -23,9 +23,9 @@ describe("FestivalDateNavigation", () => {
     render(
       <FestivalDateNavigation
         jobDates={[
-          new Date(2026, 5, 4),
-          new Date(2026, 5, 5),
-          new Date(2026, 5, 6),
+          new Date("2026-06-03T22:00:00.000Z"),
+          new Date("2026-06-04T22:00:00.000Z"),
+          new Date("2026-06-05T22:00:00.000Z"),
         ]}
         selectedDate="2026-06-04"
         onDateChange={vi.fn()}
@@ -47,9 +47,9 @@ describe("FestivalDateNavigation", () => {
     render(
       <FestivalDateNavigation
         jobDates={[
-          new Date(2026, 7, 4),
-          new Date(2026, 7, 5),
-          new Date(2026, 7, 6),
+          new Date("2026-08-03T22:00:00.000Z"),
+          new Date("2026-08-04T22:00:00.000Z"),
+          new Date("2026-08-05T22:00:00.000Z"),
         ]}
         selectedDate="2026-08-05"
         onDateChange={vi.fn()}
@@ -71,15 +71,15 @@ describe("FestivalDateNavigation", () => {
     );
   });
 
-  it("hides past dates by default and reveals them on request", () => {
-    vi.setSystemTime(new Date(2026, 7, 3, 12));
+  it("uses the Madrid day boundary when hiding and revealing past dates", () => {
+    vi.setSystemTime(new Date("2026-08-02T22:30:00.000Z"));
 
     render(
       <FestivalDateNavigation
         jobDates={[
-          new Date(2026, 7, 1),
-          new Date(2026, 7, 3),
-          new Date(2026, 7, 4),
+          new Date("2026-08-01T22:00:00.000Z"),
+          new Date("2026-08-02T22:00:00.000Z"),
+          new Date("2026-08-03T22:00:00.000Z"),
         ]}
         selectedDate="2026-08-04"
         onDateChange={vi.fn()}
@@ -90,7 +90,8 @@ describe("FestivalDateNavigation", () => {
       />,
     );
 
-    expect(screen.queryByRole("tab", { name: "Sat, Aug 1" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Sun, Aug 2" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Mon, Aug 3" })).toBeInTheDocument();
 
     const showPastDates = screen.getByRole("switch", {
       name: "Mostrar fechas pasadas",
@@ -100,6 +101,6 @@ describe("FestivalDateNavigation", () => {
     fireEvent.click(showPastDates);
 
     expect(showPastDates).toBeChecked();
-    expect(screen.getByRole("tab", { name: "Sat, Aug 1" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Sun, Aug 2" })).toBeInTheDocument();
   });
 });

--- a/src/components/ui/__tests__/dropdown-menu.test.tsx
+++ b/src/components/ui/__tests__/dropdown-menu.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+describe("DropdownMenuContent", () => {
+  it("leaves fixed positioning to the Radix collision-aware wrapper", () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger asChild>
+          <button type="button">Abrir acciones</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Editar artista</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    const menu = screen.getByRole("menu");
+    const positioningWrapper = menu.closest("[data-radix-popper-content-wrapper]");
+
+    expect(positioningWrapper).not.toBeNull();
+    expect(positioningWrapper).toHaveStyle({ position: "fixed" });
+    expect(menu).not.toHaveStyle({ position: "fixed" });
+  });
+});

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -66,10 +66,6 @@ const DropdownMenuContent = React.forwardRef<
         "z-[9999] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
-      style={{
-        position: 'fixed',
-        ...props.style
-      }}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>

--- a/src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts
+++ b/src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildArtistFlexDateRange,
   formatArtistDateTimeForFlex,
   formatArtistExtrasFolderDocumentNumber,
 } from "../useCreateExtrasPresupuesto";
@@ -36,6 +37,32 @@ describe("formatArtistDateTimeForFlex", () => {
     expect(() => formatArtistDateTimeForFlex("2026-07-18", "24:00")).toThrow(
       "Hora de artista invalida"
     );
+  });
+
+  it("reports a domain error instead of crashing when a time is null", () => {
+    expect(() => formatArtistDateTimeForFlex("2026-07-18", null)).toThrow(
+      "Hora de artista invalida para Flex: (vacia)"
+    );
+  });
+});
+
+describe("buildArtistFlexDateRange", () => {
+  it("uses the festival operating day when the artist has no show times", () => {
+    expect(
+      buildArtistFlexDateRange("2026-08-05", null, null, false, "07:00")
+    ).toEqual({
+      plannedStartDate: "2026-08-05T07:00:00.000Z",
+      plannedEndDate: "2026-08-06T07:00:00.000Z",
+    });
+  });
+
+  it("preserves the artist show range when both times are available", () => {
+    expect(
+      buildArtistFlexDateRange("2026-08-05", "20:00", "21:30", false, "07:00")
+    ).toEqual({
+      plannedStartDate: "2026-08-05T20:00:00.000Z",
+      plannedEndDate: "2026-08-05T21:30:00.000Z",
+    });
   });
 });
 

--- a/src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts
+++ b/src/hooks/festival/__tests__/useCreateExtrasPresupuesto.test.ts
@@ -3,7 +3,7 @@ import {
   buildArtistFlexDateRange,
   formatArtistDateTimeForFlex,
   formatArtistExtrasFolderDocumentNumber,
-} from "../useCreateExtrasPresupuesto";
+} from "@/hooks/festival/useCreateExtrasPresupuesto";
 
 vi.mock("sonner", () => ({
   toast: {

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -13,8 +13,11 @@ const jobCreationQueues = new Map<string, Promise<void>>();
 const RETRY_DELAYS = [500, 1000, 2000];
 const FLEX_TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/;
 
-export function formatArtistDateTimeForFlex(date: string, time: string): string {
-  const match = time.match(FLEX_TIME_PATTERN);
+export function formatArtistDateTimeForFlex(
+  date: string,
+  time: string | null | undefined,
+): string {
+  const match = typeof time === "string" ? time.match(FLEX_TIME_PATTERN) : null;
   if (!match) {
     throw new Error(`Hora de artista invalida para Flex: ${time || "(vacia)"}`);
   }
@@ -22,6 +25,28 @@ export function formatArtistDateTimeForFlex(date: string, time: string): string 
   const [, hours, minutes, seconds = "00"] = match;
 
   return `${date}T${hours}:${minutes}:${seconds}.000Z`;
+}
+
+export function buildArtistFlexDateRange(
+  artistDate: string,
+  showStart: string | null | undefined,
+  showEnd: string | null | undefined,
+  isAfterMidnight = false,
+  dayStartTime = "07:00",
+): { plannedStartDate: string; plannedEndDate: string } {
+  const parsedDate = parseISO(artistDate);
+  const effectiveShowStart = showStart?.trim() || dayStartTime;
+  const effectiveShowEnd = showEnd?.trim() || dayStartTime;
+  const endDateBase =
+    isAfterMidnight || !showEnd?.trim() ? addDays(parsedDate, 1) : parsedDate;
+
+  return {
+    plannedStartDate: formatArtistDateTimeForFlex(artistDate, effectiveShowStart),
+    plannedEndDate: formatArtistDateTimeForFlex(
+      format(endDateBase, "yyyy-MM-dd"),
+      effectiveShowEnd,
+    ),
+  };
 }
 
 export function formatArtistExtrasFolderDocumentNumber(date: Date): string {
@@ -41,7 +66,10 @@ async function insertWithRetry(insertFn: () => Promise<{ error: unknown }>): Pro
   throw lastError;
 }
 
-export function useCreateExtrasPresupuesto(jobId: string | undefined) {
+export function useCreateExtrasPresupuesto(
+  jobId: string | undefined,
+  dayStartTime = "07:00",
+) {
   const [creatingExtrasForArtistIds, setCreatingExtrasForArtistIds] = useState<Set<string>>(new Set());
 
   const addCreating = (id: string) =>
@@ -54,8 +82,8 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
     artistId: string,
     artistName: string,
     artistDate: string,   // YYYY-MM-DD
-    showStart: string,    // HH:MM
-    showEnd: string,      // HH:MM
+    showStart: string | null | undefined, // HH:MM when scheduled
+    showEnd: string | null | undefined,   // HH:MM when scheduled
     isAfterMidnight = false
   ) => {
     if (!jobId) {
@@ -88,10 +116,13 @@ export function useCreateExtrasPresupuesto(jobId: string | undefined) {
 
       // 2. Build Flex date strings from the artist's local show day/time
       const parsedDate = parseISO(artistDate);
-      const endDateBase = isAfterMidnight ? addDays(parsedDate, 1) : parsedDate;
-
-      const plannedStartDate = formatArtistDateTimeForFlex(artistDate, showStart);
-      const plannedEndDate = formatArtistDateTimeForFlex(format(endDateBase, "yyyy-MM-dd"), showEnd);
+      const { plannedStartDate, plannedEndDate } = buildArtistFlexDateRange(
+        artistDate,
+        showStart,
+        showEnd,
+        isAfterMidnight,
+        dayStartTime,
+      );
 
       // 3. Compute document number: DDMMAA.xSQT
       //    Count runs inside the queue so the ordinal is always fresh.

--- a/src/hooks/festival/useCreateExtrasPresupuesto.ts
+++ b/src/hooks/festival/useCreateExtrasPresupuesto.ts
@@ -13,6 +13,11 @@ const jobCreationQueues = new Map<string, Promise<void>>();
 const RETRY_DELAYS = [500, 1000, 2000];
 const FLEX_TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d))?$/;
 
+/**
+ * Formats a festival wall-clock value for Flex's ISO-like date contract.
+ * Flex expects the local schedule fields with a trailing `Z`; this value must
+ * not be converted to a UTC instant or the displayed schedule will shift.
+ */
 export function formatArtistDateTimeForFlex(
   date: string,
   time: string | null | undefined,
@@ -27,6 +32,10 @@ export function formatArtistDateTimeForFlex(
   return `${date}T${hours}:${minutes}:${seconds}.000Z`;
 }
 
+/**
+ * Builds the Flex schedule for an artist, falling back to the complete
+ * festival operating day when show times have not been scheduled yet.
+ */
 export function buildArtistFlexDateRange(
   artistDate: string,
   showStart: string | null | undefined,
@@ -49,6 +58,7 @@ export function buildArtistFlexDateRange(
   };
 }
 
+/** Returns the stable document number for an artist extras folder. */
 export function formatArtistExtrasFolderDocumentNumber(date: Date): string {
   return `${format(date, "ddMMyy")}ESQT`;
 }
@@ -66,6 +76,7 @@ async function insertWithRetry(insertFn: () => Promise<{ error: unknown }>): Pro
   throw lastError;
 }
 
+/** Creates artist extras folders and presupuestos in Flex for one festival. */
 export function useCreateExtrasPresupuesto(
   jobId: string | undefined,
   dayStartTime = "07:00",


### PR DESCRIPTION
## Summary

- [x] I described what changed and why.
- Affected route/feature: `/festival-management/:jobId/artists`, shared dropdown positioning, and artist extras presupuesto creation.

The artist action menu now stays inside the viewport, the selected festival date is explicit, elapsed dates are hidden by default but recoverable, and extras presupuestos can be created when show times are missing.

The dropdown bug came from forcing `position: fixed` on the inner menu, bypassing Radix’s collision-aware wrapper. The extras crash came from calling `.match()` on nullable artist times. Missing times now use the complete festival operating day. Festival navigation now uses Europe/Madrid date keys so “today,” week ranges, labels, and tabs remain stable regardless of the user’s browser timezone.

Flex’s API intentionally receives ISO-shaped local wall-clock schedule values with a trailing `Z`; the follow-up review documents and preserves that established contract rather than converting them to UTC and shifting displayed schedules.

## Risk Assessment

- [x] I assessed functional, data, and deployment risk.
- Risk level: medium
- Main risks: shared dropdown positioning could affect other menus; Madrid date normalization could alter date selection at timezone boundaries; fallback operating-day times affect new Flex extras folders when artist times are absent. Regression tests and browser checks cover these paths.
- [x] This does not touch database authorization or money paths, so the repository’s high-risk classification does not apply.

## Impact Checklist

- [x] Migration impact assessed — no schema or function changes.
- [x] Realtime/subscription impact assessed — no subscription behavior changes.
- [x] RLS/security impact assessed — no authorization changes.
- [x] Performance impact assessed — date filtering remains linear over the festival date list.

## Test Evidence

- [x] I ran relevant tests and confirmed expected results.
- Commands executed locally:
  - `npm run lint` — passed with 0 errors and 361 existing warnings
  - `npm run typecheck` — passed
  - `npm run test:run` — 320 files / 1,761 tests passed
  - `npm run build` — passed
  - focused regression suite — 11 tests passed
  - touched-file ESLint — passed
  - staged secret scan — passed
- Browser evidence: verified bottom-edge action-menu collision handling and long-festival date navigation.
- GitHub evidence on the initial commit: governance, critical tests, desktop/mobile smoke tests, database lint/migration/security tests, CodeQL, dependency review, SBOM, build, lint, typecheck, full tests, Cloudflare preview, and CodeRabbit all passed. These checks are rerunning for the review follow-up commit.
- No live Flex presupuesto was created during verification.

## Rollback Plan

- [x] I documented how to safely revert this change.
- [x] I checked the production release checklist for rollback and post-deploy verification.
- Rollback steps: revert commits `d41a3361` and `8d2755d8`, redeploy `main`, then verify artist action menus, date navigation, and extras creation on the artist management route. No data backout is required.

## Migration Impact

- [x] I confirmed whether this PR changes schema/functions.
- Migration required: no
- No Supabase migration, Edge Function change, or production database push is required.